### PR TITLE
[1.14] Change plugin_dir to plugin_dirs

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -263,8 +263,8 @@ image_volumes = "{{ .ImageVolumes }}"
 network_dir = "{{ .NetworkDir }}"
 
 # Paths to directories where CNI plugin binaries are located.
-plugin_dir = [
-{{ range $opt := .PluginDir }}{{ printf "\t%q,\n" $opt }}{{ end }}]
+plugin_dirs = [
+{{ range $opt := .PluginDirs }}{{ printf "\t%q,\n" $opt }}{{ end }}]
 `))
 
 // TODO: Currently ImageDir isn't really used, so we haven't added it to this

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -170,7 +170,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 		config.NetworkDir = ctx.GlobalString("cni-config-dir")
 	}
 	if ctx.GlobalIsSet("cni-plugin-dir") {
-		config.PluginDir = ctx.GlobalStringSlice("cni-plugin-dir")
+		config.PluginDirs = ctx.GlobalStringSlice("cni-plugin-dir")
 	}
 	if ctx.GlobalIsSet("image-volumes") {
 		config.ImageVolumes = lib.ImageVolumesType(ctx.GlobalString("image-volumes"))

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -212,7 +212,7 @@ The `crio.network` table containers settings pertaining to the management of CNI
 **network_dir**="/etc/cni/net.d/"
   Path to the directory where CNI configuration files are located.
 
-**plugin_dir**=["/opt/cni/bin/",]
+**plugin_dirs**=["/opt/cni/bin/",]
   List of paths to directories where CNI plugin binaries are located.
 
 # SEE ALSO

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -201,7 +201,7 @@ var _ = t.Describe("Config", func() {
 		It("should succeed during runtime", func() {
 			// Given
 			sut.NetworkConfig.NetworkDir = validPath
-			sut.NetworkConfig.PluginDir = []string{validPath}
+			sut.NetworkConfig.PluginDirs = []string{validPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
@@ -213,7 +213,7 @@ var _ = t.Describe("Config", func() {
 		It("should fail on invalid NetworkDir", func() {
 			// Given
 			sut.NetworkConfig.NetworkDir = wrongPath
-			sut.NetworkConfig.PluginDir = []string{validPath}
+			sut.NetworkConfig.PluginDirs = []string{validPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
@@ -222,16 +222,56 @@ var _ = t.Describe("Config", func() {
 			Expect(err).NotTo(BeNil())
 		})
 
-		It("should fail on invalid PluginDir", func() {
+		It("should fail on invalid PluginDirs", func() {
 			// Given
 			sut.NetworkConfig.NetworkDir = validPath
-			sut.NetworkConfig.PluginDir = []string{wrongPath}
+			sut.NetworkConfig.PluginDirs = []string{wrongPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
+		})
+
+		It("should succeed on having PluginDir", func() {
+			// Given
+			sut.NetworkConfig.NetworkDir = validPath
+			sut.NetworkConfig.PluginDir = validPath
+			sut.NetworkConfig.PluginDirs = []string{}
+
+			// When
+			err := sut.NetworkConfig.Validate(true)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed in appending PluginDir to PluginDirs", func() {
+			// Given
+			sut.NetworkConfig.NetworkDir = validPath
+			sut.NetworkConfig.PluginDir = validPath
+			sut.NetworkConfig.PluginDirs = []string{}
+
+			// When
+			err := sut.NetworkConfig.Validate(true)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.NetworkConfig.PluginDirs[0]).To(Equal(validPath))
+		})
+
+		It("should fail in validating invalid PluginDir", func() {
+			// Given
+			sut.NetworkConfig.NetworkDir = validPath
+			sut.NetworkConfig.PluginDir = wrongPath
+			sut.NetworkConfig.PluginDirs = []string{}
+
+			// When
+			err := sut.NetworkConfig.Validate(true)
+
+			// Then
+			Expect(err).ToNot(BeNil())
 		})
 	})
 

--- a/lib/testdata/config.toml
+++ b/lib/testdata/config.toml
@@ -24,4 +24,4 @@
     image_volumes = "mkdir"
   [crio.network]
     network_dir = "/etc/cni/net.d/"
-    plugin_dir = ["/opt/cni/bin/"]
+    plugin_dirs = ["/opt/cni/bin/"]

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -54,7 +54,7 @@ func assertAllFieldsEquality(t *testing.T, c Config) {
 		{c.ImageConfig.Registries[0], "registry:4321"},
 
 		{c.NetworkConfig.NetworkDir, "/etc/cni/net.d/"},
-		{c.NetworkConfig.PluginDir[0], "/opt/cni/bin/"},
+		{c.NetworkConfig.PluginDirs[0], "/opt/cni/bin/"},
 	}
 	for _, tc := range testCases {
 		if tc.fieldValue != tc.expected {
@@ -107,7 +107,7 @@ func TestConfigValidateDefaultSuccessOnExecution(t *testing.T) {
 	defaultConfig.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
 	defaultConfig.Conmon = validPath
 	defaultConfig.NetworkConfig.NetworkDir = validPath
-	defaultConfig.NetworkConfig.PluginDir = []string{validPath}
+	defaultConfig.NetworkConfig.PluginDirs = []string{validPath}
 
 	must(t, defaultConfig.Validate(true))
 }

--- a/server/fixtures/crio.conf
+++ b/server/fixtures/crio.conf
@@ -38,4 +38,4 @@ registries = [
 
 [crio.network]
 network_dir = "/etc/cni/net.d/"
-plugin_dir = ["/opt/cni/bin/"]
+plugin_dirs = ["/opt/cni/bin/"]

--- a/server/server.go
+++ b/server/server.go
@@ -331,7 +331,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 		return nil, err
 	}
 
-	netPlugin, err := ocicni.InitCNI("", config.NetworkDir, config.PluginDir...)
+	netPlugin, err := ocicni.InitCNI("", config.NetworkDir, config.PluginDirs...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To maintain backwards compatibility, change plugin_dir to plugin_dirs in crio configs.
Mark plugin_dir depreciated, and send warning as such.

Signed-off-by: Peter Hunt <pehunt@redhat.com>