### PR TITLE
[1.13] Add state of infracontainer to disk when stopped

### DIFF
--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -119,6 +119,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
 		logrus.Warnf("failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
+	s.ContainerStateToDisk(podInfraContainer)
 
 	logrus.Infof("Stopped pod sandbox: %s", podInfraContainer.Description())
 	sb.SetStopped()


### PR DESCRIPTION
Add the state of the infracontainer when the pod is stopped.
This ensures that the pod is removed in a timely manner after
being stopped.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
