### PR TITLE
netns can be nil which can cause a segfault

### DIFF
--- a/lib/sandbox/sandbox_linux.go
+++ b/lib/sandbox/sandbox_linux.go
@@ -67,7 +67,7 @@ func (n *NetNs) SymlinkCreate(name string) error {
 	nsName := fmt.Sprintf("%s-%x", name, b)
 	symlinkPath := filepath.Join(NsRunDir, nsName)
 
-	if err := os.Symlink(n.netNS.Path(), symlinkPath); err != nil {
+	if err := os.Symlink(n.Path(), symlinkPath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
A Path() function was added for disappearing netns, so we should
use it.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
