### PR TITLE
Create network directory if it doesn't exist

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -548,8 +548,15 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 // `nil`.
 func (c *NetworkConfig) Validate(onExecution bool) error {
 	if onExecution {
-		if err := utils.IsDirectory(c.NetworkDir); err != nil {
-			return errors.Wrapf(err, "invalid network_dir: %s", err)
+		err := utils.IsDirectory(c.NetworkDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				if err = os.MkdirAll(c.NetworkDir, 0755); err != nil {
+					return errors.Wrapf(err, "Cannot create network_dir: %s", c.NetworkDir)
+				}
+			} else {
+				return errors.Wrapf(err, "invalid network_dir: %s", c.NetworkDir)
+			}
 		}
 
 		for _, pluginDir := range c.PluginDirs {

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -271,13 +271,32 @@ var _ = t.Describe("Config", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should fail on invalid NetworkDir", func() {
+		It("should create the  NetworkDir", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = invalidPath
+			tmpDir := path.Join(os.TempDir(), invalidPath)
+			sut.NetworkConfig.NetworkDir = tmpDir
 			sut.NetworkConfig.PluginDirs = []string{validDirPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
+
+			// Then
+			Expect(err).To(BeNil())
+			os.RemoveAll(tmpDir)
+		})
+
+		It("should fail on invalid NetworkDir", func() {
+			// Given
+			tmpfile := path.Join(os.TempDir(), "wrong-file")
+			file, err := os.Create(tmpfile)
+			Expect(err).To(BeNil())
+			file.Close()
+			defer os.Remove(tmpfile)
+			sut.NetworkConfig.NetworkDir = tmpfile
+			sut.NetworkConfig.PluginDirs = []string{}
+
+			// When
+			err = sut.NetworkConfig.Validate(true)
 
 			// Then
 			Expect(err).NotTo(BeNil())


### PR DESCRIPTION
The default network directory does not necessarily have to exist before
the cri-o service is started. IF the planned network directory does not
exist, create it when starting the service.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>