### PR TITLE
Add missing shortflags to bin2img and copyimg to fix integration tests

### DIFF
--- a/test/bin2img/bin2img.go
+++ b/test/bin2img/bin2img.go
@@ -38,7 +38,7 @@ func main() {
 			Usage: "turn on debug logging",
 		},
 		cli.StringFlag{
-			Name:  "root",
+			Name:  "root, r",
 			Usage: "graph root directory",
 		},
 		cli.StringFlag{
@@ -46,7 +46,7 @@ func main() {
 			Usage: "run root directory",
 		},
 		cli.StringFlag{
-			Name:  "storage-driver",
+			Name:  "storage-driver, s",
 			Usage: "storage driver",
 		},
 		cli.StringSliceFlag{

--- a/test/copyimg/copyimg.go
+++ b/test/copyimg/copyimg.go
@@ -32,7 +32,7 @@ func main() {
 			Usage: "turn on debug logging",
 		},
 		cli.StringFlag{
-			Name:  "root",
+			Name:  "root, r",
 			Usage: "graph root directory",
 		},
 		cli.StringFlag{
@@ -40,7 +40,7 @@ func main() {
 			Usage: "run root directory",
 		},
 		cli.StringFlag{
-			Name:  "storage-driver",
+			Name:  "storage-driver, s",
 			Usage: "storage driver",
 		},
 		cli.StringSliceFlag{


### PR DESCRIPTION
A recent PR (#2571 ) updated usage of "--storage-driver" to "-s" in the Makefile:

https://github.com/cri-o/cri-o/blob/7e0cf4b096d7e0b952cf9c6979346b1afadb034b/Makefile#L187

However the corresponding short flags were not added to test/bin2img/bin2img.go or test/copyimg/copyimg.go

This causes integration tests to fail unless STORAGE_OPTIONS is overridden by the environment.

This commit adds the short flags "-s" (--storage-driver) and "-r" (--root) into copyimg and bin2img.

