### PR TITLE
[1.14] When plugin_dir is set, only use that value

### DIFF
--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -261,6 +261,21 @@ var _ = t.Describe("Config", func() {
 			Expect(sut.NetworkConfig.PluginDirs[0]).To(Equal(validPath))
 		})
 
+		It("should only carry PluginDir if both PluginDir and PluginDirs are specified", func() {
+			// Given
+			sut.NetworkConfig.NetworkDir = validPath
+			sut.NetworkConfig.PluginDir = validPath
+			sut.NetworkConfig.PluginDirs = []string{wrongPath}
+
+			// When
+			err := sut.NetworkConfig.Validate(true)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.NetworkConfig.PluginDirs[0]).To(Equal(validPath))
+			Expect(len(sut.NetworkConfig.PluginDirs)).To(Equal(1))
+		})
+
 		It("should fail in validating invalid PluginDir", func() {
 			// Given
 			sut.NetworkConfig.NetworkDir = validPath


### PR DESCRIPTION
We should assume that both plugin_dir and plugin_dirs should not be set. Either a user expects the legacy configuration
or is using the new one. If the user expects the legacy, we should act as though they correctly specified with the new config, rather
than allowing a mixture of new and old

Signed-off-by: Peter Hunt <pehunt@redhat.com>