### PR TITLE
Remove NET_RAW capability and add net.ipv4.ping_group_range sysctl

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "fedora/27-cloud-base"
+  config.vm.box = "fedora/30-cloud-base"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/contrib/system_containers/fedora/Dockerfile
+++ b/contrib/system_containers/fedora/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:27
+FROM registry.fedoraproject.org/fedora:30
 
 ENV VERSION=0 RELEASE=1 ARCH=x86_64
 LABEL com.redhat.component="cri-o" \

--- a/contrib/test/integration/system-packages.yml
+++ b/contrib/test/integration/system-packages.yml
@@ -86,3 +86,6 @@
 - name: Update all packages RHEL 8 and Fedora >= 30
   shell: sudo yum update -y
   when: supports_python3 is defined and supports_python3
+
+- name: Allow processes inside of containers to send ping
+  shell: sysctl -w net.ipv4.ping_group_range='0 2147483647'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -139,7 +139,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--decryption-keys-path**="": Path to load keys for image decryption. (default: "/etc/crio/keys/")
 
-**--default-capabilities**="": Capabilities to add to the containers (default: ["CHOWN" "DAC_OVERRIDE" "FSETID" "FOWNER" "NET_RAW" "SETGID" "SETUID" "SETPCAP" "NET_BIND_SERVICE" "SYS_CHROOT" "KILL"])
+**--default-capabilities**="": capabilities to add to the containers (default: "CHOWN, DAC_OVERRIDE, FSETID, FOWNER, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, KILL)
 
 **--default-mounts**="": Add one or more default mount paths in the form host:container (deprecated) (default: []) (default: [])
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -83,11 +83,11 @@ The `crio.api` table contains settings for the kubelet/gRPC interface.
 ## CRIO.RUNTIME TABLE
 The `crio.runtime` table contains settings pertaining to the OCI runtime used and options for how to set up and manage the OCI runtime.
 
-**default_ulimits**=[]
-  A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example:"nofile=1024:2048". If nothing is set here, settings will be inherited from the CRI-O daemon.
-
 **default_runtime**="runc"
   The _name_ of the OCI runtime to be used as the default.
+
+**default_ulimits**=[]
+  A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example:"nofile=1024:2048". If nothing is set here, settings will be inherited from the CRI-O daemon.
 
 **no_pivot**=false
   If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.
@@ -122,22 +122,27 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
   The default list is:
 ```
   default_capabilities = [
-          "CHOWN",
-          "DAC_OVERRIDE",
-          "FSETID",
-          "FOWNER",
-          "NET_RAW",
-          "SETGID",
-          "SETUID",
-          "SETPCAP",
-          "NET_BIND_SERVICE",
-          "SYS_CHROOT",
-          "KILL",
+	  "CHOWN",
+	  "DAC_OVERRIDE",
+	  "FSETID",
+	  "FOWNER",
+	  "SETGID",
+	  "SETUID",
+	  "SETPCAP",
+	  "NET_BIND_SERVICE",
+	  "KILL",
   ]
 ```
 
 **default_sysctls**=[]
  List of default sysctls. If it is empty or commented out, only the sysctls defined in the container json file by the user/kube will be added.
+
+  One example would be allowing ping inside of containers.  On systems that support `/proc/sys/net/ipv4/ping_group_range`, the default list could be:
+```
+  default_sysctls = [
+       "net.ipv4.ping_group_range" = "0   2147483647",
+  ]
+```
 
 **additional_devices**=[]
   List of additional devices. Specified as "<device-on-host>:<device-on-container>:<permissions>", for example: "--additional-devices=/dev/sdc:/dev/xvdc:rwm". If it is empty or commented out, only the devices defined in the container json file by the user/kube will be added.
@@ -160,6 +165,9 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
     1) `/etc/containers/mounts.conf` (i.e., default_mounts_file): This is the override file, where users can either add in their own default mounts, or override the default mounts shipped with the package.
 
     2) `/usr/share/containers/mounts.conf`: This is the default file read for mounts. If you want CRI-O to read from a different, specific mounts file, you can change the default_mounts_file. Note, if this is done, CRI-O will only add mounts it finds in this file.
+
+**bind_mount_prefix**="prefix"
+  A prefix to use for the source of the bind mounts.  This option would be useful if you were running CRI-O in a container and had the / on the host mounted as /host on your container.  Then if you ran CRI-O with the --bind-mount-prefix=/host option, CRI-O would add /host to any bind mounts it is handed over CRI.  If Kubernetes asked to have /var/lib/foobar bind mounted into the container, then CRI-O would bind mount /host/var/lib/foobar.  Since CRI-O itself is running in a container with / or the host mounted on /host, the container would end up with /var/lib/foobar from the host mounted in the container rather then /var/lib/foobar from the CRI-O container.
 
 **pids_limit**=1024
   Maximum number of processes allowed in a container.
