### PR TITLE
[1.14] Backport empty CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+---
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: alpine:latest
+    steps:
+      - run:
+          name: Noop
+          command: exit 0


### PR DESCRIPTION
We now add a stub that CircleCi does not complain any more.