### PR TITLE
[1.14] Add in-place upgrade

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -46,7 +46,7 @@ file_locking = {{ .FileLocking }}
 file_locking_path = "{{ .FileLockingPath }}"
 
 # Whether CRI-O should wipe storage after a CRI-O upgrade happens
-auto_upgrade = {{ .AutoUpgrade }}
+clear_storage_on_upgrade = {{ .ClearStorageOnUpgrade }}
 
 
 # The crio.api table contains settings for the kubelet/gRPC interface.

--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -45,6 +45,9 @@ file_locking = {{ .FileLocking }}
 # Path to the lock file.
 file_locking_path = "{{ .FileLockingPath }}"
 
+# Whether CRI-O should wipe storage after a CRI-O upgrade happens
+auto_upgrade = {{ .AutoUpgrade }}
+
 
 # The crio.api table contains settings for the kubelet/gRPC interface.
 [crio.api]

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -93,6 +93,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("file-locking") {
 		config.FileLocking = ctx.GlobalBool("file-locking")
 	}
+	if ctx.GlobalIsSet("auto-upgrade") {
+		config.AutoUpgrade = ctx.GlobalBool("auto-upgrade")
+	}
 	if ctx.GlobalIsSet("insecure-registry") {
 		config.InsecureRegistries = ctx.GlobalStringSlice("insecure-registry")
 	}
