### PR TITLE
Add live reload integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,7 @@ jobs:
               -e STORAGE_OPTIONS="--storage-driver=vfs" -e TRAVIS=true \
               -e CRIO_BINARY -e TEST_USERNS -e RUN_CRITEST \
               -v $(pwd):$WORKDIR -v $(pwd)/build/bin/ginkgo:/usr/bin/ginkgo \
-              -t --privileged --rm -w $WORKDIR \
+              --privileged --rm -w $WORKDIR \
               $IMAGE test/test_runner.sh $TEST_ARGS
           environment:
             CRIO_BINARY: "<< parameters.crio_binary >>"
@@ -234,7 +234,7 @@ jobs:
           name: lint
           command: |
             docker pull $IMAGE
-            docker run -t --privileged --rm -e GOCACHE \
+            docker run --privileged --rm -e GOCACHE \
               -v $GOCACHE:$GOCACHE -v $(pwd):$WORKDIR \
               -w $WORKDIR $IMAGE make lint
             sudo chown -R $(id -u):$(id -g) $GOCACHE

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -243,4 +243,19 @@ var _ = t.Describe("Config", func() {
 			Expect(err).NotTo(BeNil())
 		})
 	})
+
+	t.Describe("ToByte", func() {
+		It("should succeed", func() {
+			// Given
+			sut, err := server.DefaultConfig(nil)
+			Expect(err).To(BeNil())
+
+			// When
+			res, err := sut.ToBytes()
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).NotTo(BeNil())
+		})
+	})
 })

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -98,6 +98,20 @@ func (s *Server) getContainerInfo(id string, getContainerFunc, getInfraContainer
 func (s *Server) GetInfoMux() *bone.Mux {
 	mux := bone.New()
 
+	mux.Get("/config", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, err := s.config.ToBytes()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/toml")
+		if _, err := w.Write(b); err != nil {
+			http.Error(w, fmt.Sprintf("unable to write TOML: %v", err),
+				http.StatusInternalServerError)
+		}
+	}))
+
 	mux.Get("/info", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ci := s.getInfo()
 		js, err := json.Marshal(ci)

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -122,6 +122,7 @@ fi
 CRIO_SOCKET="$TESTDIR/crio.sock"
 CRIO_CONFIG="$TESTDIR/crio.conf"
 CRIO_CNI_CONFIG="$TESTDIR/cni/net.d/"
+CRIO_LOG="$TESTDIR/crio.log"
 
 # Copy all the CNI dependencies around to ensure encapsulated tests
 CRIO_CNI_PLUGIN="$TESTDIR/cni-bin"
@@ -305,7 +306,11 @@ function pull_test_containers() {
 # Start crio.
 function start_crio() {
 	setup_crio "$@"
-	"$CRIO_BINARY_PATH" --default-mounts-file "$TESTDIR/containers/mounts.conf" --log-level debug --config "$CRIO_CONFIG" & CRIO_PID=$!
+	"$CRIO_BINARY_PATH" \
+		--default-mounts-file "$TESTDIR/containers/mounts.conf" \
+		--log-level debug \
+		--config "$CRIO_CONFIG" \
+		&> >(tee "$CRIO_LOG") & CRIO_PID=$!
 	wait_until_reachable
 	pull_test_containers
 }

--- a/test/reload.bats
+++ b/test/reload.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+    start_crio
+}
+
+function teardown() {
+    cleanup_test
+}
+
+function replace_config() {
+    sed -ie 's/\('$1' = "\).*\("\)/\1'$2'\2/' "$CRIO_CONFIG"
+}
+
+function reload_crio() {
+    kill -HUP $CRIO_PID
+}
+
+function wait_for_log() {
+    CNT=0
+    while true; do
+        if [[ $CNT -gt 50 ]]; then
+            echo wait for log timed out
+            exit 1
+        fi
+
+        if grep -q "$1" "$CRIO_LOG"; then
+            break
+        fi
+
+        echo "waiting for log entry to appear ($CNT): $1"
+        sleep 0.1
+        CNT=$((CNT + 1))
+    done
+}
+
+function expect_log_success() {
+    wait_for_log '"set config '$1' to \\"'$2'\\""'
+}
+
+function expect_log_failure() {
+    wait_for_log "unable to reload configuration: $1"
+}
+
+@test "should succeed to reload" {
+    # when
+    reload_crio
+
+    # then
+    ps --pid $CRIO_PID &>/dev/null
+}
+
+@test "should succeed to reload 'log_level'" {
+    # given
+    NEW_LEVEL="warn"
+    OPTION="log_level"
+
+    # when
+    replace_config $OPTION $NEW_LEVEL
+    reload_crio
+
+    # then
+    expect_log_success $OPTION $NEW_LEVEL
+}
+
+@test "should fail to reload 'log_level' if invalid" {
+    # when
+    replace_config "log_level" "invalid"
+    reload_crio
+
+    # then
+    expect_log_failure "not a valid logrus Level"
+}
+
+
+@test "should fail to reload if config is malformed" {
+    # when
+    replace_config "log_level" '\"'
+    reload_crio
+
+    # then
+    expect_log_failure "unable to decode configuration"
+}


### PR DESCRIPTION
This commits adds the first integration test suite to the live reload
feature of CRI-O. A small refactoring of the start_crio function within
the helpers.bash is included as well. The HTTP "/info" endpoint contains
now a new field "last_reload", which specifies the last configuration
reload via SIGHUP independently if the reload has been successful or
not.

I had to remove the `-t/--tty` from the CircleCI console to avoid adding
newlines to the console output.