### PR TITLE
[1.14] Update Makefile to be usable without git

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,2 +1,13 @@
-COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
-GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
+.PHONY: git-vars
+git-vars:
+ifneq ($(wildcard .git),)
+	$(eval COMMIT_NO :=$(shell git rev-parse HEAD 2> /dev/null || true))
+	$(eval GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}"))
+	$(eval GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
+	$(eval GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g"))
+else
+	$(eval COMMIT_NO := unknown)
+	$(eval GIT_COMMIT := unknown)
+	$(eval GIT_BRANCH := unknown)
+	$(eval GIT_BRANCH_CLEAN := unknown)
+endif

--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -1,6 +1,6 @@
-include ../Makefile.inc
+all: git-vars ../bin/conmon
 
-all: ../bin/conmon
+include ../Makefile.inc
 
 src = $(wildcard *.c)
 obj = $(src:.c=.o)


### PR DESCRIPTION
### Backport of #2405

---

Some build environments will use the CRI-O sources without containing
the complete git history. To avoid annoying fatal git error messages we
now fallback to "unknown" versions if the git repository is not
available.

Cherry-picked: 33af10124c397511723ef6d59dd72edf11353277