### PR TITLE
[1.14] Fix up machine os content version and cri-o version in spec

### DIFF
--- a/contrib/test/ci/cri-o.spec
+++ b/contrib/test/ci/cri-o.spec
@@ -32,7 +32,7 @@
 %global service_name crio
 
 Name: %{repo}
-Version: 1.14
+Version: 1.14.0
 Release: 1.ci%{?dist}
 Summary: Kubernetes Container Runtime Interface for OCI-based containers
 License: ASL 2.0

--- a/images/os/Dockerfile
+++ b/images/os/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:29 AS build
 
-COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-content /srv/ /srv/
+COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.2:machine-os-content /srv/ /srv/
 RUN set -x && yum install -y ostree yum-utils selinux-policy-targeted && \
     commit=$( find /srv -name *.commit | sed -Ee 's|.*objects/(.+)/(.+)\.commit|\1\2|' | head -1 ) && \
     mkdir /tmp/working && cd /tmp/working && \


### PR DESCRIPTION
We fail if the cri-o version for 1.14 does not match a certain
pattern.
Use the 4.2 machine os content image for the ci.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>