### PR TITLE
[1.14] Return if error loading cgroup CleanupConmonCgroup

### DIFF
--- a/oci/container.go
+++ b/oci/container.go
@@ -135,6 +135,7 @@ func (c *Container) CleanupConmonCgroup() {
 	cg, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(path))
 	if err != nil {
 		logrus.Infof("error loading conmon cgroup of container %s: %v", c.ID(), err)
+		return
 	}
 	if err := cg.Delete(); err != nil {
 		logrus.Infof("error deleting conmon cgroup of container %s: %v", c.ID(), err)


### PR DESCRIPTION
Return before using nil cgroup if there was an error loading conmon
cgroup for a container.

Signed-off-by: Marius Grigoriu <marius.grigoriu@me.com>
Backported-by: Valentin Rothberg <rothberg@redhat.com>

---

Backport of https://github.com/cri-o/cri-o/pull/2621