### PR TITLE
Update codecov config to be less strict

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,13 @@ coverage:
   range: 50..75
 
   status:
-    project: true
+    project:
+      default:
+        enabled: true
+        # allowed to drop coverage and still result in a "success" commit status
+        threshold: null
+        if_not_found: success
+        if_ci_failed: error
     patch: true
     changes: false
 


### PR DESCRIPTION
I think this should solve our codecov issues with release branches. The configuration is not very well documented so I might miss some point here. Afterwards, we could enable codecov again.

/cc @umohnani8 