### PR TITLE
Add flake attempts to critest integration testing

### DIFF
--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -22,7 +22,7 @@
     state: directory
 
 - name: run critest validation
-  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.flakeAttempts=3"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
   async: 5400
@@ -35,7 +35,7 @@
   # https://bugzilla.redhat.com/show_bug.cgi?id=1414236
   # https://access.redhat.com/solutions/2897781
 - name: run critest validation
-  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.skip='should not allow privilege escalation when true'"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.skip='should not allow privilege escalation when true' --ginkgo.flakeAttempts=3"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
   async: 5400

--- a/test/critest.bats
+++ b/test/critest.bats
@@ -20,7 +20,8 @@ function teardown() {
                 --runtime-endpoint "${CRIO_SOCKET}" \
                 --image-endpoint "${CRIO_SOCKET}" \
                 --ginkgo.focus="${CRI_FOCUS}" \
-                --ginkgo.skip="${CRI_SKIP}"
+                --ginkgo.skip="${CRI_SKIP}" \
+                --ginkgo.flakeAttempts=3
 
 
     echo "$output"


### PR DESCRIPTION
I see a [flaking critest spec](https://circleci.com/gh/openSUSE/cri-o/7306) when running critest in parallel. I think this happens because image layers get removed because of the parallelism which causes other tests to fail. For now I'd suggest to enable the ginkgo `flakeAttempts` to make the tests more reliable.

References https://github.com/kubernetes-sigs/cri-tools/issues/472