### PR TITLE
[1.13] Add username and homedir to generated password

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -273,6 +273,17 @@ func setupContainerUser(specgen *generate.Generator, rootfs, mountLabel, ctrRunD
 		return fmt.Errorf("user group is specified without user or username")
 	}
 	imageUser := ""
+	homedir := ""
+	for _, env := range specgen.Config.Process.Env {
+		if strings.HasPrefix(env, "HOME=") {
+			homedir = strings.TrimPrefix(env, "HOME=")
+			break
+		}
+	}
+	if homedir == "" {
+		homedir = specgen.Config.Process.Cwd
+	}
+
 	if imageConfig != nil {
 		imageUser = imageConfig.Config.User
 	}
@@ -292,23 +303,34 @@ func setupContainerUser(specgen *generate.Generator, rootfs, mountLabel, ctrRunD
 		return err
 	}
 
-	// verify uid exists in containers /etc/passwd, else generate a passwd with the user entry
-	passwdPath, err := utils.GeneratePasswd(uid, gid, rootfs, ctrRunDir)
-	if err != nil {
-		return err
+	genPasswd := true
+	for _, mount := range specgen.Config.Mounts {
+		if mount.Destination == "/etc" ||
+			mount.Destination == "/etc/" ||
+			mount.Destination == "/etc/passwd" {
+			genPasswd = false
+			break
+		}
 	}
-	if passwdPath != "" {
-		if err := securityLabel(passwdPath, mountLabel, false); err != nil {
+	if genPasswd {
+		// verify uid exists in containers /etc/passwd, else generate a passwd with the user entry
+		passwdPath, err := utils.GeneratePasswd(containerUser, uid, gid, homedir, rootfs, ctrRunDir)
+		if err != nil {
 			return err
 		}
+		if passwdPath != "" {
+			if err := securityLabel(passwdPath, mountLabel, false); err != nil {
+				return err
+			}
 
-		mnt := rspec.Mount{
-			Type:        "bind",
-			Source:      passwdPath,
-			Destination: "/etc/passwd",
-			Options:     []string{"ro", "bind", "nodev", "nosuid", "noexec"},
+			mnt := rspec.Mount{
+				Type:        "bind",
+				Source:      passwdPath,
+				Destination: "/etc/passwd",
+				Options:     []string{"rw", "bind", "nodev", "nosuid", "noexec"},
+			}
+			specgen.AddMount(mnt)
 		}
-		specgen.AddMount(mnt)
 	}
 
 	specgen.SetProcessUID(uid)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/containers/libpod/pkg/lookup"
 	"github.com/docker/docker/pkg/symlink"
@@ -237,7 +238,7 @@ func GetUserInfo(rootfs string, userName string) (uint32, uint32, []uint32, erro
 
 // GeneratePasswd generates a container specific passwd file,
 // iff uid is not defined in the containers /etc/passwd
-func GeneratePasswd(uid, gid uint32, rootfs, rundir string) (string, error) {
+func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir string) (string, error) {
 	// if UID exists inside of container rootfs /etc/passwd then
 	// don't generate passwd
 	if _, err := lookup.GetUser(rootfs, strconv.Itoa(int(uid))); err == nil {
@@ -248,6 +249,24 @@ func GeneratePasswd(uid, gid uint32, rootfs, rundir string) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to follow symlinks to passwd file")
 	}
+	info, err := os.Stat(originPasswdFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", errors.Wrapf(err, "unable to stat passwd file %s", originPasswdFile)
+	}
+	// Check if passwd file is world writable
+	if info.Mode().Perm()&(0022) != 0 {
+		return "", nil
+	}
+	passwdUid := info.Sys().(*syscall.Stat_t).Uid
+	passwdGid := info.Sys().(*syscall.Stat_t).Gid
+
+	if uid == passwdUid && info.Mode().Perm()&(0200) != 0 {
+		return "", nil
+	}
+
 	orig, err := ioutil.ReadFile(originPasswdFile)
 	if err != nil {
 		// If no /etc/passwd in container ignore and return
@@ -256,10 +275,18 @@ func GeneratePasswd(uid, gid uint32, rootfs, rundir string) (string, error) {
 		}
 		return "", errors.Wrapf(err, "unable to read passwd file %s", originPasswdFile)
 	}
-
-	pwd := fmt.Sprintf("%s%d:x:%d:%d:container user:%s:/bin/sh\n", orig, uid, uid, gid, "/")
-	if err := ioutil.WriteFile(passwdFile, []byte(pwd), 0644); err != nil {
+	if username == "" {
+		username = "default"
+	}
+	if homedir == "" {
+		homedir = "/tmp"
+	}
+	pwd := fmt.Sprintf("%s%s:x:%d:%d:%s user:%s:/sbin/nologin\n", orig, username, uid, gid, username, homedir)
+	if err := ioutil.WriteFile(passwdFile, []byte(pwd), info.Mode()); err != nil {
 		return "", errors.Wrapf(err, "failed to create temporary passwd file")
+	}
+	if err := os.Chown(passwdFile, int(passwdUid), int(passwdGid)); err != nil {
+		return "", errors.Wrapf(err, "failed to chown temporary passwd file")
 	}
 	return passwdFile, nil
 }


### PR DESCRIPTION
When generating a an entry in the /etc/passwd file, we
need to also add username and homedir, so that the user
can properly login.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
