### PR TITLE
Remove ostree dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,6 @@ before_install:
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install libc-dev linux-libc-dev; fi
   - if [ "${TRAVIS_OS_NAME}" = osx ]; then brew update && brew install gpgme; fi
 
-install:
-  - >
-    if [ "${TRAVIS_OS_NAME}" = linux ]; then
-      OSTREE_VERSION=v2017.9;
-      git clone https://github.com/ostreedev/ostree ${TRAVIS_BUILD_DIR}/ostree &&
-      (
-        cd ${TRAVIS_BUILD_DIR}/ostree &&
-        git checkout $OSTREE_VERSION &&
-        ./autogen.sh --prefix=/usr/local &&
-        make all &&
-        sudo make install
-      )
-    fi
-
 before_script:
   - export PATH=$HOME/gopath/bin:$PATH
   - export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && apt-get install -y \
     libfuse-dev \
     libnet-dev \
     libnl-3-dev \
-    libostree-dev \
     libprotobuf-dev \
     libprotobuf-c0-dev \
     libseccomp2 \

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -41,7 +41,6 @@
     - oci-umount
     - openssl
     - openssl-devel
-    - ostree-devel
     - pkgconfig
     - python
     - python2-crypto

--- a/hack/ostree_tag.sh
+++ b/hack/ostree_tag.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-if ! pkg-config ostree-1 2> /dev/null ; then
-	echo containers_image_ostree_stub
-fi


### PR DESCRIPTION
Since ostree is not needed any more we can remove the installation from our CI to gain a general speedup. Beside this, the script `hack/ostree_tag.sh` does not seem to be needed any more.