### PR TITLE
Ensure the test suite configures config directories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ testunit: ${GINKGO}
 	${BUILD_BIN_PATH}/ginkgo \
 		${TESTFLAGS} \
 		-r \
+		--trace \
 		--cover \
 		--covermode atomic \
 		--outputdir ${COVERAGE_PATH} \

--- a/lib/config.go
+++ b/lib/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/storage"
 	cstorage "github.com/containers/storage"
 	"github.com/cri-o/cri-o/oci"
+	"github.com/cri-o/cri-o/utils"
 	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -525,8 +526,8 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 		}
 
 		for _, hooksDir := range c.HooksDir {
-			if _, err := os.Stat(hooksDir); err != nil {
-				return errors.Wrapf(err, "invalid hooks_dir entry")
+			if err := utils.IsDirectory(hooksDir); err != nil {
+				return errors.Wrapf(err, "invalid hooks_dir: %s", err)
 			}
 		}
 
@@ -544,8 +545,8 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 // `nil`.
 func (c *NetworkConfig) Validate(onExecution bool) error {
 	if onExecution {
-		if _, err := os.Stat(c.NetworkDir); err != nil {
-			return errors.Wrapf(err, "invalid network_dir")
+		if err := utils.IsDirectory(c.NetworkDir); err != nil {
+			return errors.Wrapf(err, "invalid network_dir: %s", err)
 		}
 
 		for _, pluginDir := range c.PluginDir {

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -23,11 +23,6 @@ var _ = t.Describe("Config", func() {
 		Expect(sut).NotTo(BeNil())
 	})
 
-	const (
-		validPath = "/bin/sh"
-		wrongPath = "/wrong"
-	)
-
 	t.Describe("ValidateConfig", func() {
 		It("should succeed with default config", func() {
 			// Given
@@ -52,7 +47,7 @@ var _ = t.Describe("Config", func() {
 		It("should fail with invalid runtime config", func() {
 			// Given
 			sut.RootConfig.LogDir = "."
-			sut.AdditionalDevices = []string{wrongPath}
+			sut.AdditionalDevices = []string{invalidPath}
 
 			// When
 			err := sut.Validate(nil, true)
@@ -64,9 +59,9 @@ var _ = t.Describe("Config", func() {
 		It("should fail with invalid network config", func() {
 			// Given
 			sut.RootConfig.LogDir = "."
-			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
-			sut.Conmon = validPath
-			sut.NetworkConfig.NetworkDir = wrongPath
+			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validDirPath}
+			sut.Conmon = validFilePath
+			sut.NetworkConfig.NetworkDir = invalidPath
 
 			// When
 			err := sut.Validate(nil, true)
@@ -88,8 +83,8 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed during runtime", func() {
 			// Given
-			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
-			sut.Conmon = validPath
+			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validFilePath}
+			sut.Conmon = validFilePath
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, true)
@@ -101,8 +96,8 @@ var _ = t.Describe("Config", func() {
 		It("should succeed with additional devices", func() {
 			// Given
 			sut.AdditionalDevices = []string{"/dev/null:/dev/null:rw"}
-			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
-			sut.Conmon = validPath
+			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validFilePath}
+			sut.Conmon = validFilePath
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, true)
@@ -113,9 +108,9 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed with hooks directories", func() {
 			// Given
-			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
-			sut.Conmon = validPath
-			sut.HooksDir = []string{validPath}
+			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validFilePath}
+			sut.Conmon = validFilePath
+			sut.HooksDir = []string{validDirPath}
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, true)
@@ -126,9 +121,22 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail on invalid hooks directory", func() {
 			// Given
-			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
-			sut.Conmon = validPath
-			sut.HooksDir = []string{wrongPath}
+			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validFilePath}
+			sut.Conmon = validFilePath
+			sut.HooksDir = []string{invalidPath}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, true)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should fail if the hooks directory is not a directory", func() {
+			// Given
+			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validFilePath}
+			sut.Conmon = validFilePath
+			sut.HooksDir = []string{validFilePath}
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, true)
@@ -139,9 +147,9 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail on invalid conmon path", func() {
 			// Given
-			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
-			sut.Conmon = wrongPath
-			sut.HooksDir = []string{validPath}
+			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validFilePath}
+			sut.Conmon = invalidPath
+			sut.HooksDir = []string{validDirPath}
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, true)
@@ -152,7 +160,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail on wrong DefaultUlimits", func() {
 			// Given
-			sut.DefaultUlimits = []string{wrongPath}
+			sut.DefaultUlimits = []string{invalidPath}
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, false)
@@ -174,7 +182,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail on invalid device", func() {
 			// Given
-			sut.AdditionalDevices = []string{wrongPath}
+			sut.AdditionalDevices = []string{invalidPath}
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, false)
@@ -251,7 +259,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed during runtime", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validPath
+			sut.NetworkConfig.NetworkDir = validDirPath
 			tmpDir := path.Join(os.TempDir(), "cni-test")
 			sut.NetworkConfig.PluginDir = []string{tmpDir}
 			defer os.RemoveAll(tmpDir)
@@ -265,7 +273,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail on invalid NetworkDir", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = wrongPath
+			sut.NetworkConfig.NetworkDir = invalidPath
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
@@ -276,8 +284,8 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail on PluginDir without permissions", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validPath
-			sut.NetworkConfig.PluginDir = []string{wrongPath}
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDir = []string{invalidPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
@@ -288,8 +296,8 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail on invalid PluginDir", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validPath
-			sut.NetworkConfig.PluginDir = []string{validPath}
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDir = []string{invalidPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cri-o/cri-o/oci"
 	"github.com/cri-o/cri-o/pkg/annotations"
 	"github.com/cri-o/cri-o/pkg/storage"
+	"github.com/cri-o/cri-o/utils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/truncindex"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
@@ -131,8 +132,7 @@ func New(ctx context.Context, systemContext *types.SystemContext, configIface Co
 	hookDirectories := config.HooksDir
 	if config.HooksDir == nil {
 		for _, hooksDir := range []string{hooks.DefaultDir, hooks.OverrideDir} {
-			_, err = os.Stat(hooksDir)
-			if err == nil {
+			if err := utils.IsDirectory(hooksDir); err == nil {
 				hookDirectories = append(hookDirectories, hooksDir)
 				logrus.Warnf("implicit hook directories are deprecated; set --hooks-dir=%q explicitly to continue to load hooks from this directory", hooksDir)
 			}

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -38,11 +38,16 @@ var (
 	sut            *lib.ContainerServer
 	mySandbox      *sandbox.Sandbox
 	myContainer    *oci.Container
+
+	validDirPath string
 )
 
 const (
 	sandboxID   = "sandboxID"
 	containerID = "containerID"
+
+	validFilePath = "/bin/sh"
+	invalidPath   = "/wrong"
 )
 
 var _ = BeforeSuite(func() {
@@ -99,6 +104,8 @@ var _ = BeforeSuite(func() {
 	libMock = libmock.NewMockConfigIface(mockCtrl)
 	storeMock = containerstoragemock.NewMockStore(mockCtrl)
 	ociRuntimeMock = ocimock.NewMockRuntimeImpl(mockCtrl)
+
+	validDirPath = t.MustTempDir("crio-empty")
 })
 
 var _ = AfterSuite(func() {

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cri-o/cri-o/oci"
 	"github.com/cri-o/cri-o/pkg/annotations"
 	"github.com/cri-o/cri-o/pkg/storage"
+	"github.com/cri-o/cri-o/utils"
 	dockermounts "github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -123,7 +124,7 @@ func addDevicesPlatform(sb *sandbox.Sandbox, containerConfig *pb.ContainerConfig
 		if err == devices.ErrNotADevice {
 
 			// check if it is a directory
-			if src, e := os.Stat(path); e == nil && src.IsDir() {
+			if e := utils.IsDirectory(path); e == nil {
 
 				// mount the internal devices recursively
 				filepath.Walk(path, func(dpath string, f os.FileInfo, e error) error {

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // GetDiskUsageStats accepts a path to a directory or file
@@ -25,4 +26,24 @@ func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, err error) {
 	}
 
 	return dirSize, inodeCount, err
+}
+
+// IsDirectory tests whether the given path exists and is a directory. It
+// follows symlinks.
+func IsDirectory(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	if !info.Mode().IsDir() {
+		// Return a PathError to be consistent with os.Stat().
+		return &os.PathError{
+			Op:   "stat",
+			Path: path,
+			Err:  syscall.ENOTDIR,
+		}
+	}
+
+	return nil
 }

--- a/utils/filesystem_test.go
+++ b/utils/filesystem_test.go
@@ -1,6 +1,8 @@
 package utils_test
 
 import (
+	"os"
+
 	"github.com/cri-o/cri-o/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,6 +31,20 @@ var _ = t.Describe("Filesystem", func() {
 			Expect(err).NotTo(BeNil())
 			Expect(bytes).To(BeEquivalentTo(0))
 			Expect(inodes).To(BeEquivalentTo(0))
+		})
+	})
+
+	t.Describe("IsDirectory", func() {
+		It("should succeed on a directory", func() {
+			Expect(utils.IsDirectory(".")).To(BeNil())
+		})
+
+		It("should fail on a file", func() {
+			Expect(utils.IsDirectory(os.Args[0])).NotTo(BeNil())
+		})
+
+		It("should fail on a missing path", func() {
+			Expect(utils.IsDirectory("/no/such/path")).NotTo(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
If you run the test suite on a host that already has a default
OCI hooks directory, the test suite can fail because it is unable
to parse the host' hooks configuration. Since the tests should
be isolated from the host, ensure that we always specify a safe
default for directories that can be searched for configuration.

Verify that configuration directories are actually directories,
and add the ginkgo `--trace` option to assist in test failure
debugging.

Signed-off-by: James Peach <jpeach@apache.org>