### PR TITLE
Allow building with go1.10

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -207,7 +207,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) (string, error) {
 }
 
 func writeCrioGoroutineStacks() {
-	path := filepath.Join("/tmp", fmt.Sprintf("crio-goroutine-stacks-%s.log", strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", "")))
+	path := filepath.Join("/tmp", fmt.Sprintf("crio-goroutine-stacks-%s.log", strings.Replace(time.Now().Format(time.RFC3339), ":", "", -1))) // nolint: gocritic
 	if err := utils.WriteGoroutineStacksToFile(path); err != nil {
 		logrus.Warnf("Failed to write goroutine stacks: %s", err)
 	}

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -172,7 +172,7 @@ func (r *runtimeVM) startRuntimeDaemon(c *Container) error {
 	args = append(args, "start")
 
 	// Modify the runtime path so that it complies with v2 shim API
-	newRuntimePath := strings.ReplaceAll(r.path, "-", ".")
+	newRuntimePath := strings.Replace(r.path, "-", ".", -1) // nolint: gocritic
 
 	// Setup default namespace
 	r.ctx = namespaces.WithNamespace(r.ctx, namespaces.Default)

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -69,7 +69,7 @@ apt-get update -qq && apt-get install -y \
 
 If using an older release or a long-term support release, be careful to double-check that the version of `runc` is new enough (running `runc --version` should produce `spec: 1.0.0`), or else build your own.
 
-Be careful to double-check that the version of golang is new enough, version 1.12.x or higher is required.  If needed, golang kits are available at https://golang.org/dl/
+Be careful to double-check that the version of golang is new enough, version 1.10.x or higher is required.  If needed, golang kits are available at https://golang.org/dl/
 
 ## Get Source Code
 


### PR DESCRIPTION
**- What I did**

Build cri-o with go1.10 (the default go version in Buildroot 2018.05.x, used by minikube)

**- How I did it**

Built the minikube.iso, see https://github.com/kubernetes/minikube/pull/4703 and `make out/minikube.iso`

**- How to verify it**

`minikube start --container-runtime=cri-o --iso-url=file://$PWD/out/minikube.iso`

**- Description for the changelog**

Allow building with go1.10

Closes #2573