### PR TITLE
Fix mentioned distributions within the setup tutorial

### DIFF
--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -39,7 +39,8 @@ yum install -y \
   runc
 ```
 
-Debian, Ubuntu, and related distributions:
+On Ubuntu distributions, there is a dedicated PPA provided by
+[Project Atomic](https://www.projectatomic.io/):
 
 ```bash
 # Add containers-common and cri-o-runc


### PR DESCRIPTION
Currently, the PPA from project atomic only works on Ubuntu. We should
only mention that distribution there otherwise it won't work.