### PR TITLE
[1.14] Fix integration tests for CNI update

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -490,6 +490,7 @@ function parse_pod_ip() {
 		if [ "$cidr" == "$arg" ]
 		then
 			echo `echo "$arg" | sed "s/\/[0-9][0-9]//"`
+			break
 		fi
 	done
 }

--- a/test/network.bats
+++ b/test/network.bats
@@ -182,7 +182,7 @@ function teardown() {
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed after network setup
 	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip*
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | grep -v lock | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }
 
@@ -196,6 +196,6 @@ function teardown() {
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed during network setup after the CNI plugin itself succeeded
 	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip*
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | grep -v lock | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }


### PR DESCRIPTION
The AMI update requires a fix of the pod IP retrieval to finally work
again.

Unblocks https://github.com/cri-o/cri-o/pull/2605