### PR TITLE
Add AUDIT_WRITE to default capabilities

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -100,7 +100,7 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 
 **--cpu-profile**="": set the CPU profile file path
 
-**--default-capabilities**="": capabilities to add to the containers (default: "CHOWN, DAC_OVERRIDE, FSETID, FOWNER, NET_RAW, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, KILL)
+**--default-capabilities**="": capabilities to add to the containers (default: "AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FSETID, FOWNER, NET_RAW, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, KILL)
 
 **--default-mounts**="": add one or more default mount paths in the form host:container (deprecated - add the default mounts to /etc/containers/mounts.conf instead)
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -111,6 +111,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
   The default list is:
 ```
   default_capabilities = [
+          "AUDIT_WRITE",
           "CHOWN",
           "DAC_OVERRIDE",
           "FSETID",

--- a/internal/lib/config/config.go
+++ b/internal/lib/config/config.go
@@ -97,6 +97,7 @@ const (
 
 // DefaultCapabilities for the default_capabilities option in the crio.conf file
 var DefaultCapabilities = []string{
+	"AUDIT_WRITE",
 	"CHOWN",
 	"DAC_OVERRIDE",
 	"FSETID",


### PR DESCRIPTION
To keep the compatibility with Docker we should add the `AUDIT_WRITE`
capability as a default, too.

Reference: https://github.com/moby/moby/pull/7179

Needs a backport to release-1.15 if acceptable.

/cc @rhatdan 