### PR TITLE
[1.14] Add crio-wipe

### DIFF
--- a/contrib/crio-wipe/README.md
+++ b/contrib/crio-wipe/README.md
@@ -1,0 +1,27 @@
+# crio-wipe
+
+crio-wipe is a program that reads CRI-O's version file, and compares it to the output of crio --version.
+If the version is deemed old enough, crio-wipe wipes container storage on the node.
+If there is no version file present, or the version file is malformatted, crio-wipe also will wipe the storage.
+
+
+crio-wipe returns 0 on success and 1 on error. If a wipe happened, it will be noted in stdout. Otherwise, crio-wipe will not wipe silently
+
+
+crio-wipe by default assumes:
+* the containers storage directory is `/var/lib/containers`
+* the location of the version file is `/var/lib/crio/version`
+* formatting of `crio --version` resembles `crio version $MAJOR.$MINOR...`
+* formatting of version file resembles `"$MAJOR.$MINOR...`
+
+The latter two formatting assumptions can only be changed by changing crio-wipe
+
+Users have access to these flags to change crio-wipe's behavior:
+
+| Flag         | Usage                                                                 |
+|--------------|-----------------------------------------------------------------------|
+| -d [value]   | Change the location of the storage dir to be wiped                    |
+| -f [value]   | Change the location of the version file to be read as the old version |
+| -w [integer] | Non-zero values tell crio-wipe to not actually remove the storage-dir |
+
+crio-wipe has a test suite that can be run with `bats test.bats`

