### PR TITLE
Add missing global-auth-file CLI flag

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -76,6 +76,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) (string, error) {
 	if ctx.GlobalIsSet("pause-image-auth-file") {
 		config.PauseImageAuthFile = ctx.GlobalString("pause-image-auth-file")
 	}
+	if ctx.GlobalIsSet("global-auth-file") {
+		config.GlobalAuthFile = ctx.GlobalString("global-auth-file")
+	}
 	if ctx.GlobalIsSet("signature-policy") {
 		config.SignaturePolicyPath = ctx.GlobalString("signature-policy")
 	}
@@ -339,7 +342,11 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "pause-image-auth-file",
-			Usage: fmt.Sprintf("path to a config file containing credentials for --pause-image (default: %s)", defConf.PauseImageAuthFile),
+			Usage: fmt.Sprintf("path to a config file containing credentials for --pause-image (default: %q)", defConf.PauseImageAuthFile),
+		},
+		cli.StringFlag{
+			Name:  "global-auth-file",
+			Usage: fmt.Sprintf("path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries (default: %q)", defConf.GlobalAuthFile),
 		},
 		cli.StringFlag{
 			Name:  "signature-policy",

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -159,6 +159,8 @@ If `hooks_dir` is unset, CRI-O will currently default to `/usr/share/containers/
 
 **--pause-image-auth-file**="": Path to a config file containing credentials for --pause-image (default: "")
 
+**--global-auth-file**="": Path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.
+
 **--pids-limit**="": Maximum number of processes allowed in a container (default: 1024)
 
 **--profile**="": enable pprof remote profiler on localhost:6060


### PR DESCRIPTION
This commit adds the corresponding CLI flag to `config.GlobalAuthFile`.