### PR TITLE
Update bats tests to run in parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
     libtool \
     libudev-dev \
     libsystemd-dev \
+    parallel \
     protobuf-c-compiler \
     protobuf-compiler \
     python-minimal \
@@ -43,12 +44,13 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean
 
 # install bats
-ENV BATS_COMMIT v1.1.0
+ENV BATS_COMMIT 8789f910812afbf6b87dd371ee5ae30592f1423f
 RUN cd /tmp \
     && git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core \
     && git checkout -q "$BATS_COMMIT" \
     && ./install.sh /usr/local
+RUN mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
 # install criu
 ENV CRIU_VERSION 3.9
@@ -81,9 +83,6 @@ RUN set -x \
        && mkdir -p /opt/cni/bin \
        && cp bin/* /opt/cni/bin/ \
        && rm -rf "$GOPATH"
-
-# Install CNI bridge plugin test wrapper
-COPY test/cni_plugin_helper.bash /opt/cni/bin/cni_plugin_helper.bash
 
 # Install crictl
 ENV CRICTL_COMMIT 98eea54af789ae13edce79cba101fb9ac8e7b241

--- a/contrib/test/integration/build/parallel.yml
+++ b/contrib/test/integration/build/parallel.yml
@@ -1,0 +1,23 @@
+---
+- name: install parallel package for Fedora
+  package:
+    name: parallel
+    state: present
+  when: ansible_distribution in ['Fedora', 'CentOS']
+
+- name: download parallel sources
+  unarchive:
+    src: https://ftp.gnu.org/gnu/parallel/parallel-20190322.tar.bz2
+    dest: "{{ ansible_env.HOME }}"
+    remote_src: yes
+  when: ansible_distribution in ['RedHat']
+
+- name: install parallel from sources
+  shell: |
+    ./configure
+    make
+    cp ./src/{env_parallel*,niceload,parallel,parcat,parset,sql} /usr/bin
+    ln -s /usr/bin/parallel /usr/bin/sem
+  args:
+    chdir: "{{ ansible_env.HOME }}/parallel-20190322"
+  when: ansible_distribution in ['RedHat']

--- a/contrib/test/integration/build/plugins.yml
+++ b/contrib/test/integration/build/plugins.yml
@@ -34,10 +34,3 @@
   command: "./build.sh"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/containernetworking/plugins"
-
-- name: install CNI plugin test helper
-  copy:
-    src: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/test/cni_plugin_helper.bash"
-    dest: "/opt/cni/bin/cni_plugin_helper.bash"
-    mode: "o=rwx,g=rx,o=rx"
-    remote_src: yes

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -65,6 +65,8 @@
   tags:
     - integration
   tasks:
+    - name: install parallel
+      include: build/parallel.yml
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:

--- a/test/cni_plugin_helper.bash
+++ b/test/cni_plugin_helper.bash
@@ -25,12 +25,14 @@ elif [[ -z "${K8S_POD_NAME}" ]]; then
 	exit 1
 fi
 
-echo "FOUND_CNI_CONTAINERID=${CNI_CONTAINERID}" >> /tmp/plugin_test_args.out
-echo "FOUND_K8S_POD_NAMESPACE=${K8S_POD_NAMESPACE}" >> /tmp/plugin_test_args.out
-echo "FOUND_K8S_POD_NAME=${K8S_POD_NAME}" >> /tmp/plugin_test_args.out
+TEST_DIR=%TEST_DIR%
 
-. /tmp/cni_plugin_helper_input.env
-rm -f /tmp/cni_plugin_helper_input.env
+echo "FOUND_CNI_CONTAINERID=${CNI_CONTAINERID}" >> "$TEST_DIR"/plugin_test_args.out
+echo "FOUND_K8S_POD_NAMESPACE=${K8S_POD_NAMESPACE}" >> "$TEST_DIR"/plugin_test_args.out
+echo "FOUND_K8S_POD_NAME=${K8S_POD_NAME}" >> "$TEST_DIR"/plugin_test_args.out
+
+. "$TEST_DIR"/cni_plugin_helper_input.env
+rm -f "$TEST_DIR"/cni_plugin_helper_input.env
 
 result=$(/opt/cni/bin/bridge $@) || exit $?
 

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -62,7 +62,7 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	pod_id="$output"
-	run crictl create "$TESTDIR"/seccomp2.json "$TESTDATA"/sandbox_config.json
+	run crictl create "$pod_id" "$TESTDIR"/seccomp2.json "$TESTDIR"/seccomp_profile1.json
 	echo "$output"
 	[ "$status" -eq 0 ]
 	ctr_id="$output"
@@ -184,7 +184,7 @@ function teardown() {
 
 # 6. test running with ctr docker/default
 # test that we cannot run with a syscall blocked by the default seccomp profile
-@test "ctr seccomp profiles runtime/default" {
+@test "ctr seccomp profiles docker/default" {
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -70,11 +70,16 @@ STREAM_PORT=${STREAM_PORT:-10010}
 METRICS_PORT=${METRICS_PORT:-9090}
 
 TESTDIR=$(mktemp -d)
+RANDOM_STRING=${TESTDIR: -10}
 
 # Setup default hooks dir
 HOOKSDIR=$TESTDIR/hooks
 mkdir ${HOOKSDIR}
 HOOKS_OPTS="--hooks-dir=$HOOKSDIR"
+
+HOOKSCHECK=$TESTDIR/hookscheck
+CONTAINER_EXITS_DIR=$TESTDIR/containers/exits
+CONTAINER_ATTACH_SOCKET_DIR=$TESTDIR/containers
 
 # Setup default mounts using deprecated --default-mounts flag
 # should be removed, once the flag is removed
@@ -113,7 +118,14 @@ fi
 CRIO_SOCKET="$TESTDIR/crio.sock"
 CRIO_CONFIG="$TESTDIR/crio.conf"
 CRIO_CNI_CONFIG="$TESTDIR/cni/net.d/"
-CRIO_CNI_PLUGIN=${CRIO_CNI_PLUGIN:-/opt/cni/bin/}
+
+# Copy all the CNI dependencies around to ensure encapsulated tests
+CRIO_CNI_PLUGIN="$TESTDIR/cni-bin"
+mkdir "$CRIO_CNI_PLUGIN"
+cp /opt/cni/bin/* "$CRIO_CNI_PLUGIN"
+cp "$INTEGRATION_ROOT"/cni_plugin_helper.bash "$CRIO_CNI_PLUGIN"
+sed -i "s;%TEST_DIR%;$TESTDIR;" "$CRIO_CNI_PLUGIN"/cni_plugin_helper.bash
+
 POD_CIDR="10.88.0.0/16"
 POD_CIDR_MASK="10.88.*.*"
 
@@ -243,8 +255,10 @@ function setup_crio() {
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/image-volume-test:latest --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --default-capabilities "$capabilities" --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --stream-port "$STREAM_PORT" --cgroup-manager "$CGROUP_MANAGER" --default-mounts-file "$TESTDIR/containers/mounts.conf" --registry "quay.io" --default-runtime $DEFAULT_RUNTIME --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY:$RUNTIME_ROOT" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" $DEVICES $ULIMITS --uid-mappings "$UID_MAPPINGS" --gid-mappings "$GID_MAPPINGS" --default-sysctls "$TEST_SYSCTL" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
+	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --default-capabilities "$capabilities" --conmon "$TESTDIR/conmon" --listen "$CRIO_SOCKET" --stream-port "$((STREAM_PORT + BATS_TEST_NUMBER))" --cgroup-manager "$CGROUP_MANAGER" --default-mounts-file "$TESTDIR/containers/mounts.conf" --registry "quay.io" --default-runtime $DEFAULT_RUNTIME --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY:$RUNTIME_ROOT" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" $DEVICES $ULIMITS --uid-mappings "$UID_MAPPINGS" --gid-mappings "$GID_MAPPINGS" --default-sysctls "$TEST_SYSCTL" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
 	sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?default_ulimits = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i $CRIO_CONFIG
+	sed -ie 's;\(container_exits_dir =\) \(.*\);\1 "'$CONTAINER_EXITS_DIR'";g' $CRIO_CONFIG
+	sed -ie 's;\(container_attach_socket_dir =\) \(.*\);\1 "'$CONTAINER_ATTACH_SOCKET_DIR'";g' $CRIO_CONFIG
 	# Prepare the CNI configuration files, we're running with non host networking by default
 	if [[ -n "$5" ]]; then
 		netfunc="$5"
@@ -344,7 +358,7 @@ function cleanup_ctrs() {
 			done
 		fi
 	fi
-	rm -f /run/hookscheck
+	rm -f $HOOKSCHECK
 }
 
 function cleanup_images() {
@@ -467,7 +481,7 @@ function write_plugin_test_args_network_conf() {
 	cat >$CRIO_CNI_CONFIG/10-plugin-test-args.conf <<-EOF
 {
     "cniVersion": "0.2.0",
-    "name": "crionet_test_args",
+    "name": "crionet_test_args_$RANDOM_STRING",
     "type": "cni_plugin_helper.bash",
     "bridge": "cni0",
     "isGateway": true,
@@ -483,7 +497,7 @@ function write_plugin_test_args_network_conf() {
 EOF
 
 	if [[ -n "$2" ]]; then
-		echo "DEBUG_ARGS=$2" > /tmp/cni_plugin_helper_input.env
+		echo "DEBUG_ARGS=$2" > "$TESTDIR"/cni_plugin_helper_input.env
 	fi
 
 	echo 0

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -6,11 +6,12 @@ function teardown() {
 	cleanup_test
 }
 
-cp hooks/checkhook.sh ${HOOKSDIR}
+sed "s|HOOKSCHECK|${HOOKSCHECK}|" hooks/checkhook.sh > ${HOOKSDIR}/checkhook.sh
+chmod +x ${HOOKSDIR}/checkhook.sh
 sed "s|HOOKSDIR|${HOOKSDIR}|" hooks/checkhook.json > ${HOOKSDIR}/checkhook.json
 
 @test "pod test hooks" {
-	rm -f /run/hookscheck
+	rm -f ${HOOKSCHECK}
 	start_crio
 	run crictl runp "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -29,7 +30,7 @@ sed "s|HOOKSDIR|${HOOKSDIR}|" hooks/checkhook.json > ${HOOKSDIR}/checkhook.json
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run cat /run/hookscheck
+	run cat ${HOOKSCHECK}
 	echo "$output"
 	[ "$status" -eq 0 ]
 	cleanup_ctrs

--- a/test/hooks/checkhook.sh
+++ b/test/hooks/checkhook.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-echo $@ >> /run/hookscheck
+echo $@ >> HOOKSCHECK
 read line
-echo $line >> /run/hookscheck
+echo $line >> HOOKSCHECK

--- a/test/network.bats
+++ b/test/network.bats
@@ -6,7 +6,7 @@ function teardown() {
 	cleanup_ctrs
 	cleanup_pods
 	stop_crio
-	rm -f /var/lib/cni/networks/crionet_test_args/*
+	rm -f /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING/*
 	chmod 0755 $CONMON_BINARY
 	cleanup_test
 }
@@ -132,14 +132,12 @@ function teardown() {
 	run crictl runp "$TESTDATA"/sandbox_config.json
 	[ "$status" -eq 0 ]
 
-	. /tmp/plugin_test_args.out
+	. $TESTDIR/plugin_test_args.out
 
 	[ "$FOUND_CNI_CONTAINERID" != "redhat.test.crio" ]
 	[ "$FOUND_CNI_CONTAINERID" != "podsandbox1" ]
 	[ "$FOUND_K8S_POD_NAMESPACE" = "redhat.test.crio" ]
 	[ "$FOUND_K8S_POD_NAME" = "podsandbox1" ]
-
-	rm -rf /tmp/plugin_test_args.out
 }
 
 @test "Connect to pod hostport from the host" {
@@ -173,16 +171,16 @@ function teardown() {
 
 	# make conmon non-executable to cause the sandbox setup to fail after
 	# networking has been configured
-	chmod 0644 $CONMON_BINARY
+	chmod 0644 $TESTDIR/conmon
 	run crictl runp "$TESTDATA"/sandbox_config.json
-	chmod 0755 $CONMON_BINARY
+	chmod 0755 $TESTDIR/conmon
 	echo "$output"
 	[ "$status" -ne 0 ]
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed after network setup
-	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip*
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
+	rm -f /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING/last_reserved_ip*
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }
 
@@ -195,7 +193,7 @@ function teardown() {
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed during network setup after the CNI plugin itself succeeded
-	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip*
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
+	rm -f /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING/last_reserved_ip*
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -97,7 +97,7 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	for i in $("$RUNTIME" list -q | xargs); do "$RUNTIME" delete -f $i; done
+	"$RUNTIME" delete -f "$pod_id"
 
 	start_crio
 
@@ -128,7 +128,8 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	for i in $("$RUNTIME" list -q | xargs); do "$RUNTIME" delete -f $i; done
+	"$RUNTIME" delete -f "$pod_id"
+	"$RUNTIME" delete -f "$ctr_id"
 
 	start_crio
 
@@ -164,7 +165,8 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	for i in $("$RUNTIME" list -q | xargs); do "$RUNTIME" delete -f $i; done
+	"$RUNTIME" delete -f "$pod_id"
+	"$RUNTIME" delete -f "$ctr_id"
 
 	start_crio
 
@@ -196,7 +198,7 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	for i in $("$RUNTIME" list -q | xargs); do "$RUNTIME" delete -f $i; done
+	"$RUNTIME" delete -f "$pod_id"
 
 	start_crio
 
@@ -233,7 +235,8 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	for i in $("$RUNTIME" list -q | xargs); do "$RUNTIME" delete -f $i; done
+	"$RUNTIME" delete -f "$pod_id"
+	"$RUNTIME" delete -f "$ctr_id"
 
 	start_crio
 	run crictl pods --quiet
@@ -287,7 +290,8 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runtime state and config.json going away
-	for i in $("$RUNTIME" list -q | xargs); do "$RUNTIME" delete -f $i; done
+	"$RUNTIME" delete -f "$pod_id"
+	"$RUNTIME" delete -f "$ctr_id"
 	find $TESTDIR/ -name config.json -exec rm \{\} \;
 	find $TESTDIR/ -name shm -exec umount -l \{\} \;
 

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -30,5 +30,8 @@ function execute() {
 # Tests to run. Defaults to all.
 TESTS=${@:-.}
 
+# The number of parallel jobs to execute
+JOBS=${JOBS:-$(($(nproc --all)*4))}
+
 # Run the tests.
-execute time bats --tap $TESTS
+execute time bats --jobs "$JOBS" --tap $TESTS


### PR DESCRIPTION
This PR utilizes the parallelism support of bats and applies them to the integration tests. All integration tests should now run int ~15min instead of >30min. 