### PR TITLE
[1.14] container_status: Use cached value of image name

### DIFF
--- a/server/container_status.go
+++ b/server/container_status.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containers/image/types"
 	"github.com/cri-o/cri-o/oci"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -38,11 +37,10 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 			Labels:      c.Labels(),
 			Annotations: c.Annotations(),
 			ImageRef:    c.ImageRef(),
+			Image: &pb.ImageSpec{
+				Image: c.ImageName(),
+			},
 		},
-	}
-	resp.Status.Image = &pb.ImageSpec{Image: c.Image()}
-	if status, err := s.StorageImageServer().ImageStatus(&types.SystemContext{}, c.ImageRef()); err == nil {
-		resp.Status.Image.Image = status.Name
 	}
 
 	mounts := []*pb.Mount{}


### PR DESCRIPTION
Use the name we stored in the container object in container status
rather than recalculating it.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

@nalind ptal. I am reversing what was introduced in f3b7065bd80a53e4c48e8c45c36dcb86717e1578.