### PR TITLE
[1.14] switch to e2e.test

### DIFF
--- a/contrib/test/integration/e2e-base.yml
+++ b/contrib/test/integration/e2e-base.yml
@@ -50,3 +50,20 @@
 
 - name: Enable iptables NAT for the bridge
   command: sysctl -w net.bridge.bridge-nf-call-iptables=1
+
+- name: make test binary
+  make:
+    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+    params:
+      WHAT: test/e2e/e2e.test
+
+- name: make kubectl binary
+  make:
+    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+    params:
+      WHAT: cmd/kubectl
+
+- name: add kubectl and e2e.test to path
+  shell: export PATH=$PATH:$PWD/_output/bin/kubectl:$PWD/_output/bin/e2e.test
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"

--- a/contrib/test/integration/e2e-features.yml
+++ b/contrib/test/integration/e2e-features.yml
@@ -9,17 +9,19 @@
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
   set_fact:
     e2e_shell_cmd: >
-        GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y /usr/bin/go run hack/e2e.go
-            --test
-            --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
-                        --ginkgo.focus=\[Feature:SecurityContext\]
-                        --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates
-                        --report-dir={{ artifacts }}"
+        GINKGO_PARALLEL=y _output/bin/e2e.test
+            --ginkgo.flakeAttempts=3
+            --container-runtime=remote
+            --ginkgo.parallel.total=6
+            --provider=local
+            --host=https://{{ ansible_default_ipv4.address }}:6443
+            --ginkgo.focus="\[Feature:SecurityContext\]"
+            --ginkgo.skip="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates"
+            --report-dir={{ artifacts }}
             &> {{ artifacts }}/e2e.log
-  # Fix vim syntax hilighting: "
+  # Fix vim syntax highlighting: "
 
 - block:
-
     - name: run e2e tests
       shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
       args:

--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -8,16 +8,18 @@
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
   set_fact:
     e2e_shell_cmd: >
-        GINKGO_TOLERATE_FLAKES="y" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y /usr/bin/go run hack/e2e.go
-            --test
-            --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
-                        --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates|\[sig-storage\].In-tree.Volumes.\[Driver:.local\]|\[sig-storage\].CSI.Volumes.CSI.Topology.test.using.GCE.PD.driver
-                        --report-dir={{ artifacts }}"
+        GINKGO_PARALLEL=y _output/bin/e2e.test
+            --ginkgo.flakeAttempts=3
+            --container-runtime=remote
+            --ginkgo.parallel.total=6
+            --provider=local
+            --host=https://{{ ansible_default_ipv4.address }}:6443
+            --ginkgo.skip="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates|\[sig-storage\].In-tree.Volumes.\[Driver:.local\]|\[sig-storage\].CSI.Volumes.CSI.Topology.test.using.GCE.PD.driver"
+            --report-dir={{ artifacts }}
             &> {{ artifacts }}/e2e.log
   # Fix vim syntax hilighting: "
 
 - block:
-
     - name: Disable selinux during e2e tests
       command: 'setenforce 0'
       when: not e2e_selinux_enabled


### PR DESCRIPTION
To save CI from upstream kubernetes getting kubetest poorly

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
