### PR TITLE
Bump up minMemoryLimit to 12Mb

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -36,7 +36,7 @@ import (
 
 // minMemoryLimit is the minimum memory that must be set for a container.
 // A lower value would result in the container failing to start.
-const minMemoryLimit = 4194304
+const minMemoryLimit = 12582912
 
 type configDevice struct {
 	Device   rspec.LinuxDevice

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -262,7 +262,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 
 		It("should succeed with systemd manager with valid memory ", func() {
 			// Given
-			cgroup, tmpDir := prepareCgroupDirs(0644, "5000000")
+			cgroup, tmpDir := prepareCgroupDirs(0644, "13000000")
 
 			// When
 			res, err := server.AddCgroupAnnotation(g, tmpDir,


### PR DESCRIPTION
Bump up the minimum memory limit allowed for running containers
from 4Mb to 12Mb.

Will backport to 1.14 and 1.13 as well.
For https://bugzilla.redhat.com/show_bug.cgi?id=1705322

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

