### PR TITLE
Refactor sandbox and container name reservation

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -560,7 +560,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		return nil, fmt.Errorf("CreateContainerRequest.ContainerConfig.Name is empty")
 	}
 
-	containerID, containerName, err := s.generateContainerIDandName(sb.Metadata(), containerConfig)
+	containerID, containerName, err := s.ReserveContainerIDandName(sb.Metadata(), containerConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/server/naming.go
+++ b/server/naming.go
@@ -46,30 +46,43 @@ func makeContainerName(sandboxMetadata *pb.PodSandboxMetadata, containerConfig *
 	}, nameDelimiter)
 }
 
-func (s *Server) generatePodIDandName(sandboxConfig *pb.PodSandboxConfig) (id, name string, err error) {
-	id = stringid.GenerateNonCryptoID()
-	if sandboxConfig.Metadata.Namespace == "" {
-		return "", "", fmt.Errorf("cannot generate pod ID without namespace")
+func (s *Server) ReservePodIDAndName(config *pb.PodSandboxConfig) (id, name string, err error) {
+
+	if config == nil || config.Metadata == nil || config.Metadata.Namespace == "" {
+		return "", "", fmt.Errorf("cannot generate pod name without namespace")
 	}
-	name, err = s.ReservePodName(id, makeSandboxName(sandboxConfig))
+
+	id = stringid.GenerateNonCryptoID()
+	name, err = s.ReservePodName(id, makeSandboxName(config))
+
 	if err != nil {
 		return "", "", err
 	}
-	return id, name, err
+	return id, name, nil
 }
 
-func (s *Server) generateContainerIDandNameForSandbox(sandboxConfig *pb.PodSandboxConfig) (id, name string, err error) {
-	id = stringid.GenerateNonCryptoID()
-	name, err = s.ReserveContainerName(id, makeSandboxContainerName(sandboxConfig))
-	if err != nil {
-		return "", "", err
+func (s *Server) ReserveSandboxContainerIDAndName(config *pb.PodSandboxConfig) (name string, err error) {
+
+	if config == nil || config.Metadata == nil {
+		return "", fmt.Errorf("cannot generate sandbox container name without metadata")
 	}
-	return id, name, err
+
+	id := stringid.GenerateNonCryptoID()
+	name, err = s.ReserveContainerName(id, makeSandboxContainerName(config))
+	if err != nil {
+		return "", err
+	}
+	return name, err
 }
 
-func (s *Server) generateContainerIDandName(sandboxMetadata *pb.PodSandboxMetadata, containerConfig *pb.ContainerConfig) (id, name string, err error) {
+func (s *Server) ReserveContainerIDandName(sandboxMetadata *pb.PodSandboxMetadata, config *pb.ContainerConfig) (id, name string, err error) {
+
+	if config == nil || config.Metadata == nil || sandboxMetadata == nil {
+		return "", "", fmt.Errorf("cannot generate container name without metadata")
+	}
+
 	id = stringid.GenerateNonCryptoID()
-	name, err = s.ReserveContainerName(id, makeContainerName(sandboxMetadata, containerConfig))
+	name, err = s.ReserveContainerName(id, makeContainerName(sandboxMetadata, config))
 	if err != nil {
 		return "", "", err
 	}

--- a/server/naming_test.go
+++ b/server/naming_test.go
@@ -1,0 +1,218 @@
+package server_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+// The actual test suite
+var _ = t.Describe("Server", func() {
+	// Prepare the sut
+	BeforeEach(beforeEach)
+	AfterEach(afterEach)
+
+	t.Describe("ReservePodIDAndName", func() {
+		It("should succeed", func() {
+			// Given
+			// When
+			id, name, err := sut.ReservePodIDAndName(
+				&pb.PodSandboxConfig{
+					Metadata: &pb.PodSandboxMetadata{
+						Namespace: "default",
+					},
+				})
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(id).NotTo(BeEmpty())
+			Expect(name).NotTo(BeEmpty())
+		})
+
+		It("should fail without metadata", func() {
+			// Given
+			// When
+			id, name, err := sut.ReservePodIDAndName(nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(id).To(BeEmpty())
+			Expect(name).To(BeEmpty())
+		})
+
+		It("should fail without sandbox config", func() {
+			// Given
+			// When
+			id, name, err := sut.ReservePodIDAndName(&pb.PodSandboxConfig{})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(id).To(BeEmpty())
+			Expect(name).To(BeEmpty())
+		})
+
+		It("should fail without namespace", func() {
+			// Given
+			// When
+			id, name, err := sut.ReservePodIDAndName(
+				&pb.PodSandboxConfig{Metadata: &pb.PodSandboxMetadata{}})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(id).To(BeEmpty())
+			Expect(name).To(BeEmpty())
+		})
+
+		It("should fail if name is already reserved", func() {
+			// Given
+			metadata := &pb.PodSandboxMetadata{
+				Namespace: "default",
+				Name:      "name",
+			}
+			_, _, err := sut.ReservePodIDAndName(
+				&pb.PodSandboxConfig{Metadata: metadata})
+			Expect(err).To(BeNil())
+
+			// When
+			id, name, err := sut.ReservePodIDAndName(
+				&pb.PodSandboxConfig{Metadata: metadata})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(id).To(BeEmpty())
+			Expect(name).To(BeEmpty())
+		})
+	})
+
+	t.Describe("ReserveSandboxContainerIDAndName", func() {
+		It("should succeed", func() {
+			// Given
+			// When
+			name, err := sut.ReserveSandboxContainerIDAndName(
+				&pb.PodSandboxConfig{
+					Metadata: &pb.PodSandboxMetadata{
+						Namespace: "default",
+					},
+				})
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(name).NotTo(BeEmpty())
+		})
+
+		It("should fail without metadata", func() {
+			// Given
+			// When
+			name, err := sut.ReserveSandboxContainerIDAndName(nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(name).To(BeEmpty())
+		})
+
+		It("should fail without sandbox config", func() {
+			// Given
+			// When
+			name, err := sut.ReserveSandboxContainerIDAndName(&pb.PodSandboxConfig{})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(name).To(BeEmpty())
+		})
+
+		It("should fail if name is already reserved", func() {
+			// Given
+			metadata := &pb.PodSandboxMetadata{
+				Namespace: "default",
+				Name:      "name",
+			}
+			_, err := sut.ReserveSandboxContainerIDAndName(
+				&pb.PodSandboxConfig{Metadata: metadata})
+			Expect(err).To(BeNil())
+
+			// When
+			name, err := sut.ReserveSandboxContainerIDAndName(
+				&pb.PodSandboxConfig{Metadata: metadata})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(name).To(BeEmpty())
+		})
+	})
+
+	t.Describe("ReserveContainerIDandName", func() {
+		It("should succeed", func() {
+			// Given
+			// When
+			id, name, err := sut.ReserveContainerIDandName(
+				&pb.PodSandboxMetadata{},
+				&pb.ContainerConfig{
+					Metadata: &pb.ContainerMetadata{
+						Name: "container",
+					},
+				})
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(id).NotTo(BeEmpty())
+			Expect(name).NotTo(BeEmpty())
+		})
+
+		It("should fail without container config", func() {
+			// Given
+			// When
+			id, name, err := sut.ReserveContainerIDandName(
+				&pb.PodSandboxMetadata{}, nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(id).To(BeEmpty())
+			Expect(name).To(BeEmpty())
+		})
+
+		It("should fail without metadata", func() {
+			// Given
+			// When
+			id, name, err := sut.ReserveContainerIDandName(nil,
+				&pb.ContainerConfig{})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(id).To(BeEmpty())
+			Expect(name).To(BeEmpty())
+		})
+
+		It("should fail without container config", func() {
+			// Given
+			// When
+			id, name, err := sut.ReserveContainerIDandName(
+				&pb.PodSandboxMetadata{}, nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(id).To(BeEmpty())
+			Expect(name).To(BeEmpty())
+		})
+
+		It("should fail if name is already reserved", func() {
+			// Given
+			metadata := &pb.ContainerMetadata{
+				Name: "name",
+			}
+			_, _, err := sut.ReserveContainerIDandName(
+				&pb.PodSandboxMetadata{},
+				&pb.ContainerConfig{Metadata: metadata})
+			Expect(err).To(BeNil())
+
+			// When
+			id, name, err := sut.ReserveContainerIDandName(
+				&pb.PodSandboxMetadata{},
+				&pb.ContainerConfig{Metadata: metadata})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(id).To(BeEmpty())
+			Expect(name).To(BeEmpty())
+		})
+	})
+})

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"regexp"
 
 	"github.com/cri-o/cri-o/oci"
 	"golang.org/x/net/context"
@@ -70,10 +69,6 @@ func (s *Server) runtimeHandler(req *pb.RunPodSandboxRequest) (string, error) {
 
 	return handler, nil
 }
-
-var (
-	conflictRE = regexp.MustCompile(`already reserved for pod "([0-9a-z]+)"`)
-)
 
 // RunPodSandbox creates and runs a pod-level sandbox.
 func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (resp *pb.RunPodSandboxResponse, err error) {


### PR DESCRIPTION
This commit refactors the name generation of containers and sandboxes,
whereas the unit tests have been added as well.

The handling of duplicate sandbox ids has been removed, since these code
paths were not possible any more after the merge of commit 187f850. This
also removes a regular expression parsing of an error message.

This commit reduced the cyclomatic complexity of `runPodSandbox()` down
to 116 and increases the overall testability and coverage.

---

Refers to #1988

WDYT about the removal of the duplicate ID handling? To me it seemed pretty unlikely that this happens and if so, is removing the pod including all its workload the right approach? I thought "no", so I'd go for a removal of the code part.