### PR TITLE
WIP: Update test dependencies

### DIFF
--- a/contrib/test/integration/build/bats.yml
+++ b/contrib/test/integration/build/bats.yml
@@ -4,6 +4,7 @@
   git:
     repo: "https://github.com/bats-core/bats-core.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/bats-core/bats-core"
+    depth: 1
 
 - name: install bats
   command: "./install.sh /usr/local"

--- a/contrib/test/integration/build/cri-tools.yml
+++ b/contrib/test/integration/build/cri-tools.yml
@@ -1,26 +1,13 @@
 ---
 
-- name: clone cri-tools source repo
-  git:
-    repo: "https://github.com/kubernetes-sigs/cri-tools.git"
-    dest: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-tools"
-    version: "{{ cri_tools_git_version }}"
-    force: "{{ force_clone | default(False) | bool}}"
+- name: download crictl
+  unarchive:
+    src: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.14.0/crictl-v1.14.0-linux-amd64.tar.gz
+    dest: /usr/bin
+    remote_src: yes
 
-- name: install crictl
-  command: "/usr/bin/go install github.com/kubernetes-sigs/cri-tools/cmd/crictl"
-
-- name: install critest
-  command: "/usr/bin/go test -c github.com/kubernetes-sigs/cri-tools/cmd/critest -o {{ ansible_env.GOPATH }}/bin/critest"
-
-- name: link crictl
-  file:
-    src: "{{ ansible_env.GOPATH }}/bin/crictl"
-    dest: /usr/bin/crictl
-    state: link
-
-- name: link critest
-  file:
-    src: "{{ ansible_env.GOPATH }}/bin/critest"
-    dest: /usr/bin/critest
-    state: link
+- name: download critest
+  unarchive:
+    src: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.14.0/critest-v1.14.0-linux-amd64.tar.gz
+    dest: /usr/bin
+    remote_src: yes

--- a/contrib/test/integration/build/plugins.yml
+++ b/contrib/test/integration/build/plugins.yml
@@ -1,36 +1,7 @@
 ---
 
-- name: clone plugins source repo
-  git:
-    repo: "https://github.com/containernetworking/plugins.git"
-    dest: "{{ ansible_env.GOPATH }}/src/github.com/containernetworking/plugins"
-    version: "dcf7368eeab15e2affc6256f0bb1e84dd46a34de"
-
-- name: build plugins
-  command: "./build.sh"
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/containernetworking/plugins"
-
-- name: install plugins
-  copy:
-    src: "{{ ansible_env.GOPATH }}/src/github.com/containernetworking/plugins/bin/{{ item }}"
-    dest: "/opt/cni/bin"
-    mode: "o=rwx,g=rx,o=rx"
+- name: download plugins
+  unarchive:
+    src: https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-amd64-v0.7.5.tgz
+    dest: /opt/cni/bin
     remote_src: yes
-  with_items:
-    - bridge
-    - dhcp
-    - flannel
-    - host-local
-    - ipvlan
-    - loopback
-    - macvlan
-    - ptp
-    - sample
-    - tuning
-    - vlan
-
-- name: build plugins
-  command: "./build.sh"
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/containernetworking/plugins"

--- a/contrib/test/integration/build/runc.yml
+++ b/contrib/test/integration/build/runc.yml
@@ -1,23 +1,7 @@
 ---
 
-- name: clone runc source repo
-  git:
-    repo: "https://github.com/opencontainers/runc.git"
-    dest: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-    version: "10d38b660a77168360df3522881e2dc2be5056bd"
-
-- name: build runc
-  make:
-    params: BUILDTAGS="seccomp selinux"
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-
-- name: install runc
-  make:
-    target: "install"
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-
-- name: link runc
-  file:
-    src: /usr/local/sbin/runc
-    dest: /usr/bin/runc
-    state: link
+- name: download runc
+  get_url:
+    url: https://github.com/opencontainers/runc/releases/download/v1.0.0-rc8/runc.amd64
+    dest: /usr/local/sbin/runc
+    mode: 0755

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -1,3 +1,4 @@
+---
 - hosts: all
   remote_user: root
   vars_files:
@@ -16,24 +17,21 @@
     - name: clone build and install bats
       include: "build/bats.yml"
 
-    - name: clone build and install cri-tools
+    - name: install cri-tools
       include: "build/cri-tools.yml"
-      vars:
-        cri_tools_git_version: "ff8d2e81baf8ff720fb916e42da57c2b772bd19e"
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
-      vars:
       vars:
         k8s_git_version: "release-1.12"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
 
-    - name: clone build and install runc
+    - name: install runc
       include: "build/runc.yml"
       when: "{{ build_runc | default(True) | bool}}"
 
-    - name: clone build and install networking plugins
+    - name: install networking plugins
       include: "build/plugins.yml"
 
 - hosts: all
@@ -51,7 +49,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.12.2"
+        version: "1.12.2"
     - name: clone build and install cri-o
       include: "build/cri-o.yml"
   post_tasks:
@@ -67,11 +65,8 @@
   tasks:
     - name: install parallel
       include: build/parallel.yml
-    - name: clone build and install cri-tools
+    - name: install cri-tools
       include: "build/cri-tools.yml"
-      vars:
-        force_clone: True
-        cri_tools_git_version: "ff8d2e81baf8ff720fb916e42da57c2b772bd19e"
     - name: run cri-o integration tests
       include: test.yml
 
@@ -84,9 +79,6 @@
   tasks:
     - name: setup critest
       include: "build/cri-tools.yml"
-      vars:
-          force_clone: True
-          cri_tools_git_version: "ff8d2e81baf8ff720fb916e42da57c2b772bd19e"
     - name: run critest validation and benchmarks
       include: critest.yml
 

--- a/test/network.bats
+++ b/test/network.bats
@@ -180,7 +180,7 @@ function teardown() {
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed after network setup
 	rm -f /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING/last_reserved_ip*
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING | wc -l)
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING | grep -v lock | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }
 
@@ -194,6 +194,6 @@ function teardown() {
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed during network setup after the CNI plugin itself succeeded
 	rm -f /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING/last_reserved_ip*
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING | wc -l)
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING | grep -v lock | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }


### PR DESCRIPTION
Update container and ansible dependencies:

- crictl/critest to v1.14.0
- runc to v1.0.0-rc8
- CNI plugins to v0.7.5

Beside that, the main installation of these tools has been changed to
download the build artifacts instead of building them from source. This
should speedup the overall test setup.

Two tests in test/network.bats had to be fixed as well for the CNI
plugins v0.7.5 release.