### PR TITLE
container_status: Use cached value of image name

### DIFF
--- a/server/container_status.go
+++ b/server/container_status.go
@@ -36,11 +36,10 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 			Labels:      c.Labels(),
 			Annotations: c.Annotations(),
 			ImageRef:    c.ImageRef(),
+			Image: &pb.ImageSpec{
+				Image: c.ImageName(),
+			},
 		},
-	}
-	resp.Status.Image = &pb.ImageSpec{Image: c.Image()}
-	if status, err := s.StorageImageServer().ImageStatus(s.systemContext, c.ImageRef()); err == nil {
-		resp.Status.Image.Image = status.Name
 	}
 
 	mounts := []*pb.Mount{}

--- a/server/container_status_test.go
+++ b/server/container_status_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/cri-o/cri-o/internal/pkg/storage"
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -32,11 +30,6 @@ var _ = t.Describe("ContainerStatus", func() {
 			addContainerAndSandbox()
 			testContainer.AddVolume(oci.ContainerVolume{})
 			testContainer.SetState(givenState)
-
-			gomock.InOrder(
-				imageServerMock.EXPECT().ImageStatus(gomock.Any(),
-					gomock.Any()).Return(&storage.ImageResult{}, nil),
-			)
 
 			// When
 			response, err := sut.ContainerStatus(context.Background(),


### PR DESCRIPTION
Use the name we stored in the container object in container status
rather than recalculating it.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

