### PR TITLE
Add gocritic appendAssign linter and fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters-settings:
   gocritic:
     enabled-checks:
       # Diagnostic
+      - appendAssign
       - argOrder
       - badCond
       - caseOrder
@@ -56,7 +57,6 @@ linters-settings:
       - nilValReturn
       - offBy1
       - weakCond
-      # - appendAssign
       # - octalLiteral
       # - sloppyReassign
 

--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -128,8 +128,10 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 	}
 	cmd.ExtraFiles = append(cmd.ExtraFiles, childPipe, childStartPipe)
 	// 0, 1 and 2 are stdin, stdout and stderr
-	cmd.Env = append(r.conmonEnv, fmt.Sprintf("_OCI_SYNCPIPE=%d", 3))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("_OCI_STARTPIPE=%d", 4))
+	cmd.Env = r.conmonEnv
+	cmd.Env = append(cmd.Env,
+		fmt.Sprintf("_OCI_SYNCPIPE=%d", 3),
+		fmt.Sprintf("_OCI_STARTPIPE=%d", 4))
 	if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", v))
 	}
@@ -391,7 +393,8 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 	cmd.Stderr = &stderrBuf
 	cmd.ExtraFiles = append(cmd.ExtraFiles, childPipe)
 	// 0, 1 and 2 are stdin, stdout and stderr
-	cmd.Env = append(r.conmonEnv, fmt.Sprintf("_OCI_SYNCPIPE=%d", 3))
+	cmd.Env = r.conmonEnv
+	cmd.Env = append(cmd.Env, fmt.Sprintf("_OCI_SYNCPIPE=%d", 3))
 	if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", v))
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -251,7 +251,8 @@ func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig
 	var args []string
 	if len(kubeCommands) != 0 {
 		entrypoint = kubeCommands[0]
-		args = append(kubeCommands[1:], kubeArgs...)
+		args = kubeCommands[1:]
+		args = append(args, kubeArgs...)
 	} else {
 		entrypoint = kubeArgs[0]
 		args = kubeArgs[1:]

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -917,7 +917,8 @@ func clearReadOnly(m *rspec.Mount) {
 			opt = append(opt, o)
 		}
 	}
-	m.Options = append(opt, "rw")
+	m.Options = opt
+	m.Options = append(m.Options, "rw")
 }
 
 func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, specgen *generate.Generator, bindMountPrefix string) ([]oci.ContainerVolume, []rspec.Mount, error) {


### PR DESCRIPTION
This commit fixes issues related to the `appendAssign` linter, which
detects suspicious append result assignments.