### PR TITLE
Update unit test target to not run `mockgen`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,11 @@ jobs:
           keys:
             - v1-unit-tests-{{ checksum "go.sum" }}
       - run:
+          name: check mocks
+          command: |
+            make mockgen
+            hack/tree_status.sh
+      - run:
           name: unit tests
           command: make testunit
       - store_test_results:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ jobs:
     - stage: Test
       name: build, unit test and code coverage report
       script:
+        - make mockgen
+        - hack/tree_status.sh
         - make testunit
         - make
         - make codecov

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ vendor:
 		$(GO) mod vendor && \
 		$(GO) mod verify
 
-testunit: mockgen ${GINKGO}
+testunit: ${GINKGO}
 	rm -rf ${COVERAGE_PATH} && mkdir -p ${COVERAGE_PATH}
 	rm -rf ${JUNIT_PATH} && mkdir -p ${JUNIT_PATH}
 	${BUILD_BIN_PATH}/ginkgo \

--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -6,7 +6,7 @@ if [[ -z $STATUS ]]
 then
 	echo "tree is clean"
 else
-	echo "tree is dirty, please commit all changes and sync the vendor.conf"
+	echo "tree is dirty, please commit all changes"
 	echo ""
 	echo "$STATUS"
 	exit 1


### PR DESCRIPTION
The mockgen target takes too much time on local machines to run before
every test. This commit splits up the workflow and should provide a
better local developer experience when running unit tests. The CI
scripts have been adapted to check for modified mocks and fail in that
case.