### PR TITLE
[1.11] conmon: check it is a valid pid before killing it

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -1667,9 +1667,11 @@ int main(int argc, char *argv[])
 			ret = waitpid(create_pid, &runtime_status, 0);
 		while (ret < 0 && errno == EINTR);
 		if (ret < 0) {
-			int old_errno = errno;
-			kill(create_pid, SIGKILL);
-			errno = old_errno;
+			if (create_pid > 0) {
+				int old_errno = errno;
+				kill(create_pid, SIGKILL);
+				errno = old_errno;
+			}
 			pexitf("Failed to wait for `runtime %s`", opt_exec ? "exec" : "create");
 		}
 	}
@@ -1760,7 +1762,8 @@ int main(int argc, char *argv[])
 	const char *exit_message = NULL;
 
 	if (timed_out) {
-		kill(container_pid, SIGKILL);
+		if (container_pid > 0)
+			kill(container_pid, SIGKILL);
 		exit_message = "command timed out";
 	} else {
 		exit_status = get_exit_status(container_status);

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -457,6 +457,7 @@ function parse_pod_ip() {
 		if [ "$cidr" == "$arg" ]
 		then
 			echo `echo "$arg" | sed "s/\/[0-9][0-9]//"`
+			break
 		fi
 	done
 }

--- a/test/network.bats
+++ b/test/network.bats
@@ -181,8 +181,8 @@ function teardown() {
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed after network setup
-	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
+	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip*
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | grep -v lock | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }
 
@@ -195,7 +195,7 @@ function teardown() {
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed during network setup after the CNI plugin itself succeeded
-	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip
-	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
+	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip*
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | grep -v lock | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.11.15"
+const Version = "1.11.16-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.11.15-dev"
+const Version = "1.11.15"


### PR DESCRIPTION
always check it is a valid PID before passing it down to kill(2).

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1730919

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com
Side-ported-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
