### PR TITLE
Remove deprecated implicit hooks directory handling

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -145,8 +145,6 @@ For the annotation conditions, CRI-O uses the Kubernetes annotations, which are 
 
 For the bind-mount conditions, only mounts explicitly requested by Kubernetes configuration are considered.  Bind mounts that CRI-O inserts by default (e.g. `/dev/shm`) are not considered.
 
-If `hooks_dir` is unset, CRI-O will currently default to `/usr/share/containers/oci/hooks.d` and `/etc/containers/oci/hooks.d` in order of increasing precedence.  Using these defaults is deprecated, and callers should migrate to explicitly setting `hooks_dir`.
-
 **--insecure-registry**="": Enable insecure registry communication, i.e., enable un-encrypted and/or untrusted communication.
 
 1. List of insecure registries can contain an element with CIDR notation to specify a whole subnet.

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -140,8 +140,6 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 
   For the bind-mount conditions, only mounts explicitly requested by Kubernetes configuration are considered.  Bind mounts that CRI-O inserts by default (e.g. `/dev/shm`) are not considered.
 
-  If `hooks_dir` is unset, CRI-O will currently default to `/usr/share/containers/oci/hooks.d` and `/etc/containers/oci/hooks.d` in order of increasing precedence.  Using these defaults is deprecated, and callers should migrate to explicitly setting `hooks_dir`.
-
 **default_mounts**=[]
   List of default mounts for each container. **Deprecated:** this option will be removed in future versions in favor of `default_mounts_file`.
 

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/pkg/storage"
-	"github.com/cri-o/cri-o/utils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/truncindex"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
@@ -116,17 +115,7 @@ func New(ctx context.Context, systemContext *types.SystemContext, configIface li
 
 	runtime := oci.New(config)
 
-	hookDirectories := config.HooksDir
-	if config.HooksDir == nil {
-		for _, hooksDir := range []string{hooks.DefaultDir, hooks.OverrideDir} {
-			if err := utils.IsDirectory(hooksDir); err == nil {
-				hookDirectories = append(hookDirectories, hooksDir)
-				logrus.Warnf("implicit hook directories are deprecated; set --hooks-dir=%q explicitly to continue to load hooks from this directory", hooksDir)
-			}
-		}
-	}
-
-	newHooks, err := hooks.New(ctx, hookDirectories, []string{})
+	newHooks, err := hooks.New(ctx, config.HooksDir, []string{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If `hooks_dir` is unset, CRI-O will not longer default to
`/usr/share/containers/oci/hooks.d` and `/etc/containers/oci/hooks.d`
because this behavior is depcrecated since some releases.

Documentation has been adapted as well.
