### PR TITLE
Add infra container check for pod sandbox

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -469,6 +469,10 @@ func (s *Server) StartExitMonitor() {
 						sb := s.GetSandbox(containerID)
 						if sb != nil {
 							c := sb.InfraContainer()
+							if c == nil {
+								logrus.Warnf("no infra container set for sandbox: %v", containerID)
+								continue
+							}
 							logrus.Debugf("sandbox exited and found: %v", containerID)
 							err := s.Runtime().UpdateContainerStatus(c)
 							if err != nil {


### PR DESCRIPTION
On improper API usage it is possible to setup a sandbox without any infra container. This commit adds an additional check for that case.