### PR TITLE
[1.13] Fix integration tests for missing cni_plugin_helper.bash

### DIFF
--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -30,5 +30,8 @@ function execute() {
 # Tests to run. Defaults to all.
 TESTS=${@:-.}
 
+# Copy the cni helper
+cp cni_plugin_helper.bash /opt/cni/bin
+
 # Run the tests.
 execute time bats --tap $TESTS


### PR DESCRIPTION
This is a trivial test if the release-1.13 pipeline runs as intended whether to check if we need to apply a fix.

Relates to: #2285

---

Edit: Found the problem, applied a quick fix and changed the commit message:

```
Some test machines do not have the `cni_plugin_helper.bash` installed
when running the integration tests. This commit fixes it with a manual
installation before running the actual suite.
```