### PR TITLE
Fix mentioned distributions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Fedora, CentOS, RHEL, and related distributions:
 openSUSE:
 ```sudo zypper install cri-o```
 
-Debian, Ubuntu, and related distributions:
+On Ubuntu distributions, there is a dedicated PPA provided by
+[Project Atomic](https://www.projectatomic.io/):
 
 ```bash
 sudo apt-add-repository ppa:projectatomic/ppa


### PR DESCRIPTION
Currently, the PPA from project atomic only works on Ubuntu. We should
only mention that distribution there otherwise it won't work.