### PR TITLE
[1.15] privileged: set mounts to rw

### DIFF
--- a/test/testdata/container_config_privileged.json
+++ b/test/testdata/container_config_privileged.json
@@ -1,0 +1,74 @@
+{
+	"metadata": {
+		"name": "container1",
+		"attempt": 1
+	},
+	"image": {
+		"image": "quay.io/crio/redis:alpine"
+	},
+	"command": [
+		"/bin/ls"
+	],
+	"args": [],
+	"working_dir": "/",
+	"envs": [
+		{
+			"key": "PATH",
+			"value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+		},
+		{
+			"key": "TERM",
+			"value": "xterm"
+		},
+		{
+			"key": "TESTDIR",
+			"value": "test/dir1"
+		},
+		{
+			"key": "TESTFILE",
+			"value": "test/file1"
+		}
+	],
+	"labels": {
+		"type": "small",
+		"batch": "no"
+	},
+	"annotations": {
+		"owner": "dragon",
+		"daemon": "crio"
+	},
+	"log_path": "",
+	"stdin": false,
+	"stdin_once": false,
+	"tty": false,
+	"linux": {
+		"privileged": true,
+		"resources": {
+			"cpu_period": 10000,
+			"cpu_quota": 20000,
+			"cpu_shares": 512,
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
+		},
+		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
+			"readonly_rootfs": false,
+			"selinux_options": {
+				"user": "system_u",
+				"role": "system_r",
+				"type": "svirt_lxc_net_t",
+				"level": "s0:c4,c5"
+			},
+			"capabilities": {
+				"add_capabilities": [
+					"setuid",
+					"setgid"
+				],
+				"drop_capabilities": [
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
Set all OCI mounts as privileged when running in privileged mode.

Backport-of: d3a50d86f8803e21b9ff8e28d4d821bf677a70ac
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
