### PR TITLE
Round 2 of integration test fixes

### DIFF
--- a/test/apparmor.bats
+++ b/test/apparmor.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
     cleanup_test
 }
@@ -35,10 +39,6 @@ function teardown() {
     run crictl exec --sync "$ctr_id" touch test.txt
     echo "$output"
     [ "$status" -eq 0 ]
-
-    cleanup_ctrs
-    cleanup_pods
-    stop_crio
 }
 
 # 2. test running with loading a specific apparmor profile as crio default apparmor profile.
@@ -71,9 +71,6 @@ function teardown() {
     echo "$output"
     [[ "$output" =~ "Permission denied" ]]
 
-    cleanup_ctrs
-    cleanup_pods
-    stop_crio
     remove_apparmor_profile "$APPARMOR_TEST_PROFILE_PATH"
 }
 
@@ -107,9 +104,6 @@ function teardown() {
     echo "$output"
     [[ "$output" =~ "Permission denied" ]]
 
-    cleanup_ctrs
-    cleanup_pods
-    stop_crio
     remove_apparmor_profile "$APPARMOR_TEST_PROFILE_PATH"
 }
 
@@ -138,10 +132,6 @@ function teardown() {
     echo "$output"
     [ "$status" -ne 0 ]
     [[ "$output" =~ "Creating container failed" ]]
-
-    cleanup_ctrs
-    cleanup_pods
-    stop_crio
 }
 
 # 5. test running with default apparmor profile unloaded.
@@ -169,8 +159,4 @@ function teardown() {
     run crictl create "$pod_id" "$TESTDIR"/apparmor_container5.json "$TESTDIR"/apparmor5.json
     echo "$output"
     [ "$status" -ne 0 ]
-
-    cleanup_ctrs
-    cleanup_pods
-    stop_crio
 }

--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -34,9 +38,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "conmon custom cgroup" {
@@ -59,7 +60,4 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }

--- a/test/critest.bats
+++ b/test/critest.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
     cleanup_test
 }

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -2,7 +2,13 @@
 
 load helpers
 
+function setup() {
+	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
+	setup_test
+}
+
 function teardown() {
+	rm -f "$newconfig"
 	cleanup_test
 }
 
