### PR TITLE
[1.9]  Add state of infracontainer to disk when stopped

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -538,9 +538,9 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 	if err := ctr.FromDisk(); err != nil {
 		return err
 	}
-	// ignore errors, this is a best effort to have up-to-date info about
-	// a given container before its state gets stored
-	c.runtime.UpdateStatus(ctr)
+	if err := c.runtime.UpdateStatus(ctr); err != nil {
+		return fmt.Errorf("error retrieving container state %q: %v", ctr.ID(), err)
+	}
 
 	return nil
 }
@@ -548,9 +548,11 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 // ContainerStateToDisk writes the container's state information to a JSON file
 // on disk
 func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
-	// ignore errors, this is a best effort to have up-to-date info about
+	// log errors as warning, this is a best effort to have up-to-date info about
 	// a given container before its state gets stored
-	c.Runtime().UpdateStatus(ctr)
+	if err := c.Runtime().UpdateStatus(ctr); err != nil {
+		logrus.Warnf("error updating the container status %q: %v", ctr.ID(), err)
+	}
 
 	jsonSource, err := ioutils.NewAtomicFileWriter(ctr.StatePath(), 0644)
 	if err != nil {

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -111,6 +111,7 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
 		logrus.Warnf("failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
+	s.ContainerStateToDisk(podInfraContainer)
 
 	sb.SetStopped()
 	resp = &pb.StopPodSandboxResponse{}


### PR DESCRIPTION
Add the state of the infracontainer when the pod is stopped.
This ensures that the pod is removed in a timely manner after
being stopped.

Changed up the path to match the current cri-o/cri-o repo path, hopefully tests will pass this way.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>