### PR TITLE
[1.14] Choose IP similarly to kubelet

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -278,4 +279,25 @@ func getUlimitsFromConfig(config Config) ([]ulimit, error) {
 // Translate container labels to a description of the container
 func translateLabelsToDescription(labels map[string]string) string {
 	return fmt.Sprintf("%s/%s/%s", labels[types.KubernetesPodNamespaceLabel], labels[types.KubernetesPodNameLabel], labels[types.KubernetesContainerNameLabel])
+}
+
+// Validate given hostIP IP belongs to the current host
+// adapted from github.com/kubernetes/kubernetes/pkg/kubelet/kubelet_node_status.go
+func isValidHostIP(hostIP net.IP) bool {
+	if hostIP.To4() == nil {
+		return false
+	}
+	if hostIP.IsLoopback() {
+		return false
+	}
+	if hostIP.IsMulticast() {
+		return false
+	}
+	if hostIP.IsLinkLocalUnicast() {
+		return false
+	}
+	if hostIP.IsUnspecified() {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Instead of failing when we can't find an IP unambiguously, choose an IP using the following heuristic:
1. configured value is chosen if set
2. legacy way of calling ChooseHostIP (this is the last step in the kubelet, but we want to keep behavior the same)
3. attempt to use the hostname to find it
4. loop through available interfaces, filter out ones the kubelet would, and choose the first available.

for the 4th step, these interfaces are ordered by when they're configured on operating system level, and not alphabetically.
This is good, because we don't want a CNI network preceeding one that will connect us to the net just because the former is 9.x... and latter 10.x...

Ultimately, we want to rely on ChooseHostIP as much as possible, but now have fallbacks in case a default route isn't set

Signed-off-by: Peter Hunt <pehunt@redhat.com>