### PR TITLE
Add live reload feature to pause configuration

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -243,13 +243,16 @@ runtime_root = "{{ $runtime_handler.RuntimeRoot }}"
 default_transport = "{{ .DefaultTransport }}"
 
 # The image used to instantiate infra containers.
+# This option supports live configuration reload.
 pause_image = "{{ .PauseImage }}"
 
 # If not empty, the path to a docker/config.json-like file containing credentials
 # necessary for pulling the image specified by pause_image above.
+# This option supports live configuration reload.
 pause_image_auth_file = "{{ .PauseImageAuthFile }}"
 
 # The command to run to have a container stay in the paused state.
+# This option supports live configuration reload.
 pause_command = "{{ .PauseCommand }}"
 
 # Path to the file which decides what sort of policy we use when deciding

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -190,13 +190,13 @@ CRI-O reads its configured registries defaults from the system wide containers-r
   Default transport for pulling images from a remote container storage.
 
 **pause_image**="k8s.gcr.io/pause:3.1"
-  The image used to instantiate infra containers.
+  The image used to instantiate infra containers. This option supports live configuration reload.
 
 **pause_image_auth_file**=""
- If not empty, the path to a docker/config.json-like file containing credentials necessary for pulling the image specified by pause_image above.
+ If not empty, the path to a docker/config.json-like file containing credentials necessary for pulling the image specified by pause_image above. This option supports live configuration reload.
 
 **pause_command**="/pause"
-  The command to run to have a container stay in the paused state.
+  The command to run to have a container stay in the paused state. This option supports live configuration reload.
 
 **signature_policy**="/etc/containers/policy.json"
   Path to the file which decides what sort of policy we use when deciding whether or not to trust an image that we've pulled. It is not recommended that this option be used, as the default behavior of using the system-wide default policy (i.e., /etc/containers/policy.json) is most often preferred. Please refer to containers-policy.json(5) for more details.

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -111,7 +111,7 @@ func New(ctx context.Context, systemContext *types.SystemContext, configIface Co
 		return nil, err
 	}
 
-	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.PauseImage, config.PauseImageAuthFile)
+	storageRuntimeService := storage.GetRuntimeService(ctx, imageService)
 
 	runtime, err := oci.New(config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.ConmonCgroup, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.LogToJournald, config.NoPivot, config.CtrStopTimeout)
 	if err != nil {

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -23,7 +23,7 @@ var _ = t.Describe("Runtime", func() {
 	// Prepare the system under test and register a test name and key before
 	// each test
 	BeforeEach(func() {
-		sut = storage.GetRuntimeService(context.Background(), imageServerMock, "", "")
+		sut = storage.GetRuntimeService(context.Background(), imageServerMock)
 		Expect(sut).NotTo(BeNil())
 	})
 
@@ -589,7 +589,7 @@ var _ = t.Describe("Runtime", func() {
 			It("should succeed to create a pod sandbox", func() {
 				// When
 				info, err = sut.CreatePodSandbox(&types.SystemContext{},
-					"podName", "podID", "imagename",
+					"podName", "podID", "imagename", "",
 					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 					"containerName", "metadataName",
 					"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
@@ -739,7 +739,7 @@ var _ = t.Describe("Runtime", func() {
 
 			// When
 			_, err := sut.CreatePodSandbox(&types.SystemContext{},
-				"podName", "podID", "imagename",
+				"podName", "podID", "imagename", "",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
@@ -764,7 +764,7 @@ var _ = t.Describe("Runtime", func() {
 
 			// When
 			_, err := sut.CreatePodSandbox(&types.SystemContext{},
-				"podName", "podID", "imagename",
+				"podName", "podID", "imagename", "",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
@@ -784,7 +784,7 @@ var _ = t.Describe("Runtime", func() {
 
 			// When
 			_, err := sut.CreatePodSandbox(&types.SystemContext{},
-				"podName", "podID", "imagename",
+				"podName", "podID", "imagename", "",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
@@ -921,7 +921,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should pull pauseImage if not available locally, using default credentials", func() {
 			// The system under test
-			sut := storage.GetRuntimeService(context.Background(), imageServerMock, "pauseimagename", "")
+			sut := storage.GetRuntimeService(context.Background(), imageServerMock)
 			Expect(sut).NotTo(BeNil())
 
 			// Given
@@ -929,7 +929,7 @@ var _ = t.Describe("Runtime", func() {
 
 			// When
 			info, err = sut.CreatePodSandbox(&types.SystemContext{},
-				"podName", "podID", "pauseimagename",
+				"podName", "podID", "pauseimagename", "",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})
@@ -937,7 +937,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should pull pauseImage if not available locally, using provided credential file", func() {
 			// The system under test
-			sut := storage.GetRuntimeService(context.Background(), imageServerMock, "pauseimagename", "/var/non-default/credentials.json")
+			sut := storage.GetRuntimeService(context.Background(), imageServerMock)
 			Expect(sut).NotTo(BeNil())
 
 			// Given
@@ -945,7 +945,7 @@ var _ = t.Describe("Runtime", func() {
 
 			// When
 			info, err = sut.CreatePodSandbox(&types.SystemContext{},
-				"podName", "podID", "pauseimagename",
+				"podName", "podID", "pauseimagename", "/var/non-default/credentials.json",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, &copy.Options{})

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -111,7 +111,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	podContainer, err := s.StorageRuntimeServer().CreatePodSandbox(s.systemContext,
 		name, id,
-		s.config.PauseImage, "",
+		s.config.PauseImage,
+		s.config.PauseImageAuthFile,
+		"",
 		containerName,
 		req.GetConfig().GetMetadata().GetName(),
 		req.GetConfig().GetMetadata().GetUid(),

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -37,7 +37,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 				runtimeServerMock.EXPECT().CreatePodSandbox(gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).
 					Return(storage.ContainerInfo{
 						RunDir: "/tmp",
 						Config: &v1.Image{Config: v1.ImageConfig{}},
@@ -116,7 +117,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 				runtimeServerMock.EXPECT().CreatePodSandbox(gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).
 					Return(storage.ContainerInfo{}, nil),
 				runtimeServerMock.EXPECT().RemovePodSandbox(gomock.Any()).
 					Return(nil),

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -193,18 +193,18 @@ func (mr *MockRuntimeServerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3,
 }
 
 // CreatePodSandbox mocks base method
-func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 string, arg9 uint32, arg10 *idtools.IDMappings, arg11 []string, arg12 *copy.Options) (storage0.ContainerInfo, error) {
+func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 string, arg10 uint32, arg11 *idtools.IDMappings, arg12 []string, arg13 *copy.Options) (storage0.ContainerInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePodSandbox", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
+	ret := m.ctrl.Call(m, "CreatePodSandbox", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
 	ret0, _ := ret[0].(storage0.ContainerInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePodSandbox indicates an expected call of CreatePodSandbox
-func (mr *MockRuntimeServerMockRecorder) CreatePodSandbox(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12 interface{}) *gomock.Call {
+func (mr *MockRuntimeServerMockRecorder) CreatePodSandbox(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePodSandbox", reflect.TypeOf((*MockRuntimeServer)(nil).CreatePodSandbox), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePodSandbox", reflect.TypeOf((*MockRuntimeServer)(nil).CreatePodSandbox), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
 }
 
 // DeleteContainer mocks base method


### PR DESCRIPTION
This commit adds the reload feature for the `pause_image`,
`pause_image_auth_file` and `pause_command` options. To be able to
reload the options on a server configuration level, we now have to
let the server pass in the options instead of adding them as member
of the `runtimeServer`. Documentation and tests have been adapted as
well.