### PR TITLE
Check inotify events read return code

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -569,10 +569,13 @@ static gboolean check_cgroup2_oom()
 static gboolean oom_cb_cgroup_v2(int fd, GIOCondition condition, G_GNUC_UNUSED gpointer user_data)
 {
 	struct inotify_event events[10];
+	ssize_t num_read = 0;
 	gboolean ret = G_SOURCE_REMOVE;
 
 	/* Drop the inotify events.  */
-	read(fd, &events, sizeof(events));
+	num_read = read(fd, &events, sizeof(events));
+	if (num_read < 0)
+		nwarn("Failed to read inotify events");
 
 	if ((condition & G_IO_IN) != 0) {
 		ret = check_cgroup2_oom();


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

http://jenkins.katacontainers.io/job/kata-containers-firecracker-PR/252/consoleText
 
```
cc -std=c99 -Os -Wall -Wextra -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -DVERSION=\"1.15.0\" -DGIT_COMMIT=\"unknown\"  -D USE_JOURNALD=0   -c -o conmon.o conmon.c
conmon.c: In function ‘oom_cb_cgroup_v2’:
conmon.c:575:2: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
  read(fd, &events, sizeof(events));

  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

**- Description for the changelog**
Check inotify events read return code
