### PR TITLE
[1.14] restore: Filter podman containers

### DIFF
--- a/cmd/crio/wipe.go
+++ b/cmd/crio/wipe.go
@@ -89,8 +89,7 @@ func (c ContainerStore) getCrioContainersAndImages() (crioContainers, crioImages
 		if err := json.Unmarshal([]byte(metadataString), &metadata); err != nil {
 			continue
 		}
-		// CRI-O pods differ from libpod pods because they contain a PodName and PodID annotation
-		if metadata.PodName == "" || metadata.PodID == "" {
+		if !storage.IsCrioContainer(metadata) {
 			continue
 		}
 		crioContainers = append(crioContainers, id)

--- a/pkg/storage/utils.go
+++ b/pkg/storage/utils.go
@@ -1,0 +1,8 @@
+package storage
+
+// IsCrioContainer returns whether a container coming from storage was created by CRI-O
+// CRI-O sandboxes and containers differ from libpod container and pods because they require
+// a PodName and PodID annotation
+func IsCrioContainer(md RuntimeContainerMetadata) bool {
+	return md.PodName != "" && md.PodID != ""
+}

--- a/server/server.go
+++ b/server/server.go
@@ -156,6 +156,10 @@ func (s *Server) restore() {
 			logrus.Warnf("error parsing metadata for %s: %v, ignoring", containers[i].ID, err2)
 			continue
 		}
+		if !storage.IsCrioContainer(metadata) {
+			logrus.Debugf("container %s determined to not be a CRI-O container or sandbox", containers[i].ID)
+			continue
+		}
 		names[containers[i].ID] = containers[i].Names
 		if metadata.Pod {
 			pods[containers[i].ID] = &metadata


### PR DESCRIPTION
before, the restore code would find every container in container storage. This would include podman containers. However, CRI-O never actually filtered podman containers out. This caused podman containers to have their configs and storage removed, so they couldn't be inspected.

Fix this by filtering for podman containers, similarly to how `crio wipe` does. While the current method isn't beautiful or elegant, it gets the job done, and opens the door for a lees implementation dependent solution

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1758500

Signed-off-by: Peter Hunt <pehunt@redhat.com>