### PR TITLE
Add context based logging facade and interceptors

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/containers/libpod/pkg/hooks/0.1.0"
 	"github.com/containers/storage/pkg/reexec"
 	libconfig "github.com/cri-o/cri-o/internal/lib/config"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"github.com/cri-o/cri-o/internal/pkg/signals"
 	"github.com/cri-o/cri-o/internal/version"
 	"github.com/cri-o/cri-o/server"
@@ -595,6 +596,8 @@ func main() {
 		}
 
 		grpcServer := grpc.NewServer(
+			grpc.UnaryInterceptor(log.UnaryInterceptor()),
+			grpc.StreamInterceptor(log.StreamInterceptor()),
 			grpc.MaxSendMsgSize(config.GRPCMaxSendMsgSize),
 			grpc.MaxRecvMsgSize(config.GRPCMaxRecvMsgSize),
 		)

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golangci/golangci-lint v1.17.1
 	github.com/google/renameio v0.1.0
+	github.com/google/uuid v1.1.1
 	github.com/hpcloud/tail v1.0.0
 	github.com/kr/pty v1.1.8
 	github.com/onsi/ginkgo v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=

--- a/internal/pkg/log/interceptors.go
+++ b/internal/pkg/log/interceptors.go
@@ -1,0 +1,73 @@
+package log
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+type ServerStream struct {
+	grpc.ServerStream
+	NewContext context.Context
+}
+
+func (w *ServerStream) Context() context.Context {
+	return w.NewContext
+}
+
+func NewServerStream(stream grpc.ServerStream) *ServerStream {
+	if existing, ok := stream.(*ServerStream); ok {
+		return existing
+	}
+	return &ServerStream{ServerStream: stream, NewContext: stream.Context()}
+}
+
+func StreamInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		stream grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+
+		newCtx := addRequestID(stream.Context())
+		newStream := NewServerStream(stream)
+		newStream.NewContext = newCtx
+
+		err := handler(srv, newStream)
+
+		if err != nil {
+			Debugf(newCtx, "stream error: %+v", err)
+		}
+
+		return err
+	}
+}
+
+func UnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+
+		newCtx := addRequestID(ctx)
+		Debugf(newCtx, "request: %+v", req)
+
+		resp, err := handler(newCtx, req)
+
+		if err != nil {
+			Debugf(newCtx, "response error: %+v", err)
+		} else {
+			Debugf(newCtx, "response: %+v", resp)
+		}
+
+		return resp, err
+	}
+}
+
+func addRequestID(ctx context.Context) context.Context {
+	return context.WithValue(ctx, id{}, uuid.New().String())
+}

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -1,0 +1,40 @@
+// Package log provides a global interface to logging functionality
+package log
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+type id struct{}
+
+func Debugf(ctx context.Context, format string, args ...interface{}) {
+	entry(ctx).Debugf(format, args...)
+}
+
+func Infof(ctx context.Context, format string, args ...interface{}) {
+	entry(ctx).Infof(format, args...)
+}
+
+func Warnf(ctx context.Context, format string, args ...interface{}) {
+	entry(ctx).Warnf(format, args...)
+}
+
+func Errorf(ctx context.Context, format string, args ...interface{}) {
+	entry(ctx).Errorf(format, args...)
+}
+
+func entry(ctx context.Context) *logrus.Entry {
+	logger := logrus.StandardLogger()
+	if ctx == nil {
+		return logrus.NewEntry(logger)
+	}
+
+	idValue := ctx.Value(id{})
+	if ret, ok := idValue.(string); ok {
+		return logger.WithField("id", ret)
+	}
+
+	return logrus.NewEntry(logger)
+}

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/tools/remotecommand"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -19,7 +18,6 @@ func (s *Server) Attach(ctx context.Context, req *pb.AttachRequest) (resp *pb.At
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-	logrus.Debugf("AttachRequest %+v", req)
 
 	resp, err = s.getAttach(req)
 	if err != nil {

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -3,6 +3,7 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/opencontainers/runtime-tools/generate"
@@ -23,7 +24,7 @@ func TestAddOCIBindsForDev(t *testing.T) {
 			},
 		},
 	}
