### PR TITLE
[1.14] Fix container image used for integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y \
     libnl-3-dev \
     libostree-dev \
     libprotobuf-dev \
-    libprotobuf-c0-dev \
+    libprotobuf-c-dev \
     libseccomp2 \
     libseccomp-dev \
     libtool \

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -352,6 +352,9 @@ function teardown() {
 }
 
 @test "ctr journald logging" {
+	if [[ "$TRAVIS" == "true" ]]; then
+		skip "travis does not support journald logging"
+	fi
 	# ensure we have journald logging capability
 	enabled=$(check_journald)
 	if [[ "$enabled" -ne 0 ]]; then


### PR DESCRIPTION
The package `libprotobuf-c0-dev` changed to `libprotobuf-c-dev`, so we
adapt our Dockerfile to it.

Cherry-picked: fa7b9795095a4dca64f60d5f9adb0d1bfe9da0d1
Backport of: #2651