### PR TITLE
server/container_create: Drop 'stage' environment variable from hooks

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -429,7 +429,6 @@ func addOCIHook(specgen *generate.Generator, hook lib.HookParams) error {
 		h := rspec.Hook{
 			Path: hook.Hook,
 			Args: append([]string{hook.Hook}, hook.Arguments...),
-			Env:  []string{fmt.Sprintf("stage=%s", stage)},
 		}
 		switch stage {
 		case "prestart":


### PR DESCRIPTION
This was added in #1244 to replace an earlier approach where the stage was `Args[1]`.  However, the most portable way of determining the stage is to read [the state from stdin][1] and extract [the container `status`][2].  Tools can upgrade with the following mapping:

| Stage     | Status  |
| --------- | ------  |
| prestart  | created |
| poststart | running |
| poststop  | stopped |

Because the stage variable was never documented and has yet to be included in a tagged release, I don't think we need backwards compat for this removal.

@rhatdan, this should address [your concerns about portably determining the stage][3].

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.1/config.md#L387
[2]: https://github.com/opencontainers/runtime-spec/blame/v1.0.1/runtime.md#L16
[3]: https://github.com/kubernetes-incubator/cri-o/pull/1244#issuecomment-355753859