### PR TITLE
Fix parallel make build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ release-note:
 	@$(GOPATH)/bin/release-tool -n $(release)
 
 conmon/config.h: cmd/crio-config/config.go oci/oci.go
-	$(GO) build -i $(LDFLAGS) -o bin/crio-config $(PROJECT)/cmd/crio-config
+	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS)" -o bin/crio-config $(PROJECT)/cmd/crio-config
 	( cd conmon && $(CURDIR)/bin/crio-config )
 
 clean:


### PR DESCRIPTION
If one tries to build release 1.14.0 using parallel make `make -jX` the
build fails with go build of config.h unable to satisfy seccomp
dependency. This patch tries to mimic what is done on other components
where BUILDTAGS are added if they exist in the system

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>
(cherry picked from commit e24d57d688392e49594ef39eec0ff9f9344231e8)
Backport of PR: https://github.com/kubernetes-sigs/cri-o/pull/2201
