### PR TITLE
[1.13] Containers run as a USER should have UID in /etc/passwd

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -14,11 +13,11 @@ import (
 	"github.com/cri-o/cri-o/lib/sandbox"
 	"github.com/cri-o/cri-o/pkg/seccomp"
 	"github.com/cri-o/cri-o/pkg/storage"
+	"github.com/cri-o/cri-o/utils"
 	dockermounts "github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/runc/libcontainer/user"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
@@ -266,7 +265,7 @@ func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig
 }
 
 // setupContainerUser sets the UID, GID and supplemental groups in OCI runtime config
-func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.LinuxContainerSecurityContext, imageConfig *v1.Image) error {
+func setupContainerUser(specgen *generate.Generator, rootfs, mountLabel, ctrRunDir string, sc *pb.LinuxContainerSecurityContext, imageConfig *v1.Image) error {
 	if sc == nil {
 		return nil
 	}
@@ -285,13 +284,31 @@ func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.Linux
 	if err != nil {
 		return err
 	}
-
 	logrus.Debugf("CONTAINER USER: %+v", containerUser)
 
 	// Add uid, gid and groups from user
-	uid, gid, addGroups, err := getUserInfo(rootfs, containerUser)
+	uid, gid, addGroups, err := utils.GetUserInfo(rootfs, containerUser)
 	if err != nil {
 		return err
+	}
+
+	// verify uid exists in containers /etc/passwd, else generate a passwd with the user entry
+	passwdPath, err := utils.GeneratePasswd(uid, gid, rootfs, ctrRunDir)
+	if err != nil {
+		return err
+	}
+	if passwdPath != "" {
+		if err := securityLabel(passwdPath, mountLabel, false); err != nil {
+			return err
+		}
+
+		mnt := rspec.Mount{
+			Type:        "bind",
+			Source:      passwdPath,
+			Destination: "/etc/passwd",
+			Options:     []string{"ro", "bind", "nodev", "nosuid", "noexec"},
+		}
+		specgen.AddMount(mnt)
 	}
 
 	specgen.SetProcessUID(uid)
@@ -634,47 +651,4 @@ func (s *Server) getAppArmorProfileName(profile string) string {
 	}
 
 	return strings.TrimPrefix(profile, apparmorLocalHostPrefix)
-}
-
-// openContainerFile opens a file inside a container rootfs safely
-func openContainerFile(rootfs string, path string) (io.ReadCloser, error) {
-	fp, err := symlink.FollowSymlinkInScope(filepath.Join(rootfs, path), rootfs)
-	if err != nil {
-		return nil, err
-	}
-	return os.Open(fp)
-}
-
-// getUserInfo returns UID, GID and additional groups for specified user
-// by looking them up in /etc/passwd and /etc/group
-func getUserInfo(rootfs string, userName string) (uint32, uint32, []uint32, error) {
-	// We don't care if we can't open the file because
-	// not all images will have these files
-	passwdFile, err := openContainerFile(rootfs, "/etc/passwd")
-	if err != nil {
-		logrus.Warnf("Failed to open /etc/passwd: %v", err)
-	} else {
-		defer passwdFile.Close()
-	}
-
-	groupFile, err := openContainerFile(rootfs, "/etc/group")
-	if err != nil {
-		logrus.Warnf("Failed to open /etc/group: %v", err)
-	} else {
-		defer groupFile.Close()
-	}
-
-	execUser, err := user.GetExecUser(userName, nil, passwdFile, groupFile)
-	if err != nil {
-		return 0, 0, nil, err
-	}
-
-	uid := uint32(execUser.Uid)
-	gid := uint32(execUser.Gid)
-	var additionalGids []uint32
-	for _, g := range execUser.Sgids {
-		additionalGids = append(additionalGids, uint32(g))
-	}
-
-	return uid, gid, additionalGids, nil
 }

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -882,7 +882,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 
 	// Setup user and groups
 	if linux != nil {
-		if err = setupContainerUser(&specgen, mountPoint, linux.GetSecurityContext(), containerImageConfig); err != nil {
+		if err = setupContainerUser(&specgen, mountPoint, mountLabel, containerInfo.RunDir, linux.GetSecurityContext(), containerImageConfig); err != nil {
 			return nil, err
 		}
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,12 +2,23 @@ package utils
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+
+	"github.com/containers/libpod/pkg/lookup"
+	"github.com/docker/docker/pkg/symlink"
+	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	systemdDbus "github.com/coreos/go-systemd/dbus"
 	"github.com/godbus/dbus"
@@ -172,4 +183,83 @@ func WriteGoroutineStacksToFile(path string) error {
 	defer f.Sync()
 
 	return WriteGoroutineStacks(f)
+}
+
+// GenerateID generates a random unique id.
+func GenerateID() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// openContainerFile opens a file inside a container rootfs safely
+func openContainerFile(rootfs string, path string) (io.ReadCloser, error) {
+	fp, err := symlink.FollowSymlinkInScope(filepath.Join(rootfs, path), rootfs)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(fp)
+}
+
+// GetUserInfo returns UID, GID and additional groups for specified user
+// by looking them up in /etc/passwd and /etc/group
+func GetUserInfo(rootfs string, userName string) (uint32, uint32, []uint32, error) {
+	// We don't care if we can't open the file because
+	// not all images will have these files
+	passwdFile, err := openContainerFile(rootfs, "/etc/passwd")
+	if err != nil {
+		logrus.Warnf("Failed to open /etc/passwd: %v", err)
+	} else {
+		defer passwdFile.Close()
+	}
+
+	groupFile, err := openContainerFile(rootfs, "/etc/group")
+	if err != nil {
+		logrus.Warnf("Failed to open /etc/group: %v", err)
+	} else {
+		defer groupFile.Close()
+	}
+
+	execUser, err := user.GetExecUser(userName, nil, passwdFile, groupFile)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+
+	uid := uint32(execUser.Uid)
+	gid := uint32(execUser.Gid)
+	var additionalGids []uint32
+	for _, g := range execUser.Sgids {
+		additionalGids = append(additionalGids, uint32(g))
+	}
+
+	return uid, gid, additionalGids, nil
+}
+
+// GeneratePasswd generates a container specific passwd file,
+// iff uid is not defined in the containers /etc/passwd
+func GeneratePasswd(uid, gid uint32, rootfs, rundir string) (string, error) {
+	// if UID exists inside of container rootfs /etc/passwd then
+	// don't generate passwd
+	if _, err := lookup.GetUser(rootfs, strconv.Itoa(int(uid))); err == nil {
+		return "", nil
+	}
+	passwdFile := filepath.Join(rundir, "passwd")
+	originPasswdFile, err := symlink.FollowSymlinkInScope(filepath.Join(rootfs, "/etc/passwd"), rootfs)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to follow symlinks to passwd file")
+	}
+	orig, err := ioutil.ReadFile(originPasswdFile)
+	if err != nil {
+		// If no /etc/passwd in container ignore and return
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", errors.Wrapf(err, "unable to read passwd file %s", originPasswdFile)
+	}
+
+	pwd := fmt.Sprintf("%s%d:x:%d:%d:container user:%s:/bin/sh\n", orig, uid, uid, gid, "/")
+	if err := ioutil.WriteFile(passwdFile, []byte(pwd), 0644); err != nil {
+		return "", errors.Wrapf(err, "failed to create temporary passwd file")
+	}
+	return passwdFile, nil
 }

--- a/vendor/github.com/containers/libpod/pkg/lookup/lookup.go
+++ b/vendor/github.com/containers/libpod/pkg/lookup/lookup.go
@@ -1,0 +1,158 @@
+package lookup
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/cyphar/filepath-securejoin"
+	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	etcpasswd = "/etc/passwd"
+	etcgroup  = "/etc/group"
+)
+
+// Overrides allows you to override defaults in GetUserGroupInfo
+type Overrides struct {
+	DefaultUser            *user.ExecUser
+	ContainerEtcPasswdPath string
+	ContainerEtcGroupPath  string
+}
+
+// GetUserGroupInfo takes string forms of the the container's mount path and the container user and
+// returns a ExecUser with uid, gid, sgids, and home.  And override can be provided for defaults.
+func GetUserGroupInfo(containerMount, containerUser string, override *Overrides) (*user.ExecUser, error) {
+	var (
+		passwdDest, groupDest string
+		defaultExecUser       *user.ExecUser
+		err                   error
+	)
+	passwdPath := etcpasswd
+	groupPath := etcgroup
+
+	if override != nil {
+		// Check for an override /etc/passwd path
+		if override.ContainerEtcPasswdPath != "" {
+			passwdPath = override.ContainerEtcPasswdPath
+		}
+		// Check for an override for /etc/group path
+		if override.ContainerEtcGroupPath != "" {
+			groupPath = override.ContainerEtcGroupPath
+		}
+	}
+
+	// Check for an override default user
+	if override != nil && override.DefaultUser != nil {
+		defaultExecUser = override.DefaultUser
+	} else {
+		// Define a default container user
+		//defaultExecUser = &user.ExecUser{
+		//	Uid:  0,
+		//	Gid:  0,
+		//	Home: "/",
+		defaultExecUser = nil
+
+	}
+
+	// Make sure the /etc/group  and /etc/passwd destinations are not a symlink to something naughty
+	if passwdDest, err = securejoin.SecureJoin(containerMount, passwdPath); err != nil {
+		logrus.Debug(err)
+		return nil, err
+	}
+	if groupDest, err = securejoin.SecureJoin(containerMount, groupPath); err != nil {
+		logrus.Debug(err)
+		return nil, err
+	}
+	return user.GetExecUserPath(containerUser, defaultExecUser, passwdDest, groupDest)
+}
+
+// GetContainerGroups uses securejoin to get a list of numerical groupids from a container. Per the runc
+// function it calls: If a group name cannot be found, an error will be returned. If a group id cannot be found,
+// or the given group data is nil, the id will be returned as-is  provided it is in the legal range.
+func GetContainerGroups(groups []string, containerMount string, override *Overrides) ([]uint32, error) {
+	var (
+		groupDest string
+		err       error
+		uintgids  []uint32
+	)
+
+	groupPath := etcgroup
+	if override != nil && override.ContainerEtcGroupPath != "" {
+		groupPath = override.ContainerEtcGroupPath
+	}
+
+	if groupDest, err = securejoin.SecureJoin(containerMount, groupPath); err != nil {
+		logrus.Debug(err)
+		return nil, err
+	}
+
+	gids, err := user.GetAdditionalGroupsPath(groups, groupDest)
+	if err != nil {
+		return nil, err
+	}
+	// For libpod, we want []uint32s
+	for _, gid := range gids {
+		uintgids = append(uintgids, uint32(gid))
+	}
+	return uintgids, nil
+}
+
+// GetUser takes a containermount path and user name or id and returns
+// a matching User structure from /etc/passwd.  If it cannot locate a user
+// with the provided information, an ErrNoPasswdEntries is returned.
+func GetUser(containerMount, userIDorName string) (*user.User, error) {
+	var inputIsName bool
+	uid, err := strconv.Atoi(userIDorName)
+	if err != nil {
+		inputIsName = true
+	}
+	passwdDest, err := securejoin.SecureJoin(containerMount, etcpasswd)
+	if err != nil {
+		return nil, err
+	}
+	users, err := user.ParsePasswdFileFilter(passwdDest, func(u user.User) bool {
+		if inputIsName {
+			return u.Name == userIDorName
+		}
+		return u.Uid == uid
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if len(users) > 0 {
+		return &users[0], nil
+	}
+	return nil, user.ErrNoPasswdEntries
+}
+
+// GetGroup takes ac ontainermount path and a group name or id and returns
+// a match Group struct from /etc/group.  if it cannot locate a group,
+// an ErrNoGroupEntries error is returned.
+func GetGroup(containerMount, groupIDorName string) (*user.Group, error) {
+	var inputIsName bool
+	gid, err := strconv.Atoi(groupIDorName)
+	if err != nil {
+		inputIsName = true
+	}
+
+	groupDest, err := securejoin.SecureJoin(containerMount, etcgroup)
+	if err != nil {
+		return nil, err
+	}
+
+	groups, err := user.ParseGroupFileFilter(groupDest, func(g user.Group) bool {
+		if inputIsName {
+			return g.Name == groupIDorName
+		}
+		return g.Gid == gid
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if len(groups) > 0 {
+		return &groups[0], nil
+	}
+	return nil, user.ErrNoGroupEntries
+}


### PR DESCRIPTION
Create a new /etc/passwd in the container with a record for the
user account that is running the container.

This will allow getpwuid calls to succeed inside of the container.
We have seen failures where getpwduid was not successful.

Also vendor in an update libpod packages
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

Cherry-pick 77408ef1490002e62c88baacc5c994e97aa793c6