### PR TITLE
[1.13] e2e: regenerate api before making k8s

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -13,6 +13,14 @@
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
 
+# There were issues where the known violations upstream didn't match those found.
+# Since we're pulling right from upstream, and not changing anything, there shouldn't be risk in doing this
+- name: update api violations
+  make:
+    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+    target: "generated_files"
+    params: UPDATE_API_KNOWN_VIOLATIONS=true
+
 - name: build kubernetes
   make:
     chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -30,6 +30,8 @@
 
     - name: clone build and install kubetest
       include: "build/kubetest.yml"
+      vars:
+        force_clone: true
 
     - name: clone build and install runc
       include: "build/runc.yml"
@@ -127,6 +129,8 @@
 
     - name: clone build and install kubetest
       include: "build/kubetest.yml"
+      vars:
+        force_clone: true
 
     - name: run k8s e2e tests
       include: e2e.yml
@@ -148,6 +152,8 @@
 
     - name: clone build and install kubetest
       include: "build/kubetest.yml"
+      vars:
+        force_clone: true
 
     - name: run k8s e2e features tests
       include: e2e-features.yml


### PR DESCRIPTION
there were problems found by not doing so

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
