### PR TITLE
WIP enable ssh in e2e tests

### DIFF
--- a/contrib/test/integration/e2e-base.yml
+++ b/contrib/test/integration/e2e-base.yml
@@ -11,6 +11,14 @@
         runtime_type = "oci"
         runtime_root = "/run/runc"
 
+- name: create ssh keys
+  user:
+    name: "{{ ssh_user }}"
+    generate_ssh_key: yes
+    ssh_key_bits: 2048
+    ssh_key_file: "{{ ssh_location }}"
+  register: keyfile
+
 - name: enable and start CRI-O
   systemd:
     name: crio

--- a/contrib/test/integration/e2e-base.yml
+++ b/contrib/test/integration/e2e-base.yml
@@ -12,12 +12,15 @@
         runtime_root = "/run/runc"
 
 - name: create ssh keys
-  user:
-    name: "{{ ssh_user }}"
-    generate_ssh_key: yes
-    ssh_key_bits: 2048
-    ssh_key_file: "{{ ssh_location }}"
-  register: keyfile
+  shell: ssh-keygen -b 2048 -t rsa -f "{{ ssh_location }}" -q -N ""
+  args:
+    creates: "{{ ssh_location }}"
+
+- name: add key file to authorized_users
+  authorized_key:
+    user: "{{ ssh_user }}"
+    state: present
+    key: "{{ lookup('file', ssh_location + '.pub') }} "
 
 - name: enable and start CRI-O
   systemd:

--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -11,13 +11,13 @@
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
   set_fact:
     e2e_shell_cmd: >
-        KUBE_CONTAINER_RUNTIME="remote" GINKGO_TOLERATE_FLAKES="y" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y /usr/bin/go run hack/e2e.go
+        KUBE_CONTAINER_RUNTIME="remote" GINKGO_TOLERATE_FLAKES="y" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y KUBE_SSH_USER="{{ ssh_user }}" LOCAL_SSH_KEY="{{ ssh_location }}" /usr/bin/go run hack/e2e.go
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
                         --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates|\[sig-storage\].In-tree.Volumes.\[Driver:.local\]|\[sig-storage\].CSI.Volumes.CSI.Topology.test.using.GCE.PD.driver
                         --report-dir={{ artifacts }}"
             &> {{ artifacts }}/e2e.log
-  # Fix vim syntax hilighting: "
+  # Fix vim syntax highlighting: "
 
 - block:
 

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -118,8 +118,8 @@
       include: "build/kubernetes.yml"
       vars:
         force_clone: true
-        k8s_git_version: "master"
-        k8s_github_fork: "kubernetes"
+        k8s_git_version: "drop-commit-f22b67dd8f9f4c1ce7"
+        k8s_github_fork: "haircommander"
         crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests
       include: e2e.yml
@@ -135,8 +135,8 @@
       include: "build/kubernetes.yml"
       vars:
         force_clone: true
-        k8s_git_version: "master"
-        k8s_github_fork: "kubernetes"
+        k8s_git_version: "drop-commit-f22b67dd8f9f4c1ce7"
+        k8s_github_fork: "haircommander"
         crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e features tests
       include: e2e-features.yml

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -20,6 +20,10 @@ int_test_env:
     STORAGE_OPTIONS: >
         --storage-driver=overlay
 
+# for ssh ID generation
+ssh_user: "{{ lookup('env','USER') }}"
+ssh_location: "{{ lookup('env','HOME') }}/.ssh/id_rsa"
+
 # Additional environment variables for integration tests w/ userNS enabled
 userns_int_test_env:
     TEST_USERNS: "1"  # Consumed by test/test_runner.sh, by way of Makefile


### PR DESCRIPTION
while still dropping  f22b67dd8f9f4c1ce7 because a work around hasn't been found yet.