### PR TITLE
Add codecov upload step to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,9 @@ jobs:
       - run:
           name: unit tests
           command: make testunit
+      - run:
+          name: code coverage
+          command: make codecov
       - store_test_results:
           path: build/junit
       - save_cache:


### PR DESCRIPTION
This step was missing during the migration from travis to CircleCI.
We're now able to upload the coverage directly from CircleCI, too.