### PR TITLE
[1.14] Bump up minMemoryLimit to 12Mb

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -36,7 +36,7 @@ import (
 
 // minMemoryLimit is the minimum memory that must be set for a container.
 // A lower value would result in the container failing to start.
-const minMemoryLimit = 4194304
+const minMemoryLimit = 12582912
 
 type configDevice struct {
 	Device   rspec.LinuxDevice


### PR DESCRIPTION
Bump up the minimum memory limit allowed for running containers
from 4Mb to 12Mb.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>