### PR TITLE
Remove unnecessary nolints

### DIFF
--- a/lib/kill.go
+++ b/lib/kill.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ContainerKill sends the user provided signal to the containers primary process.
-func (c *ContainerServer) ContainerKill(container string, killSignal syscall.Signal) (string, error) { // nolint
+func (c *ContainerServer) ContainerKill(container string, killSignal syscall.Signal) (string, error) {
 	ctr, err := c.LookupContainer(container)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to find container %s", container)

--- a/lib/sandbox/suite_test.go
+++ b/lib/sandbox/suite_test.go
@@ -20,7 +20,6 @@ func TestSandbox(t *testing.T) {
 	RunSpecs(t, "Sandbox")
 }
 
-// nolint: gochecknoglobals
 var (
 	t              *TestFramework
 	testSandbox    *sandbox.Sandbox

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -27,7 +27,6 @@ func TestLib(t *testing.T) {
 	RunSpecs(t, "Lib")
 }
 
-// nolint: gochecknoglobals
 var (
 	t              *TestFramework
 	mockCtrl       *gomock.Controller

--- a/lib/wait.go
+++ b/lib/wait.go
@@ -21,12 +21,7 @@ func (c *ContainerServer) ContainerWait(container string) (int32, error) {
 
 	err = wait.PollImmediateInfinite(1,
 		func() (bool, error) {
-			if !isStopped(c, ctr) {
-				return false, nil
-			} else { // nolint
-				return true, nil // nolint
-			} // nolint
-
+			return isStopped(c, ctr), nil
 		},
 	)
 

--- a/oci/suite_test.go
+++ b/oci/suite_test.go
@@ -19,7 +19,6 @@ func TestOci(t *testing.T) {
 	RunSpecs(t, "Oci")
 }
 
-// nolint: gochecknoglobals
 var (
 	t         *TestFramework
 	mockCtrl  *gomock.Controller

--- a/pkg/findprocess/findprocess_test.go
+++ b/pkg/findprocess/findprocess_test.go
@@ -16,7 +16,6 @@ func TestFindprocess(t *testing.T) {
 	RunSpecs(t, "Findprocess")
 }
 
-// nolint: gochecknoglobals
 var t *TestFramework
 
 var _ = BeforeSuite(func() {

--- a/pkg/seccomp/seccomp_test.go
+++ b/pkg/seccomp/seccomp_test.go
@@ -20,7 +20,6 @@ func TestSeccomp(t *testing.T) {
 	RunSpecs(t, "Seccomp")
 }
 
-// nolint: gochecknoglobals
 var t *TestFramework
 
 var _ = BeforeSuite(func() {

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -17,7 +17,6 @@ func TestStorage(t *testing.T) {
 	RunSpecs(t, "Storage")
 }
 
-// nolint: gochecknoglobals
 var (
 	t               *TestFramework
 	mockCtrl        *gomock.Controller

--- a/utils/suite_test.go
+++ b/utils/suite_test.go
@@ -14,7 +14,6 @@ func TestUtils(t *testing.T) {
 	RunSpecs(t, "Utils")
 }
 
-// nolint: gochecknoglobals
 var t *TestFramework
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
Since we vendored golangci lint within the repository we can safely
remove source code based nolints which would have no effect.