### PR TITLE
Add short CLI flags to common configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ integration: ${GINKGO} crioimage
 		-e CI=true \
 		-e CRIO_BINARY \
 		-e RUN_CRITEST \
-		-e STORAGE_OPTIONS="--storage-driver=vfs" \
+		-e STORAGE_OPTIONS="-s=vfs" \
 		-e TESTFLAGS \
 		-e TEST_USERNS \
 		-t --privileged --rm \

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -285,7 +285,7 @@ func main() {
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "config",
+			Name:  "config, c",
 			Value: server.CrioConfigPath,
 			Usage: "path to configuration file",
 		},
@@ -320,7 +320,7 @@ func main() {
 			Usage: "set the format used by logs ('text' (default), or 'json')",
 		},
 		cli.StringFlag{
-			Name:  "log-level",
+			Name:  "log-level, l",
 			Value: "error",
 			Usage: "log messages above specified level: debug, info, warn, error (default), fatal or panic",
 		},
@@ -346,7 +346,7 @@ func main() {
 			Usage: fmt.Sprintf("path to signature policy file (default: %q)", defConf.SignaturePolicyPath),
 		},
 		cli.StringFlag{
-			Name:  "root",
+			Name:  "root, r",
 			Usage: fmt.Sprintf("crio root dir (default: %q)", defConf.Root),
 		},
 		cli.StringFlag{
@@ -354,7 +354,7 @@ func main() {
 			Usage: fmt.Sprintf("crio state dir (default: %q)", defConf.RunRoot),
 		},
 		cli.StringFlag{
-			Name:  "storage-driver",
+			Name:  "storage-driver, s",
 			Usage: fmt.Sprintf("storage driver (default: %q)", defConf.Storage),
 		},
 		cli.StringSliceFlag{

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -87,7 +87,7 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 
 **--cni-plugin-dir**="": CNI plugin binaries directory (default: "/opt/cni/bin/")
 
-**--config**="": path to configuration file
+**--config, -c**="": path to configuration file
 
 **--conmon**="": Path to the conmon binary, used for monitoring the OCI runtime. Will be searched for using $PATH if empty. (default: "")
 
@@ -143,7 +143,7 @@ If `hooks_dir` is unset, CRI-O will currently default to `/usr/share/containers/
 
 **--log-format**="": Set the format used by logs ('text' (default), or 'json') (default: "text")
 
-**--log-level**="": log crio messages above specified level: debug, info, warn, error (default), fatal or panic
+**--log-level, -l**="": log crio messages above specified level: debug, info, warn, error (default), fatal or panic
 
 **--log-dir**="": default log directory where all logs will go unless directly specified by the kubelet
 
@@ -167,7 +167,7 @@ If `hooks_dir` is unset, CRI-O will currently default to `/usr/share/containers/
 
 **--read-only**=**true**|**false**: Run all containers in read-only mode (default: false). Automatically mount tmpfs on `/run`, `/tmp` and `/var/tmp`.
 
-**--root**="": The crio root dir (default: "/var/lib/containers/storage")
+**--root, -r**="": The crio root dir (default: "/var/lib/containers/storage")
 
 **--registry**="": Registry host which will be prepended to unqualified images, can be specified multiple times
 
@@ -181,7 +181,7 @@ If `hooks_dir` is unset, CRI-O will currently default to `/usr/share/containers/
 
 **--signature-policy**="": Path to the signature policy json file (default: "", to use the system-wide default)
 
-**--storage-driver**: OCI storage driver (default: "overlay")
+**--storage-driver, -s**: OCI storage driver (default: "overlay")
 
 **--storage-opt**: OCI storage driver option (no default)
 

--- a/test/command.bats
+++ b/test/command.bats
@@ -3,7 +3,7 @@
 load helpers
 
 @test "crio commands" {
-	run ${CRIO_BINARY_PATH} --config /dev/null config > /dev/null
+	run ${CRIO_BINARY_PATH} -c /dev/null config > /dev/null
 	echo "$output"
 	[ "$status" -eq 0 ]
 	run ${CRIO_BINARY_PATH} badoption > /dev/null


### PR DESCRIPTION
This commit adds  short flags to the config flags `root`, `log-level`,
`storage-driver` and `config` as well as their usage within our
scripting.