### PR TITLE
Update git-vars target to check for executable as well

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,6 +1,8 @@
+# vim: set syntax=make:
+
 .PHONY: git-vars
 git-vars:
-ifneq ($(wildcard .git),)
+ifeq ($(shell [[ `command -v git` && -d .git ]] && echo true),true)
 	$(eval COMMIT_NO :=$(shell git rev-parse HEAD 2> /dev/null || true))
 	$(eval GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}"))
 	$(eval GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))


### PR DESCRIPTION
If the `git` executable is not available then the `git-vars` Makefile
target will now cover that as well.

Refers to #2575