### PR TITLE
fix ami rhel7

### DIFF
--- a/contrib/test/integration/build/parallel.yml
+++ b/contrib/test/integration/build/parallel.yml
@@ -1,17 +1,16 @@
 ---
-- name:
-  include_vars:
-      file: python3.yml
+- name: include variable to check if python2-dnf can be installed
+  include: python3.yml
 
 - name: install parallel package for Fedora
   package:
     name: parallel
     state: present
-  when: not supports_python3 and ansible_distribution in ['Fedora', 'CentOS']
+  when: (supports_python3 is not defined or not supports_python3) and ansible_distribution in ['Fedora', 'CentOS']
 
 - name: install parallel package for Fedora > 30
   shell: sudo yum install -y parallel
-  when: supports_python3 and ansible_distribution in ['Fedora', 'CentOS']
+  when: supports_python3 is defined and supports_python3 and ansible_distribution in ['Fedora', 'CentOS']
 
 - name: download parallel sources
   unarchive:

--- a/contrib/test/integration/python3.yml
+++ b/contrib/test/integration/python3.yml
@@ -1,2 +1,6 @@
 ---
-supports_python3: (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8) or (ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 30)
+- name: set facts
+  set_fact:
+    supports_python3: true
+    cacheable: true
+  when: (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8) or (ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 30)

--- a/contrib/test/integration/system-packages.yml
+++ b/contrib/test/integration/system-packages.yml
@@ -1,7 +1,6 @@
 ---
-- name:
-  include_vars:
-      file: python3.yml
+- name: include variable to check if python2-dnf can be installed
+  include: python3.yml
 
 - name: Make sure we have all required packages for RHEL 7 and Fedora <= 30
   package:
@@ -61,7 +60,7 @@
     - wget
   async: '{{ 20 * 60 }}'
   poll: 10
-  when: not supports_python3
+  when: supports_python3 is not defined or not supports_python3
 
 - name: Make sure we have all required packages for RHEL 8 and Fedora >=30
   raw: >
@@ -118,7 +117,7 @@
     socat \
     tar \
     wget
-  when: supports_python3
+  when: supports_python3 is defined and supports_python3
 
 - name: Add Fedora <=29 specific packages
   package:
@@ -127,7 +126,7 @@
   with_items:
    - python2-boto
    - btrfs-progs-devel
-  when: ansible_distribution in ['Fedora'] and not supports_python3
+  when: (supports_python3 is not defined or not supports_python3) and ansible_distribution in ['Fedora']
 
 - name: Add python-boto for RHEL and CentOS
   package:
@@ -135,7 +134,7 @@
     state: present
   with_items:
    - python-boto
-  when: ansible_distribution in ['RedHat', 'CentOS'] and not supports_python3
+  when: (supports_python3 is not defined or not supports_python3) and ansible_distribution in ['RedHat', 'Centos']
 
 - name: Update all packages
   package:
@@ -143,8 +142,8 @@
     state: latest
   async: 600
   poll: 10
-  when: not supports_python3
+  when: supports_python3 is not defined or not supports_python3
 
 - name: Update all packages RHEL 8 and Fedora >= 30
   shell: sudo yum update -y
-  when: supports_python3
+  when: supports_python3 is defined and supports_python3


### PR DESCRIPTION
the ansible version on rhel 7 is old enough such that a sufficiently complex boolean expression is interpreted as a string. This causes any supports_python3 condition to not execute.

instead, use set_facts with a when, so we properly set supports_python3

Signed-off-by: Peter Hunt <pehunt@redhat.com>