### PR TITLE
pkg/storage/runtime: Drop StartContainer and StopContainer

### DIFF
--- a/lib/stop.go
+++ b/lib/stop.go
@@ -24,9 +24,6 @@ func (c *ContainerServer) ContainerStop(ctx context.Context, container string, t
 			if err := c.runtime.StopContainer(ctx, ctr, timeout); err != nil {
 				return "", errors.Wrapf(err, "failed to stop container %s", ctrID)
 			}
-			if err := c.storageRuntimeServer.StopContainer(ctrID); err != nil {
-				return "", errors.Wrapf(err, "failed to unmount container %s", ctrID)
-			}
 		}
 	}
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -483,12 +483,9 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 
 	saveOptions := generate.ExportOptions{}
-	mountPoint, err := s.StorageRuntimeServer().StartContainer(id)
-	if err != nil {
-		return nil, fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %v", containerName, sb.Name(), id, err)
-	}
-	g.AddAnnotation(annotations.MountPoint, mountPoint)
-	g.SetRootPath(mountPoint)
+
+	g.AddAnnotation(annotations.MountPoint, podContainer.MountDir)
+	g.SetRootPath(podContainer.MountDir)
 
 	hostnamePath := fmt.Sprintf("%s/hostname", podContainer.RunDir)
 	if err := ioutil.WriteFile(hostnamePath, []byte(hostname+"\n"), 0644); err != nil {
@@ -512,7 +509,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 	container.SetSpec(g.Spec())
-	container.SetMountPoint(mountPoint)
+	container.SetMountPoint(podContainer.MountDir)
 
 	sb.SetInfraContainer(container)
 

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containers/storage"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/kubernetes-incubator/cri-o/lib/sandbox"
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
@@ -69,10 +67,6 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 			if c.ID() == podInfraContainer.ID() {
 				continue
 			}
-			if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
-				// assume container already umounted
-				logrus.Warnf("failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
-			}
 		}
 		s.ContainerStateToDisk(c)
 	}
@@ -96,9 +90,6 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 				return nil, err
 			}
 		}
-	}
-	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
-		logrus.Warnf("failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
 
 	sb.SetStopped()


### PR DESCRIPTION
The underlying `github.com/containers/storage` `Store` interface exposes both `CreateContainer`/`DeleteContainer` and `Mount`/`Unmount`, but in CRI-O `Mount` always followed shortly after `CreateContainer` and `Unmount` always preceded `DeleteContainer`.  This commit removes the unused distinction.

The only user-visible change is that `Unmount` used to be called at stop-time (e.g. in `StopPodSandbox` and `ContainerStop`), but now `Unmount` happens via `DeleteContainer` at remove-time (e.g. in `RemovePodSandbox` and `ContainerServer.Remove`).  That early removal is a CRI-O optimization dating back to at least c88bc13b (#839).  But the early removal might break [eventual post-stop][1] [event hooks][2].  And if we don't need to support post-stop event hooks (the closest Kubernetes has now is [pre-stop][3] [hooks][4]), we can trigger a full removal (not just an unmount) immediately after a successful stop.  I haven't added stop-time removal yet, since there is some other cleanup I want to land first to make that easier (e.g. #1340).

[1]: https://github.com/kubernetes/kubernetes/issues/140
[2]: https://github.com/kubernetes/kubernetes/blob/release-1.5/docs/proposals/container-runtime-interface-v1.md#container-lifecycle-hooks
[3]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#lifecycle-v1-core
[4]: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks