### PR TITLE
Fix documentation between crio.conf.5.md and source

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -60,6 +60,9 @@ file_locking_path = "{{ .FileLockingPath }}"
 # Path to AF_LOCAL socket on which CRI-O will listen.
 listen = "{{ .Listen }}"
 
+# Host IP considered as the primary IP to use by CRI-O for things such as host network IP.
+host_ip = "{{ .HostIP }}"
+
 # IP address on which the stream server will listen.
 stream_address = "{{ .StreamAddress }}"
 

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -452,9 +452,8 @@ func main() {
 			Usage: fmt.Sprintf("add one or more default mount paths in the form host:container (deprecated) (default: %q)", defConf.DefaultMounts),
 		},
 		cli.StringFlag{
-			Name:   "default-mounts-file",
-			Usage:  fmt.Sprintf("path to default mounts file (default: %q)", defConf.DefaultMountsFile),
-			Hidden: true,
+			Name:  "default-mounts-file",
+			Usage: fmt.Sprintf("path to default mounts file (default: %q)", defConf.DefaultMountsFile),
 		},
 		cli.StringFlag{
 			Name:  "default-capabilities",

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -42,7 +42,7 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
 **file_locking**=false
   If set to false, in-memory locking will be used instead of file-based locking. This option is being depreciated and will soon no longer exist.
 
-**file_locking_path**="/runc/crio.lock"
+**file_locking_path**="/run/crio.lock"
   Path to the lock file. This option is being deprecated and will soon no longer exist.
 
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -224,7 +224,7 @@ CRI-O reads its configured registries defaults from the system wide containers-r
 **pause_command**="/pause"
   The command to run to have a container stay in the paused state. This option supports live configuration reload.
 
-**signature_policy**="/etc/containers/policy.json"
+**signature_policy**=""
   Path to the file which decides what sort of policy we use when deciding whether or not to trust an image that we've pulled. It is not recommended that this option be used, as the default behavior of using the system-wide default policy (i.e., /etc/containers/policy.json) is most often preferred. Please refer to containers-policy.json(5) for more details.
 
 **image_volumes**="mkdir"

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -192,7 +192,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **gid_mappings**=""
   The GID mappings for the user namespace of each container. A range is specified in the form containerGID:HostGID:Size. Multiple ranges must be separated by comma.
 
-**ctr_stop_timeout**=10
+**ctr_stop_timeout**=0
   The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container.
 
 **manage_network_ns_lifecycle**=false

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -73,6 +73,11 @@ The `crio.api` table contains settings for the kubelet/gRPC interface.
 **stream_tls_ca**=""
   Path to the x509 CA(s) file used to verify and authenticate client communication with the encrypted stream. This file can change, and CRI-O will automatically pick up the changes within 5 minutes.
 
+**grpc_max_send_msg_size**=16777216
+  Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 16 * 1024 * 1024.
+
+**grpc_max_recv_msg_size**=16777216
+  Maximum grpc receive message size. If not set or <= 0, then CRI-O will default to 16 * 1024 * 1024.
 
 ## CRIO.RUNTIME TABLE
 The `crio.runtime` table contains settings pertaining to the OCI runtime used and options for how to set up and manage the OCI runtime.

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -88,7 +88,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **default_runtime**="runc"
   The _name_ of the OCI runtime to be used as the default.
 
-**no_pivot**=*false*
+**no_pivot**=false
   If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.
 
 **conmon**=""

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -147,7 +147,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **default_mounts**=[]
   List of default mounts for each container. **Deprecated:** this option will be removed in future versions in favor of `default_mounts_file`.
 
-**default_mounts_file**="/etc/containers/mounts.conf"
+**default_mounts_file**=""
   Path to the file specifying the defaults mounts for each container. The format of the config is /SRC:/DST, one mount per line. Notice that CRI-O reads its default mounts from the following two files:
 
     1) `/etc/containers/mounts.conf` (i.e., default_mounts_file): This is the override file, where users can either add in their own default mounts, or override the default mounts shipped with the package.

--- a/internal/lib/config/config.go
+++ b/internal/lib/config/config.go
@@ -474,6 +474,7 @@ func DefaultConfig() (*Config, error) {
 			SeccompProfile:           "",
 			ApparmorProfile:          DefaultApparmorProfile,
 			CgroupManager:            cgroupManager,
+			DefaultMountsFile:        "",
 			PidsLimit:                DefaultPidsLimit,
 			ContainerExitsDir:        containerExitsDir,
 			ContainerAttachSocketDir: ContainerAttachSocketDir,


### PR DESCRIPTION
This PR fixes some documentation related issues. Every single change is done in a dedicated commit. I'm working on a script which could check these kind of issues within the CI.