### PR TITLE
Fix hack/openpgp_tag.sh on older distributions

### DIFF
--- a/hack/openpgp_tag.sh
+++ b/hack/openpgp_tag.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-if ! pkg-config gpgme 2>/dev/null; then
+if ! gpgme-config --libs &>/dev/null; then
     echo containers_image_openpgp
 fi


### PR DESCRIPTION
Some distributions do not ship the `pkg-config` files for gpgme. This
commit uses the `gpgme-config` tool to check for its availability, which
should work for every distribution.