### PR TITLE
Use only the first IP for host port allocation

### DIFF
--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -55,10 +55,12 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 		return
 	}
 
-	for _, podIPConfig := range network.IPs {
+	for idx, podIPConfig := range network.IPs {
 		podIP := strings.Split(podIPConfig.Address.String(), "/")[0]
 
-		if len(sb.PortMappings()) > 0 {
+		// Apply the hostport mappings only for the first IP to avoid allocating
+		// the same host port twice
+		if idx == 0 && len(sb.PortMappings()) > 0 {
 			ip := net.ParseIP(podIP)
 			if ip == nil {
 				err = fmt.Errorf("failed to get valid ip address for sandbox %s(%s)", sb.Name(), sb.ID())


### PR DESCRIPTION
I'm opening a separate PR for this because I think this is an implementation mistake I did during the IPv6/multi IP integration.

---
If we try to allocate the same hostport twice for a different IP, the result will always be a failure because the host port has already been allocated. To avoid this we only try to bind the port for the first seen IP.

We're currently not capable of deciding what the 'major IP' of the pod should be so we take the first one. WDYT?