### PR TITLE
Remove gofmt Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ help:
 	@echo " * 'integration' - Execute integration tests"
 	@echo " * 'clean' - Clean artifacts"
 	@echo " * 'lint' - Execute the source code linter"
-	@echo " * 'gofmt' - Verify the source code gofmt"
 
 # Dummy target for marking pattern rules phony
 .explicit_phony:
@@ -87,14 +86,10 @@ endif
 lint: .gopathok ${GOLANGCI_LINT}
 	${GOLANGCI_LINT} run --build-tags="$(BUILDTAGS) containers_image_ostree_stub"
 
-fmt: gofmt cfmt
+fmt: cfmt
 
 cfmt:
 	find . '(' -name '*.h' -o -name '*.c' ')' ! -path './vendor/*'  -exec clang-format -i {} \+
-	git diff --exit-code
-
-gofmt:
-	find . -name '*.go' ! -path './vendor/*' -exec gofmt -s -w {} \+
 	git diff --exit-code
 
 bin/conmon: conmon/config.h
@@ -336,7 +331,6 @@ endif
 	clean \
 	default \
 	docs \
-	gofmt \
 	help \
 	install \
 	lint \

--- a/contrib/test/integration/golang.yml
+++ b/contrib/test/integration/golang.yml
@@ -18,7 +18,6 @@
     state: link
   with_items:
     - go
-    - gofmt
     - godoc
 
 - name: ensure user profile exists


### PR DESCRIPTION
golangci-lint already lints with gofmt so we should avoid checking twice.