### PR TITLE
[1.16] e2e: turn on force_clone for kubetest

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -31,6 +31,8 @@
 
     - name: clone build and install kubetest
       include: "build/kubetest.yml"
+      vars:
+        force_clone: true
 
     - name: clone build and install runc
       include: "build/runc.yml"
@@ -127,6 +129,8 @@
 
     - name: clone build and install kubetest
       include: "build/kubetest.yml"
+      vars:
+        force_clone: true
 
     - name: run k8s e2e tests
       include: e2e.yml
@@ -148,6 +152,8 @@
 
     - name: clone build and install kubetest
       include: "build/kubetest.yml"
+      vars:
+        force_clone: true
 
     - name: run k8s e2e features tests
       include: e2e-features.yml


### PR DESCRIPTION
it causes issues on the git clone on fedora

Signed-off-by: Peter Hunt <pehunt@redhat.com>