### PR TITLE
Generate crio-status man page during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,9 @@ workflows:
           requires:
             - build
             - build-static
+      - docs-generation:
+          requires:
+            - build
       - docs-validation
       - ginkgo
       - git-validation
@@ -182,6 +185,25 @@ jobs:
           root: .
           paths:
             - bundle/*.tar.gz
+
+  docs-generation:
+    executor: container
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - v1-docs-generation-{{ checksum "go.sum" }}
+      - run:
+          name: doc generation
+          command: |
+            sudo make docs-generation
+            hack/tree_status.sh
+      - save_cache:
+          key: v1-docs-generation-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
 
   docs-validation:
     executor: container

--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,10 @@ completions: binaries
 
 docs: $(MANPAGES) completions
 
+docs-generation:
+	bin/crio-status md  > docs/crio-status.8.md
+	bin/crio-status man > docs/crio-status.8
+
 bundle:
 	bundle/build
 

--- a/completions/bash/crio-status
+++ b/completions/bash/crio-status
@@ -2,16 +2,19 @@ _cli_bash_autocomplete() {
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    opts="config
+    opts="complete
+completion
+config
 c
-info
-i
 containers
 container
 cs
 s
-complete
-completion
+info
+i
+man
+markdown
+md
 help
 h
 --socket

--- a/completions/fish/crio-status.fish
+++ b/completions/fish/crio-status.fish
@@ -2,7 +2,7 @@
 
 function __fish_crio-status_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i config c info i containers container cs s complete completion help h
+        if contains -- $i complete completion config c containers container cs s info i man markdown md help h
             return 1
         end
     end
@@ -14,17 +14,21 @@ complete -c crio-status -n '__fish_crio-status_no_subcommand' -f -l help -s h -d
 complete -c crio-status -n '__fish_crio-status_no_subcommand' -f -l version -s v -d 'print the version'
 complete -c crio-status -n '__fish_crio-status_no_subcommand' -f -l help -s h -d 'show help'
 complete -c crio-status -n '__fish_crio-status_no_subcommand' -f -l version -s v -d 'print the version'
-complete -c crio-status -n '__fish_seen_subcommand_from config c' -f -l help -s h -d 'show help'
-complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'config c' -d 'retrieve the configuration as a TOML string'
-complete -c crio-status -n '__fish_seen_subcommand_from config c' -l socket -s s -r -d 'absolute path to the unix socket (default: "/var/run/crio/crio.sock")'
-complete -c crio-status -n '__fish_seen_subcommand_from info i' -f -l help -s h -d 'show help'
-complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'info i' -d 'retrieve generic information'
-complete -c crio-status -n '__fish_seen_subcommand_from info i' -l socket -s s -r -d 'absolute path to the unix socket (default: "/var/run/crio/crio.sock")'
-complete -c crio-status -n '__fish_seen_subcommand_from containers container cs s' -f -l help -s h -d 'show help'
-complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'containers container cs s' -d 'retrieve information about containers'
-complete -c crio-status -n '__fish_seen_subcommand_from containers container cs s' -l socket -s s -r -d 'absolute path to the unix socket (default: "/var/run/crio/crio.sock")'
-complete -c crio-status -n '__fish_seen_subcommand_from containers container cs s' -f -l id -s i -r -d 'the container ID'
 complete -c crio-status -n '__fish_seen_subcommand_from complete completion' -f -l help -s h -d 'show help'
 complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'complete completion' -d 'Output shell completion code'
+complete -c crio-status -n '__fish_seen_subcommand_from config c' -f -l help -s h -d 'show help'
+complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'config c' -d 'Show the configuration of CRI-O as TOML string.'
+complete -c crio-status -n '__fish_seen_subcommand_from config c' -l socket -s s -r -d 'absolute path to the unix socket (default: "/var/run/crio/crio.sock")'
+complete -c crio-status -n '__fish_seen_subcommand_from containers container cs s' -f -l help -s h -d 'show help'
+complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'containers container cs s' -d 'Display detailed information about the provided container ID.'
+complete -c crio-status -n '__fish_seen_subcommand_from containers container cs s' -l socket -s s -r -d 'absolute path to the unix socket (default: "/var/run/crio/crio.sock")'
+complete -c crio-status -n '__fish_seen_subcommand_from containers container cs s' -f -l id -s i -r -d 'the container ID'
+complete -c crio-status -n '__fish_seen_subcommand_from info i' -f -l help -s h -d 'show help'
+complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'info i' -d 'Retrieve generic information about CRI-O, like the cgroup and storage driver.'
+complete -c crio-status -n '__fish_seen_subcommand_from info i' -l socket -s s -r -d 'absolute path to the unix socket (default: "/var/run/crio/crio.sock")'
+complete -c crio-status -n '__fish_seen_subcommand_from man' -f -l help -s h -d 'show help'
+complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'man' -d 'Generate the man page documentation.'
+complete -c crio-status -n '__fish_seen_subcommand_from markdown md' -f -l help -s h -d 'show help'
+complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'markdown md' -d 'Generate the markdown documentation.'
 complete -c crio-status -n '__fish_seen_subcommand_from help h' -f -l help -s h -d 'show help'
 complete -r -c crio-status -n '__fish_crio-status_no_subcommand' -a 'help h' -d 'Shows a list of commands or help for one command'

--- a/completions/zsh/_crio-status
+++ b/completions/zsh/_crio-status
@@ -1,7 +1,7 @@
 _cli_zsh_autocomplete() {
 
   local -a cmds
-  cmds=('config:retrieve the configuration as a TOML string' 'c:retrieve the configuration as a TOML string' 'info:retrieve generic information' 'i:retrieve generic information' 'containers:retrieve information about containers' 'container:retrieve information about containers' 'cs:retrieve information about containers' 's:retrieve information about containers' 'complete:Output shell completion code' 'completion:Output shell completion code' 'help:Shows a list of commands or help for one command' 'h:Shows a list of commands or help for one command')
+  cmds=('complete:Output shell completion code' 'completion:Output shell completion code' 'config:Show the configuration of CRI-O as TOML string.' 'c:Show the configuration of CRI-O as TOML string.' 'containers:Display detailed information about the provided container ID.' 'container:Display detailed information about the provided container ID.' 'cs:Display detailed information about the provided container ID.' 's:Display detailed information about the provided container ID.' 'info:Retrieve generic information about CRI-O, like the cgroup and storage driver.' 'i:Retrieve generic information about CRI-O, like the cgroup and storage driver.' 'man:Generate the man page documentation.' 'markdown:Generate the markdown documentation.' 'md:Generate the markdown documentation.' 'help:Shows a list of commands or help for one command' 'h:Shows a list of commands or help for one command')
   _describe 'commands' cmds
 
   local -a opts

--- a/docs/crio-status.8.md
+++ b/docs/crio-status.8.md
@@ -1,6 +1,6 @@
 % crio-status(8) A tool for CRI-O status retrieval
+
 % Sascha Grunert
-% JULY 2019
 
 # NAME
 
@@ -11,37 +11,37 @@ crio-status - A tool for CRI-O status retrieval
 crio-status
 
 ```
-[--socket=[value]]
-[--version|-v]
 [--help|-h]
+[--socket|-s]=[value]
+[--version|-v]
 ```
-
-# DESCRIPTION
-
-The tool `crio-status` can be used to access the provided HTTP API with a
-dedicated command line tool.
 
 **Usage**:
 
 ```
-crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+crio-status [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 ```
 
 # GLOBAL OPTIONS
 
-**--socket, -s**="": absolute path to the unix socket (default: "/var/run/crio/crio.sock")
 **--help, -h**: show help
+
+**--socket, -s**="": absolute path to the unix socket (default: "/var/run/crio/crio.sock")
+
 **--version, -v**: print the version
 
+
 # COMMANDS
+
+## complete, completion
+
+Output shell completion code
 
 ## config, c
 
 Show the configuration of CRI-O as TOML string.
 
-## info, i
-
-Retrieve generic information about CRI-O, like the cgroup and storage driver.
+**--socket, -s**="": absolute path to the unix socket (default: "/var/run/crio/crio.sock")
 
 ## containers, container, cs, s
 
@@ -49,10 +49,22 @@ Display detailed information about the provided container ID.
 
 **--id, -i**="": the container ID
 
-## complete, completion
+**--socket, -s**="": absolute path to the unix socket (default: "/var/run/crio/crio.sock")
 
-Generate bash, fish or zsh completions.
+## info, i
 
-# HISTORY
+Retrieve generic information about CRI-O, like the cgroup and storage driver.
 
-Jul 2019, Initial version by Sascha Grunert <sgrunert@suse.com>
+**--socket, -s**="": absolute path to the unix socket (default: "/var/run/crio/crio.sock")
+
+## man
+
+Generate the man page documentation.
+
+## markdown, md
+
+Generate the markdown documentation.
+
+## help, h
+
+Shows a list of commands or help for one command


### PR DESCRIPTION
The command line parser supports now direct man page generation from the
input commands and flags. This means we do not need to maintain an
intermediate markdown man page any more and can generate the
documentation directly from the command line parameters.
