### PR TITLE
Add gocritic unnamedResult linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,10 +102,10 @@ linters-settings:
       - nestingReduce
       - ptrToRefParam
       - typeUnparen
+      - unnamedResult
       - unnecessaryBlock
       # - builtinShadow
       # - importShadow
       # - paramTypeCombine
-      # - unnamedResult
   nakedret:
     max-func-lines: 15

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -132,13 +132,13 @@ func getMountInfo(mountInfos []*dockermounts.Info, dir string) *dockermounts.Inf
 	return nil
 }
 
-func getSourceMount(source string, mountInfos []*dockermounts.Info) (string, string, error) {
+func getSourceMount(source string, mountInfos []*dockermounts.Info) (path string, optionalMountInfo string, err error) {
 	mountinfo := getMountInfo(mountInfos, source)
 	if mountinfo != nil {
 		return source, mountinfo.Optional, nil
 	}
 
-	path := source
+	path = source
 	for {
 		path = filepath.Dir(path)
 		mountinfo = getMountInfo(mountInfos, path)

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -120,7 +120,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 	return resp, nil
 }
 
-func decodeDockerAuth(s string) (string, string, error) {
+func decodeDockerAuth(s string) (user string, password string, err error) {
 	decoded, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
 		return "", "", err
@@ -130,7 +130,7 @@ func decodeDockerAuth(s string) (string, string, error) {
 		// if it's invalid just skip, as docker does
 		return "", "", nil
 	}
-	user := parts[0]
-	password := strings.Trim(parts[1], "\x00")
+	user = parts[0]
+	password = strings.Trim(parts[1], "\x00")
 	return user, password, nil
 }

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -91,7 +91,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (r
 
 // getUserFromImage gets uid or user name of the image user.
 // If user is numeric, it will be treated as uid; or else, it is treated as user name.
-func getUserFromImage(user string) (*int64, string) {
+func getUserFromImage(user string) (id *int64, username string) {
 	// return both empty if user is not specified in the image.
 	if user == "" {
 		return nil, ""

--- a/server/naming.go
+++ b/server/naming.go
@@ -46,39 +46,30 @@ func makeContainerName(sandboxMetadata *pb.PodSandboxMetadata, containerConfig *
 	}, nameDelimiter)
 }
 
-func (s *Server) generatePodIDandName(sandboxConfig *pb.PodSandboxConfig) (string, string, error) {
-	var (
-		err error
-		id  = stringid.GenerateNonCryptoID()
-	)
+func (s *Server) generatePodIDandName(sandboxConfig *pb.PodSandboxConfig) (id string, name string, err error) {
+	id = stringid.GenerateNonCryptoID()
 	if sandboxConfig.Metadata.Namespace == "" {
 		return "", "", fmt.Errorf("cannot generate pod ID without namespace")
 	}
-	name, err := s.ReservePodName(id, makeSandboxName(sandboxConfig))
+	name, err = s.ReservePodName(id, makeSandboxName(sandboxConfig))
 	if err != nil {
 		return "", "", err
 	}
 	return id, name, err
 }
 
-func (s *Server) generateContainerIDandNameForSandbox(sandboxConfig *pb.PodSandboxConfig) (string, string, error) {
-	var (
-		err error
-		id  = stringid.GenerateNonCryptoID()
-	)
-	name, err := s.ReserveContainerName(id, makeSandboxContainerName(sandboxConfig))
+func (s *Server) generateContainerIDandNameForSandbox(sandboxConfig *pb.PodSandboxConfig) (id string, name string, err error) {
+	id = stringid.GenerateNonCryptoID()
+	name, err = s.ReserveContainerName(id, makeSandboxContainerName(sandboxConfig))
 	if err != nil {
 		return "", "", err
 	}
 	return id, name, err
 }
 
-func (s *Server) generateContainerIDandName(sandboxMetadata *pb.PodSandboxMetadata, containerConfig *pb.ContainerConfig) (string, string, error) {
-	var (
-		err error
-		id  = stringid.GenerateNonCryptoID()
-	)
-	name, err := s.ReserveContainerName(id, makeContainerName(sandboxMetadata, containerConfig))
+func (s *Server) generateContainerIDandName(sandboxMetadata *pb.PodSandboxMetadata, containerConfig *pb.ContainerConfig) (id string, name string, err error) {
+	id = stringid.GenerateNonCryptoID()
+	name, err = s.ReserveContainerName(id, makeContainerName(sandboxMetadata, containerConfig))
 	if err != nil {
 		return "", "", err
 	}

--- a/server/secrets.go
+++ b/server/secrets.go
@@ -80,8 +80,8 @@ func readFile(root, name string) ([]SecretData, error) {
 	return []SecretData{{Name: name, Data: bytes}}, nil
 }
 
-// getHostAndCtrDir separates the host:container paths
-func getMountsMap(path string) (string, string, error) {
+// getMountsMap separates the host:container paths
+func getMountsMap(path string) (host string, container string, err error) {
 	arr := strings.SplitN(path, ":", 2)
 	if len(arr) == 2 {
 		return arr[0], arr[1], nil

--- a/utils/io/container_io.go
+++ b/utils/io/container_io.go
@@ -199,8 +199,7 @@ func (c *ContainerIO) Attach(opts AttachOptions) {
 
 // AddOutput adds new write closers to the container stream, and returns existing
 // write closers if there are any.
-func (c *ContainerIO) AddOutput(name string, stdout, stderr io.WriteCloser) (io.WriteCloser, io.WriteCloser) {
-	var oldStdout, oldStderr io.WriteCloser
+func (c *ContainerIO) AddOutput(name string, stdout, stderr io.WriteCloser) (oldStdout io.WriteCloser, oldStderr io.WriteCloser) {
 	if stdout != nil {
 		key := streamKey(c.id, name, Stdout)
 		oldStdout = c.stdoutGroup.Get(key)

--- a/utils/io/logger.go
+++ b/utils/io/logger.go
@@ -50,7 +50,7 @@ func NewDiscardLogger() io.WriteCloser {
 // returns a channel which indicates whether the logger is stopped.
 // maxLen is the max length limit of a line. A line longer than the
 // limit will be cut into multiple lines.
-func NewCRILogger(path string, w io.Writer, stream StreamType, maxLen int) (io.WriteCloser, <-chan struct{}) {
+func NewCRILogger(path string, w io.Writer, stream StreamType, maxLen int) (pipeWriter io.WriteCloser, stopChan <-chan struct{}) {
 	logrus.Debugf("Start writing stream %q to log file %q", stream, path)
 	prc, pwc := io.Pipe()
 	stop := make(chan struct{})

--- a/utils/ioutil/write_closer.go
+++ b/utils/ioutil/write_closer.go
@@ -30,7 +30,7 @@ type writeCloseInformer struct {
 }
 
 // NewWriteCloseInformer creates the writeCloseInformer from a write closer.
-func NewWriteCloseInformer(wc io.WriteCloser) (io.WriteCloser, <-chan struct{}) {
+func NewWriteCloseInformer(wc io.WriteCloser) (informer io.WriteCloser, closeChan <-chan struct{}) {
 	close := make(chan struct{})
 	return &writeCloseInformer{
 		close: close,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -211,7 +211,7 @@ func openContainerFile(rootfs string, path string) (io.ReadCloser, error) {
 
 // GetUserInfo returns UID, GID and additional groups for specified user
 // by looking them up in /etc/passwd and /etc/group
-func GetUserInfo(rootfs string, userName string) (uint32, uint32, []uint32, error) {
+func GetUserInfo(rootfs string, userName string) (uid uint32, gid uint32, additionalGids []uint32, err error) {
 	// We don't care if we can't open the file because
 	// not all images will have these files
 	passwdFile, err := openContainerFile(rootfs, "/etc/passwd")
@@ -233,9 +233,9 @@ func GetUserInfo(rootfs string, userName string) (uint32, uint32, []uint32, erro
 		return 0, 0, nil, err
 	}
 
-	uid := uint32(execUser.Uid)
-	gid := uint32(execUser.Gid)
-	additionalGids := make([]uint32, 0, len(execUser.Sgids))
+	uid = uint32(execUser.Uid)
+	gid = uint32(execUser.Gid)
+	additionalGids = make([]uint32, 0, len(execUser.Sgids))
 	for _, g := range execUser.Sgids {
 		additionalGids = append(additionalGids, uint32(g))
 	}


### PR DESCRIPTION
This commit fixes issues related to the `unnamedResult` linter, which
detects unnamed results that may benefit from names.