### PR TITLE
c/image API use cleanups

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -270,15 +270,7 @@ func (svc *imageService) ImageStatus(systemContext *types.SystemContext, nameOrI
 	if err != nil {
 		return nil, err
 	}
-	imageFull, err := ref.NewImage(svc.ctx, systemContext)
-	if err != nil {
-		return nil, err
-	}
-	defer imageFull.Close()
-
-	size := imageSize(imageFull)
-	configDigest := imageFull.ConfigInfo().Digest
-	imageConfig, err := imageFull.OCIConfig(svc.ctx)
+	cacheItem, err := svc.buildImageCacheItem(systemContext, ref) // Single-use-only, not actually cached
 	if err != nil {
 		return nil, err
 	}
@@ -290,10 +282,10 @@ func (svc *imageService) ImageStatus(systemContext *types.SystemContext, nameOrI
 		Name:         name,
 		RepoTags:     tags,
 		RepoDigests:  repoDigests,
-		Size:         size,
+		Size:         cacheItem.size,
 		Digest:       imageDigest,
-		ConfigDigest: configDigest,
-		User:         imageConfig.Config.User,
+		ConfigDigest: cacheItem.configDigest,
+		User:         cacheItem.user,
 	}
 
 	return &result, nil

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"path"
 	"strings"
 	"sync"
 
@@ -522,7 +521,7 @@ func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageN
 		if r == "docker.io" && !strings.ContainsRune(remainder, '/') {
 			rem = "library/" + rem
 		}
-		image := path.Join(r, rem)
+		image := r + "/" + rem
 		registry, err := sysregistriesv2.FindRegistry(systemContext, image)
 		if err != nil {
 			return nil, err

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -291,9 +291,8 @@ func imageSize(img types.Image) *uint64 {
 	return nil
 }
 
-// prepareReference creates an image reference from an image string and set options
-// for the source context
-func (svc *imageService) prepareReference(imageName string, options *copy.Options) (types.ImageReference, error) {
+// remoteImageReference creates an image reference from an image string
+func (svc *imageService) remoteImageReference(imageName string) (types.ImageReference, error) {
 	if imageName == "" {
 		return nil, storage.ErrNotAnImage
 	}
@@ -308,6 +307,16 @@ func (svc *imageService) prepareReference(imageName string, options *copy.Option
 			return nil, err
 		}
 		srcRef = srcRef2
+	}
+	return srcRef, nil
+}
+
+// prepareReference creates an image reference from an image string and set options
+// for the source context
+func (svc *imageService) prepareReference(imageName string, options *copy.Options) (types.ImageReference, error) {
+	srcRef, err := svc.remoteImageReference(imageName)
+	if err != nil {
+		return nil, err
 	}
 
 	if options.SourceCtx == nil {
@@ -380,7 +389,7 @@ func (svc *imageService) UntagImage(systemContext *types.SystemContext, nameOrID
 	}
 
 	if !strings.HasPrefix(img.ID, nameOrID) {
-		namedRef, err := svc.prepareReference(nameOrID, &copy.Options{})
+		namedRef, err := svc.remoteImageReference(nameOrID)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -130,15 +130,11 @@ func sortNamesByType(names []string) (bestName string, tags, digests []string) {
 	return bestName, tags, digests
 }
 
-func (svc *imageService) makeRepoDigests(knownRepoDigests, tags []string, imageID string) (imageDigest digest.Digest, repoDigests []string) {
+func (svc *imageService) makeRepoDigests(knownRepoDigests, tags []string, img *storage.Image) (imageDigest digest.Digest, repoDigests []string) {
 	// Look up the image's digest.
-	img, err := svc.store.Image(imageID)
-	if err != nil {
-		return "", knownRepoDigests
-	}
 	imageDigest = img.Digest
 	if imageDigest == "" {
-		imgDigest, err := svc.store.ImageBigDataDigest(imageID, storage.ImageDigestBigDataKey)
+		imgDigest, err := svc.store.ImageBigDataDigest(img.ID, storage.ImageDigestBigDataKey)
 		if err != nil || imgDigest == "" {
 			return "", knownRepoDigests
 		}
@@ -212,7 +208,7 @@ func (svc *imageService) appendCachedResult(systemContext *types.SystemContext, 
 	}
 
 	name, tags, digests := sortNamesByType(image.Names)
-	imageDigest, repoDigests := svc.makeRepoDigests(digests, tags, image.ID)
+	imageDigest, repoDigests := svc.makeRepoDigests(digests, tags, image)
 	return append(results, ImageResult{
 		ID:           image.ID,
 		Name:         name,
@@ -288,7 +284,7 @@ func (svc *imageService) ImageStatus(systemContext *types.SystemContext, nameOrI
 	}
 
 	name, tags, digests := sortNamesByType(image.Names)
-	imageDigest, repoDigests := svc.makeRepoDigests(digests, tags, image.ID)
+	imageDigest, repoDigests := svc.makeRepoDigests(digests, tags, image)
 	result := ImageResult{
 		ID:           image.ID,
 		Name:         name,

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -165,14 +165,12 @@ func (svc *imageService) makeRepoDigests(knownRepoDigests, tags []string, imageI
 	// For each tagged name, parse the name, and if we can extract a named reference, convert
 	// it into a canonical reference using the digest and add it to the list.
 	for _, tag := range tags {
-		if ref, err2 := reference.ParseAnyReference(tag); err2 == nil {
-			if name, ok := ref.(reference.Named); ok {
-				trimmed := reference.TrimNamed(name)
-				if imageRef, err3 := reference.WithDigest(trimmed, imageDigest); err3 == nil {
-					if _, ok := digestMap[imageRef.String()]; !ok {
-						repoDigests = append(repoDigests, imageRef.String())
-						digestMap[imageRef.String()] = struct{}{}
-					}
+		if name, err2 := reference.ParseNormalizedNamed(tag); err2 == nil {
+			trimmed := reference.TrimNamed(name)
+			if imageRef, err3 := reference.WithDigest(trimmed, imageDigest); err3 == nil {
+				if _, ok := digestMap[imageRef.String()]; !ok {
+					repoDigests = append(repoDigests, imageRef.String())
+					digestMap[imageRef.String()] = struct{}{}
 				}
 			}
 		}

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -414,13 +414,7 @@ func (svc *imageService) PullImage(systemContext *types.SystemContext, imageName
 
 	dest := imageName
 	if srcRef.DockerReference() != nil {
-		dest = srcRef.DockerReference().Name()
-		if tagged, ok := srcRef.DockerReference().(reference.NamedTagged); ok {
-			dest = dest + ":" + tagged.Tag()
-		}
-		if canonical, ok := srcRef.DockerReference().(reference.Canonical); ok {
-			dest = dest + "@" + canonical.Digest().String()
-		}
+		dest = srcRef.DockerReference().String()
 	}
 	destRef, err := istorage.Transport.ParseStoreReference(svc.store, dest)
 	if err != nil {
@@ -451,13 +445,7 @@ func (svc *imageService) UntagImage(systemContext *types.SystemContext, nameOrID
 
 		name := nameOrID
 		if namedRef.DockerReference() != nil {
-			name = namedRef.DockerReference().Name()
-			if tagged, ok := namedRef.DockerReference().(reference.NamedTagged); ok {
-				name = name + ":" + tagged.Tag()
-			}
-			if canonical, ok := namedRef.DockerReference().(reference.Canonical); ok {
-				name = name + "@" + canonical.Digest().String()
-			}
+			name = namedRef.DockerReference().String()
 		}
 
 		prunedNames := make([]string, 0, len(img.Names))

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -350,10 +350,7 @@ func (svc *imageService) PullImage(systemContext *types.SystemContext, imageName
 		return nil, err
 	}
 
-	options := copy.Options{}
-	if inputOptions != nil {
-		options = *inputOptions // A shallow copy
-	}
+	options := *inputOptions // A shallow copy
 	srcSystemContext, srcRef, err := svc.prepareReference(options.SourceCtx, imageName)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -326,7 +326,7 @@ func (svc *imageService) prepareReference(imageName string, options *copy.Option
 	if srcRef.DockerReference() != nil {
 		hostname := reference.Domain(srcRef.DockerReference())
 		if secure := svc.isSecureIndex(hostname); !secure {
-			options.SourceCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!secure)
+			options.SourceCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
 		}
 	}
 	return srcRef, nil

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -352,7 +352,7 @@ var _ = t.Describe("Image", func() {
 							"localhost/b@sha256:" + testSHA256,
 							"localhost/c:latest"},
 					}, nil),
-
+				// buildImageCacheItem
 				mockNewImage(storeMock, testNormalizedImageName, testSHA256),
 				// makeRepoDigests
 				storeMock.EXPECT().ImageBigDataDigest(testSHA256, gomock.Any()).
@@ -397,8 +397,7 @@ var _ = t.Describe("Image", func() {
 			inOrder(
 				mockGetRef(),
 				mockGetStoreImage(storeMock, testNormalizedImageName, testSHA256),
-
-				// storageReference.NewImage fails reading the manifest:
+				// In buildImageCacheItem, storageReference.NewImage fails reading the manifest:
 				mockResolveImage(storeMock, testNormalizedImageName, testSHA256),
 				storeMock.EXPECT().ImageBigData(testSHA256, gomock.Any()).
 					Return(nil, t.TestError),

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -355,8 +355,6 @@ var _ = t.Describe("Image", func() {
 
 				mockNewImage(storeMock, testNormalizedImageName, testSHA256),
 				// makeRepoDigests
-				storeMock.EXPECT().Image(testSHA256).
-					Return(&cs.Image{ID: testImageName}, nil),
 				storeMock.EXPECT().ImageBigDataDigest(testSHA256, gomock.Any()).
 					Return(digest.Digest("a:"+testSHA256), nil),
 			)
@@ -437,8 +435,6 @@ var _ = t.Describe("Image", func() {
 					// buildImageCacheItem:
 					mockNewImage(storeMock, testSHA256, testSHA256),
 					// makeRepoDigests:
-					storeMock.EXPECT().Image(testSHA256).
-						Return(&cs.Image{ID: testImageName}, nil),
 					storeMock.EXPECT().ImageBigDataDigest(testSHA256, gomock.Any()).
 						Return(digest.Digest(""), nil),
 				)
@@ -471,10 +467,8 @@ var _ = t.Describe("Image", func() {
 				// buildImageCacheItem:
 				mockNewImage(storeMock, testNormalizedImageName, testSHA256),
 				// makeRepoDigests:
-				storeMock.EXPECT().Image(testSHA256).
-					Return(&cs.Image{ID: testImageName,
-						Names:  []string{"a", "b", "c"},
-						Digest: "digest"}, nil),
+				storeMock.EXPECT().ImageBigDataDigest(testSHA256, gomock.Any()).
+					Return(digest.Digest(""), nil),
 			)
 
 			// When

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -582,7 +582,7 @@ var _ = t.Describe("Image", func() {
 			const imageName = "tarball:../../test/testdata/image.tar"
 
 			// When
-			res, err := sut.PrepareImage(imageName, &copy.Options{})
+			res, err := sut.PrepareImage(&types.SystemContext{}, imageName)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -592,7 +592,7 @@ var _ = t.Describe("Image", func() {
 		It("should fail on invalid image name", func() {
 			// Given
 			// When
-			res, err := sut.PrepareImage("", &copy.Options{})
+			res, err := sut.PrepareImage(&types.SystemContext{}, "")
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/pkg/storage/image_test.go
+++ b/pkg/storage/image_test.go
@@ -68,8 +68,6 @@ var _ = t.Describe("Image", func() {
 		return inOrder(
 			// NewImageSource:
 			mockResolveImage(storeMock, expectedImageNameOrID, testSHA256),
-			// imageSize:
-			mockStorageImageSourceGetSize(storeMock),
 			// imageConfigDigest calling storageImageSource.GetManifest:
 			storeMock.EXPECT().ImageBigData(testSHA256, gomock.Any()).
 				Return(testManifest, nil),
@@ -369,8 +367,6 @@ var _ = t.Describe("Image", func() {
 				mockNewImage(storeMock, testNormalizedImageName, testSHA256),
 				// NewImageSource:
 				mockResolveImage(storeMock, testNormalizedImageName, testSHA256),
-				// imageSize:
-				mockStorageImageSourceGetSize(storeMock),
 				// imageConfigDigest calling storageImageSource.GetManifest:
 				storeMock.EXPECT().ImageBigData(gomock.Any(), gomock.Any()).
 					Return(testManifest, nil),
@@ -442,8 +438,6 @@ var _ = t.Describe("Image", func() {
 				mockNewImage(storeMock, testNormalizedImageName, testSHA256),
 				// NewImageSource:
 				mockResolveImage(storeMock, testNormalizedImageName, testSHA256),
-				// imageSize:
-				mockStorageImageSourceGetSize(storeMock),
 				// imageConfigDigest calling storageImageSource.GetManifest:
 				storeMock.EXPECT().ImageBigData(testSHA256, gomock.Any()).
 					Return(nil, t.TestError),

--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -88,7 +88,7 @@ type RuntimeServer interface {
 	// CreateContainer creates a container with the specified ID.
 	// Pointer arguments can be nil.  Either the image name or ID can be
 	// omitted, but not both.  All other arguments are required.
-	CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, containerID, metadataName string, attempt uint32, idMappings *idtools.IDMappings, labelOptions []string) (ContainerInfo, error)
+	CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, idMappings *idtools.IDMappings, labelOptions []string) (ContainerInfo, error)
 	// DeleteContainer deletes a container, unmounting it first if need be.
 	DeleteContainer(idOrName string) error
 
@@ -349,8 +349,8 @@ func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, po
 	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, podID, metadataName, uid, namespace, attempt, idMappings, labelOptions, true)
 }
 
-func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, containerID, metadataName string, attempt uint32, idMappings *idtools.IDMappings, labelOptions []string) (ContainerInfo, error) {
-	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, containerID, metadataName, "", "", attempt, idMappings, labelOptions, false)
+func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, idMappings *idtools.IDMappings, labelOptions []string) (ContainerInfo, error) {
+	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, "", imageID, containerName, containerID, metadataName, "", "", attempt, idMappings, labelOptions, false)
 }
 
 func (r *runtimeService) RemovePodSandbox(idOrName string) error {

--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -169,7 +169,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		// Maybe it's some other transport's copy of the image?
 		otherRef, err2 := alltransports.ParseImageName(imageName)
 		if err2 == nil && otherRef.DockerReference() != nil {
-			ref, err = istorage.Transport.ParseStoreReference(r.storageImageServer.GetStore(), otherRef.DockerReference().Name())
+			ref, err = istorage.Transport.ParseStoreReference(r.storageImageServer.GetStore(), otherRef.DockerReference().String())
 		}
 		if err != nil {
 			// Maybe the image ID is sufficient?

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -564,7 +564,7 @@ var _ = t.Describe("Runtime", func() {
 			It("should succeed to create a container", func() {
 				// When
 				info, err = sut.CreateContainer(&types.SystemContext{},
-					"podName", "podID", "imagename", "",
+					"podName", "podID", "imagename",
 					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 					"containerName", "containerID", "",
 					0, &idtools.IDMappings{}, []string{"mountLabel"})
@@ -594,7 +594,7 @@ var _ = t.Describe("Runtime", func() {
 			// Given
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
-				"podName", "", "imagename", "",
+				"podName", "", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
 				0, &idtools.IDMappings{}, []string{"mountLabel"})
@@ -608,7 +608,7 @@ var _ = t.Describe("Runtime", func() {
 			// Given
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
-				"", "podID", "imagename", "",
+				"", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
 				0, &idtools.IDMappings{}, []string{"mountLabel"})
@@ -622,7 +622,7 @@ var _ = t.Describe("Runtime", func() {
 			// Given
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
-				"podName", "podID", "", "", "",
+				"podName", "podID", "", "",
 				"containerName", "containerID", "metadataName",
 				0, &idtools.IDMappings{}, []string{"mountLabel"})
 
@@ -635,7 +635,7 @@ var _ = t.Describe("Runtime", func() {
 			// Given
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
-				"podName", "podID", "imagename", "", "imageID",
+				"podName", "podID", "imagename", "imageID",
 				"", "containerID", "metadataName",
 				0, &idtools.IDMappings{}, []string{"mountLabel"})
 
@@ -667,7 +667,7 @@ var _ = t.Describe("Runtime", func() {
 
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
-				"podName", "podID", "imagename", "",
+				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
 				0, &idtools.IDMappings{}, []string{"mountLabel"})
@@ -696,7 +696,7 @@ var _ = t.Describe("Runtime", func() {
 
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
-				"podName", "podID", "imagename", "",
+				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
 				0, &idtools.IDMappings{}, []string{"mountLabel"})
@@ -788,7 +788,7 @@ var _ = t.Describe("Runtime", func() {
 
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
-				"podName", "podID", "imagename", "",
+				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
 				0, &idtools.IDMappings{}, []string{"mountLabel"})
@@ -816,7 +816,7 @@ var _ = t.Describe("Runtime", func() {
 
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
-				"podName", "podID", "imagename", "",
+				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
 				0, &idtools.IDMappings{}, []string{"mountLabel"})

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -867,7 +867,10 @@ var _ = t.Describe("Runtime", func() {
 			Expect(sut).NotTo(BeNil())
 
 			// Given
-			mockCreatePodSandboxExpectingCopyOptions(&copy.Options{SourceCtx: &types.SystemContext{}})
+			mockCreatePodSandboxExpectingCopyOptions(&copy.Options{
+				SourceCtx:      &types.SystemContext{},
+				DestinationCtx: &types.SystemContext{},
+			})
 
 			// When
 			info, err = sut.CreatePodSandbox(&types.SystemContext{},
@@ -883,7 +886,10 @@ var _ = t.Describe("Runtime", func() {
 			Expect(sut).NotTo(BeNil())
 
 			// Given
-			mockCreatePodSandboxExpectingCopyOptions(&copy.Options{SourceCtx: &types.SystemContext{AuthFilePath: "/var/non-default/credentials.json"}})
+			mockCreatePodSandboxExpectingCopyOptions(&copy.Options{
+				SourceCtx:      &types.SystemContext{AuthFilePath: "/var/non-default/credentials.json"},
+				DestinationCtx: &types.SystemContext{},
+			})
 
 			// When
 			info, err = sut.CreatePodSandbox(&types.SystemContext{},

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -345,7 +345,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 
 	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.systemContext,
 		sb.Name(), sb.ID(),
-		image, s.config.GlobalAuthFile, imgResult.ID,
+		image, "", imgResult.ID,
 		containerName, containerID,
 		metadata.Name,
 		metadata.Attempt,

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -345,7 +345,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 
 	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.systemContext,
 		sb.Name(), sb.ID(),
-		image, "", imgResult.ID,
+		image, imgResult.ID,
 		containerName, containerID,
 		metadata.Name,
 		metadata.Attempt,

--- a/server/container_create_test.go
+++ b/server/container_create_test.go
@@ -38,7 +38,7 @@ var _ = t.Describe("ContainerCreate", func() {
 				runtimeServerMock.EXPECT().CreateContainer(
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(storage.ContainerInfo{
 						Config: &v1.Image{}}, nil),
 				runtimeServerMock.EXPECT().StartContainer(gomock.Any()).

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -66,12 +66,8 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 			}
 		}
 
-		options := &copy.Options{
-			SourceCtx: &sourceCtx,
-		}
-
 		var tmpImg types.ImageCloser
-		tmpImg, err = s.StorageImageServer().PrepareImage(img, options)
+		tmpImg, err = s.StorageImageServer().PrepareImage(&sourceCtx, img)
 		if err != nil {
 			logrus.Debugf("error preparing image %s: %v", img, err)
 			continue
@@ -94,7 +90,9 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 			logrus.Debugf("image in store has different ID, re-pulling %s", img)
 		}
 
-		_, err = s.StorageImageServer().PullImage(s.systemContext, img, options)
+		_, err = s.StorageImageServer().PullImage(s.systemContext, img, &copy.Options{
+			SourceCtx: &sourceCtx,
+		})
 		if err != nil {
 			logrus.Debugf("error pulling image %s: %v", img, err)
 			continue

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -40,7 +40,6 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 	}
 	for _, img := range images {
 		sourceCtx := *s.systemContext // A shallow copy we can modify
-		sourceCtx.DockerRegistryUserAgent = useragent.Get(ctx)
 		sourceCtx.AuthFilePath = s.config.GlobalAuthFile
 
 		if req.GetAuth() != nil {

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -91,7 +91,8 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 		}
 
 		_, err = s.StorageImageServer().PullImage(s.systemContext, img, &copy.Options{
-			SourceCtx: &sourceCtx,
+			SourceCtx:      &sourceCtx,
+			DestinationCtx: s.systemContext,
 		})
 		if err != nil {
 			logrus.Debugf("error pulling image %s: %v", img, err)

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -39,13 +39,13 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 		return nil, err
 	}
 	for _, img := range images {
-		var (
-			username string
-			password string
-		)
+		sourceCtx := *s.systemContext // A shallow copy we can modify
+		sourceCtx.DockerRegistryUserAgent = useragent.Get(ctx)
+		sourceCtx.AuthFilePath = s.config.GlobalAuthFile
+
 		if req.GetAuth() != nil {
-			username = req.GetAuth().Username
-			password = req.GetAuth().Password
+			username := req.GetAuth().Username
+			password := req.GetAuth().Password
 			if req.GetAuth().Auth != "" {
 				username, password, err = decodeDockerAuth(req.GetAuth().Auth)
 				if err != nil {

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -54,20 +54,20 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 				}
 			}
 		}
-		options := &copy.Options{
-			SourceCtx: &types.SystemContext{
-				DockerRegistryUserAgent: useragent.Get(ctx),
-				SignaturePolicyPath:     s.systemContext.SignaturePolicyPath,
-				AuthFilePath:            s.config.GlobalAuthFile,
-			},
-		}
+		sourceCtx := *s.systemContext // A shallow copy we can modify
+		sourceCtx.DockerRegistryUserAgent = useragent.Get(ctx)
+		sourceCtx.AuthFilePath = s.config.GlobalAuthFile
 
 		// Specifying a username indicates the user intends to send authentication to the registry.
 		if username != "" {
-			options.SourceCtx.DockerAuthConfig = &types.DockerAuthConfig{
+			sourceCtx.DockerAuthConfig = &types.DockerAuthConfig{
 				Username: username,
 				Password: password,
 			}
+		}
+
+		options := &copy.Options{
+			SourceCtx: &sourceCtx,
 		}
 
 		var tmpImg types.ImageCloser

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -40,7 +40,6 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 	}
 	for _, img := range images {
 		sourceCtx := *s.systemContext // A shallow copy we can modify
-		sourceCtx.AuthFilePath = s.config.GlobalAuthFile
 
 		if req.GetAuth() != nil {
 			username := req.GetAuth().Username

--- a/server/image_pull_test.go
+++ b/server/image_pull_test.go
@@ -132,12 +132,6 @@ var _ = t.Describe("ImagePull", func() {
 
 		It("should fail credential decode erros", func() {
 			// Given
-			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(
-					gomock.Any(), gomock.Any()).
-					Return([]string{"image"}, nil),
-			)
-
 			// When
 			response, err := sut.PullImage(context.Background(),
 				&pb.PullImageRequest{

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -83,12 +83,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}()
 
-	var imageAuthFile string
-	if s.config.PauseImageAuthFile != "" {
-		imageAuthFile = s.config.PauseImageAuthFile
-	} else {
-		imageAuthFile = s.config.GlobalAuthFile
-	}
 	var labelOptions []string
 	securityContext := req.GetConfig().GetLinux().GetSecurityContext()
 	selinuxConfig := securityContext.GetSelinuxOptions()
@@ -98,7 +92,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	podContainer, err := s.StorageRuntimeServer().CreatePodSandbox(s.systemContext,
 		name, id,
 		s.config.PauseImage,
-		imageAuthFile,
+		s.config.PauseImageAuthFile,
 		"",
 		containerName,
 		req.GetConfig().GetMetadata().GetName(),

--- a/server/server.go
+++ b/server/server.go
@@ -313,6 +313,7 @@ func New(
 	}
 	systemContext = &sc
 
+	systemContext.AuthFilePath = config.GlobalAuthFile
 	systemContext.DockerRegistryUserAgent = useragent.Get(ctx)
 	systemContext.SignaturePolicyPath = config.SignaturePolicyPath
 

--- a/server/server.go
+++ b/server/server.go
@@ -76,7 +76,7 @@ type Server struct {
 	*lib.ContainerServer
 	monitorsChan      chan struct{}
 	defaultIDMappings *idtools.IDMappings
-	systemContext     *types.SystemContext
+	systemContext     *types.SystemContext // Never nil
 
 	updateLock sync.RWMutex
 
@@ -305,10 +305,13 @@ func New(
 	}
 	config := configIface.GetData()
 
-	// Setup the system context if not provided
-	if systemContext == nil {
-		systemContext = &types.SystemContext{}
+	// Make a copy of systemContext we can safely modify, and which is never nil. (Note that this is a shallow copy!)
+	sc := types.SystemContext{}
+	if systemContext != nil {
+		sc = *systemContext
 	}
+	systemContext = &sc
+
 	systemContext.SignaturePolicyPath = config.SignaturePolicyPath
 
 	if err := os.MkdirAll(config.ContainerAttachSocketDir, 0755); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cri-o/cri-o/pkg/signals"
 	"github.com/cri-o/cri-o/pkg/storage"
 	"github.com/cri-o/cri-o/server/metrics"
+	"github.com/cri-o/cri-o/server/useragent"
 	"github.com/cri-o/cri-o/version"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/fsnotify/fsnotify"
@@ -312,6 +313,7 @@ func New(
 	}
 	systemContext = &sc
 
+	systemContext.DockerRegistryUserAgent = useragent.Get(ctx)
 	systemContext.SignaturePolicyPath = config.SignaturePolicyPath
 
 	if err := os.MkdirAll(config.ContainerAttachSocketDir, 0755); err != nil {

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -164,18 +164,18 @@ func (m *MockRuntimeServer) EXPECT() *MockRuntimeServerMockRecorder {
 }
 
 // CreateContainer mocks base method
-func (m *MockRuntimeServer) CreateContainer(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 string, arg9 uint32, arg10 *idtools.IDMappings, arg11 []string) (storage0.ContainerInfo, error) {
+func (m *MockRuntimeServer) CreateContainer(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7 string, arg8 uint32, arg9 *idtools.IDMappings, arg10 []string) (storage0.ContainerInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
+	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 	ret0, _ := ret[0].(storage0.ContainerInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateContainer indicates an expected call of CreateContainer
-func (mr *MockRuntimeServerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11 interface{}) *gomock.Call {
+func (mr *MockRuntimeServerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockRuntimeServer)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockRuntimeServer)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 }
 
 // CreatePodSandbox mocks base method

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -82,7 +82,7 @@ func (mr *MockImageServerMockRecorder) ListImages(arg0, arg1 interface{}) *gomoc
 }
 
 // PrepareImage mocks base method
-func (m *MockImageServer) PrepareImage(arg0 string, arg1 *copy.Options) (types.ImageCloser, error) {
+func (m *MockImageServer) PrepareImage(arg0 *types.SystemContext, arg1 string) (types.ImageCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareImage", arg0, arg1)
 	ret0, _ := ret[0].(types.ImageCloser)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,16 +89,15 @@ github.com/containers/image/types
 github.com/containers/image/pkg/sysregistriesv2
 github.com/containers/image/copy
 github.com/containers/image/docker/reference
-github.com/containers/image/manifest
 github.com/containers/image/signature
 github.com/containers/image/storage
 github.com/containers/image/transports/alltransports
 github.com/containers/image/pkg/blobinfocache/memory
+github.com/containers/image/manifest
 github.com/containers/image/image
 github.com/containers/image/pkg/blobinfocache
 github.com/containers/image/pkg/compression
 github.com/containers/image/transports
-github.com/containers/image/pkg/strslice
 github.com/containers/image/version
 github.com/containers/image/internal/tmpdir
 github.com/containers/image/pkg/blobinfocache/none
@@ -112,6 +111,7 @@ github.com/containers/image/openshift
 github.com/containers/image/ostree
 github.com/containers/image/tarball
 github.com/containers/image/pkg/blobinfocache/internal/prioritize
+github.com/containers/image/pkg/strslice
 github.com/containers/image/pkg/blobinfocache/boltdb
 github.com/containers/image/directory/explicitfilepath
 github.com/containers/image/docker/policyconfiguration


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

On top of #2514 , reviewed the uses of c/image API, and made various cleanups and smaller bug fixes.

Two notable major themes:
- `ListImages`/`ImageStatus` now do much less redundant work (decreasing the number of c/storage calls, and the implied locking operations necessary), and share more code
- `types.SystemContext` options that apply ~globally are set once in `server.Server.systemContext`, and automatically used throughout the call stack. Notably `GlobalAuthFile` is now handled only in one place.

**- How I did it**

See individual commit messages for details.

(This depends on, and currently includes #2514, I will rebase this after that PR is merged.)

**- How to verify it**

Hopefully the existing CI.

**- Description for the changelog**
`ListImages` and `ImageStatus` are now more efficient.