### PR TITLE
Add gocritic importShadow linter and fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,13 +98,13 @@ linters-settings:
       # - wrapperFunc
 
       # Opinionated
+      - importShadow
       - initClause
       - nestingReduce
       - ptrToRefParam
       - typeUnparen
       - unnecessaryBlock
       # - builtinShadow
-      # - importShadow
       # - paramTypeCombine
       # - unnamedResult
   nakedret:

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -189,7 +189,7 @@ func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error)
 		}
 	}
 
-	hooks, err := hooks.New(ctx, hookDirectories, []string{}, lang)
+	newHooks, err := hooks.New(ctx, hookDirectories, []string{}, lang)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error)
 		podNameIndex:         registrar.NewRegistrar(),
 		podIDIndex:           truncindex.NewTruncIndex([]string{}),
 		imageContext:         &types.SystemContext{SignaturePolicyPath: config.SignaturePolicyPath},
-		Hooks:                hooks,
+		Hooks:                newHooks,
 		stateLock:            lock,
 		state: &containerServerState{
 			containers:      oci.NewMemoryStore(),
@@ -674,11 +674,11 @@ type containerServerState struct {
 
 // AddContainer adds a container to the container state store
 func (c *ContainerServer) AddContainer(ctr *oci.Container) {
-	sandbox := c.state.sandboxes.Get(ctr.Sandbox())
-	if sandbox == nil {
+	newSandbox := c.state.sandboxes.Get(ctr.Sandbox())
+	if newSandbox == nil {
 		return
 	}
-	sandbox.AddContainer(ctr)
+	newSandbox.AddContainer(ctr)
 	c.state.containers.Add(ctr.ID(), ctr)
 }
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -391,11 +391,11 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	// Add cgroup mount so container process can introspect its own limits
 	specgen.AddMount(mnt)
 
-	devices, err := getDevicesFromConfig(&s.config)
+	configuredDevices, err := getDevicesFromConfig(&s.config)
 	if err != nil {
 		return nil, err
 	}
-	for _, d := range devices {
+	for _, d := range configuredDevices {
 		specgen.AddDevice(d)
 	}
 
@@ -807,15 +807,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		specgen.AddMount(mnt)
 	}
 
-	annotations := map[string]string{}
+	newAnnotations := map[string]string{}
 	for key, value := range containerConfig.GetAnnotations() {
-		annotations[key] = value
+		newAnnotations[key] = value
 	}
 	for key, value := range sb.Annotations() {
-		annotations[key] = value
+		newAnnotations[key] = value
 	}
 	if s.ContainerServer.Hooks != nil {
-		if _, err := s.ContainerServer.Hooks.Hooks(specgen.Config, annotations, len(containerConfig.GetMounts()) > 0); err != nil {
+		if _, err := s.ContainerServer.Hooks.Hooks(specgen.Config, newAnnotations, len(containerConfig.GetMounts()) > 0); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This commit fixes issues related to the `importShadow` linter, which
detects when imported package names shadowed in the assignments.