### PR TITLE
Allow containers/storage to manage SELinux labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN set -x \
 COPY test/cni_plugin_helper.bash /opt/cni/bin/cni_plugin_helper.bash
 
 # Install crictl
-ENV CRICTL_COMMIT 98eea54af789ae13edce79cba101fb9ac8e7b241
+ENV CRICTL_COMMIT ff8d2e81baf8ff720fb916e42da57c2b772bd19e
 RUN set -x \
        && export GOPATH="$(mktemp -d)" \
        && git clone https://github.com/kubernetes-sigs/cri-tools.git "$GOPATH/src/github.com/kubernetes-sigs/cri-tools" \

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -19,7 +19,7 @@
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:
-        cri_tools_git_version: "98eea54af789ae13edce79cba101fb9ac8e7b241"
+        cri_tools_git_version: "ff8d2e81baf8ff720fb916e42da57c2b772bd19e"
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
@@ -69,7 +69,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: True
-        cri_tools_git_version: "98eea54af789ae13edce79cba101fb9ac8e7b241"
+        cri_tools_git_version: "ff8d2e81baf8ff720fb916e42da57c2b772bd19e"
     - name: run cri-o integration tests
       include: test.yml
 
@@ -84,7 +84,7 @@
       include: "build/cri-tools.yml"
       vars:
           force_clone: True
-          cri_tools_git_version: "98eea54af789ae13edce79cba101fb9ac8e7b241"
+          cri_tools_git_version: "ff8d2e81baf8ff720fb916e42da57c2b772bd19e"
     - name: run critest validation and benchmarks
       include: critest.yml
 

--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -53,10 +53,12 @@ type runtimeService struct {
 // along with a copy of the configuration blob from the image that was used to
 // create the container, if the image had a configuration.
 type ContainerInfo struct {
-	ID     string
-	Dir    string
-	RunDir string
-	Config *v1.Image
+	ID           string
+	Dir          string
+	RunDir       string
+	Config       *v1.Image
+	ProcessLabel string
+	MountLabel   string
 }
 
 // RuntimeServer wraps up various CRI-related activities into a reusable
@@ -73,7 +75,7 @@ type RuntimeServer interface {
 	// both its pod's ID and its container ID.
 	// Pointer arguments can be nil.  Either the image name or ID can be
 	// omitted, but not both.  All other arguments are required.
-	CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappings *idtools.IDMappings) (ContainerInfo, error)
+	CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappings *idtools.IDMappings, labelOptions []string, copyOptions *copy.Options) (ContainerInfo, error)
 	// RemovePodSandbox deletes a pod sandbox's infrastructure container.
 	// The CRI expects that a sandbox can't be removed unless its only
 	// container is its infrastructure container, but we don't enforce that
@@ -88,7 +90,7 @@ type RuntimeServer interface {
 	// CreateContainer creates a container with the specified ID.
 	// Pointer arguments can be nil.  Either the image name or ID can be
 	// omitted, but not both.  All other arguments are required.
-	CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, mountLabel string, idMappings *idtools.IDMappings) (ContainerInfo, error)
+	CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, idMappings *idtools.IDMappings, labelOptions []string, copyOptions *copy.Options) (ContainerInfo, error)
 	// DeleteContainer deletes a container, unmounting it first if need be.
 	DeleteContainer(idOrName string) error
 
@@ -148,7 +150,7 @@ func (metadata *RuntimeContainerMetadata) SetMountLabel(mountLabel string) {
 	metadata.MountLabel = mountLabel
 }
 