@@ -214,6 +222,12 @@ The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  Th
 
 **runtime_path**=""
   Path to the OCI compatible runtime used for this runtime handler.
+
+**runtime_root**=""
+  Root directory used to store runtime data
+
+**runtime_type**="oci"
+  Type of the runtime used for this runtime handler. "oci", "vm"
 
 ## CRIO.IMAGE TABLE
 The `crio.image` table contains settings pertaining to the management of OCI images.

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -535,6 +535,7 @@ func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext)
 			Usage:     fmt.Sprintf("Path to default mounts file (default: %q)", defConf.DefaultMountsFile),
 			EnvVars:   []string{"CONTAINER_DEFAULT_MOUNTS_FILE"},
 			TakesFile: true,
+			Hidden:    true,
 		},
 		&cli.StringFlag{
 			Name:    "default-capabilities",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,12 +106,10 @@ var DefaultCapabilities = []string{
 	"DAC_OVERRIDE",
 	"FSETID",
 	"FOWNER",
-	"NET_RAW",
 	"SETGID",
 	"SETUID",
 	"SETPCAP",
 	"NET_BIND_SERVICE",
-	"SYS_CHROOT",
 	"KILL",
 }
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -166,11 +166,6 @@ additional_devices = [
 hooks_dir = [
 {{ range $hooksDir := .HooksDir }}{{ printf "\t%q, \n" $hooksDir}}{{ end }}]
 
-# List of default mounts for each container. **Deprecated:** this option will
-# be removed in future versions in favor of default_mounts_file.
-default_mounts = [
-{{ range $mount := .DefaultMounts }}{{ printf "\t%q, \n" $mount }}{{ end }}]
-
 # Path to the file specifying the defaults mounts for each container. The
 # format of the config is /SRC:/DST, one mount per line. Notice that CRI-O reads
 # its default mounts from the following two files:

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1074,7 +1074,7 @@ function teardown() {
 	run crictl exec --sync $ctr_id grep Cap /proc/1/status
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ 00000000002425fb ]]
+	[[ "$output" =~ 00000000002005fb ]]
 
 	run crictl stopp "$pod_id"
 	echo "$output"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -159,19 +159,17 @@ function setup_test() {
 	CONTAINER_EXITS_DIR=$TESTDIR/containers/exits
 	CONTAINER_ATTACH_SOCKET_DIR=$TESTDIR/containers
 
-	# Setup default mounts using deprecated --default-mounts flag
-	# should be removed, once the flag is removed
 	MOUNT_PATH="$TESTDIR/secrets"
 	mkdir ${MOUNT_PATH}
 	MOUNT_FILE="${MOUNT_PATH}/test.txt"
 	touch ${MOUNT_FILE}
 	echo "Testing secrets mounts!" > ${MOUNT_FILE}
-	DEFAULT_MOUNTS_OPTS="--default-mounts=${MOUNT_PATH}:/container/path1"
 
 	# Setup default secrets mounts
 	mkdir $TESTDIR/containers
 	touch $TESTDIR/containers/mounts.conf
 	echo "$TESTDIR/rhel/secrets:/run/secrets" > $TESTDIR/containers/mounts.conf
+	echo "${MOUNT_PATH}:/container/path1" >> $TESTDIR/containers/mounts.conf
 	mkdir -p $TESTDIR/rhel/secrets
 	touch $TESTDIR/rhel/secrets/test.txt
 	echo "Testing secrets mounts. I am mounted!" > $TESTDIR/rhel/secrets/test.txt

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -340,12 +340,10 @@ default_capabilities = [
 	"DAC_OVERRIDE",
 	"FSETID",
 	"FOWNER",
-	"NET_RAW",
 	"SETGID",
 	"SETUID",
 	"SETPCAP",
 	"NET_BIND_SERVICE",
-	"SYS_CHROOT",
 	"KILL",
 ]
 ```
@@ -354,6 +352,11 @@ and no sysctls
 default_sysctls = [
 ]
 ```
+
+One optional sysctl you might consider, if you want ping to work within
+containers and your kernel supports it is setting
+
+	"net.ipv4.ping_group_range" = "0 2147483647",
 
 Users can change either default by editing `/etc/crio/crio.conf`.
 


### PR DESCRIPTION
also grabbed some changes introduced by @Chenditang on github to
update the crio.conf man page

Increase the security of containers by removing the NET_RAW capabilty.

Add net.ipv4.ping_group_range so that ping will still work.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
