### PR TITLE
Update scripts to find correct bash path

### DIFF
--- a/hack/apparmor_tag.sh
+++ b/hack/apparmor_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if pkg-config libapparmor 2> /dev/null ; then
 	echo apparmor
 fi

--- a/hack/btrfs_installed_tag.sh
+++ b/hack/btrfs_installed_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <btrfs/ioctl.h>
 EOF

--- a/hack/btrfs_tag.sh
+++ b/hack/btrfs_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <btrfs/version.h>
 EOF

--- a/hack/libdm_installed.sh
+++ b/hack/libdm_installed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <libdevmapper.h>
 EOF

--- a/hack/libdm_no_deferred_remove_tag.sh
+++ b/hack/libdm_no_deferred_remove_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT

--- a/hack/openpgp_tag.sh
+++ b/hack/openpgp_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if ! gpgme-config --libs &>/dev/null; then
     echo containers_image_openpgp
 fi

--- a/hack/seccomp_tag.sh
+++ b/hack/seccomp_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if pkg-config libseccomp 2> /dev/null ; then
 	echo seccomp
 fi

--- a/hack/selinux_tag.sh
+++ b/hack/selinux_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if pkg-config libselinux 2> /dev/null ; then
 	echo selinux
 fi

--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 STATUS=$(git status --porcelain)

--- a/test/cni_plugin_helper.bash
+++ b/test/cni_plugin_helper.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script wraps the CNI 'bridge' plugin to provide additional testing
 # capabilities

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Root directory of integration tests.
 INTEGRATION_ROOT=$(dirname "$(readlink -f "$BASH_SOURCE")")


### PR DESCRIPTION
Some distributions have bash installed under a different path than
`/bin`, which can be retrieved via `env`.