### PR TITLE
Add release bundle target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,10 @@ workflows:
       - build
       - build-static
       - build-test-binaries
+      - bundle:
+          requires:
+            - build
+            - build-static
       - clang-format
       - ginkgo
       - git-validation
@@ -75,6 +79,7 @@ workflows:
       - lint
       - results:
           requires:
+            - bundle
             - integration
             - integration-critest
             - integration-static-glibc
@@ -106,6 +111,8 @@ jobs:
           root: .
           paths:
             - bin
+            - crio.conf
+            - docs
 
   build-static:
     executor: nix
@@ -143,6 +150,20 @@ jobs:
             - test/bin2img/bin2img
             - test/copyimg/checkseccomp/checkseccomp
             - test/copyimg/copyimg
+
+  bundle:
+    executor: docker
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: bundle
+          command: make bundle
+      - persist_to_workspace:
+          root: .
+          paths:
+            - bundle/*.tar.gz
 
   clang-format:
     executor: docker
@@ -258,6 +279,9 @@ jobs:
       - store_artifacts:
           path: build
           destination: test
+      - store_artifacts:
+          path: bundle
+          destination: bundle
 
   unit-tests:
     executor: docker

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ coverprofile
 lib/state.json
 result-*bin
 *_junit.xml
+bundle/tmp
+bundle/*.tar.gz
 
 ./Vagrantfile
 .vagrant/

--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,9 @@ docs/%.8: docs/%.8.md .gopathok ${GO_MD2MAN}
 
 docs: $(MANPAGES)
 
+bundle:
+	bundle/build
+
 install: .gopathok install.bin install.man
 
 install.bin: binaries
@@ -382,6 +385,7 @@ endif
 	bin/crio \
 	bin/pause \
 	binaries \
+	bundle \
 	build-static \
 	clean \
 	default \

--- a/bundle/Makefile
+++ b/bundle/Makefile
@@ -1,0 +1,34 @@
+PREFIX ?= $(DESTDIR)/usr/local
+ETCDIR ?= $(DESTDIR)/etc
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/share/man
+OCIDIR ?= $(PREFIX)/share/oci-umount/oci-umount.d
+SELINUX ?= $(shell selinuxenabled 2>/dev/null && echo -Z)
+
+all: install
+
+.PHONY: install
+install:
+	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-x86_64-static-glibc
+	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-x86_64-static-musl
+	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/pause-x86_64-static-glibc
+	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/pause-x86_64-static-musl
+	install $(SELINUX) -D -m 644 -t $(ETCDIR) etc/crictl.yaml
+	install $(SELINUX) -D -m 644 -t $(OCIDIR) etc/crio-umount.conf
+	install $(SELINUX) -D -m 644 -t $(ETCDIR)/crio etc/crio.conf
+	install $(SELINUX) -D -m 644 -t $(ETCDIR)/crio etc/seccomp.json
+	install $(SELINUX) -D -m 644 -t $(MANDIR)/man5 man/crio.conf.5
+	install $(SELINUX) -D -m 644 -t $(MANDIR)/man8 man/crio.8
+
+.PHONY: uninstall
+uninstall:
+	rm $(BINDIR)/crio-x86_64-static-glibc
+	rm $(BINDIR)/crio-x86_64-static-musl
+	rm $(BINDIR)/pause-x86_64-static-glibc
+	rm $(BINDIR)/pause-x86_64-static-musl
+	rm $(ETCDIR)/crictl.yaml
+	rm $(OCIDIR)/crio-umount.conf
+	rm $(ETCDIR)/crio/crio.conf
+	rm $(ETCDIR)/crio/seccomp.json
+	rm $(MANDIR)/man5/crio.conf.5
+	rm $(MANDIR)/man8/crio.8

--- a/bundle/build
+++ b/bundle/build
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+FILES_BIN=(
+    "../bin/crio-x86_64-static-glibc"
+    "../bin/crio-x86_64-static-musl"
+    "../bin/pause-x86_64-static-glibc"
+    "../bin/pause-x86_64-static-musl"
+)
+FILES_MAN=(
+    "../docs/crio.8"
+    "../docs/crio.conf.5"
+)
+FILES_ETC=(
+    "../crictl.yaml"
+    "../crio-umount.conf"
+    "../crio.conf"
+    "../seccomp.json"
+)
+
+TMPDIR=tmp
+rm -rf $TMPDIR
+mkdir -p $TMPDIR/{bin,etc,man}
+
+for FILE in "${FILES_BIN[@]}"; do
+    if [[ ! -f "$FILE" ]]; then
+        echo "File '$FILE' does not exist"
+        exit 1
+    fi
+
+    if [[ ! -x "$FILE" ]]; then
+        echo "File '$FILE' is not exectuable"
+        exit 1
+    fi
+
+    if ! file "$FILE" | grep "statically linked" | grep -q stripped; then
+        echo "Binary '$FILE' is not statically linked and stripped"
+        exit 1
+    fi
+    cp "$FILE" $TMPDIR/bin
+done
+
+for FILE in "${FILES_MAN[@]}"; do
+    if [[ ! -f "$FILE" ]]; then
+        echo "File '$FILE' does not exist"
+        exit 1
+    fi
+    cp "$FILE" $TMPDIR/man
+done
+
+for FILE in "${FILES_ETC[@]}"; do
+    if [[ ! -f "$FILE" ]]; then
+        echo "File '$FILE' does not exist"
+        exit 1
+    fi
+    cp "$FILE" $TMPDIR/etc
+done
+
+cp Makefile $TMPDIR
+
+# Create the archive
+BUNDLE=crio-$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
+ARCHIVE="$BUNDLE.tar.gz"
+rm -f "$ARCHIVE"
+tar cfz "$ARCHIVE" tmp --transform s/tmp/"$BUNDLE"/
+rm -rf tmp
+echo "Created $(pwd)/$ARCHIVE"
+
+# Test the archive
+echo "Testing archive"
+tar xf "$ARCHIVE"
+pushd "$BUNDLE"
+make DESTDIR=test
+popd
+rm -rf "$BUNDLE"


### PR DESCRIPTION
This commit adds a `bundle` Makefile target which can be used to create
a build artifact tarball which contains static binaries and necessary
configurations. The target will be used by CircleCI to provide
continuous results. We can also attach bundles for specific versions on
corresponding GitHub releases.

Example run:
https://8210-161810706-gh.circle-artifacts.com/0/bundle/crio-33a105c0e.tar.gz