### PR TITLE
server: do not add default /sys if bind mounted

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -383,15 +383,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	}
 	specgen.AddAnnotation(annotations.Volumes, string(volumesJSON))
 
-	mnt := rspec.Mount{
-		Destination: "/sys/fs/cgroup",
-		Type:        "cgroup",
-		Source:      "cgroup",
-		Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
-	}
-	// Add cgroup mount so container process can introspect its own limits
-	specgen.AddMount(mnt)
-
 	configuredDevices, err := getDevicesFromConfig(&s.config)
 	if err != nil {
 		return nil, err
@@ -600,15 +591,18 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		if err := specgen.RemoveLinuxNamespace(string(rspec.NetworkNamespace)); err != nil {
 			return nil, err
 		}
-		specgen.RemoveMount("/sys")
-		specgen.RemoveMount("/sys/cgroup")
-		sysMnt := rspec.Mount{
-			Destination: "/sys",
-			Type:        "bind",
-			Source:      "/sys",
-			Options:     []string{"nosuid", "noexec", "nodev", "ro", "rbind"},
+
+		if !isInCRIMounts("/sys", containerConfig.GetMounts()) {
+			specgen.RemoveMount("/sys")
+			specgen.RemoveMount("/sys/cgroup")
+			sysMnt := rspec.Mount{
+				Destination: "/sys",
+				Type:        "bind",
+				Source:      "/sys",
+				Options:     []string{"nosuid", "noexec", "nodev", "ro", "rbind"},
+			}
+			specgen.AddMount(sysMnt)
 		}
-		specgen.AddMount(sysMnt)
 	} else {
 		netNsPath := sb.NetNsPath()
 		if netNsPath == "" {
@@ -627,7 +621,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	// Remove the default /dev/shm mount to ensure we overwrite it
 	specgen.RemoveMount("/dev/shm")
 
-	mnt = rspec.Mount{
+	mnt := rspec.Mount{
 		Type:        "bind",
 		Source:      sb.ShmPath(),
 		Destination: "/dev/shm",
@@ -950,6 +944,10 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 			// filter out everything under /dev if /dev is a supplied mount
 			continue
 		}
+		if _, mountSys := mountSet["/sys"]; mountSys && strings.HasPrefix(dst, "/sys/") {
+			// filter out everything under /sys if /sys is a supplied mount
+			continue
+		}
 		specgen.AddMount(m)
 	}
 
@@ -1028,6 +1026,17 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 			Destination: dest,
 			Options:     options,
 		})
+	}
+
+	if _, mountSys := mountSet["/sys"]; !mountSys {
+		m := rspec.Mount{
+			Destination: "/sys/fs/cgroup",
+			Type:        "cgroup",
+			Source:      "cgroup",
+			Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
+		}
+		specgen.AddMount(m)
+
 	}
 
 	return volumes, ociMounts, nil

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -43,3 +43,32 @@ func TestAddOCIBindsForDev(t *testing.T) {
 		t.Error("no /dev mount found in spec mounts")
 	}
 }
+
+func TestAddOCIBindsForSys(t *testing.T) {
+	specgen, err := generate.New("linux")
+	if err != nil {
+
+		t.Error(err)
+	}
+	config := &pb.ContainerConfig{
+		Mounts: []*pb.Mount{
+			{
+				ContainerPath: "/sys",
+				HostPath:      "/sys",
+			},
+		},
+	}
+	_, binds, err := addOCIBindMounts("", config, &specgen, "")
+	if err != nil {
+		t.Error(err)
+	}
+	var howManySys int
+	for _, b := range binds {
+		if b.Destination == "/sys" && b.Type != "sysfs" {
+			howManySys++
+		}
+	}
+	if howManySys != 1 {
+		t.Error("there is not a single /sys bind mount")
+	}
+}


### PR DESCRIPTION
if the container is bind mounting /sys from the host, do not add
another default /sys mount.

This also prevents a "mount bomb" if there is mount with bidirectional
mount propagation that causes the rootfsPropagation to be set to
"rshared".

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1711200

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
