### PR TITLE
WIP: [1.14] bind mount netns to /var/run/...

### DIFF
--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -377,7 +377,7 @@ func (s *Sandbox) NetNsPath() string {
 	if s.netns == nil || s.netns.Get() == nil ||
 		s.netns.Get().symlink == nil {
 		if s.infraContainer != nil {
-			return fmt.Sprintf("/proc/%v/ns/net", s.infraContainer.State().Pid)
+			return fmt.Sprintf("/var/run/netns/%s", s.infraContainer.ID())
 		}
 		return ""
 	}

--- a/oci/container.go
+++ b/oci/container.go
@@ -269,7 +269,7 @@ func (c *Container) NetNsPath() (string, error) {
 	}
 
 	if c.netns == "" {
-		return fmt.Sprintf("/proc/%d/ns/net", c.state.Pid), nil
+		return fmt.Sprintf("/var/run/netns/%s", c.id), nil
 	}
 
 	return c.netns, nil

--- a/oci/container_test.go
+++ b/oci/container_test.go
@@ -166,7 +166,7 @@ var _ = t.Describe("Container", func() {
 
 	It("should succeed get NetNsPath if not provided", func() {
 		// Given
-		container, err := oci.NewContainer("", "", "", "", "",
+		container, err := oci.NewContainer("ctrid", "", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
 			"", "", "", &pb.ContainerMetadata{}, "",
 			false, false, false, false, "", "", time.Now(), "")
@@ -178,7 +178,7 @@ var _ = t.Describe("Container", func() {
 
 		// Then
 		Expect(err).To(BeNil())
-		Expect(path).To(Equal("/proc/0/ns/net"))
+		Expect(path).To(Equal("/var/run/netns/ctrid"))
 	})
 
 	It("should fail get NetNsPath if container state nil", func() {

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -629,7 +629,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		if netNsPath == "" {
 			// The sandbox does not have a permanent namespace,
 			// it's on the host one.
-			netNsPath = fmt.Sprintf("/proc/%d/ns/net", podInfraState.Pid)
+			netNsPath = fmt.Sprintf("/var/run/netns/%s", podInfraState.ID)
 		}
 
 		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.NetworkNamespace), netNsPath); err != nil {


### PR DESCRIPTION
on a reboot, the kubelet tells CRI-O to delete all stale pods. CRI-O will then try to delete the netns at /proc/<ctrpid>/ns/net. However, because CRI-O is on a node that has rebooted, all those pids are stale. At best, CNI del fails, at worst, we delete the net ns of another process.

Attempt instead to bind mount to /var/run/netns/<ctrid>, which is sufficiently unique.

Added wip because I am mostly testing if the change is this easy. if it is, we may also want to try for the other namespaces.

could fix: https://github.com/cri-o/cri-o/issues/2849

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
