### PR TITLE
[1.11] Fix integration tests

### DIFF
--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -30,5 +30,8 @@ function execute() {
 # Tests to run. Defaults to all.
 TESTS=${@:-.}
 
+# Copy the cni helper
+cp cni_plugin_helper.bash /opt/cni/bin
+
 # Run the tests.
 execute time bats --tap $TESTS


### PR DESCRIPTION
Some test machines do not have the `cni_plugin_helper.bash` installed
when running the integration tests. This commit fixes it with a manual
installation before running the actual suite.

Backport of: #2289
Cherry-pick: 67e7515f22a1a0be3aca4c65c92966b280920cd0