### PR TITLE
 conmon: use sd_journal_sendv

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -996,9 +996,6 @@ int main(int argc, char *argv[])
 	if (!opt_exec && opt_cuuid == NULL)
 		nexit("Container UUID not provided. Use --cuuid");
 
-	if (opt_name == NULL)
-		nexit("Container name not provided. Use --name");
-
 	if (opt_runtime_path == NULL)
 		nexit("Runtime path not provided. Use --runtime");
 	if (access(opt_runtime_path, X_OK) < 0)


### PR DESCRIPTION
Before, the static building of sd_journal_send args meant there were backwards compatibility issues with conmon.
Mainly, if a name wasn't inputted, any runtime would crash trying to use it.

Fix this by building the journal arguments more dynamically. This also allows the journal arguments to be extended easier.

Signed-off-by: Peter Hunt <pehunt@redhat.com>