### PR TITLE
Add static crio binary build for x86-64 (glibc and musl)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverprofile
 .gdb_history
 *gomock_reflect*
 lib/state.json
+result-*bin
 
 Vagrantfile
 .vagrant/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ services:
   - docker
 
 before_install:
-  - if [ "${TRAVIS_OS_NAME}" = linux ]; then make vendor; fi
-  - if [ "${TRAVIS_OS_NAME}" = linux ]; then ./hack/tree_status.sh; fi
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq update; fi
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev libseccomp-dev; fi
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install autoconf automake bison clang-format-3.9 e2fslibs-dev libfuse-dev libtool liblzma-dev gettext libsystemd-dev; fi
@@ -20,40 +18,70 @@ before_script:
   - export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
 env:
+  global:
+    - NIX_IMAGE=saschagrunert/crionix
+    - CONTAINER_RUNTIME=docker
 
 jobs:
   include:
-    - stage: Build and Verify
+    - stage: Lint
+      name: git validation, clang-format, golangci-lint
       script:
         - make .gitvalidation
         - make fmt
         - make lint
       go: "1.12.x"
-    - script:
+    - name: vendor
+      script:
+        - make vendor
+        - hack/tree_status.sh
+      go: "1.12.x"
+    - stage: Test
+      name: build, unit test and code coverage report
+      script:
         - make testunit
         - make
         - make codecov
       go: "1.12.x"
-    - script:
+    - name: static binary build
+      script:
+        - make build-static CONTAINER_RUNTIME=$CONTAINER_RUNTIME NIX_IMAGE=$NIX_IMAGE
+      go: "1.12.x"
+    - name: cross compilation build
+      script:
         - make local-cross
       go: "1.12.x"
       env: CROSS_PLATFORM=true
-    - script:
+    - name: latest go version (tip)
+      script:
         - make testunit
         - make
       go: tip
-    - script:
+    - name: macOS build and unit tests
+      script:
         - make testunit
         - make
       os: osx
-    - stage: Integration Test
+    - stage: Integration
+      name: default build
       script:
-        - make CONTAINER_RUNTIME=docker integration
+        - make integration CONTAINER_RUNTIME=$CONTAINER_RUNTIME
       go: "1.12.x"
-    - script:
-        - make CONTAINER_RUNTIME=docker integration
+    - name: default build with user namespace
+      script:
+        - make integration CONTAINER_RUNTIME=$CONTAINER_RUNTIME
       env: TEST_USERNS=1
       go: "1.12.x"
+    - name: static x86_64 glibc
+      script:
+        - make build-static integration CONTAINER_RUNTIME=$CONTAINER_RUNTIME NIX_IMAGE=$NIX_IMAGE
+      go: "1.12.x"
+      env: CRIO_BINARY=crio-x86_64-static-glibc
+    - name: static x86_64 musl libc
+      script:
+        - make build-static integration CONTAINER_RUNTIME=$CONTAINER_RUNTIME NIX_IMAGE=$NIX_IMAGE
+      go: "1.12.x"
+      env: CRIO_BINARY=crio-x86_64-static-musl
   allow_failures:
     - os: osx
     - go: tip

