### PR TITLE
cgroupfs: don't leak conmon cgroups

### DIFF
--- a/internal/lib/remove.go
+++ b/internal/lib/remove.go
@@ -44,6 +44,7 @@ func (c *ContainerServer) Remove(ctx context.Context, container string, force bo
 		return "", errors.Wrapf(err, "failed to delete storage for container %s", ctrID)
 	}
 
+	ctr.CleanupConmonCgroup()
 	c.ReleaseContainerName(ctr.Name())
 
 	if err := c.ctrIDIndex.Delete(ctrID); err != nil {

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -67,6 +67,8 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 			continue
 		}
 
+		c.CleanupConmonCgroup()
+
 		if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && err != storage.ErrContainerUnknown {
 			// assume container already umounted
 			logrus.Warnf("failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
@@ -83,6 +85,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	}
 
 	s.removeInfraContainer(podInfraContainer)
+	podInfraContainer.CleanupConmonCgroup()
 
 	// Remove the files related to the sandbox
 	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {


### PR DESCRIPTION
Clean up conmon cgroups when removing a sandbox.  This requires to
record the conmon's cgroup path for each container and delete if for
normal and infra containers.

Fixes: #838
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

---

Once https://github.com/containers/libpod/pull/3554 is merged, we can re-vendor libpod and everything will be clean (I tested locally). Let's get this merged before though as the logic won't change for crio.