### PR TITLE
Do not print 'unknown' versions

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -266,7 +266,7 @@ func main() {
 
 	var v []string
 	v = append(v, version.Version)
-	if gitCommit != "" {
+	if gitCommit != "" && gitCommit != "unknown" {
 		v = append(v, fmt.Sprintf("commit: %s", gitCommit))
 	}
 	app.Name = "crio"


### PR DESCRIPTION
If the version is 'unknown' we don't print it anymore to avoid user
confusion.