--- a/Dockerfile-nix
+++ b/Dockerfile-nix
@@ -1,0 +1,8 @@
+FROM nixos/nix
+RUN apk add git
+COPY . /cri-o
+ARG COMMIT
+WORKDIR cri-o/nix
+RUN nix-build --argstr revision ${COMMIT}
+WORKDIR /
+RUN rm -rf cri-o

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,88 @@
+{ revision ? "HEAD", system ? builtins.currentSystem }:
+let
+  nixpkgs = import ./nixpkgs.nix;
+
+  glibcPkgs = import (builtins.head nixpkgs) {
+    config = { packageOverrides = pkg: { go_1_11 = glibcPkgs.go_1_12; }; };
+  };
+  glibcCallPackage = glibcPkgs.lib.callPackageWith
+                     (glibcPkgs // glibcPkgs.xlibs // self);
+
+  muslPkgs = (import (builtins.head nixpkgs) {
+    config = {
+      packageOverrides = pkg: {
+        go_bootstrap = pkg.go_bootstrap.overrideAttrs (old: {
+          installPhase = ''
+            sed -i 's/TestChown/testChown/' src/os/os_unix_test.go
+          '' + old.installPhase;
+        });
+        go_1_11 = muslPkgs.go_1_12;
+        go_1_12 = pkg.go_1_12.overrideAttrs (old: {
+          prePatch = ''
+            sed -i 's/TestChown/testChown/' src/os/os_unix_test.go
+            sed -i 's/TestFileChown/testFileChown/' src/os/os_unix_test.go
+            sed -i 's/TestLchown/testLchown/' src/os/os_unix_test.go
+            sed -i 's/TestCoverageUsesAtomicModeForRace/testCoverageUsesAtomicModeForRace/' src/cmd/go/go_test.go
+            sed -i 's/TestTestRaceInstall/testTestRaceInstall/' src/cmd/go/go_test.go
+            sed -i 's/TestGoTestRaceFailures/testGoTestRaceFailures/' src/cmd/go/go_test.go
+            sed -i '/func cmdtest/a return' src/cmd/dist/test.go
+          '' + old.prePatch;
+        });
+        gnupg = glibcPkgs.gnupg;
+        systemd = (import (builtins.elemAt nixpkgs 1) {}).systemd;
+      };
+    };
+  }).pkgsMusl;
+  muslCallPackage = muslPkgs.lib.callPackageWith
+                    (muslPkgs // muslPkgs.xlibs // self);
+
+  static = pkg: pkg.overrideAttrs(old: {
+    configureFlags = (old.configureFlags or []) ++
+      [ "--without-shared" "--disable-shared" ];
+    dontDisableStatic = true;
+    enableSharedExecutables = false;
+    enableStatic = true;
+  });
+
+  patchLvm2 = pkg: pkg.overrideAttrs(old: {
+    configureFlags = [
+      "--disable-cmdlib" "--disable-readline" "--disable-udev_rules"
+      "--disable-udev_sync" "--enable-pkgconfig" "--enable-static_link"
+    ];
+    preConfigure = old.preConfigure + ''
+      substituteInPlace libdm/Makefile.in --replace \
+        SUBDIRS=dm-tools SUBDIRS=
+      substituteInPlace tools/Makefile.in --replace \
+        "TARGETS += lvm.static" ""
+      substituteInPlace tools/Makefile.in --replace \
+        "INSTALL_LVM_TARGETS += install_tools_static" ""
+    '';
+    postInstall = "";
+  });
+
+  self = {
+    cri-o-static-musl = muslCallPackage ./derivation.nix {
+      flavor = "x86_64-static-musl";
+      ldflags = ''-linkmode external -extldflags "-static"'';
+      revision = revision;
+
+      glibc = null;
+      gpgme = (static muslPkgs.gpgme);
+      libassuan = (static muslPkgs.libassuan);
+      libgpgerror = (static muslPkgs.libgpgerror);
+      libseccomp = (static muslPkgs.libseccomp);
+      lvm2 = (patchLvm2 (static muslPkgs.lvm2));
+    };
+    cri-o-static-glibc = glibcCallPackage ./derivation.nix {
+      flavor = "x86_64-static-glibc";
+      ldflags = ''-linkmode external -extldflags "-static -lm"'';
+      revision = revision;
+
+      gpgme = (static glibcPkgs.gpgme);
+      libassuan = (static glibcPkgs.libassuan);
+      libgpgerror = (static glibcPkgs.libgpgerror);
+      libseccomp = (static glibcPkgs.libseccomp);
+      lvm2 = (patchLvm2 (static glibcPkgs.lvm2));
+    };
+  };
+in self

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,0 +1,34 @@
+{ flavor, ldflags ? "", revision,
+  btrfs-progs, buildGoPackage, glibc, gpgme, libapparmor, libassuan,
+  libgpgerror, libseccomp, libselinux, lvm2, pkgconfig, stdenv }:
+
+buildGoPackage rec {
+  project = "cri-o";
+  name = "${project}-${revision}-${flavor}";
+
+  goPackagePath = "github.com/${project}/${project}";
+  src = ./..;
+
+  outputs = [ "bin" "out" ];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ btrfs-progs gpgme libapparmor libassuan
+                  libgpgerror libseccomp libselinux lvm2 ] ++
+                stdenv.lib.optionals (glibc != null) [ glibc glibc.static ];
+
+  makeFlags = ''BUILDTAGS="apparmor seccomp selinux
+    containers_image_ostree_stub"'';
+
+  buildPhase = ''
+    go build -tags ${makeFlags} -o bin/crio -buildmode=pie \
+      -ldflags '-s -w ${ldflags}' ${goPackagePath}/cmd/crio
+  '';
+  installPhase = "install -Dm755 bin/crio $bin/bin/crio-${flavor}";
+
+  meta = with import <nixpkgs/lib>; {
+    homepage = https://cri-o.io;
+    description = ''Open Container Initiative-based implementation of
+                    the Kubernetes Container Runtime Interface'';
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,14 @@
+let
+  nixpkgs = builtins.fetchTarball {
+    name = "nixos-unstable";
+    url = "https://github.com/nixos/nixpkgs/archive/" +
+      "03d6bb52b250d74d096e2286b02c51f595fa90ee.tar.gz";
+    sha256 = "0bngjc4d190bgzhgxv9jszqkapx3ngdpj08rd2arz19ncggflnxv";
+  };
+  nixpkgsMuslSystemd = builtins.fetchTarball {
+    name = "nixos-systemd-musl";
+    url = "https://github.com/dtzWill/nixpkgs/archive/" +
+      "13510d3dbe08e5bfc5454faf3fe543991dbf6e29.tar.gz";
+    sha256 = "090zagbw39fa8fgwvzcmbcr204pxcfrq1rfw7ip5z44naj6gp7qb";
+  };
+in [ nixpkgs nixpkgsMuslSystemd ]

--- a/test/command.bats
+++ b/test/command.bats
@@ -3,20 +3,20 @@
 load helpers
 
 @test "crio commands" {
-	run ${CRIO_BINARY} --config /dev/null config > /dev/null
+	run ${CRIO_BINARY_PATH} --config /dev/null config > /dev/null
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run ${CRIO_BINARY} badoption > /dev/null
+	run ${CRIO_BINARY_PATH} badoption > /dev/null
 	echo "$output"
 	[ "$status" -ne 0 ]
 }
 
 @test "invalid ulimits" {
-	run ${CRIO_BINARY} --default-ulimits doesntexist=2042
+	run ${CRIO_BINARY_PATH} --default-ulimits doesntexist=2042
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "invalid ulimit type: doesntexist" ]]
-	run ${CRIO_BINARY} --default-ulimits nproc=2042:42
+	run ${CRIO_BINARY_PATH} --default-ulimits nproc=2042:42
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "ulimit soft limit must be less than or equal to hard limit: 2042 > 42" ]]
@@ -25,26 +25,26 @@ load helpers
 }
 
 @test "invalid devices" {
-	run ${CRIO_BINARY} --additional-devices /dev/sda:/dev/foo:123
+	run ${CRIO_BINARY_PATH} --additional-devices /dev/sda:/dev/foo:123
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "invalid device mode:" ]]
-	run ${CRIO_BINARY} --additional-devices /dev/sda:/dee/foo:rm
+	run ${CRIO_BINARY_PATH} --additional-devices /dev/sda:/dee/foo:rm
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "invalid device mode:" ]]
-	run ${CRIO_BINARY} --additional-devices /dee/sda:rmw
+	run ${CRIO_BINARY_PATH} --additional-devices /dee/sda:rmw
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "invalid device mode:" ]]
 }
 
 @test "invalid metrics port" {
-	run ${CRIO_BINARY} --metrics-port foo --enable-metrics
+	run ${CRIO_BINARY_PATH} --metrics-port foo --enable-metrics
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "invalid value \"foo\" for flag" ]]
-	run ${CRIO_BINARY} --metrics-port 18446744073709551616 --enable-metrics
+	run ${CRIO_BINARY_PATH} --metrics-port 18446744073709551616 --enable-metrics
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "value out of range" ]]


### PR DESCRIPTION
This commit mainly adds a nix package for having a fully reproducible static build of CRI-O for glibc and musl libc.

- only x86-64 targets are supported for now
- the binaries are stripped
- CI builds runs within a prepared container image on travis
- the binaries are integration tested on travis as well

To test it locally without installed nix but inside a container runtime, simply run:

```
make build-static NIX_IMAGE=<IMAGE>
```

The resulting binaries should now be available within:
- `bin/crio-x86_64-static-glibc`
- `bin/crio-x86_64-static-musl`

To test it within your local nix installation, execute from the root of the git repository:

```
nix-build nix
```

The resulting binary should be now reside in:
- `result-bin/bin/crio-x86_64-static-glibc`
- `result-2-bin/bin/crio-x86_64-static-musl`

Closes #2236

The travis job has to be adapted afterwards to archive the binary and store them as tag assets. We can also decide what else has to be part of the resulting archive, like man pages and the configuration.