### PR TITLE
Move ContainerAttachSocketDir/containerExitsDir to lib

### DIFF
--- a/cmd/crio-config/config.go
+++ b/cmd/crio-config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/cri-o/cri-o/lib"
 	"github.com/cri-o/cri-o/oci"
 	"github.com/sirupsen/logrus"
 )
@@ -19,7 +20,7 @@ func main() {
 
 #endif // CONFIG_H
 `
-	if err := ioutil.WriteFile("config.h", []byte(fmt.Sprintf(output, oci.BufSize, oci.BufSize, oci.ContainerAttachSocketDir)), 0700); err != nil {
+	if err := ioutil.WriteFile("config.h", []byte(fmt.Sprintf(output, oci.BufSize, oci.BufSize, lib.ContainerAttachSocketDir)), 0700); err != nil {
 		logrus.Fatal(err)
 	}
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -388,7 +388,7 @@ func DefaultConfig() (*Config, error) {
 			CgroupManager:            cgroupManager,
 			PidsLimit:                DefaultPidsLimit,
 			ContainerExitsDir:        containerExitsDir,
-			ContainerAttachSocketDir: oci.ContainerAttachSocketDir,
+			ContainerAttachSocketDir: ContainerAttachSocketDir,
 			LogSizeMax:               DefaultLogSizeMax,
 			LogToJournald:            DefaultLogToJournald,
 			DefaultCapabilities:      DefaultCapabilities,

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -2,14 +2,13 @@
 
 package lib
 
-import "github.com/cri-o/cri-o/oci"
-
 // Defaults for linux/unix if none are specified
 const (
-	conmonPath         = "/usr/local/libexec/crio/conmon"
-	seccompProfilePath = "/etc/crio/seccomp.json"
-	cniConfigDir       = "/etc/cni/net.d/"
-	cniBinDir          = "/opt/cni/bin/"
-	lockPath           = "/run/crio.lock"
-	containerExitsDir  = oci.ContainerExitsDir
+	conmonPath               = "/usr/local/libexec/crio/conmon"
+	seccompProfilePath       = "/etc/crio/seccomp.json"
+	cniConfigDir             = "/etc/cni/net.d/"
+	cniBinDir                = "/opt/cni/bin/"
+	lockPath                 = "/run/crio.lock"
+	containerExitsDir        = "/var/run/crio/exits"
+	ContainerAttachSocketDir = "/var/run/crio"
 )

--- a/lib/config_windows.go
+++ b/lib/config_windows.go
@@ -6,10 +6,11 @@ import "github.com/cri-o/cri-o/oci"
 
 // Defaults for linux/unix if none are specified
 const (
-	conmonPath         = "C:\\crio\\bin\\conmon"
-	seccompProfilePath = "C:\\crio\\etc\\seccomp.json"
-	cniConfigDir       = "C:\\cni\\etc\\net.d\\"
-	cniBinDir          = "C:\\cni\\bin\\"
-	lockPath           = "C:\\crio\\run\\crio.lock"
-	containerExitsDir  = oci.ContainerExitsDir
+	conmonPath               = "C:\\crio\\bin\\conmon"
+	seccompProfilePath       = "C:\\crio\\etc\\seccomp.json"
+	cniConfigDir             = "C:\\cni\\etc\\net.d\\"
+	cniBinDir                = "C:\\cni\\bin\\"
+	lockPath                 = "C:\\crio\\run\\crio.lock"
+	containerExitsDir        = "C:\\crio\\run\\exits\\"
+	ContainerAttachSocketDir = "C:\\crio\\run\\"
 )

--- a/oci/oci_unix.go
+++ b/oci/oci_unix.go
@@ -17,13 +17,6 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
-const (
-	// ContainerExitsDir is the location of container exit dirs
-	ContainerExitsDir = "/var/run/crio/exits"
-	// ContainerAttachSocketDir is the location for container attach sockets
-	ContainerAttachSocketDir = "/var/run/crio"
-)
-
 func kill(pid int) error {
 	err := unix.Kill(pid, unix.SIGKILL)
 	if err != nil && err != unix.ESRCH {

--- a/oci/oci_windows.go
+++ b/oci/oci_windows.go
@@ -12,13 +12,6 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-const (
-	// ContainerExitsDir is the location of container exit dirs
-	ContainerExitsDir = "C:\\crio\\run\\exits\\"
-	// ContainerAttachSocketDir is the location for container attach sockets
-	ContainerAttachSocketDir = "C:\\crio\\run\\"
-)
-
 func kill(pid int) error {
 	proc, err := os.FindProcess(pid)
 	if err != nil {

--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -361,7 +361,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 		args = append(args, fmt.Sprintf("%d", timeout))
 	}
 	args = append(args, "-l", logPath)
-	args = append(args, "--socket-dir-path", ContainerAttachSocketDir)
+	args = append(args, "--socket-dir-path", r.containerAttachSocketDir)
 	args = append(args, "--log-level", logrus.GetLevel().String())
 
 	processFile, err := prepareProcessExec(c, command, c.terminal)

--- a/server/server.go
+++ b/server/server.go
@@ -249,7 +249,7 @@ func getIDMappings(config *Config) (*idtools.IDMappings, error) {
 
 // New creates a new Server with options provided
 func New(ctx context.Context, config *Config) (*Server, error) {
-	if err := os.MkdirAll(oci.ContainerAttachSocketDir, 0755); err != nil {
+	if err := os.MkdirAll(config.ContainerAttachSocketDir, 0755); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This commit moves the configuration variables
`ContainerAttachSocketDir` and `containerExitsDir` to the library
configuration. This fixes the issue that wrong `--socket-dir-path` is
passed to conmon if `ContainerAttachSocketDir` is configured to
somewhere else than "/var/run/crio". A second fixed issue is that the
target directory for `ContainerAttachSocketDir` is not created correctly
on server `New()`.