### PR TITLE
[1.14] conmon: use sd_journal_sendv

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -995,9 +995,6 @@ int main(int argc, char *argv[])
 	if (!opt_exec && opt_cuuid == NULL)
 		nexit("Container UUID not provided. Use --cuuid");
 
-	if (opt_name == NULL)
-		nexit("Container name not provided. Use --name");
-
 	if (opt_runtime_path == NULL)
 		nexit("Runtime path not provided. Use --runtime");
 	if (access(opt_runtime_path, X_OK) < 0)


### PR DESCRIPTION
This PR backports #2241, which fixes the current incompatibility between podman v1.3.X and conmon v1.14.1.