### PR TITLE
 Add HUP reload feature for SystemRegistries

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -631,6 +631,13 @@ func main() {
 			Name:  "stream-tls-key",
 			Usage: fmt.Sprintf("path to the key file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: %q)", defConf.StreamTLSKey),
 		},
+		cli.StringFlag{
+			Name:        "registries-conf",
+			Usage:       "path to the registries.conf file",
+			Destination: &systemContext.SystemRegistriesConfPath,
+			Hidden:      true,
+			EnvVar:      "CONTAINERS_REGISTRIES_CONF",
+		},
 	}
 
 	sort.Sort(cli.FlagsByName(app.Flags))

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -8,7 +8,9 @@ crio.conf - configuration file of the CRI-O OCI Kubernetes Container Runtime dae
 # DESCRIPTION
 The CRI-O configuration file specifies all of the available configuration options and command-line flags for the [crio(8) OCI Kubernetes Container Runtime daemon][crio], but in a TOML format that can be more easily modified and versioned.
 
-CRI-O supports partial configuration reload during runtime, which can be done by sending SIGHUP to the running process. Currently supported options are explicitly marked with 'This option supports live configuration reload'.
+CRI-O supports partial configuration reload during runtime, which can be done by sending SIGHUP to the running process. Currently supported options in `crio.conf` are explicitly marked with 'This option supports live configuration reload'.
+
+The containers-registries.conf(5) file can be reloaded as well by sending SIGHUP to the `crio` process.
 
 The default crio.conf is located at /etc/crio/crio.conf.
 

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containers/image/types"
 	cstorage "github.com/containers/storage"
 	"github.com/cri-o/cri-o/internal/lib/config"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
