### PR TITLE
Fix parallel make build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ release-note:
 	@$(GOPATH)/bin/release-tool -n $(release)
 
 conmon/config.h: cmd/crio-config/config.go oci/oci.go
-	$(GO) build -i $(LDFLAGS) -o bin/crio-config $(PROJECT)/cmd/crio-config
+	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS)" -o bin/crio-config $(PROJECT)/cmd/crio-config
 	( cd conmon && $(CURDIR)/bin/crio-config )
 
 clean:


### PR DESCRIPTION
**- What I did**
Fix build error when parallel make is called.

**- How I did it**
Pass go BUILDTAGS to the compilation of cmd/crio-config similar to cmd/crio

**- How to verify it**
use `make -jX` to build cri-o and it should succeed.

**- Description for the changelog**
Fix parallel make error.