### PR TITLE
Search conmon executable in $PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ install: .gopathok install.bin install.man
 
 install.bin: binaries
 	install ${SELINUXOPT} -D -m 755 bin/crio $(BINDIR)/crio
-	install ${SELINUXOPT} -D -m 755 bin/conmon $(LIBEXECDIR)/crio/conmon
+	install ${SELINUXOPT} -D -m 755 bin/conmon $(BINDIR)/conmon
 	install ${SELINUXOPT} -D -m 755 bin/pause $(LIBEXECDIR)/crio/pause
 
 install.man: $(MANPAGES)
@@ -372,7 +372,7 @@ install.systemd:
 
 uninstall:
 	rm -f $(BINDIR)/crio
-	rm -f $(LIBEXECDIR)/crio/conmon
+	rm -f $(BINDIR)/conmon
 	rm -f $(LIBEXECDIR)/crio/pause
 	for i in $(filter %.5,$(MANPAGES)); do \
 		rm -f $(MANDIR)/man5/$$(basename $${i}); \

--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -108,6 +108,7 @@ default_runtime = "{{ .DefaultRuntime }}"
 no_pivot = {{ .NoPivot }}
 
 # Path to the conmon binary, used for monitoring the OCI runtime.
+# Will be searched for using $PATH if empty.
 conmon = "{{ .Conmon }}"
 
 # Cgroup setting for conmon

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -89,7 +89,7 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 
 **--config**="": path to configuration file
 
-**--conmon**="": path to the conmon executable (default: "/usr/local/libexec/crio/conmon")
+**--conmon**="": Path to the conmon binary, used for monitoring the OCI runtime. Will be searched for using $PATH if empty. (default: "")
 
 **--cpu-profile**="": set the CPU profile file path
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -80,8 +80,8 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **no_pivot**=*false*
   If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.
 
-**conmon**="/usr/local/libexec/crio/conmon"
-  Path to the conmon binary, used for monitoring the OCI runtime.
+**conmon**=""
+  Path to the conmon binary, used for monitoring the OCI runtime. Will be searched for using $PATH if empty.
 
 **conmon_env**=["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
   Environment variable list for the conmon process, used for passing necessary environment variables to conmon or the runtime.

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -402,7 +402,7 @@ func DefaultConfig() (*Config, error) {
 					RuntimeRoot: DefaultRuntimeRoot,
 				},
 			},
-			Conmon: conmonPath,
+			Conmon: "",
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
@@ -561,8 +561,9 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 			}
 		}
 
-		if _, err := os.Stat(c.Conmon); err != nil {
-			return errors.Wrapf(err, "invalid conmon path")
+		// Validate the conmon path
+		if err := c.ValidateConmonPath("conmon"); err != nil {
+			return errors.Wrapf(err, "conmon validation")
 		}
 	}
 
@@ -591,6 +592,24 @@ func (c *RuntimeConfig) ValidateRuntimePaths() error {
 		logrus.Debugf("found valid runtime %q for runtime_path %q",
 			runtime, handler.RuntimePath)
 	}
+	return nil
+}
+
+// ValidateConmonPath checks if `Conmon` is set within the `RuntimeConfig`.
+// If this is not the case, it tries to find it within the $PATH variable.
+// In any other case, it simply checks if `Conmon` is a valid file.
+func (c *RuntimeConfig) ValidateConmonPath(executable string) error {
+	if c.Conmon == "" {
+		conmon, err := exec.LookPath(executable)
+		if err != nil {
+			return err
+		}
+		c.Conmon = conmon
+		logrus.Debugf("using conmon from $PATH")
+	} else if _, err := os.Stat(c.Conmon); err != nil {
+		return errors.Wrapf(err, "invalid conmon path")
+	}
+	logrus.Infof("using conmon executable %q", c.Conmon)
 	return nil
 }
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -272,6 +272,53 @@ var _ = t.Describe("Config", func() {
 		})
 	})
 
+	t.Describe("ValidateConmonPath", func() {
+		It("should succeed with valid file in $PATH", func() {
+			// Given
+			sut.RuntimeConfig.Conmon = ""
+
+			// When
+			err := sut.RuntimeConfig.ValidateConmonPath(validFilePath)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.RuntimeConfig.Conmon).To(Equal(validFilePath))
+		})
+
+		It("should fail with invalid file in $PATH", func() {
+			// Given
+			sut.RuntimeConfig.Conmon = ""
+
+			// When
+			err := sut.RuntimeConfig.ValidateConmonPath(invalidPath)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should succeed with valid file outside $PATH", func() {
+			// Given
+			sut.RuntimeConfig.Conmon = validDirPath
+
+			// When
+			err := sut.RuntimeConfig.ValidateConmonPath("")
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should fail with invalid file outside $PATH", func() {
+			// Given
+			sut.RuntimeConfig.Conmon = invalidPath
+
+			// When
+			err := sut.RuntimeConfig.ValidateConmonPath("")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
 	t.Describe("ValidateNetworkConfig", func() {
 		It("should succeed with default config", func() {
 			// Given

--- a/lib/config/config_unix.go
+++ b/lib/config/config_unix.go
@@ -4,7 +4,6 @@ package config
 
 // Defaults for linux/unix if none are specified
 const (
-	conmonPath               = "/usr/local/libexec/crio/conmon"
 	cniConfigDir             = "/etc/cni/net.d/"
 	cniBinDir                = "/opt/cni/bin/"
 	lockPath                 = "/run/crio.lock"

--- a/lib/config/config_windows.go
+++ b/lib/config/config_windows.go
@@ -6,7 +6,6 @@ import "github.com/cri-o/cri-o/oci"
 
 // Defaults for linux/unix if none are specified
 const (
-	conmonPath               = "C:\\crio\\bin\\conmon"
 	cniConfigDir             = "C:\\cni\\etc\\net.d\\"
 	cniBinDir                = "C:\\cni\\bin\\"
 	lockPath                 = "C:\\crio\\run\\crio.lock"


### PR DESCRIPTION
If conmon in the config is empty or not available, we now search it
inside the $PATH variable before actually failing.

We could do the same for the runtimes, WDYT?