### PR TITLE
Make multiple host IPs configurable

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -233,7 +233,7 @@ For the bind-mount conditions, only mounts explicitly requested by Kubernetes co
 
 **--grpc-max-send-msg-size**="": maximum grpc receive message size (default: 16 * 1024 * 1024)
 
-**--host-ip**="": host IP considered as the primary IP to use by CRI-O for things such as host network IP (default: "")
+**--host-ip**="": Host IPs are the addresses to be used for the host network and can be specified up to two times (default: [])
 
 **--manage-network-ns-lifecycle**: determines whether we pin and remove network namespace and manage its lifecycle (default: false)
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -51,7 +51,7 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
 The `crio.api` table contains settings for the kubelet/gRPC interface.
 
 **host_ip**=""
-  Host IP considered as the primary IP to use by CRI-O for things such as host network IP.
+  Host IPs are the addresses to be used for the host network. It is not possible to assign more than two addresses right now.
 
 **listen**="/var/run/crio/crio.sock"
   Path to AF_LOCAL socket on which CRI-O will listen.

--- a/internal/lib/config/config.go
+++ b/internal/lib/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -353,7 +354,7 @@ type APIConfig struct {
 	StreamTLSCA string `toml:"stream_tls_ca"`
 
 	// HostIP is the IP address that the server uses where it needs to use the primary host IP.
-	HostIP string `toml:"host_ip"`
+	HostIP []string `toml:"host_ip"`
 }
 
 // MetricsConfig specifies all necessary configuration for Prometheus based
@@ -578,6 +579,16 @@ func (c *APIConfig) Validate(onExecution bool) error {
 		if _, err := os.Stat(c.Listen); err == nil {
 			if err := os.Remove(c.Listen); err != nil {
 				return err
+			}
+		}
+
+		// Validate user provided host IPs
+		if len(c.HostIP) > 2 {
+			return errors.New("It's not possible to assign more than two host IPs")
+		}
+		for _, ip := range c.HostIP {
+			if net.ParseIP(ip) == nil {
+				return errors.Errorf("Unable to parse host IP: %v", ip)
 			}
 		}
 	}

--- a/internal/lib/config/config_test.go
+++ b/internal/lib/config/config_test.go
@@ -166,6 +166,30 @@ var _ = t.Describe("Config", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 		})
+
+		It("should fail with invalid host IP", func() {
+			// Given
+			sut = runtimeValidConfig()
+			sut.HostIP = []string{"1.2.3.4", "invalid"}
+
+			// When
+			err := sut.APIConfig.Validate(true)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should fail with more than two host IPs", func() {
+			// Given
+			sut = runtimeValidConfig()
+			sut.HostIP = []string{"1.2.3.4", "10.1.2.3", "3300::1"}
+
+			// When
+			err := sut.APIConfig.Validate(true)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
 	})
 
 	t.Describe("ValidateRuntimeConfig", func() {

--- a/internal/lib/config/template.go
+++ b/internal/lib/config/template.go
@@ -61,8 +61,10 @@ version_file = "{{ .VersionFile }}"
 # Path to AF_LOCAL socket on which CRI-O will listen.
 listen = "{{ .Listen }}"
 
-# Host IP considered as the primary IP to use by CRI-O for things such as host network IP.
-host_ip = "{{ .HostIP }}"
+# Host IPs are the addresses to be used for the host network.
+# It is not possible to assign more than two addresses right now.
+host_ip = [{{ range $opt := .HostIP }}{{ printf "\n%t%q," $opt }}{{ end }}
+]
 
 # IP address on which the stream server will listen.
 stream_address = "{{ .StreamAddress }}"

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -101,7 +101,7 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) (string, error) {
 		config.StreamAddress = ctx.GlobalString("stream-address")
 	}
 	if ctx.GlobalIsSet("host-ip") {
-		config.HostIP = ctx.GlobalString("host-ip")
+		config.HostIP = ctx.GlobalStringSlice("host-ip")
 	}
 	if ctx.GlobalIsSet("stream-port") {
 		config.StreamPort = ctx.GlobalString("stream-port")
@@ -214,9 +214,6 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) (string, error) {
 	}
 	if ctx.GlobalIsSet("grpc-max-send-msg-size") {
 		config.GRPCMaxSendMsgSize = ctx.GlobalInt("grpc-max-send-msg-size")
-	}
-	if ctx.GlobalIsSet("host-ip") {
-		config.HostIP = ctx.GlobalString("host-ip")
 	}
 	if ctx.GlobalIsSet("manage-network-ns-lifecycle") {
 		config.ManageNetworkNSLifecycle = ctx.GlobalBool("manage-network-ns-lifecycle")
@@ -574,9 +571,9 @@ func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext)
 			Usage:  fmt.Sprintf("maximum grpc receive message size (default: %q)", defConf.GRPCMaxSendMsgSize),
 			EnvVar: "CONTAINER_GRPC_MAX_SEND_MSG_SIZE",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:   "host-ip",
-			Usage:  fmt.Sprintf("host IP considered as the primary IP to use by CRI-O for things such as host network IP (default: %q)", defConf.HostIP),
+			Usage:  fmt.Sprintf("Host IPs are the addresses to be used for the host network and can be specified up to two times (default: %q)", defConf.HostIP),
 			EnvVar: "CONTAINER_HOST_IP",
 		},
 		cli.BoolFlag{


### PR DESCRIPTION
As a follow-up of #2781, we are now able to configure ~~multiple~~ up to two host IPs via the command line interface or configuration file. The specified IPs will now be verified during config validation.

@uablrek can you test if this works for you? It is now possible to run CRI-O like
```
> crio --host-ip 192.168.178.101 --host-ip 2a02:8106:20f:a000:3815:37ed:f926:e0f4
```