### PR TITLE
Add predefined build tags to .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,11 @@
 ---
 run:
+  build-tags:
+    - apparmor
+    - containers_image_ostree_stub
+    - seccomp
+    - selinux
+    - test
   concurrency: 6
   deadline: 5m
 linters:

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 	touch "$(GOPATH)/.gopathok"
 
 lint: .gopathok ${GOLANGCI_LINT}
-	${GOLANGCI_LINT} run --build-tags="test $(BUILDTAGS)"
+	${GOLANGCI_LINT} run
 
 fmt: cfmt
 


### PR DESCRIPTION
Some IDEs are able to lint via a simple invocation of `golangci-lint` in
the background. The recommended buildtags needs to be set in the
configuration to ensure that these tests have strong defaults.