### PR TITLE
test: Set container runtime to remote for e2e

### DIFF
--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -11,7 +11,7 @@
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
   set_fact:
     e2e_shell_cmd: >
-        GINKGO_TOLERATE_FLAKES="y" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y /usr/bin/go run hack/e2e.go
+        KUBE_CONTAINER_RUNTIME="remote" GINKGO_TOLERATE_FLAKES="y" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y /usr/bin/go run hack/e2e.go
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
                         --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates|\[sig-storage\].In-tree.Volumes.\[Driver:.local\]|\[sig-storage\].CSI.Volumes.CSI.Topology.test.using.GCE.PD.driver


### PR DESCRIPTION
The default is docker and it breaks us when tests depend on it.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

