### PR TITLE
Update codecov patch comparison to succeed

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,8 +16,15 @@ coverage:
         # allowed to drop coverage and still result in a "success" commit status
         threshold: null
         if_not_found: success
+        if_no_uploads: success
         if_ci_failed: error
-    patch: true
+    patch:
+      default:
+        enabled: true
+        threshold: null
+        if_not_found: success
+        if_no_uploads: success
+        if_ci_failed: error
     changes: false
 
 comment:


### PR DESCRIPTION
The patch comparison of codecov can still fail which is not what we
want. This can cause trouble if there are no coverage related code
changes involved.

Relevant codecov docs:
https://docs.codecov.io/docs/commit-status#section-patch-status