### PR TITLE
Re-enable image integration test

### DIFF
--- a/test/image.bats
+++ b/test/image.bats
@@ -136,7 +136,6 @@ function teardown() {
 }
 
 @test "image pull with signature" {
-	skip "registry has some issues"
 	start_crio "" "" --no-pause-image
 	run crictl pull "$SIGNED_IMAGE"
 	echo "$output"


### PR DESCRIPTION
The mentioned registry issues do not exist any more and therefore we can
enable the test again.