### PR TITLE
Add junit test files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverprofile
 *gomock_reflect*
 lib/state.json
 result-*bin
+*_junit.xml
 
 ./Vagrantfile
 .vagrant/


### PR DESCRIPTION
Failing tests will cause the junit XML files to not being moved into the
test results directory. We now exclude them to avoid commiting them into
the repository.