### PR TITLE
[1.14] Disable file locking by default

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -37,7 +37,7 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
 **storage_option**=[]
   List to pass options to the storage driver. Please refer to containers-storage.conf(5) to see all available storage options.
 
-**file_locking**=true
+**file_locking**=false
   If set to false, in-memory locking will be used instead of file-based locking.
 
 **file_locking_path**="/runc/crio.lock"

--- a/lib/config.go
+++ b/lib/config.go
@@ -368,7 +368,7 @@ func DefaultConfig() *Config {
 			Storage:         storage.DefaultStoreOptions.GraphDriverName,
 			StorageOptions:  storage.DefaultStoreOptions.GraphDriverOptions,
 			LogDir:          "/var/log/crio/pods",
-			FileLocking:     true,
+			FileLocking:     false,
 			FileLockingPath: lockPath,
 		},
 		RuntimeConfig: RuntimeConfig{

--- a/lib/testdata/config.toml
+++ b/lib/testdata/config.toml
@@ -3,7 +3,7 @@
   runroot = "/var/run/containers/storage"
   storage_driver = "overlay2"
   log_dir = "/var/log/crio/pods"
-  file_locking = true
+  file_locking = false
   [crio.runtime]
     runtime = "/usr/bin/runc"
     conmon = "/usr/local/libexec/crio/conmon"


### PR DESCRIPTION
File locking adds runtime overhead and thus should be opted into as a user. Disable it by default here
