### PR TITLE
[1.14] Download kubetest manually

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -71,3 +71,9 @@
         KUBECONFIG=/var/run/kubernetes/admin.kubeconfig
     regexp: 'KUBECONFIG='
     state: present
+
+- name: install kubectl (for kubetest)
+  copy:
+    src: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes/_output/bin/kubectl"
+    dest: "{{ ansible_env.GOPATH }}/bin/kubectl"
+    mode: "preserve"

--- a/contrib/test/integration/build/kubetest.yml
+++ b/contrib/test/integration/build/kubetest.yml
@@ -1,0 +1,7 @@
+---
+# per https://github.com/kubernetes/test-infra/issues/14070 we need to download
+# kubetest with go module 1.11 on and without -u. As of the time of writing this,
+# neither are happening in hack/e2e.go. instead, add this, and set --get=false when
+# running e2e
+- name: install kubetest
+  shell: GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org GO111MODULE=on go get k8s.io/test-infra/kubetest

--- a/contrib/test/integration/e2e-features.yml
+++ b/contrib/test/integration/e2e-features.yml
@@ -9,7 +9,8 @@
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
   set_fact:
     e2e_shell_cmd: >
-        KUBE_CONTAINER_RUNTIME="remote" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y /usr/bin/go run hack/e2e.go
+        KUBE_CONTAINER_RUNTIME="remote" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y
+            "{{ ansible_env.GOPATH }}"/bin/kubetest
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
                         --ginkgo.focus=\[Feature:SecurityContext\]

--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -11,7 +11,8 @@
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
   set_fact:
     e2e_shell_cmd: >
-        KUBE_CONTAINER_RUNTIME="remote" GINKGO_TOLERATE_FLAKES="y" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y KUBE_SSH_USER="{{ ssh_user }}" LOCAL_SSH_KEY="{{ ssh_location }}" /usr/bin/go run hack/e2e.go
+        KUBE_CONTAINER_RUNTIME="remote" GINKGO_TOLERATE_FLAKES="y" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y KUBE_SSH_USER="{{ ssh_user }}" LOCAL_SSH_KEY="{{ ssh_location }}"
+            "{{ ansible_env.GOPATH }}"/bin/kubetest
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
                         --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates|\[sig-storage\].In-tree.Volumes.\[Driver:.local\]|\[sig-storage\].CSI.Volumes.CSI.Topology.test.using.GCE.PD.driver

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -29,6 +29,9 @@
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
 
+    - name: clone build and install kubetest
+      include: "build/kubetest.yml"
+
     - name: clone build and install runc
       include: "build/runc.yml"
       when: "{{ build_runc | default(True) | bool}}"
@@ -121,6 +124,10 @@
         k8s_git_version: "master"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
+
+    - name: clone build and install kubetest
+      include: "build/kubetest.yml"
+
     - name: run k8s e2e tests
       include: e2e.yml
 
@@ -138,5 +145,9 @@
         k8s_git_version: "master"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
+
+    - name: clone build and install kubetest
+      include: "build/kubetest.yml"
+
     - name: run k8s e2e features tests
       include: e2e-features.yml


### PR DESCRIPTION
and set --get false when calling e2e.test

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
