### PR TITLE
Extend image pull metrics

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -10,10 +10,21 @@ import (
 const (
 	// CRIOOperationsKey is the key for CRI-O operation metrics.
 	CRIOOperationsKey = "crio_operations"
+
 	// CRIOOperationsLatencyKey is the key for the operation latency metrics.
 	CRIOOperationsLatencyKey = "crio_operations_latency_microseconds"
+
 	// CRIOOperationsErrorsKey is the key for the operation error metrics.
 	CRIOOperationsErrorsKey = "crio_operations_errors"
+
+	// CRIOImagePullsByDigestKey is the key for CRI-O image pull metrics by digest.
+	CRIOImagePullsByDigestKey = "crio_image_pulls_by_digest"
+
+	// CRIOImagePullsByNameKey is the key for CRI-O image pull metrics by name.
+	CRIOImagePullsByNameKey = "crio_image_pulls_by_name"
+
+	// CRIOImagePullsByNameSkippedKey is the key for CRI-O skipped image pull metrics by name (skipped).
+	CRIOImagePullsByNameSkippedKey = "crio_image_pulls_by_name_skipped"
 
 	// TODO(runcom):
 	// timeouts
@@ -31,6 +42,7 @@ var (
 		},
 		[]string{"operation_type"},
 	)
+
 	// CRIOOperationsLatency collects operation latency numbers by operation
 	// type.
 	CRIOOperationsLatency = prometheus.NewSummaryVec(
@@ -41,6 +53,7 @@ var (
 		},
 		[]string{"operation_type"},
 	)
+
 	// CRIOOperationsErrors collects operation errors by operation
 	// type.
 	CRIOOperationsErrors = prometheus.NewCounterVec(
@@ -50,6 +63,36 @@ var (
 			Help:      "Cumulative number of CRI-O operation errors by operation type.",
 		},
 		[]string{"operation_type"},
+	)
+
+	// CRIOImagePullsByDigest collects image pull metrics for every image digest
+	CRIOImagePullsByDigest = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      CRIOImagePullsByDigestKey,
+			Help:      "Bytes transferred by CRI-O image pulls by digest",
+		},
+		[]string{"name", "digest", "mediatype", "size"},
+	)
+
+	// CRIOImagePullsByName collects image pull metrics for every image name
+	CRIOImagePullsByName = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      CRIOImagePullsByNameKey,
+			Help:      "Bytes transferred by CRI-O image pulls by name",
+		},
+		[]string{"name", "size"},
+	)
+
+	// CRIOImagePullsByNameSkipped collects image pull metrics for every image name (skipped)
+	CRIOImagePullsByNameSkipped = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      CRIOImagePullsByNameSkippedKey,
+			Help:      "Bytes skipped by CRI-O image pulls by name",
+		},
+		[]string{"name"},
 	)
 )
 
@@ -61,6 +104,9 @@ func Register() {
 		prometheus.MustRegister(CRIOOperations)
 		prometheus.MustRegister(CRIOOperationsLatency)
 		prometheus.MustRegister(CRIOOperationsErrors)
+		prometheus.MustRegister(CRIOImagePullsByDigest)
+		prometheus.MustRegister(CRIOImagePullsByName)
+		prometheus.MustRegister(CRIOImagePullsByNameSkipped)
 	})
 }
 

--- a/tutorials/metrics.md
+++ b/tutorials/metrics.md
@@ -33,6 +33,9 @@ Beside the [default golang based metrics][2], CRI-O provides the following addit
 | `crio_operations`                      | every CRI-O RPC\*                                                                                                                       | Counter | Cumulative number of CRI-O operations by operation type.                 |
 | `crio_operations_latency_microseconds` | every CRI-O RPC\*,<br><br>`network_setup_pod` (CNI pod network setup time),<br><br>`network_setup_overall` (Overall network setup time) | Summary | Latency in microseconds of CRI-O operations. Split-up by operation type. |
 | `crio_operations_errors`               | every CRI-O RPC\*                                                                                                                       | Counter | Cumulative number of CRI-O operation errors by operation type.           |
+| `crio_image_pulls_by_digest`           | `name`, `digest`, `mediatype`, `size`                                                                                                   | Counter | Bytes transferred by CRI-O image pulls by digest.                        |
+| `crio_image_pulls_by_name`             | `name`, `size`                                                                                                                          | Counter | Bytes transferred by CRI-O image pulls by name.                          |
+| `crio_image_pulls_by_name_skipped`     | `name`                                                                                                                                  | Counter | Bytes skipped by CRI-O image pulls by name.                              |
 
 \* Available CRI-O RPC's from the [gRPC API][3]: `Attach`, `ContainerStats`, `ContainerStatus`,
 `CreateContainer`, `Exec`, `ExecSync`, `ImageFsInfo`, `ImageStatus`,


### PR DESCRIPTION
We now add a new set of image pull metrics, which collect the transferred
bytes per image name or digest every second during an image pull. We
also add a metric which collects the skipped bytes if an image has
already been downloaded.

This fixes the ignored command line parameters for the metrics, too.

Example output from the metrics server:
1. Download the image 
1. Remove the image, download it again
1. Download the already existing image 
```bash
# HELP container_runtime_crio_image_pulls_by_digest Bytes transferred by CRI-O image pulls by digest
# TYPE container_runtime_crio_image_pulls_by_digest counter
container_runtime_crio_image_pulls_by_digest{digest="sha256:2f1a357cf2898f6700b74d933e1784a348df8f719c4db77203423e63b538de9b",mediatype="application/vnd.docker.container.image.v1+json",name="docker.io/nixos/nix",size="5127"} 10254
container_runtime_crio_image_pulls_by_digest{digest="sha256:480223332b134112f7f7f1292789ae19b695c1329a7180200ae82778fab59e95",mediatype="",name="docker.io/nixos/nix",size="277005"} 554010
container_runtime_crio_image_pulls_by_digest{digest="sha256:74bc3bbbef74304d58600283df51bab6a3dbe9b1ec939bd9f5db7b3c87cfb612",mediatype="",name="docker.io/nixos/nix",size="60336471"} 1.20672942e+08
container_runtime_crio_image_pulls_by_digest{digest="sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",mediatype="",name="docker.io/nixos/nix",size="2789669"} 5.579338e+06
# HELP container_runtime_crio_image_pulls_by_name Bytes transferred by CRI-O image pulls by name
# TYPE container_runtime_crio_image_pulls_by_name counter
container_runtime_crio_image_pulls_by_name{name="docker.io/nixos/nix",size="63408272"} 1.26816544e+08
# HELP container_runtime_crio_image_pulls_by_name_skipped Bytes skipped by CRI-O image pulls by name
# TYPE container_runtime_crio_image_pulls_by_name_skipped counter
container_runtime_crio_image_pulls_by_name_skipped{name="docker.io/nixos/nix"} 1.91975283e+08
```

Closes https://github.com/cri-o/cri-o/issues/2757
Related change: https://github.com/containers/image/pull/732
Discussion on SIG Node: https://groups.google.com/forum/#!topic/kubernetes-sig-node/JHEus_TlZzA