### PR TITLE
crio-wipe: don't fail on mount

### DIFF
--- a/contrib/crio-wipe/crio-wipe.bash
+++ b/contrib/crio-wipe/crio-wipe.bash
@@ -2,7 +2,6 @@
 
 set -eu
 
-
 dir=${0%/*}
 source "$dir/lib.bash"
 

--- a/contrib/crio-wipe/lib.bash
+++ b/contrib/crio-wipe/lib.bash
@@ -13,7 +13,11 @@ get_minor() {
 perform_wipe() {
 	if [[ $WIPE -eq 0 ]]; then
 		echo "Wiping storage"
-		rm -rf "$CONTAINERS_STORAGE_DIR"
+		rm -rf "$CONTAINERS_STORAGE_DIR"/*
+		# best effort remove the parent directory. it may fail because it is mounted,
+		# but we've already removed what we want to.
+		rm -rf "$CONTAINERS_STORAGE_DIR" || true
+		exit
 	fi
 	exit 0
 }
@@ -29,6 +33,7 @@ check_versions_wipe_if_necessary() {
 	if [[ $old -lt $new ]]; then
 		echo "New version detected"
 		perform_wipe
+		exit
 	fi
 }
 
@@ -50,6 +55,7 @@ main() {
 	if ! test -f "$VERSION_FILE_LOCATION"; then
 		echo "Old version not found"
 		perform_wipe
+		exit
 	fi
 
 	OLD_VERSION=$(cat "$VERSION_FILE_LOCATION")
@@ -58,22 +64,26 @@ main() {
 	if [[ -z "$OLD_MAJOR_VERSION" ]]; then
 		>&2 echo "Invalid major version in version file"
 		perform_wipe
+		exit
 	fi
 	MAJOR_CHECK=$(check_versions_wipe_if_necessary "$NEW_MAJOR_VERSION" "$OLD_MAJOR_VERSION")
+	MAJOR_CHECK_EC=$?
 	if [[ ! -z "$MAJOR_CHECK" ]]; then
-		echo "Reading major version in file returned: $MAJOR_CHECK"
-		exit 0
+		echo "Reading major version in file exited with: $MAJOR_CHECK_EC and returned: $MAJOR_CHECK"
+		exit $MAJOR_CHECK_EC
 	fi
 
 	OLD_MINOR_VERSION=$(get_minor "$OLD_VERSION")
 	if [[ -z "$OLD_MINOR_VERSION" ]]; then
 		>&2 echo "Invalid minor version in version file"
 		perform_wipe
+		exit
 	fi
 	MINOR_CHECK=$(check_versions_wipe_if_necessary "$NEW_MINOR_VERSION" "$OLD_MINOR_VERSION")
+	MINOR_CHECK_EC=$?
 	if [[ ! -z "$MINOR_CHECK" ]]; then
-		echo "Reading minor version in file returned: $MINOR_CHECK"
-		exit 0
+		echo "Reading minor version in file exited with: $MINOR_CHECK_EC and returned: $MINOR_CHECK"
+		exit $MINOR_CHECK_EC
 	fi
 
 	# no update needed

--- a/contrib/crio-wipe/mount.bats
+++ b/contrib/crio-wipe/mount.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load lib
+load helpers
+
+function teardown() {
+	# cleanup
+	rm -f "$loop_file"
+	umount "$TMP_STORAGE"
+
+	cleanup_test
+}
+
+@test "don't fail and wipe dir if storage dir is a mount" {
+	if [[ $EUID -ne 0 ]]; then
+		skip "mount test must be run as root"
+	fi
+
+	prepare_test "crio version 1.0.0" "\"0.0.0\""
+
+	# setup lookback mount
+	loop_device=$(losetup -f)
+	loop_file="/tmp/loop.tmp"
+	dd if=/dev/zero of="$loop_file" bs=1M count=1
+	losetup "$loop_device" "$loop_file"
+	mkfs.ext4 "$loop_device"
+	mount -t ext4 "$loop_device" "$TMP_STORAGE"
+
+	run main
+	echo "$status"
+	echo "$output"
+	[ "$status" == 0 ]
+	[ -d "$TMP_STORAGE" ]
+	[ ! "$(ls -A $TMP_STORAGE)" ]
+}


### PR DESCRIPTION
best effort remove the containers storage dir. That way, if it's mounted, we don't fail after having removed what we really care about removing.
Add a test case to cover this situation
Also fix a bug where the exit code wasn't being properly propagated to main
fixes: https://github.com/cri-o/cri-o/issues/2725

Signed-off-by: Peter Hunt <pehunt@redhat.com>