### PR TITLE
Improve CI speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,14 @@ executors:
         user: circleci
     environment:
       GOCACHE: &gocache /tmp/go-build
+      JOBS: &jobs 8
     working_directory: &workdir /go/src/github.com/cri-o/cri-o
   docker-base:
     docker:
       - image: circleci/golang
     environment:
       GOCACHE: *gocache
+      JOBS: *jobs
     working_directory: *workdir
   nix:
     docker:
@@ -25,6 +27,7 @@ executors:
     environment:
       GOCACHE: *gocache
       IMAGE: *image
+      JOBS: *jobs
       WORKDIR: *workdir
 
 workflows:
@@ -81,7 +84,7 @@ jobs:
             - v1-build-{{ checksum "go.sum" }}
       - run:
           name: build
-          command: make
+          command: make -j $JOBS
       - save_cache:
           key: v1-build-{{ checksum "go.sum" }}
           paths:
@@ -116,7 +119,7 @@ jobs:
             - v1-build-test-binaries-{{ checksum "go.sum" }}
       - run:
           name: build
-          command: make test-binaries
+          command: make test-binaries -j $JOBS
       - save_cache:
           key: v1-build-test-binaries-{{ checksum "go.sum" }}
           paths:
@@ -225,7 +228,7 @@ jobs:
       - run:
           name: check mocks
           command: |
-            make mockgen
+            make mockgen -j $JOBS
             hack/tree_status.sh
       - run:
           name: unit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   global:
     - NIX_IMAGE=saschagrunert/crionix
     - CONTAINER_RUNTIME=docker
+    - JOBS=4
 
 jobs:
   include:
@@ -39,10 +40,10 @@ jobs:
     - stage: Test
       name: build, unit test and code coverage report
       script:
-        - make mockgen
+        - make mockgen -j $JOBS
         - hack/tree_status.sh
         - make testunit
-        - make
+        - make -j $JOBS
         - make codecov
       go: "1.12.x"
     - name: static binary build
@@ -57,12 +58,12 @@ jobs:
     - name: latest go version (tip)
       script:
         - make testunit
-        - make
+        - make -j $JOBS
       go: tip
     - name: macOS build and unit tests
       script:
         - make testunit
-        - make
+        - make -j $JOBS
       os: osx
     - stage: Integration
       name: default build

--- a/Makefile
+++ b/Makefile
@@ -239,42 +239,66 @@ testunit-bin:
 			--gcflags '-N' -c -o ${TESTBIN_PATH}/$$(basename $$PACKAGE) ;\
 	done
 
-mockgen: ${MOCKGEN}
+mockgen: \
+	mock-containerstorage \
+	mock-criostorage \
+	mock-lib \
+	mock-oci \
+	mock-sandbox \
+	mock-server \
+	mock-image-types \
+	mock-ocicni-types
+
+mock-containerstorage: ${MOCKGEN}
 	${MOCKGEN} \
 		${MOCKGEN_FLAGS} \
 		-package containerstoragemock \
 		-destination ${MOCK_PATH}/containerstorage/containerstorage.go \
 		github.com/containers/storage Store
+
+mock-criostorage: ${MOCKGEN}
 	${MOCKGEN} \
 		${MOCKGEN_FLAGS} \
 		-package criostoragemock \
 		-destination ${MOCK_PATH}/criostorage/criostorage.go \
 		github.com/cri-o/cri-o/pkg/storage ImageServer,RuntimeServer
+
+mock-lib: ${MOCKGEN}
 	${MOCKGEN} \
 		${MOCKGEN_FLAGS} \
 		-package libmock \
 		-destination ${MOCK_PATH}/lib/lib.go \
 		github.com/cri-o/cri-o/lib ConfigIface
+
+mock-oci: ${MOCKGEN}
 	${MOCKGEN} \
 		${MOCKGEN_FLAGS} \
 		-package ocimock \
 		-destination ${MOCK_PATH}/oci/oci.go \
 		github.com/cri-o/cri-o/oci RuntimeImpl
+
+mock-sandbox: ${MOCKGEN}
 	${MOCKGEN} \
 		${MOCKGEN_FLAGS} \
 		-package sandboxmock \
 		-destination ${MOCK_PATH}/sandbox/sandbox.go \
 		github.com/cri-o/cri-o/lib/sandbox NetNsIface
+
+mock-server: ${MOCKGEN}
 	${BUILD_BIN_PATH}/mockgen \
 		${MOCKGEN_FLAGS} \
 		-package servermock \
 		-destination ${MOCK_PATH}/server/server.go \
 		github.com/cri-o/cri-o/server ConfigIface
+
+mock-image-types: ${MOCKGEN}
 	${BUILD_BIN_PATH}/mockgen \
 		${MOCKGEN_FLAGS} \
 		-package imagetypesmock \
 		-destination ${MOCK_PATH}/containers/image/types.go \
 		github.com/containers/image/types Image
+
+mock-ocicni-types: ${MOCKGEN}
 	${BUILD_BIN_PATH}/mockgen \
 		${MOCKGEN_FLAGS} \
 		-package ocicnitypesmock \


### PR DESCRIPTION
Slightly improve the CI speed by utilizing a higher amount of parallel
jobs and separating the mock generation targets.