### PR TITLE
[1.14] Add global_auth_file option to crio.image config

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -225,11 +225,15 @@ ctr_stop_timeout = {{ .CtrStopTimeout }}
 # Default transport for pulling images from a remote container storage.
 default_transport = "{{ .DefaultTransport }}"
 
+# The path to a file containing credentials necessary for pulling images from
+# secure registries. The file is similar to that of /var/lib/kubelet/config.json
+global_auth_file = "{{ .GlobalAuthFile }}"
+
 # The image used to instantiate infra containers.
 pause_image = "{{ .PauseImage }}"
 
-# If not empty, the path to a docker/config.json-like file containing credentials
-# necessary for pulling the image specified by pause_image above.
+# The path to a file containing credentials specific for pulling the pause_image from
+# above. The file is similar to that of /var/lib/kubelet/config.json
 pause_image_auth_file = "{{ .PauseImageAuthFile }}"
 
 # The command to run to have a container stay in the paused state.

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -184,11 +184,14 @@ CRI-O reads its configured registries defaults from the system wide containers-r
 **default_transport**="docker://"
   Default transport for pulling images from a remote container storage.
 
+**global_auth_file**=""
+  The path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.
+
 **pause_image**="k8s.gcr.io/pause:3.1"
   The image used to instantiate infra containers.
 
 **pause_image_auth_file**=""
- If not empty, the path to a docker/config.json-like file containing credentials necessary for pulling the image specified by pause_image above.
+ The path to a file like /var/lib/kubelet/config.json holding credentials specific to pulling the pause_image from above.
 
 **pause_command**="/pause"
   The command to run to have a container stay in the paused state.

--- a/lib/config.go
+++ b/lib/config.go
@@ -257,11 +257,16 @@ type ImageConfig struct {
 	// DefaultTransport is a value we prefix to image names that fail to
 	// validate source references.
 	DefaultTransport string `toml:"default_transport"`
+	// GlobalAuthFile is a path to a file like /var/lib/kubelet/config.json
+	// containing credentials necessary for pulling images from secure
+	// registries.
+	GlobalAuthFile string `toml:"global_auth_file"`
 	// PauseImage is the name of an image which we use to instantiate infra
 	// containers.
 	PauseImage string `toml:"pause_image"`
-	// PauseImageAuthFile, if not empty, is a path to a docker/config.json-like
-	// file containing credentials necessary for pulling PauseImage
+	// PauseImageAuthFile, if not empty, is a path to a file like
+	// /var/lib/kubelet/config.json containing credentials necessary
+	// for pulling PauseImage
 	PauseImageAuthFile string `toml:"pause_image_auth_file"`
 	// PauseCommand is the path of the binary we run in an infra
 	// container that's been instantiated using PauseImage.
@@ -400,6 +405,7 @@ func DefaultConfig() *Config {
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport:    defaultTransport,
+			GlobalAuthFile:      "",
 			PauseImage:          pauseImage,
 			PauseImageAuthFile:  "",
 			PauseCommand:        pauseCommand,

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -133,7 +133,7 @@ func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error)
 	}
 	config := configIface.GetData()
 
-	imageService, err := storage.GetImageService(ctx, nil, store, config.DefaultTransport, config.InsecureRegistries, config.Registries)
+	imageService, err := storage.GetImageService(ctx, nil, store, config.DefaultTransport, config.GlobalAuthFile, config.InsecureRegistries, config.Registries)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -32,7 +32,7 @@ var _ = t.Describe("Image", func() {
 		var err error
 		sut, err = storage.GetImageService(
 			context.Background(), nil, storeMock, "",
-			[]string{}, []string{testRegistry},
+			"", []string{}, []string{testRegistry},
 		)
 		Expect(err).To(BeNil())
 		Expect(sut).NotTo(BeNil())
@@ -77,7 +77,7 @@ var _ = t.Describe("Image", func() {
 			// When
 			imageService, err := storage.GetImageService(
 				context.Background(), nil, storeMock, "",
-				[]string{"reg1", "reg1", "reg2"},
+				"", []string{"reg1", "reg1", "reg2"},
 				[]string{"reg3", "reg3", "reg4"},
 			)
 
@@ -93,7 +93,7 @@ var _ = t.Describe("Image", func() {
 				context.Background(),
 				&types.SystemContext{
 					SystemRegistriesConfPath: "../../test/registries.conf"},
-				storeMock, "", []string{}, []string{},
+				storeMock, "", "", []string{}, []string{},
 			)
 
 			// Then
@@ -107,7 +107,7 @@ var _ = t.Describe("Image", func() {
 
 			// When
 			imageService, err := storage.GetImageService(
-				context.Background(), nil, nil, "", []string{}, []string{},
+				context.Background(), nil, nil, "", "", []string{}, []string{},
 			)
 
 			// Then
@@ -121,7 +121,7 @@ var _ = t.Describe("Image", func() {
 			imageService, err := storage.GetImageService(
 				context.Background(),
 				&types.SystemContext{SystemRegistriesConfPath: "/invalid"},
-				storeMock, "", []string{}, []string{},
+				storeMock, "", "", []string{}, []string{},
 			)
 
 			// Then
@@ -241,7 +241,7 @@ var _ = t.Describe("Image", func() {
 
 			sut, err := storage.GetImageService(context.Background(),
 				&types.SystemContext{SystemRegistriesConfPath: file.Name()},
-				storeMock, "", []string{}, []string{})
+				storeMock, "", "", []string{}, []string{})
 			Expect(err).To(BeNil())
 			Expect(sut).NotTo(BeNil())
 

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -45,6 +45,7 @@ func assertAllFieldsEquality(t *testing.T, c Config) {
 		{c.RuntimeConfig.PidsLimit, int64(1024)},
 
 		{c.ImageConfig.DefaultTransport, "docker://"},
+		{c.ImageConfig.GlobalAuthFile, "/var/lib/kubelet/config.json"},
 		{c.ImageConfig.PauseImage, "kubernetes/pause"},
 		{c.ImageConfig.PauseImageAuthFile, "/var/lib/kubelet/config.json"},
 		{c.ImageConfig.PauseCommand, "/pause"},

--- a/server/fixtures/crio.conf
+++ b/server/fixtures/crio.conf
@@ -24,6 +24,7 @@ ctr_stop_timeout = 10
 
 [crio.image]
 default_transport = "docker://"
+global_auth_file = "/var/lib/kubelet/config.json"
 pause_image = "kubernetes/pause"
 pause_image_auth_file = "/var/lib/kubelet/config.json"
 pause_command = "/pause"

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -58,6 +58,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 			SourceCtx: &types.SystemContext{
 				DockerRegistryUserAgent: useragent.Get(ctx),
 				SignaturePolicyPath:     s.ImageContext().SignaturePolicyPath,
+				AuthFilePath:            s.config.GlobalAuthFile,
 			},
 		}
 


### PR DESCRIPTION
Add a global_auth_file option under crio.image to
the crio config. This option points to a json file
that holds the credentials required to pull images
from a secure registry. The json file is similar to
that of .docker/config.json.

Will forward-port to master as well.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>