### PR TITLE
[release-1.14] server: do not add default /sys if bind mounted

### DIFF
--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -43,3 +43,32 @@ func TestAddOCIBindsForDev(t *testing.T) {
 		t.Error("no /dev mount found in spec mounts")
 	}
 }
+
+func TestAddOCIBindsForSys(t *testing.T) {
+	specgen, err := generate.New("linux")
+	if err != nil {
+
+		t.Error(err)
+	}
+	config := &pb.ContainerConfig{
+		Mounts: []*pb.Mount{
+			{
+				ContainerPath: "/sys",
+				HostPath:      "/sys",
+			},
+		},
+	}
+	_, binds, err := addOCIBindMounts("", config, &specgen, "")
+	if err != nil {
+		t.Error(err)
+	}
+	var howManySys int
+	for _, b := range binds {
+		if b.Destination == "/sys" && b.Type != "sysfs" {
+			howManySys++
+		}
+	}
+	if howManySys != 1 {
+		t.Error("there is not a single /sys bind mount")
+	}
+}


### PR DESCRIPTION
if the container is bind mounting /sys from the host, do not add
another default /sys mount.

This also prevents a "mount bomb" if there is mount with bidirectional
mount propagation that causes the rootfsPropagation to be set to
"rshared".

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1711200

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 184e8580d112ec7f830f1054be97aa053263e7e1)
