### PR TITLE
Add missing files to static release bundle

### DIFF
--- a/bundle/Makefile
+++ b/bundle/Makefile
@@ -1,5 +1,7 @@
 PREFIX ?= $(DESTDIR)/usr/local
 ETCDIR ?= $(DESTDIR)/etc
+CONTAINERS_DIR ?= $(ETCDIR)/containers
+CNIDIR ?= $(ETCDIR)/cni/net.d
 BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man
 OCIDIR ?= $(PREFIX)/share/oci-umount/oci-umount.d
@@ -7,6 +9,9 @@ SELINUX ?= $(shell selinuxenabled 2>/dev/null && echo -Z)
 BASHINSTALLDIR ?= $(PREFIX)/share/bash-completion/completions
 FISHINSTALLDIR ?= $(PREFIX)/share/fish/completions
 ZSHINSTALLDIR ?= $(PREFIX)/share/zsh/site-functions
+SYSTEMDDIR ?= $(PREFIX)/lib/systemd/system
+
+DEFAULT_BINARY ?= crio-x86_64-static-musl
 
 all: install
 
@@ -15,8 +20,11 @@ install:
 	install $(SELINUX) -d -m 755 $(BASHINSTALLDIR)
 	install $(SELINUX) -d -m 755 $(FISHINSTALLDIR)
 	install $(SELINUX) -d -m 755 $(ZSHINSTALLDIR)
+	install $(SELINUX) -d -m 755 $(CONTAINERS_DIR)
+	install $(SELINUX) -d -m 755 $(CNIDIR)
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-x86_64-static-glibc
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-x86_64-static-musl
+	ln -sf $(BINDIR)/$(DEFAULT_BINARY) $(BINDIR)/crio
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/pause-x86_64-static-glibc
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/pause-x86_64-static-musl
 	install $(SELINUX) -D -m 644 -t $(ETCDIR) etc/crictl.yaml
@@ -27,9 +35,15 @@ install:
 	install $(SELINUX) -D -m 644 -t $(BASHINSTALLDIR) completions/bash/crio
 	install $(SELINUX) -D -m 644 -t $(FISHINSTALLDIR) completions/fish/crio.fish
 	install $(SELINUX) -D -m 644 -t $(ZSHINSTALLDIR) completions/zsh/_crio
+	install $(SELINUX) -D -m 644 -t $(CNIDIR) contrib/10-crio-bridge.conf
+	install $(SELINUX) -D -m 644 -t $(CONTAINERS_DIR) contrib/policy.json
+	install $(SELINUX) -D -m 644 -t $(SYSTEMDDIR) contrib/crio-shutdown.service
+	install $(SELINUX) -D -m 644 -t $(SYSTEMDDIR) contrib/crio-wipe.service
+	install $(SELINUX) -D -m 644 -t $(SYSTEMDDIR) contrib/crio.service
 
 .PHONY: uninstall
 uninstall:
+	rm $(BINDIR)/crio
 	rm $(BINDIR)/crio-x86_64-static-glibc
 	rm $(BINDIR)/crio-x86_64-static-musl
 	rm $(BINDIR)/pause-x86_64-static-glibc
@@ -42,3 +56,8 @@ uninstall:
 	rm $(BASHINSTALLDIR)/crio
 	rm $(FISHINSTALLDIR)/crio.fish
 	rm $(ZSHINSTALLDIR)/_crio
+	rm $(CNIDIR)/10-crio-bridge.conf
+	rm $(CONTAINERS_DIR)/policy.json
+	rm $(SYSTEMDDIR)/crio-shutdown.service
+	rm $(SYSTEMDDIR)/crio-wipe.service
+	rm $(SYSTEMDDIR)/crio.service

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -1,0 +1,31 @@
+# CRI-O static build bundle
+
+The following runtime dependencies are needed to let CRI-O work in conjunction
+with this bundle:
+
+- [runc][0]
+- [conmon][1]
+- [CNI plugins][2]
+
+[0]: https://github.com/opencontainers/runc
+[1]: https://github.com/containers/conmon
+[2]: https://github.com/containernetworking/plugins
+
+To install the bundle, run:
+
+```
+$ sudo make install
+```
+
+After that, it should be possible to start CRI-O by executing:
+
+```
+$ sudo systemctl daemon-reload
+$ sudo systemctl enable --now crio
+```
+
+To uninstall the bundle, run:
+
+```
+$ sudo make uninstall
+```

--- a/bundle/build
+++ b/bundle/build
@@ -18,49 +18,69 @@ FILES_ETC=(
     "../crio-umount.conf"
     "../crio.conf"
 )
+FILES_CONTRIB=(
+    "../contrib/cni/10-crio-bridge.conf"
+    "../contrib/policy.json"
+    "../contrib/systemd/crio-shutdown.service"
+    "../contrib/systemd/crio-wipe.service"
+    "../contrib/systemd/crio.service"
+)
 COMPLETIONS="../completions"
 
 TMPDIR=tmp
 rm -rf $TMPDIR
-mkdir -p $TMPDIR/{bin,etc,man}
+mkdir -p $TMPDIR/{bin,contrib,etc,man}
 
 cp -r $COMPLETIONS $TMPDIR
 
+ERRORED=0
 for FILE in "${FILES_BIN[@]}"; do
     if [[ ! -f "$FILE" ]]; then
         echo "File '$FILE' does not exist"
-        exit 1
-    fi
-
-    if [[ ! -x "$FILE" ]]; then
+        ERRORED=1
+    elif [[ ! -x "$FILE" ]]; then
         echo "File '$FILE' is not exectuable"
-        exit 1
-    fi
-
-    if ! file "$FILE" | grep "statically linked" | grep -q stripped; then
+        ERRORED=1
+    elif ! file "$FILE" | grep "statically linked" | grep -q stripped; then
         echo "Binary '$FILE' is not statically linked and stripped"
-        exit 1
+        ERRORED=1
+    else
+        cp "$FILE" $TMPDIR/bin
     fi
-    cp "$FILE" $TMPDIR/bin
 done
 
 for FILE in "${FILES_MAN[@]}"; do
     if [[ ! -f "$FILE" ]]; then
         echo "File '$FILE' does not exist"
-        exit 1
+        ERRORED=1
+    else
+        cp "$FILE" $TMPDIR/man
     fi
-    cp "$FILE" $TMPDIR/man
 done
 
 for FILE in "${FILES_ETC[@]}"; do
     if [[ ! -f "$FILE" ]]; then
         echo "File '$FILE' does not exist"
-        exit 1
+        ERRORED=1
+    else
+        cp "$FILE" $TMPDIR/etc
     fi
-    cp "$FILE" $TMPDIR/etc
+done
+for FILE in "${FILES_CONTRIB[@]}"; do
+    if [[ ! -f "$FILE" ]]; then
+        echo "File '$FILE' does not exist"
+        ERRORED=1
+    else
+        cp "$FILE" $TMPDIR/contrib
+    fi
 done
 
+if [[ $ERRORED == 1 ]]; then
+    exit 1
+fi
+
 cp Makefile $TMPDIR
+cp README.md $TMPDIR
 
 # Create the archive
 BUNDLE=crio-$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)

--- a/contrib/policy.json
+++ b/contrib/policy.json
@@ -1,0 +1,1 @@
+{ "default": [{ "type": "insecureAcceptAnything" }] }


### PR DESCRIPTION
We now add the CNI, systemd, policy and CRI-O wipe filed to the bundle
as well. Additional documentation how to use the bundle is now included,
too.