### PR TITLE
Revert "Add RuntimeHandler.RuntimeRoot"

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -214,7 +214,6 @@ manage_network_ns_lifecycle = {{ .ManageNetworkNSLifecycle }}
 [crio.runtime.runtimes.{{ $runtime_name }}]
 runtime_path = "{{ $runtime_handler.RuntimePath }}"
 runtime_type = "{{ $runtime_handler.RuntimeType }}"
-runtime_root = "{{ $runtime_handler.RuntimeRoot }}"
 {{ end }}
 
 # The crio.image table contains settings pertaining to the management of OCI images.

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -121,13 +121,10 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 		runtimes := ctx.GlobalStringSlice("runtimes")
 		for _, r := range runtimes {
 			fields := strings.Split(r, ":")
-			if len(fields) != 3 {
+			if fields[0] == "" {
 				return fmt.Errorf("wrong format for --runtimes: %q", r)
 			}
-			config.Runtimes[fields[0]] = oci.RuntimeHandler{
-				RuntimePath: fields[1],
-				RuntimeRoot: fields[2],
-			}
+			config.Runtimes[fields[0]] = oci.RuntimeHandler{RuntimePath: fields[1]}
 		}
 	}
 	if ctx.GlobalIsSet("selinux") {
@@ -365,7 +362,7 @@ func main() {
 		},
 		cli.StringSliceFlag{
 			Name:  "runtimes",
-			Usage: "OCI runtimes, format is runtime_name:runtime_path:runtime_root",
+			Usage: "OCI runtimes, format is runtime_name:runtime_path",
 		},
 		cli.StringFlag{
 			Name:  "seccomp-profile",

--- a/lib/config.go
+++ b/lib/config.go
@@ -376,7 +376,6 @@ func DefaultConfig() (*Config, error) {
 				"runc": {
 					RuntimePath: "/usr/bin/runc",
 					RuntimeType: "oci",
-					RuntimeRoot: "/run/runc",
 				},
 			},
 			Conmon: conmonPath,

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -93,7 +93,6 @@ type RuntimeImpl interface {
 type RuntimeHandler struct {
 	RuntimePath string `toml:"runtime_path"`
 	RuntimeType string `toml:"runtime_type"`
-	RuntimeRoot string `toml:"runtime_root"`
 }
 
 // New creates a new Runtime with options provided
@@ -242,7 +241,7 @@ func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
 
 	// If the runtime type is different from "vm", then let's fallback
 	// onto the OCI implementation by default.
-	return newRuntimeOCI(r, &rh), nil
+	return newRuntimeOCI(r, rh.RuntimePath), nil
 }
 
 // RuntimeImpl returns the runtime implementation for a given container

--- a/oci/oci_linux.go
+++ b/oci/oci_linux.go
@@ -74,8 +74,12 @@ func loadFactory(root string) (libcontainer.Factory, error) {
 }
 
 // libcontainerStats gets the stats for the container with the given id from runc/libcontainer
-func (r *runtimeOCI) libcontainerStats(ctr *Container) (*libcontainer.Stats, error) {
-	factory, err := loadFactory(r.root)
+func libcontainerStats(ctr *Container) (*libcontainer.Stats, error) {
+	// TODO: make this not hardcoded
+	// was: c.runtime.Path(ociContainer) but that returns /usr/bin/runc - how do we get /run/runc?
+	// runroot is /var/run/runc
+	// Hardcoding probably breaks Kata Containers compatibility
+	factory, err := loadFactory("/run/runc")
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +90,8 @@ func (r *runtimeOCI) libcontainerStats(ctr *Container) (*libcontainer.Stats, err
 	return container.Stats()
 }
 
-func (r *runtimeOCI) containerStats(ctr *Container) (*ContainerStats, error) {
-	libcontainerStats, err := r.libcontainerStats(ctr)
+func containerStats(ctr *Container) (*ContainerStats, error) {
+	libcontainerStats, err := libcontainerStats(ctr)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -13,7 +13,7 @@ var _ = t.Describe("Oci", func() {
 			// Given
 			// When
 			runtime, err := oci.New("runc",
-				map[string]oci.RuntimeHandler{"runc": {"/bin/sh", "", "/run/runc"}},
+				map[string]oci.RuntimeHandler{"runc": {"/bin/sh", ""}},
 				"", []string{}, "", "", "", 0, false, false, 0)
 
 			// Then
@@ -44,7 +44,7 @@ var _ = t.Describe("Oci", func() {
 			defaultRuntime = "runc"
 		)
 		runtimes := map[string]oci.RuntimeHandler{
-			defaultRuntime: {"/bin/sh", "", "/run/runc"}, invalidRuntime: {},
+			defaultRuntime: {"/bin/sh", ""}, invalidRuntime: {},
 		}
 
 		BeforeEach(func() {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -33,7 +33,6 @@ DEVICES=${DEVICES:-}
 OVERRIDE_OPTIONS=${OVERRIDE_OPTIONS:-}
 RUNTIME_PATH=$(command -v $RUNTIME || true)
 RUNTIME_BINARY=${RUNTIME_PATH:-/usr/local/sbin/runc}
-RUNTIME_ROOT=${RUNTIME_ROOT:-/run/runc}
 # Path of the apparmor_parser binary.
 APPARMOR_PARSER_BINARY=${APPARMOR_PARSER_BINARY:-/sbin/apparmor_parser}
 # Path of the apparmor profile for test.
@@ -241,7 +240,7 @@ function setup_crio() {
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/image-volume-test:latest --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --default-capabilities "$capabilities" --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --stream-port "$STREAM_PORT" --cgroup-manager "$CGROUP_MANAGER" --default-mounts-file "$TESTDIR/containers/mounts.conf" --registry "quay.io" --default-runtime $DEFAULT_RUNTIME --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY:$RUNTIME_ROOT" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" $DEVICES $ULIMITS --uid-mappings "$UID_MAPPINGS" --gid-mappings "$GID_MAPPINGS" --default-sysctls "$TEST_SYSCTL" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
+	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --default-capabilities "$capabilities" --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --stream-port "$STREAM_PORT" --cgroup-manager "$CGROUP_MANAGER" --default-mounts-file "$TESTDIR/containers/mounts.conf" --registry "quay.io" --default-runtime $DEFAULT_RUNTIME --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" $DEVICES $ULIMITS --uid-mappings "$UID_MAPPINGS" --gid-mappings "$GID_MAPPINGS" --default-sysctls "$TEST_SYSCTL" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
 	sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?default_ulimits = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i $CRIO_CONFIG
 	# Prepare the CNI configuration files, we're running with non host networking by default
 	if [[ -n "$5" ]]; then


### PR DESCRIPTION
This reverts commit 296d80b6ac61b427583e1cfe06e74da73e7e875b.

I've noticed there are still places where we cannot set the runtime root in the vendored code, so CRI-O breaks unless we set the runtime to the default setting.

I think we should first ensure the vendored libraries allow to change the runtime root.

Tracing the execs:
```
runc             13862  13201    0 /usr/local/bin/runc --root /run/runc start c0d2d88dfd487a8fadaf4c8ce1550641415f910b922f336ee1afba433db7c755                                               
sleep            13841  13835    0 /bin/sleep 9999
runc             13863  13201    0 /usr/local/bin/runc --root /run/runc state c0d2d88dfd487a8fadaf4c8ce1550641415f910b922f336ee1afba433db7c755                                               
runc             13877  13873    0 /usr/local/bin/runc state c0d2d88dfd487a8fadaf4c8ce1550641415f910b922f336ee1afba433db7c755   
```

the last state is not specifying the runtime root

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
