### PR TITLE
Refactor sandbox cgroup annotation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - gochecknoinits
     - goconst
     - gocritic
+    - gocyclo
     - gofmt
     - goimports
     - golint
@@ -40,7 +41,6 @@ linters:
     - unused
     - varcheck
     # - gochecknoglobals
-    # - gocyclo
     # - lll
 linters-settings:
   errcheck:
@@ -116,5 +116,7 @@ linters-settings:
       - typeUnparen
       - unnamedResult
       - unnecessaryBlock
+  gocyclo:
+    min-complexity: 121
   nakedret:
     max-func-lines: 15

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -2,12 +2,19 @@ package server_test
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
+	"github.com/cri-o/cri-o/oci"
+	"github.com/cri-o/cri-o/pkg/annotations"
 	"github.com/cri-o/cri-o/pkg/storage"
+	"github.com/cri-o/cri-o/server"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-tools/generate"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -127,6 +134,167 @@ var _ = t.Describe("RunPodSandbox", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 			Expect(response).To(BeNil())
+		})
+	})
+
+	t.Describe("AddCgroupAnnotation", func() {
+		var g generate.Generator
+
+		BeforeEach(func() {
+			// Given
+			var err error
+			g, err = generate.New("linux")
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed with empty parent cgroup and manager", func() {
+			// When
+			res, err := server.AddCgroupAnnotation(g, "", "", "", "id")
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(""))
+			Expect(g.Config.Annotations[annotations.CgroupParent]).To(BeEmpty())
+		})
+
+		It("should succeed with non-systemd manager", func() {
+			// Given
+			const cgroup = "someCgroup"
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, "", "manager", cgroup, "id")
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(cgroup))
+			Expect(g.Config.Annotations[annotations.CgroupParent]).To(Equal(cgroup))
+			Expect(g.Config.Linux.CgroupsPath).To(HavePrefix(cgroup))
+		})
+
+		It("should succed with systemd manager", func() {
+			// Given
+			const cgroup = "some.slice"
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, "",
+				oci.SystemdCgroupsManager, cgroup, "id")
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(cgroup))
+		})
+
+		It("should fail with non-systemd manager but systemd slice", func() {
+			// Given
+			const cgroup = "some.slice"
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, "", "manager", cgroup, "id")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(res).To(Equal(""))
+		})
+
+		It("should fail with systemd manager on invalid slice", func() {
+			// Given
+			const cgroup = "someCgroup"
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, "",
+				oci.SystemdCgroupsManager, cgroup, "id")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(res).To(Equal(""))
+		})
+
+		It("should fail with systemd manager if ExpandSlice fails", func() {
+			// Given
+			const cgroup = "some--wrong.slice"
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, "",
+				oci.SystemdCgroupsManager, cgroup, "id")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(res).To(Equal(""))
+		})
+
+		var prepareCgroupDirs = func(perm os.FileMode, content string) (string, string) {
+			const cgroup = "some.slice"
+			tmpDir := t.MustTempDir("cgroup")
+			Expect(os.MkdirAll(filepath.Join(tmpDir, cgroup), 0755)).To(BeNil())
+			Expect(ioutil.WriteFile(
+				filepath.Join(tmpDir, cgroup, "memory.limit_in_bytes"),
+				[]byte(content), perm)).To(BeNil())
+			return cgroup, tmpDir
+		}
+
+		It("should fail with systemd manager if memory read fails", func() {
+			// Given
+			cgroup, tmpDir := prepareCgroupDirs(0222, "")
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, tmpDir,
+				oci.SystemdCgroupsManager, cgroup, "id")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(res).To(Equal(""))
+		})
+
+		It("should succeed with systemd manager if memory string empty", func() {
+			// Given
+			cgroup, tmpDir := prepareCgroupDirs(0644, "")
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, tmpDir,
+				oci.SystemdCgroupsManager, cgroup, "id")
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(cgroup))
+		})
+
+		It("should succeed with systemd manager with valid memory ", func() {
+			// Given
+			cgroup, tmpDir := prepareCgroupDirs(0644, "5000000")
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, tmpDir,
+				oci.SystemdCgroupsManager, cgroup, "id")
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(cgroup))
+		})
+
+		It("should fail with systemd manager with too low memory", func() {
+			// Given
+			cgroup, tmpDir := prepareCgroupDirs(0644, "10")
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, tmpDir,
+				oci.SystemdCgroupsManager, cgroup, "id")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(res).To(Equal(""))
+		})
+
+		It("should fail with systemd manager with invalid memory ", func() {
+			// Given
+			cgroup, tmpDir := prepareCgroupDirs(0644, "invalid")
+
+			// When
+			res, err := server.AddCgroupAnnotation(g, tmpDir,
+				oci.SystemdCgroupsManager, cgroup, "id")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(res).To(Equal(""))
 		})
 	})
 })


### PR DESCRIPTION
The method `runPodSandbox` has a very high cyclomatic complexity. Now we
refactor first parts out of it and give them dedicated unit tests to
ensure the overall functionality.

Beside this, the gocyclo linter is now enabled (on its lowest possible
level) and will be continuously updated with further refactorings.