### PR TITLE
runtime: fix a regression introduced by 296d80b6ac61b427583e1cfe06e74da73e7e875b

### DIFF
--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -382,6 +382,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 	defer os.RemoveAll(processFile.Name())
 
 	args = append(args, "--exec-process-spec", processFile.Name())
+	args = append(args, "--runtime-arg", fmt.Sprintf("%s=%s", rootFlag, r.root))
 
 	cmd := exec.Command(r.conmonPath, args...)
 

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -34,7 +34,7 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	state=$($RUNTIME state "$ctr_id")
+	state=$(crictl inspect "$ctr_id")
 	pid=$(echo $state | python -c 'import json; import sys; d=json.load(sys.stdin); print d["pid"]')
 	grep 100000 /proc/$pid/uid_map
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
specify the runtime root also when using conmon exec.