### PR TITLE
Split-up build process to stabilize CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,11 @@ jobs:
             - v1-build-<< parameters.executor >>-{{ checksum "go.sum" }}
       - run: go version
       - run:
-          name: build
-          command: make -j $JOBS
+          command: make binaries -j $JOBS
+      - run:
+          command: make crio.conf
+      - run:
+          command: make docs -j $JOBS
       - save_cache:
           key: v1-build-<< parameters.executor >>-{{ checksum "go.sum" }}
           paths:


### PR DESCRIPTION
The CI sees some flakes in parallel build which should be solved in
splitting up the build process into three dedicated stages.

Example issue:
```
touch "/go/.gopathok"
make -C pause
make[1]: Entering directory '/go/src/github.com/cri-o/cri-o/pause'
cc -std=c99 -Os -Wall -Wextra -static   -c -o pause.o pause.c
mkdir -p ../bin
cc -o ../bin/pause pause.o -std=c99 -Os -Wall -Wextra -static 
make[1]: Leaving directory '/go/src/github.com/cri-o/cri-o/pause'
go build -ldflags '-s -w -X main.gitCommit="d735acbd64844c3df28c43b1db3a43c9ebb94998" -X main.buildInfo=1571914439' -tags "containers_image_ostree_stub apparmor      seccomp selinux" -o bin/crio github.com/cri-o/cri-o/cmd/crio
go build -ldflags '-s -w -X main.gitCommit="d735acbd64844c3df28c43b1db3a43c9ebb94998" -X main.buildInfo=1571914439' -tags "containers_image_ostree_stub apparmor      seccomp selinux" -o bin/crio-status github.com/cri-o/cri-o/cmd/crio-status
(/go/src/github.com/cri-o/cri-o/build/bin/go-md2man -in docs/crio-status.8.md -out docs/crio-status.8.tmp && touch docs/crio-status.8.tmp && mv docs/crio-status.8.tmp docs/crio-status.8) || \
	(/go/src/github.com/cri-o/cri-o/build/bin/go-md2man -in docs/crio-status.8.md -out docs/crio-status.8.tmp && touch docs/crio-status.8.tmp && mv docs/crio-status.8.tmp docs/crio-status.8)
(/go/src/github.com/cri-o/cri-o/build/bin/go-md2man -in docs/crio.conf.5.md -out docs/crio.conf.5.tmp && touch docs/crio.conf.5.tmp && mv docs/crio.conf.5.tmp docs/crio.conf.5) || \
	(/go/src/github.com/cri-o/cri-o/build/bin/go-md2man -in docs/crio.conf.5.md -out docs/crio.conf.5.tmp && touch docs/crio.conf.5.tmp && mv docs/crio.conf.5.tmp docs/crio.conf.5)
(/go/src/github.com/cri-o/cri-o/build/bin/go-md2man -in docs/crio.8.md -out docs/crio.8.tmp && touch docs/crio.8.tmp && mv docs/crio.8.tmp docs/crio.8) || \
	(/go/src/github.com/cri-o/cri-o/build/bin/go-md2man -in docs/crio.8.md -out docs/crio.8.tmp && touch docs/crio.8.tmp && mv docs/crio.8.tmp docs/crio.8)
./bin/crio --config=""  config  > crio.conf
bin/crio complete bash > completions/bash/crio
error loading server config: cannot open /home/circleci/.config/containers/storage.conf: open /home/circleci/.config/containers/storage.conf: file exists
WARN[0000] default configuration file does not exist: /etc/crio/crio.conf 
Makefile:143: recipe for target 'crio.conf' failed
make: *** [crio.conf] Error 1
make: *** Waiting for unfinished jobs....
bin/crio complete fish > completions/fish/crio.fish
WARN[0000] default configuration file does not exist: /etc/crio/crio.conf 
bin/crio complete zsh  > completions/zsh/_crio
WARN[0000] default configuration file does not exist: /etc/crio/crio.conf 
bin/crio-status complete bash > completions/bash/crio-status
bin/crio-status complete fish > completions/fish/crio-status.fish
bin/crio-status complete zsh  > completions/zsh/_crio-status
Exited with code 2
```