### PR TITLE
Add missing CLI flags

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -204,6 +204,46 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) (string, error) {
 	if ctx.GlobalIsSet("additional-devices") {
 		config.AdditionalDevices = ctx.GlobalStringSlice("additional-devices")
 	}
+	if ctx.GlobalIsSet("conmon-env") {
+		config.ConmonEnv = ctx.GlobalStringSlice("conmon-env")
+	}
+	if ctx.GlobalIsSet("container-attach-socket-dir") {
+		config.ContainerAttachSocketDir = ctx.GlobalString("container-attach-socket-dir")
+	}
+	if ctx.GlobalIsSet("container-exits-dir") {
+		config.ContainerExitsDir = ctx.GlobalString("container-exits-dir")
+	}
+	if ctx.GlobalIsSet("ctr-stop-timeout") {
+		config.CtrStopTimeout = ctx.GlobalInt64("ctr-stop-timeout")
+	}
+	if ctx.GlobalIsSet("grpc-max-recv-msg-size") {
+		config.GRPCMaxRecvMsgSize = ctx.GlobalInt("grpc-max-recv-msg-size")
+	}
+	if ctx.GlobalIsSet("grpc-max-send-msg-size") {
+		config.GRPCMaxSendMsgSize = ctx.GlobalInt("grpc-max-send-msg-size")
+	}
+	if ctx.GlobalIsSet("host-ip") {
+		config.HostIP = ctx.GlobalString("host-ip")
+	}
+	if ctx.GlobalIsSet("manage-network-ns-lifecycle") {
+		config.ManageNetworkNSLifecycle = ctx.GlobalBool("manage-network-ns-lifecycle")
+	}
+	if ctx.GlobalIsSet("no-pivot") {
+		config.NoPivot = ctx.GlobalBool("no-pivot")
+	}
+	if ctx.GlobalIsSet("stream-enable-tls") {
+		config.StreamEnableTLS = ctx.GlobalBool("stream-enable-tls")
+	}
+	if ctx.GlobalIsSet("stream-tls-ca") {
+		config.StreamTLSCA = ctx.GlobalString("stream-tls-ca")
+	}
+	if ctx.GlobalIsSet("stream-tls-cert") {
+		config.StreamTLSCert = ctx.GlobalString("stream-tls-cert")
+	}
+	if ctx.GlobalIsSet("stream-tls-key") {
+		config.StreamTLSKey = ctx.GlobalString("stream-tls-key")
+	}
+
 	return path, nil
 }
 
