### PR TITLE
Fallback to pause image's entrypoint when config is empty

### DIFF
--- a/internal/lib/config/template.go
+++ b/internal/lib/config/template.go
@@ -291,7 +291,9 @@ pause_image = "{{ .PauseImage }}"
 pause_image_auth_file = "{{ .PauseImageAuthFile }}"
 
 # The command to run to have a container stay in the paused state.
-# This option supports live configuration reload.
+# When explicitly set to "", it will fallback to the entrypoint and command
+# specified in the pause image. When commented out, it will fallback to the
+# default: "/pause". This option supports live configuration reload.
 pause_command = "{{ .PauseCommand }}"
 
 # Path to the file which decides what sort of policy we use when deciding

--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -133,9 +133,6 @@ const (
 	// NsRunDir is the default directory in which running network namespaces
 	// are stored
 	NsRunDir = "/var/run/netns"
-	// PodInfraCommand is the default command when starting a pod infrastructure
-	// container
-	PodInfraCommand = "/pause"
 )
 
 var (

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/containers/libpod/pkg/annotations"
+	"github.com/cri-o/cri-o/internal/lib/config"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/pkg/storage"
 	"github.com/cri-o/cri-o/server"
@@ -298,6 +299,95 @@ var _ = t.Describe("RunPodSandbox", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 			Expect(res).To(Equal(""))
+		})
+	})
+
+	t.Describe("PauseCommand", func() {
+		var cfg *config.Config
+
+		BeforeEach(func() {
+			// Given
+			var err error
+			cfg, err = config.DefaultConfig()
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed with default config", func() {
+			// When
+			res, err := server.PauseCommand(cfg, nil)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal([]string{sut.Config().PauseCommand}))
+		})
+
+		It("should succeed with Entrypoint", func() {
+			// Given
+			cfg.PauseCommand = ""
+			entrypoint := []string{"/custom-pause"}
+			image := &v1.Image{Config: v1.ImageConfig{Entrypoint: entrypoint}}
+
+			// When
+			res, err := server.PauseCommand(cfg, image)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(entrypoint))
+		})
+
+		It("should succeed with Cmd", func() {
+			// Given
+			cfg.PauseCommand = ""
+			cmd := []string{"some-cmd"}
+			image := &v1.Image{Config: v1.ImageConfig{Cmd: cmd}}
+
+			// When
+			res, err := server.PauseCommand(cfg, image)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(cmd))
+		})
+
+		It("should succeed with Entrypoint and Cmd", func() {
+			// Given
+			cfg.PauseCommand = ""
+			entrypoint := "/custom-pause"
+			cmd := "some-cmd"
+			image := &v1.Image{Config: v1.ImageConfig{
+				Entrypoint: []string{entrypoint},
+				Cmd:        []string{cmd},
+			}}
+
+			// When
+			res, err := server.PauseCommand(cfg, image)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(res).To(HaveLen(2))
+			Expect(res[0]).To(Equal(entrypoint))
+			Expect(res[1]).To(Equal(cmd))
+		})
+
+		It("should fail if config is nil", func() {
+			// When
+			res, err := server.PauseCommand(nil, nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(res).To(BeNil())
+		})
+
+		It("should fail if image config is nil", func() {
+			// Given
+			cfg.PauseCommand = ""
+
+			// When
+			res, err := server.PauseCommand(cfg, nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(res).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
The general target is to allow `pause_command = ""`, which should take the
entrypoint into account.

If the `pause_command = ""`, then its entrypoint will now be considered as
process arg, whereas the specified command in the image config will be
added as well. This keeps the backwards compatibility with images using
only `Cmd` and no `Entrypoint`.

If the `pause_command` is commented out, then it will still defaults to
`/pause`.

The logic has been refactored into a dedicated function to reduce the
cyclomatic complexity and allow proper testing.