### PR TITLE
Close temporary image in PullImage

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -89,7 +89,7 @@ type ImageServer interface {
 	ImageStatus(systemContext *types.SystemContext, filter string) (*ImageResult, error)
 	// PrepareImage returns an Image where the config digest can be grabbed
 	// for further analysis. Call Close() on the resulting image.
-	PrepareImage(imageName string, options *copy.Options) (types.Image, error)
+	PrepareImage(imageName string, options *copy.Options) (types.ImageCloser, error)
 	// PullImage imports an image from the specified location.
 	PullImage(systemContext *types.SystemContext, imageName string, options *copy.Options) (types.ImageReference, error)
 	// UntagImage removes a name from the specified image, and if it was
@@ -385,7 +385,7 @@ func (svc *imageService) prepareReference(imageName string, options *copy.Option
 	return srcRef, nil
 }
 
-func (svc *imageService) PrepareImage(imageName string, options *copy.Options) (types.Image, error) {
+func (svc *imageService) PrepareImage(imageName string, options *copy.Options) (types.ImageCloser, error) {
 	srcRef, err := svc.prepareReference(imageName, options)
 	if err != nil {
 		return nil, err

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -70,12 +70,13 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 			}
 		}
 
-		var tmpImg types.Image
+		var tmpImg types.ImageCloser
 		tmpImg, err = s.StorageImageServer().PrepareImage(img, options)
 		if err != nil {
 			logrus.Debugf("error preparing image %s: %v", img, err)
 			continue
 		}
+		defer tmpImg.Close()
 
 		var storedImage *storage.ImageResult
 		storedImage, err = s.StorageImageServer().ImageStatus(s.ImageContext(), img)

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -81,10 +81,10 @@ func (mr *MockImageServerMockRecorder) ListImages(arg0, arg1 interface{}) *gomoc
 }
 
 // PrepareImage mocks base method
-func (m *MockImageServer) PrepareImage(arg0 string, arg1 *copy.Options) (types.Image, error) {
+func (m *MockImageServer) PrepareImage(arg0 string, arg1 *copy.Options) (types.ImageCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareImage", arg0, arg1)
-	ret0, _ := ret[0].(types.Image)
+	ret0, _ := ret[0].(types.ImageCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
The ImageServer interface in pkg/storage documents that images returned
by PrepareImage() should have Close() called. Neglecting to close the
returned image will fill /var/tmp with large temporary files when using
at least the docker-archive transport.

This patch modifies said interface to allow Close() to be called and
adds a call to Close() in PullImage().

Signed-off-by: Marc Burns <m4burns@uwaterloo.ca>

Cherry-pick of: https://github.com/cri-o/cri-o/pull/2440

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
