### PR TITLE
Add gocritic builtinShadow linter and fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,6 +98,7 @@ linters-settings:
       - yodaStyleExpr
 
       # Opinionated
+      - builtinShadow
       - importShadow
       - initClause
       - nestingReduce
@@ -105,7 +106,6 @@ linters-settings:
       - typeUnparen
       - unnamedResult
       - unnecessaryBlock
-      # - builtinShadow
       # - paramTypeCombine
   nakedret:
     max-func-lines: 15

--- a/utils/io/container_io.go
+++ b/utils/io/container_io.go
@@ -184,15 +184,15 @@ func (c *ContainerIO) Attach(opts AttachOptions) {
 
 	if opts.Stdout != nil {
 		wg.Add(1)
-		wc, close := cioutil.NewWriteCloseInformer(opts.Stdout)
+		wc, channel := cioutil.NewWriteCloseInformer(opts.Stdout)
 		c.stdoutGroup.Add(stdoutKey, wc)
-		go attachStream(stdoutKey, close)
+		go attachStream(stdoutKey, channel)
 	}
 	if !opts.Tty && opts.Stderr != nil {
 		wg.Add(1)
-		wc, close := cioutil.NewWriteCloseInformer(opts.Stderr)
+		wc, channel := cioutil.NewWriteCloseInformer(opts.Stderr)
 		c.stderrGroup.Add(stderrKey, wc)
-		go attachStream(stderrKey, close)
+		go attachStream(stderrKey, channel)
 	}
 	wg.Wait()
 }

--- a/utils/ioutil/write_closer.go
+++ b/utils/ioutil/write_closer.go
@@ -31,11 +31,11 @@ type writeCloseInformer struct {
 
 // NewWriteCloseInformer creates the writeCloseInformer from a write closer.
 func NewWriteCloseInformer(wc io.WriteCloser) (informer io.WriteCloser, closeChan <-chan struct{}) {
-	close := make(chan struct{})
+	channel := make(chan struct{})
 	return &writeCloseInformer{
-		close: close,
+		close: channel,
 		wc:    wc,
-	}, close
+	}, channel
 }
 
 // Write passes through the data into the internal write closer.


### PR DESCRIPTION
This commit fixes issues related to the `builtinShadow` linter,
which detects shadowing of predeclared identifiers.