### PR TITLE
Add internal log unit tests

### DIFF
--- a/internal/pkg/log/interceptors.go
+++ b/internal/pkg/log/interceptors.go
@@ -69,5 +69,5 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 }
 
 func addRequestID(ctx context.Context) context.Context {
-	return context.WithValue(ctx, id{}, uuid.New().String())
+	return context.WithValue(ctx, ID{}, uuid.New().String())
 }

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type id struct{}
+type ID struct{}
 
 func Debugf(ctx context.Context, format string, args ...interface{}) {
 	entry(ctx).Debugf(format, args...)
@@ -31,7 +31,7 @@ func entry(ctx context.Context) *logrus.Entry {
 		return logrus.NewEntry(logger)
 	}
 
-	idValue := ctx.Value(id{})
+	idValue := ctx.Value(ID{})
 	if ret, ok := idValue.(string); ok {
 		return logger.WithField("id", ret)
 	}

--- a/internal/pkg/log/log_test.go
+++ b/internal/pkg/log/log_test.go
@@ -1,0 +1,129 @@
+package log_test
+
+import (
+	"context"
+
+	"github.com/cri-o/cri-o/internal/pkg/log"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+// The actual test suite
+var _ = t.Describe("Log", func() {
+	var ctx context.Context
+
+	const (
+		msg = "Hello world"
+		id  = "some-id"
+	)
+
+	idEntry := "id=" + id
+
+	BeforeEach(func() {
+		ctx = context.WithValue(context.Background(), log.ID{}, id)
+	})
+
+	t.Describe("Debugf", func() {
+		BeforeEach(func() { beforeEach(logrus.DebugLevel) })
+
+		It("should succeed to debug log", func() {
+			// Given
+			// When
+			log.Debugf(ctx, msg)
+
+			// Then
+			Expect(buf.String()).To(ContainSubstring(msg))
+			Expect(buf.String()).To(ContainSubstring(idEntry))
+		})
+
+		It("should succeed to debug on empty context", func() {
+			// Given
+			// When
+			log.Debugf(context.Background(), msg)
+
+			// Then
+			Expect(buf.String()).To(ContainSubstring(msg))
+			Expect(buf.String()).ToNot(ContainSubstring(idEntry))
+		})
+
+		It("should succeed to debug on nil context", func() {
+			// Given
+			// When
+			log.Debugf(nil, msg) // nolint: staticcheck
+
+			// Then
+			Expect(buf.String()).To(ContainSubstring(msg))
+			Expect(buf.String()).ToNot(ContainSubstring(idEntry))
+		})
+	})
+
+	t.Describe("Infof", func() {
+		BeforeEach(func() { beforeEach(logrus.InfoLevel) })
+
+		It("should succeed to info log", func() {
+			// Given
+			// When
+			log.Infof(ctx, msg)
+
+			// Then
+			Expect(buf.String()).To(ContainSubstring(msg))
+			Expect(buf.String()).To(ContainSubstring(idEntry))
+		})
+
+		It("should not debug log", func() {
+			// Given
+			// When
+			log.Debugf(ctx, msg)
+
+			// Then
+			Expect(buf.String()).To(BeEmpty())
+		})
+	})
+
+	t.Describe("Warnf", func() {
+		BeforeEach(func() { beforeEach(logrus.WarnLevel) })
+
+		It("should succeed to warn log", func() {
+			// Given
+			// When
+			log.Warnf(ctx, msg)
+
+			// Then
+			Expect(buf.String()).To(ContainSubstring(msg))
+			Expect(buf.String()).To(ContainSubstring(idEntry))
+		})
+
+		It("should not info log", func() {
+			// Given
+			// When
+			log.Infof(ctx, msg)
+
+			// Then
+			Expect(buf.String()).To(BeEmpty())
+		})
+	})
+
+	t.Describe("Errorf", func() {
+		BeforeEach(func() { beforeEach(logrus.ErrorLevel) })
+
+		It("should succeed to error log", func() {
+			// Given
+			// When
+			log.Errorf(ctx, msg)
+
+			// Then
+			Expect(buf.String()).To(ContainSubstring(msg))
+			Expect(buf.String()).To(ContainSubstring(idEntry))
+		})
+
+		It("should not warn log", func() {
+			// Given
+			// When
+			log.Warnf(ctx, msg)
+
+			// Then
+			Expect(buf.String()).To(BeEmpty())
+		})
+	})
+})

--- a/internal/pkg/log/suite_test.go
+++ b/internal/pkg/log/suite_test.go
@@ -1,0 +1,39 @@
+package log_test
+
+import (
+	"bytes"
+	"testing"
+
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+// TestLog runs the created specs
+func TestLog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "Log")
+}
+
+var (
+	t   *TestFramework
+	sut *logrus.Logger
+	buf *bytes.Buffer
+)
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})
+
+func beforeEach(level logrus.Level) {
+	buf = &bytes.Buffer{}
+	sut = logrus.StandardLogger()
+	sut.Level = level
+	sut.Out = buf
+}


### PR DESCRIPTION
This suite ensures that the internal log abstraction works as intended
and applies necessary unit tests to them.