### PR TITLE
Enable errcheck lint and fixup error paths

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - deadcode
     - depguard
     - dupl
+    - errcheck
     - gochecknoinits
     - goconst
     - gocritic
@@ -38,11 +39,13 @@ linters:
     - unparam
     - unused
     - varcheck
-    # - errcheck
     # - gochecknoglobals
     # - gocyclo
     # - lll
 linters-settings:
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
   gocritic:
     enabled-checks:
       # Diagnostic

--- a/client/client.go
+++ b/client/client.go
@@ -42,7 +42,9 @@ func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 // New returns a crio client
 func New(crioSocketPath string) (CrioClient, error) {
 	tr := new(http.Transport)
-	configureUnixTransport(tr, "unix", crioSocketPath)
+	if err := configureUnixTransport(tr, "unix", crioSocketPath); err != nil {
+		return nil, err
+	}
 	c := &http.Client{
 		Transport: tr,
 	}

--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -302,7 +302,7 @@ var configCommand = cli.Command{
 		var err error
 		// At this point, app.Before has already parsed the user's chosen
 		// config file. So no need to handle that here.
-		config := c.App.Metadata["config"].(*server.Config)
+		config := c.App.Metadata["config"].(*server.Config) // nolint: errcheck
 		systemContext := &types.SystemContext{}
 		if c.Bool("default") {
 			config, err = server.DefaultConfig(systemContext)

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -511,7 +511,10 @@ func main() {
 	var configPath string
 	app.Before = func(c *cli.Context) (err error) {
 		// Load the configuration file.
-		config := c.App.Metadata["config"].(*server.Config)
+		config, ok := c.App.Metadata["config"].(*server.Config)
+		if !ok {
+			return fmt.Errorf("type assertion error when accessing server config")
+		}
 		configPath, err = mergeConfig(config, c)
 		if err != nil {
 			return err
@@ -575,7 +578,11 @@ func main() {
 			return fmt.Errorf("command %q not supported", args[0])
 		}
 
-		config := c.App.Metadata["config"].(*server.Config)
+		config, ok := c.App.Metadata["config"].(*server.Config)
+		if !ok {
+			cancel()
+			return fmt.Errorf("type assertion error when accessing server config")
+		}
 
 		// Validate the configuration during runtime
 		if err := config.Validate(systemContext, true); err != nil {

--- a/lib/config.go
+++ b/lib/config.go
@@ -358,8 +358,8 @@ func (c *Config) ToFile(path string) error {
 
 // DefaultConfig returns the default configuration for crio.
 func DefaultConfig(systemContext *types.SystemContext) (*Config, error) {
-	registries, _ := sysregistries.GetRegistries(systemContext)
-	insecureRegistries, _ := sysregistries.GetInsecureRegistries(systemContext)
+	registries, _ := sysregistries.GetRegistries(systemContext)                 // nolint: errcheck
+	insecureRegistries, _ := sysregistries.GetInsecureRegistries(systemContext) // nolint: errcheck
 	storeOpts, err := storage.DefaultStoreOptions(rootless.IsRootless(), rootless.GetRootlessUID())
 	if err != nil {
 		return nil, err

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -216,7 +216,9 @@ func (c *ContainerServer) Update() error {
 			ctr := c.GetContainer(id)
 			if ctr != nil {
 				// if the container exists, update its state
-				c.ContainerStateFromDisk(c.GetContainer(id))
+				if err := c.ContainerStateFromDisk(c.GetContainer(id)); err != nil {
+					logrus.Warnf("unable to retrieve containers %s state from disk: %v", id, err)
+				}
 			}
 		}
 	})
@@ -425,7 +427,9 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	if err := label.ReserveLabel(processLabel); err != nil {
 		return err
 	}
-	sb.SetInfraContainer(scontainer)
+	if err := sb.SetInfraContainer(scontainer); err != nil {
+		return err
+	}
 	if err := c.ctrIDIndex.Add(scontainer.ID()); err != nil {
 		return err
 	}

--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -290,7 +290,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should succeed with sandbox", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			gomock.InOrder(
 				storeMock.EXPECT().Containers().
 					Return([]cstorage.Container{{ID: sandboxID}}, nil),
@@ -305,7 +305,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should succeed with container", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			sut.AddContainer(myContainer)
 			gomock.InOrder(
 				storeMock.EXPECT().Containers().
@@ -359,7 +359,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should succeed with already added sandbox", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			createDummyState()
 			mockDirs(testManifest)
 			gomock.InOrder(
@@ -662,7 +662,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed", func() {
 			// Given
 			createDummyState()
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			mockDirs(testManifest)
 
 			// When
@@ -689,7 +689,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with failing ContainerRunDirectory", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			gomock.InOrder(
 				storeMock.EXPECT().
 					FromContainerDirectory(gomock.Any(), gomock.Any()).
@@ -707,7 +707,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with failing ContainerDirectory", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			gomock.InOrder(
 				storeMock.EXPECT().
 					FromContainerDirectory(gomock.Any(), gomock.Any()).
@@ -955,7 +955,7 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("AddContainer/AddSandbox", func() {
 		It("should succeed", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			sut.AddContainer(myContainer)
 
 			// When
@@ -985,10 +985,10 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("RemoveContainer/RemoveSandbox", func() {
 		It("should succeed", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			sut.AddContainer(myContainer)
 			sut.RemoveContainer(myContainer)
-			sut.RemoveSandbox(mySandbox.ID())
+			Expect(sut.RemoveSandbox(mySandbox.ID())).To(BeNil())
 
 			// When
 			hasSandbox := sut.HasSandbox(mySandbox.ID())
@@ -1002,9 +1002,9 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail to remove container when sandbox not available", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			sut.AddContainer(myContainer)
-			sut.RemoveSandbox(mySandbox.ID())
+			Expect(sut.RemoveSandbox(mySandbox.ID())).To(BeNil())
 			sut.RemoveContainer(myContainer)
 
 			// When
@@ -1018,7 +1018,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail to remove sandbox when not available", func() {
 			// Given
-			sut.RemoveSandbox(mySandbox.ID())
+			Expect(sut.RemoveSandbox(mySandbox.ID())).To(BeNil())
 
 			// When
 			hasSandbox := sut.HasSandbox(mySandbox.ID())
@@ -1031,7 +1031,7 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("ListContainer/ListSandbox", func() {
 		It("should succeed", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			sut.AddContainer(myContainer)
 
 			// When
@@ -1046,7 +1046,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should succeed filtered", func() {
 			// Given
-			sut.AddSandbox(mySandbox)
+			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 			sut.AddContainer(myContainer)
 
 			// When

--- a/lib/pause.go
+++ b/lib/pause.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cri-o/cri-o/oci"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // ContainerPause pauses a running container.
@@ -19,7 +20,9 @@ func (c *ContainerServer) ContainerPause(container string) (string, error) {
 		if err := c.runtime.PauseContainer(ctr); err != nil {
 			return "", errors.Wrapf(err, "failed to pause container %s", ctr.ID())
 		}
-		c.ContainerStateToDisk(ctr)
+		if err := c.ContainerStateToDisk(ctr); err != nil {
+			logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
+		}
 	} else {
 		return "", fmt.Errorf("container %s is already paused", ctr.ID())
 	}
@@ -39,7 +42,9 @@ func (c *ContainerServer) ContainerUnpause(container string) (string, error) {
 		if err := c.runtime.UnpauseContainer(ctr); err != nil {
 			return "", errors.Wrapf(err, "failed to unpause container %s", ctr.ID())
 		}
-		c.ContainerStateToDisk(ctr)
+		if err := c.ContainerStateToDisk(ctr); err != nil {
+			logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
+		}
 	} else {
 		return "", fmt.Errorf("the container %s is not paused", ctr.ID())
 	}

--- a/lib/sandbox/sandbox_test.go
+++ b/lib/sandbox/sandbox_test.go
@@ -286,7 +286,7 @@ var _ = t.Describe("Sandbox", func() {
 		It("should not crash when parameter is nil", func() {
 			// Given
 			// When
-			_ = testSandbox.NetNsCreate(nil)
+			_ = testSandbox.NetNsCreate(nil) // nolint: errcheck
 
 			// Then
 		})

--- a/lib/stop.go
+++ b/lib/stop.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cri-o/cri-o/oci"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // ContainerStop stops a running container with a grace period (i.e., timeout).
@@ -32,7 +33,9 @@ func (c *ContainerServer) ContainerStop(ctx context.Context, container string, t
 		}
 	}
 
-	c.ContainerStateToDisk(ctr)
+	if err := c.ContainerStateToDisk(ctr); err != nil {
+		logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
+	}
 
 	return ctrID, nil
 }

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -169,12 +169,12 @@ func mockDirs(manifest []byte) {
 }
 
 func addContainerAndSandbox() {
-	sut.AddSandbox(mySandbox)
+	Expect(sut.AddSandbox(mySandbox)).To(BeNil())
 	sut.AddContainer(myContainer)
 	Expect(sut.CtrIDIndex().Add(containerID)).To(BeNil())
 	Expect(sut.PodIDIndex().Add(sandboxID)).To(BeNil())
 }
 
 func createDummyState() {
-	ioutil.WriteFile("state.json", []byte("{}"), 0644)
+	Expect(ioutil.WriteFile("state.json", []byte("{}"), 0644)).To(BeNil())
 }

--- a/oci/finished.go
+++ b/oci/finished.go
@@ -3,12 +3,16 @@
 package oci
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"time"
 )
 
-func getFinishedTime(fi os.FileInfo) time.Time {
-	st := fi.Sys().(*syscall.Stat_t)
-	return time.Unix(st.Ctim.Sec, st.Ctim.Nsec)
+func getFinishedTime(fi os.FileInfo) (time.Time, error) {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}, fmt.Errorf("type assertion failed")
+	}
+	return time.Unix(st.Ctim.Sec, st.Ctim.Nsec), nil
 }

--- a/oci/finished_32.go
+++ b/oci/finished_32.go
@@ -3,12 +3,16 @@
 package oci
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"time"
 )
 
-func getFinishedTime(fi os.FileInfo) time.Time {
-	st := fi.Sys().(*syscall.Stat_t)
-	return time.Unix(int64(st.Ctim.Sec), int64(st.Ctim.Nsec))
+func getFinishedTime(fi os.FileInfo) (time.Time, error) {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}, fmt.Errorf("type assertion failed")
+	}
+	return time.Unix(int64(st.Ctim.Sec), int64(st.Ctim.Nsec)), nil
 }

--- a/oci/finished_unsupported.go
+++ b/oci/finished_unsupported.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func getFinishedTime(fi os.FileInfo) time.Time {
+func getFinishedTime(fi os.FileInfo) (time.Time, error) {
 	// Windows would be like
 	//st := fi.Sys().(*syscall.Win32FileAttributeDatao)
 	//st.CreationTime.Nanoseconds()
@@ -19,5 +19,5 @@ func getFinishedTime(fi os.FileInfo) time.Time {
 	// openbsd would be like
 	//st := fi.Sys().(*syscall.Stat_t)
 	//st.Ctim.Nsec
-	return fi.ModTime()
+	return fi.ModTime(), nil
 }

--- a/pkg/findprocess/findprocess.go
+++ b/pkg/findprocess/findprocess.go
@@ -3,8 +3,9 @@
 package findprocess
 
 import (
-	"errors"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 // ErrNotFound represents a target process that does not exist or is
@@ -19,8 +20,11 @@ var ErrNotFound = errors.New("process not found")
 func FindProcess(pid int) (process *os.Process, err error) {
 	process, err = findProcess(pid)
 	if err != nil {
-		_ = process.Release()
+		releaseErr := process.Release()
 		process = nil
+		if releaseErr != nil {
+			return process, errors.Wrap(err, releaseErr.Error())
+		}
 	}
 	return process, err
 }

--- a/pkg/findprocess/findprocess_unix.go
+++ b/pkg/findprocess/findprocess_unix.go
@@ -8,9 +8,11 @@ import (
 )
 
 func findProcess(pid int) (process *os.Process, err error) {
-	// On Unix systems, FindProcess always succeeds and returns a Process
-	// for the given pid, regardless of whether the process exists.
-	process, _ = os.FindProcess(pid)
+	process, err = os.FindProcess(pid)
+	if err != nil {
+		return process, err
+	}
+
 	err = process.Signal(syscall.Signal(0))
 	if err == nil {
 		return process, nil

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -606,7 +606,9 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		return nil, err
 	}
 
-	s.ContainerStateToDisk(container)
+	if err := s.ContainerStateToDisk(container); err != nil {
+		logrus.Warnf("unable to write containers %s state to disk: %v", container.ID(), err)
+	}
 
 	container.SetCreated()
 

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -35,7 +35,9 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 		if err != nil {
 			c.SetStartFailed(err)
 		}
-		s.ContainerStateToDisk(c)
+		if err := s.ContainerStateToDisk(c); err != nil {
+			logrus.Warnf("unable to write containers %s state to disk: %v", c.ID(), err)
+		}
 	}()
 
 	err = s.Runtime().StartContainer(c)

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -106,7 +106,9 @@ func (s *Server) GetInfoMux() *bone.Mux {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(js)
+		if _, err := w.Write(js); err != nil {
+			http.Error(w, fmt.Sprintf("unable to write JSON: %v", err), http.StatusInternalServerError)
+		}
 	}))
 
 	mux.Get("/containers/:id", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -131,7 +133,9 @@ func (s *Server) GetInfoMux() *bone.Mux {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(js)
+		if _, err := w.Write(js); err != nil {
+			http.Error(w, fmt.Sprintf("unable to write JSON: %v", err), http.StatusInternalServerError)
+		}
 	}))
 
 	return mux

--- a/server/sandbox_list_test.go
+++ b/server/sandbox_list_test.go
@@ -23,7 +23,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 	t.Describe("ListPodSandbox", func() {
 		It("should succeed", func() {
 			// Given
-			sut.AddSandbox(testSandbox)
+			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
 			testContainer.SetState(&oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateRunning},
 			})
@@ -42,7 +42,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 
 		It("should succeed without infra container", func() {
 			// Given
-			sut.AddSandbox(testSandbox)
+			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
 			testSandbox.SetCreated()
 
 			// When
@@ -57,7 +57,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 
 		It("should skip not created sandboxes", func() {
 			// Given
-			sut.AddSandbox(testSandbox)
+			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
 			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
 
 			// When
@@ -129,7 +129,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 
 		It("should succeed with filter but when not finding id", func() {
 			// Given
-			sut.AddSandbox(testSandbox)
+			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
 
 			// When
 			response, err := sut.ListPodSandbox(context.Background(),

--- a/server/sandbox_remove_test.go
+++ b/server/sandbox_remove_test.go
@@ -143,7 +143,7 @@ var _ = t.Describe("RemovePodSandbox", func() {
 
 		It("should fail when infra container index removal erros", func() {
 			// Given
-			sut.AddSandbox(testSandbox)
+			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
 			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
 			Expect(sut.PodIDIndex().Add(testSandbox.ID())).To(BeNil())
 

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -87,7 +87,9 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 						// assume container already umounted
 						logrus.Warnf("failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 					}
-					s.ContainerStateToDisk(c)
+					if err := s.ContainerStateToDisk(c); err != nil {
+						return errors.Wrapf(err, "write container %q state do disk", c.Name())
+					}
 					return nil
 				})
 			}

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -219,7 +219,7 @@ func mockNewServer() {
 }
 
 func addContainerAndSandbox() {
-	sut.AddSandbox(testSandbox)
+	Expect(sut.AddSandbox(testSandbox)).To(BeNil())
 	Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
 	sut.AddContainer(testContainer)
 	Expect(sut.CtrIDIndex().Add(testContainer.ID())).To(BeNil())
@@ -247,7 +247,7 @@ var mockDirs = func(manifest []byte) {
 }
 
 func createDummyState() {
-	ioutil.WriteFile("state.json", []byte(`{}`), 0644)
+	Expect(ioutil.WriteFile("state.json", []byte(`{}`), 0644)).To(BeNil())
 }
 
 func mockRuncInLibConfig() {

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -41,8 +41,8 @@ func TestParseDNSOptions(t *testing.T) {
 			t.Error(err)
 		}
 
-		expect, _ := ioutil.ReadFile(c.Want)
-		result, _ := ioutil.ReadFile(c.Path)
+		expect, _ := ioutil.ReadFile(c.Want) // nolint: errcheck
+		result, _ := ioutil.ReadFile(c.Path) // nolint: errcheck
 		if string(expect) != string(result) {
 			t.Errorf("expect %v: \n but got : %v", string(expect), string(result))
 		}

--- a/test/bin2img/bin2img.go
+++ b/test/bin2img/bin2img.go
@@ -109,7 +109,10 @@ func main() {
 			os.Exit(1)
 		}
 		defer func() {
-			_, _ = store.Shutdown(false)
+			_, err = store.Shutdown(false)
+			if err != nil {
+				logrus.Warnf("unable to shutdown store: %v", err)
+			}
 		}()
 
 		layerBuffer := &bytes.Buffer{}

--- a/test/copyimg/copyimg.go
+++ b/test/copyimg/copyimg.go
@@ -118,7 +118,10 @@ func main() {
 				os.Exit(1)
 			}
 			defer func() {
-				_, _ = store.Shutdown(false)
+				_, err = store.Shutdown(false)
+				if err != nil {
+					logrus.Warnf("unable to shutdown store: %v", err)
+				}
 			}()
 
 			storage.Transport.SetStore(store)
@@ -143,7 +146,10 @@ func main() {
 			os.Exit(1)
 		}
 		defer func() {
-			_ = policyContext.Destroy()
+			err = policyContext.Destroy()
+			if err != nil {
+				logrus.Fatalf("unable to destroy policy context: %v", err)
+			}
 		}()
 		options := &copy.Options{}
 

--- a/utils/ioutil/read_closer.go
+++ b/utils/ioutil/read_closer.go
@@ -30,7 +30,7 @@ type wrapReadCloser struct {
 func NewWrapReadCloser(r io.Reader) io.ReadCloser {
 	pr, pw := io.Pipe()
 	go func() {
-		_, _ = io.Copy(pw, r)
+		_, _ = io.Copy(pw, r) // nolint: errcheck
 		pr.Close()
 		pw.Close()
 	}()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -189,16 +189,21 @@ func WriteGoroutineStacksToFile(path string) error {
 		return err
 	}
 	defer f.Close()
-	defer f.Sync()
 
-	return WriteGoroutineStacks(f)
+	err = WriteGoroutineStacks(f)
+	if err != nil {
+		return err
+	}
+	return f.Sync()
 }
 
 // GenerateID generates a random unique id.
-func GenerateID() string {
+func GenerateID() (string, error) {
 	b := make([]byte, 32)
-	rand.Read(b)
-	return hex.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", errors.Wrapf(err, "generate ID")
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // openContainerFile opens a file inside a container rootfs safely


### PR DESCRIPTION
This PR enables the `errcheck` linter to check for not handled errors paths. All obvious error paths are now handled and populated to the caller. Most container state related code paths are either changed to only log the issue or are excluded via a `nolint` comment.