### PR TITLE
[1.13] Add min memory limit check to sandbox_run_linux.go

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cri-o/cri-o/lib/sandbox"
 	"github.com/cri-o/cri-o/oci"
 	"github.com/cri-o/cri-o/pkg/annotations"
+	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -30,6 +31,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/leaky"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 )
+
+const cgroupMemorySubsystemMountPath = "/sys/fs/cgroup/memory"
 
 func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (resp *pb.RunPodSandboxResponse, err error) {
 	const operation = "run_pod_sandbox"
@@ -375,6 +378,30 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			}
 			g.SetLinuxCgroupsPath(cgPath + ":" + "crio" + ":" + id)
 			cgroupParent = cgPath
+
+			// check memory limit is greater than the minimum memory limit of 4Mb
+			// expand the cgroup slice path
+			slicePath, err := systemd.ExpandSlice(cgroupParent)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error expanding systemd slice path for %q", cgroupParent)
+			}
+			// read in the memory limit from the memory.limit_in_bytes file
+			fileData, err := ioutil.ReadFile(filepath.Join(cgroupMemorySubsystemMountPath, slicePath, "memory.limit_in_bytes"))
+			if err != nil {
+				return nil, errors.Wrapf(err, "error reading memory.limit_in_bytes file for slice %q", cgroupParent)
+			}
+			// strip off the newline character and convert it to an int
+			strMemory := strings.TrimRight(string(fileData), "\n")
+			if strMemory != "" {
+				memoryLimit, err := strconv.Atoi(strMemory)
+				if err != nil {
+					return nil, errors.Wrapf(err, "error converting cgroup memory value from string to int %q", strMemory)
+				}
+				// Compare with the minimum allowed memory limit
+				if memoryLimit != 0 && memoryLimit < minMemoryLimit {
+					return nil, fmt.Errorf("pod set memory limit %v too low; should be at least %v", memoryLimit, minMemoryLimit)
+				}
+			}
 		} else {
 			if strings.HasSuffix(path.Base(cgroupParent), ".slice") {
 				return nil, fmt.Errorf("cri-o configured with cgroupfs cgroup manager, but received systemd slice as parent: %s", cgroupParent)


### PR DESCRIPTION
The kubelet takes the memory limits of the containers running
in a pod and set is as the memory limit of the pod.
We were enforcing this minimum memory limit check during the
container creation time but not during the sandbox creation
time. Now we take the pod slice path and read the memory file
and double check that it is above the minimum memory limit.
Doing this also returns a correct error message when the memory
limit is too low, instead of the vague "signal killed" message.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

