### PR TITLE
Pin CircleCI base image and update builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
 
   container-base:
     docker:
-      - image: circleci/golang
+      - image: circleci/golang:1.12
     <<: *stdenv
     working_directory: *workdir
 
@@ -149,7 +149,7 @@ jobs:
             - bin
 
   build-test-binaries:
-    executor: container-base
+    executor: container
     steps:
       - checkout
       - restore_cache:
@@ -225,7 +225,7 @@ jobs:
             - build/bin/ginkgo
 
   git-validation:
-    executor: container-base
+    executor: container
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
The test-binaries target needs further dependencies which are not
fulfilled any more by circleci/golang. Beside this we pin it to the
latest 1.12 tag.