### PR TITLE
Fix possible runtime panic on store shutdown

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -608,8 +608,17 @@ func (c *ContainerServer) ReleasePodName(name string) {
 	c.podNameIndex.Release(name)
 }
 
+// recoverLogError recovers a runtime panic and logs the returned error if
+// existing
+func recoverLogError() {
+	if err := recover(); err != nil {
+		logrus.Error(err)
+	}
+}
+
 // Shutdown attempts to shut down the server's storage cleanly
 func (c *ContainerServer) Shutdown() error {
+	defer recoverLogError()
 	_, err := c.store.Shutdown(false)
 	if err != nil && errors.Cause(err) != cstorage.ErrLayerUsedByContainer {
 		return err

--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -936,6 +936,20 @@ var _ = t.Describe("ContainerServer", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 		})
+
+		It("should not panic when storage shutdown panics", func() {
+			// Given
+			gomock.InOrder(
+				storeMock.EXPECT().Shutdown(gomock.Any()).
+					Do(func() { panic("something bad happened") }),
+			)
+
+			// When
+			err := sut.Shutdown()
+
+			// Then
+			Expect(err).To(BeNil())
+		})
 	})
 
 	t.Describe("AddContainer/AddSandbox", func() {


### PR DESCRIPTION
This commit fixes a runtime panic which can happen on store shutdown,
for example if the `mountpoints.lock` file got deleted during runtime.