-	_, binds, err := addOCIBindMounts("", config, &specgen, "")
+	_, binds, err := addOCIBindMounts(context.Background(), "", config, &specgen, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -58,7 +59,7 @@ func TestAddOCIBindsForSys(t *testing.T) {
 			},
 		},
 	}
-	_, binds, err := addOCIBindMounts("", config, &specgen, "")
+	_, binds, err := addOCIBindMounts(context.Background(), "", config, &specgen, "")
 	if err != nil {
 		t.Error(err)
 	}

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/tools/remotecommand"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -19,8 +18,6 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (resp *pb.ExecRe
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-
-	logrus.Debugf("ExecRequest %+v", req)
 
 	resp, err = s.getExec(req)
 	if err != nil {

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/sirupsen/logrus"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -17,7 +17,6 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *p
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-	logrus.Debugf("ExecSyncRequest %+v", req)
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
 		return nil, err
@@ -47,7 +46,6 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *p
 		ExitCode: execResp.ExitCode,
 	}
 
-	logrus.Infof("Exec'd %s in %s", cmd, c.Description())
-	logrus.Debugf("ExecSyncResponse: %+v", resp)
+	log.Infof(ctx, "exec'd %s in %s", cmd, c.Description())
 	return resp, nil
 }

--- a/server/container_portforward.go
+++ b/server/container_portforward.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -18,7 +17,6 @@ func (s *Server) PortForward(ctx context.Context, req *pb.PortForwardRequest) (r
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-	logrus.Debugf("PortForwardRequest %+v", req)
 
 	resp, err = s.getPortForward(req)
 	if err != nil {

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -3,7 +3,7 @@ package server
 import (
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -16,7 +16,6 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-	logrus.Debugf("RemoveContainerRequest: %+v", req)
 
 	// save container description to print
 	c, err := s.GetContainerFromShortID(req.ContainerId)
@@ -29,8 +28,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		return nil, err
 	}
 
-	logrus.Infof("Removed container %s", c.Description())
+	log.Infof(ctx, "Removed container %s", c.Description())
 	resp = &pb.RemoveContainerResponse{}
-	logrus.Debugf("RemoveContainerResponse: %+v", resp)
 	return resp, nil
 }

--- a/server/container_reopen_log.go
+++ b/server/container_reopen_log.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -18,7 +17,6 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *pb.ReopenContainer
 		recordError(operation, err)
 	}()
 
-	logrus.Debugf("ReopenContainerLogRequest %+v", req)
 	containerID := req.ContainerId
 	c := s.GetContainer(containerID)
 
@@ -40,6 +38,5 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *pb.ReopenContainer
 		resp = &pb.ReopenContainerLogResponse{}
 	}
 
-	logrus.Debugf("ReopenContainerLogResponse %s: %+v", containerID, resp)
 	return resp, err
 }

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/sirupsen/logrus"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -17,7 +17,6 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-	logrus.Debugf("StartContainerRequest %+v", req)
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
 		return nil, err
@@ -36,7 +35,7 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 			c.SetStartFailed(err)
 		}
 		if err := s.ContainerStateToDisk(c); err != nil {
-			logrus.Warnf("unable to write containers %s state to disk: %v", c.ID(), err)
+			log.Warnf(ctx, "unable to write containers %s state to disk: %v", c.ID(), err)
 		}
 	}()
 
@@ -45,8 +44,7 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 		return nil, fmt.Errorf("failed to start container %s: %v", c.ID(), err)
 	}
 
-	logrus.Infof("Started container: %s", c.Description())
+	log.Infof(ctx, "Started container: %s", c.Description())
 	resp = &pb.StartContainerResponse{}
-	logrus.Debugf("StartContainerResponse %+v", resp)
 	return resp, nil
 }

