### PR TITLE
Add config interface nil check

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -127,6 +127,9 @@ func localeToLanguage(locale string) string {
 
 // New creates a new ContainerServer with options provided
 func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error) {
+	if configIface == nil {
+		return nil, fmt.Errorf("provided config is nil")
+	}
 	store, err := configIface.GetStore()
 	if err != nil {
 		return nil, err

--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -79,6 +79,16 @@ var _ = t.Describe("ContainerServer", func() {
 			Expect(server).To(BeNil())
 		})
 
+		It("should fail when config is nil", func() {
+			// Given
+			// When
+			server, err := lib.New(context.Background(), nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(server).To(BeNil())
+		})
+
 		It("should fail with invalid default runtime", func() {
 			// Given
 			config, err := lib.DefaultConfig()


### PR DESCRIPTION
This commit fixes a nil pointer dereference when creating a new
`ContainerServer` and providing `nil` as `ConfigIface`. Should no
big issue right now, but seems more safe to me.