@@ -498,6 +538,58 @@ func main() {
 		cli.StringSliceFlag{
 			Name:  "additional-devices",
 			Usage: fmt.Sprintf("devices to add to the containers (default: %q)", defConf.AdditionalDevices),
+		},
+		cli.StringSliceFlag{
+			Name:  "conmon-env",
+			Usage: fmt.Sprintf("environment variable list for the conmon process, used for passing necessary environment variables to conmon or the runtime (default: %q)", defConf.ConmonEnv),
+		},
+		cli.StringFlag{
+			Name:  "container-attach-socket-dir",
+			Usage: fmt.Sprintf("path to directory for container attach sockets (default: %q)", defConf.ContainerAttachSocketDir),
+		},
+		cli.StringFlag{
+			Name:  "container-exits-dir",
+			Usage: fmt.Sprintf("path to directory in which container exit files are written to by conmon (default: %q)", defConf.ContainerExitsDir),
+		},
+		cli.Int64Flag{
+			Name:  "ctr-stop-timeout",
+			Usage: fmt.Sprintf("the minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container (default: %q)", defConf.CtrStopTimeout),
+		},
+		cli.IntFlag{
+			Name:  "grpc-max-recv-msg-size",
+			Usage: fmt.Sprintf("maximum grpc receive message size in bytes (default: %q)", defConf.GRPCMaxRecvMsgSize),
+		},
+		cli.IntFlag{
+			Name:  "grpc-max-send-msg-size",
+			Usage: fmt.Sprintf("maximum grpc receive message size (default: %q)", defConf.GRPCMaxSendMsgSize),
+		},
+		cli.StringFlag{
+			Name:  "host-ip",
+			Usage: fmt.Sprintf("host IP considered as the primary IP to use by CRI-O for things such as host network IP (default: %q)", defConf.HostIP),
+		},
+		cli.BoolFlag{
+			Name:  "manage-network-ns-lifecycle",
+			Usage: fmt.Sprintf("determines whether we pin and remove network namespace and manage its lifecycle (default: %v)", defConf.ManageNetworkNSLifecycle),
+		},
+		cli.BoolFlag{
+			Name:  "no-pivot",
+			Usage: fmt.Sprintf("if true, the runtime will not use `pivot_root`, but instead use `MS_MOVE` (default: %v)", defConf.NoPivot),
+		},
+		cli.BoolFlag{
+			Name:  "stream-enable-tls",
+			Usage: fmt.Sprintf("enable encrypted TLS transport of the stream server (default: %v)", defConf.StreamEnableTLS),
+		},
+		cli.StringFlag{
+			Name:  "stream-tls-ca",
+			Usage: fmt.Sprintf("path to the x509 CA(s) file used to verify and authenticate client communication with the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: %q)", defConf.StreamTLSCA),
+		},
+		cli.StringFlag{
+			Name:  "stream-tls-cert",
+			Usage: fmt.Sprintf("path to the x509 certificate file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: %q)", defConf.StreamTLSCert),
+		},
+		cli.StringFlag{
+			Name:  "stream-tls-key",
+			Usage: fmt.Sprintf("path to the key file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: %q)", defConf.StreamTLSKey),
 		},
 	}
 

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -61,6 +61,19 @@ crio
 [--stream-port=[value]]
 [--uid-mappings=[value]]
 [--version|-v]
+[--conmon-env=[value]]
+[--container-attach-socket-dir=[value]]
+[--container-exits-dir=[value]]
+[--ctr-stop-timeout=[value]]
+[--grpc-max-recv-msg-size=[value]]
+[--grpc-max-send-msg-size=[value]]
+[--host-ip=[value]]
+[--manage-network-ns-lifecycle]
+[--no-pivot]
+[--stream-enable-tls]
+[--stream-tls-ca=[value]]
+[--stream-tls-cert=[value]]
+[--stream-tls-key=[value]]
 ```
 # DESCRIPTION
 OCI-based implementation of Kubernetes Container Runtime Interface Daemon
@@ -203,6 +216,32 @@ If `hooks_dir` is unset, CRI-O will currently default to `/usr/share/containers/
 **--uid-mappings**="": Specify the UID mappings to use for user namespace
 
 **--version, -v**: Print the version
+
+**--conmon-env**="": environment variable list for the conmon process, used for passing necessary environment variables to conmon or the runtime (default: "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+
+**--container-attach-socket-dir**="": path to directory for container attach sockets (default: "/var/run/crio")
+
+**--container-exits-dir**="": path to directory in which container exit files are written to by conmon (default: "/var/run/crio/exits")
+
+**--ctr-stop-timeout**="": the minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container (default: 0)
+
+**--grpc-max-recv-msg-size**="": maximum grpc receive message size in bytes (default: 16 * 1024 * 1024)
+
+**--grpc-max-send-msg-size**="": maximum grpc receive message size (default: 16 * 1024 * 1024)
+
+**--host-ip**="": host IP considered as the primary IP to use by CRI-O for things such as host network IP (default: "")
+
+**--manage-network-ns-lifecycle**: determines whether we pin and remove network namespace and manage its lifecycle (default: false)
+
+**--no-pivot**: if true, the runtime will not use `pivot_root`, but instead use `MS_MOVE` (default: false)
+
+**--stream-enable-tls**: enable encrypted TLS transport of the stream server (default: false)
+
+**--stream-tls-ca**="": path to the x509 CA(s) file used to verify and authenticate client communication with the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: "")
+
+**--stream-tls-cert**="": path to the x509 certificate file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: "")
+
+**--stream-tls-key**="": path to the key file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: "")
 
 # COMMANDS
 CRI-O's default command is to start the daemon. However, it currently offers a

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -58,13 +58,13 @@ The `crio.api` table contains settings for the kubelet/gRPC interface.
   Enable encrypted TLS transport of the stream server.
 
 **stream_tls_cert**=""
