### PR TITLE
[1.11] Add state of infracontainer to disk when stopped

### DIFF
--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -121,6 +121,7 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
 		logrus.Warnf("failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
+	s.ContainerStateToDisk(podInfraContainer)
 
 	sb.SetStopped()
 	resp = &pb.StopPodSandboxResponse{}


### PR DESCRIPTION
Add the state of the infracontainer when the pod is stopped.
This ensures that the pod is removed in a timely manner after
being stopped.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>