### PR TITLE
Add version_path option to set a custom CrioVersionPath

### DIFF
--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -590,8 +590,10 @@ func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext)
 			TakesFile:   true,
 		},
 		cli.StringFlag{
-			Name:  "version-file",
-			Usage: "Location for CRI-O to lay down the version file",
+			Name:      "version-file",
+			Usage:     "Location for CRI-O to lay down the version file",
+			EnvVar:    "CONTAINER_VERSION_FILE",
+			TakesFile: true,
 		},
 	}
 }


### PR DESCRIPTION
**- What I did**

Start crio as regular user and it fail to write version to /var/lib/crio/version.
This change adds a config option to change the path.

**- How I did it**

Set version_path=/run/user/1000/crio_version to crio.conf

**- How to verify it**

Check /run/user/1000/crio_version exists.

**- Description for the changelog**

Add version_path option to set a custom CrioVersionPath