### PR TITLE
Make integration tests more reliable

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -431,7 +431,8 @@ function cleanup_test() {
 	cleanup_pods
 	stop_crio
 	cleanup_lvm
-	rm -rf "$TESTDIR"
+	# Best effort remove the test dir, as sometime it is still busy
+	rm -rf "$TESTDIR" || true
 }
 
 


### PR DESCRIPTION
the integration_* suites have been failing because the tempdir is busy.

Make the removal best effort instead

Signed-off-by: Peter Hunt <pehunt@redhat.com>