### PR TITLE
[1.13] Fix logic of server.restore()

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -451,7 +451,9 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		}
 	}
 
-	c.ContainerStateFromDisk(scontainer)
+	if err := c.ContainerStateFromDisk(scontainer); err != nil {
+		return fmt.Errorf("error reading sandbox state from disk %q: %v", scontainer.ID(), err)
+	}
 	sb.SetCreated()
 
 	if err = label.ReserveLabel(processLabel); err != nil {
@@ -566,7 +568,9 @@ func (c *ContainerServer) LoadContainer(id string) error {
 	spp := m.Annotations[annotations.SeccompProfilePath]
 	ctr.SetSeccompProfilePath(spp)
 
-	c.ContainerStateFromDisk(ctr)
+	if err := c.ContainerStateFromDisk(ctr); err != nil {
+		return fmt.Errorf("error reading container state from disk %q: %v", ctr.ID(), err)
+	}
 	ctr.SetCreated()
 
 	c.AddContainer(ctr)
@@ -583,9 +587,9 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 	if err := ctr.FromDisk(); err != nil {
 		return err
 	}
-	// ignore errors, this is a best effort to have up-to-date info about
-	// a given container before its state gets stored
-	c.runtime.UpdateStatus(ctr)
+	if err := c.runtime.UpdateStatus(ctr); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -593,9 +597,9 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 // ContainerStateToDisk writes the container's state information to a JSON file
 // on disk
 func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
-	// ignore errors, this is a best effort to have up-to-date info about
-	// a given container before its state gets stored
-	c.Runtime().UpdateStatus(ctr)
+	if err := c.Runtime().UpdateStatus(ctr); err != nil {
+		logrus.Warnf("error updating the container status %q: %v", ctr.ID(), err)
+	}
 
 	jsonSource, err := ioutils.NewAtomicFileWriter(ctr.StatePath(), 0644)
 	if err != nil {


### PR DESCRIPTION
When cri-o is restarted, we were not returning an error if
an error ocurred when reading container state from disk. So
if the state.json file was corrupted or deleted in the meantime
the containers would be reporting an UNKOWN state and default
values for started time, created time, etc.
We now check for that and if a pod can't be restored, we delete the pod
as well as any containers associated with it. We also release the pod
and container names so that they can be used again.
We do the same for any containers that can't be restored.

Should fix https://bugzilla.redhat.com/show_bug.cgi?id=1702655

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
