### PR TITLE
userns: drop intermediate mount namespace

### DIFF
--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -337,10 +337,6 @@ func (s *Sandbox) GetContainer(name string) *oci.Container {
 // RemoveContainer deletes a container from the sandbox
 func (s *Sandbox) RemoveContainer(c *oci.Container) {
 	s.containers.Delete(c.Name())
-	intermediateMountPoint := c.IntermediateMountPoint()
-	if intermediateMountPoint != "" {
-		os.RemoveAll(intermediateMountPoint)
-	}
 }
 
 // SetInfraContainer sets the infrastructure container of a sandbox

--- a/lib/sandbox/sandbox_test.go
+++ b/lib/sandbox/sandbox_test.go
@@ -176,7 +176,6 @@ var _ = t.Describe("Sandbox", func() {
 				"imageName", "imageRef", &pb.ContainerMetadata{},
 				"testsandboxid", false, false, false, false, "",
 				"/root/for/container", time.Now(), "SIGKILL")
-			testContainer.SetIntermediateMountPoint("/tmp/file")
 			Expect(err).To(BeNil())
 			Expect(testContainer).NotTo(BeNil())
 

--- a/oci/container.go
+++ b/oci/container.go
@@ -36,26 +36,25 @@ type Container struct {
 	// this is the /var/run/storage/... directory, erased on reboot
 	bundlePath string
 	// this is the /var/lib/storage/... directory
-	dir                    string
-	stopSignal             string
-	imageName              string
-	imageRef               string
-	mountPoint             string
-	seccompProfilePath     string
-	intermediateMountPoint string
-	labels                 fields.Set
-	annotations            fields.Set
-	crioAnnotations        fields.Set
-	state                  *ContainerState
-	metadata               *pb.ContainerMetadata
-	opLock                 sync.RWMutex
-	spec                   *specs.Spec
-	idMappings             *idtools.IDMappings
-	terminal               bool
-	stdin                  bool
-	stdinOnce              bool
-	privileged             bool
-	created                bool
+	dir                string
+	stopSignal         string
+	imageName          string
+	imageRef           string
+	mountPoint         string
+	seccompProfilePath string
+	labels             fields.Set
+	annotations        fields.Set
+	crioAnnotations    fields.Set
+	state              *ContainerState
+	metadata           *pb.ContainerMetadata
+	opLock             sync.RWMutex
+	spec               *specs.Spec
+	idMappings         *idtools.IDMappings
+	terminal           bool
+	stdin              bool
+	stdinOnce          bool
+	privileged         bool
+	created            bool
 }
 
 // ContainerVolume is a bind mount for the container.
@@ -285,16 +284,6 @@ func (c *Container) SetMountPoint(mp string) {
 // MountPoint returns the container mount point
 func (c *Container) MountPoint() string {
 	return c.mountPoint
-}
-
-// SetIntermediateMountPoint sets the container intermediate mount point
-func (c *Container) SetIntermediateMountPoint(imp string) {
-	c.intermediateMountPoint = imp
-}
-
-// IntermediateMountPoint returns the container mount point
-func (c *Container) IntermediateMountPoint() string {
-	return c.intermediateMountPoint
 }
 
 // SetIDMappings sets the ID/GID mappings used for the container

--- a/oci/container_test.go
+++ b/oci/container_test.go
@@ -117,17 +117,6 @@ var _ = t.Describe("Container", func() {
 		Expect(sut.MountPoint()).To(Equal(mp))
 	})
 
-	It("should succeed to set the intermediate mount point", func() {
-		// Given
-		mp := "intermediateMountPoint"
-
-		// When
-		sut.SetIntermediateMountPoint(mp)
-
-		// Then
-		Expect(sut.IntermediateMountPoint()).To(Equal(mp))
-	})
-
 	It("should succeed to set start failed", func() {
 		// Given
 		err := fmt.Errorf("error")

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -7,16 +7,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/containers/buildah/pkg/secrets"
 	"github.com/containers/libpod/pkg/apparmor"
 	"github.com/containers/libpod/pkg/rootless"
 	createconfig "github.com/containers/libpod/pkg/spec"
-	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/lib/sandbox"
 	"github.com/cri-o/cri-o/oci"
 	"github.com/cri-o/cri-o/pkg/annotations"
@@ -30,7 +29,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-	"golang.org/x/sys/unix"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
@@ -164,130 +162,38 @@ func addDevicesPlatform(sb *sandbox.Sandbox, containerConfig *pb.ContainerConfig
 
 // createContainerPlatform performs platform dependent intermediate steps before calling the container's oci.Runtime().CreateContainer()
 func (s *Server) createContainerPlatform(container *oci.Container, infraContainer *oci.Container, cgroupParent string) error {
-	intermediateMountPoint := container.IntermediateMountPoint()
+	if s.defaultIDMappings != nil && !s.defaultIDMappings.Empty() {
+		rootPair := s.defaultIDMappings.RootPair()
 
-	if intermediateMountPoint == "" {
-		return s.Runtime().CreateContainer(container, cgroupParent)
+		for _, path := range []string{container.BundlePath(), container.MountPoint()} {
+			if err := os.Chown(path, rootPair.UID, rootPair.GID); err != nil {
+				return errors.Wrapf(err, "cannot chown %s to %d:%d", path, rootPair.UID, rootPair.GID)
+			}
+			if err := makeAccessible(path, rootPair.UID, rootPair.GID); err != nil {
+				return errors.Wrapf(err, "cannot make %s accessible to %d:%d", path, rootPair.UID, rootPair.GID)
+			}
+		}
 	}
-
-	errc := make(chan error)
-	go func() {
-		// We create a new mount namespace before running the container as the rootfs of the
-		// container is accessible only to the root user.  We use the intermediate mount
-		// namespace to bind mount the root to a directory that is accessible to the user which
-		// maps to root inside of the container/
-		// We carefully unlock the OS thread only if no errors happened.  The thread might have failed
-		// to restore the original mount namespace, and unlocking it will let it keep running
-		// in a different context than the other threads.  A thread that is still locked when the
-		// goroutine terminates is automatically destroyed.
-		var err error
-		runtime.LockOSThread()
-		defer func() {
-			if err == nil {
-				runtime.UnlockOSThread()
-			}
-			errc <- err
-		}()
-
-		fd, err := os.Open(fmt.Sprintf("/proc/%d/task/%d/ns/mnt", os.Getpid(), unix.Gettid()))
-		if err != nil {
-			return
-		}
-		defer fd.Close()
-
-		// create a new mountns on the current thread
-		if err = unix.Unshare(unix.CLONE_NEWNS); err != nil {
-			return
-		}
-		defer unix.Setns(int(fd.Fd()), unix.CLONE_NEWNS)
-
-		// don't spread our mounts around
-		err = unix.Mount("/", "/", "none", unix.MS_REC|unix.MS_SLAVE, "")
-		if err != nil {
-			return
-		}
-
-		rootUID, rootGID, err := idtools.GetRootUIDGID(container.IDMappings().UIDs(), container.IDMappings().GIDs())
-		if err != nil {
-			return
-		}
-
-		err = os.Chown(intermediateMountPoint, rootUID, rootGID)
-		if err != nil {
-			return
-		}
-		logrus.Debugf("intermediateMountPoint %s, rootUID %v, rootGID %v", intermediateMountPoint, rootUID, rootGID)
-		mountPoint := container.MountPoint()
-		err = os.Chown(mountPoint, rootUID, rootGID)
-		if err != nil {
-			return
-		}
-
-		rootPath := filepath.Join(intermediateMountPoint, "root")
-		err = idtools.MkdirAllAs(rootPath, 0700, rootUID, rootGID)
-		if err != nil {
-			return
-		}
-
-		err = unix.Mount(mountPoint, rootPath, "none", unix.MS_BIND, "")
-		if err != nil {
-			return
-		}
-
-		if infraContainer != nil {
-			infraRunDir := filepath.Join(intermediateMountPoint, "infra-rundir")
-			err = idtools.MkdirAllAs(infraRunDir, 0700, rootUID, rootGID)
-			if err != nil {
-				return
-			}
-
-			err = unix.Mount(infraContainer.BundlePath(), infraRunDir, "none", unix.MS_BIND, "")
-			if err != nil {
-				return
-			}
-			err = os.Chown(infraRunDir, rootUID, rootGID)
-			if err != nil {
-				return
-			}
-		}
-
-		runDirPath := filepath.Join(intermediateMountPoint, "rundir")
-		err = idtools.MkdirAllAs(runDirPath, 0700, rootUID, rootGID)
-		if err != nil {
-			return
-		}
-		err = chownAllFilesAt(container.BundlePath(), rootUID, rootGID)
-		if err != nil {
-			logrus.Errorf("err in chowning container.BundlePath() with rootUID %v rootGID %v: %v", rootUID, rootGID, err)
-			return
-		}
-		logrus.Debugf("chowned container.BundlePath(), %s,  with rootUID %v rootGID %v", container.BundlePath(), rootUID, rootGID)
-		err = unix.Mount(container.BundlePath(), runDirPath, "none", unix.MS_BIND, "suid")
-		if err != nil {
-			return
-		}
-
-		err = s.Runtime().CreateContainer(container, cgroupParent)
-	}()
-
-	err := <-errc
-	return err
+	return s.Runtime().CreateContainer(container, cgroupParent)
 }
 
-func chownAllFilesAt(dir string, uid int, gid int) error {
-	var files []string
-
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		files = append(files, path)
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	for _, file := range files {
-		err = os.Chown(file, uid, gid)
+// makeAccessible changes the path permission and each parent directory to have --x--x--x
+func makeAccessible(path string, uid, gid int) error {
+	for ; path != "/"; path = filepath.Dir(path) {
+		st, err := os.Stat(path)
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
+		}
+		if int(st.Sys().(*syscall.Stat_t).Uid) == uid && int(st.Sys().(*syscall.Stat_t).Gid) == gid {
+			continue
+		}
+		if st.Mode()&0111 != 0111 {
+			if err := os.Chmod(path, st.Mode()|0111); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -926,8 +832,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	container.SetIDMappings(containerIDMappings)
 	if s.defaultIDMappings != nil && !s.defaultIDMappings.Empty() {
 		userNsPath := sb.UserNsPath()
-		rootPair := s.defaultIDMappings.RootPair()
-
 		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.UserNamespace), userNsPath); err != nil {
 			return nil, err
 		}
@@ -937,23 +841,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		for _, gidmap := range s.defaultIDMappings.GIDs() {
 			specgen.AddLinuxGIDMapping(uint32(gidmap.HostID), uint32(gidmap.ContainerID), uint32(gidmap.Size))
 		}
-		err = s.configureIntermediateNamespace(&specgen, container, sb.InfraContainer())
-		if err != nil {
-			return nil, err
-		}
-
-		if sb.ResolvPath() != "" {
-			err = os.Chown(sb.ResolvPath(), rootPair.UID, rootPair.GID)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		defer func() {
-			if err != nil {
-				os.RemoveAll(container.IntermediateMountPoint())
-			}
-		}()
 	}
 
 	if os.Getenv("_CRIO_ROOTLESS") != "" {


### PR DESCRIPTION
Simplify the implementation for user namespaces by not using an
intermediate mount namespace.  For doing it, we need to relax the
permissions on the parent directories and allow browsing
them. Containers that are running without a user namespace, will still
maintain mode 0700 on their directory.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

**- What I did**
dropped intermediate mount namespace

**- How to verify it**
when using user namespaces, containers mount are accessible from the host/

**- Description for the changelog**
when using user namespaces, we no longer use an intermediate mount namespace