### PR TITLE
Add unit test inject files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ BUILD_BIN_PATH := ${BUILD_PATH}/bin
 COVERAGE_PATH := ${BUILD_PATH}/coverage
 TESTBIN_PATH := ${BUILD_PATH}/test
 MOCK_PATH := ${PWD}/test/mocks
-MOCKGEN_FLAGS := --build_flags='--tags=$(BUILDTAGS)'
+MOCKGEN_FLAGS := --build_flags='--tags=test $(BUILDTAGS)'
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
@@ -92,7 +92,7 @@ endif
 	touch "$(GOPATH)/.gopathok"
 
 lint: .gopathok ${GOLANGCI_LINT}
-	${GOLANGCI_LINT} run --build-tags="$(BUILDTAGS)"
+	${GOLANGCI_LINT} run --build-tags="test $(BUILDTAGS)"
 
 fmt: cfmt
 
@@ -208,7 +208,7 @@ testunit: mockgen ${GINKGO}
 		--covermode atomic \
 		--outputdir ${COVERAGE_PATH} \
 		--coverprofile coverprofile \
-		--tags "$(BUILDTAGS)" \
+		--tags "test $(BUILDTAGS)" \
 		--succinct
 	# fixes https://github.com/onsi/ginkgo/issues/518
 	sed -i '2,$${/^mode: atomic/d;}' ${COVERAGE_PATH}/coverprofile
@@ -219,7 +219,7 @@ testunit-bin:
 	mkdir -p ${TESTBIN_PATH}
 	for PACKAGE in `$(GO) list ./...`; do \
 		go test $$PACKAGE \
-			--tags "$(BUILDTAGS)" \
+			--tags "test $(BUILDTAGS)" \
 			--gcflags '-N' -c -o ${TESTBIN_PATH}/$$(basename $$PACKAGE) ;\
 	done
 

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -62,14 +62,6 @@ func (c *ContainerServer) Runtime() oci.RuntimeImpl {
 	return c.runtime
 }
 
-// SetRuntime can be used to explicitly specify a runtime.
-//
-// In production cases calling this function has no need because the runtime
-// will already be set by `New()`.
-func (c *ContainerServer) SetRuntime(runtime oci.RuntimeImpl) {
-	c.runtime = runtime
-}
-
 // Store returns the Store for the ContainerServer
 func (c *ContainerServer) Store() cstorage.Store {
 	return c.store

--- a/lib/container_server_test_inject.go
+++ b/lib/container_server_test_inject.go
@@ -1,0 +1,25 @@
+// +build test
+// All *_inject.go files are meant to be used by tests only. Purpose of this
+// files is to provide a way to inject mocked data into the current setup.
+
+package lib
+
+import (
+	"github.com/cri-o/cri-o/oci"
+	"github.com/cri-o/cri-o/pkg/storage"
+)
+
+// SetStorageRuntimeServer sets the runtime server for the ContainerServer
+func (c *ContainerServer) SetStorageRuntimeServer(server storage.RuntimeServer) {
+	c.storageRuntimeServer = server
+}
+
+// SetStorageImageServer sets the ImageServer for the ContainerServer
+func (c *ContainerServer) SetStorageImageServer(server storage.ImageServer) {
+	c.storageImageServer = server
+}
+
+// SetRuntime can be used to explicitly specify a runtime.
+func (c *ContainerServer) SetRuntime(runtime oci.RuntimeImpl) {
+	c.runtime = runtime
+}

--- a/oci/container.go
+++ b/oci/container.go
@@ -296,13 +296,6 @@ func (c *Container) IDMappings() *idtools.IDMappings {
 	return c.idMappings
 }
 
-// SetState sets the container state
-//
-// XXX: DO NOT EVER USE THIS, THIS IS JUST USEFUL FOR MOCKING!!!
-func (c *Container) SetState(state *ContainerState) {
-	c.state = state
-}
-
 // SetCreated sets the created flag to true once container is created
 func (c *Container) SetCreated() {
 	c.created = true

--- a/oci/container_test_inject.go
+++ b/oci/container_test_inject.go
@@ -1,0 +1,10 @@
+// +build test
+// All *_inject.go files are meant to be used by tests only. Purpose of this
+// files is to provide a way to inject mocked data into the current setup.
+
+package oci
+
+// SetState sets the container state
+func (c *Container) SetState(state *ContainerState) {
+	c.state = state
+}

--- a/server/server_test_inject.go
+++ b/server/server_test_inject.go
@@ -1,0 +1,24 @@
+// +build test
+// All *_inject.go files are meant to be used by tests only. Purpose of this
+// files is to provide a way to inject mocked data into the current setup.
+
+package server
+
+import (
+	"github.com/cri-o/ocicni/pkg/ocicni"
+)
+
+// SetStorageRuntimeServer sets the runtime server for the ContainerServer
+func (s *streamService) SetRuntimeServer(server *Server) {
+	s.runtimeServer = server
+}
+
+// SetNetPlugin sets the network plugin for the ContainerServer. The function
+// errors if a sane shutdown of the initially created network plugin failed.
+func (s *Server) SetNetPlugin(plugin ocicni.CNIPlugin) error {
+	if err := s.netPlugin.Shutdown(); err != nil {
+		return err
+	}
+	s.netPlugin = plugin
+	return nil
+}


### PR DESCRIPTION
This commit introduces a new build tag `test` to separate the testing API from the user API. All test targets have been adapted to use this tag, whereas the main binaries are excluded. This make some mentions that "this API function should not be used" obsolete and provides us more flexibility for future mocking approaches.

All methods I added here will be used by unit tests later on.