### PR TITLE
Remove CRICTL_COMMIT from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,7 @@ RUN cd /tmp &&\
     mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
 # Install crictl and critest
-ENV CRICTL_COMMIT v1.15.0
-RUN VERSION=$CRICTL_COMMIT &&\
+RUN VERSION=v1.15.0 &&\
     wget -qO- https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz \
         | tar xfz - -C /usr/bin &&\
     wget -qO- https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/critest-$VERSION-linux-amd64.tar.gz \


### PR DESCRIPTION
Since the Kata tests are now independent of the Dockerfile we are fine
removing the additional environment variable.

This is a small follow-up of: https://github.com/cri-o/cri-o/pull/2566