### PR TITLE
Allow usage of short container ID in ContainerStats()

### DIFF
--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
@@ -38,9 +37,9 @@ func (s *Server) ContainerStats(ctx context.Context, req *pb.ContainerStatsReque
 		recordError(operation, err)
 	}()
 
-	container := s.GetContainer(req.ContainerId)
-	if container == nil {
-		return nil, fmt.Errorf("invalid container")
+	container, err := s.GetContainerFromShortID(req.ContainerId)
+	if err != nil {
+		return nil, err
 	}
 
 	stats, err := s.Runtime().ContainerStats(container)


### PR DESCRIPTION
This fix allows using short container IDs in the ContainerStats() request

**- What I did**
Unlike all of the other CRI RPC calls, ContainerStats() would require using the full container ID. This change enables the short container ID to be used for the ContainerStats() call.

**- How I did it**

**- How to verify it**
Call ContainerStats() with a ContainerStatsRequest that contains a short container id. 

**- Description for the changelog**
Allow usage of short container ID in ContainerStats() request