### PR TITLE
[1.14] netns can be nil which can cause a segfault

### DIFF
--- a/lib/sandbox/sandbox_linux.go
+++ b/lib/sandbox/sandbox_linux.go
@@ -67,7 +67,7 @@ func (n *NetNs) SymlinkCreate(name string) error {
 	nsName := fmt.Sprintf("%s-%x", name, b)
 	symlinkPath := filepath.Join(NsRunDir, nsName)
 
-	if err := os.Symlink(n.netNS.Path(), symlinkPath); err != nil {
+	if err := os.Symlink(n.Path(), symlinkPath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR backports #2222

Closes #2221 
