### PR TITLE
Remove deprecated file-locking

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -45,15 +45,6 @@ var commentedConfigTemplate = template.Must(template.New("config").Parse(`
 #storage_option = [
 {{ range $opt := .StorageOptions }}{{ printf "#\t%q,\n" $opt }}{{ end }}#]
 
-# If set to false, in-memory locking will be used instead of file-based locking.
-# **Deprecated** this option will be removed in the future.
-file_locking = {{ .FileLocking }}
-
-# Path to the lock file.
-# **Deprecated** this option will be removed in the future.
-file_locking_path = "{{ .FileLockingPath }}"
-
-
 # The crio.api table contains settings for the kubelet/gRPC interface.
 [crio.api]
 

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -94,9 +94,6 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) (string, error) {
 	if ctx.GlobalIsSet("storage-opt") {
 		config.StorageOptions = ctx.GlobalStringSlice("storage-opt")
 	}
-	if ctx.GlobalIsSet("file-locking") {
-		config.FileLocking = ctx.GlobalBool("file-locking")
-	}
 	if ctx.GlobalIsSet("insecure-registry") {
 		config.InsecureRegistries = ctx.GlobalStringSlice("insecure-registry")
 	}
@@ -367,12 +364,6 @@ func main() {
 		cli.StringSliceFlag{
 			Name:  "storage-opt",
 			Usage: fmt.Sprintf("storage driver option (default: %q)", defConf.StorageOptions),
-		},
-		// XXX: DEPRECATED
-		cli.BoolFlag{
-			Name:   "file-locking",
-			Usage:  fmt.Sprintf("enable or disable file-based locking (depreciated) (default: %t)", defConf.FileLocking),
-			Hidden: true,
 		},
 		cli.StringSliceFlag{
 			Name:  "insecure-registry",

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -24,7 +24,6 @@ crio
 [--default-ulimits=[value]]
 [--default-transport=[value]]
 [--enable-metrics]
-[--file-locking]
 [--gid-mappings=[value]]
 [--help|-h]
 [--hooks-dir=[value]]
@@ -106,8 +105,6 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 **--default-transport**="": A prefix to prepend to image names that cannot be pulled as-is
 
 **--enable-metrics**: Enable metrics endpoint. Default is localhost:9090
-
-**--file-locking**: enable or disable file-based locking
 
 **--gid-mappings**: Specify the GID mappings to use for user namespace
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -39,13 +39,6 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
 **storage_option**=[]
   List to pass options to the storage driver. Please refer to containers-storage.conf(5) to see all available storage options.
 
-**file_locking**=false
-  If set to false, in-memory locking will be used instead of file-based locking. This option is being depreciated and will soon no longer exist.
-
-**file_locking_path**="/run/crio.lock"
-  Path to the lock file. This option is being deprecated and will soon no longer exist.
-
-
 ## CRIO.API TABLE
 The `crio.api` table contains settings for the kubelet/gRPC interface.
 

--- a/internal/lib/config/config.go
+++ b/internal/lib/config/config.go
@@ -134,14 +134,6 @@ type RootConfig struct {
 	// LogDir is the default log directory where all logs will go unless kubelet
 	// tells us to put them somewhere else.
 	LogDir string `toml:"log_dir"`
-
-	// FileLocking specifies whether to use file-based or in-memory locking
-	// File-based locking is required when multiple users of lib are
-	// present on the same system
-	FileLocking bool `toml:"file_locking"`
-
-	// FileLockingPath specifies the path to use for the locking.
-	FileLockingPath string `toml:"file_locking_path"`
 }
 
 // RuntimeHandler represents each item of the "crio.runtime.runtimes" TOML
@@ -441,13 +433,11 @@ func DefaultConfig() (*Config, error) {
 	}
 	return &Config{
 		RootConfig: RootConfig{
-			Root:            storeOpts.GraphRoot,
-			RunRoot:         storeOpts.RunRoot,
-			Storage:         storeOpts.GraphDriverName,
-			StorageOptions:  storeOpts.GraphDriverOptions,
-			LogDir:          "/var/log/crio/pods",
-			FileLocking:     false,
-			FileLockingPath: lockPath,
+			Root:           storeOpts.GraphRoot,
+			RunRoot:        storeOpts.RunRoot,
+			Storage:        storeOpts.GraphDriverName,
+			StorageOptions: storeOpts.GraphDriverOptions,
+			LogDir:         "/var/log/crio/pods",
 		},
 		APIConfig: APIConfig{
 			Listen:             CrioSocketPath,

--- a/internal/lib/config/config_unix.go
+++ b/internal/lib/config/config_unix.go
@@ -6,7 +6,6 @@ package config
 const (
 	cniConfigDir             = "/etc/cni/net.d/"
 	cniBinDir                = "/opt/cni/bin/"
-	lockPath                 = "/run/crio.lock"
 	containerExitsDir        = "/var/run/crio/exits"
 	ContainerAttachSocketDir = "/var/run/crio"
 

--- a/internal/lib/config/config_windows.go
+++ b/internal/lib/config/config_windows.go
@@ -8,7 +8,6 @@ import "github.com/cri-o/cri-o/internal/oci"
 const (
 	cniConfigDir             = "C:\\cni\\etc\\net.d\\"
 	cniBinDir                = "C:\\cni\\bin\\"
-	lockPath                 = "C:\\crio\\run\\crio.lock"
 	containerExitsDir        = "C:\\crio\\run\\exits\\"
 	ContainerAttachSocketDir = "C:\\crio\\run\\"
 

--- a/internal/lib/config/testdata/config.toml
+++ b/internal/lib/config/testdata/config.toml
@@ -3,7 +3,6 @@
   runroot = "/var/run/containers/storage"
   storage_driver = "overlay2"
   log_dir = "/var/log/crio/pods"
-  file_locking = false
   [crio.runtime]
     runtime = "/usr/bin/runc"
     conmon = "/usr/local/libexec/crio/conmon"

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -116,17 +116,6 @@ func New(ctx context.Context, systemContext *types.SystemContext, configIface li
 
 	runtime := oci.New(config)
 
-	var lock sync.Locker
-	if config.FileLocking {
-		fileLock, err := cstorage.GetLockfile(config.FileLockingPath)
-		if err != nil {
-			return nil, fmt.Errorf("error obtaining lockfile: %v", err)
-		}
-		lock = fileLock
-	} else {
-		lock = new(sync.Mutex)
-	}
-
 	hookDirectories := config.HooksDir
 	if config.HooksDir == nil {
 		for _, hooksDir := range []string{hooks.DefaultDir, hooks.OverrideDir} {
@@ -152,7 +141,7 @@ func New(ctx context.Context, systemContext *types.SystemContext, configIface li
 		podNameIndex:         registrar.NewRegistrar(),
 		podIDIndex:           truncindex.NewTruncIndex([]string{}),
 		Hooks:                newHooks,
-		stateLock:            lock,
+		stateLock:            &sync.Mutex{},
 		state: &containerServerState{
 			containers:      oci.NewMemoryStore(),
 			infraContainers: oci.NewMemoryStore(),

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -33,7 +33,6 @@ var _ = t.Describe("ContainerServer", func() {
 			// Setup config
 			config, err := libconfig.DefaultConfig()
 			Expect(err).To(BeNil())
-			config.FileLockingPath = tmpfile.Name()
 			config.HooksDir = []string{}
 
 			// Specify mocks
@@ -91,30 +90,10 @@ var _ = t.Describe("ContainerServer", func() {
 			Expect(server).To(BeNil())
 		})
 
-		It("should fail with invalid lockfile", func() {
-			// Given
-			config, err := libconfig.DefaultConfig()
-			Expect(err).To(BeNil())
-			config.FileLocking = true
-			config.FileLockingPath = "/invalid/file"
-			gomock.InOrder(
-				libMock.EXPECT().GetStore().Return(storeMock, nil),
-				libMock.EXPECT().GetData().Return(config),
-			)
-
-			// When
-			server, err := lib.New(context.Background(), nil, libMock)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(server).To(BeNil())
-		})
-
 		It("should fail with invalid hooks dir", func() {
 			// Given
 			config, err := libconfig.DefaultConfig()
 			Expect(err).To(BeNil())
-			config.FileLocking = false
 			config.HooksDir = []string{"/invalid-dir"}
 			gomock.InOrder(
 				libMock.EXPECT().GetStore().Return(storeMock, nil),

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -125,7 +125,6 @@ func beforeEach() {
 	// Set the config
 	config, err := libconfig.DefaultConfig()
 	Expect(err).To(BeNil())
-	config.FileLocking = false
 	config.LogDir = "."
 	config.HooksDir = []string{}
 


### PR DESCRIPTION
We deprecated file-locking with the last release so it could be removed
for the next one. Tests and documentation has been adapted as well.