### PR TITLE
Allow pause static compilation to be optional

### DIFF
--- a/pause/Makefile
+++ b/pause/Makefile
@@ -2,8 +2,7 @@ src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
 override LIBS +=
-CFLAGS ?= -std=c99 -Os -Wall -Wextra
-override CFLAGS += -static
+CFLAGS ?= -std=c99 -Os -Wall -Wextra -static
 
 ../bin/pause: $(obj) | ../bin
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)


### PR DESCRIPTION
when trying to set crio up on rhel8, I got a compile error:

/bin/ld: cannot find -lc
collect2: error: ld returned 1 exit status

this is from the unconditional compilation of -static.
allow a user to override buildling statically

Signed-off-by: Peter Hunt <pehunt@redhat.com>