### PR TITLE
[1.13] Update device cgroup permissions for configured devices.

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -37,6 +37,11 @@ import (
 // A lower value would result in the container failing to start.
 const minMemoryLimit = 4194304
 
+type configDevice struct {
+	Device   rspec.LinuxDevice
+	Resource rspec.LinuxDeviceCgroup
+}
+
 func findCgroupMountpoint(name string) error {
 	// Set up pids limit if pids cgroup is mounted
 	_, err := cgroups.FindCgroupMountpoint(name)
@@ -368,12 +373,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	}
 	specgen.AddAnnotation(annotations.Volumes, string(volumesJSON))
 
-	devices, err := getDevicesFromConfig(s.config)
+	configuredDevices, err := getDevicesFromConfig(&s.config)
 	if err != nil {
 		return nil, err
 	}
-	for _, d := range devices {
-		specgen.AddDevice(d)
+	for i := range configuredDevices {
+		d := &configuredDevices[i]
+
+		specgen.AddDevice(d.Device)
+		specgen.AddLinuxResourcesDevice(d.Resource.Allow, d.Resource.Type, d.Resource.Major, d.Resource.Minor, d.Resource.Access)
 	}
 
 	if err := addDevices(sb, containerConfig, &specgen); err != nil {
@@ -1121,28 +1129,44 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 	return volumes, ociMounts, nil
 }
 
-func getDevicesFromConfig(config Config) ([]rspec.LinuxDevice, error) {
-	var linuxdevs []rspec.LinuxDevice
+func getDevicesFromConfig(config *Config) ([]configDevice, error) {
+	linuxdevs := make([]configDevice, 0, len(config.RuntimeConfig.AdditionalDevices))
+
 	for _, d := range config.RuntimeConfig.AdditionalDevices {
 		src, dst, permissions, err := createconfig.ParseDevice(d)
 		if err != nil {
 			return nil, err
 		}
+
+		logrus.Debugf("adding device src=%s dst=%s mode=%s", src, dst, permissions)
+
 		dev, err := devices.DeviceFromPath(src, permissions)
 		if err != nil {
 			return nil, errors.Wrapf(err, "%s is not a valid device", src)
 		}
+
 		dev.Path = dst
-		linuxdev := rspec.LinuxDevice{
-			Path:     dev.Path,
-			Type:     string(dev.Type),
-			Major:    dev.Major,
-			Minor:    dev.Minor,
-			FileMode: &dev.FileMode,
-			UID:      &dev.Uid,
-			GID:      &dev.Gid,
-		}
-		linuxdevs = append(linuxdevs, linuxdev)
+
+		linuxdevs = append(linuxdevs,
+			configDevice{
+				Device: rspec.LinuxDevice{
+					Path:     dev.Path,
+					Type:     string(dev.Type),
+					Major:    dev.Major,
+					Minor:    dev.Minor,
+					FileMode: &dev.FileMode,
+					UID:      &dev.Uid,
+					GID:      &dev.Gid,
+				},
+				Resource: rspec.LinuxDeviceCgroup{
+					Allow:  true,
+					Type:   string(dev.Type),
+					Major:  &dev.Major,
+					Minor:  &dev.Minor,
+					Access: permissions,
+				},
+			})
 	}
+
 	return linuxdevs, nil
 }


### PR DESCRIPTION
When additional devices are configured in `crio.conf`, they
are correctly bound into the container, but the devices cgroup
permissions were not propagated. Ensure that we propagate the
requested permissions down to the continer spec so that the access
is correct.

This fixes #2214.

Signed-off-by: James Peach <jpeach@apache.org>

Backport to 1.13 branch

Signed-off-by: Peter Hunt <pehunt@redhat.com>
