### PR TITLE
[1.14] enable inline exec and attach test

### DIFF
--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -11,7 +11,7 @@
         GINKGO_TOLERATE_FLAKES="y" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y /usr/bin/go run hack/e2e.go
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
-                        --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates|\[sig-storage\].In-tree.Volumes.\[Driver:.local\]|\[sig-storage\].CSI.Volumes.CSI.Topology.test.using.GCE.PD.driver
+                        --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates|\[sig-storage\].In-tree.Volumes.\[Driver:.local\]|\[sig-storage\].CSI.Volumes.CSI.Topology.test.using.GCE.PD.driver
                         --report-dir={{ artifacts }}"
             &> {{ artifacts }}/e2e.log
   # Fix vim syntax hilighting: "

--- a/oci/container.go
+++ b/oci/container.go
@@ -339,3 +339,8 @@ func (c *Container) SetStartFailed(err error) {
 func (c *Container) Description() string {
 	return fmt.Sprintf("%s/%s/%s", c.Labels()[types.KubernetesPodNamespaceLabel], c.Labels()[types.KubernetesPodNameLabel], c.Labels()[types.KubernetesContainerNameLabel])
 }
+
+// StdinOnce returns whether stdin once is set for the container.
+func (c *Container) StdinOnce() bool {
+	return c.stdinOnce
+}

--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -740,6 +740,9 @@ func (r *runtimeOCI) AttachContainer(c *Container, inputStream io.Reader, output
 	case err := <-receiveStdout:
 		return err
 	case err := <-stdinDone:
+		if !c.StdinOnce() && !tty {
+			return nil
+		}
 		if _, ok := err.(utils.DetachError); ok {
 			return nil
 		}


### PR DESCRIPTION
Detach automatically on stdin EOF for a non-tty attach when stdin Once is not set.
Forward port of https://github.com/cri-o/cri-o/pull/2129
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1723295

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

Signed-off-by: Peter Hunt <pehunt@redhat.com>