--- a/contrib/crio-wipe/crio-wipe.bash
+++ b/contrib/crio-wipe/crio-wipe.bash
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eu
+
+
+dir=${0%/*}
+source "$dir/lib.bash"
+
+VERSION_FILE_LOCATION="/var/lib/crio/version"
+CONTAINERS_STORAGE_DIR="/var/lib/containers"
+NEW_VERSION=$(crio --version)
+WIPE=0
+
+print_usage() {
+	echo "$(basename $0) [-f version-file-location] [-d containers-storage-dir] [-w wipe]"
+}
+
+# process command variables
+while getopts 'f:d:w:h' OPTION; do
+	case "$OPTION" in
+		f) VERSION_FILE_LOCATION="$OPTARG" ;;
+		d) CONTAINERS_STORAGE_DIR="$OPTARG" ;;
+		w)
+		# We need to make sure arguments to -w are integers.
+		# the way to check this is verifying it can be compared with -eq,
+		# which only accepts numerical arguments
+		if [ -n "$OPTARG" ] && [ "$OPTARG" -eq "$OPTARG" ] 2>/dev/null; then
+			WIPE=$OPTARG
+		else
+			>&2 echo "argument to -w needs to be an integer"
+			exit 1
+		fi
+			;;
+	h) print_usage; exit 0;;
+		?) print_usage &> 2; exit 1;;
+	esac
+done
+shift "$(($OPTIND -1))"
+
+main

--- a/contrib/crio-wipe/crio-wipe.service
+++ b/contrib/crio-wipe/crio-wipe.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=CRI-O Auto Update Script
+Before=crio.service
+RequiresMountsFor=/var/lib/containers
+
+[Service]
+ExecStart=/bin/bash /var/lib/crio/crio-wipe/crio-wipe.bash
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/crio-wipe/helpers.bash
+++ b/contrib/crio-wipe/helpers.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -eu
+
+prepare_test() {
+	NEW_VERSION="$1"
+	WIPE=0
+	TESTDIR=$(mktemp -d)
+	# create and set our version file
+	VERSION_FILE_LOCATION="$TESTDIR"/version.tmp
+	if [[ ! -z ${2+x} ]]; then
+		echo "$2" > "$VERSION_FILE_LOCATION"
+	fi
+
+
+	# setup storage dir
+	TMP_STORAGE="$TESTDIR/tmp"
+	mkdir "$TMP_STORAGE"
+	CONTAINERS_STORAGE_DIR="$TMP_STORAGE"
+}
+
+cleanup_test() {
+	rm -rf "$TESTDIR"
+}

--- a/contrib/crio-wipe/lib.bash
+++ b/contrib/crio-wipe/lib.bash
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -eu
+
+get_major() {
+	echo "$@" | grep -Po '^(\"|crio version )?\K\d(?=\..*)' || true
+}
+
+get_minor() {
+	echo "$@" | grep -Po '^(\"|crio version )?\d\.\K\d+(?=\..*)' || true
+}
+
+perform_wipe() {
+	if [[ $WIPE -eq 0 ]]; then
+		echo "Wiping storage"
+		rm -rf "$CONTAINERS_STORAGE_DIR"
+	fi
+	exit 0
+}
+
+check_versions_wipe_if_necessary() {
+	# $1 should be the new version
+	# $2 should be the old version
+
+	# cast as integers to be used
+	new=$(("$1" + 0))
+	old=$(("$2" + 0))
+	if [[ $old -lt $new ]]; then
+		echo "New version detected"
+		perform_wipe
+	fi
+}
+
+main() {
+	# Fail and don't update if current major or minor versions can't be read
+	NEW_MAJOR_VERSION=$(get_major "$NEW_VERSION")
+	if [[ -z "$NEW_MAJOR_VERSION" ]]; then
+		>&2 echo "New major version not set"
+		exit 1
+	fi
+
+	NEW_MINOR_VERSION=$(get_minor "$NEW_VERSION")
+	if [[ -z "$NEW_MINOR_VERSION" ]]; then
+		>&2 echo "New minor version not set"
+		exit 1
+	fi
+
+	# Unconditionally update if there is no version file
+	if ! test -f "$VERSION_FILE_LOCATION"; then
+		echo "Old version not found"
+		perform_wipe
+	fi
+
+	OLD_VERSION=$(cat "$VERSION_FILE_LOCATION")
+
+	OLD_MAJOR_VERSION=$(get_major "$OLD_VERSION")
+	if [[ -z "$OLD_MAJOR_VERSION" ]]; then
+		>&2 echo "Invalid major version in version file"
+		perform_wipe
+	fi
+	MAJOR_CHECK=$(check_versions_wipe_if_necessary "$NEW_MAJOR_VERSION" "$OLD_MAJOR_VERSION")
+	if [[ ! -z "$MAJOR_CHECK" ]]; then
+		echo "Reading major version in file returned: $MAJOR_CHECK"
+		exit 0
+	fi
+
+	OLD_MINOR_VERSION=$(get_minor "$OLD_VERSION")
+	if [[ -z "$OLD_MINOR_VERSION" ]]; then
+		>&2 echo "Invalid minor version in version file"
+		perform_wipe
+	fi
+	MINOR_CHECK=$(check_versions_wipe_if_necessary "$NEW_MINOR_VERSION" "$OLD_MINOR_VERSION")
+	if [[ ! -z "$MINOR_CHECK" ]]; then
+		echo "Reading minor version in file returned: $MINOR_CHECK"
+		exit 0
+	fi
+
+	# no update needed
+	exit 0
+}

--- a/contrib/crio-wipe/test.bats
+++ b/contrib/crio-wipe/test.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+load lib
+load helpers
+
+function teardown() {
+	cleanup_test
+}
+
+@test "don't upgrade if not told to wipe" {
+	prepare_test "crio version 1.1.1"
+	WIPE=1
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 0 ]
+	[ -d "$TMP_STORAGE" ]
+}
+
+@test "upgrade with no version file" {
+	prepare_test "crio version 1.1.1"
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 0 ]
+	[ ! -d "$TMP_STORAGE" ]
+}
+
+@test "don't upgrade with same version" {
+	prepare_test "crio version 1.13.1" "\"1.13.1\""
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 0 ]
+	[ -d "$TMP_STORAGE" ]
+}
+
+@test "don't upgrade for sub-minor releases" {
+	prepare_test "crio version 1.13.2" "\"1.13.1\""
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 0 ]
+	[ -d "$TMP_STORAGE" ]
+}
+
+@test "upgrade for minor releases" {
+	prepare_test "crio version 1.14.0" "\"1.13.1\""
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 0 ]
+	[ ! -d "$TMP_STORAGE" ]
+}
+
+@test "upgrade for major release" {
+	prepare_test "crio version 2.0.0" "\"1.13.1\""
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 0 ]
+	[ ! -d "$TMP_STORAGE" ]
+}
+
+@test "fail and not upgrade with bad version format" {
+	prepare_test "crio version bad format" "\"1.13.1\""
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 1 ]
+	[ -d "$TMP_STORAGE" ]
+}
+
+@test "fail and not upgrade with bad minor version format" {
+	prepare_test "crio version 1.bad minor format.11" "\"1.13.1\""
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 1 ]
+	[ -d "$TMP_STORAGE" ]
+}
+
+@test "fail and upgrade with faulty version file" {
+	prepare_test "crio version 1.1.1" "bad format"
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 0 ]
+	[ ! -d "$TMP_STORAGE" ]
+}
+
+@test "fail and upgrade with faulty minor version in version file" {
+	prepare_test "crio version 1.14.11" "\"1.x.14\""
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 0 ]
+	[ ! -d "$TMP_STORAGE" ]
+}


### PR DESCRIPTION
crio-wipe is a program that compares the version file to crio --version, and if the version is sufficiently new, crio-wipe clears storage.

It should be used on any system where it is desired crio auto upgrades between versions

Relies on: https://github.com/cri-o/cri-o/pull/2397

Signed-off-by: Peter Hunt <pehunt@redhat.com>