### PR TITLE
[1.14] Fix logic of server.restore()

### DIFF
--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -338,6 +338,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed with removed container", func() {
 			// Given
 			mockDirs(testManifest)
+			createDummyState()
 			gomock.InOrder(
 				storeMock.EXPECT().Containers().
 					Return([]cstorage.Container{{}}, nil),
@@ -357,6 +358,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed with already added sandbox", func() {
 			// Given
 			sut.AddSandbox(mySandbox)
+			createDummyState()
 			mockDirs(testManifest)
 			gomock.InOrder(
 				storeMock.EXPECT().Containers().
@@ -374,6 +376,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail when storage fails", func() {
 			// Given
+			createDummyState()
 			gomock.InOrder(
 				storeMock.EXPECT().Containers().Return(nil, t.TestError),
 			)
@@ -389,6 +392,7 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("LoadSandbox", func() {
 		It("should succeed", func() {
 			// Given
+			createDummyState()
 			mockDirs(testManifest)
 
 			// When
@@ -400,6 +404,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should succeed with invalid network namespace", func() {
 			// Given
+			createDummyState()
 			manifest := bytes.Replace(testManifest,
 				[]byte(`{"type": "network", "path": "default"}`),
 				[]byte(`{"type": "", "path": ""},{"type": "network", "path": ""}`), 1,
@@ -415,6 +420,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should succeed with missing network namespace", func() {
 			// Given
+			createDummyState()
 			manifest := bytes.Replace(testManifest,
 				[]byte(`{"type": "network", "path": "default"}`),
 				[]byte(`{}`), 1,
@@ -655,6 +661,7 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("LoadContainer", func() {
 		It("should succeed", func() {
 			// Given
+			createDummyState()
 			sut.AddSandbox(mySandbox)
 			mockDirs(testManifest)
 

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -2,6 +2,7 @@ package lib_test
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -165,4 +166,8 @@ func addContainerAndSandbox() {
 	sut.AddContainer(myContainer)
 	Expect(sut.CtrIDIndex().Add(containerID)).To(BeNil())
 	Expect(sut.PodIDIndex().Add(sandboxID)).To(BeNil())
+}
+
+func createDummyState() {
+	ioutil.WriteFile("state.json", []byte("{}"), 0644)
 }


### PR DESCRIPTION
When cri-o is restarted, we were not returning an error if
an error ocurred when reading container state from disk. So
if the state.json file was corrupted or deleted in the meantime
the containers would be reporting an UNKOWN state and default
values for started time, created time, etc.
We now check for that and if a pod can't be restored, we delete the pod
as well as any containers associated with it. We also release the pod
and container names so that they can be used again.
We do the same for any containers that can't be restored.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>