### PR TITLE
Do not crash when netns is not set up

### DIFF
--- a/lib/sandbox/sandbox_linux.go
+++ b/lib/sandbox/sandbox_linux.go
@@ -4,6 +4,7 @@ package sandbox
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -58,6 +59,9 @@ type NetNs struct {
 
 // SymlinkCreate creates the necessary symlinks for the NetNs
 func (n *NetNs) SymlinkCreate(name string) error {
+	if n.netNS == nil {
+		return errors.New("no netns set up")
+	}
 	b := make([]byte, 4)
 	_, randErr := rand.Reader.Read(b)
 	if randErr != nil {


### PR DESCRIPTION
**- What I did**
Fixed a nil pointer when cri-o gets into a state where it tries to clean up existing networks which do not have netns created.

```
time="2019-04-02 10:59:08.732093623+02:00" level=info msg="About to del CNI network mynet (type=calico)"
panic: runtime error: invalid memory address or nil pointer dereference
... stacktrace ...
```

**- Description for the changelog**
Do not crash when tearing down a pod that doesn't have netns created