-func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, uid, namespace string, attempt uint32, mountLabel string, idMappings *idtools.IDMappings) (ContainerInfo, error) {
+func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, uid, namespace string, attempt uint32, idMappings *idtools.IDMappings, labelOptions []string, options *copy.Options) (ContainerInfo, error) {
 	var ref types.ImageReference
 	if podName == "" || podID == "" {
 		return ContainerInfo{}, ErrInvalidPodName
@@ -189,7 +191,6 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 			return ContainerInfo{}, ErrInvalidImageName
 		}
 		logrus.Debugf("couldn't find image %q, retrieving it", image)
-		options := &copy.Options{}
 		if r.pauseImageAuthFile != "" {
 			options.SourceCtx = &types.SystemContext{
 				AuthFilePath: r.pauseImageAuthFile,
@@ -246,7 +247,6 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		Namespace:     namespace,
 		Attempt:       attempt,
 		CreatedAt:     time.Now().Unix(),
-		MountLabel:    mountLabel,
 	}
 	mdata, err := json.Marshal(&metadata)
 	if err != nil {
@@ -259,12 +259,13 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		names = append(names, metadata.PodName)
 	}
 
-	var coptions *cstorage.ContainerOptions
-	if idMappings != nil {
-		coptions = &cstorage.ContainerOptions{IDMappingOptions: cstorage.IDMappingOptions{UIDMap: idMappings.UIDs(), GIDMap: idMappings.GIDs()}}
+	coptions := cstorage.ContainerOptions{
+		LabelOpts: labelOptions,
 	}
-
-	container, err := r.storageImageServer.GetStore().CreateContainer(containerID, names, img.ID, "", string(mdata), coptions)
+	if idMappings != nil {
+		coptions.IDMappingOptions = cstorage.IDMappingOptions{UIDMap: idMappings.UIDs(), GIDMap: idMappings.GIDs()}
+	}
+	container, err := r.storageImageServer.GetStore().CreateContainer(containerID, names, img.ID, "", string(mdata), &coptions)
 	if err != nil {
 		if metadata.Pod {
 			logrus.Debugf("failed to create pod sandbox %s(%s): %v", metadata.PodName, metadata.PodID, err)
@@ -329,20 +330,24 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		logrus.Debugf("container %q has run directory %q", container.ID, containerRunDir)
 	}
 
+	metadata.MountLabel = container.MountLabel()
+
 	return ContainerInfo{
-		ID:     container.ID,
-		Dir:    containerDir,
-		RunDir: containerRunDir,
-		Config: imageConfig,
+		ID:           container.ID,
+		Dir:          containerDir,
+		RunDir:       containerRunDir,
+		Config:       imageConfig,
+		ProcessLabel: container.ProcessLabel(),
+		MountLabel:   container.MountLabel(),
 	}, nil
 }
 
-func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappings *idtools.IDMappings) (ContainerInfo, error) {
-	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, podID, metadataName, uid, namespace, attempt, "", idMappings)
+func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappings *idtools.IDMappings, labelOptions []string, copyOptions *copy.Options) (ContainerInfo, error) {
+	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, podID, metadataName, uid, namespace, attempt, idMappings, labelOptions, copyOptions)
 }
 
