### PR TITLE
Add CircleCI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,257 @@
+---
+version: 2.1
+
+executors:
+  docker:
+    docker:
+      - image: &image saschagrunert/criocircle
+        user: circleci
+    environment:
+      GOCACHE: &gocache /tmp/go-build
+    working_directory: &workdir /go/src/github.com/cri-o/cri-o
+  docker-base:
+    docker:
+      - image: circleci/golang
+    environment:
+      GOCACHE: *gocache
+    working_directory: *workdir
+  nix:
+    docker:
+      - image: saschagrunert/crionix
+  machine:
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-1604:201903-01
+    environment:
+      GOCACHE: *gocache
+      IMAGE: *image
+      WORKDIR: *workdir
+
+workflows:
+  version: 2
+  pipeline:
+    jobs:
+      - build
+      - build-static
+      - build-test-binaries
+      - clang-format
+      - git-validation
+      - integration:
+          requires:
+            - build
+            - build-test-binaries
+      - integration:
+          name: integration-userns
+          test_userns: '1'
+          requires:
+            - build
+            - build-test-binaries
+      - integration:
+          name: integration-static-glibc
+          crio_binary: crio-x86_64-static-glibc
+          requires:
+            - build
+            - build-static
+            - build-test-binaries
+      - integration:
+          name: integration-static-musl
+          crio_binary: crio-x86_64-static-musl
+          requires:
+            - build
+            - build-static
+            - build-test-binaries
+      - lint
+      - results:
+          requires:
+            - integration
+            - integration-static-glibc
+            - integration-static-musl
+            - integration-userns
+            - unit-tests
+      - unit-tests
+      - vendor
+
+jobs:
+  build:
+    executor: docker
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-build-{{ checksum "go.sum" }}
+      - run:
+          name: build
+          command: make
+      - save_cache:
+          key: v1-build-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+            - build/bin/go-md2man
+      - persist_to_workspace:
+          root: .
+          paths:
+            - bin
+
+  build-static:
+    executor: nix
+    steps:
+      - checkout
+      - run:
+          name: build
+          command: |
+            nix-build nix
+            mkdir -p bin
+            cp result-*bin/bin/crio-* bin
+      - persist_to_workspace:
+          root: .
+          paths:
+            - bin
+
+  build-test-binaries:
+    executor: docker-base
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-build-test-binaries-{{ checksum "go.sum" }}
+      - run:
+          name: build
+          command: make test-binaries
+      - save_cache:
+          key: v1-build-test-binaries-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+      - persist_to_workspace:
+          root: .
+          paths:
+            - test/bin2img/bin2img
+            - test/copyimg/checkseccomp/checkseccomp
+            - test/copyimg/copyimg
+
+  clang-format:
+    executor: docker
+    steps:
+      - checkout
+      - run: make fmt
+
+  git-validation:
+    executor: docker-base
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-git-validation-{{ checksum "go.sum" }}
+      - run:
+          name: git validation to merge base
+          command: |
+            export MERGE_BASE=$(git merge-base origin/master \
+                                $(git rev-parse --abbrev-ref HEAD))
+            make .gitvalidation EPOCH_TEST_COMMIT=$MERGE_BASE
+      - save_cache:
+          key: v1-git-validation-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+            - build/bin/git-validation
+
+  integration:
+    executor: machine
+    parameters:
+      crio_binary:
+        type: string
+        default: crio
+      test_userns:
+        type: string
+        default: ''
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: integration test
+          command: |
+            docker pull $IMAGE
+            docker run -e APPARMOR_PARAMETERS_FILE_PATH=skip \
+              -e STORAGE_OPTIONS="--storage-driver=vfs" -e TRAVIS=true \
+              -e CRIO_BINARY -e TEST_USERNS -t --privileged --rm \
+              -v $(pwd):$WORKDIR \
+              -w $WORKDIR \
+              $IMAGE test/test_runner.sh
+          environment:
+            CRIO_BINARY: "<< parameters.crio_binary >>"
+            TEST_USERNS: "<< parameters.test_userns >>"
+
+  lint:
+    executor: machine
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-golangci-lint-{{ checksum "go.sum" }}
+      - run:
+          name: lint
+          command: |
+            docker pull $IMAGE
+            docker run -t --privileged --rm -e GOCACHE \
+              -v $GOCACHE:$GOCACHE -v $(pwd):$WORKDIR \
+              -w $WORKDIR $IMAGE make lint
+            sudo chown -R $(id -u):$(id -g) $GOCACHE
+      - save_cache:
+          key: v1-golangci-lint-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+            - build/bin/golangci-lint
+
+  results:
+    executor: docker-base
+    steps:
+      - attach_workspace:
+          at: .
+      - store_test_results:
+          path: build/junit
+      - store_artifacts:
+          path: bin
+          destination: bin
+      - store_artifacts:
+          path: build
+          destination: test
+
+  unit-tests:
+    executor: docker
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-unit-tests-{{ checksum "go.sum" }}
+      - run:
+          name: unit tests
+          command: make testunit
+      - store_test_results:
+          path: build/junit
+      - save_cache:
+          key: v1-unit-tests-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+            - build/bin/ginkgo
+            - build/bin/mockgen
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build/coverage
+            - build/junit
+
+  vendor:
+    executor: docker-base
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-vendor-{{ checksum "go.sum" }}
+      - run:
+          name: check vendoring
+          command: |
+            make vendor
+            hack/tree_status.sh
+      - save_cache:
+          key: v1-vendor-{{ checksum "go.sum" }}
+          paths:
+            - /go/pkg

