### PR TITLE
Update PluginDir to be created if not existing

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -507,7 +507,7 @@ func (c *NetworkConfig) Validate(onExecution bool) error {
 		}
 
 		for _, pluginDir := range c.PluginDir {
-			if _, err := os.Stat(pluginDir); err != nil {
+			if err := os.MkdirAll(pluginDir, 0755); err != nil {
 				return errors.Wrapf(err, "invalid plugin_dir entry")
 			}
 		}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/cri-o/cri-o/lib"
@@ -113,7 +114,9 @@ func TestConfigValidateDefaultSuccessOnExecution(t *testing.T) {
 	defaultConfig.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
 	defaultConfig.Conmon = validPath
 	defaultConfig.NetworkConfig.NetworkDir = validPath
-	defaultConfig.NetworkConfig.PluginDir = []string{validPath}
+	tmpDir := path.Join(os.TempDir(), "cni-test")
+	defaultConfig.NetworkConfig.PluginDir = []string{tmpDir}
+	defer os.RemoveAll(tmpDir)
 
 	must(t, defaultConfig.Validate(true))
 }


### PR DESCRIPTION
Kubernetes DeamonSets should be able to add CNI plugins after the start
of CRI-O. But currently, CRI-O fails to start if the PluginDir is not
available. This is now solved by simply creating the directory on
configuration validation.

Furthermore, it will be now validated if the specified PluginDirs are
real directories (and not a files for example).