### PR TITLE
Fix SELinux denials in e2e_features_* tests

### DIFF
--- a/contrib/test/integration/e2e-features.yml
+++ b/contrib/test/integration/e2e-features.yml
@@ -20,9 +20,18 @@
 
 - block:
 
+    - name: Disable selinux during e2e tests
+      command: 'setenforce 0'
+      when: not e2e_selinux_enabled
+
     - name: run e2e tests
       shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
       args:
         chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
       async: '{{ 60 * 60 * 4 }}'  # seconds
       poll: 60
+
+  always:
+
+    - name: Re-enable SELinux after e2e tests
+      command: 'setenforce 1'


### PR DESCRIPTION
For now, by turning it off.