### PR TITLE
Remove terminal watch after success

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -703,7 +703,9 @@ exit:
 	/* Clean up everything */
 	close(connfd);
 
-	return G_SOURCE_CONTINUE;
+	/* Since we've gotten our console from the runtime, we no longer need to
+	   be listening on this callback. */
+	return G_SOURCE_REMOVE;
 }
 
 static int get_exit_status(int status)

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -1307,11 +1307,10 @@ int main(int argc, char *argv[])
 		pexit("Failed to set handler for SIGCHLD");
 
 	if (csname != NULL) {
-		guint terminal_watch = g_unix_fd_add(console_socket_fd, G_IO_IN, terminal_accept_cb, csname);
+		g_unix_fd_add(console_socket_fd, G_IO_IN, terminal_accept_cb, csname);
 		/* Process any SIGCHLD we may have missed before the signal handler was in place.  */
 		check_child_processes(pid_to_handler);
 		g_main_loop_run(main_loop);
-		g_source_remove(terminal_watch);
 	} else {
 		int ret;
 		/* Wait for our create child to exit with the return code. */


### PR DESCRIPTION
We used to continue to listen on the console socket for our terminal master, even though we've already cleaned everything else up.

Instead, we should just remove the callback, so there's no chance of calling it later and printing a very confusing looking loop of "trying to connect, failed to connect".

Signed-off-by: Peter Hunt <pehunt@redhat.com>