-  Path to the x509 certificate file used to serve the encrypted stream. This file can change, and CRI-O will automatically pick up the changes within 5 minutes.
+  Path to the x509 certificate file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes.
 
 **stream_tls_key**=""
-  Path to the key file used to serve the encrypted stream. This file can change, and CRI-O will automatically pick up the changes within 5 minutes.
+  Path to the key file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes.
 
 **stream_tls_ca**=""
-  Path to the x509 CA(s) file used to verify and authenticate client communication with the encrypted stream. This file can change, and CRI-O will automatically pick up the changes within 5 minutes.
+  Path to the x509 CA(s) file used to verify and authenticate client communication with the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes.
 
 **grpc_max_send_msg_size**=16777216
   Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 16 * 1024 * 1024.

--- a/internal/lib/config/template.go
+++ b/internal/lib/config/template.go
@@ -72,11 +72,11 @@ stream_enable_tls = {{ .StreamEnableTLS }}
 stream_tls_cert = "{{ .StreamTLSCert }}"
 
 # Path to the key file used to serve the encrypted stream. This file can
-# change, and CRI-O will automatically pick up the changes within 5 minutes.
+# change and CRI-O will automatically pick up the changes within 5 minutes.
 stream_tls_key = "{{ .StreamTLSKey }}"
 
 # Path to the x509 CA(s) file used to verify and authenticate client
-# communication with the encrypted stream. This file can change, and CRI-O will
+# communication with the encrypted stream. This file can change and CRI-O will
 # automatically pick up the changes within 5 minutes.
 stream_tls_ca = "{{ .StreamTLSCA }}"
 

--- a/test/docs-validation/main.go
+++ b/test/docs-validation/main.go
@@ -40,24 +40,6 @@ var (
 		"storage_driver",   // user dependent
 	}
 
-	// CLI options which should be not checked at all
-	excludedCLIOptions = []string{
-		"conmon-env",                  // not existing
-		"container-attach-socket-dir", // not existing
-		"container-exits-dir",         // not existing
-		"ctr-stop-timeout",            // not existing
-		"file-locking-path",           // not existing
-		"grpc-max-recv-msg-size",      // not existing
-		"grpc-max-send-msg-size",      // not existing
-		"host-ip",                     // not existing
-		"manage-network-ns-lifecycle", // not existing
-		"no-pivot",                    // not existing
-		"stream-enable-tls",           // not existing
-		"stream-tls-ca",               // not existing
-		"stream-tls-cert",             // not existing
-		"stream-tls-key",              // not existing
-	}
-
 	// Mapping for inconsistencies between tags and CLI arguments
 	tagToCLIOption = map[string]string{
 		"network_dir":         "cni-config-dir",
@@ -169,12 +151,6 @@ func validateCli(cfg *config.Config) (failed bool) {
 		if val, ok := tagToCLIOption[entry.tag]; ok {
 			logrus.Debugf("Mapping `%s` to `%s`", entry.tag, val)
 			cliOption = val
-		}
-
-		// Skip whitelisted items
-		if stringInSlice(cliOption, excludedCLIOptions) {
-			logrus.Debugf("Skipping excluded CLI option `%s`", cliOption)
-			continue
 		}
 
 		// Lookup the tag


### PR DESCRIPTION
This commits adds all missing CLI flags which are not yet existing but
possible to set via the configuration file. These are:

- `--conmon-env`
- `--container-attach-socket-dir`
- `--container-exits-dir`
- `--ctr-stop-timeout`
- `--file-locking-path`
- `--grpc-max-recv-msg-size`
- `--grpc-max-send-msg-size`
- `--host-ip`
- `--manage-network-ns-lifecycle`
- `--no-pivot`
- `--stream-enable-tls`
- `--stream-tls-ca`
- `--stream-tls-cert`
- `--stream-tls-key`

The deprecated file locking related flag has been removed from the
docs check.
