### PR TITLE
Update device cgroup permissions for configured devices.

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -143,6 +143,73 @@ function teardown() {
 	stop_crio
 }
 
+@test "additional devices permissions" {
+	# We need a ubiquitously configured device that isn't in the
+	# OCI spec default set.
+	local readonly device="/dev/loop-control"
+	local readonly timeout=30
+
+	if test -n "$UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
+	if ! test -r $device ; then
+		skip "$device not readable"
+	fi
+
+	if ! test -w $device ; then
+		skip "$device not writeable"
+	fi
+
+	DEVICES="--additional-devices ${device}:${device}:w" start_crio
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+        # Ensure the device is there.
+	run crictl exec --timeout=$timeout --sync "$ctr_id" ls $device
+	echo $output
+	[ "$status" -eq 0 ]
+	[[ "$output" == "$device" ]]
+
+	# Dump the deviced cgroup configuration for debugging.
+	run crictl exec --timeout=$timeout --sync "$ctr_id" cat /sys/fs/cgroup/devices/devices.list
+	echo $output
+	[[ "$output" =~ "c 10:237 w" ]]
+
+        # Opening the device in read mode should fail because the device
+        # cgroup access only allows writes.
+	run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=$device of=/dev/null count=1
+	echo $output
+	[[ "$output" =~ "Operation not permitted" ]]
+
+        # The write should be allowed by the devices cgroup policy, so we
+        # should see an EINVAL from the device when the device fails it.
+	run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=/dev/zero of=$device count=1
+	echo $output
+	[[ "$output" =~ "Invalid argument" ]]
+
+	run crictl stopp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rmp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+
 @test "ctr remove" {
 	start_crio
 	run crictl runp "$TESTDATA"/sandbox_config.json


### PR DESCRIPTION
**- What I did**

When additional devices are configured in `crio.conf`, they
are correctly bound into the container, but the devices cgroup
permissions were not propagated. Ensure that we propagate the
requested permissions down to the continer spec so that the access
is correct.

**- How I did it**

Update the spec to create the right container devices when we configure the devices group.

**- How to verify it**

Added a test to ensure that `/dev/kvm` can be made readable in a container by using the `additional_devices` configuration.

**- Description for the changelog**

Ensured that the `additional_devices` configuration parameter populates the requested device nodes inside the container with the correct permissions.