### PR TITLE
Improve build and runtime customization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ GOLANGCI_LINT := ${BUILD_BIN_PATH}/golangci-lint
 
 NIX_IMAGE := saschagrunert/crionix:1.0.0
 
+# pass crio CLI options to generate custom crio.conf build time
+CONF_OVERRIDES ?=
+
 CROSS_BUILD_TARGETS := \
 	bin/crio.cross.windows.amd64 \
 	bin/crio.cross.darwin.amd64 \
@@ -132,7 +135,7 @@ nix-image: git-vars
 		--build-arg COMMIT=$(COMMIT_NO) -f Dockerfile-nix .
 
 crio.conf: bin/crio
-	./bin/crio --config="" config --default > crio.conf
+	./bin/crio --config="" $(CONF_OVERRIDES) config  > crio.conf
 
 release-note: ${RELEASE_TOOL}
 	${RELEASE_TOOL} -n $(release)

--- a/contrib/systemd/crio.service
+++ b/contrib/systemd/crio.service
@@ -9,6 +9,8 @@ Type=notify
 EnvironmentFile=-/etc/sysconfig/crio
 Environment=GOTRACEBACK=crash
 ExecStart=/usr/local/bin/crio \
+          $CRIO_CONFIG_OPTIONS \
+          $CRIO_RUNTIME_OPTIONS \
           $CRIO_STORAGE_OPTIONS \
           $CRIO_NETWORK_OPTIONS \
           $CRIO_METRICS_OPTIONS


### PR DESCRIPTION

**- What I did**
- changed Makefile to pass config parameters to crio.conf generation
- changed main to set runtime-untrusted from command line
- changed crio.service to enable easier cmdline customization 

**- How I did it**

**- How to verify it**
- pass ```--runtime-untrusted``` from crio cmdline with various parametes
- build with ```make CONF_OVERRIDES="<any accepted cmdline>"``` to customize ```crio.conf```
- set ```crio.service.d/test.conf``` with ```[Service]\nEnvironment="CRIO_RUNTIME_OPTIONS=--untrusted-runtime /path/to/runtime"```

**- Description for the changelog**
Add --runtime-untrusted command line option
Improve build and runtime customization