### PR TITLE
[1.14] Add global_auth_file option to crio.image config

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -225,11 +225,15 @@ ctr_stop_timeout = {{ .CtrStopTimeout }}
 # Default transport for pulling images from a remote container storage.
 default_transport = "{{ .DefaultTransport }}"
 
+# The path to a file containing credentials necessary for pulling images from
+# secure registries. The file is similar to that of /var/lib/kubelet/config.json
+global_auth_file = "{{ .GlobalAuthFile }}"
+
 # The image used to instantiate infra containers.
 pause_image = "{{ .PauseImage }}"
 
-# If not empty, the path to a docker/config.json-like file containing credentials
-# necessary for pulling the image specified by pause_image above.
+# The path to a file containing credentials specific for pulling the pause_image from
+# above. The file is similar to that of /var/lib/kubelet/config.json
 pause_image_auth_file = "{{ .PauseImageAuthFile }}"
 
 # The command to run to have a container stay in the paused state.

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -184,11 +184,14 @@ CRI-O reads its configured registries defaults from the system wide containers-r
 **default_transport**="docker://"
   Default transport for pulling images from a remote container storage.
 
+**global_auth_file**=""
+  The path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.
+
 **pause_image**="k8s.gcr.io/pause:3.1"
   The image used to instantiate infra containers.
 
 **pause_image_auth_file**=""
- If not empty, the path to a docker/config.json-like file containing credentials necessary for pulling the image specified by pause_image above.
+ The path to a file like /var/lib/kubelet/config.json holding credentials specific to pulling the pause_image from above.
 
 **pause_command**="/pause"
   The command to run to have a container stay in the paused state.

--- a/lib/config.go
+++ b/lib/config.go
@@ -257,11 +257,16 @@ type ImageConfig struct {
 	// DefaultTransport is a value we prefix to image names that fail to
 	// validate source references.
 	DefaultTransport string `toml:"default_transport"`
+	// GlobalAuthFile is a path to a file like /var/lib/kubelet/config.json
+	// containing credentials necessary for pulling images from secure
+	// registries.
+	GlobalAuthFile string `toml:"global_auth_file"`
 	// PauseImage is the name of an image which we use to instantiate infra
 	// containers.
 	PauseImage string `toml:"pause_image"`
-	// PauseImageAuthFile, if not empty, is a path to a docker/config.json-like
-	// file containing credentials necessary for pulling PauseImage
+	// PauseImageAuthFile, if not empty, is a path to a file like
+	// /var/lib/kubelet/config.json containing credentials necessary
+	// for pulling PauseImage
 	PauseImageAuthFile string `toml:"pause_image_auth_file"`
 	// PauseCommand is the path of the binary we run in an infra
 	// container that's been instantiated using PauseImage.
@@ -400,6 +405,7 @@ func DefaultConfig() *Config {
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport:    defaultTransport,
+			GlobalAuthFile:      "",
 			PauseImage:          pauseImage,
 			PauseImageAuthFile:  "",
 			PauseCommand:        pauseCommand,

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -138,7 +138,7 @@ func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error)
 		return nil, err
 	}
 
-	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.PauseImage, config.PauseImageAuthFile)
+	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.GlobalAuthFile, config.PauseImage, config.PauseImageAuthFile)
 
 	runtime, err := oci.New(config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.LogToJournald, config.NoPivot, config.CtrStopTimeout)
 	if err != nil {

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -133,7 +133,7 @@ func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error)
 	}
 	config := configIface.GetData()
 
-	imageService, err := storage.GetImageService(ctx, nil, store, config.DefaultTransport, config.GlobalAuthFile, config.InsecureRegistries, config.Registries)
+	imageService, err := storage.GetImageService(ctx, nil, store, config.DefaultTransport, config.InsecureRegistries, config.Registries)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -133,7 +133,7 @@ func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error)
 	}
 	config := configIface.GetData()
 
