### PR TITLE
Improve e2e test output readability

### DIFF
--- a/contrib/test/integration/e2e-features.yml
+++ b/contrib/test/integration/e2e-features.yml
@@ -14,6 +14,8 @@
             --provider=local
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
+                        --ginkgo.noColor
+                        --ginkgo.succinct
                         --ginkgo.focus=\[Feature:SecurityContext\]
                         --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates
                         --report-dir={{ artifacts }}"

--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -17,6 +17,8 @@
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
                         --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates|\[sig-storage\].In-tree.Volumes.\[Driver:.local\]|\[sig-storage\].CSI.Volumes.CSI.Topology.test.using.GCE.PD.driver|\[sig\-storage\]\sCSI\sVolumes\s\[Driver\:\scsi\-hostpath\]\s\[Testpattern\:\sDynamic\sPV\s\(block\svolmode\)\]\svolumes\sshould\sstore\sdata
+                        --ginkgo.noColor
+                        --ginkgo.succinct
                         --report-dir={{ artifacts }}"
             &> {{ artifacts }}/e2e.log
   # Fix vim syntax highlighting: "


### PR DESCRIPTION
The `succinct` output of ginkgo should reduce the noise within the
tests, whereas the `noColor` should make it overall more readable.