### PR TITLE
Add gocritic sloppyReassign linter and fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,10 +55,10 @@ linters-settings:
       - flagName
       - nilValReturn
       - offBy1
+      - sloppyReassign
       - weakCond
       # - appendAssign
       # - octalLiteral
-      # - sloppyReassign
 
       # Performance
       - equalFold

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -280,7 +280,7 @@ func (c *ContainerServer) Update() error {
 		}
 		c.ReleaseContainerName(ctr.Name())
 		c.RemoveContainer(ctr)
-		if err = c.ctrIDIndex.Delete(ctr.ID()); err != nil {
+		if err := c.ctrIDIndex.Delete(ctr.ID()); err != nil {
 			return err
 		}
 		logrus.Debugf("forgetting removed pod container %s", ctr.ID())
@@ -301,7 +301,7 @@ func (c *ContainerServer) Update() error {
 		podInfraContainer := sb.InfraContainer()
 		c.ReleaseContainerName(podInfraContainer.Name())
 		c.RemoveContainer(podInfraContainer)
-		if err = c.ctrIDIndex.Delete(podInfraContainer.ID()); err != nil {
+		if err := c.ctrIDIndex.Delete(podInfraContainer.ID()); err != nil {
 			return err
 		}
 		sb.RemoveInfraContainer()
@@ -309,7 +309,7 @@ func (c *ContainerServer) Update() error {
 		if err := c.RemoveSandbox(sb.ID()); err != nil {
 			logrus.Warnf("failed to remove sandbox ID %s: %v", sb.ID(), err)
 		}
-		if err = c.podIDIndex.Delete(sb.ID()); err != nil {
+		if err := c.podIDIndex.Delete(sb.ID()); err != nil {
 			return err
 		}
 		logrus.Debugf("forgetting removed pod %s", sb.ID())
@@ -340,11 +340,11 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 	var m rspec.Spec
-	if err = json.Unmarshal(config, &m); err != nil {
+	if err := json.Unmarshal(config, &m); err != nil {
 		return err
 	}
 	labels := make(map[string]string)
-	if err = json.Unmarshal([]byte(m.Annotations[annotations.Labels]), &labels); err != nil {
+	if err := json.Unmarshal([]byte(m.Annotations[annotations.Labels]), &labels); err != nil {
 		return err
 	}
 	name := m.Annotations[annotations.Name]
@@ -358,7 +358,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		}
 	}()
 	var metadata pb.PodSandboxMetadata
-	if err = json.Unmarshal([]byte(m.Annotations[annotations.Metadata]), &metadata); err != nil {
+	if err := json.Unmarshal([]byte(m.Annotations[annotations.Metadata]), &metadata); err != nil {
 		return err
 	}
 
@@ -375,7 +375,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	spp := m.Annotations[annotations.SeccompProfilePath]
 
 	kubeAnnotations := make(map[string]string)
-	if err = json.Unmarshal([]byte(m.Annotations[annotations.Annotations]), &kubeAnnotations); err != nil {
+	if err := json.Unmarshal([]byte(m.Annotations[annotations.Annotations]), &kubeAnnotations); err != nil {
 		return err
 	}
 
@@ -471,14 +471,14 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	c.ContainerStateFromDisk(scontainer)
 	sb.SetCreated()
 
-	if err = label.ReserveLabel(processLabel); err != nil {
+	if err := label.ReserveLabel(processLabel); err != nil {
 		return err
 	}
 	sb.SetInfraContainer(scontainer)
-	if err = c.ctrIDIndex.Add(scontainer.ID()); err != nil {
+	if err := c.ctrIDIndex.Add(scontainer.ID()); err != nil {
 		return err
 	}
-	if err = c.podIDIndex.Add(id); err != nil {
+	if err := c.podIDIndex.Add(id); err != nil {
 		return err
 	}
 	return nil
@@ -507,11 +507,11 @@ func (c *ContainerServer) LoadContainer(id string) error {
 		return err
 	}
 	var m rspec.Spec
-	if err = json.Unmarshal(config, &m); err != nil {
+	if err := json.Unmarshal(config, &m); err != nil {
 		return err
 	}
 	labels := make(map[string]string)
-	if err = json.Unmarshal([]byte(m.Annotations[annotations.Labels]), &labels); err != nil {
+	if err := json.Unmarshal([]byte(m.Annotations[annotations.Labels]), &labels); err != nil {
 		return err
 	}
 	name := m.Annotations[annotations.Name]
@@ -527,7 +527,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 	}()
 
 	var metadata pb.ContainerMetadata
-	if err = json.Unmarshal([]byte(m.Annotations[annotations.Metadata]), &metadata); err != nil {
+	if err := json.Unmarshal([]byte(m.Annotations[annotations.Metadata]), &metadata); err != nil {
 		return err
 	}
 	sb := c.GetSandbox(m.Annotations[annotations.SandboxID])
@@ -565,7 +565,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 	}
 
 	kubeAnnotations := make(map[string]string)
-	if err = json.Unmarshal([]byte(m.Annotations[annotations.Annotations]), &kubeAnnotations); err != nil {
+	if err := json.Unmarshal([]byte(m.Annotations[annotations.Annotations]), &kubeAnnotations); err != nil {
 		return err
 	}
 

--- a/lib/kill.go
+++ b/lib/kill.go
@@ -21,7 +21,7 @@ func (c *ContainerServer) ContainerKill(container string, killSignal syscall.Sig
 		return "", errors.Errorf("cannot kill container %s: it is not running", container)
 	}
 
-	if err = c.runtime.SignalContainer(ctr, killSignal); err != nil {
+	if err := c.runtime.SignalContainer(ctr, killSignal); err != nil {
 		return "", err
 	}
 

--- a/lib/rename.go
+++ b/lib/rename.go
@@ -35,22 +35,22 @@ func (c *ContainerServer) ContainerRename(container, name string) error {
 	}()
 
 	// Update state.json
-	if err = c.updateStateName(ctr, name); err != nil {
+	if err := c.updateStateName(ctr, name); err != nil {
 		return err
 	}
 
 	// Update config.json
 	configRuntimePath := filepath.Join(ctr.BundlePath(), configFile)
-	if err = updateConfigName(configRuntimePath, name); err != nil {
+	if err := updateConfigName(configRuntimePath, name); err != nil {
 		return err
 	}
 	configStoragePath := filepath.Join(ctr.Dir(), configFile)
-	if err = updateConfigName(configStoragePath, name); err != nil {
+	if err := updateConfigName(configStoragePath, name); err != nil {
 		return err
 	}
 
 	// Update containers.json
-	if err = c.store.SetNames(ctr.ID(), []string{name}); err != nil {
+	if err := c.store.SetNames(ctr.ID(), []string{name}); err != nil {
 		return err
 	}
 	return nil

--- a/oci/runtime_vm.go
+++ b/oci/runtime_vm.go
@@ -89,7 +89,7 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err erro
 	defer c.opLock.Unlock()
 
 	// First thing, we need to start the runtime daemon
-	if err = r.startRuntimeDaemon(c); err != nil {
+	if err := r.startRuntimeDaemon(c); err != nil {
 		return err
 	}
 
@@ -355,7 +355,7 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 	}()
 
 	// Start the process
-	if err = r.start(ctx, c.ID(), execID); err != nil {
+	if err := r.start(ctx, c.ID(), execID); err != nil {
 		return -1, err
 	}
 

--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -397,7 +397,7 @@ func (r *runtimeService) GetContainerMetadata(idOrName string) (RuntimeContainer
 	if err != nil {
 		return metadata, err
 	}
-	if err = json.Unmarshal([]byte(mdata), &metadata); err != nil {
+	if err := json.Unmarshal([]byte(mdata), &metadata); err != nil {
 		return metadata, err
 	}
 	return metadata, nil
@@ -412,7 +412,7 @@ func (r *runtimeService) StartContainer(idOrName string) (string, error) {
 		return "", err
 	}
 	metadata := RuntimeContainerMetadata{}
-	if err = json.Unmarshal([]byte(container.Metadata), &metadata); err != nil {
+	if err := json.Unmarshal([]byte(container.Metadata), &metadata); err != nil {
 		return "", err
 	}
 	mountPoint, err := r.storageImageServer.GetStore().Mount(container.ID, metadata.MountLabel)

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -590,7 +590,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		}
 	}()
 
-	if err = s.CtrIDIndex().Add(containerID); err != nil {
+	if err := s.CtrIDIndex().Add(containerID); err != nil {
 		return nil, err
 	}
 	defer func() {
@@ -601,7 +601,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		}
 	}()
 
-	if err = s.createContainerPlatform(container, sb.InfraContainer(), sb.CgroupParent()); err != nil {
+	if err := s.createContainerPlatform(container, sb.InfraContainer(), sb.CgroupParent()); err != nil {
 		return nil, err
 	}
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -717,7 +717,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 
 	spp := containerConfig.GetLinux().GetSecurityContext().GetSeccompProfilePath()
 	if !privileged {
-		if err = s.setupSeccomp(&specgen, spp); err != nil {
+		if err := s.setupSeccomp(&specgen, spp); err != nil {
 			return nil, err
 		}
 	}
@@ -822,7 +822,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 
 	// Setup user and groups
 	if linux != nil {
-		if err = setupContainerUser(&specgen, mountPoint, mountLabel, containerInfo.RunDir, linux.GetSecurityContext(), containerImageConfig); err != nil {
+		if err := setupContainerUser(&specgen, mountPoint, mountLabel, containerInfo.RunDir, linux.GetSecurityContext(), containerImageConfig); err != nil {
 			return nil, err
 		}
 	}
@@ -861,10 +861,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	}
 
 	saveOptions := generate.ExportOptions{}
-	if err = specgen.SaveToFile(filepath.Join(containerInfo.Dir, "config.json"), saveOptions); err != nil {
+	if err := specgen.SaveToFile(filepath.Join(containerInfo.Dir, "config.json"), saveOptions); err != nil {
 		return nil, err
 	}
-	if err = specgen.SaveToFile(filepath.Join(containerInfo.RunDir, "config.json"), saveOptions); err != nil {
+	if err := specgen.SaveToFile(filepath.Join(containerInfo.RunDir, "config.json"), saveOptions); err != nil {
 		return nil, err
 	}
 

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -23,7 +23,7 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *p
 		return nil, err
 	}
 
-	if err = s.Runtime().UpdateContainerStatus(c); err != nil {
+	if err := s.Runtime().UpdateContainerStatus(c); err != nil {
 		return nil, err
 	}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -232,7 +232,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if logDir == "" {
 		logDir = filepath.Join(s.config.LogDir, id)
 	}
-	if err = os.MkdirAll(logDir, 0700); err != nil {
+	if err := os.MkdirAll(logDir, 0700); err != nil {
 		return nil, err
 	}
 	// This should always be absolute from k8s.
@@ -303,7 +303,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 
-	if err = s.CtrIDIndex().Add(id); err != nil {
+	if err := s.CtrIDIndex().Add(id); err != nil {
 		return nil, err
 	}
 
@@ -440,7 +440,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}()
 
-	if err = s.PodIDIndex().Add(id); err != nil {
+	if err := s.PodIDIndex().Add(id); err != nil {
 		return nil, err
 	}
 
@@ -492,7 +492,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	} else if s.config.Config.ManageNetworkNSLifecycle {
 		// Create the sandbox network namespace
-		if err = sb.NetNsCreate(nil); err != nil {
+		if err := sb.NetNsCreate(nil); err != nil {
 			return nil, err
 		}
 
@@ -633,7 +633,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation(annotations.SeccompProfilePath, spp)
 	sb.SetSeccompProfilePath(spp)
 	if !privileged {
-		if err = s.setupSeccomp(&g, spp); err != nil {
+		if err := s.setupSeccomp(&g, spp); err != nil {
 			return nil, err
 		}
 	}
@@ -663,11 +663,11 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	}
 
-	if err = s.createContainerPlatform(container, nil, sb.CgroupParent()); err != nil {
+	if err := s.createContainerPlatform(container, nil, sb.CgroupParent()); err != nil {
 		return nil, err
 	}
 
-	if err = s.Runtime().StartContainer(container); err != nil {
+	if err := s.Runtime().StartContainer(container); err != nil {
 		return nil, err
 	}
 
@@ -713,7 +713,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 func setupShm(podSandboxRunDir, mountLabel string) (shmPath string, err error) {
 	shmPath = filepath.Join(podSandboxRunDir, "shm")
-	if err = os.Mkdir(shmPath, 0700); err != nil {
+	if err := os.Mkdir(shmPath, 0700); err != nil {
 		return "", err
 	}
 	shmOptions := "mode=1777,size=" + strconv.Itoa(sandbox.DefaultShmSize)


### PR DESCRIPTION
This commit fixes issues related to the `sloppyReassign` linter, which
detects suspicious and confusing re-assignments.