### PR TITLE
[1.14] Add username and homedir to generated password

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -273,6 +273,17 @@ func setupContainerUser(specgen *generate.Generator, rootfs, mountLabel, ctrRunD
 		return fmt.Errorf("user group is specified without user or username")
 	}
 	imageUser := ""
+	homedir := ""
+	for _, env := range specgen.Config.Process.Env {
+		if strings.HasPrefix(env, "HOME=") {
+			homedir = strings.TrimPrefix(env, "HOME=")
+			break
+		}
+	}
+	if homedir == "" {
+		homedir = specgen.Config.Process.Cwd
+	}
+
 	if imageConfig != nil {
 		imageUser = imageConfig.Config.User
 	}
@@ -289,23 +300,34 @@ func setupContainerUser(specgen *generate.Generator, rootfs, mountLabel, ctrRunD
 		return err
 	}
 
-	// verify uid exists in containers /etc/passwd, else generate a passwd with the user entry
-	passwdPath, err := utils.GeneratePasswd(uid, gid, rootfs, ctrRunDir)
-	if err != nil {
-		return err
+	genPasswd := true
+	for _, mount := range specgen.Config.Mounts {
+		if mount.Destination == "/etc" ||
+			mount.Destination == "/etc/" ||
+			mount.Destination == "/etc/passwd" {
+			genPasswd = false
+			break
+		}
 	}
-	if passwdPath != "" {
-		if err := securityLabel(passwdPath, mountLabel, false); err != nil {
+	if genPasswd {
+		// verify uid exists in containers /etc/passwd, else generate a passwd with the user entry
+		passwdPath, err := utils.GeneratePasswd(containerUser, uid, gid, homedir, rootfs, ctrRunDir)
+		if err != nil {
 			return err
 		}
+		if passwdPath != "" {
+			if err := securityLabel(passwdPath, mountLabel, false); err != nil {
+				return err
+			}
 
-		mnt := rspec.Mount{
-			Type:        "bind",
-			Source:      passwdPath,
-			Destination: "/etc/passwd",
-			Options:     []string{"ro", "bind", "nodev", "nosuid", "noexec"},
+			mnt := rspec.Mount{
+				Type:        "bind",
+				Source:      passwdPath,
+				Destination: "/etc/passwd",
+				Options:     []string{"rw", "bind", "nodev", "nosuid", "noexec"},
+			}
+			specgen.AddMount(mnt)
 		}
-		specgen.AddMount(mnt)
 	}
 
 	specgen.SetProcessUID(uid)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -259,7 +259,7 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file isn't created.
-			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
 
@@ -278,7 +278,7 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file isn't created.
-			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
 
@@ -297,7 +297,7 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file isn't created.
-			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
 
@@ -316,9 +316,9 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should not be empty because an updated /etc/passwd file is created.
-			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
-			Expect(passwdFile).To(Not(BeEmpty()))
+			Expect(passwdFile).ToNot(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300")
@@ -332,7 +332,7 @@ var _ = t.Describe("Utils", func() {
 			dir := createEtcFiles()
 			defer os.RemoveAll(dir)
 			_, _, _, err := utils.GetUserInfo(dir, "blah")
-			Expect(err).To(Not(BeNil()))
+			Expect(err).ToNot(BeNil())
 		})
 
 		It("should succeed with existing user and group", func() {
@@ -342,7 +342,7 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file is not created.
-			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
 
@@ -361,7 +361,7 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file is not created.
-			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
 
@@ -380,7 +380,7 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file is not created.
-			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
 
@@ -399,9 +399,9 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should not be empty because an updated /etc/passwd file is created.
-			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
-			Expect(passwdFile).To(Not(BeEmpty()))
+			Expect(passwdFile).ToNot(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:250")
@@ -418,9 +418,9 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should not be empty because an updated /etc/passwd file is created.
-			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
-			Expect(passwdFile).To(Not(BeEmpty()))
+			Expect(passwdFile).ToNot(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:mail")

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version is the version of the build.
-const Version = "1.14.6"
+const Version = "1.14.7-dev"
 
 // WriteVersionFile writes the version information to a given file
 // file is the location of the old version file

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version is the version of the build.
-const Version = "1.14.6-dev"
+const Version = "1.14.6"
 
 // WriteVersionFile writes the version information to a given file
 // file is the location of the old version file


### PR DESCRIPTION
When generating a an entry in the /etc/passwd file, we
need to also add username and homedir, so that the user
can properly login.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Port of #2325 