### PR TITLE
Bump AMI runc version to v1.0.0-rc9

### DIFF
--- a/contrib/test/integration/build/runc.yml
+++ b/contrib/test/integration/build/runc.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/opencontainers/runc.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-    version: "10d38b660a77168360df3522881e2dc2be5056bd"
+    version: v1.0.0-rc9
 
 - name: build runc
   make:


### PR DESCRIPTION
We should test against the latest version of runc.

/test ami