### PR TITLE
Fix redundant if in lib/rename.go

### DIFF
--- a/lib/rename.go
+++ b/lib/rename.go
@@ -50,10 +50,7 @@ func (c *ContainerServer) ContainerRename(container, name string) error {
 	}
 
 	// Update containers.json
-	if err := c.store.SetNames(ctr.ID(), []string{name}); err != nil {
-		return err
-	}
-	return nil
+	return c.store.SetNames(ctr.ID(), []string{name})
 }
 
 func updateConfigName(configPath, name string) error {


### PR DESCRIPTION
This PR fixes a `redundant if` I came across, which our linter didn't see.

I'm a bit curious why not...