### PR TITLE
Change default apparmor profile to actually contain the version

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -77,7 +77,7 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 # GLOBAL OPTIONS
 **--additional-devices**="": devices to add to the containers
 
-**--apparmor-profile**="": Name of the apparmor profile to be used as the runtime's default (default: "crio-default")
+**--apparmor-profile**="": Name of the apparmor profile to be used as the runtime's default. The default profile name is "crio-default-" followed by the version string of CRI-O.
 
 **--bind-mount-prefix**="": A prefix to use for the source of the bind mounts.  This option would be useful if you were running CRI-O in a container.  And had `/` mounted on `/host` in your container.  Then if you ran CRI-O with the `--bind-mount-prefix=/host` option, CRI-O would add /host to any bind mounts it is handed over CRI.  If Kubernetes asked to have `/var/lib/foobar` bind mounted into the container, then CRI-O would bind mount `/host/var/lib/foobar`.  Since CRI-O itself is running in a container with `/` or the host mounted on `/host`, the container would end up with `/var/lib/foobar` from the host mounted in the container rather then `/var/lib/foobar` from the CRI-O container.
 

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/storage"
 	cstorage "github.com/containers/storage"
 	"github.com/cri-o/cri-o/utils"
+	"github.com/cri-o/cri-o/version"
 	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -23,14 +24,14 @@ import (
 
 // Defaults if none are specified
 const (
-	pauseImage          = "k8s.gcr.io/pause:3.1"
-	pauseCommand        = "/pause"
-	defaultTransport    = "docker://"
-	apparmorProfileName = "crio-default"
-	defaultRuntime      = "runc"
-	DefaultRuntimeType  = "oci"
-	DefaultRuntimeRoot  = "/run/runc"
-	cgroupManager       = "cgroupfs"
+	pauseImage             = "k8s.gcr.io/pause:3.1"
+	pauseCommand           = "/pause"
+	defaultTransport       = "docker://"
+	defaultRuntime         = "runc"
+	DefaultRuntimeType     = "oci"
+	DefaultRuntimeRoot     = "/run/runc"
+	cgroupManager          = "cgroupfs"
+	DefaultApparmorProfile = "crio-default-" + version.Version
 )
 
 // Config represents the entire set of configuration values that can be set for
@@ -409,7 +410,7 @@ func DefaultConfig() (*Config, error) {
 			ConmonCgroup:             "pod",
 			SELinux:                  selinuxEnabled(),
 			SeccompProfile:           "",
-			ApparmorProfile:          apparmorProfileName,
+			ApparmorProfile:          DefaultApparmorProfile,
 			CgroupManager:            cgroupManager,
 			PidsLimit:                DefaultPidsLimit,
 			ContainerExitsDir:        containerExitsDir,

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/libpod/pkg/apparmor"
 	"github.com/containers/libpod/pkg/rootless"
 	createconfig "github.com/containers/libpod/pkg/spec"
+	libconfig "github.com/cri-o/cri-o/lib/config"
 	"github.com/cri-o/cri-o/lib/sandbox"
 	"github.com/cri-o/cri-o/oci"
 	"github.com/cri-o/cri-o/pkg/annotations"
@@ -424,13 +425,13 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		appArmorProfileName := s.getAppArmorProfileName(containerConfig.GetLinux().GetSecurityContext().GetApparmorProfile())
 		if appArmorProfileName != "" {
 			// reload default apparmor profile if it is unloaded.
-			if s.appArmorProfile == apparmorDefaultProfile {
-				isLoaded, err := apparmor.IsLoaded(apparmorDefaultProfile)
+			if s.appArmorProfile == libconfig.DefaultApparmorProfile {
+				isLoaded, err := apparmor.IsLoaded(libconfig.DefaultApparmorProfile)
 				if err != nil {
 					return nil, err
 				}
 				if !isLoaded {
-					if err := apparmor.InstallDefault(apparmorDefaultProfile); err != nil {
+					if err := apparmor.InstallDefault(libconfig.DefaultApparmorProfile); err != nil {
 						return nil, err
 					}
 				}


### PR DESCRIPTION
This ensures that the default configuration of CRI-O always installs
the default apparmor profile named `crio-default-vx.xx.x[-dev]`. The
logging verbosity has been increased during startup to give the user a
higher transparency about the current profile.