### PR TITLE
[1.14] Small crio wipe fix

### DIFF
--- a/contrib/crio-wipe/crio-wipe.bash
+++ b/contrib/crio-wipe/crio-wipe.bash
@@ -31,8 +31,8 @@ while getopts 'f:d:w:h' OPTION; do
 			exit 1
 		fi
 			;;
-	h) print_usage; exit 0;;
-		?) print_usage &> 2; exit 1;;
+		h) print_usage; exit 0;;
+		?) >&2 print_usage; exit 1;;
 	esac
 done
 shift "$(($OPTIND -1))"


### PR DESCRIPTION
Stderr was redirected improperly when calling crio-wipe with invalid arguments. Fix this, and an indentation problem

Signed-off-by: Peter Hunt <pehunt@redhat.com>