### PR TITLE
Add filename log hook

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -532,6 +532,7 @@ func main() {
 			return err
 		}
 		logrus.SetLevel(level)
+		logrus.AddHook(log.NewFilenameHook())
 
 		if path := c.GlobalString("log"); path != "" {
 			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)

--- a/internal/pkg/log/hooks.go
+++ b/internal/pkg/log/hooks.go
@@ -1,0 +1,114 @@
+package log
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+type FileNameHook struct {
+	field      string
+	skipPrefix []string
+	formatter  logrus.Formatter
+	Formatter  func(file, function string, line int) string
+}
+
+type wrapper struct {
+	old  logrus.Formatter
+	hook *FileNameHook
+}
+
+// NewFilenameHook creates a new default FileNameHook
+func NewFilenameHook() *FileNameHook {
+	return &FileNameHook{
+		field:      "file",
+		skipPrefix: []string{"log/", "logrus/", "logrus@"},
+		Formatter: func(file, function string, line int) string {
+			return fmt.Sprintf("%s:%d", file, line)
+		},
+	}
+}
+
+// Levels returns the levels for which the hook is activated. This contains
+// currently only the DebugLevel
+func (f *FileNameHook) Levels() []logrus.Level {
+	return []logrus.Level{logrus.DebugLevel}
+}
+
+// Fire executes the hook for every logrus entry
+func (f *FileNameHook) Fire(entry *logrus.Entry) error {
+	if f.formatter != entry.Logger.Formatter {
+		f.formatter = &wrapper{entry.Logger.Formatter, f}
+	}
+	entry.Logger.Formatter = f.formatter
+	return nil
+}
+
+// Format returns the log format including the caller as field
+func (w *wrapper) Format(entry *logrus.Entry) ([]byte, error) {
+	field := entry.WithField(
+		w.hook.field,
+		w.hook.Formatter(w.hook.findCaller()),
+	)
+	field.Level = entry.Level
+	field.Message = entry.Message
+	return w.old.Format(field)
+}
+
+// findCaller returns the file, function and line number for the current call
+func (f *FileNameHook) findCaller() (file, function string, line int) {
+	var pc uintptr
+	// The maximum amount of frames to be iterated
+	const maxFrames = 10
+	for i := 0; i < maxFrames; i++ {
+		// The amount of frames to be skipped to land at the actual caller
+		const skipFrames = 5
+		pc, file, line = caller(skipFrames + i)
+		if !f.shouldSkipPrefix(file) {
+			break
+		}
+	}
+	if pc != 0 {
+		frames := runtime.CallersFrames([]uintptr{pc})
+		frame, _ := frames.Next()
+		function = frame.Function
+	}
+
+	return file, function, line
+}
+
+// caller reports file and line number information about function invocations
+// on the calling goroutine's stack. The argument skip is the number of stack
+// frames to ascend, with 0 identifying the caller of Caller.
+func caller(skip int) (pc uintptr, file string, line int) {
+	ok := false
+	pc, file, line, ok = runtime.Caller(skip)
+	if !ok {
+		return 0, "", 0
+	}
+
+	n := 0
+	for i := len(file) - 1; i > 0; i-- {
+		if file[i] == '/' {
+			n++
+			if n >= 2 {
+				file = file[i+1:]
+				break
+			}
+		}
+	}
+
+	return pc, file, line
+}
+
+// shouldSkipPrefix returns true if the hook should be skipped, otherwise false
+func (f *FileNameHook) shouldSkipPrefix(file string) bool {
+	for i := range f.skipPrefix {
+		if strings.HasPrefix(file, f.skipPrefix[i]) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The newly added log hook will be only executed on debug output, since it
might be possible that it has performance drawbacks. When debug output
is enabled, then we now retrieve the correct file location for the log
message as well via the field `file="name:line"`.

---

Example for debug (with the new `file` field):
```
DEBU[2019-07-22 10:29:52.218612088+02:00] using runtime executable from $PATH "/usr/sbin/runc"  file="config/config.go:695"
DEBU[2019-07-22 10:29:52.218696862+02:00] found valid runtime "runc" for runtime_path "/usr/sbin/runc"  file="config/config.go:701"
INFO[2019-07-22 10:29:52.218830929+02:00] using conmon executable "/usr/lib/crio/bin/conmon"  file="config/config.go:721"
DEBU[2019-07-22 10:29:52.218984011+02:00] [graphdriver] trying provided driver "btrfs"  file="drivers/driver.go:235"
DEBU[2019-07-22 10:29:52.222049152+02:00] reading hooks from /usr/share/containers/oci/hooks.d  file="hooks/read.go:65"
```

Example for info (as usual):
```
INFO[2019-07-22 10:33:09.407344412+02:00] using conmon executable "/usr/lib/crio/bin/conmon"
INFO[2019-07-22 10:33:09.413212160+02:00] Found CNI network crio (type=bridge) at /etc/cni/net.d/20-crio.conf
INFO[2019-07-22 10:33:09.413364554+02:00] Found CNI network podman (type=bridge) at /etc/cni/net.d/87-podman-bridge.conflist
INFO[2019-07-22 10:33:09.432670861+02:00] no seccomp profile specified, using the internal default
INFO[2019-07-22 10:33:09.432792856+02:00] installing default apparmor profile: crio-default-1.15.1-dev
```