### PR TITLE
Update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.12
 	github.com/VividCortex/ewma v1.1.1 // indirect
-	github.com/blang/semver v3.5.0+incompatible
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/checkpoint-restore/go-criu v0.0.0-20190109184317-bdb7599cd87b // indirect
 	github.com/containerd/cgroups v0.0.0-20180515175038-5e610833b720
-	github.com/containerd/containerd v1.2.6
+	github.com/containerd/containerd v1.2.7
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
 	github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448 // indirect
 	github.com/containerd/go-runc v0.0.0-20190226155025-7d11b49dc076 // indirect
@@ -18,9 +18,9 @@ require (
 	github.com/containerd/ttrpc v0.0.0-20180920185216-2a805f718635
 	github.com/containernetworking/cni v0.7.1
 	github.com/containernetworking/plugins v0.8.1
-	github.com/containers/buildah v1.8.4
+	github.com/containers/buildah v1.9.0
 	github.com/containers/image v2.0.0+incompatible
-	github.com/containers/libpod v1.4.1
+	github.com/containers/libpod v1.4.2
 	github.com/containers/psgo v1.3.0 // indirect
 	github.com/containers/storage v1.12.10
 	github.com/coreos/go-iptables v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c/go.mod h1:Xe6ZsFhtM8HrDku0pxJ3/Lr51rwykrzgFwpmTzleatY=
@@ -65,6 +67,8 @@ github.com/containerd/console v0.0.0-20170925154832-84eeaae905fa/go.mod h1:Tj/on
 github.com/containerd/containerd v1.0.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.2.6 h1:K38ZSAA9oKSrX3iFNY+4SddZ8hH1TCMCerc8NHfcKBQ=
 github.com/containerd/containerd v1.2.6/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.2.7 h1:8lqLbl7u1j3MmiL9cJ/O275crSq7bfwUayvvatEupQk=
+github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc h1:TP+534wVlf61smEIq1nwLLAjQVEK2EADoW3CX9AuT+8=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -91,6 +95,8 @@ github.com/containers/buildah v1.7.2 h1:N9Kp1TuDjhoSWlNVJOOza71udunDS23/eY0jzZGW
 github.com/containers/buildah v1.7.2/go.mod h1:1CsiLJvyU+h+wOjnqJJOWuJCVcMxZOr5HN/gHGdzJxY=
 github.com/containers/buildah v1.8.4 h1:06c+UNeEWMa2wA1Z7muZ0ZqUzE91sDuZJbB0BiZaeYQ=
 github.com/containers/buildah v1.8.4/go.mod h1:1CsiLJvyU+h+wOjnqJJOWuJCVcMxZOr5HN/gHGdzJxY=
+github.com/containers/buildah v1.9.0 h1:ktVRCGNoVfW8PlTuCKUeh+zGdqn1Nik80DSWvGX+v4Y=
+github.com/containers/buildah v1.9.0/go.mod h1:1CsiLJvyU+h+wOjnqJJOWuJCVcMxZOr5HN/gHGdzJxY=
 github.com/containers/image v1.5.1 h1:ssEuj1c24uJvdMkUa2IrawuEFZBP12p6WzrjNBTQxE0=
 github.com/containers/image v1.5.1/go.mod h1:8Vtij257IWSanUQKe1tAeNOm2sRVkSqQTVQ1IlwI3+M=
 github.com/containers/image v2.0.0+incompatible h1:FTr6Br7jlIKNCKMjSOMbAxKp2keQ0//jzJaYNTVhauk=
@@ -106,6 +112,8 @@ github.com/containers/libpod v1.4.0-0.20190614192453-4a450d55d95f/go.mod h1:KkaK
 github.com/containers/libpod v1.4.0 h1:iLZb4IZYO0g8Du4wooV1950kvFjk8j3PTfN2LEZ4Mv8=
 github.com/containers/libpod v1.4.1 h1:V14YAS1Nw3hnDUoeQRA+kGO5MWrGAfW46UfPmoelm6w=
 github.com/containers/libpod v1.4.1/go.mod h1:KkaKUNtjfQIm83bee5nnVvfcWUImCPUHjoUrQMvIlII=
+github.com/containers/libpod v1.4.2 h1:4ZkinyMwtatmHaE7kdQCH/oJMha2qcl3HwQUdSCbsBE=
+github.com/containers/libpod v1.4.2/go.mod h1:KkaKUNtjfQIm83bee5nnVvfcWUImCPUHjoUrQMvIlII=
 github.com/containers/psgo v1.2.1 h1:nKpO4UMCtbiwbWQgPmCF8RuXH+tfL+B0szW3Gt12j1U=
 github.com/containers/psgo v1.2.1/go.mod h1:7MELvPTW1fj6yMrwD9I1Iasx1vU+hKlRkHXAJ51sFtU=
 github.com/containers/psgo v1.3.0 h1:kDhiA4gNNyJ2qCzmOuBf6AmrF/Pp+6Jo98P68R7fB8I=
@@ -160,6 +168,8 @@ github.com/docker/docker-credential-helpers v0.6.2/go.mod h1:WRaJzqw3CTB9bk10avu
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
+github.com/docker/go-events v0.0.0-20170721190031-9461782956ad h1:VXIse57M5C6ezDuCPyq6QmMvEJ2xclYKZ35SfkXdm3E=
+github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 h1:X0fj836zx99zFu83v/M79DuBn84IL/Syx1SY6Y5ZEMA=
 github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -263,6 +273,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/gogo/googleapis v1.2.0 h1:Z0v3OJDotX9ZBpdz2V+AI7F4fITSZhVE5mg6GQppwMM=
+github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=

--- a/vendor/github.com/blang/semver/.travis.yml
+++ b/vendor/github.com/blang/semver/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+matrix:
+  include:
+  - go: 1.4.3
+  - go: 1.5.4
+  - go: 1.6.3
+  - go: 1.7
+  - go: tip
+  allow_failures:
+  - go: tip
+install:
+- go get golang.org/x/tools/cmd/cover
+- go get github.com/mattn/goveralls
+script:
+- echo "Test and track coverage" ; $HOME/gopath/bin/goveralls -package "." -service=travis-ci
+  -repotoken $COVERALLS_TOKEN
+- echo "Build examples" ; cd examples && go build
+- echo "Check if gofmt'd" ; diff -u <(echo -n) <(gofmt -d -s .)
+env:
+  global:
+    secure: HroGEAUQpVq9zX1b1VIkraLiywhGbzvNnTZq2TMxgK7JHP8xqNplAeF1izrR2i4QLL9nsY+9WtYss4QuPvEtZcVHUobw6XnL6radF7jS1LgfYZ9Y7oF+zogZ2I5QUMRLGA7rcxQ05s7mKq3XZQfeqaNts4bms/eZRefWuaFZbkw=

--- a/vendor/github.com/blang/semver/README.md
+++ b/vendor/github.com/blang/semver/README.md
@@ -1,4 +1,4 @@
-semver for golang [![Build Status](https://drone.io/github.com/blang/semver/status.png)](https://drone.io/github.com/blang/semver/latest) [![GoDoc](https://godoc.org/github.com/blang/semver?status.png)](https://godoc.org/github.com/blang/semver) [![Coverage Status](https://img.shields.io/coveralls/blang/semver.svg)](https://coveralls.io/r/blang/semver?branch=master)
+semver for golang [![Build Status](https://travis-ci.org/blang/semver.svg?branch=master)](https://travis-ci.org/blang/semver) [![GoDoc](https://godoc.org/github.com/blang/semver?status.png)](https://godoc.org/github.com/blang/semver) [![Coverage Status](https://img.shields.io/coveralls/blang/semver.svg)](https://coveralls.io/r/blang/semver?branch=master)
 ======
 
 semver is a [Semantic Versioning](http://semver.org/) library written in golang. It fully covers spec version `2.0.0`.
@@ -41,6 +41,7 @@ Features
 - Compare Helper Methods
 - InPlace manipulation
 - Ranges `>=1.0.0 <2.0.0 || >=3.0.0 !3.0.1-beta.1`
+- Wildcards `>=1.x`, `<=2.5.x`
 - Sortable (implements sort.Interface)
 - database/sql compatible (sql.Scanner/Valuer)
 - encoding/json compatible (json.Marshaler/Unmarshaler)
@@ -58,6 +59,8 @@ A condition is composed of an operator and a version. The supported operators ar
 - `>=1.0.0` Greater than or equal to `1.0.0`
 - `1.0.0`, `=1.0.0`, `==1.0.0` Equal to `1.0.0`
 - `!1.0.0`, `!=1.0.0` Not equal to `1.0.0`. Excludes version `1.0.0`.
+
+Note that spaces between the operator and the version will be gracefully tolerated.
 
 A `Range` can link multiple `Ranges` separated by space:
 

--- a/vendor/github.com/blang/semver/package.json
+++ b/vendor/github.com/blang/semver/package.json
@@ -12,6 +12,6 @@
   "license": "MIT",
   "name": "semver",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.4.0"
+  "version": "3.5.1"
 }
 

--- a/vendor/github.com/containerd/containerd/api/types/descriptor.pb.go
+++ b/vendor/github.com/containerd/containerd/api/types/descriptor.pb.go
@@ -28,6 +28,7 @@ import github_com_opencontainers_go_digest "github.com/opencontainers/go-digest"
 
 import strings "strings"
 import reflect "reflect"
+import sortkeys "github.com/gogo/protobuf/sortkeys"
 
 import io "io"
 
@@ -48,9 +49,10 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 // oci descriptor found in a manifest.
 // See https://godoc.org/github.com/opencontainers/image-spec/specs-go/v1#Descriptor
 type Descriptor struct {
-	MediaType string                                     `protobuf:"bytes,1,opt,name=media_type,json=mediaType,proto3" json:"media_type,omitempty"`
-	Digest    github_com_opencontainers_go_digest.Digest `protobuf:"bytes,2,opt,name=digest,proto3,customtype=github.com/opencontainers/go-digest.Digest" json:"digest"`
-	Size_     int64                                      `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
+	MediaType   string                                     `protobuf:"bytes,1,opt,name=media_type,json=mediaType,proto3" json:"media_type,omitempty"`
+	Digest      github_com_opencontainers_go_digest.Digest `protobuf:"bytes,2,opt,name=digest,proto3,customtype=github.com/opencontainers/go-digest.Digest" json:"digest"`
+	Size_       int64                                      `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
+	Annotations map[string]string                          `protobuf:"bytes,5,rep,name=annotations" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
 func (m *Descriptor) Reset()                    { *m = Descriptor{} }
@@ -92,6 +94,23 @@ func (m *Descriptor) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintDescriptor(dAtA, i, uint64(m.Size_))
 	}
+	if len(m.Annotations) > 0 {
+		for k, _ := range m.Annotations {
+			dAtA[i] = 0x2a
+			i++
+			v := m.Annotations[k]
+			mapSize := 1 + len(k) + sovDescriptor(uint64(len(k))) + 1 + len(v) + sovDescriptor(uint64(len(v)))
+			i = encodeVarintDescriptor(dAtA, i, uint64(mapSize))
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintDescriptor(dAtA, i, uint64(len(k)))
+			i += copy(dAtA[i:], k)
+			dAtA[i] = 0x12
+			i++
+			i = encodeVarintDescriptor(dAtA, i, uint64(len(v)))
+			i += copy(dAtA[i:], v)
+		}
+	}
 	return i, nil
 }
 
@@ -118,6 +137,14 @@ func (m *Descriptor) Size() (n int) {
 	if m.Size_ != 0 {
 		n += 1 + sovDescriptor(uint64(m.Size_))
 	}
+	if len(m.Annotations) > 0 {
+		for k, v := range m.Annotations {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovDescriptor(uint64(len(k))) + 1 + len(v) + sovDescriptor(uint64(len(v)))
+			n += mapEntrySize + 1 + sovDescriptor(uint64(mapEntrySize))
+		}
+	}
 	return n
 }
 
@@ -138,10 +165,21 @@ func (this *Descriptor) String() string {
 	if this == nil {
 		return "nil"
 	}
+	keysForAnnotations := make([]string, 0, len(this.Annotations))
+	for k, _ := range this.Annotations {
+		keysForAnnotations = append(keysForAnnotations, k)
+	}
+	sortkeys.Strings(keysForAnnotations)
+	mapStringForAnnotations := "map[string]string{"
+	for _, k := range keysForAnnotations {
+		mapStringForAnnotations += fmt.Sprintf("%v: %v,", k, this.Annotations[k])
+	}
+	mapStringForAnnotations += "}"
 	s := strings.Join([]string{`&Descriptor{`,
 		`MediaType:` + fmt.Sprintf("%v", this.MediaType) + `,`,
 		`Digest:` + fmt.Sprintf("%v", this.Digest) + `,`,
 		`Size_:` + fmt.Sprintf("%v", this.Size_) + `,`,
+		`Annotations:` + mapStringForAnnotations + `,`,
 		`}`,
 	}, "")
 	return s
@@ -260,6 +298,124 @@ func (m *Descriptor) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Annotations", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDescriptor
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDescriptor
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Annotations == nil {
+				m.Annotations = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowDescriptor
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= (uint64(b) & 0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowDescriptor
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthDescriptor
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowDescriptor
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthDescriptor
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipDescriptor(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthDescriptor
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Annotations[mapkey] = mapvalue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipDescriptor(dAtA[iNdEx:])
@@ -391,20 +547,25 @@ func init() {
 }
 
 var fileDescriptorDescriptor = []byte{
-	// 234 bytes of a gzipped FileDescriptorProto
+	// 311 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xb2, 0x4e, 0xcf, 0x2c, 0xc9,
 	0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0x4f, 0xce, 0xcf, 0x2b, 0x49, 0xcc, 0xcc, 0x4b, 0x2d,
 	0x4a, 0x41, 0x66, 0x26, 0x16, 0x64, 0xea, 0x97, 0x54, 0x16, 0xa4, 0x16, 0xeb, 0xa7, 0xa4, 0x16,
 	0x27, 0x17, 0x65, 0x16, 0x94, 0xe4, 0x17, 0xe9, 0x15, 0x14, 0xe5, 0x97, 0xe4, 0x0b, 0x09, 0x20,
 	0x94, 0xe9, 0x81, 0x95, 0x48, 0x89, 0xa4, 0xe7, 0xa7, 0xe7, 0x83, 0x25, 0xf5, 0x41, 0x2c, 0x88,
-	0x3a, 0xa5, 0x6e, 0x46, 0x2e, 0x2e, 0x17, 0xb8, 0x66, 0x21, 0x59, 0x2e, 0xae, 0xdc, 0xd4, 0x94,
-	0xcc, 0xc4, 0x78, 0x90, 0x1e, 0x09, 0x46, 0x05, 0x46, 0x0d, 0xce, 0x20, 0x4e, 0xb0, 0x48, 0x48,
-	0x65, 0x41, 0xaa, 0x90, 0x17, 0x17, 0x5b, 0x4a, 0x66, 0x7a, 0x6a, 0x71, 0x89, 0x04, 0x13, 0x48,
-	0xca, 0xc9, 0xe8, 0xc4, 0x3d, 0x79, 0x86, 0x5b, 0xf7, 0xe4, 0xb5, 0x90, 0x9c, 0x9a, 0x5f, 0x90,
-	0x9a, 0x07, 0xb7, 0xbc, 0x58, 0x3f, 0x3d, 0x5f, 0x17, 0xa2, 0x45, 0xcf, 0x05, 0x4c, 0x05, 0x41,
-	0x4d, 0x10, 0x12, 0xe2, 0x62, 0x29, 0xce, 0xac, 0x4a, 0x95, 0x60, 0x56, 0x60, 0xd4, 0x60, 0x0e,
-	0x02, 0xb3, 0x9d, 0xbc, 0x4e, 0x3c, 0x94, 0x63, 0xb8, 0xf1, 0x50, 0x8e, 0xa1, 0xe1, 0x91, 0x1c,
-	0xe3, 0x89, 0x47, 0x72, 0x8c, 0x17, 0x1e, 0xc9, 0x31, 0x3e, 0x78, 0x24, 0xc7, 0x18, 0x65, 0x40,
-	0x7c, 0x60, 0x58, 0x83, 0xc9, 0x08, 0x86, 0x24, 0x36, 0xb0, 0x17, 0x8d, 0x01, 0x01, 0x00, 0x00,
-	0xff, 0xff, 0xea, 0xac, 0x78, 0x9a, 0x49, 0x01, 0x00, 0x00,
+	0x3a, 0xa5, 0x39, 0x4c, 0x5c, 0x5c, 0x2e, 0x70, 0xcd, 0x42, 0xb2, 0x5c, 0x5c, 0xb9, 0xa9, 0x29,
+	0x99, 0x89, 0xf1, 0x20, 0x3d, 0x12, 0x8c, 0x0a, 0x8c, 0x1a, 0x9c, 0x41, 0x9c, 0x60, 0x91, 0x90,
+	0xca, 0x82, 0x54, 0x21, 0x2f, 0x2e, 0xb6, 0x94, 0xcc, 0xf4, 0xd4, 0xe2, 0x12, 0x09, 0x26, 0x90,
+	0x94, 0x93, 0xd1, 0x89, 0x7b, 0xf2, 0x0c, 0xb7, 0xee, 0xc9, 0x6b, 0x21, 0x39, 0x35, 0xbf, 0x20,
+	0x35, 0x0f, 0x6e, 0x79, 0xb1, 0x7e, 0x7a, 0xbe, 0x2e, 0x44, 0x8b, 0x9e, 0x0b, 0x98, 0x0a, 0x82,
+	0x9a, 0x20, 0x24, 0xc4, 0xc5, 0x52, 0x9c, 0x59, 0x95, 0x2a, 0xc1, 0xac, 0xc0, 0xa8, 0xc1, 0x1c,
+	0x04, 0x66, 0x0b, 0xf9, 0x73, 0x71, 0x27, 0xe6, 0xe5, 0xe5, 0x97, 0x24, 0x96, 0x64, 0xe6, 0xe7,
+	0x15, 0x4b, 0xb0, 0x2a, 0x30, 0x6b, 0x70, 0x1b, 0xe9, 0xea, 0xa1, 0xfb, 0x45, 0x0f, 0xe1, 0x62,
+	0x3d, 0x47, 0x84, 0x7a, 0xd7, 0xbc, 0x92, 0xa2, 0xca, 0x20, 0x64, 0x13, 0xa4, 0xec, 0xb8, 0x04,
+	0xd0, 0x15, 0x08, 0x09, 0x70, 0x31, 0x67, 0xa7, 0x56, 0x42, 0x3d, 0x07, 0x62, 0x0a, 0x89, 0x70,
+	0xb1, 0x96, 0x25, 0xe6, 0x94, 0xa6, 0x42, 0x7c, 0x15, 0x04, 0xe1, 0x58, 0x31, 0x59, 0x30, 0x3a,
+	0x79, 0x9d, 0x78, 0x28, 0xc7, 0x70, 0xe3, 0xa1, 0x1c, 0x43, 0xc3, 0x23, 0x39, 0xc6, 0x13, 0x8f,
+	0xe4, 0x18, 0x2f, 0x3c, 0x92, 0x63, 0x7c, 0xf0, 0x48, 0x8e, 0x31, 0xca, 0x80, 0xf8, 0xd8, 0xb1,
+	0x06, 0x93, 0x11, 0x0c, 0x49, 0x6c, 0xe0, 0x30, 0x37, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0x22,
+	0x8a, 0x20, 0x4a, 0xda, 0x01, 0x00, 0x00,
 }

--- a/vendor/github.com/containerd/containerd/api/types/descriptor.proto
+++ b/vendor/github.com/containerd/containerd/api/types/descriptor.proto
@@ -15,4 +15,5 @@ message Descriptor {
 	string media_type = 1;
 	string digest = 2 [(gogoproto.customtype) = "github.com/opencontainers/go-digest.Digest", (gogoproto.nullable) = false];
 	int64 size = 3;
+	map<string, string> annotations = 5;
 }

--- a/vendor/github.com/containers/buildah/buildah.go
+++ b/vendor/github.com/containers/buildah/buildah.go
@@ -26,7 +26,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.8.4"
+	Version = "1.9.0"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,7 @@
+- Changelog for v1.9.0 (2019-06-15)
+  * buildah-run: fix-out-of-range panic (2)
+  * Bump back to v1.9.0-dev
+
 - Changelog for v1.8.4 (2019-06-13)
     Update containers/image to v2.0.0
     run: fix hang with run and --isolation=chroot

--- a/vendor/github.com/containers/buildah/run_linux.go
+++ b/vendor/github.com/containers/buildah/run_linux.go
@@ -1134,8 +1134,14 @@ func runCopyStdio(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copy
 		setNonblock(wfd, writeDesc[wfd], false)
 	}
 
-	setNonblock(stdioPipe[unix.Stdin][1], writeDesc[stdioPipe[unix.Stdin][1]], true)
+	if copyPipes {
+		setNonblock(stdioPipe[unix.Stdin][1], writeDesc[stdioPipe[unix.Stdin][1]], true)
+	}
 
+	runCopyStdioPassData(stdio, copyPipes, stdioPipe, copyConsole, consoleListener, finishCopy, finishedCopy, spec, relayMap, relayBuffer, readDesc, writeDesc)
+}
+
+func runCopyStdioPassData(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copyConsole bool, consoleListener *net.UnixListener, finishCopy []int, finishedCopy chan struct{}, spec *specs.Spec, relayMap map[int]int, relayBuffer map[int]*bytes.Buffer, readDesc map[int]string, writeDesc map[int]string) {
 	closeStdin := false
 
 	// Pass data back and forth.

--- a/vendor/github.com/containers/libpod/libpod/container_api.go
+++ b/vendor/github.com/containers/libpod/libpod/container_api.go
@@ -180,7 +180,7 @@ func (c *Container) StopWithTimeout(timeout uint) error {
 	if c.state.State == ContainerStateConfigured ||
 		c.state.State == ContainerStateUnknown ||
 		c.state.State == ContainerStatePaused {
-		return errors.Wrapf(ErrCtrStateInvalid, "can only stop created, running, or stopped containers. %s in state %s", c.ID(), c.state.State.String())
+		return errors.Wrapf(ErrCtrStateInvalid, "can only stop created, running, or stopped containers. %s is in state %s", c.ID(), c.state.State.String())
 	}
 
 	if c.state.State == ContainerStateStopped ||
@@ -203,7 +203,7 @@ func (c *Container) Kill(signal uint) error {
 	}
 
 	if c.state.State != ContainerStateRunning {
-		return errors.Wrapf(ErrCtrStateInvalid, "can only kill running containers")
+		return errors.Wrapf(ErrCtrStateInvalid, "can only kill running containers. %s is in state %s", c.ID(), c.state.State.String())
 	}
 
 	defer c.newContainerEvent(events.Kill)

--- a/vendor/github.com/containers/libpod/libpod/container_inspect.go
+++ b/vendor/github.com/containers/libpod/libpod/container_inspect.go
@@ -1,8 +1,10 @@
 package libpod
 
 import (
+	"strings"
 	"time"
 
+	"github.com/containers/image/manifest"
 	"github.com/containers/libpod/libpod/driver"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -49,6 +51,53 @@ type InspectContainerData struct {
 	ExitCommand     []string                `json:"ExitCommand"`
 	Namespace       string                  `json:"Namespace"`
 	IsInfra         bool                    `json:"IsInfra"`
+	Config          *InspectContainerConfig `json:"Config"`
+}
+
+// InspectContainerConfig holds further data about how a container was initially
+// configured.
+type InspectContainerConfig struct {
+	// Container hostname
+	Hostname string `json:"Hostname"`
+	// Container domain name - unused at present
+	DomainName string `json:"Domainname"`
+	// User the container was launched with
+	User string `json:"User"`
+	// Unused, at present
+	AttachStdin bool `json:"AttachStdin"`
+	// Unused, at present
+	AttachStdout bool `json:"AttachStdout"`
+	// Unused, at present
+	AttachStderr bool `json:"AttachStderr"`
+	// Whether the container creates a TTY
+	Tty bool `json:"Tty"`
+	// Whether the container leaves STDIN open
+	OpenStdin bool `json:"OpenStdin"`
+	// Whether STDIN is only left open once.
+	// Presently not supported by Podman, unused.
+	StdinOnce bool `json:"StdinOnce"`
+	// Container environment variables
+	Env []string `json:"Env"`
+	// Container command
+	Cmd []string `json:"Cmd"`
+	// Container image
+	Image string `json:"Image"`
+	// Unused, at present. I've never seen this field populated.
+	Volumes map[string]struct{} `json:"Volumes"`
+	// Container working directory
+	WorkingDir string `json:"WorkingDir"`
+	// Container entrypoint
+	Entrypoint string `json:"Entrypoint"`
+	// On-build arguments - presently unused. More of Buildah's domain.
+	OnBuild *string `json:"OnBuild"`
+	// Container labels
+	Labels map[string]string `json:"Labels"`
+	// Container annotations
+	Annotations map[string]string `json:"Annotations"`
+	// Container stop signal
+	StopSignal uint `json:"StopSignal"`
+	// Configured healthcheck for the container
+	Healthcheck *manifest.Schema2HealthConfig `json:"Healthcheck,omitempty"`
 }
 
 // InspectMount provides a record of a single mount in a container. It contains
@@ -192,7 +241,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *driver.Data) 
 		}
 	}
 
-	mounts, err := c.getInspectMounts()
+	mounts, err := c.getInspectMounts(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -284,6 +333,12 @@ func (c *Container) getContainerInspectData(size bool, driverData *driver.Data) 
 	// Get information on the container's network namespace (if present)
 	data = c.getContainerNetworkInfo(data)
 
+	inspectConfig, err := c.generateInspectContainerConfig(spec)
+	if err != nil {
+		return nil, err
+	}
+	data.Config = inspectConfig
+
 	if size {
 		rootFsSize, err := c.rootFsSize()
 		if err != nil {
@@ -302,7 +357,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *driver.Data) 
 // Get inspect-formatted mounts list.
 // Only includes user-specified mounts. Only includes bind mounts and named
 // volumes, not tmpfs volumes.
-func (c *Container) getInspectMounts() ([]*InspectMount, error) {
+func (c *Container) getInspectMounts(ctrSpec *spec.Spec) ([]*InspectMount, error) {
 	inspectMounts := []*InspectMount{}
 
 	// No mounts, return early
@@ -319,7 +374,7 @@ func (c *Container) getInspectMounts() ([]*InspectMount, error) {
 	for _, namedVol := range c.config.NamedVolumes {
 		namedVolumes[namedVol.Dest] = namedVol
 	}
-	for _, mount := range c.config.Spec.Mounts {
+	for _, mount := range ctrSpec.Mounts {
 		mounts[mount.Destination] = mount
 	}
 
@@ -400,4 +455,57 @@ func parseMountOptionsForInspect(options []string, mount *InspectMount) {
 	mount.Propagation = mountProp
 	mount.Mode = zZ
 	mount.Options = otherOpts
+}
+
+// Generate the InspectContainerConfig struct for the Config field of Inspect.
+func (c *Container) generateInspectContainerConfig(spec *spec.Spec) (*InspectContainerConfig, error) {
+	ctrConfig := new(InspectContainerConfig)
+
+	ctrConfig.Hostname = c.Hostname()
+	ctrConfig.User = c.config.User
+	if spec.Process != nil {
+		ctrConfig.Tty = spec.Process.Terminal
+		ctrConfig.Env = []string{}
+		for _, val := range spec.Process.Env {
+			ctrConfig.Env = append(ctrConfig.Env, val)
+		}
+		ctrConfig.WorkingDir = spec.Process.Cwd
+	}
+
+	ctrConfig.OpenStdin = c.config.Stdin
+	ctrConfig.Image = c.config.RootfsImageName
+
+	// Leave empty is not explicitly overwritten by user
+	if len(c.config.Command) != 0 {
+		ctrConfig.Cmd = []string{}
+		for _, val := range c.config.Command {
+			ctrConfig.Cmd = append(ctrConfig.Cmd, val)
+		}
+	}
+
+	// Leave empty if not explicitly overwritten by user
+	if len(c.config.Entrypoint) != 0 {
+		ctrConfig.Entrypoint = strings.Join(c.config.Entrypoint, " ")
+	}
+
+	if len(c.config.Labels) != 0 {
+		ctrConfig.Labels = make(map[string]string)
+		for k, v := range c.config.Labels {
+			ctrConfig.Labels[k] = v
+		}
+	}
+
+	if len(spec.Annotations) != 0 {
+		ctrConfig.Annotations = make(map[string]string)
+		for k, v := range spec.Annotations {
+			ctrConfig.Annotations[k] = v
+		}
+	}
+
+	ctrConfig.StopSignal = c.config.StopSignal
+	// TODO: should JSON deep copy this to ensure internal pointers don't
+	// leak.
+	ctrConfig.Healthcheck = c.config.HealthCheckConfig
+
+	return ctrConfig, nil
 }

--- a/vendor/github.com/containers/libpod/libpod/container_internal_linux.go
+++ b/vendor/github.com/containers/libpod/libpod/container_internal_linux.go
@@ -424,7 +424,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 // It also expects to be able to write to /sys/fs/cgroup/systemd and /var/log/journal
 func (c *Container) setupSystemd(mounts []spec.Mount, g generate.Generator) error {
 	options := []string{"rw", "rprivate", "noexec", "nosuid", "nodev"}
-	for _, dest := range []string{"/run"} {
+	for _, dest := range []string{"/run", "/run/lock"} {
 		if MountExists(mounts, dest) {
 			continue
 		}

--- a/vendor/github.com/containers/libpod/libpod/runtime.go
+++ b/vendor/github.com/containers/libpod/libpod/runtime.go
@@ -42,11 +42,20 @@ const (
 	SQLiteStateStore RuntimeStateStore = iota
 	// BoltDBStateStore is a state backed by a BoltDB database
 	BoltDBStateStore RuntimeStateStore = iota
+)
+
+var (
+	// InstallPrefix is the prefix where podman will be installed.
+	// It can be overridden at build time.
+	installPrefix = "/usr/local"
+	// EtcDir is the sysconfdir where podman should look for system config files.
+	// It can be overridden at build time.
+	etcDir = "/etc"
 
 	// SeccompDefaultPath defines the default seccomp path
-	SeccompDefaultPath = "/usr/share/containers/seccomp.json"
+	SeccompDefaultPath = installPrefix + "/share/containers/seccomp.json"
 	// SeccompOverridePath if this exists it overrides the default seccomp path
-	SeccompOverridePath = "/etc/crio/seccomp.json"
+	SeccompOverridePath = etcDir + "/crio/seccomp.json"
 
 	// ConfigPath is the path to the libpod configuration file
 	// This file is loaded to replace the builtin default config before
@@ -54,11 +63,11 @@ const (
 	// If it is not present, the builtin default config is used instead
 	// This path can be overridden when the runtime is created by using
 	// NewRuntimeFromConfig() instead of NewRuntime()
-	ConfigPath = "/usr/share/containers/libpod.conf"
+	ConfigPath = installPrefix + "/share/containers/libpod.conf"
 	// OverrideConfigPath is the path to an override for the default libpod
 	// configuration file. If OverrideConfigPath exists, it will be used in
 	// place of the configuration file pointed to by ConfigPath.
-	OverrideConfigPath = "/etc/containers/libpod.conf"
+	OverrideConfigPath = etcDir + "/containers/libpod.conf"
 
 	// DefaultInfraImage to use for infra container
 	DefaultInfraImage = "k8s.gcr.io/pause:3.1"
@@ -300,7 +309,7 @@ func defaultRuntimeConfig() (RuntimeConfig, error) {
 		TmpDir:                "",
 		MaxLogSize:            -1,
 		NoPivotRoot:           false,
-		CNIConfigDir:          "/etc/cni/net.d/",
+		CNIConfigDir:          etcDir + "/cni/net.d/",
 		CNIPluginDir:          []string{"/usr/libexec/cni", "/usr/lib/cni", "/usr/local/lib/cni", "/opt/cni/bin"},
 		InfraCommand:          DefaultInfraCommand,
 		InfraImage:            DefaultInfraImage,

--- a/vendor/github.com/containers/libpod/version/version.go
+++ b/vendor/github.com/containers/libpod/version/version.go
@@ -4,7 +4,7 @@ package version
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-const Version = "1.4.1"
+const Version = "1.4.2"
 
 // RemoteAPIVersion is the version for the remote
 // client API.  It is used to determine compatibility

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/OpenPeeDeeP/depguard
 github.com/VividCortex/ewma
 # github.com/beorn7/perks v1.0.0
 github.com/beorn7/perks/quantile
-# github.com/blang/semver v3.5.0+incompatible
+# github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
 # github.com/checkpoint-restore/go-criu v0.0.0-20190109184317-bdb7599cd87b
 github.com/checkpoint-restore/go-criu/rpc
@@ -38,7 +38,7 @@ github.com/checkpoint-restore/go-criu
 github.com/containerd/cgroups
 # github.com/containerd/console v0.0.0-20170925154832-84eeaae905fa
 github.com/containerd/console
-# github.com/containerd/containerd v1.2.6
+# github.com/containerd/containerd v1.2.7
 github.com/containerd/containerd/api/types/task
 github.com/containerd/containerd/namespaces
 github.com/containerd/containerd/runtime/v2/shim
@@ -71,7 +71,7 @@ github.com/containernetworking/cni/pkg/invoke
 github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v0.8.1
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.8.4
+# github.com/containers/buildah v1.9.0
 github.com/containers/buildah/pkg/secrets
 github.com/containers/buildah
 github.com/containers/buildah/imagebuildah
@@ -120,7 +120,7 @@ github.com/containers/image/pkg/tlsclientconfig
 github.com/containers/image/docker/tarfile
 github.com/containers/image/oci/internal
 github.com/containers/image/pkg/sysregistries
-# github.com/containers/libpod v1.4.1
+# github.com/containers/libpod v1.4.2
 github.com/containers/libpod/pkg/hooks/0.1.0
 github.com/containers/libpod/pkg/hooks
 github.com/containers/libpod/pkg/registrar


### PR DESCRIPTION
- Bump github.com/containerd/containerd from 1.2.6 to 1.2.7
- Bump github.com/blang/semver from 3.5.0+incompatible to 3.5.1+incompatible
- Bump github.com/containers/buildah from 1.8.4 to 1.9.0
- Bump github.com/containers/libpod from 1.4.1 to 1.4.2