### PR TITLE
Update error handling paths for sandbox add and removal

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -311,7 +311,9 @@ func (c *ContainerServer) Update() error {
 		}
 		sb.RemoveInfraContainer()
 		c.ReleasePodName(sb.Name())
-		c.RemoveSandbox(sb.ID())
+		if err := c.RemoveSandbox(sb.ID()); err != nil {
+			logrus.Warnf("failed to remove sandbox ID %s: %v", sb.ID(), err)
+		}
 		if err = c.podIDIndex.Delete(sb.ID()); err != nil {
 			return err
 		}
@@ -417,11 +419,15 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		}
 	}
 
-	c.AddSandbox(sb)
+	if err := c.AddSandbox(sb); err != nil {
+		return err
+	}
 
 	defer func() {
 		if err != nil {
-			c.RemoveSandbox(sb.ID())
+			if err := c.RemoveSandbox(sb.ID()); err != nil {
+				logrus.Warnf("could not remove sandbox ID %s: %v", sb.ID(), err)
+			}
 		}
 	}()
 
@@ -741,12 +747,12 @@ func (c *ContainerServer) ListContainers(filters ...func(*oci.Container) bool) (
 }
 
 // AddSandbox adds a sandbox to the sandbox state store
-func (c *ContainerServer) AddSandbox(sb *sandbox.Sandbox) {
+func (c *ContainerServer) AddSandbox(sb *sandbox.Sandbox) error {
 	c.state.sandboxes.Add(sb.ID(), sb)
 
 	c.stateLock.Lock()
-	c.addSandboxPlatform(sb)
-	c.stateLock.Unlock()
+	defer c.stateLock.Unlock()
+	return c.addSandboxPlatform(sb)
 }
 
 // GetSandbox returns a sandbox by its ID
@@ -769,17 +775,20 @@ func (c *ContainerServer) HasSandbox(id string) bool {
 }
 
 // RemoveSandbox removes a sandbox from the state store
-func (c *ContainerServer) RemoveSandbox(id string) {
+func (c *ContainerServer) RemoveSandbox(id string) error {
 	sb := c.state.sandboxes.Get(id)
 	if sb == nil {
-		return
+		return nil
 	}
 
 	c.stateLock.Lock()
-	c.removeSandboxPlatform(sb)
-	c.stateLock.Unlock()
+	defer c.stateLock.Unlock()
+	if err := c.removeSandboxPlatform(sb); err != nil {
+		return err
+	}
 
 	c.state.sandboxes.Delete(id)
+	return nil
 }
 
 // ListSandboxes lists all sandboxes in the state store

--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -615,9 +615,7 @@ var _ = t.Describe("ContainerServer", func() {
 			Expect(err).NotTo(BeNil())
 		})
 
-		// TODO(sgrunert): uncomment when the following issue is resolved:
-		// https://github.com/cri-o/cri-o/issues/1987
-		/* FIt("should fail with invalid network selinux labels", func() {
+		It("should fail with invalid network selinux labels", func() {
 			// Given
 			manifest := bytes.Replace(testManifest,
 				[]byte(`"selinuxLabel": "system_u:system_r:container_runtime_t:s0"`),
@@ -634,7 +632,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 			// Then
 			Expect(err).NotTo(BeNil())
-		}) */
+		})
 
 		It("should fail with container directory", func() {
 			// Given

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -98,7 +98,9 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	}
 
 	s.ReleasePodName(sb.Name())
-	s.removeSandbox(sb.ID())
+	if err := s.removeSandbox(sb.ID()); err != nil {
+		logrus.Warnf("failed to remove sandbox: %v", err)
+	}
 	if err := s.PodIDIndex().Delete(sb.ID()); err != nil {
 		return nil, fmt.Errorf("failed to delete pod sandbox %s from index: %v", sb.ID(), err)
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -395,10 +395,14 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 
-	s.addSandbox(sb)
+	if err := s.addSandbox(sb); err != nil {
+		return nil, err
+	}
 	defer func() {
 		if err != nil {
-			s.removeSandbox(id)
+			if err := s.removeSandbox(id); err != nil {
+				logrus.Warnf("could not remove pod sandbox: %v", err)
+			}
 		}
 	}()
 

--- a/server/secrets.go
+++ b/server/secrets.go
@@ -138,9 +138,13 @@ func secretMounts(defaultMountsPaths []string, mountLabel, containerWorkingDir s
 			return nil, errors.Wrapf(err, "getting host secret data failed")
 		}
 		for _, s := range data {
-			s.SaveTo(ctrDirOnHost)
+			if err := s.SaveTo(ctrDirOnHost); err != nil {
+				return nil, err
+			}
 		}
-		label.Relabel(ctrDirOnHost, mountLabel, false)
+		if err := label.Relabel(ctrDirOnHost, mountLabel, false); err != nil {
+			return nil, err
+		}
 
 		m := rspec.Mount{
 			Source:      ctrDirOnHost,

--- a/server/server.go
+++ b/server/server.go
@@ -405,16 +405,16 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 	return s, nil
 }
 
-func (s *Server) addSandbox(sb *sandbox.Sandbox) {
-	s.ContainerServer.AddSandbox(sb)
+func (s *Server) addSandbox(sb *sandbox.Sandbox) error {
+	return s.ContainerServer.AddSandbox(sb)
 }
 
 func (s *Server) getSandbox(id string) *sandbox.Sandbox {
 	return s.ContainerServer.GetSandbox(id)
 }
 
-func (s *Server) removeSandbox(id string) {
-	s.ContainerServer.RemoveSandbox(id)
+func (s *Server) removeSandbox(id string) error {
+	return s.ContainerServer.RemoveSandbox(id)
 }
 
 func (s *Server) addContainer(c *oci.Container) {


### PR DESCRIPTION
Hey, this PR updates all related error paths to actually return the new introduced error possibilities from selinux-go 1.2. Beside this the crashing unit test can now be enabled.

Fixes #1987 