### PR TITLE
Makefile: Exclude OSTree, btrfs, and device-mapper for bin/crio.cross.%

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,11 @@ jobs:
       go: "1.10.x"
       env: CROSS_PLATFORM=true
     - script:
+        - make local-cross
+      go: "1.10.x"
+      env: CROSS_PLATFORM=true
+      os: osx
+    - script:
         - sudo "PATH=$PATH" make testunit
         - make
       go: tip

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ bin/crio.cross.%: .gopathok
 	TARGET="$*"; \
 	GOOS="$${TARGET%%.*}" \
 	GOARCH="$${TARGET##*.}" \
-	$(GO) build -i $(LDFLAGS) -tags "containers_image_openpgp btrfs_noversion" -o "$@" $(PROJECT)/cmd/crio
+	$(GO) build -i $(LDFLAGS) -tags 'containers_image_openpgp containers_image_ostree_stub exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay' -o "$@" $(PROJECT)/cmd/crio
 
 crioimage:
 	docker build -t ${CRIO_IMAGE} .


### PR DESCRIPTION
[OSTree is Linux-specific][1], and non-Linux OSes are unlikely to have the btrfs or device-mapper libraries.

We don't actually need `btrfs_noversion` (only consumed by `vendor/github.com/containers/storage/drivers/btrfs/version*.go`), because `exclude_graphdriver_btrfs` prevents the btrfs driver from being registered entirely.

I've added an OS X cross-compile check to `.travis.yml` to make it easier to detect these sorts of issues in the future.

Even on Linux, these changes should help us [avoid][2]:

```
  ==> make bin/crio.cross.linux.amd64
  # github.com/kubernetes-incubator/cri-o/vendor/github.com/containers/storage/pkg/devicemapper
  vendor/github.com/containers/storage/pkg/devicemapper/devmapper_wrapper_deferred_remove.go:12:13: could not determine kind of name for C.dm_task_deferred_remove
  # github.com/kubernetes-incubator/cri-o/vendor/github.com/containers/image/ostree
  vendor/github.com/containers/image/ostree/ostree_dest.go:198: cannot use &context (type **_Ctype_char) as type *_Ctype_security_context_t in argument to func literal
  make[1]: *** [bin/crio.cross.linux.amd64] Error 2
```

due to missing/different system libraries.

[1]: https://ostree.readthedocs.io/en/stable/manual/introduction/#introduction
[2]: https://travis-ci.org/kubernetes-incubator/cri-o/jobs/395210934#L1108