### PR TITLE
makeRepoDigests(): add all manifest digests to RepoDigests

### DIFF
--- a/internal/pkg/storage/image.go
+++ b/internal/pkg/storage/image.go
@@ -131,7 +131,7 @@ func sortNamesByType(names []string) (bestName string, tags, digests []string) {
 }
 
 func (svc *imageService) makeRepoDigests(knownRepoDigests, tags []string, img *storage.Image) (imageDigest digest.Digest, repoDigests []string) {
-	// Look up the image's digest.
+	// Look up the image's digests.
 	imageDigest = img.Digest
 	if imageDigest == "" {
 		imgDigest, err := svc.store.ImageBigDataDigest(img.ID, storage.ImageDigestBigDataKey)
@@ -140,9 +140,11 @@ func (svc *imageService) makeRepoDigests(knownRepoDigests, tags []string, img *s
 		}
 		imageDigest = imgDigest
 	}
-	// If there are no names to convert to canonical references, we're done.
-	if len(tags) == 0 {
-		return imageDigest, knownRepoDigests
+	imageDigests := []digest.Digest{imageDigest}
+	for _, anotherImageDigest := range img.Digests {
+		if anotherImageDigest != imageDigest {
+			imageDigests = append(imageDigests, anotherImageDigest)
+		}
 	}
 	// We only want to supplement what's already explicitly in the list, so keep track of values
 	// that we already know.
@@ -153,13 +155,17 @@ func (svc *imageService) makeRepoDigests(knownRepoDigests, tags []string, img *s
 	}
 	// For each tagged name, parse the name, and if we can extract a named reference, convert
 	// it into a canonical reference using the digest and add it to the list.
-	for _, tag := range tags {
-		if name, err2 := reference.ParseNormalizedNamed(tag); err2 == nil {
-			trimmed := reference.TrimNamed(name)
-			if imageRef, err3 := reference.WithDigest(trimmed, imageDigest); err3 == nil {
-				if _, ok := digestMap[imageRef.String()]; !ok {
-					repoDigests = append(repoDigests, imageRef.String())
-					digestMap[imageRef.String()] = struct{}{}
+	for _, name := range append(tags, knownRepoDigests...) {
+		if ref, err2 := reference.ParseNormalizedNamed(name); err2 == nil {
+			if name, ok := ref.(reference.Named); ok {
+				trimmed := reference.TrimNamed(name)
+				for _, imageDigest := range imageDigests {
+					if imageRef, err3 := reference.WithDigest(trimmed, imageDigest); err3 == nil {
+						if _, ok := digestMap[imageRef.String()]; !ok {
+							repoDigests = append(repoDigests, imageRef.String())
+							digestMap[imageRef.String()] = struct{}{}
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
If we've pulled down more than one manifest for an image (e.g., using different digests for the same image, as identified by its configuration blob), return all of their digests in RepoDigests when we're asked about the image.