### PR TITLE
Fix git-vars target for shells which do not default to bash

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -2,7 +2,7 @@
 
 .PHONY: git-vars
 git-vars:
-ifeq ($(shell [[ `command -v git` && -d .git ]] && echo true),true)
+ifeq ($(shell bash -c '[[ `command -v git` && `git rev-parse --git-dir 2>/dev/null` ]] && echo true'),true)
 	$(eval COMMIT_NO :=$(shell git rev-parse HEAD 2> /dev/null || true))
 	$(eval GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}"))
 	$(eval GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))

--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -7,7 +7,7 @@ obj = $(src:.c=.o)
 
 override LIBS += $(shell pkg-config --libs glib-2.0)
 
-VERSION = $(shell sed -n -e 's/^const Version = "\([^"]*\)"/\1/p' ../version/version.go)
+VERSION = $(shell sed -n -e 's/^const Version = "\([^"]*\)"/\1/p' ../internal/version/version.go)
 
 CFLAGS ?= -std=c99 -Os -Wall -Wextra
 override CFLAGS += $(shell pkg-config --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"


### PR DESCRIPTION
Some environments default to `/bin/sh` as shell, which will break the
`git-vars` target because of its `[[ .. ]]` syntax. To avoid such, we
now execute a bash shell around it.

Another fix included in this commit is that the `.git` directory does
not necessary needs to be part of the current working directory, for
example when including the Makefile.inc in the `conmon` dir. For that
we now use the command `git rev-parse --git-dir` to avoid this issue.

The version.go file is now located in `internal/version`, which has been
fixed as well.

---

The output can be verified at: https://circleci.com/gh/openSUSE/cri-o/12346