--- a/Dockerfile-circleci
+++ b/Dockerfile-circleci
@@ -1,0 +1,73 @@
+FROM circleci/golang:1.12
+USER root
+
+RUN echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" | \
+    tee -a /etc/apt/sources.list.d/llvm.list && \
+    wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
+
+RUN apt-get update &&\
+    apt-get install -y \
+    apparmor \
+    autoconf \
+    automake \
+    bison \
+    bsdmainutils \
+    btrfs-tools \
+    build-essential \
+    clang-format \
+    e2fslibs-dev \
+    gawk \
+    gettext \
+    iptables \
+    libaio-dev \
+    libapparmor-dev \
+    libcap-dev \
+    libdevmapper-dev \
+    libdevmapper1.02.1 \
+    libfuse-dev \
+    libglib2.0-dev \
+    libgpgme11-dev \
+    liblzma-dev \
+    libnet-dev \
+    libnl-3-dev \
+    libprotobuf-c0-dev \
+    libprotobuf-dev \
+    libseccomp-dev \
+    libseccomp2 \
+    libsystemd-dev \
+    libtool \
+    libudev-dev \
+    protobuf-c-compiler \
+    protobuf-compiler \
+    python-protobuf \
+    socat &&\
+    apt-get clean
+
+# Install bats
+RUN cd /tmp &&\
+    git clone https://github.com/bats-core/bats-core.git --depth=1 &&\
+    cd bats-core &&\
+    ./install.sh /usr &&\
+    rm -rf /tmp/bats-core &&\
+    mkdir -p ~/.parallel && touch ~/.parallel/will-cite
+
+# Install crictl
+RUN VERSION=v1.14.0 &&\
+    wget -qO- https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz \
+        | tar xfz - -C /usr/bin
+
+# Install runc
+RUN VERSION=v1.0.0-rc8 &&\
+    wget -q -O /usr/bin/runc https://github.com/opencontainers/runc/releases/download/$VERSION/runc.amd64 &&\
+    chmod +x /usr/bin/runc
+
+# Install CNI plugins
+RUN VERSION=v0.6.0-rc1 &&\
+    mkdir -p /opt/cni/bin &&\
+    wget -qO- https://github.com/containernetworking/plugins/releases/download/$VERSION/cni-plugins-amd64-$VERSION.tgz \
+        | tar xfz - -C /opt/cni/bin
+
+# Make sure we have some policy for pulling images
+RUN mkdir -p /etc/containers
+COPY test/policy.json /etc/containers/policy.json
+COPY test/redhat_sigstore.yaml /etc/containers/registries.d/registry.access.redhat.com.yaml

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ CONTAINER_RUNTIME ?= podman
 BUILD_PATH := $(shell pwd)/build
 BUILD_BIN_PATH := ${BUILD_PATH}/bin
 COVERAGE_PATH := ${BUILD_PATH}/coverage
+JUNIT_PATH := ${BUILD_PATH}/junit
 TESTBIN_PATH := ${BUILD_PATH}/test
 MOCK_PATH := ${PWD}/test/mocks
 MOCKGEN_FLAGS := --build_flags='--tags=test $(BUILDTAGS)'
@@ -214,6 +215,7 @@ vendor:
 
 testunit: mockgen ${GINKGO}
 	rm -rf ${COVERAGE_PATH} && mkdir -p ${COVERAGE_PATH}
+	rm -rf ${JUNIT_PATH} && mkdir -p ${JUNIT_PATH}
 	${BUILD_BIN_PATH}/ginkgo \
 		${TESTFLAGS} \
 		-r \
@@ -227,6 +229,7 @@ testunit: mockgen ${GINKGO}
 	sed -i '2,$${/^mode: atomic/d;}' ${COVERAGE_PATH}/coverprofile
 	$(GO) tool cover -html=${COVERAGE_PATH}/coverprofile -o ${COVERAGE_PATH}/coverage.html
 	$(GO) tool cover -func=${COVERAGE_PATH}/coverprofile | sed -n 's/\(total:\).*\([0-9][0-9].[0-9]\)/\1 \2/p'
+	find . -name '*_junit.xml' -exec mv -t ${JUNIT_PATH} {} +
 
 testunit-bin:
 	mkdir -p ${TESTBIN_PATH}

