### PR TITLE
Add nakedret linter and related fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - interfacer
     - maligned
     - misspell
+    - nakedret
     - prealloc
     - scopelint
     - staticcheck
@@ -35,7 +36,6 @@ linters:
     # - gochecknoglobals
     # - gocyclo
     # - lll
-    # - nakedret
 linters-settings:
   gocritic:
     enabled-checks:
@@ -107,3 +107,5 @@ linters-settings:
       # - importShadow
       # - paramTypeCombine
       # - unnamedResult
+  nakedret:
+    max-func-lines: 15

--- a/oci/runtime_vm.go
+++ b/oci/runtime_vm.go
@@ -408,7 +408,7 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 		return -1, err
 	}
 
-	return
+	return exitCode, err
 }
 
 // UpdateContainer updates container resources

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -71,7 +71,7 @@ func (s *Server) networkStart(sb *sandbox.Sandbox) (podIP string, result cnitype
 		}
 
 	}
-	return
+	return podIP, result, err
 }
 
 // getSandboxIP retrieves the IP address for the sandbox


### PR DESCRIPTION
Nakedret is a Go static analysis tool to find naked returns in functions
greater than a specified function length. This commit enables the linter
via golangci-lint and fixes issues on functions with a larger line
length of `15`.