### PR TITLE
Update end-to-end tests to run with Kubernetes release branches

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -118,7 +118,7 @@
       include: "build/kubernetes.yml"
       vars:
         force_clone: true
-        k8s_git_version: "master"
+        k8s_git_version: "release-1.15"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests
@@ -135,7 +135,7 @@
       include: "build/kubernetes.yml"
       vars:
         force_clone: true
-        k8s_git_version: "master"
+        k8s_git_version: "release-1.15"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e features tests


### PR DESCRIPTION
This should fix the failling e2e tests. I'd like to suggest to stick to the release branches since the [CI signal](https://github.com/orgs/kubernetes/projects/11) seems to change a lot lately.

We could add a end-to-end test to the master which is allowed to fail, but I'm not sure if this is easily achievable with prow. WDYT?