### PR TITLE
WIP: bind mount netns to /var/run/...

### DIFF
--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -373,7 +373,7 @@ func (s *Sandbox) NetNsPath() string {
 	if s.netns == nil || s.netns.Get() == nil ||
 		s.netns.Get().symlink == nil {
 		if s.infraContainer != nil {
-			return fmt.Sprintf("/proc/%v/ns/net", s.infraContainer.State().Pid)
+			return fmt.Sprintf("/var/run/netns/%s", s.infraContainer.ID())
 		}
 		return ""
 	}

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -267,7 +267,7 @@ func (c *Container) NetNsPath() (string, error) {
 	}
 
 	if c.netns == "" {
-		return fmt.Sprintf("/proc/%d/ns/net", c.state.Pid), nil
+		return fmt.Sprintf("/var/run/netns/%s", c.id), nil
 	}
 
 	return c.netns, nil

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -155,7 +155,7 @@ var _ = t.Describe("Container", func() {
 
 	It("should succeed get NetNsPath if not provided", func() {
 		// Given
-		container, err := oci.NewContainer("", "", "", "", "",
+		container, err := oci.NewContainer("ctrid", "", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
 			"", "", "", &pb.ContainerMetadata{}, "",
 			false, false, false, false, "", "", time.Now(), "")
@@ -167,7 +167,7 @@ var _ = t.Describe("Container", func() {
 
 		// Then
 		Expect(err).To(BeNil())
-		Expect(path).To(Equal("/proc/0/ns/net"))
+		Expect(path).To(Equal("/var/run/netns/ctrid"))
 	})
 
 	It("should fail get NetNsPath if container state nil", func() {

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -619,7 +619,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		if netNsPath == "" {
 			// The sandbox does not have a permanent namespace,
 			// it's on the host one.
-			netNsPath = fmt.Sprintf("/proc/%d/ns/net", podInfraState.Pid)
+			netNsPath = fmt.Sprintf("/var/run/netns/%s", podInfraState.ID)
 		}
 
 		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.NetworkNamespace), netNsPath); err != nil {


### PR DESCRIPTION
on a reboot, the kubelet tells CRI-O to delete all stale pods. CRI-O will then try to delete the netns at /proc/<ctrpid>/ns/net. However, because CRI-O is on a node that has rebooted, all those pids are stale. At best, CNI del fails, at worst, we delete the net ns of another process.

Attempt instead to bind mount to /var/run/netns/<ctrid>, which is sufficiently unique.

Added wip because I am mostly testing if the change is this easy. if it is, we may also want to try for the other namespaces.

could fix: #2849

Signed-off-by: Peter Hunt <pehunt@redhat.com>