@@ -338,6 +341,10 @@ func main() {
 		cli.BoolFlag{
 			Name:  "file-locking",
 			Usage: "enable or disable file-based locking",
+		},
+		cli.StringFlag{
+			Name:  "auto-upgrade",
+			Usage: "Wipe storage upon a new CRI-O version being detected",
 		},
 		cli.StringSliceFlag{
 			Name:  "insecure-registry",
@@ -586,6 +593,9 @@ func main() {
 		service, err := server.New(ctx, config)
 		if err != nil {
 			logrus.Fatal(err)
+		}
+		if err := version.WriteVersionFile(server.CrioVersionPath, gitCommit); err != nil {
+			logrus.Errorf(err.Error())
 		}
 
 		if c.GlobalBool("enable-metrics") {

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -93,8 +93,8 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("file-locking") {
 		config.FileLocking = ctx.GlobalBool("file-locking")
 	}
-	if ctx.GlobalIsSet("auto-upgrade") {
-		config.AutoUpgrade = ctx.GlobalBool("auto-upgrade")
+	if ctx.GlobalIsSet("clear-storage-on-upgrade") {
+		config.ClearStorageOnUpgrade = ctx.GlobalBool("clear-storage-on-upgrade")
 	}
 	if ctx.GlobalIsSet("insecure-registry") {
 		config.InsecureRegistries = ctx.GlobalStringSlice("insecure-registry")
@@ -343,7 +343,7 @@ func main() {
 			Usage: "enable or disable file-based locking",
 		},
 		cli.StringFlag{
-			Name:  "auto-upgrade",
+			Name:  "clear-storage-on-upgrade",
 			Usage: "Wipe storage upon a new CRI-O version being detected",
 		},
 		cli.StringSliceFlag{

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -43,7 +43,7 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
 **file_locking_path**="/runc/crio.lock"
   Path to the lock file.
 
-**auto_upgrade**=false
+**clear_storage_on_upgrade**=false
   If set to true, CRI-O will wipe storage after detecting a new version, to allow for an automatic upgrade.
 
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -43,6 +43,9 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
 **file_locking_path**="/runc/crio.lock"
   Path to the lock file.
 
+**auto_upgrade**=false
+  If set to true, CRI-O will wipe storage after detecting a new version, to allow for an automatic upgrade.
+
 
 ## CRIO.API TABLE
 The `crio.api` table contains settings for the kubelet/gRPC interface.

--- a/lib/config.go
+++ b/lib/config.go
@@ -126,13 +126,16 @@ type RootConfig struct {
 	// tells us to put them somewhere else.
 	LogDir string `toml:"log_dir"`
 
+	// FileLockingPath specifies the path to use for the locking.
+	FileLockingPath string `toml:"file_locking_path"`
+
 	// FileLocking specifies whether to use file-based or in-memory locking
 	// File-based locking is required when multiple users of lib are
 	// present on the same system
 	FileLocking bool `toml:"file_locking"`
 
-	// FileLockingPath specifies the path to use for the locking.
-	FileLockingPath string `toml:"file_locking_path"`
+	// Whether CRI-O should wipe storage after a CRI-O upgrade happens
+	AutoUpgrade bool `toml:"auto_upgrade"`
 }
 
 // RuntimeConfig represents the "crio.runtime" TOML config table.
@@ -369,6 +372,7 @@ func DefaultConfig() (*Config, error) {
 			LogDir:          "/var/log/crio/pods",
 			FileLocking:     true,
 			FileLockingPath: lockPath,
+			AutoUpgrade:     false,
 		},
 		RuntimeConfig: RuntimeConfig{
 			DefaultRuntime: "runc",

--- a/lib/config.go
+++ b/lib/config.go
@@ -135,7 +135,7 @@ type RootConfig struct {
 	FileLocking bool `toml:"file_locking"`
 
 	// Whether CRI-O should wipe storage after a CRI-O upgrade happens
-	AutoUpgrade bool `toml:"auto_upgrade"`
+	ClearStorageOnUpgrade bool `toml:"clear_storage_on_upgrade"`
 }
 
 // RuntimeConfig represents the "crio.runtime" TOML config table.
@@ -365,14 +365,14 @@ func DefaultConfig() (*Config, error) {
 	}
 	return &Config{
 		RootConfig: RootConfig{
-			Root:            storeOpts.GraphRoot,
-			RunRoot:         storeOpts.RunRoot,
-			Storage:         storeOpts.GraphDriverName,
-			StorageOptions:  storeOpts.GraphDriverOptions,
-			LogDir:          "/var/log/crio/pods",
-			FileLocking:     true,
-			FileLockingPath: lockPath,
-			AutoUpgrade:     false,
+			Root:                  storeOpts.GraphRoot,
+			RunRoot:               storeOpts.RunRoot,
+			Storage:               storeOpts.GraphDriverName,
+			StorageOptions:        storeOpts.GraphDriverOptions,
+			LogDir:                "/var/log/crio/pods",
+			FileLocking:           true,
+			FileLockingPath:       lockPath,
+			ClearStorageOnUpgrade: false,
 		},
 		RuntimeConfig: RuntimeConfig{
 			DefaultRuntime: "runc",

--- a/lib/testdata/config.toml
+++ b/lib/testdata/config.toml
@@ -4,7 +4,7 @@
   storage_driver = "overlay2"
   log_dir = "/var/log/crio/pods"
   file_locking = true
-  auto_upgrade = false
+  clear_storage_on_upgrade = false
   [crio.runtime]
     runtime = "/usr/bin/runc"
     conmon = "/usr/local/libexec/crio/conmon"

--- a/lib/testdata/config.toml
+++ b/lib/testdata/config.toml
@@ -4,6 +4,7 @@
   storage_driver = "overlay2"
   log_dir = "/var/log/crio/pods"
   file_locking = true
+  auto_upgrade = false
   [crio.runtime]
     runtime = "/usr/bin/runc"
     conmon = "/usr/local/libexec/crio/conmon"

--- a/server/config_unix.go
+++ b/server/config_unix.go
@@ -7,3 +7,6 @@ const CrioConfigPath = "/etc/crio/crio.conf"
 
 // CrioSocketPath is where the unix socket is located
 const CrioSocketPath = "/var/run/crio/crio.sock"
+
+// CrioVersionPath is where the CRI-O version file is located
+const CrioVersionPath = "/etc/crio/version"

--- a/server/config_windows.go
+++ b/server/config_windows.go
@@ -7,3 +7,6 @@ var CrioConfigPath = "C:\\crio\\etc\\crio.conf"
 
 // CrioSocketPath is where the unix socket is located
 const CrioSocketPath = "C:\\crio\\run\\crio.sock"
+
+// CrioVersionPath is where the CRI-O version file is located
+var CrioConfigPath = "C:\\crio\\etc\\version"

--- a/server/server.go
+++ b/server/server.go
@@ -344,6 +344,18 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 		return nil, err
 	}
 
+	if config.AutoUpgrade {
+		upgrade, err := version.ShouldCrioUpgrade(CrioVersionPath)
+		if err != nil {
+			logrus.Errorf(err.Error())
+		}
+		if upgrade {
+			logrus.Debugf("New version detected, upgrading")
+			if err = s.Store().Wipe(); err != nil {
+				logrus.Errorf(err.Error())
+			}
+		}
+	}
 	s.restore()
 	s.cleanupSandboxesOnShutdown(ctx)
 

--- a/server/server.go
+++ b/server/server.go
@@ -344,7 +344,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 		return nil, err
 	}
 
-	if config.AutoUpgrade {
+	if config.ClearStorageOnUpgrade {
 		upgrade, err := version.ShouldCrioUpgrade(CrioVersionPath)
 		if err != nil {
 			logrus.Errorf(err.Error())

--- a/vendor.conf
+++ b/vendor.conf
@@ -59,6 +59,7 @@ github.com/blang/semver v3.5.0
 github.com/BurntSushi/toml v0.3.0
 github.com/davecgh/go-spew v1.1.0
 github.com/google/gofuzz 44d81051d367757e1c7c6a5a86423ece9afcf63c
+github.com/google/renameio v0.1.0
 github.com/spf13/pflag 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 golang.org/x/crypto 49796115aa4b964c318aad4f3084fdb41e9aa067
 golang.org/x/net e147a9138326bc0e9d4e179541ffd8af41cff8a9

--- a/vendor/github.com/google/renameio/LICENSE
+++ b/vendor/github.com/google/renameio/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/renameio/README.md
+++ b/vendor/github.com/google/renameio/README.md
@@ -1,0 +1,51 @@
+[![Build Status](https://travis-ci.org/google/renameio.svg?branch=master)](https://travis-ci.org/google/renameio)
+[![GoDoc](https://godoc.org/github.com/google/renameio?status.svg)](https://godoc.org/github.com/google/renameio)
+[![Go Report Card](https://goreportcard.com/badge/github.com/google/renameio)](https://goreportcard.com/report/github.com/google/renameio)
+
+The `renameio` Go package provides a way to atomically create or replace a file or
+symbolic link.
+
+## Atomicity vs durability
+
+`renameio` concerns itself *only* with atomicity, i.e. making sure applications
+never see unexpected file content (a half-written file, or a 0-byte file).
+
+As a practical example, consider https://manpages.debian.org/: if there is a
+power outage while the site is updating, we are okay with losing the manpages
+which were being rendered at the time of the power outage. They will be added in
+a later run of the software. We are not okay with having a manpage replaced by a
+0-byte file under any circumstances, though.
+
+## Advantages of this package
+
+There are other packages for atomically replacing files, and sometimes ad-hoc
+implementations can be found in programs.
+
+A naive approach to the problem is to create a temporary file followed by a call
+to `os.Rename()`. However, there are a number of subtleties which make the
+correct sequence of operations hard to identify:
+
+* The temporary file should be removed when an error occurs, but a remove must
+  not be attempted if the rename succeeded, as a new file might have been
+  created with the same name. This renders a throwaway `defer
+  os.Remove(t.Name())` insufficient; state must be kept.
+
+* The temporary file must be created on the same file system (same mount point)
+  for the rename to work, but the TMPDIR environment variable should still be
+  respected, e.g. to direct temporary files into a separate directory outside of
+  the webserver’s document root but on the same file system.
+
+* On POSIX operating systems, the
+  [`fsync`](https://manpages.debian.org/stretch/manpages-dev/fsync.2) system
+  call must be used to ensure that the `os.Rename()` call will not result in a
+  0-length file.
+
+This package attempts to get all of these details right, provides an intuitive,
+yet flexible API and caters to use-cases where high performance is required.
+
+## Disclaimer
+
+This is not an official Google product (experimental or otherwise), it
+is just code that happens to be owned by Google.
+
+This project is not affiliated with the Go project.

--- a/vendor/github.com/google/renameio/doc.go
+++ b/vendor/github.com/google/renameio/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package renameio provides a way to atomically create or replace a file or
+// symbolic link.
+//
+// Caveat: this package requires the file system rename(2) implementation to be
+// atomic. Notably, this is not the case when using NFS with multiple clients:
+// https://stackoverflow.com/a/41396801
+package renameio

--- a/vendor/github.com/google/renameio/go.mod
+++ b/vendor/github.com/google/renameio/go.mod
@@ -1,0 +1,1 @@
+module github.com/google/renameio

--- a/vendor/github.com/google/renameio/tempfile.go
+++ b/vendor/github.com/google/renameio/tempfile.go
@@ -1,0 +1,175 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renameio
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// TempDir checks whether os.TempDir() can be used as a temporary directory for
+// later atomically replacing files within dest. If no (os.TempDir() resides on
+// a different mount point), dest is returned.
+//
+// Note that the returned value ceases to be valid once either os.TempDir()
+// changes (e.g. on Linux, once the TMPDIR environment variable changes) or the
+// file system is unmounted.
+func TempDir(dest string) string {
+	return tempDir("", filepath.Join(dest, "renameio-TempDir"))
+}
+
+func tempDir(dir, dest string) string {
+	if dir != "" {
+		return dir // caller-specified directory always wins
+	}
+
+	// Chose the destination directory as temporary directory so that we
+	// definitely can rename the file, for which both temporary and destination
+	// file need to point to the same mount point.
+	fallback := filepath.Dir(dest)
+
+	// The user might have overridden the os.TempDir() return value by setting
+	// the TMPDIR environment variable.
+	tmpdir := os.TempDir()
+
+	testsrc, err := ioutil.TempFile(tmpdir, "."+filepath.Base(dest))
+	if err != nil {
+		return fallback
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			os.Remove(testsrc.Name())
+		}
+	}()
+	testsrc.Close()
+
+	testdest, err := ioutil.TempFile(filepath.Dir(dest), "."+filepath.Base(dest))
+	if err != nil {
+		return fallback
+	}
+	defer os.Remove(testdest.Name())
+	testdest.Close()
+
+	if err := os.Rename(testsrc.Name(), testdest.Name()); err != nil {
+		return fallback
+	}
+	cleanup = false // testsrc no longer exists
+	return tmpdir
+}
+
+// PendingFile is a pending temporary file, waiting to replace the destination
+// path in a call to CloseAtomicallyReplace.
+type PendingFile struct {
+	*os.File
+
+	path   string
+	done   bool
+	closed bool
+}
+
+// Cleanup is a no-op if CloseAtomicallyReplace succeeded, and otherwise closes
+// and removes the temporary file.
+func (t *PendingFile) Cleanup() error {
+	if t.done {
+		return nil
+	}
+	// An error occurred. Close and remove the tempfile. Errors are returned for
+	// reporting, there is nothing the caller can recover here.
+	var closeErr error
+	if !t.closed {
+		closeErr = t.Close()
+	}
+	if err := os.Remove(t.Name()); err != nil {
+		return err
+	}
+	return closeErr
+}
+
+// CloseAtomicallyReplace closes the temporary file and atomically replaces
+// the destination file with it, i.e., a concurrent open(2) call will either
+// open the file previously located at the destination path (if any), or the
+// just written file, but the file will always be present.
+func (t *PendingFile) CloseAtomicallyReplace() error {
+	// Even on an ordered file system (e.g. ext4 with data=ordered) or file
+	// systems with write barriers, we cannot skip the fsync(2) call as per
+	// Theodore Ts'o (ext2/3/4 lead developer):
+	//
+	// > data=ordered only guarantees the avoidance of stale data (e.g., the previous
+	// > contents of a data block showing up after a crash, where the previous data
+	// > could be someone's love letters, medical records, etc.). Without the fsync(2)
+	// > a zero-length file is a valid and possible outcome after the rename.
+	if err := t.Sync(); err != nil {
+		return err
+	}
+	t.closed = true
+	if err := t.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(t.Name(), t.path); err != nil {
+		return err
+	}
+	t.done = true
+	return nil
+}
+
+// TempFile wraps ioutil.TempFile for the use case of atomically creating or
+// replacing the destination file at path.
+//
+// If dir is the empty string, TempDir(filepath.Base(path)) is used. If you are
+// going to write a large number of files to the same file system, store the
+// result of TempDir(filepath.Base(path)) and pass it instead of the empty
+// string.
+//
+// The file's permissions will be 0600 by default. You can change these by
+// explicitly calling Chmod on the returned PendingFile.
+func TempFile(dir, path string) (*PendingFile, error) {
+	f, err := ioutil.TempFile(tempDir(dir, path), "."+filepath.Base(path))
+	if err != nil {
+		return nil, err
+	}
+
+	return &PendingFile{File: f, path: path}, nil
+}
+
+// Symlink wraps os.Symlink, replacing an existing symlink with the same name
+// atomically (os.Symlink fails when newname already exists, at least on Linux).
+func Symlink(oldname, newname string) error {
+	// Fast path: if newname does not exist yet, we can skip the whole dance
+	// below.
+	if err := os.Symlink(oldname, newname); err == nil || !os.IsExist(err) {
+		return err
+	}
+
+	// We need to use ioutil.TempDir, as we cannot overwrite a ioutil.TempFile,
+	// and removing+symlinking creates a TOCTOU race.
+	d, err := ioutil.TempDir(filepath.Dir(newname), "."+filepath.Base(newname))
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(d)
+
+	symlink := filepath.Join(d, "tmp.symlink")
+	if err := os.Symlink(oldname, symlink); err != nil {
+		return err
+	}
+
+	if err := os.Rename(symlink, newname); err != nil {
+		return err
+	}
+
+	return os.RemoveAll(d)
+}

--- a/vendor/github.com/google/renameio/writefile.go
+++ b/vendor/github.com/google/renameio/writefile.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renameio
+
+import "os"
+
+// WriteFile mirrors ioutil.WriteFile, replacing an existing file with the same
+// name atomically.
+func WriteFile(filename string, data []byte, perm os.FileMode) error {
+	t, err := TempFile("", filename)
+	if err != nil {
+		return err
+	}
+	defer t.Cleanup()
+
+	// Set permissions before writing data, in case the data is sensitive.
+	if err := t.Chmod(perm); err != nil {
+		return err
+	}
+
+	if _, err := t.Write(data); err != nil {
+		return err
+	}
+
+	return t.CloseAtomicallyReplace()
+}

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-    "github.com/google/renameio"
+	"github.com/google/renameio"
 )
 
 // Version is the version of the build.

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,113 @@
 package version
 
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/blang/semver"
+    "github.com/google/renameio"
+)
+
 // Version is the version of the build.
 const Version = "1.14.1-dev"
+
+// WriteVersionFile writes the version information to a given file
+// file is the location of the old version file
+// gitCommit is the current git commit version. It will be added to the file
+// to aid in debugging, but will not be used to compare versions
+func WriteVersionFile(file string, gitCommit string) error {
+	current, err := parseVersionConstant(gitCommit)
+	// Sanity check-this should never happen
+	if err != nil {
+		return err
+	}
+	json, err := current.MarshalJSON()
+	// Sanity check-this should never happen
+	if err != nil {
+		return err
+	}
+
+	return renameio.WriteFile(file, json, 0644)
+}
+
+// ShouldCrioUpgrade returns whether the currentVerison is
+// a version that is far enough in the future from the pastVersion
+// to warrant upgrading the node.
+// file is the location of the old version file
+func ShouldCrioUpgrade(file string) (bool, error) {
+	old, err := parseVersionFile(file)
+	if err != nil {
+		// If the file doesn't exist, an upgrade should happen.
+		// This is an expected case and thus not an error
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		// If our error is something else, we probably should upgrade
+		// but let's pass along the error so it can be dealt with
+		// by the caller
+		return true, err
+	}
+
+	// gitCommit is currently not used to check whether crio should upgrade
+	current, err := parseVersionConstant("")
+	// Sanity check-this should never happen
+	if err != nil {
+		return true, err
+	}
+
+	if old.Major < current.Major {
+		return true, nil
+	}
+	if old.Major > current.Major {
+		return false, nil
+	}
+
+	if old.Minor < current.Minor {
+		return true, nil
+	}
+	// As of now, we only care about major and minor versions
+	// If these aren't out of date, no need to upgrade
+	return false, nil
+}
+
+// parseVersionConstant parses the Version variable above
+// a const crioVersion would be kept, but golang doesn't support
+// const structs. We will instead spend some runtime on CRI-O startup
+// Because the version string doesn't keep track of the git commit,
+// but it could be useful for debugging, we pass it in here
+// If our version constant is properly formatted, this should never error
+func parseVersionConstant(gitCommit string) (*semver.Version, error) {
+	v, err := semver.Make(Version)
+	if err != nil {
+		return nil, err
+	}
+	if gitCommit != "" {
+		gitBuild, err := semver.NewBuildVersion(strings.Trim(gitCommit, "\""))
+		if err != nil {
+			return nil, err
+		}
+		v.Build = append(v.Build, gitBuild)
+	}
+	return &v, nil
+}
+
+// parseVersionFile reads a given version.json file for the previous version
+func parseVersionFile(file string) (*semver.Version, error) {
+	vFile, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+
+	vBytes, err := ioutil.ReadAll(vFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var v semver.Version
+	err = v.UnmarshalJSON(vBytes)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}


### PR DESCRIPTION
Support in-place upgrades in CRI-O

Add functionality to version.go to write, read and compare a version.json file.
If the CRI-O version is sufficiently old (differs by a minor version), then we wipe storage to allow kubelet to repopulate images and containers in a (potentially) new format.
Only do this if --clear-storage-on-update configuration is set, to not surprise anyone by destroying their storage :)

note: once this PR lands, I will add a PR in 1.13 to lay down the version file at startup (though the case of not having a version is already handled)