-	imageService, err := storage.GetImageService(ctx, nil, store, config.DefaultTransport, config.InsecureRegistries, config.Registries)
+	imageService, err := storage.GetImageService(ctx, nil, store, config.DefaultTransport, config.GlobalAuthFile, config.InsecureRegistries, config.Registries)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -66,7 +66,6 @@ type imageCache map[string]imageCacheItem
 type imageService struct {
 	store                       storage.Store
 	defaultTransport            string
-	globalAuthFile              string
 	insecureRegistryCIDRs       []*net.IPNet
 	indexConfigs                map[string]*indexInfo
 	unqualifiedSearchRegistries []string
@@ -408,11 +407,7 @@ func (svc *imageService) PullImage(systemContext *types.SystemContext, imageName
 		return nil, err
 	}
 	if options == nil {
-		options = &copy.Options{
-			SourceCtx: &types.SystemContext{
-				AuthFilePath: svc.globalAuthFile,
-			},
-		}
+		options = &copy.Options{}
 	}
 
 	srcRef, err := svc.prepareReference(imageName, options)
@@ -607,7 +602,7 @@ func (svc *imageService) ResolveNames(imageName string) ([]string, error) {
 // which will prepend the passed-in defaultTransport value to an image name if
 // a name that's passed to its PullImage() method can't be resolved to an image
 // in the store and can't be resolved to a source on its own.
-func GetImageService(ctx context.Context, sc *types.SystemContext, store storage.Store, defaultTransport, globalAuthFile string, insecureRegistries []string, registries []string) (ImageServer, error) {
+func GetImageService(ctx context.Context, sc *types.SystemContext, store storage.Store, defaultTransport string, insecureRegistries []string, registries []string) (ImageServer, error) {
 	if store == nil {
 		var err error
 		store, err = storage.GetStore(storage.DefaultStoreOptions)
@@ -619,7 +614,6 @@ func GetImageService(ctx context.Context, sc *types.SystemContext, store storage
 	is := &imageService{
 		store:                 store,
 		defaultTransport:      defaultTransport,
-		globalAuthFile:        globalAuthFile,
 		indexConfigs:          make(map[string]*indexInfo),
 		insecureRegistryCIDRs: make([]*net.IPNet, 0),
 		imageCache:            make(map[string]imageCacheItem),

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 )
 
 // The actual test suite
@@ -32,7 +32,7 @@ var _ = t.Describe("Image", func() {
 		var err error
 		sut, err = storage.GetImageService(
 			context.Background(), nil, storeMock, "",
-			"", []string{}, []string{testRegistry},
+			[]string{}, []string{testRegistry},
 		)
 		Expect(err).To(BeNil())
 		Expect(sut).NotTo(BeNil())
@@ -77,7 +77,7 @@ var _ = t.Describe("Image", func() {
 			// When
 			imageService, err := storage.GetImageService(
 				context.Background(), nil, storeMock, "",
-				"", []string{"reg1", "reg1", "reg2"},
+				[]string{"reg1", "reg1", "reg2"},
 				[]string{"reg3", "reg3", "reg4"},
 			)
 
@@ -93,7 +93,7 @@ var _ = t.Describe("Image", func() {
 				context.Background(),
 				&types.SystemContext{
 					SystemRegistriesConfPath: "../../test/registries.conf"},
-				storeMock, "", "", []string{}, []string{},
+				storeMock, "", []string{}, []string{},
 			)
 
 			// Then
@@ -107,7 +107,7 @@ var _ = t.Describe("Image", func() {
 
 			// When
 			imageService, err := storage.GetImageService(
-				context.Background(), nil, nil, "", "", []string{}, []string{},
+				context.Background(), nil, nil, "", []string{}, []string{},
 			)
 
 			// Then
@@ -121,7 +121,7 @@ var _ = t.Describe("Image", func() {
 			imageService, err := storage.GetImageService(
 				context.Background(),
 				&types.SystemContext{SystemRegistriesConfPath: "/invalid"},
-				storeMock, "", "", []string{}, []string{},
+				storeMock, "", []string{}, []string{},
 			)
 
 			// Then
@@ -241,7 +241,7 @@ var _ = t.Describe("Image", func() {
 
 			sut, err := storage.GetImageService(context.Background(),
 				&types.SystemContext{SystemRegistriesConfPath: file.Name()},
-				storeMock, "", "", []string{}, []string{})
+				storeMock, "", []string{}, []string{})
 			Expect(err).To(BeNil())
 			Expect(sut).NotTo(BeNil())
 

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -32,7 +32,7 @@ var _ = t.Describe("Image", func() {
 		var err error
 		sut, err = storage.GetImageService(
 			context.Background(), nil, storeMock, "",
-			[]string{}, []string{testRegistry},
+			"", []string{}, []string{testRegistry},
 		)
 		Expect(err).To(BeNil())
 		Expect(sut).NotTo(BeNil())
@@ -77,7 +77,7 @@ var _ = t.Describe("Image", func() {
 			// When
 			imageService, err := storage.GetImageService(
 				context.Background(), nil, storeMock, "",
-				[]string{"reg1", "reg1", "reg2"},
+				"", []string{"reg1", "reg1", "reg2"},
 				[]string{"reg3", "reg3", "reg4"},
 			)
 
@@ -93,7 +93,7 @@ var _ = t.Describe("Image", func() {
 				context.Background(),
 				&types.SystemContext{
 					SystemRegistriesConfPath: "../../test/registries.conf"},
-				storeMock, "", []string{}, []string{},
+				storeMock, "", "", []string{}, []string{},
 			)
 
 			// Then
@@ -107,7 +107,7 @@ var _ = t.Describe("Image", func() {
 
 			// When
 			imageService, err := storage.GetImageService(
-				context.Background(), nil, nil, "", []string{}, []string{},
+				context.Background(), nil, nil, "", "", []string{}, []string{},
 			)
 
 			// Then
@@ -121,7 +121,7 @@ var _ = t.Describe("Image", func() {
 			imageService, err := storage.GetImageService(
 				context.Background(),
 				&types.SystemContext{SystemRegistriesConfPath: "/invalid"},
-				storeMock, "", []string{}, []string{},
+				storeMock, "", "", []string{}, []string{},
 			)
 
 			// Then
@@ -241,7 +241,7 @@ var _ = t.Describe("Image", func() {
 
 			sut, err := storage.GetImageService(context.Background(),
 				&types.SystemContext{SystemRegistriesConfPath: file.Name()},
-				storeMock, "", []string{}, []string{})
+				storeMock, "", "", []string{}, []string{})
 			Expect(err).To(BeNil())
 			Expect(sut).NotTo(BeNil())
 

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -23,7 +23,7 @@ var _ = t.Describe("Runtime", func() {
 	// Prepare the system under test and register a test name and key before
 	// each test
 	BeforeEach(func() {
-		sut = storage.GetRuntimeService(context.Background(), imageServerMock, "", "")
+		sut = storage.GetRuntimeService(context.Background(), imageServerMock, "", "", "")
 		Expect(sut).NotTo(BeNil())
 	})
 
@@ -921,11 +921,11 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should pull pauseImage if not available locally, using default credentials", func() {
 			// The system under test
-			sut := storage.GetRuntimeService(context.Background(), imageServerMock, "pauseimagename", "")
+			sut := storage.GetRuntimeService(context.Background(), imageServerMock, "", "pauseimagename", "")
 			Expect(sut).NotTo(BeNil())
 
 			// Given
-			mockCreatePodSandboxExpectingCopyOptions(&copy.Options{})
+			mockCreatePodSandboxExpectingCopyOptions(&copy.Options{SourceCtx: &types.SystemContext{}})
 
 			// When
 			info, err = sut.CreatePodSandbox(&types.SystemContext{},
@@ -937,7 +937,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should pull pauseImage if not available locally, using provided credential file", func() {
 			// The system under test
-			sut := storage.GetRuntimeService(context.Background(), imageServerMock, "pauseimagename", "/var/non-default/credentials.json")
+			sut := storage.GetRuntimeService(context.Background(), imageServerMock, "", "pauseimagename", "/var/non-default/credentials.json")
 			Expect(sut).NotTo(BeNil())
 
 			// Given

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -45,6 +45,7 @@ func assertAllFieldsEquality(t *testing.T, c Config) {
 		{c.RuntimeConfig.PidsLimit, int64(1024)},
 
 		{c.ImageConfig.DefaultTransport, "docker://"},
+		{c.ImageConfig.GlobalAuthFile, "/var/lib/kubelet/config.json"},
 		{c.ImageConfig.PauseImage, "kubernetes/pause"},
 		{c.ImageConfig.PauseImageAuthFile, "/var/lib/kubelet/config.json"},
 		{c.ImageConfig.PauseCommand, "/pause"},

--- a/server/fixtures/crio.conf
+++ b/server/fixtures/crio.conf
@@ -24,6 +24,7 @@ ctr_stop_timeout = 10
 
 [crio.image]
 default_transport = "docker://"
+global_auth_file = "/var/lib/kubelet/config.json"
 pause_image = "kubernetes/pause"
 pause_image_auth_file = "/var/lib/kubelet/config.json"
 pause_command = "/pause"

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -58,6 +58,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 			SourceCtx: &types.SystemContext{
 				DockerRegistryUserAgent: useragent.Get(ctx),
 				SignaturePolicyPath:     s.ImageContext().SignaturePolicyPath,
+				AuthFilePath:            s.config.GlobalAuthFile,
 			},
 		}
 

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -64,11 +64,9 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 
 		// Specifying a username indicates the user intends to send authentication to the registry.
 		if username != "" {
-			options.SourceCtx = &types.SystemContext{
-				DockerAuthConfig: &types.DockerAuthConfig{
-					Username: username,
-					Password: password,
-				},
+			options.SourceCtx.DockerAuthConfig = &types.DockerAuthConfig{
+				Username: username,
+				Password: password,
 			}
 		}
 


### PR DESCRIPTION
> Add a global_auth_file option under crio.image to the crio config. This option points to a json file that holds the credentials required to pull images from a secure registry. The json file is similar to that of .docker/config.json.
>
> Will forward-port to master as well.

This starts with #2498, and:
- removes some dead code
- fixes the case when the CRI client provides credentials (for the primary registry)
- adds use of `globalAuthFile` for the pause image if no specific credentials are provided

This is a functionally minimal set of changes that reflect how the API is probably _intended_ to be used, but not quite exhaustive for how it _could_ be used (e.g. it seems that calling CRI `ImageStatus` with a `docker://example.com/foo:tar` image name would actually try to contact the remote registry!). I do plan to clean all of this up / make it explicit, but that will be a separate `master`-only PR.