### PR TITLE
pkg/storage test cleanups

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -95,8 +95,6 @@ type ImageServer interface {
 	// UntagImage removes a name from the specified image, and if it was
 	// the only name the image had, removes the image.
 	UntagImage(systemContext *types.SystemContext, imageName string) error
-	// RemoveImage deletes the specified image.
-	RemoveImage(systemContext *types.SystemContext, imageName string) error
 	// GetStore returns the reference to the storage library Store which
 	// the image server uses to hold images, and is the destination used
 	// when it's asked to pull an image.
@@ -476,14 +474,6 @@ func (svc *imageService) UntagImage(systemContext *types.SystemContext, nameOrID
 		}
 	}
 
-	return ref.DeleteImage(svc.ctx, systemContext)
-}
-
-func (svc *imageService) RemoveImage(systemContext *types.SystemContext, nameOrID string) error {
-	ref, err := svc.getRef(nameOrID)
-	if err != nil {
-		return err
-	}
 	return ref.DeleteImage(svc.ctx, systemContext)
 }
 

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -259,54 +259,6 @@ var _ = t.Describe("Image", func() {
 		})
 	})
 
-	t.Describe("RemoveImage", func() {
-		It("should succeed to remove an image on first store ref", func() {
-			// Given
-			mockGetRef()
-			gomock.InOrder(
-				storeMock.EXPECT().Image(gomock.Any()).
-					Return(&cs.Image{ID: testImageName}, nil),
-				storeMock.EXPECT().DeleteImage(gomock.Any(), gomock.Any()).
-					Return(nil, nil),
-			)
-
-			// When
-			err := sut.RemoveImage(&types.SystemContext{}, testImageName)
-
-			// Then
-			Expect(err).To(BeNil())
-		})
-
-		It("should succeed to remove an image on second store ref", func() {
-			// Given
-			gomock.InOrder(
-				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
-			)
-			mockGetRef()
-			gomock.InOrder(
-				storeMock.EXPECT().Image(gomock.Any()).
-					Return(&cs.Image{ID: testImageName}, nil),
-				storeMock.EXPECT().DeleteImage(gomock.Any(), gomock.Any()).
-					Return(nil, nil),
-			)
-
-			// When
-			err := sut.RemoveImage(&types.SystemContext{}, testImageName)
-
-			// Then
-			Expect(err).To(BeNil())
-		})
-
-		It("should fail to remove an image with invalid name", func() {
-			// Given
-			// When
-			err := sut.RemoveImage(&types.SystemContext{}, "")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-	})
-
 	t.Describe("UntagImage", func() {
 		It("should succeed to untag an image", func() {
 			// Given

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -60,8 +60,8 @@ var _ = t.Describe("Image", func() {
 		)
 	}
 
-	mockListImage := func() {
-		gomock.InOrder(
+	mockListImage := func() mockSequence {
+		return inOrder(
 			storeMock.EXPECT().Image(gomock.Any()).
 				Return(&cs.Image{ID: testImageName}, nil),
 			storeMock.EXPECT().ListImageBigData(gomock.Any()).
@@ -262,8 +262,8 @@ var _ = t.Describe("Image", func() {
 	t.Describe("UntagImage", func() {
 		It("should succeed to untag an image", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(&cs.Image{ID: testImageName}, nil),
 				storeMock.EXPECT().Image(gomock.Any()).
@@ -290,8 +290,8 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to untag an image with invalid name", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
 			)
 
@@ -304,8 +304,8 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to untag an image with failed reference preparation", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(&cs.Image{ID: "otherImage"}, nil),
 			)
@@ -371,8 +371,8 @@ var _ = t.Describe("Image", func() {
 	t.Describe("ImageStatus", func() {
 		It("should succeed to get the image status with digest", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(&cs.Image{ID: testImageName,
 						Names: []string{"a@sha256:" + testSHA256,
@@ -386,9 +386,7 @@ var _ = t.Describe("Image", func() {
 					Return([]string{""}, nil),
 				storeMock.EXPECT().ImageBigDataSize(gomock.Any(), gomock.Any()).
 					Return(int64(0), nil),
-			)
-			mockListImage()
-			gomock.InOrder(
+				mockListImage(),
 				storeMock.EXPECT().ImageBigDataDigest(gomock.Any(), gomock.Any()).
 					Return(digest.Digest("a:"+testSHA256), nil),
 			)
@@ -413,8 +411,8 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to get on wrong store image", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
 			)
 
@@ -428,8 +426,8 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to get on wrong image search", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(&cs.Image{ID: testImageName}, nil),
 				storeMock.EXPECT().Image(gomock.Any()).
@@ -448,8 +446,8 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to get on wrong image config digest", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(&cs.Image{ID: testImageName}, nil),
 				storeMock.EXPECT().Image(gomock.Any()).
@@ -496,8 +494,8 @@ var _ = t.Describe("Image", func() {
 
 		It("should succeed to list multiple images without filter", func() {
 			// Given
-			mockLoop := func() {
-				gomock.InOrder(
+			mockLoop := func() mockSequence {
+				return inOrder(
 					storeMock.EXPECT().ImageBigData(gomock.Any(), gomock.Any()).
 						Return(testManifest, nil),
 					storeMock.EXPECT().ListImageBigData(gomock.Any()).
@@ -517,12 +515,12 @@ var _ = t.Describe("Image", func() {
 						{ID: testSHA256}},
 					nil),
 				mockParseStoreReference(storeMock, "@"+testSHA256),
+				mockListImage(),
+				mockLoop(),
+				mockParseStoreReference(storeMock, "@"+testSHA256),
+				mockListImage(),
+				mockLoop(),
 			)
-			mockListImage()
-			mockLoop()
-			mockParseStoreReference(storeMock, "@"+testSHA256)
-			mockListImage()
-			mockLoop()
 
 			// When
 			res, err := sut.ListImages(&types.SystemContext{}, "")
@@ -534,13 +532,11 @@ var _ = t.Describe("Image", func() {
 
 		It("should succeed to list images with filter", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(&cs.Image{ID: testImageName}, nil),
-			)
-			mockListImage()
-			gomock.InOrder(
+				mockListImage(),
 				storeMock.EXPECT().ImageBigData(gomock.Any(), gomock.Any()).
 					Return(testManifest, nil),
 				storeMock.EXPECT().ListImageBigData(gomock.Any()).
@@ -564,8 +560,8 @@ var _ = t.Describe("Image", func() {
 
 		It("should succeed to list images on wrong image retrieval", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
 			)
 
@@ -592,13 +588,11 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to list images with filter on wrong append cache", func() {
 			// Given
-			mockGetRef()
-			gomock.InOrder(
+			inOrder(
+				mockGetRef(),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(&cs.Image{ID: testImageName}, nil),
-			)
-			mockListImage()
-			gomock.InOrder(
+				mockListImage(),
 				storeMock.EXPECT().ImageBigData(gomock.Any(), gomock.Any()).
 					Return(nil, t.TestError),
 			)

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -53,11 +53,8 @@ var _ = t.Describe("Image", func() {
 	})
 
 	mockParseStoreReference := func() {
-		gomock.InOrder(
-			storeMock.EXPECT().GraphOptions().Return([]string{}),
-			storeMock.EXPECT().GraphDriverName().Return(""),
-			storeMock.EXPECT().GraphRoot().Return(""),
-			storeMock.EXPECT().RunRoot().Return(""),
+		inOrder(
+			mockStorageReferenceStringWithinTransport(storeMock),
 		)
 	}
 

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/containers/libpod/pkg/rootless"
 	cs "github.com/containers/storage"
 	"github.com/cri-o/cri-o/pkg/storage"
+	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 )
 
 // The actual test suite
@@ -25,11 +26,20 @@ var _ = t.Describe("Image", func() {
 		testSHA256    = "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"
 	)
 
+	var (
+		mockCtrl  *gomock.Controller
+		storeMock *containerstoragemock.MockStore
+	)
+
 	// The system under test
 	var sut storage.ImageServer
 
 	// Prepare the system under test
 	BeforeEach(func() {
+		// Setup the mocks
+		mockCtrl = gomock.NewController(GinkgoT())
+		storeMock = containerstoragemock.NewMockStore(mockCtrl)
+
 		var err error
 		sut, err = storage.GetImageService(
 			context.Background(), nil, storeMock, "",
@@ -37,6 +47,9 @@ var _ = t.Describe("Image", func() {
 		)
 		Expect(err).To(BeNil())
 		Expect(sut).NotTo(BeNil())
+	})
+	AfterEach(func() {
+		mockCtrl.Finish()
 	})
 
 	mockParseStoreReference := func() {
@@ -337,7 +350,6 @@ var _ = t.Describe("Image", func() {
 			mockGetRef()
 			gomock.InOrder(
 				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
-				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
 			)
 
 			// When
@@ -460,7 +472,6 @@ var _ = t.Describe("Image", func() {
 			// Given
 			mockGetRef()
 			gomock.InOrder(
-				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
 				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
 			)
 
@@ -612,7 +623,6 @@ var _ = t.Describe("Image", func() {
 			// Given
 			mockGetRef()
 			gomock.InOrder(
-				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
 				storeMock.EXPECT().Image(gomock.Any()).Return(nil, t.TestError),
 			)
 

--- a/pkg/storage/mock_helpers_test.go
+++ b/pkg/storage/mock_helpers_test.go
@@ -53,7 +53,6 @@ func mockStorageReferenceStringWithinTransport(storeMock *containerstoragemock.M
 }
 
 // containers/image/storage.Transport.ParseStoreReference
-// expectedImageName can be "" to bypass the “is this a valid digest prefix” check  FIXME: the caller should actually demonstrate knowledge of the right value
 func mockParseStoreReference(storeMock *containerstoragemock.MockStore, expectedImageName string) mockSequence {
 	// ParseStoreReference calls store.Image() to check whether short strings are possible prefixes of IDs of existing images
 	// (either using the unambiguous "@idPrefix" syntax, or the ambiguous "idPrefix" syntax).
@@ -89,20 +88,20 @@ func mockGetStoreImage(storeMock *containerstoragemock.MockStore, expectedImageN
 }
 
 // containers/image/storage.storageReference.resolveImage
-// expectedImageName must be in the fully normalized format (reference.Named.String())!
+// expectedImageNameOrID, if a name, must be in the fully normalized format (reference.Named.String())!
 // resolvedImageID may be "" to simulate a missing image
-func mockResolveImage(storeMock *containerstoragemock.MockStore, expectedImageName, resolvedImageID string) mockSequence {
+func mockResolveImage(storeMock *containerstoragemock.MockStore, expectedImageNameOrID, resolvedImageID string) mockSequence {
 	if resolvedImageID == "" {
 		return inOrder(
-			storeMock.EXPECT().Image(expectedImageName).Return(nil, cstorage.ErrImageUnknown),
-			// Assuming expectedImageName does not have a digest, so resolveName does not call ImagesByDigest
+			storeMock.EXPECT().Image(expectedImageNameOrID).Return(nil, cstorage.ErrImageUnknown),
+			// Assuming expectedImageNameOrID does not have a digest, so resolveName does not call ImagesByDigest
 			mockStorageReferenceStringWithinTransport(storeMock),
 			mockStorageReferenceStringWithinTransport(storeMock),
 		)
 	}
 	return inOrder(
-		storeMock.EXPECT().Image(expectedImageName).
-			Return(&cstorage.Image{ID: resolvedImageID, Names: []string{expectedImageName}}, nil),
+		storeMock.EXPECT().Image(expectedImageNameOrID).
+			Return(&cstorage.Image{ID: resolvedImageID, Names: []string{expectedImageNameOrID}}, nil),
 	)
 }
 

--- a/pkg/storage/mock_helpers_test.go
+++ b/pkg/storage/mock_helpers_test.go
@@ -1,0 +1,40 @@
+package storage_test
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+)
+
+type mockSequence struct {
+	first, last *gomock.Call // may be both nil (= the default value of mockSequence) to mean empty sequence
+}
+
+// like gomock.inOrder, but can be nested
+func inOrder(calls ...interface{}) mockSequence {
+	var first, last *gomock.Call
+	// This implementation does a few more assignments and checks than strictly necessary, but it is O(N) and reasonably easy to read, so, whatever.
+	for i := 0; i < len(calls); i++ {
+		var elem mockSequence
+		switch e := calls[i].(type) {
+		case mockSequence:
+			elem = e
+		case *gomock.Call:
+			elem = mockSequence{e, e}
+		default:
+			Fail(fmt.Sprintf("Invalid inOrder parameter %#v", e))
+		}
+
+		if elem.first == nil {
+			continue
+		}
+		if first == nil {
+			first = elem.first
+		} else if last != nil {
+			elem.first.After(last)
+		}
+		last = elem.last
+	}
+	return mockSequence{first, last}
+}

--- a/pkg/storage/mock_helpers_test.go
+++ b/pkg/storage/mock_helpers_test.go
@@ -3,6 +3,7 @@ package storage_test
 import (
 	"fmt"
 
+	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 )
@@ -37,4 +38,14 @@ func inOrder(calls ...interface{}) mockSequence {
 		last = elem.last
 	}
 	return mockSequence{first, last}
+}
+
+// containers/image/storage.storageReference.StringWithinTransport
+func mockStorageReferenceStringWithinTransport(storeMock *containerstoragemock.MockStore) mockSequence {
+	return inOrder(
+		storeMock.EXPECT().GraphOptions().Return([]string{}),
+		storeMock.EXPECT().GraphDriverName().Return(""),
+		storeMock.EXPECT().GraphRoot().Return(""),
+		storeMock.EXPECT().RunRoot().Return(""),
+	)
 }

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -42,9 +42,9 @@ var _ = t.Describe("Runtime", func() {
 		mockCtrl.Finish()
 	})
 
-	// Mock helpers
-	mockToCreate := func() {
-		inOrder(
+	// The part of createContainerOrPodSandbox before a CreateContainer call, if the image already exists locally.
+	mockCreateContainerOrPodSandboxImageExists := func() mockSequence {
+		return inOrder(
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			mockParseStoreReference(storeMock, "imagename"),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
@@ -543,8 +543,8 @@ var _ = t.Describe("Runtime", func() {
 
 			BeforeEach(func() {
 				// Given
-				mockToCreate()
-				gomock.InOrder(
+				inOrder(
+					mockCreateContainerOrPodSandboxImageExists(),
 					storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(&cs.Container{ID: "id"}, nil),
@@ -646,8 +646,8 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on run dir error", func() {
 			// Given
-			mockToCreate()
-			gomock.InOrder(
+			inOrder(
+				mockCreateContainerOrPodSandboxImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&cs.Container{ID: "id"}, nil),
@@ -678,8 +678,8 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on container dir error", func() {
 			// Given
-			mockToCreate()
-			gomock.InOrder(
+			inOrder(
+				mockCreateContainerOrPodSandboxImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&cs.Container{ID: "id"}, nil),
@@ -707,8 +707,8 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a pod sandbox on set names error", func() {
 			// Given
-			mockToCreate()
-			gomock.InOrder(
+			inOrder(
+				mockCreateContainerOrPodSandboxImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&cs.Container{ID: "id"}, nil),
@@ -734,8 +734,8 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a pod sandbox on names retrieval error", func() {
 			// Given
-			mockToCreate()
-			gomock.InOrder(
+			inOrder(
+				mockCreateContainerOrPodSandboxImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&cs.Container{ID: "id"}, nil),
@@ -759,8 +759,8 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a pod sandbox on main creation error", func() {
 			// Given
-			mockToCreate()
-			gomock.InOrder(
+			inOrder(
+				mockCreateContainerOrPodSandboxImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, t.TestError),
@@ -779,8 +779,8 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on main creation error", func() {
 			// Given
-			mockToCreate()
-			gomock.InOrder(
+			inOrder(
+				mockCreateContainerOrPodSandboxImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, t.TestError),

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -47,9 +47,7 @@ var _ = t.Describe("Runtime", func() {
 	mockToCreate := func() {
 		inOrder(
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
-			storeMock.EXPECT().Image(gomock.Any()).
-				Return(nil, cstorage.ErrImageUnknown),
-			mockStorageReferenceStringWithinTransport(storeMock),
+			mockParseStoreReference(storeMock, "imagename"),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			storeMock.EXPECT().Image(gomock.Any()).
 				Return(&cs.Image{
@@ -830,8 +828,7 @@ var _ = t.Describe("Runtime", func() {
 			// Given
 			inOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().Image(gomock.Any()).Return(&cs.Image{}, nil),
-				mockStorageReferenceStringWithinTransport(storeMock),
+				mockParseStoreReference(storeMock, "imagename"),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(&cs.Image{
@@ -863,19 +860,12 @@ var _ = t.Describe("Runtime", func() {
 		var err error
 
 		mockCreatePodSandboxExpectingCopyOptions := func(expectedCopyOptions *copy.Options) {
-			inOrder(
-				// istorage.Transport.ParseStoreReference
-				storeMock.EXPECT().Image(gomock.Any()).Return(nil, cstorage.ErrImageUnknown),
-				mockStorageReferenceStringWithinTransport(storeMock),
-			)
+			mockParseStoreReference(storeMock, "pauseimagename")
 			pulledRef, err := istorage.Transport.ParseStoreReference(storeMock, "pauseimagename")
 			Expect(err).To(BeNil())
 			inOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				// istorage.Transport.ParseStoreReference
-				storeMock.EXPECT().Image(gomock.Any()).Return(nil, cstorage.ErrImageUnknown),
-				mockStorageReferenceStringWithinTransport(storeMock),
-
+				mockParseStoreReference(storeMock, "pauseimagename"),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				// istorage.Transport.GetStoreImage
 				storeMock.EXPECT().Image("docker.io/library/pauseimagename:latest").Return(nil, cstorage.ErrImageUnknown),

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -45,14 +45,11 @@ var _ = t.Describe("Runtime", func() {
 
 	// Mock helpers
 	mockToCreate := func() {
-		gomock.InOrder(
+		inOrder(
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			storeMock.EXPECT().Image(gomock.Any()).
 				Return(nil, cstorage.ErrImageUnknown),
-			storeMock.EXPECT().GraphOptions().Return([]string{}),
-			storeMock.EXPECT().GraphDriverName().Return(""),
-			storeMock.EXPECT().GraphRoot().Return(""),
-			storeMock.EXPECT().RunRoot().Return(""),
+			mockStorageReferenceStringWithinTransport(storeMock),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			storeMock.EXPECT().Image(gomock.Any()).
 				Return(&cs.Image{
@@ -831,13 +828,10 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on image pull error", func() {
 			// Given
-			gomock.InOrder(
+			inOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Image(gomock.Any()).Return(&cs.Image{}, nil),
-				storeMock.EXPECT().GraphOptions().Return([]string{}),
-				storeMock.EXPECT().GraphDriverName().Return(""),
-				storeMock.EXPECT().GraphRoot().Return(""),
-				storeMock.EXPECT().RunRoot().Return(""),
+				mockStorageReferenceStringWithinTransport(storeMock),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(&cs.Image{
@@ -869,37 +863,25 @@ var _ = t.Describe("Runtime", func() {
 		var err error
 
 		mockCreatePodSandboxExpectingCopyOptions := func(expectedCopyOptions *copy.Options) {
-			gomock.InOrder(
+			inOrder(
 				// istorage.Transport.ParseStoreReference
 				storeMock.EXPECT().Image(gomock.Any()).Return(nil, cstorage.ErrImageUnknown),
-				storeMock.EXPECT().GraphOptions().Return([]string{}),
-				storeMock.EXPECT().GraphDriverName().Return(""),
-				storeMock.EXPECT().GraphRoot().Return(""),
-				storeMock.EXPECT().RunRoot().Return(""),
+				mockStorageReferenceStringWithinTransport(storeMock),
 			)
 			pulledRef, err := istorage.Transport.ParseStoreReference(storeMock, "pauseimagename")
 			Expect(err).To(BeNil())
-			gomock.InOrder(
+			inOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				// istorage.Transport.ParseStoreReference
 				storeMock.EXPECT().Image(gomock.Any()).Return(nil, cstorage.ErrImageUnknown),
-				storeMock.EXPECT().GraphOptions().Return([]string{}),
-				storeMock.EXPECT().GraphDriverName().Return(""),
-				storeMock.EXPECT().GraphRoot().Return(""),
-				storeMock.EXPECT().RunRoot().Return(""),
+				mockStorageReferenceStringWithinTransport(storeMock),
 
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				// istorage.Transport.GetStoreImage
 				storeMock.EXPECT().Image("docker.io/library/pauseimagename:latest").Return(nil, cstorage.ErrImageUnknown),
 				storeMock.EXPECT().Image("docker.io/library/pauseimagename:latest").Return(nil, cstorage.ErrImageUnknown),
-				storeMock.EXPECT().GraphOptions().Return([]string{}),
-				storeMock.EXPECT().GraphDriverName().Return(""),
-				storeMock.EXPECT().GraphRoot().Return(""),
-				storeMock.EXPECT().RunRoot().Return(""),
-				storeMock.EXPECT().GraphOptions().Return([]string{}),
-				storeMock.EXPECT().GraphDriverName().Return(""),
-				storeMock.EXPECT().GraphRoot().Return(""),
-				storeMock.EXPECT().RunRoot().Return(""),
+				mockStorageReferenceStringWithinTransport(storeMock),
+				mockStorageReferenceStringWithinTransport(storeMock),
 
 				imageServerMock.EXPECT().PullImage(gomock.Any(), "pauseimagename", expectedCopyOptions).Return(pulledRef, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -62,16 +62,10 @@ var _ = t.Describe("Runtime", func() {
 
 	// nolint: dupl
 	t.Describe("GetRunDir", func() {
-		// Prepare the mock
-		BeforeEach(func() {
-			gomock.InOrder(
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-			)
-		})
-
 		It("should succeed to retrieve the run dir", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(&cs.Container{}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
@@ -90,6 +84,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to retrieve the run dir on not existing container", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(nil, t.TestError),
 			)
@@ -105,6 +100,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to retrieve the run dir on invalid container ID", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(nil, cs.ErrContainerUnknown),
 			)
@@ -121,16 +117,10 @@ var _ = t.Describe("Runtime", func() {
 
 	// nolint: dupl
 	t.Describe("GetWorkDir", func() {
-		// Prepare the mock
-		BeforeEach(func() {
-			gomock.InOrder(
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-			)
-		})
-
 		It("should succeed to retrieve the work dir", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(&cs.Container{}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
@@ -149,6 +139,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to retrieve the work dir on not existing container", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(nil, t.TestError),
 			)
@@ -164,6 +155,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to retrieve the work dir on invalid container ID", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(nil, cs.ErrContainerUnknown),
 			)
@@ -242,16 +234,10 @@ var _ = t.Describe("Runtime", func() {
 	})
 
 	t.Describe("StartContainer", func() {
-		// Prepare the mock
-		BeforeEach(func() {
-			gomock.InOrder(
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-			)
-		})
-
 		It("should succeed to start a container", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(&cs.Container{Metadata: "{}"}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
@@ -270,6 +256,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to start a container on store error", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(nil, t.TestError),
 			)
@@ -285,6 +272,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to start a container on unknown ID", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(nil, cs.ErrContainerUnknown),
 			)
@@ -301,6 +289,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to start a container on invalid metadata", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(&cs.Container{Metadata: "invalid"}, nil),
 			)
@@ -316,6 +305,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to start a container on mount error", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(&cs.Container{Metadata: "{}"}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
@@ -333,16 +323,10 @@ var _ = t.Describe("Runtime", func() {
 	})
 
 	t.Describe("GetContainerMetadata", func() {
-		// Prepare the mock
-		BeforeEach(func() {
-			gomock.InOrder(
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-			)
-		})
-
 		It("should succeed to retrieve the container metadata", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Metadata(gomock.Any()).
 					Return(`{"Pod": true}`, nil),
 			)
@@ -359,6 +343,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to retrieve the container metadata on store error", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Metadata(gomock.Any()).
 					Return("", t.TestError),
 			)
@@ -374,6 +359,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to retrieve the container metadata on invalid JSON", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Metadata(gomock.Any()).
 					Return("invalid", nil),
 			)
@@ -486,16 +472,10 @@ var _ = t.Describe("Runtime", func() {
 	})
 
 	t.Describe("RemovePodSandbox", func() {
-		// Prepare the mock
-		BeforeEach(func() {
-			gomock.InOrder(
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-			)
-		})
-
 		It("should succeed to remove the pod sandbox", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(&cs.Container{}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
@@ -513,6 +493,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to remove the pod sandbox on store error", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(nil, t.TestError),
 			)
@@ -527,6 +508,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to remove the pod sandbox on invalid sandbox ID", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(nil, cs.ErrContainerUnknown),
 			)
@@ -542,6 +524,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to remove the pod sandbox on deletion error", func() {
 			// Given
 			gomock.InOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Container(gomock.Any()).
 					Return(&cs.Container{}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -10,6 +10,8 @@ import (
 	cstorage "github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/pkg/storage"
+	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
+	criostoragemock "github.com/cri-o/cri-o/test/mocks/criostorage"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,14 +19,28 @@ import (
 
 // The actual test suite
 var _ = t.Describe("Runtime", func() {
+	var (
+		mockCtrl        *gomock.Controller
+		storeMock       *containerstoragemock.MockStore
+		imageServerMock *criostoragemock.MockImageServer
+	)
+
 	// The system under test
 	var sut storage.RuntimeServer
 
 	// Prepare the system under test and register a test name and key before
 	// each test
 	BeforeEach(func() {
+		// Setup the mocks
+		mockCtrl = gomock.NewController(GinkgoT())
+		storeMock = containerstoragemock.NewMockStore(mockCtrl)
+		imageServerMock = criostoragemock.NewMockImageServer(mockCtrl)
+
 		sut = storage.GetRuntimeService(context.Background(), imageServerMock)
 		Expect(sut).NotTo(BeNil())
+	})
+	AfterEach(func() {
+		mockCtrl.Finish()
 	})
 
 	// Mock helpers

--- a/pkg/storage/suite_test.go
+++ b/pkg/storage/suite_test.go
@@ -4,9 +4,6 @@ import (
 	"testing"
 
 	. "github.com/cri-o/cri-o/test/framework"
-	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
-	criostoragemock "github.com/cri-o/cri-o/test/mocks/criostorage"
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -18,11 +15,8 @@ func TestStorage(t *testing.T) {
 }
 
 var (
-	t               *TestFramework
-	mockCtrl        *gomock.Controller
-	storeMock       *containerstoragemock.MockStore
-	imageServerMock *criostoragemock.MockImageServer
-	testManifest    []byte
+	t            *TestFramework
+	testManifest []byte
 )
 
 var _ = BeforeSuite(func() {
@@ -34,14 +28,8 @@ var _ = BeforeSuite(func() {
 		[]byte(`{"schemaVersion": 1,"fsLayers":[{"blobSum": ""}],` +
 			`"history": [{"v1Compatibility": "{\"id\":\"e45a5af57b00862e5ef57` +
 			`82a9925979a02ba2b12dff832fd0991335f4a11e5c5\",\"parent\":\"\"}\n"}]}`)
-
-	// Setup the mocks
-	mockCtrl = gomock.NewController(GinkgoT())
-	storeMock = containerstoragemock.NewMockStore(mockCtrl)
-	imageServerMock = criostoragemock.NewMockImageServer(mockCtrl)
 })
 
 var _ = AfterSuite(func() {
 	t.Teardown()
-	mockCtrl.Finish()
 })

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -111,20 +111,6 @@ func (mr *MockImageServerMockRecorder) PullImage(arg0, arg1, arg2 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockImageServer)(nil).PullImage), arg0, arg1, arg2)
 }
 
-// RemoveImage mocks base method
-func (m *MockImageServer) RemoveImage(arg0 *types.SystemContext, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveImage", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveImage indicates an expected call of RemoveImage
-func (mr *MockImageServerMockRecorder) RemoveImage(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImage", reflect.TypeOf((*MockImageServer)(nil).RemoveImage), arg0, arg1)
-}
-
 // ResolveNames mocks base method
 func (m *MockImageServer) ResolveNames(arg0 *types.SystemContext, arg1 string) ([]string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Significantly rewritten the gomock-based tests in pkg/storage , to hopefully make it plausible to change the code base under test by making the test structure more readable.

**- How I did it**

See the individual commit messages for details.

(Resisted a _very serious_ temptation to just remove the tests; looking at the actual input parameters and control flow, they are, even after this fix, clearly not testing realistic scenarios, ignoring many values on input and returning nonsensical outputs. The computed code coverage is basically only good to confirm that it is possible not to crash on those lines.)

The most important idea is adding an `inOrder` helper, a more useful variant of `gomock.InOrder` that is composable; and based on that, creating a series of `mock$function` helpers that mirror the call stack of the implementation under test. For example, we can have a single `mockNewImage` call that sets up expectations for a series of calls to c/storage, and that can be reasoned about as a single unit.

Yes, this makes the test structure demonstrably very tightly coupled to the implementation (and implementation details of c/image/storage); but it was just as coupled before, only in a less visible way.

**- How to verify it**

Tests should continue to pass.  This does not touch non-test code, except for removing a dead method.

**- Description for the changelog**
N/A.