### PR TITLE
Bump cri-tools to v1.15.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 stdenv: &stdenv
   environment:
     GOCACHE: &gocache /tmp/go-build
-    IMAGE: &image saschagrunert/criocircle:1.0.0
+    IMAGE: &image saschagrunert/criocircle:1.1.0
     JOBS: &jobs 8
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o
 
@@ -18,7 +18,7 @@ executors:
 
   container-legacy:
     docker:
-      - image: saschagrunert/criocircle:1.0.0-go-1.10
+      - image: saschagrunert/criocircle:1.1.0-go-1.10
         user: circleci
     <<: *stdenv
     working_directory: *workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,11 @@ RUN cd /tmp &&\
     mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
 # Install crictl and critest
-ENV CRICTL_COMMIT v1.14.0
-RUN wget -qO- https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_COMMIT/crictl-$CRICTL_COMMIT-linux-amd64.tar.gz \
+ENV CRICTL_COMMIT v1.15.0
+RUN VERSION=$CRICTL_COMMIT &&\
+    wget -qO- https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz \
         | tar xfz - -C /usr/bin &&\
-    wget -qO- https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_COMMIT/critest-$CRICTL_COMMIT-linux-amd64.tar.gz \
+    wget -qO- https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/critest-$VERSION-linux-amd64.tar.gz \
         | tar xfz - -C /usr/bin
 
 # Install runc

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -20,7 +20,7 @@
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:
-        cri_tools_git_version: "ff8d2e81baf8ff720fb916e42da57c2b772bd19e"
+        cri_tools_git_version: v1.15.0
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
@@ -71,7 +71,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: true
-        cri_tools_git_version: "ff8d2e81baf8ff720fb916e42da57c2b772bd19e"
+        cri_tools_git_version: v1.15.0
     - name: run cri-o integration tests
       include: test.yml
 
@@ -86,7 +86,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: true
-        cri_tools_git_version: "ff8d2e81baf8ff720fb916e42da57c2b772bd19e"
+        cri_tools_git_version: v1.15.0
     - name: run critest validation and benchmarks
       include: critest.yml
 

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -276,9 +276,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run crictl rmp "$pod_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
 
 	cleanup_ctrs
 	cleanup_pods


### PR DESCRIPTION
This also updates the image used by CircleCI. We have to modify the
idempotency test because crictl now errors if the pod does not exist any
more.

~Needs https://github.com/kata-containers/tests/pull/1778 merged before kata works.~
