### PR TITLE
Add openpgp_tag.sh as fallback if no gpgme is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ BUILDTAGS ?= containers_image_ostree_stub \
 			 $(shell hack/btrfs_tag.sh) \
 			 $(shell hack/libdm_installed.sh) \
 			 $(shell hack/libdm_no_deferred_remove_tag.sh) \
+			 $(shell hack/openpgp_tag.sh) \
 			 $(shell hack/seccomp_tag.sh) \
 			 $(shell hack/selinux_tag.sh)
 CRICTL_CONFIG_DIR=${DESTDIR}/etc

--- a/hack/openpgp_tag.sh
+++ b/hack/openpgp_tag.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if ! pkg-config gpgme 2>/dev/null; then
+    echo containers_image_openpgp
+fi


### PR DESCRIPTION
Hey, I'm not sure if we want to support this but we can build CRI-O without `gpgme-devel`, `libassuan-devel` and `libgpg-error-devel`.
