### PR TITLE
Fix Vagrantfile vendor inconsistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverprofile
 lib/state.json
 result-*bin
 
-Vagrantfile
+./Vagrantfile
 .vagrant/
 
 .vscode/

--- a/vendor/github.com/containers/storage/Vagrantfile
+++ b/vendor/github.com/containers/storage/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+#  The fedora/28-cloud-base and debian/jessie64 boxes are also available for
+#  the "virtualbox" provider.  Set the VAGRANT_PROVIDER environment variable to
+#  "virtualbox" to use them instead.
+#
+Vagrant.configure("2") do |config|
+  config.vm.define "fedora" do |c|
+    c.vm.box = "fedora/28-cloud-base"
+    c.vm.synced_folder ".", "/vagrant", type: "rsync",
+      rsync__exclude: "bundles", rsync__args: ["-vadz", "--delete"]
+    c.vm.provision "shell", inline: <<-SHELL
+      sudo /vagrant/vagrant/provision.sh
+    SHELL
+  end
+  config.vm.define "debian" do |c|
+    c.vm.box = "debian/jessie64"
+    c.vm.synced_folder ".", "/vagrant", type: "rsync",
+      rsync__exclude: "bundles", rsync__args: ["-vadz", "--delete"]
+    c.vm.provision "shell", inline: <<-SHELL
+      sudo /vagrant/vagrant/provision.sh
+    SHELL
+  end
+end

--- a/vendor/github.com/mistifyio/go-zfs/Vagrantfile
+++ b/vendor/github.com/mistifyio/go-zfs/Vagrantfile
@@ -1,0 +1,34 @@
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.box = "ubuntu/trusty64"
+	config.ssh.forward_agent = true
+
+	config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/mistifyio/go-zfs", create: true
+
+    config.vm.provision "shell", inline: <<EOF
+cat << END > /etc/profile.d/go.sh
+export GOPATH=\\$HOME/go
+export PATH=\\$GOPATH/bin:/usr/local/go/bin:\\$PATH
+END
+
+chown -R vagrant /home/vagrant/go
+
+apt-get update
+apt-get install -y software-properties-common curl
+apt-add-repository --yes ppa:zfs-native/stable
+apt-get update
+apt-get install -y ubuntu-zfs
+
+cd /home/vagrant
+curl -z go1.3.3.linux-amd64.tar.gz -L -O https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz
+tar -C /usr/local -zxf /home/vagrant/go1.3.3.linux-amd64.tar.gz
+
+cat << END > /etc/sudoers.d/go
+Defaults env_keep += "GOPATH"
+END
+
+EOF
+
+end


### PR DESCRIPTION
We excluded two vendored files due to the gitignore of all Vagrantfiles
within the repository. This lead into small file inconsistencies on
disk, for example when executing `git clean -fdx`.