### PR TITLE
src directory creation should probably be labelled

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -1068,6 +1068,8 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 		}
 		src := filepath.Join(bindMountPrefix, mount.GetHostPath())
 
+		mountPointCreated := false
+
 		resolvedSrc, err := resolveSymbolicLink(src, bindMountPrefix)
 		if err == nil {
 			src = resolvedSrc
@@ -1076,6 +1078,8 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 				return nil, nil, fmt.Errorf("failed to resolve symlink %q: %v", src, err)
 			} else if err = os.MkdirAll(src, 0755); err != nil {
 				return nil, nil, fmt.Errorf("failed to mkdir %s: %s", src, err)
+			} else {
+				mountPointCreated = true
 			}
 		}
 
@@ -1115,7 +1119,7 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 			options = append(options, "rprivate")
 		}
 
-		if mount.SelinuxRelabel {
+		if mount.SelinuxRelabel || mountPointCreated {
 			if err := securityLabel(src, mountLabel, false); err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
**- What I did**
If crio needs to create the source directory on an OCI bind, then it should be labelled with the correct label. By labelling the created source directory, then it can be shared between the pod. Thoughts?

**- How I did it**

**- How to verify it**
The following pod will fail on an RHCOS or selinux machine.

```
  apiVersion: v1
  kind: Pod
  metadata:
    name: test-pod-1
    namespace: test
  spec:
    containers:
    - name: writer
      image: fedora
      command:
      - /bin/sh
      - -c
      - |
        #!/bin/sh
        set -euxo pipefail
        ls -alZ / /opt/ /opt/openshift /opt/openshift/test1
        echo hello > /opt/openshift/test1/test.txt
      volumeMounts:
      - name: discovery
        mountPath: /opt/openshift/test1
    - name: reader
      image: fedora
      command:
      - /bin/sh
      - -c
      - |
        #!/bin/sh
        set -euxo pipefail
        ls -alZ / /opt/ /opt/openshift /opt/openshift/test1
        cat /opt/openshift/test1/test.txt
      volumeMounts:
      - name: discovery
        mountPath: /opt/openshift/test1
    volumes:
    - name: discovery
      hostPath:
        path: /opt/openshift/test1
```

**- Description for the changelog**

