### PR TITLE
Require libseccomp >= 2.4.1-1 for CI

### DIFF
--- a/contrib/test/ci/cri-o.spec
+++ b/contrib/test/ci/cri-o.spec
@@ -64,6 +64,7 @@ Provides: ocid = %{version}-%{release}
 Provides: %{service_name} = %{version}-%{release}
 Requires: containernetworking-plugins >= 0.7.5-1
 Requires: conmon
+Requires: libseccomp >= 2.4.1-1
 
 %description
 %{summary}


### PR DESCRIPTION
With the current libseccomp, we see:
`undefined symbol: seccomp_api_get`.

Updating libseccomp to 2.4.1 resolves this issue.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@umohnani8 PTAL