### PR TITLE
[1.14] Create network and plugin directories

### DIFF
--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -3,6 +3,7 @@ package lib_test
 import (
 	"io/ioutil"
 	"os"
+	"path"
 
 	"github.com/cri-o/cri-o/lib"
 	"github.com/cri-o/cri-o/oci"
@@ -200,8 +201,8 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed during runtime", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validPath
-			sut.NetworkConfig.PluginDirs = []string{validPath}
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDirs = []string{validDirPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
@@ -210,25 +211,63 @@ var _ = t.Describe("Config", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should fail on invalid NetworkDir", func() {
+		It("should create the NetworkDir", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = wrongPath
-			sut.NetworkConfig.PluginDirs = []string{validPath}
+			tmpDir := path.Join(os.TempDir(), wrongPath)
+			sut.NetworkConfig.NetworkDir = tmpDir
+			sut.NetworkConfig.PluginDirs = []string{validDirPath}
 
 			// When
 			err := sut.NetworkConfig.Validate(true)
 
 			// Then
+			Expect(err).To(BeNil())
+			os.RemoveAll(tmpDir)
+		})
+
+		It("should fail on invalid NetworkDir", func() {
+			// Given
+			tmpfile := path.Join(os.TempDir(), "wrong-file")
+			file, err := os.Create(tmpfile)
+			Expect(err).To(BeNil())
+			file.Close()
+			defer os.Remove(tmpfile)
+			sut.NetworkConfig.NetworkDir = tmpfile
+			sut.NetworkConfig.PluginDirs = []string{}
+
+			// When
+			err = sut.NetworkConfig.Validate(true)
+
+			// Then
 			Expect(err).NotTo(BeNil())
+		})
+
+		It("should create the PluginDirs", func() {
+			// Given
+			tmpDir := path.Join(os.TempDir(), wrongPath)
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDirs = []string{tmpDir}
+
+			// When
+			err := sut.NetworkConfig.Validate(true)
+
+			// Then
+			Expect(err).To(BeNil())
+			os.RemoveAll(tmpDir)
 		})
 
 		It("should fail on invalid PluginDirs", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validPath
-			sut.NetworkConfig.PluginDirs = []string{wrongPath}
+			tmpfile := path.Join(os.TempDir(), "wrong-file")
+			file, err := os.Create(tmpfile)
+			Expect(err).To(BeNil())
+			file.Close()
+			defer os.Remove(tmpfile)
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDirs = []string{tmpfile}
 
 			// When
-			err := sut.NetworkConfig.Validate(true)
+			err = sut.NetworkConfig.Validate(true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -236,8 +275,8 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed on having PluginDir", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validPath
-			sut.NetworkConfig.PluginDir = validPath
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDir = validDirPath
 			sut.NetworkConfig.PluginDirs = []string{}
 
 			// When
@@ -249,8 +288,8 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed in appending PluginDir to PluginDirs", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validPath
-			sut.NetworkConfig.PluginDir = validPath
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDir = validDirPath
 			sut.NetworkConfig.PluginDirs = []string{}
 
 			// When
@@ -258,13 +297,13 @@ var _ = t.Describe("Config", func() {
 
 			// Then
 			Expect(err).To(BeNil())
-			Expect(sut.NetworkConfig.PluginDirs[0]).To(Equal(validPath))
+			Expect(sut.NetworkConfig.PluginDirs[0]).To(Equal(validDirPath))
 		})
 
 		It("should only carry PluginDir if both PluginDir and PluginDirs are specified", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validPath
-			sut.NetworkConfig.PluginDir = validPath
+			sut.NetworkConfig.NetworkDir = validDirPath
+			sut.NetworkConfig.PluginDir = validDirPath
 			sut.NetworkConfig.PluginDirs = []string{wrongPath}
 
 			// When
@@ -272,13 +311,13 @@ var _ = t.Describe("Config", func() {
 
 			// Then
 			Expect(err).To(BeNil())
-			Expect(sut.NetworkConfig.PluginDirs[0]).To(Equal(validPath))
+			Expect(sut.NetworkConfig.PluginDirs[0]).To(Equal(validDirPath))
 			Expect(len(sut.NetworkConfig.PluginDirs)).To(Equal(1))
 		})
 
 		It("should fail in validating invalid PluginDir", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validPath
+			sut.NetworkConfig.NetworkDir = validDirPath
 			sut.NetworkConfig.PluginDir = wrongPath
 			sut.NetworkConfig.PluginDirs = []string{}
 

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -39,6 +40,7 @@ var (
 	sut            *lib.ContainerServer
 	mySandbox      *sandbox.Sandbox
 	myContainer    *oci.Container
+	validDirPath   string
 )
 
 const (
@@ -100,6 +102,7 @@ var _ = BeforeSuite(func() {
 	libMock = libmock.NewMockConfigIface(mockCtrl)
 	storeMock = containerstoragemock.NewMockStore(mockCtrl)
 	ociRuntimeMock = ocimock.NewMockRuntimeImpl(mockCtrl)
+	validDirPath = path.Join(os.TempDir(), "crio-empty")
 })
 
 var _ = AfterSuite(func() {

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/cri-o/cri-o/lib"
@@ -104,10 +105,12 @@ func TestConfigValidateDefaultSuccessOnExecution(t *testing.T) {
 	// since some test systems do not have runc installed, assume a more
 	// generally available executable
 	const validPath = "/bin/sh"
-	defaultConfig.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
+	validDirPath := path.Join(os.TempDir(), "crio-empty")
+	defer os.RemoveAll(validDirPath)
+	defaultConfig.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validDirPath}
 	defaultConfig.Conmon = validPath
-	defaultConfig.NetworkConfig.NetworkDir = validPath
-	defaultConfig.NetworkConfig.PluginDirs = []string{validPath}
+	defaultConfig.NetworkConfig.NetworkDir = validDirPath
+	defaultConfig.NetworkConfig.PluginDirs = []string{validDirPath}
 
 	must(t, defaultConfig.Validate(true))
 }

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // GetDiskUsageStats accepts a path to a directory or file
@@ -25,4 +26,24 @@ func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, err error) {
 	}
 
 	return dirSize, inodeCount, err
+}
+
+// IsDirectory tests whether the given path exists and is a directory. It
+// follows symlinks.
+func IsDirectory(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	if !info.Mode().IsDir() {
+		// Return a PathError to be consistent with os.Stat().
+		return &os.PathError{
+			Op:   "stat",
+			Path: path,
+			Err:  syscall.ENOTDIR,
+		}
+	}
+
+	return nil
 }

--- a/utils/filesystem_test.go
+++ b/utils/filesystem_test.go
@@ -1,6 +1,8 @@
 package utils_test
 
 import (
+	"os"
+
 	"github.com/cri-o/cri-o/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,6 +31,20 @@ var _ = t.Describe("Filesystem", func() {
 			Expect(err).NotTo(BeNil())
 			Expect(bytes).To(BeEquivalentTo(0))
 			Expect(inodes).To(BeEquivalentTo(0))
+		})
+	})
+
+	t.Describe("IsDirectory", func() {
+		It("should succeed on a directory", func() {
+			Expect(utils.IsDirectory(".")).To(BeNil())
+		})
+
+		It("should fail on a file", func() {
+			Expect(utils.IsDirectory(os.Args[0])).NotTo(BeNil())
+		})
+
+		It("should fail on a missing path", func() {
+			Expect(utils.IsDirectory("/no/such/path")).NotTo(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
Create network and plugins directories if they don't exist

There are situations where pods using the host network wish to inject plugins and networks for cri-o to use later. To do this, cri-o needs to be able to get there. Create network and plugins dirs and allow cri-o to continue until the kubelet asks it for a plugin or network it doesn't have.