--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -3,7 +3,7 @@ package server
 import (
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -27,14 +27,14 @@ func (s *Server) ListContainerStats(ctx context.Context, req *pb.ListContainerSt
 			PodSandboxId:  req.Filter.PodSandboxId,
 			LabelSelector: req.Filter.LabelSelector,
 		}
-		ctrList = s.filterContainerList(cFilter, ctrList)
+		ctrList = s.filterContainerList(ctx, cFilter, ctrList)
 	}
 
 	allStats := make([]*pb.ContainerStats, 0, len(ctrList))
 	for _, container := range ctrList {
 		stats, err := s.Runtime().ContainerStats(container)
 		if err != nil {
-			logrus.Warnf("unable to get stats for container %s", container.ID())
+			log.Warnf(ctx, "unable to get stats for container %s", container.ID())
 			continue
 		}
 		response := buildContainerStats(stats, container)

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/sirupsen/logrus"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -23,7 +23,6 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-	logrus.Debugf("ContainerStatusRequest %+v", req)
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
 		return nil, err
@@ -62,7 +61,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	if cState.ExitCode == -1 {
 		err := s.Runtime().UpdateContainerStatus(c)
 		if err != nil {
-			logrus.Warnf("Failed to UpdateStatus of container %s: %v", c.ID(), err)
+			log.Warnf(ctx, "Failed to UpdateStatus of container %s: %v", c.ID(), err)
 		}
 		cState = c.State()
 	}
@@ -106,6 +105,5 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		}
 	}
 
-	logrus.Debugf("ContainerStatusResponse: %+v", resp)
 	return resp, nil
 }

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -3,7 +3,7 @@ package server
 import (
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -15,7 +15,6 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-	logrus.Debugf("StopContainerRequest %+v", req)
 
 	// save container description to print
 	c, err := s.GetContainerFromShortID(req.ContainerId)
@@ -29,8 +28,7 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 		return nil, err
 	}
 
-	logrus.Infof("Stopped container %s", description)
+	log.Infof(ctx, "stopped container: %s", description)
 	resp = &pb.StopContainerResponse{}
-	logrus.Debugf("StopContainerResponse %s: %+v", req.ContainerId, resp)
 	return resp, nil
 }

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/gogo/protobuf/proto"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -19,7 +18,6 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *pb.UpdateCon
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-	logrus.Debugf("UpdateContainerResources %+v", req)
 
 	c, err := s.GetContainerFromShortID(req.GetContainerId())
 	if err != nil {

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/pkg/storage"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -17,7 +16,6 @@ func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (res
 		recordError(operation, err)
 	}()
 
-	logrus.Debugf("ListImagesRequest: %+v", req)
 	filter := ""
 	reqFilter := req.GetFilter()
 	if reqFilter != nil {
@@ -35,7 +33,6 @@ func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (res
 		image := ConvertImage(&results[i])
 		resp.Images = append(resp.Images, image)
 	}
-	logrus.Debugf("ListImagesResponse: %+v", resp)
 	return resp, nil
 }
 

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"github.com/cri-o/cri-o/internal/pkg/storage"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -18,7 +18,6 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (r
 		recordError(operation, err)
 	}()
 
