### PR TITLE
conmon: properly set conmon logs

### DIFF
--- a/conmon/utils.c
+++ b/conmon/utils.c
@@ -1,6 +1,9 @@
 #include "utils.h"
 #include <string.h>
 
+log_level_t log_level = WARN_LEVEL;
+char *cid = NULL;
+bool use_syslog = false;
 /* Set the log level for this call. log level defaults to warning.
    parse the string value of level_name to the appropriate log_level_t enum value
 */

--- a/conmon/utils.h
+++ b/conmon/utils.h
@@ -29,9 +29,9 @@ typedef enum {
 
 // Default log level is Warning, This will be configured before any logging
 // should happen
-static log_level_t log_level = WARN_LEVEL;
-static char *cid = NULL;
-static bool use_syslog = false;
+extern log_level_t log_level;
+extern char *cid;
+extern bool use_syslog;
 
 #define pexit(s) \
 	do { \


### PR DESCRIPTION
conmon logging levels, syslog and container ID are now set correctly

This fix also fixes compilation for gcc 9 (which only breaks if syslog default is changed in the code, but it was annoying to deal with)

Signed-off-by: Peter Hunt <pehunt@redhat.com>
