### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
 
 SELINUXOPT ?= $(shell selinuxenabled 2>/dev/null && echo -Z)
 
-BUILD_INFO := $(shell date +%s)
+SOURCE_DATE_EPOCH ?= $(shell date +%s)
 
 GO_MD2MAN := ${BUILD_BIN_PATH}/go-md2man
 GINKGO := ${BUILD_BIN_PATH}/ginkgo
@@ -62,7 +62,7 @@ GOPKGBASEDIR := $(shell dirname "$(GOPKGDIR)")
 # Update VPATH so make finds .gopathok
 VPATH := $(VPATH):$(GOPATH)
 SHRINKFLAGS := -s -w
-BASE_LDFLAGS = ${SHRINKFLAGS} -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO}
+BASE_LDFLAGS = ${SHRINKFLAGS} -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${SOURCE_DATE_EPOCH}
 LDFLAGS = -ldflags '${BASE_LDFLAGS}'
 
 all: binaries crio.conf docs


### PR DESCRIPTION
**- What I did**
Make cri-o build reproducibly by default.

**- How I did it**
Default `BUILD_INFO` to `SOURCE_DATE_EPOCH`, if available.

**- How to verify it**
1. `export SOURCE_DATE_EPOCH=123456`
2. Do 2 clean builds within `taskset 1` (needed because of some go parallelism bug) and compare `/usr/bin/crio` - should have identical content between builds.

**- Description for the changelog**
Allow to override build date with SOURCE_DATE_EPOCH


in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

While it is already possible to do reproducible builds without
this patch, this patch makes it the default,
so that distributions do not have to discover the BUILD_INFO variable.

Without this patch, `/usr/bin/crio` differs in ELF section .note.go.buildid

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>