### PR TITLE
Don't disable SELinux in e2e tests anymore

### DIFF
--- a/contrib/test/integration/e2e-features.yml
+++ b/contrib/test/integration/e2e-features.yml
@@ -19,20 +19,9 @@
             &> {{ artifacts }}/e2e.log
   # Fix vim syntax hilighting: "
 
-- block:
-
-    - name: Disable selinux during e2e tests
-      command: 'setenforce 0'
-      when: not e2e_selinux_enabled
-
-    - name: run e2e tests
-      shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
-      args:
-        chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
-      async: '{{ 60 * 60 * 4 }}'  # seconds
-      poll: 60
-
-  always:
-
-    - name: Re-enable SELinux after e2e tests
-      command: 'setenforce 1'
+- name: run e2e tests
+  shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+  async: '{{ 60 * 60 * 4 }}'  # seconds
+  poll: 60

--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -25,18 +25,9 @@
 
 - block:
 
-    - name: Disable selinux during e2e tests
-      command: 'setenforce 0'
-      when: not e2e_selinux_enabled
-
     - name: run e2e tests
       shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
       args:
         chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
       async: '{{ 60 * 60 * 4 }}'  # seconds
       poll: 60
-
-  always:
-
-    - name: Re-enable SELinux after e2e tests
-      command: 'setenforce 1'

--- a/contrib/test/integration/node-e2e.yml
+++ b/contrib/test/integration/node-e2e.yml
@@ -13,25 +13,14 @@
 - name: Flush the iptables
   command: iptables -F
 
-- block:
-
-    - name: Disable selinux during node-e2e tests
-      command: 'setenforce 0'
-      when: not node_e2e_selinux_enabled
-
-    - name: run node-e2e tests
-      shell: |
-        # parametrize crio socket
-        # cgroup-driver???
-        # TODO(runcom): remove conformance focus, we want everything for testgrid
-        make test-e2e-node PARALLELISM=1 RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/crio.sock IMAGE_SERVICE_ENDPOINT=/var/run/crio/crio.sock TEST_ARGS='--prepull-images=true --kubelet-flags="--cgroup-driver=systemd"' FOCUS="\[Conformance\]" &> {{ artifacts }}/node-e2e.log
-      args:
-        chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
-      async: '{{ 60 * 60 * 2 }}'  # seconds
-      poll: 60
-      ignore_errors: true
-
-  always:
-
-    - name: Re-enable SELinux after node-e2e tests
-      command: 'setenforce 1'
+- name: run node-e2e tests
+  shell: |
+    # parametrize crio socket
+    # cgroup-driver???
+    # TODO(runcom): remove conformance focus, we want everything for testgrid
+    make test-e2e-node PARALLELISM=1 RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/crio.sock IMAGE_SERVICE_ENDPOINT=/var/run/crio/crio.sock TEST_ARGS='--prepull-images=true --kubelet-flags="--cgroup-driver=systemd"' FOCUS="\[Conformance\]" &> {{ artifacts }}/node-e2e.log
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+  async: '{{ 60 * 60 * 2 }}'  # seconds
+  poll: 60
+  ignore_errors: true

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -14,10 +14,6 @@
 
 - block:
 
-    - name: Disable selinux during integration tests
-      command: 'setenforce 0'
-      when: not integration_selinux_enabled
-
     - name: run integration tests
       shell: "make localintegration >& {{ crio_integration_filepath }}"
       args:
@@ -33,8 +29,3 @@
       environment: '{{ int_test_env | combine(userns_int_test_env) }} '
       async: '{{ 60 * 30 }}'  # seconds
       poll: 30
-
-  always:
-
-    - name: Re-enable SELinux after integration tests
-      command: 'setenforce 1'

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -2,7 +2,7 @@
 
 # When False, disable SELinux on the system during specific tests
 integration_selinux_enabled: True
-e2e_selinux_enabled: False
+e2e_selinux_enabled: True
 node_e2e_selinux_enabled: False
 manage_ns_lifecycle: True
 


### PR DESCRIPTION
By relabeling /var to be used by kubernetes

Signed-off-by: Peter Hunt <pehunt@redhat.com>