### PR TITLE
[1.14] run crio-wipe from /usr and add system-preset

### DIFF
--- a/contrib/crio-wipe/50-crio-wipe.preset
+++ b/contrib/crio-wipe/50-crio-wipe.preset
@@ -1,0 +1,1 @@
+disable crio-wipe.service

--- a/contrib/crio-wipe/crio-wipe.service
+++ b/contrib/crio-wipe/crio-wipe.service
@@ -4,7 +4,7 @@ Before=crio.service
 RequiresMountsFor=/var/lib/containers
 
 [Service]
-ExecStart=/bin/bash /var/lib/crio/crio-wipe/crio-wipe.bash
+ExecStart=/bin/bash /usr/local/libexec/crio/crio-wipe/crio-wipe.bash
 Type=oneshot
 
 [Install]

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version is the version of the build.
-const Version = "1.14.7"
+const Version = "1.14.8-dev"
 
 // WriteVersionFile writes the version information to a given file
 // file is the location of the old version file

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version is the version of the build.
-const Version = "1.14.7-dev"
+const Version = "1.14.7"
 
 // WriteVersionFile writes the version information to a given file
 // file is the location of the old version file


### PR DESCRIPTION
In openshift, the machine-os-content container is spilled onto disk, and pivot is called. pivot only copies /usr and /etc, and ignores /var. Thus, for crio-wipe to actually exist on reboot, it must be installed into usr.

Signed-off-by: Peter Hunt <pehunt@redhat.com>