### PR TITLE
Add gocritic wrapperFunc linter and fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,8 +94,8 @@ linters-settings:
       - unlambda
       - unslice
       - valSwap
+      - wrapperFunc
       - yodaStyleExpr
-      # - wrapperFunc
 
       # Opinionated
       - initClause

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -203,7 +203,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 }
 
 func writeCrioGoroutineStacks() {
-	path := filepath.Join("/tmp", fmt.Sprintf("crio-goroutine-stacks-%s.log", strings.Replace(time.Now().Format(time.RFC3339), ":", "", -1)))
+	path := filepath.Join("/tmp", fmt.Sprintf("crio-goroutine-stacks-%s.log", strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", "")))
 	if err := utils.WriteGoroutineStacksToFile(path); err != nil {
 		logrus.Warnf("Failed to write goroutine stacks: %s", err)
 	}

--- a/oci/runtime_vm.go
+++ b/oci/runtime_vm.go
@@ -170,7 +170,7 @@ func (r *runtimeVM) startRuntimeDaemon(c *Container) error {
 	args = append(args, "start")
 
 	// Modify the runtime path so that it complies with v2 shim API
-	newRuntimePath := strings.Replace(r.path, "-", ".", -1)
+	newRuntimePath := strings.ReplaceAll(r.path, "-", ".")
 
 	// Setup default namespace
 	r.ctx = namespaces.WithNamespace(r.ctx, namespaces.Default)


### PR DESCRIPTION
This commit fixes issues related to the `wrapperFunc` linter,
which detects function calls that can be replaced with convenience
wrappers.