### PR TITLE
Add stylecheck, unused and gosimple linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - goimports
     - golint
     - gosec
+    - gosimple
     - govet
     - ineffassign
     - interfacer
@@ -24,9 +25,11 @@ linters:
     - scopelint
     - staticcheck
     - structcheck
+    - stylecheck
     - typecheck
     - unconvert
     - unparam
+    - unused
     - varcheck
     # - errcheck
     # - gochecknoglobals


### PR DESCRIPTION
This commits enables the above mentioned linters. No further code
changes are needed due to test passing on `make lint`. :tada: 