### PR TITLE
[master] Change plugin_dir to plugin_dirs and remove plugin dir from config

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -280,8 +280,8 @@ image_volumes = "{{ .ImageVolumes }}"
 network_dir = "{{ .NetworkDir }}"
 
 # Paths to directories where CNI plugin binaries are located.
-plugin_dir = [
-{{ range $opt := .PluginDir }}{{ printf "\t%q,\n" $opt }}{{ end }}]
+plugin_dirs = [
+{{ range $opt := .PluginDirs }}{{ printf "\t%q,\n" $opt }}{{ end }}]
 `))
 
 // TODO: Currently ImageDir isn't really used, so we haven't added it to this

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -178,7 +178,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) (string, error) {
 		config.NetworkDir = ctx.GlobalString("cni-config-dir")
 	}
 	if ctx.GlobalIsSet("cni-plugin-dir") {
-		config.PluginDir = ctx.GlobalStringSlice("cni-plugin-dir")
+		config.PluginDirs = ctx.GlobalStringSlice("cni-plugin-dir")
 	}
 	if ctx.GlobalIsSet("image-volumes") {
 		config.ImageVolumes = lib.ImageVolumesType(ctx.GlobalString("image-volumes"))

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -217,7 +217,7 @@ The `crio.network` table containers settings pertaining to the management of CNI
 **network_dir**="/etc/cni/net.d/"
   Path to the directory where CNI configuration files are located.
 
-**plugin_dir**=["/opt/cni/bin/",]
+**plugin_dirs**=["/opt/cni/bin/",]
   List of paths to directories where CNI plugin binaries are located.
 
 # SEE ALSO

--- a/lib/config.go
+++ b/lib/config.go
@@ -566,6 +566,10 @@ func (c *NetworkConfig) Validate(onExecution bool) error {
 			// Append PluginDir to PluginDirs, so from now on we can operate in terms of PluginDirs and not worry
 			// about missing cases.
 			c.PluginDirs = append(c.PluginDirs, c.PluginDir)
+
+			// Empty the pluginDir so on future config calls we don't print it out
+			// thus seemlessly transitioning and depreciating the option
+			c.PluginDir = ""
 		}
 	}
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -289,7 +289,10 @@ type NetworkConfig struct {
 	NetworkDir string `toml:"network_dir"`
 
 	// PluginDir is where CNI plugin binaries are stored.
-	PluginDir []string `toml:"plugin_dir"`
+	PluginDir string `toml:"plugin_dir,omitempty"`
+
+	// PluginDirs is where CNI plugin binaries are stored.
+	PluginDirs []string `toml:"plugin_dirs"`
 }
 
 // tomlConfig is another way of looking at a Config, which is
@@ -415,7 +418,7 @@ func DefaultConfig(systemContext *types.SystemContext) (*Config, error) {
 		},
 		NetworkConfig: NetworkConfig{
 			NetworkDir: cniConfigDir,
-			PluginDir:  []string{cniBinDir},
+			PluginDirs: []string{cniBinDir},
 		},
 	}, nil
 }
@@ -549,10 +552,20 @@ func (c *NetworkConfig) Validate(onExecution bool) error {
 			return errors.Wrapf(err, "invalid network_dir: %s", err)
 		}
 
-		for _, pluginDir := range c.PluginDir {
+		for _, pluginDir := range c.PluginDirs {
 			if err := os.MkdirAll(pluginDir, 0755); err != nil {
+				return errors.Wrapf(err, "invalid plugin_dirs entry")
+			}
+		}
+		// While the plugin_dir option is being deprecated, we need this check
+		if c.PluginDir != "" {
+			logrus.Warnf("The config field plugin_dir is being deprecated. Please use plugin_dirs instead")
+			if err := os.MkdirAll(c.PluginDir, 0755); err != nil {
 				return errors.Wrapf(err, "invalid plugin_dir entry")
 			}
+			// Append PluginDir to PluginDirs, so from now on we can operate in terms of PluginDirs and not worry
+			// about missing cases.
+			c.PluginDirs = append(c.PluginDirs, c.PluginDir)
 		}
 	}
 

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -261,7 +261,7 @@ var _ = t.Describe("Config", func() {
 			// Given
 			sut.NetworkConfig.NetworkDir = validDirPath
 			tmpDir := path.Join(os.TempDir(), "cni-test")
-			sut.NetworkConfig.PluginDir = []string{tmpDir}
+			sut.NetworkConfig.PluginDirs = []string{tmpDir}
 			defer os.RemoveAll(tmpDir)
 
 			// When
@@ -274,6 +274,7 @@ var _ = t.Describe("Config", func() {
 		It("should fail on invalid NetworkDir", func() {
 			// Given
 			sut.NetworkConfig.NetworkDir = invalidPath
+			sut.NetworkConfig.PluginDirs = []string{validDirPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
@@ -282,10 +283,10 @@ var _ = t.Describe("Config", func() {
 			Expect(err).NotTo(BeNil())
 		})
 
-		It("should fail on PluginDir without permissions", func() {
+		It("should fail on invalid PluginDirs", func() {
 			// Given
 			sut.NetworkConfig.NetworkDir = validDirPath
-			sut.NetworkConfig.PluginDir = []string{invalidPath}
+			sut.NetworkConfig.PluginDirs = []string{invalidPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
@@ -294,16 +295,44 @@ var _ = t.Describe("Config", func() {
 			Expect(err).NotTo(BeNil())
 		})
 
-		It("should fail on invalid PluginDir", func() {
+		It("should succeed on having PluginDir", func() {
 			// Given
 			sut.NetworkConfig.NetworkDir = validDirPath
-			sut.NetworkConfig.PluginDir = []string{invalidPath}
+			sut.NetworkConfig.PluginDir = validDirPath
+			sut.NetworkConfig.PluginDirs = []string{}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
 
 			// Then
-			Expect(err).NotTo(BeNil())
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed in appending PluginDir to PluginDirs", func() {
+			// Given
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDir = validDirPath
+			sut.NetworkConfig.PluginDirs = []string{}
+
+			// When
+			err := sut.NetworkConfig.Validate(true)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.NetworkConfig.PluginDirs[0]).To(Equal(validDirPath))
+		})
+
+		It("should fail in validating invalid PluginDir", func() {
+			// Given
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDir = invalidPath
+			sut.NetworkConfig.PluginDirs = []string{}
+
+			// When
+			err := sut.NetworkConfig.Validate(true)
+
+			// Then
+			Expect(err).ToNot(BeNil())
 		})
 	})
 

--- a/lib/testdata/config.toml
+++ b/lib/testdata/config.toml
@@ -24,4 +24,4 @@
     image_volumes = "mkdir"
   [crio.network]
     network_dir = "/etc/cni/net.d/"
-    plugin_dir = ["/opt/cni/bin/"]
+    plugin_dirs = ["/opt/cni/bin/"]

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -160,7 +160,7 @@ var _ = t.Describe("Config", func() {
 			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
 			sut.Conmon = validPath
 			tmpDir := path.Join(os.TempDir(), "cni-test")
-			sut.NetworkConfig.PluginDir = []string{tmpDir}
+			sut.NetworkConfig.PluginDirs = []string{tmpDir}
 			sut.NetworkDir = os.TempDir()
 			sut.LogDir = "."
 			defer os.RemoveAll(tmpDir)
@@ -176,7 +176,7 @@ var _ = t.Describe("Config", func() {
 			// Given
 			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
 			sut.Conmon = validPath
-			sut.PluginDir = []string{validPath}
+			sut.PluginDirs = []string{validPath}
 			sut.NetworkConfig.NetworkDir = wrongPath
 
 			// When

--- a/server/fixtures/crio.conf
+++ b/server/fixtures/crio.conf
@@ -38,4 +38,4 @@ registries = [
 
 [crio.network]
 network_dir = "/etc/cni/net.d/"
-plugin_dir = ["/opt/cni/bin/"]
+plugin_dirs = ["/opt/cni/bin/"]

--- a/server/server.go
+++ b/server/server.go
@@ -318,7 +318,7 @@ func New(
 		return nil, err
 	}
 
-	netPlugin, err := ocicni.InitCNI("", config.NetworkDir, config.PluginDir...)
+	netPlugin, err := ocicni.InitCNI("", config.NetworkDir, config.PluginDirs...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -151,7 +151,7 @@ var beforeEach = func() {
 	// be empty so we don't erroneously load anything and make tests
 	// unreproducible.
 	serverConfig.NetworkDir = emptyDir
-	serverConfig.PluginDir = []string{emptyDir}
+	serverConfig.PluginDirs = []string{emptyDir}
 	serverConfig.HooksDir = []string{emptyDir}
 
 	// Prepare the library config
@@ -162,7 +162,7 @@ var beforeEach = func() {
 	libConfig.LogDir = serverConfig.LogDir
 
 	libConfig.NetworkDir = serverConfig.NetworkDir
-	libConfig.PluginDir = serverConfig.PluginDir
+	libConfig.PluginDirs = serverConfig.PluginDirs
 	libConfig.HooksDir = serverConfig.HooksDir
 
 	// Initialize test container and sandbox


### PR DESCRIPTION
To maintain backwards compatibility, change plugin_dir to plugin_dirs in crio configs.
Mark plugin_dir depreciated, and send warning as such.


also, ensure future config files generated by crio will not include plugin_dir,
which allows for a seemless transition between config members
