### PR TITLE
Fixes assumption that socklen_t is always an unsigned long

### DIFF
--- a/conmon/cmsg.c
+++ b/conmon/cmsg.c
@@ -145,7 +145,7 @@ struct file_t recvfd(int sockfd)
 	if (cmsg->cmsg_type != SCM_RIGHTS)
 		errorf("recvfd: expected SCM_RIGHTS in cmsg: %d", cmsg->cmsg_type);
 	if (cmsg->cmsg_len != CMSG_LEN(sizeof(int)))
-		errorf("recvfd: expected correct CMSG_LEN in cmsg: %lu", cmsg->cmsg_len);
+		errorf("recvfd: expected correct CMSG_LEN in cmsg: %lu", (unsigned long) cmsg->cmsg_len);
 
 	fdptr = (int *)CMSG_DATA(cmsg);
 	if (!fdptr || *fdptr < 0)

--- a/conmon/cmsg.c
+++ b/conmon/cmsg.c
@@ -145,7 +145,7 @@ struct file_t recvfd(int sockfd)
 	if (cmsg->cmsg_type != SCM_RIGHTS)
 		errorf("recvfd: expected SCM_RIGHTS in cmsg: %d", cmsg->cmsg_type);
 	if (cmsg->cmsg_len != CMSG_LEN(sizeof(int)))
-		errorf("recvfd: expected correct CMSG_LEN in cmsg: %lu", (unsigned long) cmsg->cmsg_len);
+		errorf("recvfd: expected correct CMSG_LEN in cmsg: %lu", (unsigned long)cmsg->cmsg_len);
 
 	fdptr = (int *)CMSG_DATA(cmsg);
 	if (!fdptr || *fdptr < 0)


### PR DESCRIPTION
**- What I did**

Cast socklen_t to an unsigned long. Fixes #2321.

**- How to verify it**

Successfully built conmon with Alpine/musl.

**- Description for the changelog**

Cast socklen_t to an unsigned long. Fixes #2321.
