### PR TITLE
[1.16] reduce infra container's selinux privilege

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -104,9 +104,8 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		s.defaultIDMappings,
 		labelOptions)
 	mountLabel = podContainer.MountLabel
-	if !s.privilegedSandbox(req) {
-		processLabel = podContainer.ProcessLabel
-	}
+	processLabel = podContainer.ProcessLabel
+
 	if errors.Cause(err) == storage.ErrDuplicateName {
 		return nil, fmt.Errorf("pod sandbox with name %q already exists", name)
 	}


### PR DESCRIPTION
before, if a pod was privileged, a pause container was set as privileged. This caused the rest of the containers in the pod to also need to inherit privileged labels from the pod (so they can join the pause container's namespaces).

In reality, there's little need for the pause container to have privileged (spc_t) label. It can manage an unprivileged namespace, and containers can join regardless of privilege. Further, the privilege of the pause container doesn't affect its ability to reap (if the pod shares pid).

Unconditionally set the pause container's process label, so the rest of the (unprivileged) containers in the pod inherit it.

Signed-off-by: Peter Hunt <pehunt@redhat.com>