### PR TITLE
Fix parse of memory.limit_in_bytes on 32-bit machines

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -726,7 +726,7 @@ func AddCgroupAnnotation(ctx context.Context, g generate.Generator, mountPath, c
 				// strip off the newline character and convert it to an int
 				strMemory := strings.TrimRight(string(fileData), "\n")
 				if strMemory != "" {
-					memoryLimit, err := strconv.Atoi(strMemory)
+					memoryLimit, err := strconv.ParseInt(strMemory, 10, 64)
 					if err != nil {
 						return "", errors.Wrapf(err, "error converting cgroup memory value from string to int %q", strMemory)
 					}


### PR DESCRIPTION
Signed-off-by: Richard Kojedzinszky <richard@kojedz.in>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Forward port of #2668
