### PR TITLE
Discover runtimePath from $PATH environment

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -125,7 +125,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) (string, error) {
 			if len(fields) != 3 {
 				return path, fmt.Errorf("wrong format for --runtimes: %q", r)
 			}
-			config.Runtimes[fields[0]] = libconfig.RuntimeHandler{
+			config.Runtimes[fields[0]] = &libconfig.RuntimeHandler{
 				RuntimePath: fields[1],
 				RuntimeRoot: fields[2],
 			}

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -114,10 +114,7 @@ func New(ctx context.Context, systemContext *types.SystemContext, configIface li
 
 	storageRuntimeService := storage.GetRuntimeService(ctx, imageService)
 
-	runtime, err := oci.New(config)
-	if err != nil {
-		return nil, err
-	}
+	runtime := oci.New(config)
 
 	var lock sync.Locker
 	if config.FileLocking {

--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -10,37 +10,16 @@ import (
 // The actual test suite
 var _ = t.Describe("Oci", func() {
 	t.Describe("New", func() {
-		It("should succeed with default runtime", func() {
+		It("should succeed with default config", func() {
 			// Given
 			c, err := config.DefaultConfig()
 			Expect(err).To(BeNil())
-			c.Runtimes = map[string]config.RuntimeHandler{"runc": {
-				RuntimePath: "/bin/sh",
-				RuntimeType: "",
-				RuntimeRoot: "/run/runc",
-			}}
-			c.DefaultRuntime = "runc"
 
 			// When
-			runtime, err := oci.New(c)
+			runtime := oci.New(c)
 
 			// Then
-			Expect(err).To(BeNil())
 			Expect(runtime).NotTo(BeNil())
-		})
-
-		It("should fail if no runtime configured for default runtime", func() {
-			// Given
-			c, err := config.DefaultConfig()
-			Expect(err).To(BeNil())
-			c.DefaultRuntime = ""
-
-			// When
-			runtime, err := oci.New(c)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(runtime).To(BeNil())
 		})
 	})
 
@@ -53,7 +32,7 @@ var _ = t.Describe("Oci", func() {
 			invalidRuntime = "invalid"
 			defaultRuntime = "runc"
 		)
-		runtimes := map[string]config.RuntimeHandler{
+		runtimes := config.Runtimes{
 			defaultRuntime: {
 				RuntimePath: "/bin/sh",
 				RuntimeType: "",
@@ -67,8 +46,7 @@ var _ = t.Describe("Oci", func() {
 			c.DefaultRuntime = defaultRuntime
 			c.Runtimes = runtimes
 
-			sut, err = oci.New(c)
-			Expect(err).To(BeNil())
+			sut = oci.New(c)
 			Expect(sut).NotTo(BeNil())
 		})
 
@@ -89,36 +67,6 @@ var _ = t.Describe("Oci", func() {
 			// Then
 			Expect(err).To(BeNil())
 			Expect(handler).To(Equal(runtimes[defaultRuntime]))
-		})
-
-		It("should fail to validate an inexisting runtime handler", func() {
-			// Given
-			// When
-			handler, err := sut.ValidateRuntimeHandler("not_existing")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(handler).To(Equal(config.RuntimeHandler{}))
-		})
-
-		It("should fail to validate an invalid runtime path", func() {
-			// Given
-			// When
-			handler, err := sut.ValidateRuntimeHandler(invalidRuntime)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(handler).To(Equal(config.RuntimeHandler{}))
-		})
-
-		It("should fail to validate an empty runtime handler", func() {
-			// Given
-			// When
-			handler, err := sut.ValidateRuntimeHandler("")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(handler).To(Equal(config.RuntimeHandler{}))
 		})
 	})
 

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -141,7 +141,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed with runtime cheks", func() {
 			// Given
-			sut.Runtimes["runc"] = config.RuntimeHandler{RuntimePath: validPath}
+			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validPath}
 			sut.Conmon = validPath
 			tmpDir := t.MustTempDir("cni-test")
 			sut.NetworkConfig.PluginDirs = []string{tmpDir}
@@ -157,7 +157,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail with invalid network configuration", func() {
 			// Given
-			sut.Runtimes["runc"] = config.RuntimeHandler{RuntimePath: validPath}
+			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validPath}
 			sut.Conmon = validPath
 			sut.PluginDirs = []string{validPath}
 			sut.NetworkConfig.NetworkDir = wrongPath

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -251,7 +251,7 @@ func createDummyState() {
 }
 
 func mockRuncInLibConfig() {
-	libConfig.Runtimes["runc"] = config.RuntimeHandler{
+	libConfig.Runtimes["runc"] = &config.RuntimeHandler{
 		RuntimePath: "/bin/echo",
 	}
 }


### PR DESCRIPTION
The default runtime path for `runc` is now `""` and we discover the
executable directly from the local $PATH environment. Is it nevertheless
possible to set the `runtime_path` directly, where we still test for
existence on runtime.

The validation of the runtime handlers within `oci.go` has been cleaned
up, to bring back the matter of concerns to `config.go`. We now use
pointers to easily update the runtime handlers during validation, where
a new type `Runtimes` got introduced.

All tests have been adapted as well.