### PR TITLE
[1.16] Fallback to pause image's entrypoint when config is empty

### DIFF
--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -133,9 +133,6 @@ const (
 	// NsRunDir is the default directory in which running network namespaces
 	// are stored
 	NsRunDir = "/var/run/netns"
-	// PodInfraCommand is the default command when starting a pod infrastructure
-	// container
-	PodInfraCommand = "/pause"
 )
 
 var (

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -294,7 +294,9 @@ pause_image = "{{ .PauseImage }}"
 pause_image_auth_file = "{{ .PauseImageAuthFile }}"
 
 # The command to run to have a container stay in the paused state.
-# This option supports live configuration reload.
+# When explicitly set to "", it will fallback to the entrypoint and command
+# specified in the pause image. When commented out, it will fallback to the
+# default: "/pause". This option supports live configuration reload.
 pause_command = "{{ .PauseCommand }}"
 
 # Path to the file which decides what sort of policy we use when deciding

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/pkg/log"
+	"github.com/cri-o/cri-o/pkg/config"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -141,15 +143,12 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	// setup defaults for the pod sandbox
 	g.SetRootReadonly(true)
-	if s.config.PauseCommand == "" {
-		if podContainer.Config != nil {
-			g.SetProcessArgs(podContainer.Config.Config.Cmd)
-		} else {
-			g.SetProcessArgs([]string{sandbox.PodInfraCommand})
-		}
-	} else {
-		g.SetProcessArgs([]string{s.config.PauseCommand})
+
+	pauseCommand, err := PauseCommand(s.Config(), podContainer.Config)
+	if err != nil {
+		return nil, err
 	}
+	g.SetProcessArgs(pauseCommand)
 
 	// set DNS options
 	if req.GetConfig().GetDnsConfig() != nil {
@@ -749,4 +748,31 @@ func AddCgroupAnnotation(ctx context.Context, g generate.Generator, mountPath, c
 	g.AddAnnotation(annotations.CgroupParent, cgroupParent)
 
 	return cgroupParent, nil
+}
+
+// PauseCommand returns the pause command for the provided image configuration.
+func PauseCommand(cfg *config.Config, image *v1.Image) ([]string, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("provided configuration is nil")
+	}
+
+	// This has been explicitly set by the user, since the configuration
+	// default is `/pause`
+	if cfg.PauseCommand == "" {
+		if image == nil ||
+			(len(image.Config.Entrypoint) == 0 && len(image.Config.Cmd) == 0) {
+
+			return nil, fmt.Errorf(
+				"unable to run pause image %q: %s",
+				cfg.PauseImage,
+				"neither Cmd nor Entrypoint specified",
+			)
+		}
+		cmd := []string{}
+		cmd = append(cmd, image.Config.Entrypoint...)
+		cmd = append(cmd, image.Config.Cmd...)
+		return cmd, nil
+
+	}
+	return []string{cfg.PauseCommand}, nil
 }


### PR DESCRIPTION
If the `pause_command = ""`, then its entrypoint will now be considered as
process arg, whereas the specified command in the image config will be
added as well.

If the `pause_command` is commented out, then it will still default to
`/pause`.

Backport of https://github.com/cri-o/cri-o/pull/2881
Cherry-picked: 37b42b5c1414c9e8ff902b0edf8f2987cce5b6f8
