### PR TITLE
Fix CRI-O apt-get version

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ On Ubuntu distributions, there is a dedicated PPA provided by
 ```bash
 sudo apt-add-repository ppa:projectatomic/ppa
 sudo apt-get update -qq
-sudo apt-get install crio
+sudo apt-get install cri-o-[REQUIRED VERSION]
 ```
 
 Alternatively, if you'd rather build `CRI-O` from source, checkout our [setup


### PR DESCRIPTION
Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Modify README.md to install the CRI-O package correctly.

**- How I did it**
Change the apt-get install command  on Ubuntu distributions.

**- How to verify it**
I actually installed CRI-O using my modified README.md.
In addition to that, I confirmed below Kubernetes's document.
https://v1-15.docs.kubernetes.io/docs/setup/production-environment/container-runtimes/

**- Description for the changelog**
Fix CRI-O apt-get version
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
