### PR TITLE
[1.14] version: if git commit is empty, silently ignore

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -49,10 +49,10 @@ func parseVersionConstant(versionString, gitCommit string) (*semver.Version, err
 	}
 	if gitCommit != "" {
 		gitBuild, err := semver.NewBuildVersion(strings.Trim(gitCommit, "\""))
-		if err != nil {
-			return nil, err
+		// If gitCommit is empty, silently error, as it's helpful, but not needed.
+		if err == nil {
+			v.Build = append(v.Build, gitBuild)
 		}
-		v.Build = append(v.Build, gitBuild)
 	}
 	return &v, nil
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -48,6 +48,17 @@ func TestParseVersionAddsGitCommit(t *testing.T) {
 	}
 }
 
+func TestParseVersionIgnoresEmptyGitCommit(t *testing.T) {
+	gitCommit := ""
+	v, err := parseVersionConstant("1.1.1", gitCommit)
+	must(t, err)
+
+	// git commit should be included in semver as Build
+	if len(v.Build) != 0 {
+		t.Error(errors.Errorf("Git commit added despite being empty"))
+	}
+}
+
 func TestParseVersionBadVersion(t *testing.T) {
 	_, err := parseVersionConstant("badversion", "")
 	fails(t, err)


### PR DESCRIPTION
There isn't a technical reason we need to error if the gitCommit isn't defined.
Since gitCommit isn't always defined, silently move on instead.

Signed-off-by: Peter Hunt <pehunt@redhat.com>
