### PR TITLE
[1.14] Fix `make vendor` on travis and integration tests

### DIFF
--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -30,5 +30,8 @@ function execute() {
 # Tests to run. Defaults to all.
 TESTS=${@:-.}
 
+# Copy the cni helper
+cp cni_plugin_helper.bash /opt/cni/bin
+
 # Run the tests.
 execute time bats --tap $TESTS

--- a/vendor/github.com/fsouza/go-dockerclient/go.mod
+++ b/vendor/github.com/fsouza/go-dockerclient/go.mod
@@ -1,0 +1,42 @@
+module github.com/fsouza/go-dockerclient
+
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+	github.com/Microsoft/go-winio v0.4.11
+	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5
+	github.com/containerd/continuity v0.0.0-20180814194400-c7c5070e6f6e // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/docker v0.7.3-0.20180827131323-0c5f8d2b9b23
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.3.3
+	github.com/docker/libnetwork v0.8.0-dev.2.0.20180608203834-19279f049241 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/gogo/protobuf v1.1.1 // indirect
+	github.com/golang/protobuf v1.2.0 // indirect
+	github.com/google/go-cmp v0.2.0
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/mux v1.6.2
+	github.com/hpcloud/tail v1.0.0 // indirect
+	github.com/onsi/ginkgo v1.6.0 // indirect
+	github.com/onsi/gomega v1.4.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/opencontainers/runc v0.1.1 // indirect
+	github.com/pkg/errors v0.8.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.0.6
+	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/vishvananda/netlink v1.0.0 // indirect
+	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
+	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac // indirect
+	golang.org/x/net v0.0.0-20180826012351-8a410e7b638d // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
+	golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87
+	golang.org/x/text v0.3.0 // indirect
+	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
+	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.2.1 // indirect
+	gotest.tools v2.1.0+incompatible // indirect
+)

--- a/vendor/github.com/lithammer/dedent/go.mod
+++ b/vendor/github.com/lithammer/dedent/go.mod
@@ -1,0 +1,1 @@
+module github.com/lithammer/dedent

--- a/vendor/github.com/onsi/gomega/go.mod
+++ b/vendor/github.com/onsi/gomega/go.mod
@@ -1,0 +1,15 @@
+module github.com/onsi/gomega
+
+require (
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/golang/protobuf v1.2.0
+	github.com/hpcloud/tail v1.0.0 // indirect
+	github.com/onsi/ginkgo v1.6.0
+	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
+	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e // indirect
+	golang.org/x/text v0.3.0 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.2.1
+)

--- a/vendor/golang.org/x/sys/go.mod
+++ b/vendor/golang.org/x/sys/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/sys
+
+go 1.12

--- a/vendor/golang.org/x/text/go.mod
+++ b/vendor/golang.org/x/text/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/text
+
+require golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e

--- a/vendor/gopkg.in/yaml.v2/go.mod
+++ b/vendor/gopkg.in/yaml.v2/go.mod
@@ -1,0 +1,5 @@
+module "gopkg.in/yaml.v2"
+
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)


### PR DESCRIPTION
We pull the latest version of vndr during `make vendor`, which breaks up
the CI pipeline because of an upstream change.

Relates to: https://github.com/LK4D4/vndr/commit/a6135d4a2be464cb8bf5c3ae61f86da8ac9d6fde

On top of that I cherry picket the integration test fixes.