### PR TITLE
Changes for the RHEL 8 distribution dependencies in the setup.md under Tutorials folder

### DIFF
--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -43,14 +43,14 @@ RHEL 8 distributions:
 
 Make sure you are subscribed to the following repositories: \
 BaseOS/x86_64 \
-Appstream/x86_64 \
+Appstream/x86_64 
 
 Follow the guide below to subscribe to the repositories if not already subscribed: \
 https://access.redhat.com/solutions/265523
 
 This required go version 12.1 or greater. Use the link below to install the appropriate go version for the system:\
 (Replace apt-get with yum for Linux based machines) \
-https://tecadmin.net/install-go-on-ubuntu/ \
+https://tecadmin.net/install-go-on-ubuntu/ 
 
 ```bash
 yum install -y \
@@ -62,10 +62,10 @@ yum install -y \
   glibc-static \
   runc \
 ```
-Use wget to download and run the following dependency: \
+Use wget to download and run the following dependency: 
 
 (Here is a link on how to install a source rpm on RHEL: \
-https://www.itechlounge.net/2012/12/linux-how-to-install-source-rpm-on-rhelcentos/) \
+https://www.itechlounge.net/2012/12/linux-how-to-install-source-rpm-on-rhelcentos/) 
 
   Dependency: gpgme-devel \
   Link: http://download.eng.bos.redhat.com/brewroot/packages/gpgme/1.10.0/6.el8/x86_64/
@@ -86,7 +86,7 @@ https://www.itechlounge.net/2012/12/linux-how-to-install-source-rpm-on-rhelcento
   Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
 
   Dependency: go-md2man \
-  Command: go get github.com/cpuguy83/go-md2man \
+  Command: go get github.com/cpuguy83/go-md2man 
 
 
 

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -41,16 +41,16 @@ yum install -y \
 
 RHEL 8 distributions:
 
-Make sure you are subscribed to the following repositories:
-BaseOS/x86_64
-Appstream/x86_64
+Make sure you are subscribed to the following repositories: \
+BaseOS/x86_64 \
+Appstream/x86_64 \
 
-Follow the guide below to subscribe to the repositories if not already subscribed:
+Follow the guide below to subscribe to the repositories if not already subscribed: \
 https://access.redhat.com/solutions/265523
 
-This required go version 12.1 or greater. Use the link below to install the appropriate go version for the system:
-(Replace apt-get with yum for Linux based machines)
-https://tecadmin.net/install-go-on-ubuntu/
+This required go version 12.1 or greater. Use the link below to install the appropriate go version for the system:\
+(Replace apt-get with yum for Linux based machines) \
+https://tecadmin.net/install-go-on-ubuntu/ \
 
 ```bash
 yum install -y \
@@ -62,31 +62,31 @@ yum install -y \
   glibc-static \
   runc \
 ```
-Use wget to download and run the following dependency:
+Use wget to download and run the following dependency: \
 
-(Here is a link on how to install a source rpm on RHEL:
-https://www.itechlounge.net/2012/12/linux-how-to-install-source-rpm-on-rhelcentos/)
+(Here is a link on how to install a source rpm on RHEL: \
+https://www.itechlounge.net/2012/12/linux-how-to-install-source-rpm-on-rhelcentos/) \
 
   Dependency: gpgme-devel \
   Link: http://download.eng.bos.redhat.com/brewroot/packages/gpgme/1.10.0/6.el8/x86_64/
 
-  Dependency: libassuan
+  Dependency: libassuan \
   Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
 
-  Dependency: libgpg-error
+  Dependency: libgpg-error \
   Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
 
-  Dependency: libseccomp
+  Dependency: libseccomp \
   Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
 
-  Dependency: libselinux
+  Dependency: libselinux \
   Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
 
-  Dependency: pkgconfig
+  Dependency: pkgconfig \
   Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
 
-  Dependency: go-md2man
-  Command: go get github.com/cpuguy83/go-md2man
+  Dependency: go-md2man \
+  Command: go get github.com/cpuguy83/go-md2man \
 
 
 

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -67,7 +67,7 @@ Use wget to download and run the following dependency:
 (Here is a link on how to install a source rpm on RHEL:
 https://www.itechlounge.net/2012/12/linux-how-to-install-source-rpm-on-rhelcentos/)
 
-  Dependency: gpgme-devel
+  Dependency: gpgme-devel \
   Link: http://download.eng.bos.redhat.com/brewroot/packages/gpgme/1.10.0/6.el8/x86_64/
 
   Dependency: libassuan

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -48,8 +48,8 @@ Appstream/x86_64
 Follow the guide below to subscribe to the repositories if not already subscribed: \
 https://access.redhat.com/solutions/265523
 
-This required go version 12.1 or greater. Use the link below to install the appropriate go version for the system:\
-(Replace apt-get with yum for Linux based machines) \
+This requires go version 1.12 or greater. Use the link below to install the appropriate go version for the system:\
+(Replace apt-get with yum for RHEL based machines) \
 https://tecadmin.net/install-go-on-ubuntu/ 
 
 ```bash
@@ -62,7 +62,7 @@ yum install -y \
   glibc-static \
   runc \
 ```
-Use wget to download and run the following dependency: 
+Use wget to download and run the following dependencies: 
 
 (Here is a link on how to install a source rpm on RHEL: \
 https://www.itechlounge.net/2012/12/linux-how-to-install-source-rpm-on-rhelcentos/) 

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -17,7 +17,7 @@ Latest version of `runc` is expected to be installed on the system. It is picked
 
 **Required**
 
-Fedora, CentOS, RHEL, and related distributions:
+Fedora, RHEL, CentOS and related distributions:
 
 ```bash
 yum install -y \
@@ -38,6 +38,57 @@ yum install -y \
   pkgconfig \
   runc
 ```
+
+RHEL 8 distributions:
+
+Make sure you are subscribed to the following repositories:
+BaseOS/x86_64
+Appstream/x86_64
+
+Follow the guide below to subscribe to the repositories if not already subscribed:
+https://access.redhat.com/solutions/265523
+
+This required go version 12.1 or greater. Use the link below to install the appropriate go version for the system:
+(Replace apt-get with yum for Linux based machines)
+https://tecadmin.net/install-go-on-ubuntu/
+
+```bash
+yum install -y \
+  containers-common \
+  device-mapper-devel \
+  git \
+  glib2-devel \
+  glibc-devel \
+  glibc-static \
+  runc \
+```
+Use wget to download and run the following dependency:
+
+(Here is a link on how to install a source rpm on RHEL:
+https://www.itechlounge.net/2012/12/linux-how-to-install-source-rpm-on-rhelcentos/)
+
+  Dependency: gpgme-devel
+  Link: http://download.eng.bos.redhat.com/brewroot/packages/gpgme/1.10.0/6.el8/x86_64/
+
+  Dependency: libassuan
+  Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
+
+  Dependency: libgpg-error
+  Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
+
+  Dependency: libseccomp
+  Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
+
+  Dependency: libselinux
+  Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
+
+  Dependency: pkgconfig
+  Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
+
+  Dependency: go-md2man
+  Command: go get github.com/cpuguy83/go-md2man
+
+
 
 Debian, Ubuntu, and related distributions:
 


### PR DESCRIPTION
There were several dependencies which couldn't be installed using 'yum install command' for the RHEL8 distribution while creating crio from source. The 'setup.md' file has been modified with a separate section added for the RHEL8 distribution which has the links for installing the dependencies using rpm(s).