@@ -34,10 +40,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "reason: Completed" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr termination reason Error" {
@@ -61,10 +63,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "reason: Error" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ulimits" {
@@ -104,9 +102,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "additional devices support" {
@@ -138,9 +133,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "additional devices permissions" {
@@ -204,9 +196,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 
@@ -232,9 +221,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr lifecycle" {
@@ -302,9 +288,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "" ]]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 
@@ -316,7 +299,6 @@ function teardown() {
 	pod_id="$output"
 
 	# Create a new container.
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_config_logging.json "$newconfig"
 	sed -i 's|"%shellcommand%"|"echo here is some output \&\& echo and some from stderr >\&2"|' "$newconfig"
 	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
@@ -345,10 +327,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr journald logging" {
@@ -368,7 +346,6 @@ function teardown() {
 	stderr="here is some error"
 
 	# Create a new container.
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_config_logging.json "$newconfig"
 	sed -i 's|"%shellcommand%"|"echo '"$stdout"' \&\& echo '"$stderr"' >\&2"|' "$newconfig"
 	cat "$newconfig"
@@ -396,10 +373,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr logging [tty=true]" {
@@ -410,7 +383,6 @@ function teardown() {
 	pod_id="$output"
 
 	# Create a new container.
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_config_logging.json "$newconfig"
 	sed -i 's|"%shellcommand%"|"echo here is some output"|' "$newconfig"
 	sed -i 's|"tty": false,|"tty": true,|' "$newconfig"
@@ -442,10 +414,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr log max" {
@@ -456,7 +424,6 @@ function teardown() {
 	pod_id="$output"
 
 	# Create a new container.
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_config_logging.json "$newconfig"
 	sed -i 's|"%shellcommand%"|"for i in $(seq 250); do echo $i; done"|' "$newconfig"
 	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
@@ -485,10 +452,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr log max with default value" {
@@ -500,7 +463,6 @@ function teardown() {
 	pod_id="$output"
 
 	# Create a new container.
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_config_logging.json "$newconfig"
 	sed -i 's|"%shellcommand%"|"for i in $(seq 250); do echo $i; done"|' "$newconfig"
 	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
@@ -529,10 +491,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr log max with minimum value" {
@@ -544,7 +502,6 @@ function teardown() {
 	pod_id="$output"
 
 	# Create a new container.
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_config_logging.json "$newconfig"
 	sed -i 's|"%shellcommand%"|"for i in $(seq 250); do echo $i; done"|' "$newconfig"
 	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
@@ -573,10 +530,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr partial line logging" {
@@ -587,7 +540,6 @@ function teardown() {
 	pod_id="$output"
 
 	# Create a new container.
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_config_logging.json "$newconfig"
 	sed -i 's|"%shellcommand%"|"echo -n hello"|' "$newconfig"
 	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
@@ -615,10 +567,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 # regression test for #127
@@ -645,10 +593,6 @@ function teardown() {
 		echo "$output"
 		[ "$status" -eq 0 ]
 	done
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr list filtering" {
@@ -749,9 +693,6 @@ function teardown() {
 	run crictl rmp "$pod3_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr list label filtering" {
@@ -815,9 +756,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr metadata in list & status" {
@@ -844,10 +782,6 @@ function teardown() {
 	# TODO: expected value should not hard coded here
 	[[ "$output" =~ "Name: container1" ]]
 	[[ "$output" =~ "Attempt: 1" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr execsync conflicting with conmon flags parsing" {
@@ -867,9 +801,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "hello world" ]]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr execsync" {
@@ -899,9 +830,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr device add" {
@@ -916,7 +844,6 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	pod_id="$output"
 
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_redis_device.json "$newconfig"
 	sed -i 's|"%containerdevicepath%"|"/dev/mynull"|' "$newconfig"
 
@@ -939,9 +866,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "privileged ctr device add" {
@@ -956,7 +880,6 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	pod_id="$output"
 
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_redis_device.json "$newconfig"
 	sed -i 's|"%containerdevicepath%"|"/dev/mynull"|' "$newconfig"
 	sed -i 's|"%privilegedboolean%"|true|' "$newconfig"
@@ -978,9 +901,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "privileged ctr add duplicate device as host" {
@@ -995,7 +915,6 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	pod_id="$output"
 
-	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
 	cp "$TESTDATA"/container_redis_device.json "$newconfig"
 	sed -i 's|"%containerdevicepath%"|"/dev/random"|' "$newconfig"
 	sed -i 's|"%privilegedboolean%"|true|' "$newconfig"
@@ -1003,9 +922,6 @@ function teardown() {
 	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config_privileged.json
 	echo "$output"
 	[ "$status" -ne 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr hostname env" {
@@ -1028,9 +944,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr execsync failure" {
@@ -1049,10 +962,6 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" doesnotexist
 	echo "$output"
 	[ "$status" -ne 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr execsync exit code" {
@@ -1071,9 +980,6 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" false
 	echo "$output"
 	[ "$status" -ne 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr execsync std{out,err}" {
@@ -1113,9 +1019,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr stop idempotent" {
@@ -1137,10 +1040,6 @@ function teardown() {
 	run crictl stop "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr caps drop" {
@@ -1154,10 +1053,6 @@ function teardown() {
 	run crictl create "$TESTDIR"/container_config_caps.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr with default list of capabilities from crio.conf" {
@@ -1184,9 +1079,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr with list of capabilities given by user in crio.conf" {
@@ -1214,9 +1106,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "run ctr with image with Config.Volumes" {
@@ -1236,10 +1125,6 @@ function teardown() {
 	run crictl create "$pod_id" "$TESTDIR"/container_config_volumes.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr oom" {
@@ -1279,9 +1164,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr /etc/resolv.conf rw/ro mode" {
@@ -1308,9 +1190,6 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	run wait_until_exit "$ctr_id"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr create with non-existent command" {
@@ -1330,9 +1209,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr create with non-existent command [tty]" {
@@ -1352,9 +1228,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr update resources" {
@@ -1408,10 +1281,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "10000" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr correctly setup working directory" {
@@ -1437,10 +1306,6 @@ function teardown() {
 	[ "$status" -ne 0 ]
 	ctr_id="$output"
 	[[ "$output" =~ "not a directory" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr execsync conflicting with conmon env" {
@@ -1465,9 +1330,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "acustompathinpath" ]]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr resources" {
@@ -1492,10 +1354,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "0" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr with non-root user has no effective capabilities" {
@@ -1525,9 +1383,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr with low memory configured should not be created" {
@@ -1548,9 +1403,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr expose metrics with default port" {
@@ -1584,9 +1436,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr expose metrics with custom port" {
@@ -1620,9 +1469,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 
@@ -1650,8 +1496,4 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -37,10 +41,6 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" chmod 777 .
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 # 2. test running with ctr runtime/default
@@ -75,10 +75,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "Operation not permitted" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 # 3. test running with ctr unconfined and profile empty
@@ -112,10 +108,6 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" chmod 777 .
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 # 4. test running with ctr wrong profile name
@@ -143,10 +135,6 @@ function teardown() {
 	[[ "$status" -ne 0 ]]
 	[[ "$output" =~ "unknown seccomp profile option:"  ]]
 	[[ "$output" =~ "wontwork"  ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 # 5. test running with ctr localhost/profile_name
@@ -179,10 +167,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "Operation not permitted" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 # 6. test running with ctr docker/default
@@ -217,8 +201,4 @@ function teardown() {
 	echo "$output"
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "Operation not permitted" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -45,8 +49,4 @@ function teardown() {
 	echo "$out"
 	[[ "$out" =~ "100000" ]]
 	[[ "$out" =~ "200000" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }

--- a/test/default_mounts.bats
+++ b/test/default_mounts.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -34,9 +38,6 @@ function teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "key.pem" ]]
-    cleanup_ctrs
-    cleanup_pods
-    stop_crio
 }
 
 @test "default mounts correctly sorted with other mounts" {
@@ -71,9 +72,6 @@ function teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Testing secrets mounts. I am mounted!" ]]
-    cleanup_ctrs
-    cleanup_pods
-    stop_crio
 }
 
 @test "test deprecated --default-mounts flag" {
@@ -90,7 +88,4 @@ function teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "test.txt" ]]
-    cleanup_ctrs
-    cleanup_pods
-    stop_crio
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -544,16 +544,16 @@ function check_pod_cidr() {
 }
 
 function parse_pod_ip() {
-    inet=$(crictl exec --sync "$1" ip addr show dev eth0 scope global 2>&1 | grep "$2")
-    echo "$inet" | sed -n 's;.*\('"$3"'.*\)/.*;\1;p'
+	inet=$(crictl exec --sync "$1" ip addr show dev eth0 scope global 2>&1 | grep "$2")
+	echo "$inet" | sed -n 's;.*\('"$3"'.*\)/.*;\1;p'
 }
 
 function parse_pod_ipv4() {
-    parse_pod_ip "$1" 'inet ' $POD_IPV4_CIDR_START
+	parse_pod_ip "$1" 'inet ' $POD_IPV4_CIDR_START
 }
 
 function parse_pod_ipv6() {
-    parse_pod_ip "$1" inet6 $POD_IPV6_CIDR_START
+	parse_pod_ip "$1" inet6 $POD_IPV6_CIDR_START
 }
 
 function get_host_ip() {
@@ -563,27 +563,27 @@ function get_host_ip() {
 }
 
 function ping_pod() {
-    ipv4=$(parse_pod_ipv4 "$1")
-    ping -W 1 -c 5 "$ipv4"
-    echo "$output"
-    [ "$status" -eq 0 ]
+	ipv4=$(parse_pod_ipv4 "$1")
+	ping -W 1 -c 5 "$ipv4"
+	echo "$output"
+	[ "$status" -eq 0 ]
 
-    ipv6=$(parse_pod_ipv6 "$1")
-    ping6 -W 1 -c 5 "$ipv6"
-    echo "$output"
-    [ "$status" -eq 0 ]
+	ipv6=$(parse_pod_ipv6 "$1")
+	ping6 -W 1 -c 5 "$ipv6"
+	echo "$output"
+	[ "$status" -eq 0 ]
 }
 
 function ping_pod_from_pod() {
-    ipv4=$(parse_pod_ipv4 "$1")
-    run crictl exec --sync "$2" ping -W 1 -c 2 "$ipv4"
-    echo "$output"
-    [ "$status" -eq 0 ]
+	ipv4=$(parse_pod_ipv4 "$1")
+	run crictl exec --sync "$2" ping -W 1 -c 2 "$ipv4"
+	echo "$output"
+	[ "$status" -eq 0 ]
 
-    ipv6=$(parse_pod_ipv6 "$1")
-    run crictl exec --sync "$2" ping6 -W 1 -c 2 "$ipv6"
-    echo "$output"
-    [ "$status" -eq 0 ]
+	ipv6=$(parse_pod_ipv6 "$1")
+	run crictl exec --sync "$2" ping6 -W 1 -c 2 "$ipv6"
+	echo "$output"
+	[ "$status" -eq 0 ]
 }
 
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -442,7 +442,7 @@ function cleanup_test() {
 	cleanup_pods
 	stop_crio
 	cleanup_lvm
-	rm -r "$TESTDIR"
+	rm -r "$TESTDIR" || true
 }
 
 

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -2,13 +2,17 @@
 
 load helpers
 
+function setup() {
+	setup_test
+	sed "s|HOOKSCHECK|${HOOKSCHECK}|" "$INTEGRATION_ROOT"/hooks/checkhook.sh > ${HOOKSDIR}/checkhook.sh
+	chmod +x ${HOOKSDIR}/checkhook.sh
+	sed "s|HOOKSDIR|${HOOKSDIR}|" "$INTEGRATION_ROOT"/hooks/checkhook.json > ${HOOKSDIR}/checkhook.json
+
+}
+
 function teardown() {
 	cleanup_test
 }
-
-sed "s|HOOKSCHECK|${HOOKSCHECK}|" hooks/checkhook.sh > ${HOOKSDIR}/checkhook.sh
-chmod +x ${HOOKSDIR}/checkhook.sh
-sed "s|HOOKSDIR|${HOOKSDIR}|" hooks/checkhook.json > ${HOOKSDIR}/checkhook.json
 
 @test "pod test hooks" {
 	rm -f ${HOOKSCHECK}
@@ -33,7 +37,4 @@ sed "s|HOOKSDIR|${HOOKSDIR}|" hooks/checkhook.json > ${HOOKSDIR}/checkhook.json
 	run cat ${HOOKSCHECK}
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }

--- a/test/image.bats
+++ b/test/image.bats
@@ -6,6 +6,10 @@ IMAGE=quay.io/crio/pause
 SIGNED_IMAGE=registry.access.redhat.com/rhel7-atomic:latest
 UNSIGNED_IMAGE=quay.io/crio/hello-world:latest
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -24,9 +28,6 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "container status when created by image ID" {
@@ -49,10 +50,6 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "image: quay.io/crio/redis:alpine" ]]
 	[[ "$output" =~ "imageRef: $REDIS_IMAGEREF" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "container status when created by image tagged reference" {
@@ -75,10 +72,6 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "image: quay.io/crio/redis:alpine" ]]
 	[[ "$output" =~ "imageRef: $REDIS_IMAGEREF" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "container status when created by image canonical reference" {
@@ -105,10 +98,6 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "image: quay.io/crio/redis:alpine" ]]
 	[[ "$output" =~ "imageRef: $REDIS_IMAGEREF" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "image pull and list" {
@@ -132,7 +121,6 @@ function teardown() {
 	echo "$output"
 	[ "$output" != "" ]
 	cleanup_images
-	stop_crio
 }
 
 @test "image pull with signature" {
@@ -142,7 +130,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	cleanup_images
-	stop_crio
 }
 
 @test "image pull without signature" {
@@ -151,7 +138,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -ne 0 ]
 	cleanup_images
-	stop_crio
 }
 
 @test "image pull and list by tag and ID" {
@@ -177,7 +163,6 @@ function teardown() {
 	[ "$output" != "" ]
 
 	cleanup_images
-	stop_crio
 }
 
 @test "image pull and list by digest and ID" {
@@ -203,7 +188,6 @@ function teardown() {
 	[ "$output" != "" ]
 
 	cleanup_images
-	stop_crio
 }
 
 @test "image list with filter" {
@@ -227,7 +211,6 @@ function teardown() {
 		status=1
 	done
 	cleanup_images
-	stop_crio
 }
 
 @test "image list/remove" {
@@ -253,7 +236,6 @@ function teardown() {
 		status=1
 	done
 	cleanup_images
-	stop_crio
 }
 
 @test "image status/remove" {
@@ -283,5 +265,4 @@ function teardown() {
 		status=1
 	done
 	cleanup_images
-	stop_crio
 }

--- a/test/image_remove.bats
+++ b/test/image_remove.bats
@@ -4,6 +4,10 @@ load helpers
 
 IMAGE=quay.io/crio/pause
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }

--- a/test/image_volume.bats
+++ b/test/image_volume.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -31,9 +35,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "image volume bind" {
@@ -64,9 +65,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "image volume user mkdir" {

--- a/test/inspect.bats
+++ b/test/inspect.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -53,10 +57,6 @@ function teardown() {
 # TODO: add some other check based on the json below:
 #
 # {"name":"k8s_container1_podsandbox1_redhat.test.crio_redhat-test-crio_1","pid":27477,"image":"redis:alpine","created_time":1505223601111546169,"labels":{"batch":"no","type":"small"},"annotations":{"daemon":"crio","owner":"dragon"},"log_path":"/var/log/crio/pods/297d014ba2c54236779da0c2f80dfba45dc31b106e4cd126a1c3c6d78edc2201/81567e9573ea798d6494c9aab156103ee91b72180fd3841a7c24d2ca39886ba2.log","root":"/tmp/tmp.0bkjphWudF/crio/overlay/d7cfc1de83cab9f377a4a1542427d2a019e85a70c1c660a9e6cf9e254df68873/merged","sandbox":"297d014ba2c54236779da0c2f80dfba45dc31b106e4cd126a1c3c6d78edc2201","ip_addresses":"[10.88.9.153]"}
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "ctr inspect not found" {

--- a/test/namespaces.bats
+++ b/test/namespaces.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -30,7 +34,4 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }

--- a/test/network.bats
+++ b/test/network.bats
@@ -2,13 +2,14 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
+	cleanup_test
 	rm -f /var/lib/cni/networks/crionet_test_args_$RANDOM_STRING/*
 	chmod 0755 $CONMON_BINARY
-	cleanup_test
 }
 
 @test "ensure correct hostname" {

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -29,9 +33,6 @@ function teardown() {
 	run crictl rmp "$id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "pod remove" {
@@ -53,9 +54,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "pod stop ignores not found sandboxes" {
@@ -75,10 +73,6 @@ function teardown() {
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "pod list filtering" {
@@ -169,8 +163,6 @@ function teardown() {
 	run crictl rmp "$pod3_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_pods
-	stop_crio
 }
 
 @test "pod metadata in list & status" {
@@ -197,9 +189,6 @@ function teardown() {
 	[[ "$output" =~ "UID: redhat-test-crio" ]]
 	[[ "$output" =~ "Namespace: redhat.test.crio" ]]
 	[[ "$output" =~ "Attempt: 1" ]]
-
-	cleanup_pods
-	stop_crio
 }
 
 @test "pass pod sysctls to runtime" {
@@ -241,9 +230,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "net.ipv4.ip_forward = 1" ]]
-
-	cleanup_pods
-	stop_crio
 }
 
 @test "pod stop idempotent" {
@@ -258,10 +244,6 @@ function teardown() {
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "pod remove idempotent" {
@@ -276,10 +258,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "pod stop idempotent with ctrs already stopped" {
@@ -301,10 +279,6 @@ function teardown() {
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "restart crio and still get pod status" {
@@ -322,10 +296,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "$output" != "" ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "invalid systemd cgroup_parent fail" {
@@ -362,7 +332,4 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "Burstable-pod_integration_tests_123.slice" ]]
-
-	cleanup_pods
-	stop_crio
 }

--- a/test/reload.bats
+++ b/test/reload.bats
@@ -3,6 +3,7 @@
 load helpers
 
 function setup() {
+	setup_test
     start_crio
 
     # the default log_level is `error` so we have to adapt it before running

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -77,10 +81,6 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	output=`echo "$output" | grep State`
 	[[ "${output}" == "${ctr_status_info}" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "crio restore with bad state and pod stopped" {
@@ -104,9 +104,6 @@ function teardown() {
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_pods
-	stop_crio
 }
 
 @test "crio restore with bad state and ctr stopped" {
@@ -136,10 +133,6 @@ function teardown() {
 	run crictl stop "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "crio restore with bad state and ctr removed" {
@@ -174,10 +167,6 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 1 ]
 	[[ "${output}" =~ "not found" ]]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "crio restore with bad state and pod removed" {
@@ -205,9 +194,6 @@ function teardown() {
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_pods
-	stop_crio
 }
 
 @test "crio restore with bad state" {
@@ -269,10 +255,6 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }
 
 @test "crio restore with missing config.json" {
@@ -317,8 +299,4 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }

--- a/test/runtimeversion.bats
+++ b/test/runtimeversion.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }

--- a/test/selinux.bats
+++ b/test/selinux.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -19,8 +23,4 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }

--- a/test/shm.bats
+++ b/test/shm.bats
@@ -2,6 +2,10 @@
 
 load helpers
 
+function setup() {
+	setup_test
+}
+
 function teardown() {
 	cleanup_test
 }
@@ -33,8 +37,4 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" ls /dev/shm/testdata
 	echo "$output"
 	[ "$status" -eq 0 ]
-
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }

--- a/test/status.bats
+++ b/test/status.bats
@@ -3,7 +3,7 @@
 load helpers
 
 function setup() {
-	setup_test
+    setup_test
     start_crio
 }
 

--- a/test/status.bats
+++ b/test/status.bats
@@ -3,6 +3,7 @@
 load helpers
 
 function setup() {
+	setup_test
     start_crio
 }
 


### PR DESCRIPTION
Clean up the integration tests by cleaning /tmp more consistently (more details in commit message) and remove the `|| true` hack to work on getting to the bottom of those flakes.