### PR TITLE
Only enable circleCI on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,9 @@ workflows:
 
 jobs:
   build:
+    branches:
+      only:
+        - master
     executor: docker
     steps:
       - checkout


### PR DESCRIPTION
Until we add support on other branches
(I'm not sure this will actually fix the problems in the other branches, because they have no config at all...)

Signed-off-by: Peter Hunt <pehunt@redhat.com>