### PR TITLE
tests: added metrics test to ctr.bats and command.bats

### DIFF
--- a/test/command.bats
+++ b/test/command.bats
@@ -38,3 +38,14 @@ load helpers
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "invalid device mode:" ]]
 }
+
+@test "invalid metrics port" {
+	run ${CRIO_BINARY} --metrics-port foo --enable-metrics
+	echo $output
+	[ "$status" -ne 0 ]
+	[[ "$output" =~ "invalid value \"foo\" for flag" ]]
+	run ${CRIO_BINARY} --metrics-port 18446744073709551616 --enable-metrics
+	echo $output
+	[ "$status" -ne 0 ]
+	[[ "$output" =~ "value out of range" ]]
+}


### PR DESCRIPTION
$ bats -f "ctr expose metrics" test/ctr.bats 
 ✓ ctr expose metrics with default port
 ✓ ctr expose metrics with custom port

2 tests, 0 failures

$ bats -f "invalid metrics port" test/command.bats 
 ✓ invalid metrics port

1 test, 0 failures

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
added metrics test to ctr.bats and command.bats

**- How I did it**

- add positive testing to ctr.bats

  - [x]     expose metrics with default port
  - [x]     expose metrics with custom port

- add negative testing to command.bats
  - [x]    invalid metrics port

**- How to verify it**
$ bats -f "ctr expose metrics" test/ctr.bats 
$ bats -f "invalid metrics port" test/command.bats 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
