### PR TITLE
server/sandbox_run: Drop PodInfraCommand fallback

### DIFF
--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -114,9 +114,6 @@ const (
 	// NsRunDir is the default directory in which running network namespaces
 	// are stored
 	NsRunDir = "/var/run/netns"
-	// PodInfraCommand is the default command when starting a pod infrastructure
-	// container
-	PodInfraCommand = "/pause"
 )
 
 var (

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -242,18 +242,7 @@ func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, ociConfig *v1.
 		return nil, fmt.Errorf("no command specified")
 	}
 
-	// create entrypoint and args
-	var entrypoint string
-	var args []string
-	if len(kubeCommands) != 0 {
-		entrypoint = kubeCommands[0]
-		args = append(kubeCommands[1:], kubeArgs...)
-	} else {
-		entrypoint = kubeArgs[0]
-		args = kubeArgs[1:]
-	}
-
-	processArgs := append([]string{entrypoint}, args...)
+	processArgs := append(kubeCommands, kubeArgs...)
 
 	logrus.Debugf("OCI process args %v", processArgs)
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -238,10 +238,6 @@ func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, ociConfig *v1.
 		}
 	}
 
-	if len(kubeCommands) == 0 && len(kubeArgs) == 0 {
-		return nil, fmt.Errorf("no command specified")
-	}
-
 	processArgs := append(kubeCommands, kubeArgs...)
 
 	logrus.Debugf("OCI process args %v", processArgs)

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -219,7 +219,7 @@ func addDevices(sb *sandbox.Sandbox, containerConfig *pb.ContainerConfig, specge
 }
 
 // buildOCIProcessArgs build an OCI compatible process arguments slice.
-func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig *v1.Image) ([]string, error) {
+func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, ociConfig *v1.ImageConfig) ([]string, error) {
 	//# Start the nginx container using the default command, but use custom
 	//arguments (arg1 .. argN) for that command.
 	//kubectl run nginx --image=nginx -- <arg1> <arg2> ... <argN>
@@ -231,15 +231,10 @@ func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig
 	kubeArgs := containerKubeConfig.Args
 
 	// merge image config and kube config
-	// same as docker does today...
-	if imageOCIConfig != nil {
-		if len(kubeCommands) == 0 {
-			if len(kubeArgs) == 0 {
-				kubeArgs = imageOCIConfig.Config.Cmd
-			}
-			if kubeCommands == nil {
-				kubeCommands = imageOCIConfig.Config.Entrypoint
-			}
+	if ociConfig != nil && len(kubeCommands) == 0 {
+		kubeCommands = ociConfig.Entrypoint
+		if len(kubeArgs) == 0 {
+			kubeArgs = ociConfig.Cmd
 		}
 	}
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -810,9 +810,12 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		return nil, err
 	}
 
-	processArgs, err := buildOCIProcessArgs(containerConfig, containerImageConfig)
-	if err != nil {
-		return nil, err
+	processArgs := []string{}
+	if containerImageConfig != nil {
+		processArgs, err = buildOCIProcessArgs(containerConfig, &containerImageConfig.Config)
+		if err != nil {
+			return nil, err
+		}
 	}
 	specgen.SetProcessArgs(processArgs)
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -817,6 +817,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 			return nil, err
 		}
 	}
+	if len(processArgs) == 0 {
+		return nil, fmt.Errorf("no command specified")
+	}
 	specgen.SetProcessArgs(processArgs)
 
 	envs := mergeEnvs(containerImageConfig, containerConfig.GetEnvs())


### PR DESCRIPTION
There's no reason to assume the pause image contains a `/pause` command, and it seems more sane to assume that the pause container has configured `Entrypoint` and `Cmd` appropriately without our having to repair anything.

Also consider both `Entrypoint` and `Cmd` in the image config when populating the runtime config.  The image-spec wording for this is [here][1].  This will keep the `kubernetes/pause` image working, because [that image sets `Entrypoint`][2].

Down the road we might be able to use image-tools [image → runtime config converter][3].  It's currently a private method with public access restricted to full bundle unpacks.

[1]: https://github.com/opencontainers/image-spec/blob/v1.0.1/conversion.md#verbatim-fields
[2]: https://github.com/kubernetes/kubernetes/blob/v1.9.2/build/pause/Dockerfile#L18
[3]: https://github.com/opencontainers/image-tools/blob/v0.3.0/image/config.go#L68