### PR TITLE
crio-wipe: Fix int compare in lib.bash

### DIFF
--- a/contrib/crio-wipe/lib.bash
+++ b/contrib/crio-wipe/lib.bash
@@ -23,8 +23,9 @@ check_versions_wipe_if_necessary() {
 	# $2 should be the old version
 
 	# cast as integers to be used
-	new=$(("$1" + 0))
-	old=$(("$2" + 0))
+	declare -i new=$1
+	declare -i old=$2
+
 	if [[ $old -lt $new ]]; then
 		echo "New version detected"
 		perform_wipe


### PR DESCRIPTION
With the current code running crio-wipe.bash will
error on operand expected (error token is ""1" + 0").

This patch uses  declare -i will define new/old as integer

Fixes #2704

Signed-off-by: Moshe Levi <moshele@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
just run ./crio-wipe.bash
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
