### PR TITLE
Cleanup SystemContext usage

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"text/template"
 
+	"github.com/containers/image/types"
 	"github.com/cri-o/cri-o/server"
 	"github.com/urfave/cli"
 )
@@ -299,15 +300,16 @@ var configCommand = cli.Command{
 		// At this point, app.Before has already parsed the user's chosen
 		// config file. So no need to handle that here.
 		config := c.App.Metadata["config"].(*server.Config)
+		systemContext := &types.SystemContext{}
 		if c.Bool("default") {
-			config, err = server.DefaultConfig()
+			config, err = server.DefaultConfig(systemContext)
 			if err != nil {
 				return err
 			}
 		}
 
 		// Validate the configuration during generation
-		if err = config.Validate(false); err != nil {
+		if err = config.Validate(systemContext, false); err != nil {
 			return err
 		}
 

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/image/types"
 	_ "github.com/containers/libpod/pkg/hooks/0.1.0"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/cri-o/cri-o/lib"
@@ -270,7 +271,8 @@ func main() {
 	app.Usage = "crio server"
 	app.Version = strings.Join(v, "\n")
 
-	defConf, err := server.DefaultConfig()
+	systemContext := &types.SystemContext{}
+	defConf, err := server.DefaultConfig(systemContext)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error loading server config: %v", err)
 		os.Exit(1)
@@ -569,7 +571,7 @@ func main() {
 		config := c.App.Metadata["config"].(*server.Config)
 
 		// Validate the configuration during runtime
-		if err := config.Validate(true); err != nil {
+		if err := config.Validate(systemContext, true); err != nil {
 			cancel()
 			return err
 		}
@@ -606,7 +608,7 @@ func main() {
 			grpc.MaxRecvMsgSize(config.GRPCMaxRecvMsgSize),
 		)
 
-		service, err := server.New(ctx, configPath, config)
+		service, err := server.New(ctx, systemContext, configPath, config)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -18,7 +18,7 @@ var _ = t.Describe("Config", func() {
 
 	BeforeEach(func() {
 		var err error
-		sut, err = lib.DefaultConfig()
+		sut, err = lib.DefaultConfig(nil)
 		Expect(err).To(BeNil())
 		Expect(sut).NotTo(BeNil())
 	})
@@ -32,7 +32,7 @@ var _ = t.Describe("Config", func() {
 		It("should succeed with default config", func() {
 			// Given
 			// When
-			err := sut.Validate(false)
+			err := sut.Validate(nil, false)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -43,7 +43,7 @@ var _ = t.Describe("Config", func() {
 			sut.RootConfig.LogDir = "/dev/null"
 
 			// When
-			err := sut.Validate(true)
+			err := sut.Validate(nil, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -55,7 +55,7 @@ var _ = t.Describe("Config", func() {
 			sut.AdditionalDevices = []string{wrongPath}
 
 			// When
-			err := sut.Validate(true)
+			err := sut.Validate(nil, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -69,7 +69,7 @@ var _ = t.Describe("Config", func() {
 			sut.NetworkConfig.NetworkDir = wrongPath
 
 			// When
-			err := sut.Validate(true)
+			err := sut.Validate(nil, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -80,7 +80,7 @@ var _ = t.Describe("Config", func() {
 		It("should succeed with default config", func() {
 			// Given
 			// When
-			err := sut.RuntimeConfig.Validate(false)
+			err := sut.RuntimeConfig.Validate(nil, false)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -92,7 +92,7 @@ var _ = t.Describe("Config", func() {
 			sut.Conmon = validPath
 
 			// When
-			err := sut.RuntimeConfig.Validate(true)
+			err := sut.RuntimeConfig.Validate(nil, true)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -105,7 +105,7 @@ var _ = t.Describe("Config", func() {
 			sut.Conmon = validPath
 
 			// When
-			err := sut.RuntimeConfig.Validate(true)
+			err := sut.RuntimeConfig.Validate(nil, true)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -118,7 +118,7 @@ var _ = t.Describe("Config", func() {
 			sut.HooksDir = []string{validPath}
 
 			// When
-			err := sut.RuntimeConfig.Validate(true)
+			err := sut.RuntimeConfig.Validate(nil, true)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -131,7 +131,7 @@ var _ = t.Describe("Config", func() {
 			sut.HooksDir = []string{wrongPath}
 
 			// When
-			err := sut.RuntimeConfig.Validate(true)
+			err := sut.RuntimeConfig.Validate(nil, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -144,7 +144,7 @@ var _ = t.Describe("Config", func() {
 			sut.HooksDir = []string{validPath}
 
 			// When
-			err := sut.RuntimeConfig.Validate(true)
+			err := sut.RuntimeConfig.Validate(nil, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -155,7 +155,7 @@ var _ = t.Describe("Config", func() {
 			sut.DefaultUlimits = []string{wrongPath}
 
 			// When
-			err := sut.RuntimeConfig.Validate(false)
+			err := sut.RuntimeConfig.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -166,7 +166,7 @@ var _ = t.Describe("Config", func() {
 			sut.AdditionalDevices = []string{"::::"}
 
 			// When
-			err := sut.RuntimeConfig.Validate(false)
+			err := sut.RuntimeConfig.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -177,7 +177,7 @@ var _ = t.Describe("Config", func() {
 			sut.AdditionalDevices = []string{wrongPath}
 
 			// When
-			err := sut.RuntimeConfig.Validate(false)
+			err := sut.RuntimeConfig.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -188,7 +188,7 @@ var _ = t.Describe("Config", func() {
 			sut.AdditionalDevices = []string{"/dev/null:/dev/null:abc"}
 
 			// When
-			err := sut.RuntimeConfig.Validate(false)
+			err := sut.RuntimeConfig.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -199,7 +199,7 @@ var _ = t.Describe("Config", func() {
 			sut.AdditionalDevices = []string{"wrong:/dev/null:rw"}
 
 			// When
-			err := sut.RuntimeConfig.Validate(false)
+			err := sut.RuntimeConfig.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -210,7 +210,7 @@ var _ = t.Describe("Config", func() {
 			sut.AdditionalDevices = []string{"/dev/null:wrong:rw"}
 
 			// When
-			err := sut.RuntimeConfig.Validate(false)
+			err := sut.RuntimeConfig.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -221,7 +221,7 @@ var _ = t.Describe("Config", func() {
 			sut.Runtimes = make(map[string]oci.RuntimeHandler)
 
 			// When
-			err := sut.RuntimeConfig.Validate(false)
+			err := sut.RuntimeConfig.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -232,7 +232,7 @@ var _ = t.Describe("Config", func() {
 			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: "not-existing"}
 
 			// When
-			err := sut.RuntimeConfig.Validate(true)
+			err := sut.RuntimeConfig.Validate(nil, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -30,7 +30,7 @@ var _ = t.Describe("ContainerServer", func() {
 			defer os.Remove(tmpfile.Name())
 
 			// Setup config
-			config, err := lib.DefaultConfig()
+			config, err := lib.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 			config.FileLockingPath = tmpfile.Name()
 			config.HooksDir = []string{}
@@ -42,7 +42,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			server, err := lib.New(context.Background(), libMock)
+			server, err := lib.New(context.Background(), nil, libMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -56,7 +56,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			server, err := lib.New(context.Background(), libMock)
+			server, err := lib.New(context.Background(), nil, libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -64,7 +64,7 @@ var _ = t.Describe("ContainerServer", func() {
 		})
 
 		It("should fail when Store is nil", func() {
-			config, err := lib.DefaultConfig()
+			config, err := lib.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 			// Given
 			gomock.InOrder(
@@ -73,7 +73,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			server, err := lib.New(context.Background(), libMock)
+			server, err := lib.New(context.Background(), nil, libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -83,7 +83,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should fail when config is nil", func() {
 			// Given
 			// When
-			server, err := lib.New(context.Background(), nil)
+			server, err := lib.New(context.Background(), nil, nil)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -92,7 +92,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with invalid default runtime", func() {
 			// Given
-			config, err := lib.DefaultConfig()
+			config, err := lib.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 			config.DefaultRuntime = "invalid-runtime"
 			gomock.InOrder(
@@ -101,7 +101,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			server, err := lib.New(context.Background(), libMock)
+			server, err := lib.New(context.Background(), nil, libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -110,7 +110,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with invalid lockfile", func() {
 			// Given
-			config, err := lib.DefaultConfig()
+			config, err := lib.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 			config.FileLocking = true
 			config.FileLockingPath = "/invalid/file"
@@ -120,7 +120,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			server, err := lib.New(context.Background(), libMock)
+			server, err := lib.New(context.Background(), nil, libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -129,7 +129,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with invalid hooks dir", func() {
 			// Given
-			config, err := lib.DefaultConfig()
+			config, err := lib.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 			config.FileLocking = false
 			config.HooksDir = []string{"/invalid-dir"}
@@ -139,7 +139,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			server, err := lib.New(context.Background(), libMock)
+			server, err := lib.New(context.Background(), nil, libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -207,15 +207,6 @@ var _ = t.Describe("ContainerServer", func() {
 			// Given
 			// When
 			res := sut.PodIDIndex()
-
-			// Then
-			Expect(res).NotTo(BeNil())
-		})
-
-		It("should succeed to get the ImageContext", func() {
-			// Given
-			// When
-			res := sut.ImageContext()
 
 			// Then
 			Expect(res).NotTo(BeNil())

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -118,7 +118,7 @@ func beforeEach() {
 	logrus.SetLevel(logrus.PanicLevel)
 
 	// Set the config
-	config, err := lib.DefaultConfig()
+	config, err := lib.DefaultConfig(nil)
 	Expect(err).To(BeNil())
 	config.FileLocking = false
 	config.LogDir = "."
@@ -130,7 +130,7 @@ func beforeEach() {
 	)
 
 	// Setup the sut
-	sut, err = lib.New(context.Background(), libMock)
+	sut, err = lib.New(context.Background(), nil, libMock)
 	Expect(err).To(BeNil())
 	Expect(sut).NotTo(BeNil())
 

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -155,7 +155,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(testImageName)
+			names, err := sut.ResolveNames(nil, testImageName)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -172,7 +172,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(imageName)
+			names, err := sut.ResolveNames(nil, imageName)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -188,7 +188,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(testImageName)
+			names, err := sut.ResolveNames(nil, testImageName)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -204,7 +204,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(testSHA256)
+			names, err := sut.ResolveNames(nil, testSHA256)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -220,7 +220,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames("camelCaseName")
+			names, err := sut.ResolveNames(nil, "camelCaseName")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -246,7 +246,7 @@ var _ = t.Describe("Image", func() {
 			Expect(sut).NotTo(BeNil())
 
 			// When
-			names, err := sut.ResolveNames(testImageName)
+			names, err := sut.ResolveNames(nil, testImageName)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/config.go
+++ b/server/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 
 	"github.com/BurntSushi/toml"
+	"github.com/containers/image/types"
 	"github.com/cri-o/cri-o/lib"
 	"github.com/cri-o/cri-o/oci"
 	"github.com/pkg/errors"
@@ -144,8 +145,8 @@ func (c *Config) ToFile(path string) error {
 }
 
 // DefaultConfig returns the default configuration for crio.
-func DefaultConfig() (*Config, error) {
-	conf, err := lib.DefaultConfig()
+func DefaultConfig(systemContext *types.SystemContext) (*Config, error) {
+	conf, err := lib.DefaultConfig(systemContext)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +166,7 @@ func DefaultConfig() (*Config, error) {
 // The parameter `onExecution` specifies if the validation should include
 // execution checks. It returns an `error` on validation failure, otherwise
 // `nil`.
-func (c *Config) Validate(onExecution bool) error {
+func (c *Config) Validate(systemContext *types.SystemContext, onExecution bool) error {
 	switch c.ImageVolumes {
 	case lib.ImageVolumesMkdir:
 	case lib.ImageVolumesIgnore:
@@ -174,7 +175,7 @@ func (c *Config) Validate(onExecution bool) error {
 		return fmt.Errorf("unrecognized image volume type specified")
 	}
 
-	if err := c.Config.Validate(onExecution); err != nil {
+	if err := c.Config.Validate(systemContext, onExecution); err != nil {
 		return errors.Wrapf(err, "library config validation")
 	}
 
@@ -194,9 +195,9 @@ func (c *Config) Validate(onExecution bool) error {
 
 // Reload reloads the configuration with the config at the provided `fileName`
 // path. The method errors in case of any read or update failure.
-func (c *Config) Reload(fileName string) error {
+func (c *Config) Reload(systemContext *types.SystemContext, fileName string) error {
 	// Reload the config
-	newConfig, err := DefaultConfig()
+	newConfig, err := DefaultConfig(systemContext)
 	if err != nil {
 		return fmt.Errorf("unable to create default config")
 	}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -26,7 +26,7 @@ var _ = t.Describe("Config", func() {
 	t.Describe("UpdateFromFile", func() {
 		It("should succeed", func() {
 			// Given
-			sut, err := server.DefaultConfig()
+			sut, err := server.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 			const filePath = "crio-test.conf"
 			Expect(sut.ToFile(filePath)).To(BeNil())
@@ -37,7 +37,7 @@ var _ = t.Describe("Config", func() {
 
 			// Then
 			Expect(err).To(BeNil())
-			expected, err := server.DefaultConfig()
+			expected, err := server.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 			Expect(sut).To(Equal(expected))
 		})
@@ -65,7 +65,7 @@ var _ = t.Describe("Config", func() {
 		It("should succeed", func() {
 			// Given
 			const filePath = "crio-tofile.conf"
-			sut, err := server.DefaultConfig()
+			sut, err := server.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 			defer os.RemoveAll(filePath)
 
@@ -81,7 +81,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail when file not writeable", func() {
 			// Given
-			sut, err := server.DefaultConfig()
+			sut, err := server.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 
 			// When
@@ -95,7 +95,7 @@ var _ = t.Describe("Config", func() {
 	t.Describe("GetData", func() {
 		It("should succeed with default config", func() {
 			// Given
-			sut, err := server.DefaultConfig()
+			sut, err := server.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 
 			// When
@@ -118,7 +118,7 @@ var _ = t.Describe("Config", func() {
 	t.Describe("GetLibConfigIface", func() {
 		It("should succeed with default config", func() {
 			// Given
-			sut, err := server.DefaultConfig()
+			sut, err := server.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 
 			// When
@@ -142,14 +142,14 @@ var _ = t.Describe("Config", func() {
 		// Setup the system under test
 		BeforeEach(func() {
 			var err error
-			sut, err = server.DefaultConfig()
+			sut, err = server.DefaultConfig(nil)
 			Expect(err).To(BeNil())
 		})
 
 		It("should succeed with default config", func() {
 			// Given
 			// When
-			err := sut.Validate(false)
+			err := sut.Validate(nil, false)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -166,7 +166,7 @@ var _ = t.Describe("Config", func() {
 			defer os.RemoveAll(tmpDir)
 
 			// When
-			err := sut.Validate(true)
+			err := sut.Validate(nil, true)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -180,7 +180,7 @@ var _ = t.Describe("Config", func() {
 			sut.NetworkConfig.NetworkDir = wrongPath
 
 			// When
-			err := sut.Validate(true)
+			err := sut.Validate(nil, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -191,7 +191,7 @@ var _ = t.Describe("Config", func() {
 			sut.ImageVolumes = wrongPath
 
 			// When
-			err := sut.Validate(false)
+			err := sut.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -202,7 +202,7 @@ var _ = t.Describe("Config", func() {
 			sut.DefaultUlimits = []string{wrongPath}
 
 			// When
-			err := sut.Validate(false)
+			err := sut.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -214,7 +214,7 @@ var _ = t.Describe("Config", func() {
 			sut.ManageNetworkNSLifecycle = true
 
 			// When
-			err := sut.Validate(false)
+			err := sut.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -226,7 +226,7 @@ var _ = t.Describe("Config", func() {
 			sut.ManageNetworkNSLifecycle = true
 
 			// When
-			err := sut.Validate(false)
+			err := sut.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -237,7 +237,7 @@ var _ = t.Describe("Config", func() {
 			sut.LogSizeMax = 1
 
 			// When
-			err := sut.Validate(false)
+			err := sut.Validate(nil, false)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -288,7 +288,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	if image == "" {
 		return nil, fmt.Errorf("CreateContainerRequest.ContainerConfig.Image.Image is empty")
 	}
-	images, err := s.StorageImageServer().ResolveNames(image)
+	images, err := s.StorageImageServer().ResolveNames(s.systemContext, image)
 	if err != nil {
 		if err == storage.ErrCannotParseImageID {
 			images = append(images, image)
@@ -303,7 +303,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		imgResultErr error
 	)
 	for _, img := range images {
-		imgResult, imgResultErr = s.StorageImageServer().ImageStatus(s.ImageContext(), img)
+		imgResult, imgResultErr = s.StorageImageServer().ImageStatus(s.systemContext, img)
 		if imgResultErr == nil {
 			break
 		}
@@ -336,7 +336,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	containerIDMappings := s.defaultIDMappings
 	metadata := containerConfig.GetMetadata()
 
-	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.ImageContext(),
+	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.systemContext,
 		sb.Name(), sb.ID(),
 		image, imgResult.ID,
 		containerName, containerID,

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containers/image/types"
 	"github.com/cri-o/cri-o/oci"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -41,7 +40,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		},
 	}
 	resp.Status.Image = &pb.ImageSpec{Image: c.Image()}
-	if status, err := s.StorageImageServer().ImageStatus(&types.SystemContext{}, c.ImageRef()); err == nil {
+	if status, err := s.StorageImageServer().ImageStatus(s.systemContext, c.ImageRef()); err == nil {
 		resp.Status.Image.Image = status.Name
 	}
 

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -25,7 +25,7 @@ func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (res
 			filter = filterImage.Image
 		}
 	}
-	results, err := s.StorageImageServer().ListImages(s.ImageContext(), filter)
+	results, err := s.StorageImageServer().ListImages(s.systemContext, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -34,7 +34,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 		images []string
 		pulled string
 	)
-	images, err = s.StorageImageServer().ResolveNames(image)
+	images, err = s.StorageImageServer().ResolveNames(s.systemContext, image)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 		options := &copy.Options{
 			SourceCtx: &types.SystemContext{
 				DockerRegistryUserAgent: useragent.Get(ctx),
-				SignaturePolicyPath:     s.ImageContext().SignaturePolicyPath,
+				SignaturePolicyPath:     s.systemContext.SignaturePolicyPath,
 			},
 		}
 
@@ -79,7 +79,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 		}
 
 		var storedImage *storage.ImageResult
-		storedImage, err = s.StorageImageServer().ImageStatus(s.ImageContext(), img)
+		storedImage, err = s.StorageImageServer().ImageStatus(s.systemContext, img)
 		if err == nil {
 			tmpImgConfigDigest := tmpImg.ConfigInfo().Digest
 			if tmpImgConfigDigest.String() == "" {
@@ -94,7 +94,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 			logrus.Debugf("image in store has different ID, re-pulling %s", img)
 		}
 
-		_, err = s.StorageImageServer().PullImage(s.ImageContext(), img, options)
+		_, err = s.StorageImageServer().PullImage(s.systemContext, img, options)
 		if err != nil {
 			logrus.Debugf("error pulling image %s: %v", img, err)
 			continue
@@ -105,7 +105,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 	if pulled == "" && err != nil {
 		return nil, err
 	}
-	status, err := s.StorageImageServer().ImageStatus(s.ImageContext(), pulled)
+	status, err := s.StorageImageServer().ImageStatus(s.systemContext, pulled)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_pull_test.go
+++ b/server/image_pull_test.go
@@ -25,7 +25,8 @@ var _ = t.Describe("ImagePull", func() {
 		It("should succeed with pull", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().PrepareImage(gomock.Any(),
 					gomock.Any()).Return(imageMock, nil),
@@ -56,7 +57,8 @@ var _ = t.Describe("ImagePull", func() {
 		It("should succeed when already pulled", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().PrepareImage(gomock.Any(),
 					gomock.Any()).Return(imageMock, nil),
@@ -91,7 +93,8 @@ var _ = t.Describe("ImagePull", func() {
 		It("should fail when second image status retrieval errors", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().PrepareImage(gomock.Any(),
 					gomock.Any()).Return(imageMock, nil),
@@ -127,7 +130,8 @@ var _ = t.Describe("ImagePull", func() {
 		It("should fail credential decode erros", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 			)
 
@@ -148,7 +152,8 @@ var _ = t.Describe("ImagePull", func() {
 		It("should fail when image pull erros", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().PrepareImage(gomock.Any(),
 					gomock.Any()).Return(imageMock, nil),
@@ -175,7 +180,8 @@ var _ = t.Describe("ImagePull", func() {
 		It("should fail when prepare image errors", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().PrepareImage(gomock.Any(),
 					gomock.Any()).Return(nil, t.TestError),
@@ -194,7 +200,8 @@ var _ = t.Describe("ImagePull", func() {
 		It("should fail when resolve names errors", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return(nil, t.TestError),
 			)
 			// When

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -31,7 +31,7 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (r
 		images  []string
 		deleted bool
 	)
-	images, err = s.StorageImageServer().ResolveNames(image)
+	images, err = s.StorageImageServer().ResolveNames(s.systemContext, image)
 	if err != nil {
 		if err == storage.ErrCannotParseImageID {
 			images = append(images, image)
@@ -40,7 +40,7 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (r
 		}
 	}
 	for _, img := range images {
-		err = s.StorageImageServer().UntagImage(s.ImageContext(), img)
+		err = s.StorageImageServer().UntagImage(s.systemContext, img)
 		if err != nil {
 			logrus.Debugf("error deleting image %s: %v", img, err)
 			continue

--- a/server/image_remove_test.go
+++ b/server/image_remove_test.go
@@ -25,7 +25,8 @@ var _ = t.Describe("ImageRemove", func() {
 		It("should succeed", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().UntagImage(gomock.Any(),
 					gomock.Any()).Return(nil),
@@ -42,7 +43,8 @@ var _ = t.Describe("ImageRemove", func() {
 		It("should succeed when image id cannot be parsed", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return(nil, storage.ErrCannotParseImageID),
 				imageServerMock.EXPECT().UntagImage(gomock.Any(),
 					gomock.Any()).Return(nil),
@@ -59,7 +61,8 @@ var _ = t.Describe("ImageRemove", func() {
 		It("should fail when image untag errors", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().UntagImage(gomock.Any(),
 					gomock.Any()).Return(t.TestError),
@@ -76,7 +79,8 @@ var _ = t.Describe("ImageRemove", func() {
 		It("should fail when name resolving errors", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return(nil, t.TestError),
 			)
 			// When

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -31,7 +31,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (r
 	if image == "" {
 		return nil, fmt.Errorf("no image specified")
 	}
-	images, err := s.StorageImageServer().ResolveNames(image)
+	images, err := s.StorageImageServer().ResolveNames(s.systemContext, image)
 	if err != nil {
 		if err == pkgstorage.ErrCannotParseImageID {
 			images = append(images, image)
@@ -44,7 +44,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (r
 		lastErr  error
 	)
 	for _, image := range images {
-		status, err := s.StorageImageServer().ImageStatus(s.ImageContext(), image)
+		status, err := s.StorageImageServer().ImageStatus(s.systemContext, image)
 		if err != nil {
 			if errors.Cause(err) == storage.ErrImageUnknown {
 				logrus.Warnf("imageStatus: can't find %s", image)

--- a/server/image_status_test.go
+++ b/server/image_status_test.go
@@ -27,7 +27,8 @@ var _ = t.Describe("ImageStatus", func() {
 			// Given
 			size := uint64(100)
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().ImageStatus(
 					gomock.Any(), gomock.Any()).
@@ -47,7 +48,8 @@ var _ = t.Describe("ImageStatus", func() {
 		It("should succeed with wrong image id", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return(nil, storage.ErrCannotParseImageID),
 				imageServerMock.EXPECT().ImageStatus(
 					gomock.Any(), gomock.Any()).
@@ -66,7 +68,8 @@ var _ = t.Describe("ImageStatus", func() {
 		It("should succeed with unknown image", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().ImageStatus(
 					gomock.Any(), gomock.Any()).
@@ -85,7 +88,8 @@ var _ = t.Describe("ImageStatus", func() {
 		It("should fail with wrong image status retrieval", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return([]string{"image"}, nil),
 				imageServerMock.EXPECT().ImageStatus(
 					gomock.Any(), gomock.Any()).
@@ -104,7 +108,8 @@ var _ = t.Describe("ImageStatus", func() {
 		It("should fail if resolve names failed", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(gomock.Any()).
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
 					Return(nil, t.TestError),
 			)
 

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"net/http"
 
-	cimage "github.com/containers/image/types"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/lib/sandbox"
 	"github.com/cri-o/cri-o/oci"
@@ -74,7 +73,7 @@ func (s *Server) getContainerInfo(id string, getContainerFunc, getInfraContainer
 	}
 	image := ctr.Image()
 	if s.ContainerServer != nil && s.ContainerServer.StorageImageServer() != nil {
-		if status, err := s.ContainerServer.StorageImageServer().ImageStatus(&cimage.SystemContext{}, ctr.ImageRef()); err == nil {
+		if status, err := s.ContainerServer.StorageImageServer().ImageStatus(s.systemContext, ctr.ImageRef()); err == nil {
 			image = status.Name
 		}
 	}

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetInfo(t *testing.T) {
-	c, err := lib.DefaultConfig()
+	c, err := lib.DefaultConfig(nil)
 	if err != nil {
 		t.Fatal("error loading default config")
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -109,7 +109,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if selinuxConfig != nil {
 		labelOptions = getLabelOptions(selinuxConfig)
 	}
-	podContainer, err := s.StorageRuntimeServer().CreatePodSandbox(s.ImageContext(),
+	podContainer, err := s.StorageRuntimeServer().CreatePodSandbox(s.systemContext,
 		name, id,
 		s.config.PauseImage, "",
 		containerName,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/containers/image/types"
 	cstorage "github.com/containers/storage"
 	"github.com/cri-o/cri-o/pkg/signals"
 	"github.com/cri-o/cri-o/server"
@@ -39,7 +40,7 @@ var _ = t.Describe("Server", func() {
 			mockNewServer()
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -55,7 +56,7 @@ var _ = t.Describe("Server", func() {
 
 			// When
 			server, err := server.New(
-				context.Background(), tmpFile, serverMock,
+				context.Background(), nil, tmpFile, serverMock,
 			)
 
 			// Then
@@ -71,7 +72,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.GIDMappings = "1:1:1"
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -86,7 +87,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.StreamTLSCert = "../test/testdata/cert.pem"
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -122,7 +123,7 @@ var _ = t.Describe("Server", func() {
 			)
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -132,7 +133,7 @@ var _ = t.Describe("Server", func() {
 		It("should fail when provided config is nil", func() {
 			// Given
 			// When
-			server, err := server.New(context.Background(), "", nil)
+			server, err := server.New(context.Background(), nil, "", nil)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -147,7 +148,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.ContainerAttachSocketDir = invalidDir
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -162,7 +163,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.ContainerExitsDir = invalidDir
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -177,7 +178,7 @@ var _ = t.Describe("Server", func() {
 			)
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -195,7 +196,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.NetworkDir = invalidDir
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -215,7 +216,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.GIDMappings = g
 
 			// When
-			sut, err := server.New(context.Background(), "", serverMock)
+			sut, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -237,7 +238,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.SeccompProfile = invalidDir
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -255,7 +256,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.SeccompProfile = "/dev/null"
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -269,7 +270,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.StreamPort = invalid
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -284,7 +285,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.StreamTLSKey = invalid
 
 			// When
-			server, err := server.New(context.Background(), "", serverMock)
+			server, err := server.New(context.Background(), nil, "", serverMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -370,7 +371,12 @@ var _ = t.Describe("Server", func() {
 
 			// When
 			ch, err := sut.StartConfigWatcher(
-				tmpFile, func(fileName string) error { return nil },
+				tmpFile, func(
+					systemContext *types.SystemContext,
+					fileName string,
+				) error {
+					return nil
+				},
 			)
 			ch <- signals.Hup
 
@@ -385,7 +391,12 @@ var _ = t.Describe("Server", func() {
 
 			// When
 			ch, err := sut.StartConfigWatcher(
-				tmpFile, func(fileName string) error { return t.TestError },
+				tmpFile, func(
+					systemContext *types.SystemContext,
+					fileName string,
+				) error {
+					return t.TestError
+				},
 			)
 			ch <- signals.Hup
 

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -136,7 +136,7 @@ var beforeEach = func() {
 	// Prepare the server config
 	testPath = "test"
 	var err error
-	serverConfig, err = server.DefaultConfig()
+	serverConfig, err = server.DefaultConfig(nil)
 	Expect(err).To(BeNil())
 	serverConfig.ContainerAttachSocketDir = testPath
 	serverConfig.ContainerExitsDir = path.Join(testPath, "exits")
@@ -145,7 +145,7 @@ var beforeEach = func() {
 	serverConfig.NetworkDir = os.TempDir()
 
 	// Prepare the library config
-	libConfig, err = lib.DefaultConfig()
+	libConfig, err = lib.DefaultConfig(nil)
 	Expect(err).To(BeNil())
 	libConfig.FileLocking = false
 	libConfig.Runtimes["runc"] = serverConfig.Runtimes["runc"]
@@ -183,7 +183,7 @@ var afterEach = func() {
 var setupSUT = func() {
 	var err error
 	mockNewServer()
-	sut, err = server.New(context.Background(), "", serverMock)
+	sut, err = server.New(context.Background(), nil, "", serverMock)
 	Expect(err).To(BeNil())
 	Expect(sut).NotTo(BeNil())
 

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -126,18 +126,18 @@ func (mr *MockImageServerMockRecorder) RemoveImage(arg0, arg1 interface{}) *gomo
 }
 
 // ResolveNames mocks base method
-func (m *MockImageServer) ResolveNames(arg0 string) ([]string, error) {
+func (m *MockImageServer) ResolveNames(arg0 *types.SystemContext, arg1 string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveNames", arg0)
+	ret := m.ctrl.Call(m, "ResolveNames", arg0, arg1)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveNames indicates an expected call of ResolveNames
-func (mr *MockImageServerMockRecorder) ResolveNames(arg0 interface{}) *gomock.Call {
+func (mr *MockImageServerMockRecorder) ResolveNames(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNames", reflect.TypeOf((*MockImageServer)(nil).ResolveNames), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNames", reflect.TypeOf((*MockImageServer)(nil).ResolveNames), arg0, arg1)
 }
 
 // UntagImage mocks base method

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -73,9 +73,9 @@ github.com/containers/buildah/pkg/blobcache
 github.com/containers/buildah/pkg/chrootuser
 github.com/containers/buildah/unshare
 # github.com/containers/image v1.5.1
+github.com/containers/image/types
 github.com/containers/image/pkg/sysregistries
 github.com/containers/image/pkg/sysregistriesv2
-github.com/containers/image/types
 github.com/containers/image/copy
 github.com/containers/image/docker/reference
 github.com/containers/image/manifest


### PR DESCRIPTION
The SystemContext is now created from the main binaries like
`cmd/crio/main.go` and then passed down to the actual methods. For this
we now store the `systemContext` at the `Server` in substition to the
`ImageContext` of the `ContainerServer`. All tests have been adapted as
well.