### PR TITLE
Disable file locking by default and mark depreciated

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -46,9 +46,11 @@ var commentedConfigTemplate = template.Must(template.New("config").Parse(`
 {{ range $opt := .StorageOptions }}{{ printf "#\t%q,\n" $opt }}{{ end }}#]
 
 # If set to false, in-memory locking will be used instead of file-based locking.
+# **Deprecated** this option will be removed in the future.
 file_locking = {{ .FileLocking }}
 
 # Path to the lock file.
+# **Deprecated** this option will be removed in the future.
 file_locking_path = "{{ .FileLockingPath }}"
 
 

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -361,9 +361,11 @@ func main() {
 			Name:  "storage-opt",
 			Usage: fmt.Sprintf("storage driver option (default: %q)", defConf.StorageOptions),
 		},
+		// XXX: DEPRECATED
 		cli.BoolFlag{
-			Name:  "file-locking",
-			Usage: fmt.Sprintf("enable or disable file-based locking (default: %t)", defConf.FileLocking),
+			Name:   "file-locking",
+			Usage:  fmt.Sprintf("enable or disable file-based locking (depreciated) (default: %t)", defConf.FileLocking),
+			Hidden: true,
 		},
 		cli.StringSliceFlag{
 			Name:  "insecure-registry",
@@ -379,8 +381,9 @@ func main() {
 		},
 		// XXX: DEPRECATED
 		cli.StringFlag{
-			Name:  "runtime",
-			Usage: "OCI runtime path",
+			Name:   "runtime",
+			Usage:  "OCI runtime path",
+			Hidden: true,
 		},
 		cli.StringFlag{
 			Name:  "default-runtime",

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -39,7 +39,7 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
 **storage_option**=[]
   List to pass options to the storage driver. Please refer to containers-storage.conf(5) to see all available storage options.
 
-**file_locking**=true
+**file_locking**=false
   If set to false, in-memory locking will be used instead of file-based locking.
 
 **file_locking_path**="/runc/crio.lock"

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -40,10 +40,10 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
   List to pass options to the storage driver. Please refer to containers-storage.conf(5) to see all available storage options.
 
 **file_locking**=false
-  If set to false, in-memory locking will be used instead of file-based locking.
+  If set to false, in-memory locking will be used instead of file-based locking. This option is being depreciated and will soon no longer exist.
 
 **file_locking_path**="/runc/crio.lock"
-  Path to the lock file.
+  Path to the lock file. This option is being deprecated and will soon no longer exist.
 
 
 ## CRIO.API TABLE

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -395,7 +395,7 @@ func DefaultConfig(systemContext *types.SystemContext) (*Config, error) {
 			Storage:         storeOpts.GraphDriverName,
 			StorageOptions:  storeOpts.GraphDriverOptions,
 			LogDir:          "/var/log/crio/pods",
-			FileLocking:     true,
+			FileLocking:     false,
 			FileLockingPath: lockPath,
 		},
 		RuntimeConfig: RuntimeConfig{

--- a/lib/config/testdata/config.toml
+++ b/lib/config/testdata/config.toml
@@ -3,7 +3,7 @@
   runroot = "/var/run/containers/storage"
   storage_driver = "overlay2"
   log_dir = "/var/log/crio/pods"
-  file_locking = true
+  file_locking = false
   [crio.runtime]
     runtime = "/usr/bin/runc"
     conmon = "/usr/local/libexec/crio/conmon"


### PR DESCRIPTION
File locking adds runtime overhead and thus should be opted into as a user. Disable it by default here