### PR TITLE
[1.13] restore: Filter podman containers

### DIFF
--- a/pkg/storage/utils.go
+++ b/pkg/storage/utils.go
@@ -1,0 +1,8 @@
+package storage
+
+// IsCrioContainer returns whether a container coming from storage was created by CRI-O
+// CRI-O sandboxes and containers differ from libpod container and pods because they require
+// a PodName and PodID annotation
+func IsCrioContainer(md RuntimeContainerMetadata) bool {
+	return md.PodName != "" && md.PodID != ""
+}

--- a/server/server.go
+++ b/server/server.go
@@ -161,6 +161,11 @@ func (s *Server) restore() {
 			logrus.Warnf("error parsing metadata for %s: %v, ignoring", container.ID, err2)
 			continue
 		}
+		if !storage.IsCrioContainer(metadata) {
+			logrus.Debugf("container %s determined to not be a CRI-O container or sandbox", container.ID)
+			continue
+		}
+
 		names[container.ID] = container.Names
 		if metadata.Pod {
 			pods[container.ID] = &metadata


### PR DESCRIPTION
before, the restore code would find every container in container storage. This would include podman containers. However, CRI-O never actually filtered podman containers out. This caused podman containers to have their configs and storage removed, so they couldn't be inspected.

Fix this by filtering for podman containers, by filtering containers that don't have a required CRI-O annotation

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
