### PR TITLE
Update Dockerfile CNI plugins to v0.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,9 @@ RUN VERSION=v1.0.0-rc8 &&\
     chmod +x /usr/bin/runc
 
 # Install CNI plugins
-RUN VERSION=v0.7.5 &&\
+RUN VERSION=v0.8.0 &&\
     mkdir -p /opt/cni/bin &&\
-    wget -qO- https://github.com/containernetworking/plugins/releases/download/$VERSION/cni-plugins-amd64-$VERSION.tgz \
+    wget -qO- https://github.com/containernetworking/plugins/releases/download/$VERSION/cni-plugins-linux-amd64-$VERSION.tgz \
         | tar xfz - -C /opt/cni/bin
 
 # Install crictl

--- a/Dockerfile-circleci
+++ b/Dockerfile-circleci
@@ -62,9 +62,9 @@ RUN VERSION=v1.0.0-rc8 &&\
     chmod +x /usr/bin/runc
 
 # Install CNI plugins
-RUN VERSION=v0.6.0-rc1 &&\
+RUN VERSION=v0.8.0 &&\
     mkdir -p /opt/cni/bin &&\
-    wget -qO- https://github.com/containernetworking/plugins/releases/download/$VERSION/cni-plugins-amd64-$VERSION.tgz \
+    wget -qO- https://github.com/containernetworking/plugins/releases/download/$VERSION/cni-plugins-linux-amd64-$VERSION.tgz \
         | tar xfz - -C /opt/cni/bin
 
 # Make sure we have some policy for pulling images

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -529,6 +529,7 @@ function parse_pod_ip() {
 		if [ "$cidr" == "$arg" ]
 		then
 			echo `echo "$arg" | sed "s/\/[0-9][0-9]//"`
+			break
 		fi
 	done
 }


### PR DESCRIPTION
This commit updates the CNI plugins and fixes the related pod IP parsing for the integration tests.