### PR TITLE
Add state of infracontainer to disk when stopped

### DIFF
--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -135,6 +135,9 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
 		logrus.Warnf("failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
+	if err := s.ContainerStateToDisk(podInfraContainer); err != nil {
+		logrus.Warnf("error writing pod infra container %q state to disk: %v", podInfraContainer.ID(), err)
+	}
 
 	logrus.Infof("Stopped pod sandbox: %s", podInfraContainer.Description())
 	sb.SetStopped()

--- a/server/sandbox_stop_test.go
+++ b/server/sandbox_stop_test.go
@@ -38,6 +38,8 @@ var _ = t.Describe("PodSandboxStatus", func() {
 					gomock.Any()).Return(nil),
 				runtimeServerMock.EXPECT().StopContainer(gomock.Any()).
 					Return(nil),
+				ociRuntimeMock.EXPECT().UpdateContainerStatus(gomock.Any()).
+					Return(nil),
 			)
 
 			// When
@@ -65,6 +67,8 @@ var _ = t.Describe("PodSandboxStatus", func() {
 					gomock.Any()).Return(nil),
 				runtimeServerMock.EXPECT().StopContainer(gomock.Any()).
 					Return(t.TestError),
+				ociRuntimeMock.EXPECT().UpdateContainerStatus(gomock.Any()).
+					Return(nil),
 			)
 
 			// When


### PR DESCRIPTION
Add the state of the infracontainer when the pod is stopped.
This ensures that the pod is removed in a timely manner after
being stopped.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>