### PR TITLE
Update cri-tools to v1.16.0

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -20,7 +20,7 @@
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:
-        cri_tools_git_version: v1.15.0
+        cri_tools_git_version: v1.16.0
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
@@ -84,7 +84,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: true
-        cri_tools_git_version: v1.15.0
+        cri_tools_git_version: v1.16.0
     - name: run cri-o integration tests
       include: test.yml
 
@@ -99,7 +99,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: true
-        cri_tools_git_version: v1.15.0
+        cri_tools_git_version: v1.16.0
     - name: run critest validation and benchmarks
       include: critest.yml
 

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -212,6 +212,9 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+	run crictl stop "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
 	run crictl rm "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
This uses the latest cri-tools version in the ansible based test setups.