### PR TITLE
[master] Add option to inject init binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ test/copyimg/copyimg: .gopathok $(wildcard test/copyimg/*.go)
 test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
 	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkseccomp
 
+test/catatonit/catatonit:
+	./test/catatonit/install_catatonit.sh test
+
 bin/crio: .gopathok
 	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/crio
 
@@ -157,8 +160,8 @@ endif
 	rm -f test/bin2img/bin2img
 	rm -f test/copyimg/copyimg
 	rm -f test/checkseccomp/checkseccomp
+	rm -f test/catatonit/catatonit
 	rm -rf ${BUILD_BIN_PATH}
-
 # the approach here, rather than this target depending on the build targets
 # directly, is such that each target should try to build regardless if it
 # fails. And return a non-zero exit if _any_ target fails.
@@ -276,7 +279,7 @@ localintegration: clean binaries test-binaries
 	./test/test_runner.sh ${TESTFLAGS}
 
 binaries: bin/crio bin/conmon bin/pause
-test-binaries: test/bin2img/bin2img test/copyimg/copyimg test/checkseccomp/checkseccomp
+test-binaries: test/bin2img/bin2img test/copyimg/copyimg test/checkseccomp/checkseccomp test/catatonit/catatonit
 
 MANPAGES_MD := $(wildcard docs/*.md)
 MANPAGES    := $(MANPAGES_MD:%.md=%)

--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -166,6 +166,12 @@ default_mounts = [
 # Maximum number of processes allowed in a container.
 pids_limit = {{ .PidsLimit }}
 
+# Path to init binary to run inside containers that forwards signals and reaps processes
+# if the container has a private pid namespace
+# If the path is empty, init will not be used.
+# Note this binary will be bind mounted in /sbin/crioinit and run followed by '--', the standard for container init processes
+init = "{{ .Init }}"
+
 # Maximum sized allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If it is positive, it must be >= 8192 to
 # match/exceed conmon's read buffer. The file is truncated and re-opened so the

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -163,6 +163,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("pids-limit") {
 		config.PidsLimit = ctx.GlobalInt64("pids-limit")
 	}
+	if ctx.GlobalIsSet("init") {
+		config.Init = ctx.GlobalString("init")
+	}
 	if ctx.GlobalIsSet("log-size-max") {
 		config.LogSizeMax = ctx.GlobalInt64("log-size-max")
 	}
@@ -395,6 +398,10 @@ func main() {
 			Name:  "pids-limit",
 			Value: lib.DefaultPidsLimit,
 			Usage: "maximum number of processes allowed in a container",
+		},
+		cli.StringFlag{
+			Name:  "init",
+			Usage: fmt.Sprintf("Path to an init binary that forwards signals and reaps processes inside containers if the container has a private pid namespace (default: %s)", defConf.Init),
 		},
 		cli.Int64Flag{
 			Name:  "log-size-max",

--- a/lib/config.go
+++ b/lib/config.go
@@ -84,6 +84,10 @@ const (
 	// DefaultLogToJournald is the default value for whether conmon should
 	// log to journald in addition to kubernetes log file.
 	DefaultLogToJournald = false
+
+	// DefaultInitPath is the default value for the path to the init binary
+	// It defaults to empty, signaling to not use an init if not specified
+	DefaultInitPath = ""
 )
 
 // DefaultCapabilities for the default_capabilities option in the crio.conf file
@@ -218,6 +222,12 @@ type RuntimeConfig struct {
 	// PidsLimit is the number of processes each container is restricted to
 	// by the cgroup process number controller.
 	PidsLimit int64 `toml:"pids_limit"`
+
+	// Path to init binary to run inside containers that forwards signals and reaps processes
+	// if the container has a private pid namespace
+	// If the path is empty, init will not be used.
+	// Note this binary will be bind mounted in /sbin/crioinit and run followed by '--', the standard for container init processes
+	Init string `toml:"init"`
 
 	// LogSizeMax is the maximum number of bytes after which the log file
 	// will be truncated. It can be expressed as a human-friendly string
@@ -388,6 +398,7 @@ func DefaultConfig() (*Config, error) {
 			ApparmorProfile:          apparmorProfileName,
 			CgroupManager:            cgroupManager,
 			PidsLimit:                DefaultPidsLimit,
+			Init:                     DefaultInitPath,
 			ContainerExitsDir:        containerExitsDir,
 			ContainerAttachSocketDir: ContainerAttachSocketDir,
 			LogSizeMax:               DefaultLogSizeMax,

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -139,7 +139,7 @@ func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error)
 
 	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.PauseImage, config.PauseImageAuthFile)
 
-	runtime, err := oci.New(config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.LogToJournald, config.NoPivot, config.CtrStopTimeout)
+	runtime, err := oci.New(config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.LogToJournald, config.NoPivot, config.CtrStopTimeout, config.Init)
 	if err != nil {
 		return nil, err
 	}
@@ -451,6 +451,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 
+	// TODO FIXME We currently don't set anything up for the init binary here.
 	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, privileged, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
@@ -574,6 +575,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 		return err
 	}
 
+	// TODO FIXME We currently don't set anything up for the init binary here.
 	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, img, imgName, imgRef, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.Privileged(), sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -56,6 +56,7 @@ type Runtime struct {
 	logToJournald            bool
 	noPivot                  bool
 	ctrStopTimeout           int64
+	init                     string
 
 	runtimeImplList map[string]RuntimeImpl
 }
@@ -107,7 +108,8 @@ func New(defaultRuntime string,
 	logSizeMax int64,
 	logToJournald bool,
 	noPivot bool,
-	ctrStopTimeout int64) (*Runtime, error) {
+	ctrStopTimeout int64,
+	init string) (*Runtime, error) {
 
 	defRuntime, ok := runtimes[defaultRuntime]
 	if !ok {
@@ -130,6 +132,7 @@ func New(defaultRuntime string,
 		noPivot:                  noPivot,
 		ctrStopTimeout:           ctrStopTimeout,
 		runtimeImplList:          make(map[string]RuntimeImpl),
+		init:                     init,
 	}, nil
 }
 

--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -14,7 +14,7 @@ var _ = t.Describe("Oci", func() {
 			// When
 			runtime, err := oci.New("runc",
 				map[string]oci.RuntimeHandler{"runc": {"/bin/sh", "", "/run/runc"}},
-				"", []string{}, "", "", "", 0, false, false, 0)
+				"", []string{}, "", "", "", 0, false, false, 0, "")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -26,7 +26,7 @@ var _ = t.Describe("Oci", func() {
 			// When
 			runtime, err := oci.New("",
 				map[string]oci.RuntimeHandler{}, "", []string{},
-				"", "", "", 0, false, false, 0)
+				"", "", "", 0, false, false, 0, "")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -51,7 +51,7 @@ var _ = t.Describe("Oci", func() {
 			var err error
 			sut, err = oci.New(defaultRuntime,
 				runtimes,
-				"", []string{}, "", "", "", 0, false, false, 0)
+				"", []string{}, "", "", "", 0, false, false, 0, "")
 
 			Expect(err).To(BeNil())
 			Expect(sut).NotTo(BeNil())

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -218,7 +218,7 @@ func addDevices(sb *sandbox.Sandbox, containerConfig *pb.ContainerConfig, specge
 }
 
 // buildOCIProcessArgs build an OCI compatible process arguments slice.
-func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig *v1.Image) ([]string, error) {
+func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig *v1.Image, initArgs []string) ([]string, error) {
 	// # Start the nginx container using the default command, but use custom
 	// arguments (arg1 .. argN) for that command.
 	// kubectl run nginx --image=nginx -- <arg1> <arg2> ... <argN>
@@ -258,6 +258,7 @@ func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig
 	}
 
 	processArgs := append([]string{entrypoint}, args...)
+	processArgs = append(initArgs, processArgs...)
 
 	logrus.Debugf("OCI process args %v", processArgs)
 

--- a/test/catatonit/install_catatonit.sh
+++ b/test/catatonit/install_catatonit.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+BASE_PATH="$1"
+CATATONIT_PATH="${BASE_PATH}/catatonit"
+CATATONIT_VERSION="v0.1.3"
+
+if [ -f $CATATONIT_PATH ]; then
+    echo "skipping ... catatonit is already installed"
+else
+    echo "downloading catatonit to $CATATONIT_PATH"
+    curl -o catatonit -L https://github.com/openSUSE/catatonit/releases/download/$CATATONIT_VERSION/catatonit.x86_64
+    chmod +x catatonit
+    install ${SELINUXOPT} -d -m 755 $BASE_PATH
+    install ${SELINUXOPT} -m 755 catatonit $CATATONIT_PATH
+    rm catatonit
+fi

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -59,6 +59,8 @@ ARTIFACTS_PATH=${ARTIFACTS_PATH:-${CRIO_ROOT}/cri-o/.artifacts}
 CHECKSECCOMP_BINARY=${CHECKSECCOMP_BINARY:-${CRIO_ROOT}/cri-o/test/checkseccomp/checkseccomp}
 # The default log directory where all logs will go unless directly specified by the kubelet
 DEFAULT_LOG_PATH=${DEFAULT_LOG_PATH:-/var/log/crio/pods}
+# Path of the init binary binary.
+INIT_BINARY=${INIT_BINARY:-${CRIO_ROOT}/cri-o/test/catatonit/catatonit}
 # Cgroup manager to be used
 CGROUP_MANAGER=${CGROUP_MANAGER:-cgroupfs}
 # Image volumes handling
@@ -313,6 +315,14 @@ function start_crio() {
 function start_crio_journald() {
 	setup_crio "$@"
 	"$CRIO_BINARY_PATH" --default-mounts-file "$TESTDIR/containers/mounts.conf" --log-level debug --log-journald --config "$CRIO_CONFIG" & CRIO_PID=$!
+	wait_until_reachable
+	pull_test_containers
+}
+
+# Start crio with an init binary
+function start_crio_init() {
+	setup_crio "$@"
+	"$CRIO_BINARY_PATH" --default-mounts-file "$TESTDIR/containers/mounts.conf" --log-level debug --init "$INIT_BINARY" --config "$CRIO_CONFIG" & CRIO_PID=$!
 	wait_until_reachable
 	pull_test_containers
 }

--- a/test/namespaces.bats
+++ b/test/namespaces.bats
@@ -6,13 +6,18 @@ function teardown() {
 	cleanup_test
 }
 
-@test "pid_namespace_mode_pod_test" {
+@test "pid namespace mode pod test" {
 	start_crio
-	run crictl runp "$TESTDATA"/sandbox_pidnamespacemode_config.json
+
+	newconfigsandbox=$(mktemp --tmpdir crio-config.XXXXXX.json)
+	cp "$TESTDATA"/sandbox_pidnamespacemode_config.json "$newconfigsandbox"
+	sed -i 's|"%pidmode%"|0|' "$newconfigsandbox"
+
+	run crictl runp "$newconfigsandbox"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	pod_id="$output"
-	run crictl create "$pod_id" "$TESTDATA"/container_redis_namespace.json "$TESTDATA"/sandbox_pidnamespacemode_config.json
+	run crictl create "$pod_id" "$TESTDATA"/container_redis_namespace.json "$newconfigsandbox"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	ctr_id="$output"
@@ -23,6 +28,41 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ pause ]]
+
+	run crictl stopp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rmp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "pid namespace mode container with init" {
+	start_crio_init
+
+	newconfigsandbox=$(mktemp --tmpdir crio-config.XXXXXX.json)
+	cp "$TESTDATA"/sandbox_pidnamespacemode_config.json "$newconfigsandbox"
+	sed -i 's|"%pidmode%"|1|' "$newconfigsandbox"
+
+	run crictl runp "$newconfigsandbox"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run crictl create "$pod_id" "$TESTDATA"/container_redis_namespace.json "$newconfigsandbox"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	[ "$status" -eq 0 ]
+
+	run crictl exec --sync "$ctr_id" ps | grep -v 'init' | grep ps | awk '{print $1}'
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 1 ]]
 
 	run crictl stopp "$pod_id"
 	echo "$output"

--- a/test/testdata/sandbox_pidnamespacemode_config.json
+++ b/test/testdata/sandbox_pidnamespacemode_config.json
@@ -40,7 +40,7 @@
 				"host_network": false,
 				"host_pid": false,
                 "host_ipc": false,
-                "pid": 0
+                "pid": "%pidmode%"
 			},
 			"selinux_options": {
 				"user": "system_u",


### PR DESCRIPTION
When a container is run with a private PID namespace, we want the user to be able to define an init binary and run their containers with it.
To do this:
	Add --init and --init-path as options in cri-o CLI and config files. The defaults are false and /usr/libexec/crio/catatonit
	Add a mount '/dev/init' that ro bind mounts the init binary the user specified if we are in a private PIDNS, and prepend '/dev/init --' to the process args
	Add bats test to verify functionality
	Add a install_catatonit.sh that pulls catatonit binary for testing with with bats.