--- a/lib/sandbox/suite_test.go
+++ b/lib/sandbox/suite_test.go
@@ -17,7 +17,7 @@ import (
 // TestSandbox runs the created specs
 func TestSandbox(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Sandbox")
+	RunFrameworkSpecs(t, "Sandbox")
 }
 
 var (

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -24,7 +24,7 @@ import (
 // TestLib runs the created specs
 func TestLib(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Lib")
+	RunFrameworkSpecs(t, "Lib")
 }
 
 var (

--- a/oci/suite_test.go
+++ b/oci/suite_test.go
@@ -16,7 +16,7 @@ import (
 // TestOci runs the created specs
 func TestOci(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Oci")
+	RunFrameworkSpecs(t, "Oci")
 }
 
 var (

--- a/pkg/findprocess/findprocess_test.go
+++ b/pkg/findprocess/findprocess_test.go
@@ -13,7 +13,7 @@ import (
 // TestFindprocess runs the created specs
 func TestFindprocess(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Findprocess")
+	RunFrameworkSpecs(t, "Findprocess")
 }
 
 var t *TestFramework

--- a/pkg/seccomp/seccomp_test.go
+++ b/pkg/seccomp/seccomp_test.go
@@ -17,7 +17,7 @@ import (
 // TestSeccomp runs the created specs
 func TestSeccomp(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Seccomp")
+	RunFrameworkSpecs(t, "Seccomp")
 }
 
 var t *TestFramework

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -14,7 +14,7 @@ import (
 // TestStorage runs the created specs
 func TestStorage(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Storage")
+	RunFrameworkSpecs(t, "Storage")
 }
 
 var (

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -2,8 +2,11 @@ package framework
 
 import (
 	"fmt"
+	"strings"
+	"testing"
 
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
 )
 
@@ -53,4 +56,11 @@ func (t *TestFramework) Teardown() {
 // Describe is a convenience wrapper around the `ginkgo.Describe` function
 func (t *TestFramework) Describe(text string, body func()) bool {
 	return ginkgo.Describe("cri-o: "+text, body)
+}
+
+// RunFrameworkSpecs is a convenience wrapper for running tests
+func RunFrameworkSpecs(t *testing.T, suiteName string) {
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, suiteName,
+		[]ginkgo.Reporter{reporters.NewJUnitReporter(
+			fmt.Sprintf("%v_junit.xml", strings.ToLower(suiteName)))})
 }

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -6,6 +6,7 @@ TEST_USERNS=${TEST_USERNS:-}
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 if [[ -n "$TEST_USERNS" ]]; then
+    echo "Enabled user namespace testing"
     export UID_MAPPINGS="0:100000:100000"
     export GID_MAPPINGS="0:200000:100000"
 

--- a/utils/suite_test.go
+++ b/utils/suite_test.go
@@ -11,7 +11,7 @@ import (
 // TestUtils runs the created specs
 func TestUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Utils")
+	RunFrameworkSpecs(t, "Utils")
 }
 
 var t *TestFramework

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -515,6 +515,7 @@ github.com/nbutton23/zxcvbn-go/frequency
 github.com/nbutton23/zxcvbn-go/data
 # github.com/onsi/ginkgo v1.8.0
 github.com/onsi/ginkgo
+github.com/onsi/ginkgo/reporters
 github.com/onsi/ginkgo/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
@@ -523,7 +524,6 @@ github.com/onsi/ginkgo/internal/remote
 github.com/onsi/ginkgo/internal/suite
 github.com/onsi/ginkgo/internal/testingtproxy
 github.com/onsi/ginkgo/internal/writer
-github.com/onsi/ginkgo/reporters
 github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/types


### PR DESCRIPTION
Hey :wave:, this PR adds the CircleCI test pipeline, which includes a docker base image and the ginkgo junit test extension. The pipeline mainly clones the current travis behavior, but in an optimized fashion. Target is to utilize CircleCIs artifact, caching and workspace features to do no task twice and ensure an optimal build and test process. More information and benefits can be found in #2294.

An example test pipeline can be found here:
https://circleci.com/workflow-run/a48896d8-c6dc-4558-8de1-92670f0cbcea

The following CircleCI settings should be ensured by a repository administrator 
https://circleci.com/gh/cri-o/cri-o/edit#advanced-settings:
- GitHub Status updates: **On**
- Free and Open Source: **On**
- Build forked pull requests: **Off**
- Pass secrets to builds from forked pull requests: **Off**
- Only build pull requests: **Off**
- Auto-cancel redundant builds: **On**
- Enable pipelines: **On**

Please ensure that the parallelism is set to the maximum (for free accounts: 4) here:
https://circleci.com/gh/cri-o/cri-o/edit#parallel-builds

A good plan would be to run the first master build **after** this PR got merged via:
https://circleci.com/setup-project/gh/cri-o/cri-o

Closes: #2294 
