### PR TITLE
Add `log_dir`/`--log-dir` validation to be absolute

### DIFF
--- a/internal/lib/config/config.go
+++ b/internal/lib/config/config.go
@@ -564,6 +564,9 @@ func (c *APIConfig) Validate(onExecution bool) error {
 // `nil`.
 func (c *RootConfig) Validate(onExecution bool) error {
 	if onExecution {
+		if !filepath.IsAbs(c.LogDir) {
+			return errors.New("log_dir is not an absolute path")
+		}
 		if err := os.MkdirAll(c.LogDir, 0700); err != nil {
 			return errors.Wrapf(err, "invalid log_dir")
 		}

--- a/internal/lib/config/config_test.go
+++ b/internal/lib/config/config_test.go
@@ -21,7 +21,7 @@ var _ = t.Describe("Config", func() {
 		tmpDir := t.MustTempDir("cni-test")
 		sut.NetworkConfig.PluginDirs = []string{tmpDir}
 		sut.NetworkDir = os.TempDir()
-		sut.LogDir = "."
+		sut.LogDir = "/"
 		sut.Listen = t.MustTempFile("crio.sock")
 		return sut
 	}
@@ -47,7 +47,7 @@ var _ = t.Describe("Config", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should fail with invalid root config", func() {
+		It("should fail with invalid log_dir", func() {
 			// Given
 			sut.RootConfig.LogDir = "/dev/null"
 
@@ -72,7 +72,6 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail with invalid api config", func() {
 			// Given
-			sut.RootConfig.LogDir = "."
 			sut.AdditionalDevices = []string{invalidPath}
 
 			// When
@@ -84,7 +83,6 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail with invalid network config", func() {
 			// Given
-			sut.RootConfig.LogDir = "."
 			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validDirPath}
 			sut.Conmon = validFilePath
 			sut.NetworkConfig.NetworkDir = invalidPath
@@ -615,7 +613,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed during runtime", func() {
 			// Given
-			sut.RootConfig.LogDir = "."
+			sut = runtimeValidConfig()
 
 			// When
 			err := sut.RootConfig.Validate(true)
@@ -630,6 +628,17 @@ var _ = t.Describe("Config", func() {
 
 			// When
 			err := sut.RootConfig.Validate(true)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should fail with non absolute log_dir", func() {
+			// Given
+			sut.RootConfig.LogDir = "test"
+
+			// When
+			err := sut.Validate(nil, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -134,8 +135,9 @@ var beforeEach = func() {
 		}}`)
 
 	// Prepare the server config
-	testPath = "test"
 	var err error
+	testPath, err = filepath.Abs("test")
+	Expect(err).To(BeNil())
 	serverConfig, err = config.DefaultConfig()
 	Expect(err).To(BeNil())
 	serverConfig.ContainerAttachSocketDir = testPath


### PR DESCRIPTION
If the log_dir is an relative path, then the creation of the
container/sandbox will fail during runtime. To avoid this, we now
pre-check if the path is absolute. All tests have been adapted as well.