### PR TITLE
Remove invalid unit test to unblock master branch CI

### DIFF
--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -91,24 +91,6 @@ var _ = t.Describe("ContainerServer", func() {
 			Expect(server).To(BeNil())
 		})
 
-		It("should fail with invalid default runtime", func() {
-			// Given
-			config, err := libconfig.DefaultConfig()
-			Expect(err).To(BeNil())
-			config.DefaultRuntime = "invalid-runtime"
-			gomock.InOrder(
-				libMock.EXPECT().GetStore().Return(storeMock, nil),
-				libMock.EXPECT().GetData().Return(config),
-			)
-
-			// When
-			server, err := lib.New(context.Background(), nil, libMock)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(server).To(BeNil())
-		})
-
 		It("should fail with invalid lockfile", func() {
 			// Given
 			config, err := libconfig.DefaultConfig()


### PR DESCRIPTION
The library creation does not validate the runtime config that tight any
more, so we should remove that invalid use case.