### PR TITLE
rhel Dockerfile: skopeo-containers => containers-common

### DIFF
--- a/contrib/system_containers/rhel/Dockerfile
+++ b/contrib/system_containers/rhel/Dockerfile
@@ -10,8 +10,8 @@
 FROM rhel7:7-released
 
 RUN \
-    yum install --setopt=tsflags=nodocs -y socat iptables cri-o iproute runc skopeo-containers container-selinux && \
-    rpm -V socat iptables cri-o iproute runc skopeo-containers container-selinux && \
+    yum install --setopt=tsflags=nodocs -y socat iptables cri-o iproute runc containers-common container-selinux && \
+    rpm -V socat iptables cri-o iproute runc containers-common container-selinux && \
     yum clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ /exports/hostfs/var/lib/containers/storage/ && \
     cp /etc/crio/* /exports/hostfs/etc/crio && \


### PR DESCRIPTION
@runcom I'm guessing the preference would be to use what will actually be installed. Alternatively, you could just remove it from the rpm -V. Ref. https://jira.coreos.com/browse/ART-410

**- What I did**
Updated RHEL Dockerfile so it will use the updated package name

**- How I did it**
Changed skopeo-containers => containers-common

**- How to verify it**
Run a downstream build

**- Description for the changelog**
Downstream skopeo-containers is obsoleted by containers-common and so that RPM installs but then rpm -V fails. Use new name instead.
