### PR TITLE
[release-1.12] config: fix specified settings

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -32,12 +32,16 @@ var commentedConfigTemplate = template.Must(template.New("config").Parse(`
 
 # Storage driver used to manage the storage of images and containers. Please
 # refer to containers-storage.conf(5) to see all available storage drivers.
-#storage_driver = "{{ .Storage }}"
+{{ if .Storage }}
+storage_driver = "{{ .Storage }}"
+{{ end }}
 
 # List to pass options to the storage driver. Please refer to
 # containers-storage.conf(5) to see all available storage options.
-#storage_option = [
-{{ range $opt := .StorageOptions }}{{ printf "#\t%q,\n" $opt }}{{ end }}#]
+{{ if .StorageOptions }}
+storage_option = [
+{{ range $opt := .StorageOptions }}{{ printf "\t%q,\n" $opt }}{{ end }}]
+{{ end }}
 
 # If set to false, in-memory locking will be used instead of file-based locking.
 file_locking = {{ .FileLocking }}
@@ -83,8 +87,8 @@ stream_tls_ca = "{{ .StreamTLSCA }}"
 # "<ulimit name>=<soft limit>:<hard limit>", for example:
 # "nofile=1024:2048"
 # If nothing is set here, settings will be inherited from the CRI-O daemon
-#default_ulimits = [
-{{ range $ulimit := .DefaultUlimits }}{{ printf "#\t%q,\n" $ulimit }}{{ end }}#]
+default_ulimits = [
+{{ range $ulimit := .DefaultUlimits }}{{ printf "\t%q,\n" $ulimit }}{{ end }}]
 
 # Path to the OCI compatible runtime used for trusted container workloads. This
 # is a mandatory setting as this runtime will be the default and will also be

--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -29,6 +29,20 @@
     target: install.systemd
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-o"
 
+- name: generate config
+  shell: "./bin/crio --storage-driver=overlay --storage-opt=overlay.override_kernel_check=1 --cgroup-manager=systemd config >crio.conf"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-o"
+  async: 5400
+  poll: 30
+
+- name: tweak Makefile
+  replace:
+    regexp: 'install.config: crio.conf'
+    replace: 'install.config:'
+    name: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-o/Makefile"
+    backup: yes
+
 - name: install cri-o config
   make:
     target: install.config
@@ -47,20 +61,6 @@
     - src: test/redhat_sigstore.yaml
       dest: /etc/containers/registries.d/registry.access.redhat.com.yaml
 
-- name: run with overlay
-  replace:
-    regexp: 'storage_driver = ""'
-    replace: 'storage_driver = "overlay"'
-    name: /etc/crio/crio.conf
-    backup: yes
-
-- name: run with systemd cgroup manager
-  replace:
-    regexp: 'cgroup_manager = "cgroupfs"'
-    replace: 'cgroup_manager = "systemd"'
-    name: /etc/crio/crio.conf
-    backup: yes
-
 - name: add quay.io and docker.io as default registries
   lineinfile:
     dest: /etc/crio/crio.conf
@@ -70,14 +70,3 @@
     insertafter: 'registries = \['
     regexp: 'quay\.io, docker\.io'
     state: present
-
-- name: add overlay storage opts on RHEL/CentOS
-  lineinfile:
-    dest: /etc/crio/crio.conf
-    line: |
-          # Added by Ansible from build/cri-o.yml
-          storage_option = [ "overlay.override_kernel_check=1", ]
-    insertafter: 'storage_option = \['
-    regexp: 'overlay\.override_kernel_check=1'
-    state: present
-  when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'

--- a/lib/config.go
+++ b/lib/config.go
@@ -360,7 +360,7 @@ func DefaultConfig() *Config {
 			Storage:         storage.DefaultStoreOptions.GraphDriverName,
 			StorageOptions:  storage.DefaultStoreOptions.GraphDriverOptions,
 			LogDir:          "/var/log/crio/pods",
-			FileLocking:     true,
+			FileLocking:     false,
 			FileLockingPath: lockPath,
 		},
 		RuntimeConfig: RuntimeConfig{


### PR DESCRIPTION
I've noticed the cri-o RPM generates the configuration using this
snippet:

./bin/crio ... --storage-driver=overlay
--storage-opt="overlay.override_kernel_check=1" config ...

However, the storage options aren't actually set because they are
commented out in the config stub we use to generate the config file.
This has worked till now because /etc/containers/storage.conf contains
valid settings used implicitely by cri-o but we should not rely on that
since we're actually generating the configuration ourselves.

This commit add checks around the config generation to make sure the
correct options are picked and printed.
This commit also de-comment ulimits settings as that's the correct
thing to do since the empty list is the same as commenting it out and
also, it's needed if someone specifies a config with ulimits.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