-	logrus.Debugf("RemoveImageRequest: %+v", req)
 	image := ""
 	img := req.GetImage()
 	if img != nil {
@@ -42,7 +41,7 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (r
 	for _, img := range images {
 		err = s.StorageImageServer().UntagImage(s.systemContext, img)
 		if err != nil {
-			logrus.Debugf("error deleting image %s: %v", img, err)
+			log.Debugf(ctx, "error deleting image %s: %v", img, err)
 			continue
 		}
 		deleted = true
@@ -52,6 +51,5 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (r
 		return nil, err
 	}
 	resp = &pb.RemoveImageResponse{}
-	logrus.Debugf("RemoveImageResponse: %+v", resp)
 	return resp, nil
 }

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/containers/storage"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	pkgstorage "github.com/cri-o/cri-o/internal/pkg/storage"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -22,7 +22,6 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (r
 		recordError(operation, err)
 	}()
 
-	logrus.Debugf("ImageStatusRequest: %+v", req)
 	image := ""
 	img := req.GetImage()
 	if img != nil {
@@ -47,11 +46,11 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (r
 		status, err := s.StorageImageServer().ImageStatus(s.systemContext, image)
 		if err != nil {
 			if errors.Cause(err) == storage.ErrImageUnknown {
-				logrus.Warnf("imageStatus: can't find %s", image)
+				log.Warnf(ctx, "imageStatus: can't find %s", image)
 				notfound = true
 				continue
 			}
-			logrus.Warnf("imageStatus: error getting status from %s: %v", image, err)
+			log.Warnf(ctx, "imageStatus: error getting status from %s: %v", image, err)
 			lastErr = err
 			continue
 		}
@@ -85,7 +84,6 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (r
 	if notfound && resp == nil {
 		return &pb.ImageStatusResponse{}, nil
 	}
-	logrus.Debugf("ImageStatusResponse: %+v", resp)
 	return resp, nil
 }
 

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/sirupsen/logrus"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/fields"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -37,7 +37,6 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 		recordError(operation, err)
 	}()
 
-	logrus.Debugf("ListPodSandboxRequest %+v", req)
 	var pods []*pb.PodSandbox
 	var podList []*sandbox.Sandbox
 	podList = append(podList, s.ContainerServer.ListSandboxes()...)
@@ -51,7 +50,7 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 				// Not finding an ID in a filtered list should not be considered
 				// and error; it might have been deleted when stop was done.
 				// Log and return an empty struct.
-				logrus.Warnf("unable to find pod %s with filter", filter.Id)
+				log.Warnf(ctx, "unable to find pod %s with filter", filter.Id)
 				return &pb.ListPodSandboxResponse{}, nil
 			}
 			sb := s.getSandbox(id)
@@ -98,6 +97,5 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 	resp = &pb.ListPodSandboxResponse{
 		Items: pods,
 	}
-	logrus.Debugf("ListPodSandboxResponse %+v", resp)
 	return resp, nil
 }

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -149,7 +149,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 
 		It("should succeed with empty parent cgroup and manager", func() {
 			// When
-			res, err := server.AddCgroupAnnotation(g, "", "", "", "id")
+			res, err := server.AddCgroupAnnotation(context.Background(), g, "",
+				"", "", "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -162,7 +163,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 			const cgroup = "someCgroup"
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, "", "manager", cgroup, "id")
+			res, err := server.AddCgroupAnnotation(context.Background(), g, "",
+				"manager", cgroup, "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -176,7 +178,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 			const cgroup = "some.slice"
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, "",
+			res, err := server.AddCgroupAnnotation(context.Background(), g, "",
 				oci.SystemdCgroupsManager, cgroup, "id")
 
 			// Then
@@ -189,7 +191,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 			const cgroup = "some.slice"
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, "", "manager", cgroup, "id")
+			res, err := server.AddCgroupAnnotation(context.Background(), g, "",
+				"manager", cgroup, "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -201,7 +204,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 			const cgroup = "someCgroup"
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, "",
+			res, err := server.AddCgroupAnnotation(context.Background(), g, "",
 				oci.SystemdCgroupsManager, cgroup, "id")
 
 			// Then
@@ -214,7 +217,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 			const cgroup = "some--wrong.slice"
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, "",
+			res, err := server.AddCgroupAnnotation(context.Background(), g, "",
 				oci.SystemdCgroupsManager, cgroup, "id")
 
 			// Then
@@ -237,8 +240,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 			cgroup, tmpDir := prepareCgroupDirs(0222, "")
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, tmpDir,
-				oci.SystemdCgroupsManager, cgroup, "id")
+			res, err := server.AddCgroupAnnotation(context.Background(), g,
+				tmpDir, oci.SystemdCgroupsManager, cgroup, "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -250,8 +253,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 			cgroup, tmpDir := prepareCgroupDirs(0644, "")
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, tmpDir,
-				oci.SystemdCgroupsManager, cgroup, "id")
+			res, err := server.AddCgroupAnnotation(context.Background(), g,
+				tmpDir, oci.SystemdCgroupsManager, cgroup, "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -263,8 +266,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 			cgroup, tmpDir := prepareCgroupDirs(0644, "13000000")
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, tmpDir,
-				oci.SystemdCgroupsManager, cgroup, "id")
+			res, err := server.AddCgroupAnnotation(context.Background(), g,
+				tmpDir, oci.SystemdCgroupsManager, cgroup, "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -276,8 +279,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 			cgroup, tmpDir := prepareCgroupDirs(0644, "10")
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, tmpDir,
-				oci.SystemdCgroupsManager, cgroup, "id")
+			res, err := server.AddCgroupAnnotation(context.Background(), g,
+				tmpDir, oci.SystemdCgroupsManager, cgroup, "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -289,8 +292,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 			cgroup, tmpDir := prepareCgroupDirs(0644, "invalid")
 
 			// When
-			res, err := server.AddCgroupAnnotation(g, tmpDir,
-				oci.SystemdCgroupsManager, cgroup, "id")
+			res, err := server.AddCgroupAnnotation(context.Background(), g,
+				tmpDir, oci.SystemdCgroupsManager, cgroup, "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -17,7 +16,6 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 		recordError(operation, err)
 	}()
 
-	logrus.Debugf("PodSandboxStatusRequest %+v", req)
 	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
 	if err != nil {
 		return nil, err
@@ -55,6 +53,5 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 		},
 	}
 
-	logrus.Debugf("PodSandboxStatusResponse: %+v", resp)
 	return resp, nil
 }

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/sirupsen/logrus"
+	"github.com/cri-o/cri-o/internal/pkg/log"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -15,13 +15,13 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 
 // stopAllPodSandboxes removes all pod sandboxes
 func (s *Server) stopAllPodSandboxes(ctx context.Context) {
-	logrus.Debugf("stopAllPodSandboxes")
+	log.Debugf(ctx, "stopAllPodSandboxes")
 	for _, sb := range s.ContainerServer.ListSandboxes() {
 		pod := &pb.StopPodSandboxRequest{
 			PodSandboxId: sb.ID(),
 		}
 		if _, err := s.StopPodSandbox(ctx, pod); err != nil {
-			logrus.Warnf("could not StopPodSandbox %s: %v", sb.ID(), err)
+			log.Warnf(ctx, "could not StopPodSandbox %s: %v", sb.ID(), err)
 		}
 	}
 }

--- a/vendor/github.com/google/uuid/go.mod
+++ b/vendor/github.com/google/uuid/go.mod
@@ -1,0 +1,1 @@
+module github.com/google/uuid

--- a/vendor/github.com/google/uuid/node.go
+++ b/vendor/github.com/google/uuid/node.go
@@ -48,6 +48,7 @@ func setNodeInterface(name string) bool {
 	// does not specify a specific interface generate a random Node ID
 	// (section 4.1.6)
 	if name == "" {
+		ifname = "random"
 		randomBits(nodeID[:])
 		return true
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -452,7 +452,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/gofuzz
 # github.com/google/renameio v0.1.0
 github.com/google/renameio
-# github.com/google/uuid v1.0.0
+# github.com/google/uuid v1.1.1
 github.com/google/uuid
 # github.com/googleapis/gnostic v0.3.0
 github.com/googleapis/gnostic/OpenAPIv2


### PR DESCRIPTION
This commit adds stream and unary based logging interceptors which
automatically add an request ID (UUID) to the given context. The request
and responses are logged automatically from now on.

All functionality will be wrapped within the internal `log` package to
isolate implementation details, whereas logs within the `server` package
have been adapted to use the new `log` package.

---

We now add two interceptors to the GRPC server creation, whereas the request and responses are logged by default. A logging message would look like this for example:

```
DEBU[2019-07-02 10:27:29.269823804+02:00] request: &ListImagesRequest{Filter:&ImageFilter{Image:&ImageSpec{Image:,},},}  id=659a66be-d629-4fd0-9930-ce41e2888783
DEBU[2019-07-02 10:27:29.270081547+02:00] response: &ListImagesResponse{Images:[],}     id=659a66be-d629-4fd0-9930-ce41e2888783
```

We can see that we now have a UUID field attached to every message, whereas this UUID will be generated by the intercepting middleware. Everytime we now use the new `log` package within `cri-o/cri-o/pkg/log`, we are able to pass the context in and create a log entry which also uses this UUID.