-func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, mountLabel string, idMappings *idtools.IDMappings) (ContainerInfo, error) {
-	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, "", "", attempt, mountLabel, idMappings)
+func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, idMappings *idtools.IDMappings, labelOptions []string, copyOptions *copy.Options) (ContainerInfo, error) {
+	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, "", "", attempt, idMappings, labelOptions, copyOptions)
 }
 
 func (r *runtimeService) RemovePodSandbox(idOrName string) error {

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -583,7 +583,7 @@ var _ = t.Describe("Runtime", func() {
 					"podName", "podID", "imagename",
 					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 					"containerName", "containerID", "",
-					0, "mountLabel", &idtools.IDMappings{})
+					0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 			})
 
 			It("should succeed to create a pod sandbox", func() {
@@ -592,7 +592,7 @@ var _ = t.Describe("Runtime", func() {
 					"podName", "podID", "imagename",
 					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 					"containerName", "metadataName",
-					"uid", "namespace", 0, &idtools.IDMappings{})
+					"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			})
 
@@ -613,7 +613,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, "mountLabel", &idtools.IDMappings{})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -627,7 +627,7 @@ var _ = t.Describe("Runtime", func() {
 				"", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, "mountLabel", &idtools.IDMappings{})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -640,7 +640,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "", "",
 				"containerName", "containerID", "metadataName",
-				0, "mountLabel", &idtools.IDMappings{})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -653,7 +653,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "imagename", "imageID",
 				"", "containerID", "metadataName",
-				0, "mountLabel", &idtools.IDMappings{})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -686,7 +686,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, "mountLabel", &idtools.IDMappings{})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -715,7 +715,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, "mountLabel", &idtools.IDMappings{})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -742,7 +742,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -767,7 +767,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -787,7 +787,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -807,7 +807,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, "mountLabel", &idtools.IDMappings{})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -841,7 +841,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, "mountLabel", &idtools.IDMappings{})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -932,7 +932,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "pauseimagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 		})
 
 		It("should pull pauseImage if not available locally, using provided credential file", func() {
@@ -948,7 +948,7 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "pauseimagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
 		})
 
 		AfterEach(func() {

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 
 	"github.com/cri-o/cri-o/oci"
-	"github.com/opencontainers/selinux/go-selinux/label"
 	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
@@ -127,7 +126,7 @@ func (s *Server) setPodSandboxMountLabel(id, mountLabel string) error {
 	return s.StorageRuntimeServer().SetContainerMetadata(id, &storageMetadata)
 }
 
-func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (string, string, error) {
+func getLabelOptions(selinuxOptions *pb.SELinuxOption) []string {
 	labels := []string{}
 	if selinuxOptions != nil {
 		if selinuxOptions.User != "" {
@@ -143,18 +142,7 @@ func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (string
 			labels = append(labels, "level:"+selinuxOptions.Level)
 		}
 	}
-	var (
-		processLabel, mountLabel string
-		err                      error
-	)
-	processLabel, mountLabel, err = label.InitLabels(labels)
-	if err != nil {
-		return "", "", err
-	}
-	if privileged {
-		processLabel = ""
-	}
-	return processLabel, mountLabel, nil
+	return labels
 }
 
 // convertCgroupFsNameToSystemd converts an expanded cgroupfs name to its systemd name.

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cri-o/cri-o/oci"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/symlink"
-	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -112,10 +111,6 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		if err := sb.NetNsRemove(); err != nil {
 			return nil, err
 		}
-	}
-
-	if err := label.ReleaseLabel(sb.ProcessLabel()); err != nil {
-		return nil, err
 	}
 
 	// unmount the shm for the pod

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -915,8 +915,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	run crictl exec --sync "$ctr_id" false
 	echo "$output"
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "Exit code: 1" ]]
+	[ "$status" -ne 0 ]
 	cleanup_ctrs
 	cleanup_pods
 	stop_crio

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -71,8 +71,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	run crictl exec --sync "$ctr_id" chmod 777 .
 	echo "$output"
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "Exit code: 1" ]]
+	[ "$status" -ne 0 ]
 	[[ "$output" =~ "Operation not permitted" ]]
 
 	cleanup_ctrs
@@ -173,8 +172,8 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	run crictl exec --sync "$ctr_id" chmod 777 .
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "Exit code: 1" ]]
+	echo "$output"
+	[ "$status" -ne 0 ]
 	[[ "$output" =~ "Operation not permitted" ]]
 
 	cleanup_ctrs
@@ -211,8 +210,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	run crictl exec --sync "$ctr_id" chmod 777 .
 	echo "$output"
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "Exit code: 1" ]]
+	[ "$status" -ne 0 ]
 	[[ "$output" =~ "Operation not permitted" ]]
 
 	cleanup_ctrs

--- a/test/image_volume.bats
+++ b/test/image_volume.bats
@@ -23,8 +23,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	run crictl exec --sync "$ctr_id" ls /imagevolume
 	echo "$output"
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "Exit code: 1" ]]
+	[ "$status" -ne 0 ]
 	[[ "$output" =~ "ls: /imagevolume: No such file or directory" ]]
 	run crictl stopp "$pod_id"
 	echo "$output"


### PR DESCRIPTION
We want to be able to share SELinux labels with podman and buildah
as well as any platform that uses containers/storage. By allowing
containers/storage to manage them, we get uniqueness in the labels.

Taking over https://github.com/kubernetes-sigs/cri-o/pull/1868

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

