### PR TITLE
Fix error when run root is empty

### DIFF
--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -35,6 +35,9 @@ const (
 
 	// Command line flag used to specify the run root directory
 	rootFlag = "--root"
+
+	// default run root to be used for OCI runtime if it is not set by handler
+	defaultRunRoot = "/run/runc"
 )
 
 // runtimeOCI is the Runtime interface implementation relying on conmon to
@@ -48,10 +51,14 @@ type runtimeOCI struct {
 
 // newRuntimeOCI creates a new runtimeOCI instance
 func newRuntimeOCI(r *Runtime, handler *RuntimeHandler) RuntimeImpl {
+	runRoot := defaultRunRoot
+	if handler.RuntimeRoot != "" {
+		runRoot = handler.RuntimeRoot
+	}
 	return &runtimeOCI{
 		Runtime: r,
 		path:    handler.RuntimePath,
-		root:    handler.RuntimeRoot,
+		root:    runRoot,
 	}
 }
 


### PR DESCRIPTION
There exist situations in which run root can be empty for a runtime. The main situation we could encounter is during an upgrade from 1.14 -> master (and soon 1.15), the crio.conf won't have a runtime.runroot specified (because it is a new feature). 

This PR has two possible solutions for this problem. One is we could only specify the run root to the runtime if it is set. This is a bit verbose, but doesn't require hardcoding a default in the runtime_oci.

The second is simply set a default if it is not set. It's much cleaner.

I am opening a WIP PR with both, and upon deciding which (or both) is better I'll update the PR and take the WIP off