### PR TITLE
[1.14] fix selinux label on volume mount directory creation

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -169,6 +169,12 @@ func addImageVolumes(rootfs string, s *Server, containerInfo *storage.ContainerI
 			if err1 := idtools.MkdirAllAndChownNew(fp, 0755, IDs); err1 != nil {
 				return nil, err1
 			}
+			// Label the source with the sandbox selinux mount label
+			if mountLabel != "" {
+				if err1 := securityLabel(fp, mountLabel, true); err1 != nil {
+					return nil, err1
+				}
+			}
 		case lib.ImageVolumesBind:
 			volumeDirName := stringid.GenerateNonCryptoID()
 			src := filepath.Join(containerInfo.RunDir, "mounts", volumeDirName)


### PR DESCRIPTION
**- What I did**
If the host directory is not created, and cri-o must create the directory, the selinux label needs to be applied to the new directory.

- How I did it

**- How I did it**

**- How to verify it**

**- Description for the changelog**
```
Fix for the selinux label on a newly created host directory.
```
