### PR TITLE
Add metrics to configuration file

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -239,6 +239,15 @@ The `crio.network` table containers settings pertaining to the management of CNI
 **plugin_dirs**=["/opt/cni/bin/",]
   List of paths to directories where CNI plugin binaries are located.
 
+## CRIO.METRICS TABLE
+The `crio.metrics` table containers settings pertaining to the Prometheus based metrics retrieval.
+
+**enable_metrics**=false
+  Globally enable or disable metrics support.
+
+**metrics_port**=9090
+  The port on which the metrics server will listen.
+
 # SEE ALSO
 containers-storage.conf(5), containers-policy.json(5), containers-registries.conf(5), crio(8)
 

--- a/internal/lib/config/config.go
+++ b/internal/lib/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	RuntimeConfig
 	ImageConfig
 	NetworkConfig
+	MetricsConfig
 }
 
 // Iface provides a config interface for data encapsulation
@@ -348,6 +349,16 @@ type APIConfig struct {
 	HostIP string `toml:"host_ip"`
 }
 
+// MetricsConfig specifies all necessary configuration for Prometheus based
+// metrics retrieval
+type MetricsConfig struct {
+	// EnableMetrics can be used to globally enable or disable metrics support
+	EnableMetrics bool `toml:"enable_metrics"`
+
+	// MetricsPort is the port on which the metrics server will listen.
+	MetricsPort int `toml:"metrics_port"`
+}
+
 // tomlConfig is another way of looking at a Config, which is
 // TOML-friendly (it has all of the explicit tables). It's just used for
 // conversions.
@@ -358,6 +369,7 @@ type tomlConfig struct {
 		Runtime struct{ RuntimeConfig } `toml:"runtime"`
 		Image   struct{ ImageConfig }   `toml:"image"`
 		Network struct{ NetworkConfig } `toml:"network"`
+		Metrics struct{ MetricsConfig } `toml:"metrics"`
 	} `toml:"crio"`
 }
 
@@ -367,6 +379,7 @@ func (t *tomlConfig) toConfig(c *Config) {
 	c.RuntimeConfig = t.Crio.Runtime.RuntimeConfig
 	c.ImageConfig = t.Crio.Image.ImageConfig
 	c.NetworkConfig = t.Crio.Network.NetworkConfig
+	c.MetricsConfig = t.Crio.Metrics.MetricsConfig
 }
 
 func (t *tomlConfig) fromConfig(c *Config) {
@@ -375,6 +388,7 @@ func (t *tomlConfig) fromConfig(c *Config) {
 	t.Crio.Runtime.RuntimeConfig = c.RuntimeConfig
 	t.Crio.Image.ImageConfig = c.ImageConfig
 	t.Crio.Network.NetworkConfig = c.NetworkConfig
+	t.Crio.Metrics.MetricsConfig = c.MetricsConfig
 }
 
 // UpdateFromFile populates the Config from the TOML-encoded file at the given path.
@@ -491,6 +505,10 @@ func DefaultConfig() (*Config, error) {
 		NetworkConfig: NetworkConfig{
 			NetworkDir: cniConfigDir,
 			PluginDirs: []string{cniBinDir},
+		},
+		MetricsConfig: MetricsConfig{
+			EnableMetrics: false,
+			MetricsPort:   9090,
 		},
 	}, nil
 }

--- a/internal/lib/config/template.go
+++ b/internal/lib/config/template.go
@@ -299,4 +299,13 @@ network_dir = "{{ .NetworkDir }}"
 # Paths to directories where CNI plugin binaries are located.
 plugin_dirs = [
 {{ range $opt := .PluginDirs }}{{ printf "\t%q,\n" $opt }}{{ end }}]
+
+# A necessary configuration for Prometheus based metrics retrieval
+[crio.metrics]
+
+# Globally enable or disable metrics support.
+enable_metrics = {{ .EnableMetrics }}
+
+# The port on which the metrics server will listen.
+metrics_port = {{ .MetricsPort }}
 `


### PR DESCRIPTION
The metrics can now being configured via the crio.conf configuration
file, too. This means we move the metrics server creation logic into
the library and adapt all necessary documentation.