### PR TITLE
Update e2e tests to be tested against k8s release-1.14

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -24,8 +24,7 @@
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
       vars:
-      vars:
-        k8s_git_version: "release-1.12"
+        k8s_git_version: "release-1.14"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
 
@@ -101,7 +100,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
-          k8s_git_version: "release-1.12"
+          k8s_git_version: "release-1.14"
           k8s_github_fork: "kubernetes"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s node-e2e tests
@@ -118,7 +117,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
-          k8s_git_version: "master"
+          k8s_git_version: "release-1.14"
           k8s_github_fork: "kubernetes"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests
@@ -135,7 +134,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
-          k8s_git_version: "master"
+          k8s_git_version: "release-1.14"
           k8s_github_fork: "kubernetes"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e features tests


### PR DESCRIPTION
This is just yet another approach to see if we can stabilize the e2e tests by early adopting release branches instead of testing the Kubernetes master.

If we decide to go that way we would have to backport the fix to further release branches.