### PR TITLE
Burst for bandwidth can be only 4GB

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -129,11 +129,11 @@ func (s *Server) newPodNetwork(sb *sandbox.Sandbox) (ocicni.PodNetwork, error) {
 		bwConfig = &ocicni.BandwidthConfig{}
 		if ingress > 0 {
 			bwConfig.IngressRate = uint64(ingress)
-			bwConfig.IngressBurst = math.MaxUint64
+			bwConfig.IngressBurst = math.MaxUint32 * 8 // 4GB burst limit
 		}
 		if egress > 0 {
 			bwConfig.EgressRate = uint64(egress)
-			bwConfig.EgressBurst = math.MaxUint64
+			bwConfig.EgressBurst = math.MaxUint32 * 8 // 4GB burst limit
 		}
 	}
 


### PR DESCRIPTION
**- What I did** 
Set bandwidth default burst limits to 4GB instead of UInt64 Max to accomodate the same logic as per [https://github.com/containernetworking/plugins/pull/389](here)

**- How I did it**
Changing from MaxUInt64 to MaxUint32 * 8

**- How to verify it**
Compile and use with the PR with [https://github.com/containernetworking/plugins/pull/389](this) CNI plugin

**- Description for the changelog**
Limit bandwidth burst to 4GB