### PR TITLE
[release-1.9] runPodSandbox: clean up containers on error path

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -544,6 +544,20 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 
+	defer func() {
+		if err != nil {
+			// Clean-up steps from RemovePodSanbox
+			timeout := int64(10)
+			if err2 := s.Runtime().StopContainer(ctx, container, timeout); err2 != nil {
+				logrus.Warnf("failed to stop container %s: %v", container.Name(), err2)
+			}
+			if err2 := s.Runtime().DeleteContainer(container); err2 != nil {
+				logrus.Warnf("failed to delete container %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
+			}
+			s.ContainerStateToDisk(container)
+		}
+	}()
+
 	s.ContainerStateToDisk(container)
 
 	if !s.config.Config.ManageNetworkNSLifecycle {


### PR DESCRIPTION
If the CNI setup fails in runPodSandbox, the infra container started is
not stopped/removed and leaks.

Ensure the necessary clean-up steps are executed on error
path.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
