### PR TITLE
Return if error loading cgroup CleanupConmonCgroup

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -193,6 +193,7 @@ func (c *Container) CleanupConmonCgroup() {
 	cg, err := cgroups.Load(path)
 	if err != nil {
 		logrus.Infof("error loading conmon cgroup of container %s: %v", c.ID(), err)
+		return
 	}
 	if err := cg.Delete(); err != nil {
 		logrus.Infof("error deleting conmon cgroup of container %s: %v", c.ID(), err)


### PR DESCRIPTION
Return before using nil cgroup if there was an error loading conmon cgroup for a container

Fixes #2620 

**- What I did**
Return if error loading cgroup before calling cg.Delete()

**- How to verify it**
Looks like CleanupConmonCgroup doesn't have any tests. What would be a good way to test this?

**- Description for the changelog**
Don't panic if conmon cgroup could not be loaded during cleanup (Fixes #2620)