### PR TITLE
[1.16] remove docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ executors:
 
   machine:
     machine:
-      docker_layer_caching: true
       image: ubuntu-1604:201903-01
     <<: *stdenv
 


### PR DESCRIPTION
it seems it's not allowed in the free version

Signed-off-by: Peter Hunt <pehunt@redhat.com>