### PR TITLE
Remove git-vars from conmon/config.h generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ crio.conf: bin/crio
 release-note: ${RELEASE_TOOL}
 	${RELEASE_TOOL} -n $(release)
 
-conmon/config.h: git-vars cmd/crio-config/config.go internal/oci/oci.go
+conmon/config.h: cmd/crio-config/config.go internal/oci/oci.go
 	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o bin/crio-config $(PROJECT)/cmd/crio-config
 	( cd conmon && $(CURDIR)/bin/crio-config )
 


### PR DESCRIPTION
The `git-vars` target force a rebuild of the `config.h` even if it
already exist. This can break build-setups, so we remove it from the
`config.h` generation.

Related discussion: https://github.com/kubernetes/minikube/pull/4703/files#r301143546