### PR TITLE
oci/oci: Fatal cgroup-setup errors

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -224,7 +224,7 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error)
 
 	// Platform specific container setup
 	if err := r.createContainerPlatform(c, cgroupParent, cmd.Process.Pid); err != nil {
-		logrus.Warnf("%s", err)
+		return err
 	}
 
 	/* We set the cgroup, now the child can start creating children */

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,6 +9,7 @@ import (
 
 	systemdDbus "github.com/coreos/go-systemd/dbus"
 	"github.com/godbus/dbus"
+	"github.com/sirupsen/logrus"
 )
 
 // ExecCmd executes a command with args and returns its output as a string along
@@ -60,6 +61,7 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	properties = append(properties, newProp("Delegate", true))
 	properties = append(properties, newProp("DefaultDependencies", false))
 	ch := make(chan string)
+	logrus.Debugf("start transient unit %s (%+v)", unitName, properties)
 	_, err = conn.StartTransientUnit(unitName, "replace", properties, ch)
 	if err != nil {
 		return err


### PR DESCRIPTION
These cgroup actions been non-fatal since they landed in 8c0ff7d9 (#385) and c199f63d (#812).  But cgroups are an important security mechanism, and silently ignoring cgroup-setup failures makes me jumpy ;).  This commit turns the old warnings into fatal container-creation errors.

Spun off from [here][1].

[1]: https://github.com/kubernetes-incubator/cri-o/pull/1407#discussion_r179027255