### PR TITLE
RFC: Don't read registries.conf for the defaults of --registry and --insecure-registry

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -308,7 +308,7 @@ var configCommand = cli.Command{
 		config := c.App.Metadata["config"].(*server.Config) // nolint: errcheck
 		systemContext := &types.SystemContext{}
 		if c.Bool("default") {
-			config, err = server.DefaultConfig(systemContext)
+			config, err = server.DefaultConfig()
 			if err != nil {
 				return err
 			}

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -371,7 +371,7 @@ func main() {
 		},
 		cli.StringSliceFlag{
 			Name:  "registry",
-			Usage: fmt.Sprintf("registry to be prepended when pulling unqualified images, can be specified multiple times (default: %q)", defConf.Registries),
+			Usage: fmt.Sprintf("registry to be prepended when pulling unqualified images, can be specified multiple times (default: configured in /etc/containers/registries.conf)"),
 		},
 		cli.StringFlag{
 			Name:  "default-transport",

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -274,7 +274,7 @@ func main() {
 	app.Version = strings.Join(v, "\n")
 
 	systemContext := &types.SystemContext{}
-	defConf, err := server.DefaultConfig(systemContext)
+	defConf, err := server.DefaultConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error loading server config: %v", err)
 		os.Exit(1)

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -370,7 +370,7 @@ func (c *Config) ToFile(path string) error {
 }
 
 // DefaultConfig returns the default configuration for crio.
-func DefaultConfig(systemContext *types.SystemContext) (*Config, error) {
+func DefaultConfig() (*Config, error) {
 	storeOpts, err := storage.DefaultStoreOptions(rootless.IsRootless(), rootless.GetRootlessUID())
 	if err != nil {
 		return nil, err

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -371,19 +371,6 @@ func (c *Config) ToFile(path string) error {
 
 // DefaultConfig returns the default configuration for crio.
 func DefaultConfig(systemContext *types.SystemContext) (*Config, error) {
-	registries, err := sysregistriesv2.UnqualifiedSearchRegistries(systemContext)
-	if err != nil {
-		registries = nil // Ignore the error otherwise
-	}
-	insecureRegistries := []string{}
-	allRegistries, err := sysregistriesv2.GetRegistries(systemContext)
-	if err == nil { // Ignore the error otherwise
-		for _, reg := range allRegistries {
-			if reg.Insecure {
-				insecureRegistries = append(insecureRegistries, reg.Prefix)
-			}
-		}
-	}
 	storeOpts, err := storage.DefaultStoreOptions(rootless.IsRootless(), rootless.GetRootlessUID())
 	if err != nil {
 		return nil, err
@@ -434,8 +421,8 @@ func DefaultConfig(systemContext *types.SystemContext) (*Config, error) {
 			PauseCommand:        pauseCommand,
 			SignaturePolicyPath: "",
 			ImageVolumes:        ImageVolumesMkdir,
-			Registries:          registries,
-			InsecureRegistries:  insecureRegistries,
+			Registries:          []string{},
+			InsecureRegistries:  []string{},
 		},
 		NetworkConfig: NetworkConfig{
 			NetworkDir: cniConfigDir,

--- a/lib/config/suite_test.go
+++ b/lib/config/suite_test.go
@@ -39,7 +39,7 @@ var _ = AfterSuite(func() {
 
 func beforeEach() {
 	var err error
-	sut, err = config.DefaultConfig(nil)
+	sut, err = config.DefaultConfig()
 	Expect(err).To(BeNil())
 	Expect(sut).NotTo(BeNil())
 }

--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -31,7 +31,7 @@ var _ = t.Describe("ContainerServer", func() {
 			defer os.Remove(tmpfile.Name())
 
 			// Setup config
-			config, err := libconfig.DefaultConfig(nil)
+			config, err := libconfig.DefaultConfig()
 			Expect(err).To(BeNil())
 			config.FileLockingPath = tmpfile.Name()
 			config.HooksDir = []string{}
@@ -65,7 +65,7 @@ var _ = t.Describe("ContainerServer", func() {
 		})
 
 		It("should fail when Store is nil", func() {
-			config, err := libconfig.DefaultConfig(nil)
+			config, err := libconfig.DefaultConfig()
 			Expect(err).To(BeNil())
 			// Given
 			gomock.InOrder(
@@ -93,7 +93,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with invalid default runtime", func() {
 			// Given
-			config, err := libconfig.DefaultConfig(nil)
+			config, err := libconfig.DefaultConfig()
 			Expect(err).To(BeNil())
 			config.DefaultRuntime = "invalid-runtime"
 			gomock.InOrder(
@@ -111,7 +111,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with invalid lockfile", func() {
 			// Given
-			config, err := libconfig.DefaultConfig(nil)
+			config, err := libconfig.DefaultConfig()
 			Expect(err).To(BeNil())
 			config.FileLocking = true
 			config.FileLockingPath = "/invalid/file"
@@ -130,7 +130,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with invalid hooks dir", func() {
 			// Given
-			config, err := libconfig.DefaultConfig(nil)
+			config, err := libconfig.DefaultConfig()
 			Expect(err).To(BeNil())
 			config.FileLocking = false
 			config.HooksDir = []string{"/invalid-dir"}

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -123,7 +123,7 @@ func beforeEach() {
 	logrus.SetLevel(logrus.PanicLevel)
 
 	// Set the config
-	config, err := libconfig.DefaultConfig(nil)
+	config, err := libconfig.DefaultConfig()
 	Expect(err).To(BeNil())
 	config.FileLocking = false
 	config.LogDir = "."

--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -12,7 +12,7 @@ var _ = t.Describe("Oci", func() {
 	t.Describe("New", func() {
 		It("should succeed with default runtime", func() {
 			// Given
-			c, err := config.DefaultConfig(nil)
+			c, err := config.DefaultConfig()
 			Expect(err).To(BeNil())
 			c.Runtimes = map[string]config.RuntimeHandler{"runc": {
 				RuntimePath: "/bin/sh",
@@ -31,7 +31,7 @@ var _ = t.Describe("Oci", func() {
 
 		It("should fail if no runtime configured for default runtime", func() {
 			// Given
-			c, err := config.DefaultConfig(nil)
+			c, err := config.DefaultConfig()
 			Expect(err).To(BeNil())
 			c.DefaultRuntime = ""
 
@@ -62,7 +62,7 @@ var _ = t.Describe("Oci", func() {
 		}
 
 		BeforeEach(func() {
-			c, err := config.DefaultConfig(nil)
+			c, err := config.DefaultConfig()
 			Expect(err).To(BeNil())
 			c.DefaultRuntime = defaultRuntime
 			c.Runtimes = runtimes

--- a/server/config.go
+++ b/server/config.go
@@ -157,8 +157,8 @@ func (c *Config) ToBytes() ([]byte, error) {
 }
 
 // DefaultConfig returns the default configuration for crio.
-func DefaultConfig(systemContext *types.SystemContext) (*Config, error) {
-	conf, err := config.DefaultConfig(systemContext)
+func DefaultConfig() (*Config, error) {
+	conf, err := config.DefaultConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -207,9 +207,9 @@ func (c *Config) Validate(systemContext *types.SystemContext, onExecution bool) 
 
 // Reload reloads the configuration with the config at the provided `fileName`
 // path. The method errors in case of any read or update failure.
-func (c *Config) Reload(systemContext *types.SystemContext, fileName string) error {
+func (c *Config) Reload(fileName string) error {
 	// Reload the config
-	newConfig, err := DefaultConfig(systemContext)
+	newConfig, err := DefaultConfig()
 	if err != nil {
 		return fmt.Errorf("unable to create default config")
 	}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -21,7 +21,7 @@ var _ = t.Describe("Config", func() {
 	)
 
 	var defaultConfig = func() *server.Config {
-		config, err := server.DefaultConfig(nil)
+		config, err := server.DefaultConfig()
 		Expect(err).To(BeNil())
 		return config
 	}
@@ -260,7 +260,7 @@ var _ = t.Describe("Config", func() {
 			Expect(sut.ToFile(filePath)).To(BeNil())
 
 			// When
-			err := sut.Reload(nil, filePath)
+			err := sut.Reload(filePath)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -269,7 +269,7 @@ var _ = t.Describe("Config", func() {
 		It("should fail with invalid config path", func() {
 			// Given
 			// When
-			err := sut.Reload(nil, "")
+			err := sut.Reload("")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -283,7 +283,7 @@ var _ = t.Describe("Config", func() {
 			)
 
 			// When
-			err := sut.Reload(nil, filePath)
+			err := sut.Reload(filePath)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -297,7 +297,7 @@ var _ = t.Describe("Config", func() {
 			)
 
 			// When
-			err := sut.Reload(nil, filePath)
+			err := sut.Reload(filePath)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetInfo(t *testing.T) {
-	c, err := config.DefaultConfig(nil)
+	c, err := config.DefaultConfig()
 	if err != nil {
 		t.Fatal("error loading default config")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -577,7 +577,7 @@ func (s *Server) StartExitMonitor() {
 // not exist or is not accessible.
 func (s *Server) StartConfigWatcher(
 	fileName string,
-	reloadFunc func(*types.SystemContext, string) error,
+	reloadFunc func(string) error,
 ) (chan os.Signal, error) {
 	// Validate the arguments
 	if _, err := os.Stat(fileName); err != nil {
@@ -596,7 +596,7 @@ func (s *Server) StartConfigWatcher(
 			// Block until the signal is received
 			<-c
 			logrus.Infof("reloading configuration %q", fileName)
-			if err := reloadFunc(s.systemContext, fileName); err != nil {
+			if err := reloadFunc(fileName); err != nil {
 				logrus.Errorf("unable to reload configuration: %v", err)
 				continue
 			}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/containers/image/types"
 	cstorage "github.com/containers/storage"
 	"github.com/cri-o/cri-o/pkg/signals"
 	"github.com/cri-o/cri-o/server"
@@ -371,10 +370,7 @@ var _ = t.Describe("Server", func() {
 
 			// When
 			ch, err := sut.StartConfigWatcher(
-				tmpFile, func(
-					systemContext *types.SystemContext,
-					fileName string,
-				) error {
+				tmpFile, func(fileName string) error {
 					return nil
 				},
 			)
@@ -391,10 +387,7 @@ var _ = t.Describe("Server", func() {
 
 			// When
 			ch, err := sut.StartConfigWatcher(
-				tmpFile, func(
-					systemContext *types.SystemContext,
-					fileName string,
-				) error {
+				tmpFile, func(fileName string) error {
 					return t.TestError
 				},
 			)

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -140,7 +140,7 @@ var beforeEach = func() {
 	// Prepare the server config
 	testPath = "test"
 	var err error
-	serverConfig, err = server.DefaultConfig(nil)
+	serverConfig, err = server.DefaultConfig()
 	Expect(err).To(BeNil())
 	serverConfig.ContainerAttachSocketDir = testPath
 	serverConfig.ContainerExitsDir = path.Join(testPath, "exits")
@@ -155,7 +155,7 @@ var beforeEach = func() {
 	serverConfig.HooksDir = []string{emptyDir}
 
 	// Prepare the library config
-	libConfig, err = config.DefaultConfig(nil)
+	libConfig, err = config.DefaultConfig()
 	Expect(err).To(BeNil())
 	libConfig.FileLocking = false
 	libConfig.Runtimes["runc"] = serverConfig.Runtimes["runc"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Motivated by https://github.com/cri-o/cri-o/pull/2494#pullrequestreview-251539419, changed `lib.DefaultConfig` to not read defaults from `registries.conf`.

**- How I did it**

Don't read `registries.conf` for the defaults of `--registry` and `--insecure-registry`:

In both cases, the `ImageService` falls back to `registries.conf` anyway if the values are not specified (explicitly for the search path, and implicitly in containers/image/docker for insecure registries).  The default values in `lib.DefaultConfig` really make a difference only:
- in the help text of `--registry`, which was a bit misleading by suggesting a hard-coded default instead of pointing to `registries.conf`
- in the output of `crio config --default`, which previously copied the search list from `registries.conf` into the generated output, probably something the user does not really want (but it did not matter anyway because the generated output comments the value out)

Also, the `--insecure-registry` list as implemented in CRI-O only works at the level of registries, while the configuration in `sysregistriesv2` now works at the repository level; this did not really hurt (the repository entries were ignored in CRI-O and applied in c/image/docker), but it caused invalid/ignored entries to be used throughout the CRI-O codebase.

It's overall much simpler to just use empty defaults, and let the fallback happen elsewhere.

(Note that `lib.RuntimeConfig.Validate` does call `sysregistriesv2.GetRegistries`, which ensures that `registries.conf` is reasonably valid at the time CRI-O is starting, so this does not affect `registries.conf` validation / impact on CRI-O startup.)


Then, simplified the call stack by dropping unnecessary `types.SystemContext` parameters.

**- How to verify it**

Existing tests, hopefully. The `crio --help` and `crio config --default` output should change a bit.

**- Description for the changelog**

Data automatically used from `registries.conf` no longer shows up as implied-to-be-hard-coded defaults for CRI-O options.