### PR TITLE
Usernamespaces: Support supplemental groups

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -392,6 +392,13 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		for _, gidmap := range s.defaultIDMappings.GIDs() {
 			g.AddLinuxGIDMapping(uint32(gidmap.HostID), uint32(gidmap.ContainerID), uint32(gidmap.Size))
 		}
+		for _, group := range req.GetConfig().GetLinux().GetSecurityContext().GetSupplementalGroups() {
+			logrus.Debugf("Adding namespace 1:1 mapping for group id %v", group)
+			err = s.addAdditionalGIDToLinuxGIDMappings(&g, uint32(group))
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	sb, err := sandbox.New(id, namespace, name, kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, trusted, runtimeHandler, resolvPath, hostname, portMappings, hostNetwork)


### PR DESCRIPTION
For each supplemental/Additional GID, add a 1:1 mapping in the
`GIDMappings`, where GID mapped on host is same as GID in the container
usernamespace with size of 1.

Signed-off-by: vikaschoudhary16 <vichoudh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
