### PR TITLE
[1.12] Fix integration tests for CNI update

### DIFF
--- a/test/cni_plugin_helper.bash
+++ b/test/cni_plugin_helper.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script wraps the CNI 'bridge' plugin to provide additional testing
 # capabilities
@@ -25,12 +25,14 @@ elif [[ -z "${K8S_POD_NAME}" ]]; then
 	exit 1
 fi
 
-echo "FOUND_CNI_CONTAINERID=${CNI_CONTAINERID}" >> /tmp/plugin_test_args.out
-echo "FOUND_K8S_POD_NAMESPACE=${K8S_POD_NAMESPACE}" >> /tmp/plugin_test_args.out
-echo "FOUND_K8S_POD_NAME=${K8S_POD_NAME}" >> /tmp/plugin_test_args.out
+TEST_DIR=%TEST_DIR%
 
-. /tmp/cni_plugin_helper_input.env
-rm -f /tmp/cni_plugin_helper_input.env
+echo "FOUND_CNI_CONTAINERID=${CNI_CONTAINERID}" >> "$TEST_DIR"/plugin_test_args.out
+echo "FOUND_K8S_POD_NAMESPACE=${K8S_POD_NAMESPACE}" >> "$TEST_DIR"/plugin_test_args.out
+echo "FOUND_K8S_POD_NAME=${K8S_POD_NAME}" >> "$TEST_DIR"/plugin_test_args.out
+
+. "$TEST_DIR"/cni_plugin_helper_input.env
+rm -f "$TEST_DIR"/cni_plugin_helper_input.env
 
 result=$(/opt/cni/bin/bridge $@) || exit $?
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -66,6 +66,7 @@ LOG_SIZE_MAX_LIMIT=${LOG_SIZE_MAX_LIMIT:--1}
 STREAM_PORT=${STREAM_PORT:-10010}
 
 TESTDIR=$(mktemp -d)
+RANDOM_STRING=${TESTDIR: -10}
 
 # podman pull needs a configuration file for shortname pulls
 export REGISTRIES_CONFIG_PATH="$INTEGRATION_ROOT/registries.conf"
@@ -112,7 +113,15 @@ fi
 CRIO_SOCKET="$TESTDIR/crio.sock"
 CRIO_CONFIG="$TESTDIR/crio.conf"
 CRIO_CNI_CONFIG="$TESTDIR/cni/net.d/"
-CRIO_CNI_PLUGIN=${CRIO_CNI_PLUGIN:-/opt/cni/bin/}
+CRIO_LOG="$TESTDIR/crio.log"
+
+# Copy all the CNI dependencies around to ensure encapsulated tests
+CRIO_CNI_PLUGIN="$TESTDIR/cni-bin"
+mkdir "$CRIO_CNI_PLUGIN"
+cp /opt/cni/bin/* "$CRIO_CNI_PLUGIN"
+cp "$INTEGRATION_ROOT"/cni_plugin_helper.bash "$CRIO_CNI_PLUGIN"
+sed -i "s;%TEST_DIR%;$TESTDIR;" "$CRIO_CNI_PLUGIN"/cni_plugin_helper.bash
+
 POD_CIDR="10.88.0.0/16"
 POD_CIDR_MASK="10.88.*.*"
 
@@ -448,7 +457,7 @@ function write_plugin_test_args_network_conf() {
 	cat >$CRIO_CNI_CONFIG/10-plugin-test-args.conf <<-EOF
 {
     "cniVersion": "0.2.0",
-    "name": "crionet_test_args",
+    "name": "crionet_test_args_$RANDOM_STRING",
     "type": "cni_plugin_helper.bash",
     "bridge": "cni0",
     "isGateway": true,
@@ -464,7 +473,7 @@ function write_plugin_test_args_network_conf() {
 EOF
 
 	if [[ -n "$2" ]]; then
-		echo "DEBUG_ARGS=$2" > /tmp/cni_plugin_helper_input.env
+		echo "DEBUG_ARGS=$2" > "$TESTDIR"/cni_plugin_helper_input.env
 	fi
 
 	echo 0
@@ -492,6 +501,7 @@ function parse_pod_ip() {
 		if [ "$cidr" == "$arg" ]
 		then
 			echo `echo "$arg" | sed "s/\/[0-9][0-9]//"`
+			break
 		fi
 	done
 }

--- a/test/network.bats
+++ b/test/network.bats
@@ -6,7 +6,7 @@ function teardown() {
 	cleanup_ctrs
 	cleanup_pods
 	stop_crio
-	rm -f /var/lib/cni/networks/crionet_test_args/*
+	rm -f /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING/*
 	chmod 0755 $CONMON_BINARY
 	cleanup_test
 }
@@ -132,14 +132,12 @@ function teardown() {
 	run crictl runp "$TESTDATA"/sandbox_config.json
 	[ "$status" -eq 0 ]
 
-	. /tmp/plugin_test_args.out
+	. $TESTDIR/plugin_test_args.out
 
 	[ "$FOUND_CNI_CONTAINERID" != "redhat.test.crio" ]
 	[ "$FOUND_CNI_CONTAINERID" != "podsandbox1" ]
 	[ "$FOUND_K8S_POD_NAMESPACE" = "redhat.test.crio" ]
 	[ "$FOUND_K8S_POD_NAME" = "podsandbox1" ]
-
-	rm -rf /tmp/plugin_test_args.out
 }
 
 @test "Connect to pod hostport from the host" {
@@ -181,8 +179,8 @@ function teardown() {
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed after network setup
-	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
+	rm -f /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING/last_reserved_ip*
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING | grep -v lock | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }
 
@@ -195,7 +193,7 @@ function teardown() {
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed during network setup after the CNI plugin itself succeeded
-	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
+	rm -f /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING/last_reserved_ip*
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING | grep -v lock | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }


### PR DESCRIPTION
The AMI update requires a fix of the pod IP retrieval to finally work
again.

Cherry-picked: 82d6ddec8397d8426d34c85eccb7a018ec86d94e

Backport of #2608