### PR TITLE
[1.16] Move e2e tests to k8s release-1.16 branch

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -131,7 +131,7 @@
       include: "build/kubernetes.yml"
       vars:
         force_clone: true
-        k8s_git_version: "master"
+        k8s_git_version: "release-1.16"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
 
@@ -154,7 +154,7 @@
       include: "build/kubernetes.yml"
       vars:
         force_clone: true
-        k8s_git_version: "master"
+        k8s_git_version: "release-1.16"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
 


### PR DESCRIPTION
Should fix the broken fedora tests.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