@@ -179,9 +180,13 @@ var afterEach = func() {
 }
 
 var setupSUT = func() {
+	setupSUTWithContext(nil)
+}
+
+var setupSUTWithContext = func(ctx *types.SystemContext) {
 	var err error
 	mockNewServer()
-	sut, err = server.New(context.Background(), nil, "", libMock)
+	sut, err = server.New(context.Background(), ctx, "", libMock)
 	Expect(err).To(BeNil())
 	Expect(sut).NotTo(BeNil())
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -614,3 +614,25 @@ function wait_until_exit() {
 	done
 	return 1
 }
+
+function reload_crio() {
+    kill -HUP $CRIO_PID
+}
+
+function wait_for_log() {
+    CNT=0
+    while true; do
+        if [[ $CNT -gt 50 ]]; then
+            echo wait for log timed out
+            exit 1
+        fi
+
+        if grep -q "$1" "$CRIO_LOG"; then
+            break
+        fi
+
+        echo "waiting for log entry to appear ($CNT): $1"
+        sleep 0.1
+        CNT=$((CNT + 1))
+    done
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -636,3 +636,7 @@ function wait_for_log() {
         CNT=$((CNT + 1))
     done
 }
+
+function replace_config() {
+    sed -ie 's;\('$1' = "\).*\("\);\1'$2'\2;' "$CRIO_CONFIG"
+}

--- a/test/reload_config.bats
+++ b/test/reload_config.bats
@@ -19,28 +19,6 @@ function replace_config() {
     sed -ie 's;\('$1' = "\).*\("\);\1'$2'\2;' "$CRIO_CONFIG"
 }
 
-function reload_crio() {
-    kill -HUP $CRIO_PID
-}
-
-function wait_for_log() {
-    CNT=0
-    while true; do
-        if [[ $CNT -gt 50 ]]; then
-            echo wait for log timed out
-            exit 1
-        fi
-
-        if grep -q "$1" "$CRIO_LOG"; then
-            break
-        fi
-
-        echo "waiting for log entry to appear ($CNT): $1"
-        sleep 0.1
-        CNT=$((CNT + 1))
-    done
-}
-
 function expect_log_success() {
     wait_for_log '"set config '$1' to \\"'$2'\\""'
 }
@@ -49,7 +27,7 @@ function expect_log_failure() {
     wait_for_log "unable to reload configuration: $1"
 }
 
-@test "should succeed to reload" {
+@test "reload config should succeed" {
     # when
     reload_crio
 
@@ -57,7 +35,7 @@ function expect_log_failure() {
     ps --pid $CRIO_PID &>/dev/null
 }
 
-@test "should succeed to reload 'log_level'" {
+@test "reload config should succeed with 'log_level'" {
     # given
     NEW_LEVEL="warn"
     OPTION="log_level"
@@ -70,7 +48,7 @@ function expect_log_failure() {
     expect_log_success $OPTION $NEW_LEVEL
 }
 
-@test "should fail to reload 'log_level' if invalid" {
+@test "reload config should fail with 'log_level' if invalid" {
     # when
     replace_config "log_level" "invalid"
     reload_crio
@@ -80,7 +58,7 @@ function expect_log_failure() {
 }
 
 
-@test "should fail to reload if config is malformed" {
+@test "reload config should fail with if config is malformed" {
     # when
     replace_config "log_level" '\"'
     reload_crio
@@ -89,7 +67,7 @@ function expect_log_failure() {
     expect_log_failure "unable to decode configuration"
 }
 
-@test "should succeed to reload 'pause_image'" {
+@test "reload config should succeed with 'pause_image'" {
     # given
     NEW_OPTION="new-image"
     OPTION="pause_image"
@@ -102,7 +80,7 @@ function expect_log_failure() {
     expect_log_success $OPTION $NEW_OPTION
 }
 
-@test "should succeed to reload 'pause_command'" {
+@test "reload config should succeed with 'pause_command'" {
     # given
     NEW_OPTION="new-command"
     OPTION="pause_command"
@@ -115,7 +93,7 @@ function expect_log_failure() {
     expect_log_success $OPTION $NEW_OPTION
 }
 
-@test "should succeed to reload 'pause_image_auth_file'" {
+@test "reload config should succeed with 'pause_image_auth_file'" {
     # given
     NEW_OPTION="$TESTDIR/auth_file"
     OPTION="pause_image_auth_file"
@@ -129,7 +107,7 @@ function expect_log_failure() {
     expect_log_success $OPTION $NEW_OPTION
 }
 
-@test "should fail to reload non existing 'pause_image_auth_file'" {
+@test "reload config should fail with non existing 'pause_image_auth_file'" {
     # given
     NEW_OPTION="$TESTDIR/auth_file"
     OPTION="pause_image_auth_file"

--- a/test/reload_config.bats
+++ b/test/reload_config.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# vim: set syntax=sh:
 
 load helpers
 
@@ -13,10 +14,6 @@ function setup() {
 
 function teardown() {
     cleanup_test
-}
-
-function replace_config() {
-    sed -ie 's;\('$1' = "\).*\("\);\1'$2'\2;' "$CRIO_CONFIG"
 }
 
 function expect_log_success() {

--- a/test/reload_system.bats
+++ b/test/reload_system.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# vim: set syntax=sh:
+
+load helpers
+
+function setup() {
+    setup_test
+    export TEST_IMAGE=quay.io/saschagrunert/hello-world \
+           CONTAINERS_REGISTRIES_CONF="$TESTDIR/containers/registries.conf"
+    printf "[[registry]]\nlocation = 'quay.io/saschagrunert'\nblocked = true" \
+        >> $CONTAINERS_REGISTRIES_CONF
+}
+
+function teardown() {
+    cleanup_test
+}
+
+function expect_log_success() {
+    wait_for_log "applied new registry configuration"
+}
+
+function expect_log_failure() {
+    wait_for_log "system registries reload failed"
+}
+
+function expect_pull_image() {
+    run crictl pull "$TEST_IMAGE"
+    echo "$output"
+    [ "$status" -eq $1 ]
+}
+
+@test "reload system registries should succeed" {
+    # given
+    start_crio
+    replace_config "log_level" "debug"
+
+    # when
+    reload_crio
+
+    # then
+    expect_log_success
+    expect_pull_image 1
+}
+
+@test "reload system registries should succeed with new registry" {
+    # given
+    start_crio
+    replace_config "log_level" "debug"
+    sed -i 's;true;false;g' "$CONTAINERS_REGISTRIES_CONF"
+
+    # when
+    reload_crio
+
+    # then
+    expect_log_success
+    expect_pull_image 0
+}
+
+@test "reload system registries should fail on invalid syntax in file" {
+    # given
+    start_crio
+    echo invalid >> "$CONTAINERS_REGISTRIES_CONF"
+
+    # when
+    reload_crio
+
+    # then
+    expect_log_failure
+}


### PR DESCRIPTION
This enables SIGHUP based system registry reload via a new configuration
watcher. The path of the system registries.conf can be now set via an
hidden command line flag of CRI-O as well.

The configuration reload based integration tests start now all with
'reload config', whereas the helper functions `reload_crio` and
`wait_for_log` are globally available.

Integration tests for the feature have been added as well as unit tests.
