### PR TITLE
Update unit tests to use empty CNI hooks dir per default

### DIFF
--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -33,6 +33,7 @@ var _ = t.Describe("ContainerServer", func() {
 			config, err := lib.DefaultConfig()
 			Expect(err).To(BeNil())
 			config.FileLockingPath = tmpfile.Name()
+			config.HooksDir = []string{}
 
 			// Specify mocks
 			gomock.InOrder(

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -121,6 +121,7 @@ func beforeEach() {
 	Expect(err).To(BeNil())
 	config.FileLocking = false
 	config.LogDir = "."
+	config.HooksDir = []string{}
 
 	gomock.InOrder(
 		libMock.EXPECT().GetStore().Return(storeMock, nil),


### PR DESCRIPTION
This makes the unit tests more system independent, since we do not automatically fallback to the default OCI hooks directories.

Closes #2229