### PR TITLE
[1.15] Fix container image used for integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update &&\
     liblzma-dev \
     libnet-dev \
     libnl-3-dev \
-    libprotobuf-c0-dev \
+    libprotobuf-c-dev \
     libprotobuf-dev \
     libseccomp-dev \
     libseccomp2 \


### PR DESCRIPTION
The package `libprotobuf-c0-dev` changed to `libprotobuf-c-dev`, so we
adapt our Dockerfile to it.

Cherry-picked: fa7b9795095a4dca64f60d5f9adb0d1bfe9da0d1
Backport of: #2651