### PR TITLE
[1.15] Add release bundle target and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,9 @@ build-static: git-vars
 		"nix-build cri-o/nix --argstr revision $(COMMIT_NO) && \
 		mkdir -p cri-o/bin && \
 		cp result-*bin/bin/crio-* cri-o/bin && \
-		cp result-*bin/libexec/crio/* cri-o/bin && \
-		chown -R $(shell id -u):$(shell id -g) cri-o/bin"
+		cp result-*bin/libexec/crio/* cri-o/bin"
+
+release-bundle: clean build-static docs crio.conf bundle
 
 nix-image: git-vars
 	time $(CONTAINER_RUNTIME) build -t $(NIX_IMAGE) \
@@ -403,5 +404,6 @@ git-validation: .gopathok git-vars ${GIT_VALIDATION}
 	lint \
 	local-cross \
 	nix-image \
+	release-bundle \
 	uninstall \
 	vendor

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -197,6 +197,18 @@ nix-build nix
 The resulting binary should be now available in `result-bin/bin` and
 `result-2-bin/bin`.
 
+### Creating a release archive
+
+A release bundle consists of all static binaries, the man pages and
+configuration files like `crio.conf`. The `release-bundle` target can be used to
+build a new release archive within the current repository:
+
+```
+make release-bundle
+...
+Created ./bundle/crio-v1.15.0.tar.gz
+```
+
 ## Setup CNI networking
 
 A proper description of setting up CNI networking is given in the


### PR DESCRIPTION
This commit adds a new `release-bundle` target for building a static
release archive locally. Documentation has been added as well. Since we
default to rootless podman, the additional `chown` is not needed any
more when compiling a static binary.