### PR TITLE
Fix logic of server.restore()

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -468,7 +468,9 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		}
 	}
 
-	c.ContainerStateFromDisk(scontainer)
+	if err := c.ContainerStateFromDisk(scontainer); err != nil {
+		return fmt.Errorf("error reading sandbox state from disk %q: %v", scontainer.ID(), err)
+	}
 	sb.SetCreated()
 
 	if err = label.ReserveLabel(processLabel); err != nil {
@@ -583,7 +585,9 @@ func (c *ContainerServer) LoadContainer(id string) error {
 	spp := m.Annotations[annotations.SeccompProfilePath]
 	ctr.SetSeccompProfilePath(spp)
 
-	c.ContainerStateFromDisk(ctr)
+	if err := c.ContainerStateFromDisk(ctr); err != nil {
+		return fmt.Errorf("error reading container state from disk %q: %v", ctr.ID(), err)
+	}
 	ctr.SetCreated()
 
 	c.AddContainer(ctr)
@@ -600,9 +604,9 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 	if err := ctr.FromDisk(); err != nil {
 		return err
 	}
-	// ignore errors, this is a best effort to have up-to-date info about
-	// a given container before its state gets stored
-	c.runtime.UpdateContainerStatus(ctr)
+	if err := c.runtime.UpdateContainerStatus(ctr); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -610,9 +614,9 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 // ContainerStateToDisk writes the container's state information to a JSON file
 // on disk
 func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
-	// ignore errors, this is a best effort to have up-to-date info about
-	// a given container before its state gets stored
-	c.Runtime().UpdateContainerStatus(ctr)
+	if err := c.Runtime().UpdateContainerStatus(ctr); err != nil {
+		logrus.Warnf("error updating the container status %q: %v", ctr.ID(), err)
+	}
 
 	jsonSource, err := ioutils.NewAtomicFileWriter(ctr.StatePath(), 0644)
 	if err != nil {

--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -349,6 +349,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed with removed container", func() {
 			// Given
 			mockDirs(testManifest)
+			createDummyState()
 			gomock.InOrder(
 				storeMock.EXPECT().Containers().
 					Return([]cstorage.Container{{}}, nil),
@@ -368,6 +369,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed with already added sandbox", func() {
 			// Given
 			sut.AddSandbox(mySandbox)
+			createDummyState()
 			mockDirs(testManifest)
 			gomock.InOrder(
 				storeMock.EXPECT().Containers().
@@ -385,6 +387,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail when storage fails", func() {
 			// Given
+			createDummyState()
 			gomock.InOrder(
 				storeMock.EXPECT().Containers().Return(nil, t.TestError),
 			)
@@ -400,6 +403,7 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("LoadSandbox", func() {
 		It("should succeed", func() {
 			// Given
+			createDummyState()
 			mockDirs(testManifest)
 
 			// When
@@ -411,6 +415,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should succeed with invalid network namespace", func() {
 			// Given
+			createDummyState()
 			manifest := bytes.Replace(testManifest,
 				[]byte(`{"type": "network", "path": "default"}`),
 				[]byte(`{"type": "", "path": ""},{"type": "network", "path": ""}`), 1,
@@ -426,6 +431,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should succeed with missing network namespace", func() {
 			// Given
+			createDummyState()
 			manifest := bytes.Replace(testManifest,
 				[]byte(`{"type": "network", "path": "default"}`),
 				[]byte(`{}`), 1,
@@ -664,6 +670,7 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("LoadContainer", func() {
 		It("should succeed", func() {
 			// Given
+			createDummyState()
 			sut.AddSandbox(mySandbox)
 			mockDirs(testManifest)
 

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -2,6 +2,7 @@ package lib_test
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -165,4 +166,8 @@ func addContainerAndSandbox() {
 	sut.AddContainer(myContainer)
 	Expect(sut.CtrIDIndex().Add(containerID)).To(BeNil())
 	Expect(sut.PodIDIndex().Add(sandboxID)).To(BeNil())
+}
+
+func createDummyState() {
+	ioutil.WriteFile("state.json", []byte("{}"), 0644)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -149,38 +149,72 @@ func (s *Server) restore() {
 	pods := map[string]*storage.RuntimeContainerMetadata{}
 	podContainers := map[string]*storage.RuntimeContainerMetadata{}
 	names := map[string][]string{}
+	deletedPods := map[string]bool{}
 	for i := range containers {
-		container := &containers[i]
-		metadata, err2 := s.StorageRuntimeServer().GetContainerMetadata(container.ID)
+		metadata, err2 := s.StorageRuntimeServer().GetContainerMetadata(containers[i].ID)
 		if err2 != nil {
-			logrus.Warnf("error parsing metadata for %s: %v, ignoring", container.ID, err2)
+			logrus.Warnf("error parsing metadata for %s: %v, ignoring", containers[i].ID, err2)
 			continue
 		}
-		names[container.ID] = container.Names
+		names[containers[i].ID] = containers[i].Names
 		if metadata.Pod {
-			pods[container.ID] = &metadata
+			pods[containers[i].ID] = &metadata
 		} else {
-			podContainers[container.ID] = &metadata
+			podContainers[containers[i].ID] = &metadata
 		}
 	}
-	for containerID, metadata := range pods {
-		if err = s.LoadSandbox(containerID); err != nil {
-			logrus.Warnf("could not restore sandbox %s container %s: %v", metadata.PodID, containerID, err)
-			for _, n := range names[containerID] {
-				s.Store().DeleteContainer(n)
+
+	// Go through all the pods and check if it can be restored. If an error occurs, delete the pod and any containers
+	// associated with it. Release the pod and container names as well.
+	for sbID, metadata := range pods {
+		if err = s.LoadSandbox(sbID); err == nil {
+			continue
+		}
+		logrus.Warnf("could not restore sandbox %s container %s: %v", metadata.PodID, sbID, err)
+		for _, n := range names[sbID] {
+			s.Store().DeleteContainer(n)
+			// Release the infra container name and the pod name for future use
+			if strings.Contains(n, infraName) {
+				s.ReleaseContainerName(n)
+			} else {
+				s.ReleasePodName(n)
+			}
+
+		}
+		// Go through the containers and delete any container that was under the deleted pod
+		logrus.Warnf("deleting all containers under sandbox %s since it could not be restored", sbID)
+		for k, v := range podContainers {
+			if v.PodID == sbID {
+				for _, n := range names[k] {
+					s.Store().DeleteContainer(n)
+					// Release the container name for future use
+					s.ReleaseContainerName(n)
+				}
 			}
 		}
+		// Add the pod id to the list of deletedPods so we don't try to restore IPs for it later on
+		deletedPods[sbID] = true
 	}
+
+	// Go through all the containers and check if it can be restored. If an error occurs, delete the conainer and
+	// release the name associated with you.
 	for containerID := range podContainers {
 		if err := s.LoadContainer(containerID); err != nil {
 			logrus.Warnf("could not restore container %s: %v", containerID, err)
 			for _, n := range names[containerID] {
 				s.Store().DeleteContainer(n)
+				// Release the container name
+				s.ReleaseContainerName(n)
 			}
 		}
 	}
+
 	// Restore sandbox IPs
 	for _, sb := range s.ListSandboxes() {
+		// Move on if pod was deleted
+		if ok := deletedPods[sb.ID()]; ok {
+			continue
+		}
 		ip, err := s.getSandboxIP(sb)
 		if err != nil {
 			logrus.Warnf("could not restore sandbox IP for %v: %v", sb.ID(), err)


### PR DESCRIPTION
When cri-o is restarted, we were not returning an error if
an error ocurred when reading container state from disk. So
if the state.json file was corrupted or deleted in the meantime
the containers would be reporting an UNKOWN state and default
values for started time, created time, etc.
We now check for that and if a pod can't be restored, we delete the pod
as well as any containers associated with it. We also release the pod
and container names so that they can be used again.
We do the same for any containers that can't be restored.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>