### PR TITLE
[1.14] Update device cgroup permissions for configured devices.

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -37,6 +37,11 @@ import (
 // A lower value would result in the container failing to start.
 const minMemoryLimit = 4194304
 
+type configDevice struct {
+	Device   rspec.LinuxDevice
+	Resource rspec.LinuxDeviceCgroup
+}
+
 func findCgroupMountpoint(name string) error {
 	// Set up pids limit if pids cgroup is mounted
 	_, err := cgroups.FindCgroupMountpoint("", name)
@@ -392,12 +397,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	}
 	specgen.AddAnnotation(annotations.Volumes, string(volumesJSON))
 
-	devices, err := getDevicesFromConfig(s.config)
+	configuredDevices, err := getDevicesFromConfig(&s.config)
 	if err != nil {
 		return nil, err
 	}
-	for _, d := range devices {
-		specgen.AddDevice(d)
+	for i := range configuredDevices {
+		d := &configuredDevices[i]
+
+		specgen.AddDevice(d.Device)
+		specgen.AddLinuxResourcesDevice(d.Resource.Allow, d.Resource.Type, d.Resource.Major, d.Resource.Minor, d.Resource.Access)
 	}
 
 	if err := addDevices(sb, containerConfig, &specgen); err != nil {
@@ -1139,28 +1147,44 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 	return volumes, ociMounts, nil
 }
 
-func getDevicesFromConfig(config Config) ([]rspec.LinuxDevice, error) {
-	linuxdevs := make([]rspec.LinuxDevice, 0, len(config.RuntimeConfig.AdditionalDevices))
+func getDevicesFromConfig(config *Config) ([]configDevice, error) {
+	linuxdevs := make([]configDevice, 0, len(config.RuntimeConfig.AdditionalDevices))
+
 	for _, d := range config.RuntimeConfig.AdditionalDevices {
 		src, dst, permissions, err := createconfig.ParseDevice(d)
 		if err != nil {
 			return nil, err
 		}
+
+		logrus.Debugf("adding device src=%s dst=%s mode=%s", src, dst, permissions)
+
 		dev, err := devices.DeviceFromPath(src, permissions)
 		if err != nil {
 			return nil, errors.Wrapf(err, "%s is not a valid device", src)
 		}
+
 		dev.Path = dst
-		linuxdev := rspec.LinuxDevice{
-			Path:     dev.Path,
-			Type:     string(dev.Type),
-			Major:    dev.Major,
-			Minor:    dev.Minor,
-			FileMode: &dev.FileMode,
-			UID:      &dev.Uid,
-			GID:      &dev.Gid,
-		}
-		linuxdevs = append(linuxdevs, linuxdev)
+
+		linuxdevs = append(linuxdevs,
+			configDevice{
+				Device: rspec.LinuxDevice{
+					Path:     dev.Path,
+					Type:     string(dev.Type),
+					Major:    dev.Major,
+					Minor:    dev.Minor,
+					FileMode: &dev.FileMode,
+					UID:      &dev.Uid,
+					GID:      &dev.Gid,
+				},
+				Resource: rspec.LinuxDeviceCgroup{
+					Allow:  true,
+					Type:   string(dev.Type),
+					Major:  &dev.Major,
+					Minor:  &dev.Minor,
+					Access: permissions,
+				},
+			})
 	}
+
 	return linuxdevs, nil
 }

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -143,6 +143,73 @@ function teardown() {
 	stop_crio
 }
 
+@test "additional devices permissions" {
+	# We need a ubiquitously configured device that isn't in the
+	# OCI spec default set.
+	local readonly device="/dev/loop-control"
+	local readonly timeout=30
+
+	if test -n "$UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
+	if ! test -r $device ; then
+		skip "$device not readable"
+	fi
+
+	if ! test -w $device ; then
+		skip "$device not writeable"
+	fi
+
+	DEVICES="--additional-devices ${device}:${device}:w" start_crio
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+        # Ensure the device is there.
+	run crictl exec --timeout=$timeout --sync "$ctr_id" ls $device
+	echo $output
+	[ "$status" -eq 0 ]
+	[[ "$output" == "$device" ]]
+
+	# Dump the deviced cgroup configuration for debugging.
+	run crictl exec --timeout=$timeout --sync "$ctr_id" cat /sys/fs/cgroup/devices/devices.list
+	echo $output
+	[[ "$output" =~ "c 10:237 w" ]]
+
+        # Opening the device in read mode should fail because the device
+        # cgroup access only allows writes.
+	run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=$device of=/dev/null count=1
+	echo $output
+	[[ "$output" =~ "Operation not permitted" ]]
+
+        # The write should be allowed by the devices cgroup policy, so we
+        # should see an EINVAL from the device when the device fails it.
+	run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=/dev/zero of=$device count=1
+	echo $output
+	[[ "$output" =~ "Invalid argument" ]]
+
+	run crictl stopp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rmp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+
 @test "ctr remove" {
 	start_crio
 	run crictl runp "$TESTDATA"/sandbox_config.json


### PR DESCRIPTION
When additional devices are configured in `crio.conf`, they
are correctly bound into the container, but the devices cgroup
permissions were not propagated. Ensure that we propagate the
requested permissions down to the continer spec so that the access
is correct.

This fixes #2214.

Signed-off-by: James Peach <jpeach@apache.org>

Backport to 1.14 branch

Signed-off-by: Peter Hunt <pehunt@redhat.com>