### PR TITLE
Add RuntimeHandler.RuntimeRoot

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -214,6 +214,7 @@ manage_network_ns_lifecycle = {{ .ManageNetworkNSLifecycle }}
 [crio.runtime.runtimes.{{ $runtime_name }}]
 runtime_path = "{{ $runtime_handler.RuntimePath }}"
 runtime_type = "{{ $runtime_handler.RuntimeType }}"
+runtime_root = "{{ $runtime_handler.RuntimeRoot }}"
 {{ end }}
 
 # The crio.image table contains settings pertaining to the management of OCI images.

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -121,10 +121,13 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 		runtimes := ctx.GlobalStringSlice("runtimes")
 		for _, r := range runtimes {
 			fields := strings.Split(r, ":")
-			if fields[0] == "" {
+			if len(fields) != 3 {
 				return fmt.Errorf("wrong format for --runtimes: %q", r)
 			}
-			config.Runtimes[fields[0]] = oci.RuntimeHandler{RuntimePath: fields[1]}
+			config.Runtimes[fields[0]] = oci.RuntimeHandler{
+				RuntimePath: fields[1],
+				RuntimeRoot: fields[2],
+			}
 		}
 	}
 	if ctx.GlobalIsSet("selinux") {
@@ -362,7 +365,7 @@ func main() {
 		},
 		cli.StringSliceFlag{
 			Name:  "runtimes",
-			Usage: "OCI runtimes, format is runtime_name:runtime_path",
+			Usage: "OCI runtimes, format is runtime_name:runtime_path:runtime_root",
 		},
 		cli.StringFlag{
 			Name:  "seccomp-profile",

--- a/lib/config.go
+++ b/lib/config.go
@@ -376,6 +376,7 @@ func DefaultConfig() (*Config, error) {
 				"runc": {
 					RuntimePath: "/usr/bin/runc",
 					RuntimeType: "oci",
+					RuntimeRoot: "/run/runc",
 				},
 			},
 			Conmon: conmonPath,

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -93,6 +93,7 @@ type RuntimeImpl interface {
 type RuntimeHandler struct {
 	RuntimePath string `toml:"runtime_path"`
 	RuntimeType string `toml:"runtime_type"`
+	RuntimeRoot string `toml:"runtime_root"`
 }
 
 // New creates a new Runtime with options provided
@@ -241,7 +242,7 @@ func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
 
 	// If the runtime type is different from "vm", then let's fallback
 	// onto the OCI implementation by default.
-	return newRuntimeOCI(r, rh.RuntimePath), nil
+	return newRuntimeOCI(r, &rh), nil
 }
 
 // RuntimeImpl returns the runtime implementation for a given container

--- a/oci/oci_linux.go
+++ b/oci/oci_linux.go
@@ -74,12 +74,8 @@ func loadFactory(root string) (libcontainer.Factory, error) {
 }
 
 // libcontainerStats gets the stats for the container with the given id from runc/libcontainer
-func libcontainerStats(ctr *Container) (*libcontainer.Stats, error) {
-	// TODO: make this not hardcoded
-	// was: c.runtime.Path(ociContainer) but that returns /usr/bin/runc - how do we get /run/runc?
-	// runroot is /var/run/runc
-	// Hardcoding probably breaks Kata Containers compatibility
-	factory, err := loadFactory("/run/runc")
+func (r *runtimeOCI) libcontainerStats(ctr *Container) (*libcontainer.Stats, error) {
+	factory, err := loadFactory(r.root)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +86,8 @@ func libcontainerStats(ctr *Container) (*libcontainer.Stats, error) {
 	return container.Stats()
 }
 
-func containerStats(ctr *Container) (*ContainerStats, error) {
-	libcontainerStats, err := libcontainerStats(ctr)
+func (r *runtimeOCI) containerStats(ctr *Container) (*ContainerStats, error) {
+	libcontainerStats, err := r.libcontainerStats(ctr)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -13,7 +13,7 @@ var _ = t.Describe("Oci", func() {
 			// Given
 			// When
 			runtime, err := oci.New("runc",
-				map[string]oci.RuntimeHandler{"runc": {"/bin/sh", ""}},
+				map[string]oci.RuntimeHandler{"runc": {"/bin/sh", "", "/run/runc"}},
 				"", []string{}, "", "", "", 0, false, false, 0)
 
 			// Then
@@ -44,7 +44,7 @@ var _ = t.Describe("Oci", func() {
 			defaultRuntime = "runc"
 		)
 		runtimes := map[string]oci.RuntimeHandler{
-			defaultRuntime: {"/bin/sh", ""}, invalidRuntime: {},
+			defaultRuntime: {"/bin/sh", "", "/run/runc"}, invalidRuntime: {},
 		}
 
 		BeforeEach(func() {

--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -31,6 +31,9 @@ import (
 const (
 	// RuntimeTypeOCI is the type representing the RuntimeOCI implementation.
 	RuntimeTypeOCI = "oci"
+
+	// Command line flag used to specify the run root directory
+	rootFlag = "--root"
 )
 
 // runtimeOCI is the Runtime interface implementation relying on conmon to
@@ -39,13 +42,15 @@ type runtimeOCI struct {
 	*Runtime
 
 	path string
+	root string
 }
 
 // newRuntimeOCI creates a new runtimeOCI instance
-func newRuntimeOCI(r *Runtime, path string) RuntimeImpl {
+func newRuntimeOCI(r *Runtime, handler *RuntimeHandler) RuntimeImpl {
 	return &runtimeOCI{
 		Runtime: r,
-		path:    path,
+		path:    handler.RuntimePath,
+		root:    handler.RuntimeRoot,
 	}
 }
 
@@ -90,6 +95,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 	args = append(args, "--exit-dir", r.containerExitsDir)
 	args = append(args, "--socket-dir-path", r.containerAttachSocketDir)
 	args = append(args, "--log-level", logrus.GetLevel().String())
+	args = append(args, "--runtime-arg", fmt.Sprintf("%s=%s", rootFlag, r.root))
 	if r.logSizeMax >= 0 {
 		args = append(args, "--log-size-max", fmt.Sprintf("%v", r.logSizeMax))
 	}
@@ -203,7 +209,9 @@ func (r *runtimeOCI) StartContainer(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.path, "start", c.id); err != nil {
+	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr,
+		r.path, rootFlag, r.root, "start", c.id); err != nil {
+
 		return err
 	}
 	c.state.Started = time.Now()
@@ -278,7 +286,7 @@ func (r *runtimeOCI) ExecContainer(c *Container, cmd []string, stdin io.Reader, 
 	}
 	defer os.RemoveAll(processFile.Name())
 
-	args := []string{"exec"}
+	args := []string{rootFlag, r.root, "exec"}
 	args = append(args, "--process", processFile.Name())
 	args = append(args, c.ID())
 	execCmd := exec.Command(r.path, args...)
@@ -459,7 +467,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 
 // UpdateContainer updates container resources
 func (r *runtimeOCI) UpdateContainer(c *Container, res *rspec.LinuxResources) error {
-	cmd := exec.Command(r.path, "update", "--resources", "-", c.id)
+	cmd := exec.Command(r.path, rootFlag, r.root, "update", "--resources", "-", c.id)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -553,7 +561,9 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 	}
 
 	if timeout > 0 {
-		if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.path, "kill", c.id, c.GetStopSignal()); err != nil {
+		if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr,
+			r.path, rootFlag, r.root, "kill", c.id, c.GetStopSignal()); err != nil {
+
 			if err := checkProcessGone(c); err != nil {
 				return fmt.Errorf("failed to stop container %q: %v", c.id, err)
 			}
@@ -565,7 +575,9 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 		logrus.Warnf("Stop container %q timed out: %v", c.id, err)
 	}
 
-	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.path, "kill", c.id, "KILL"); err != nil {
+	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr,
+		r.path, rootFlag, r.root, "kill", c.id, "KILL"); err != nil {
+
 		if err := checkProcessGone(c); err != nil {
 			return fmt.Errorf("failed to stop container %q: %v", c.id, err)
 		}
@@ -594,7 +606,7 @@ func (r *runtimeOCI) DeleteContainer(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	_, err := utils.ExecCmd(r.path, "delete", "--force", c.id)
+	_, err := utils.ExecCmd(r.path, rootFlag, r.root, "delete", "--force", c.id)
 	return err
 }
 
@@ -603,7 +615,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	cmd := exec.Command(r.path, "state", c.id)
+	cmd := exec.Command(r.path, rootFlag, r.root, "state", c.id)
 	if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", v))
 	}
@@ -672,7 +684,7 @@ func (r *runtimeOCI) PauseContainer(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	_, err := utils.ExecCmd(r.path, "pause", c.id)
+	_, err := utils.ExecCmd(r.path, rootFlag, r.root, "pause", c.id)
 	return err
 }
 
@@ -681,7 +693,7 @@ func (r *runtimeOCI) UnpauseContainer(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	_, err := utils.ExecCmd(r.path, "resume", c.id)
+	_, err := utils.ExecCmd(r.path, rootFlag, r.root, "resume", c.id)
 	return err
 }
 
@@ -694,7 +706,7 @@ func (r *runtimeOCI) ContainerStats(c *Container) (*ContainerStats, error) {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	return containerStats(c)
+	return r.containerStats(c)
 }
 
 // SignalContainer sends a signal to a container process.
@@ -707,7 +719,8 @@ func (r *runtimeOCI) SignalContainer(c *Container, sig syscall.Signal) error {
 		return err
 	}
 
-	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.path, "kill", c.ID(), signalString)
+	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.path,
+		rootFlag, r.root, "kill", c.ID(), signalString)
 }
 
 // AttachContainer attaches IO to a running container.

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -33,6 +33,7 @@ DEVICES=${DEVICES:-}
 OVERRIDE_OPTIONS=${OVERRIDE_OPTIONS:-}
 RUNTIME_PATH=$(command -v $RUNTIME || true)
 RUNTIME_BINARY=${RUNTIME_PATH:-/usr/local/sbin/runc}
+RUNTIME_ROOT=${RUNTIME_ROOT:-/run/runc}
 # Path of the apparmor_parser binary.
 APPARMOR_PARSER_BINARY=${APPARMOR_PARSER_BINARY:-/sbin/apparmor_parser}
 # Path of the apparmor profile for test.
@@ -240,7 +241,7 @@ function setup_crio() {
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/image-volume-test:latest --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --default-capabilities "$capabilities" --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --stream-port "$STREAM_PORT" --cgroup-manager "$CGROUP_MANAGER" --default-mounts-file "$TESTDIR/containers/mounts.conf" --registry "quay.io" --default-runtime $DEFAULT_RUNTIME --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" $DEVICES $ULIMITS --uid-mappings "$UID_MAPPINGS" --gid-mappings "$GID_MAPPINGS" --default-sysctls "$TEST_SYSCTL" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
+	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --default-capabilities "$capabilities" --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --stream-port "$STREAM_PORT" --cgroup-manager "$CGROUP_MANAGER" --default-mounts-file "$TESTDIR/containers/mounts.conf" --registry "quay.io" --default-runtime $DEFAULT_RUNTIME --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY:$RUNTIME_ROOT" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" $DEVICES $ULIMITS --uid-mappings "$UID_MAPPINGS" --gid-mappings "$GID_MAPPINGS" --default-sysctls "$TEST_SYSCTL" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
 	sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?default_ulimits = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i $CRIO_CONFIG
 	# Prepare the CNI configuration files, we're running with non host networking by default
 	if [[ -n "$5" ]]; then


### PR DESCRIPTION
Hey there, the main intention of this PR is to resolve this TODO:

https://github.com/kubernetes-sigs/cri-o/blob/7a9445829c6165d62a75bcdab1843b264bb01f37/oci/oci_linux.go#L75-L80

My approach would be to introduce a RuntimeRoot for the RuntimeHandler and pass it around where it is necessary. This would also help in unit testing, since we now could use a temporarily run root directory for runc where we are privileged.

WDYT?