### PR TITLE
Add config hot reload feature (`log_level`)

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -17,6 +17,11 @@ var commentedConfigTemplate = template.Must(template.New("config").Parse(`
 #
 # Please refer to crio.conf(5) for details of all configuration options.
 
+# CRI-O supports partial configuration reload during runtime, which can be
+# done by sending SIGHUP to the running process. Currently supported options
+# are explicitly mentioned with: 'This option supports live configuration
+# reload'.
+
 # CRI-O reads its storage defaults from the containers-storage.conf(5) file
 # located at /etc/containers/storage.conf. Modify this storage configuration if
 # you want to change the system's defaults. If you want to modify storage just
@@ -185,7 +190,8 @@ container_attach_socket_dir = "{{ .ContainerAttachSocketDir }}"
 read_only = {{ .ReadOnly }}
 
 # Changes the verbosity of the logs based on the level it is set to. Options
-# are fatal, panic, error, warn, info, and debug.
+# are fatal, panic, error, warn, info, and debug. This option supports live
+# configuration reload.
 log_level = "{{ .LogLevel }}"
 
 # The default log directory where all logs will go unless directly specified by the kubelet

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -8,6 +8,8 @@ crio.conf - configuration file of the CRI-O OCI Kubernetes Container Runtime dae
 # DESCRIPTION
 The CRI-O configuration file specifies all of the available configuration options and command-line flags for the [crio(8) OCI Kubernetes Container Runtime daemon][crio], but in a TOML format that can be more easily modified and versioned.
 
+CRI-O supports partial configuration reload during runtime, which can be done by sending SIGHUP to the running process. Currently supported options are explicitly marked with 'This option supports live configuration reload'.
+
 The default crio.conf is located at /etc/crio/crio.conf.
 
 # FORMAT
@@ -159,7 +161,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
   If set to true, all containers will run in read-only mode.
 
 **log_level**="error"
-  Changes the verbosity of the logs based on the level it is set to. Options are fatal, panic, error, warn, info, and debug.
+  Changes the verbosity of the logs based on the level it is set to. Options are fatal, panic, error, warn, info, and debug. This option supports live configuration reload.
 
 **log_dir**="/var/log/crio/pods"
   The default log directory where all logs will go unless directly specified by the kubelet

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
@@ -23,6 +24,7 @@ import (
 	"github.com/cri-o/cri-o/lib/sandbox"
 	"github.com/cri-o/cri-o/oci"
 	"github.com/cri-o/cri-o/pkg/seccomp"
+	"github.com/cri-o/cri-o/pkg/signals"
 	"github.com/cri-o/cri-o/pkg/storage"
 	"github.com/cri-o/cri-o/server/metrics"
 	"github.com/cri-o/cri-o/version"
@@ -281,8 +283,9 @@ func getIDMappings(config *Config) (*idtools.IDMappings, error) {
 	return idtools.NewIDMappingsFromMaps(parsedUIDsMappings, parsedGIDsMappings), nil
 }
 
-// New creates a new Server with options provided
-func New(ctx context.Context, configIface ConfigIface) (*Server, error) {
+// New creates a new Server with the provided context, configPath and
+// configuration
+func New(ctx context.Context, configPath string, configIface ConfigIface) (*Server, error) {
 	if configIface == nil || configIface.GetData() == nil {
 		return nil, fmt.Errorf("provided configuration interface or its data is nil")
 	}
@@ -406,6 +409,13 @@ func New(ctx context.Context, configIface ConfigIface) (*Server, error) {
 	}()
 
 	logrus.Debugf("sandboxes: %v", s.ContainerServer.ListSandboxes())
+
+	// Start a configuration watcher for the default config
+	if _, err := s.StartConfigWatcher(configPath, s.config.Reload); err != nil {
+		logrus.Warnf("unable to start config watcher for file %q: %v",
+			configPath, err)
+	}
+
 	return s, nil
 }
 
@@ -467,7 +477,7 @@ func (s *Server) CreateMetricsEndpoint() (*http.ServeMux, error) {
 	return mux, nil
 }
 
-// StopMonitors stops al the monitors
+// StopMonitors stops all the monitors
 func (s *Server) StopMonitors() {
 	close(s.monitorsChan)
 }
@@ -537,4 +547,39 @@ func (s *Server) StartExitMonitor() {
 		close(done)
 	}
 	<-done
+}
+
+// StartConfigWatcher starts a new watching go routine for the provided
+// `fileName` and `reloadFunc`. The method errors if the given fileName does
+// not exist or is not accessible.
+func (s *Server) StartConfigWatcher(
+	fileName string,
+	reloadFunc func(string) error,
+) (chan os.Signal, error) {
+	// Validate the arguments
+	if _, err := os.Stat(fileName); err != nil {
+		return nil, err
+	}
+	if reloadFunc == nil {
+		return nil, fmt.Errorf("provided reload closure is nil")
+	}
+
+	// Setup the signal notifier
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, signals.Hup)
+
+	go func() {
+		for {
+			// Block until the signal is received
+			<-c
+			logrus.Infof("reloading configuration %q", fileName)
+			if err := reloadFunc(fileName); err != nil {
+				logrus.Errorf("unable to reload configuration: %v", err)
+				continue
+			}
+		}
+	}()
+
+	logrus.Debugf("registered SIGHUP watcher for file %q", fileName)
+	return c, nil
 }

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -183,7 +183,7 @@ var afterEach = func() {
 var setupSUT = func() {
 	var err error
 	mockNewServer()
-	sut, err = server.New(context.Background(), serverMock)
+	sut, err = server.New(context.Background(), "", serverMock)
 	Expect(err).To(BeNil())
 	Expect(sut).NotTo(BeNil())
 


### PR DESCRIPTION
Hey there :wave:, this is an idea I had recently, so I want to put it under discussion here.

I think it would be nice to reload the CRI-O configuration files (`/etc/crio/crio.conf`, `/etc/containers/*`) without restarting the application. This is surely a feature where it has to be decided per option if an application restart is sensible, so I would add an extra documentation part for every "hot reloadable" option.

For a small test I implemented the feature for the `log_level` option within this PR. It actually works by sending `SIGHUP` to the `crio` process:

```
...
DEBU[2019-05-09 14:04:01.433231541+02:00] successfully registered config file watcher
...
DEBU[2019-05-09 14:04:11.294262201+02:00] reloading configuration
INFO[2019-05-09 14:04:11.298918608+02:00] set config log level to "error"
INFO[2019-05-09 14:04:17.583173259+02:00] set config log level to "info"
INFO[2019-05-09 14:04:24.454580923+02:00] set config log level to "debug"
...
```

What do you think? Do you think this is something where we should follow up?

---

**Edit:** Implemented it via the handling of `SIGHUP` and adapted documentation and tests. PTAL