### PR TITLE
Update build dependencies (go 1.13)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,9 @@ version: 2.1
 stdenv: &stdenv
   environment:
     GOCACHE: &gocache /tmp/go-build
-    IMAGE: &image quay.io/crio/crio-build-amd64-go1.12:1.0.0
-    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.10:1.0.0
-    IMAGE386: &image386 quay.io/crio/crio-build-386-go1.12:1.0.0
+    IMAGE: &image quay.io/crio/crio-build-amd64-go1.13:1.1.0
+    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.10:1.1.0
+    IMAGE386: &image386 quay.io/crio/crio-build-386-go1.13:1.1.0
     JOBS: &jobs 8
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o
 
@@ -74,6 +74,7 @@ workflows:
       - integration:
           name: integration-critest
           run_critest: '1'
+          jobs: 1
           test_args: critest.bats
           requires:
             - build
@@ -282,6 +283,9 @@ jobs:
       test_userns:
         type: string
         default: ''
+      jobs:
+        type: integer
+        default: *jobs
     steps:
       - checkout
       - attach_workspace:
@@ -300,12 +304,14 @@ jobs:
               -e RUN_CRITEST \
               -e STORAGE_OPTIONS="-s=vfs" \
               -e TEST_USERNS \
+              -e JOBS \
               -v $(pwd)/build/bin/ginkgo:/usr/bin/ginkgo \
               -v $(pwd):$WORKDIR \
               -w $WORKDIR \
               $IMAGE \
               test/test_runner.sh $TEST_ARGS
           environment:
+            JOBS: "<< parameters.jobs >>"
             CRIO_BINARY: "<< parameters.crio_binary >>"
             RUN_CRITEST: "<< parameters.run_critest >>"
             TEST_ARGS: "<< parameters.test_args >>"
@@ -356,7 +362,6 @@ jobs:
           name: check mocks
           command: |
             make mockgen -j $JOBS
-            hack/tree_status.sh
       - run:
           name: unit tests
           command: make testunit

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ SHRINKFLAGS := -s -w
 BASE_LDFLAGS = ${SHRINKFLAGS} -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${SOURCE_DATE_EPOCH}
 LDFLAGS = -ldflags '${BASE_LDFLAGS}'
 
-TESTIMAGE_VERSION := 1.0.0
+TESTIMAGE_VERSION := 1.1.0
 TESTIMAGE_REGISTRY := quay.io/crio
 TESTIMAGE_SCRIPT := scripts/build-test-image -r $(TESTIMAGE_REGISTRY) -v $(TESTIMAGE_VERSION)
 TESTIMAGE_NAME ?= $(shell $(TESTIMAGE_SCRIPT) -d)
@@ -183,8 +183,8 @@ local-image:
 	$(TESTIMAGE_SCRIPT)
 
 test-images:
-	$(TESTIMAGE_SCRIPT) -g 1.12 -a amd64
-	$(TESTIMAGE_SCRIPT) -g 1.12 -a 386
+	$(TESTIMAGE_SCRIPT) -g 1.13 -a amd64
+	$(TESTIMAGE_SCRIPT) -g 1.13 -a 386
 	$(TESTIMAGE_SCRIPT) -g 1.10 -a amd64
 
 dbuild:

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -20,7 +20,7 @@
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:
-        cri_tools_git_version: v1.15.0
+        cri_tools_git_version: v1.16.1
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
@@ -84,7 +84,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: true
-        cri_tools_git_version: v1.15.0
+        cri_tools_git_version: v1.16.1
     - name: run cri-o integration tests
       include: test.yml
 
@@ -99,7 +99,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: true
-        cri_tools_git_version: v1.15.0
+        cri_tools_git_version: v1.16.1
     - name: run critest validation and benchmarks
       include: critest.yml
 

--- a/scripts/build-test-image
+++ b/scripts/build-test-image
@@ -7,23 +7,23 @@ fi
 
 # Versions to be used
 declare -A VERSIONS=(
-    ["cni-plugins"]=v0.8.1
+    ["cni-plugins"]=v0.8.2
     ["conmon"]=v2.0.0
-    ["cri-tools"]=v1.15.0
-    ["runc"]=v1.0.0-rc8
+    ["cri-tools"]=v1.16.1
+    ["runc"]=v1.0.0-rc9
 )
 
 # Available architectures and go versions
 ARCH_386=386
 ARCH_AMD64=amd64
-GO_112=1.12
+GO_113=1.13
 GO_110=1.10
 
 # The default values
 TARGET_IMAGE=crio-build
 REGISTRY=
 ARCH=$ARCH_AMD64
-GO=$GO_112
+GO=$GO_113
 BASE_IMAGE=docker.io/golang
 TAG=latest
 DRYRUN=false
@@ -31,9 +31,9 @@ WORK_CTR=
 
 # All supported image digests
 declare -A IMAGES=(
-    # go 1.12.8 digests
-    ["$GO_112:$ARCH_AMD64"]=2e26d966bd353054990a17f8856ffa66ca6f8a02b2c9fc748ae4bea65817a578
-    ["$GO_112:$ARCH_386"]=fda5925d674d472a0f16e9e7976246852e3c03b1819d84b4e41b030eca9cb373
+    # go 1.13.4 digests
+    ["$GO_113:$ARCH_AMD64"]=80bf73289b856e9a9cb518e76380575b4328b031dd9f593c7c7b3c75c5598048
+    ["$GO_113:$ARCH_386"]=eab1380f36935fa5787b1b88fcaf4b33c50d3f782277adee544d3c434b345bf4
 
     # go 1.10.8 digests
     ["$GO_110:$ARCH_AMD64"]=eac40ba14416262e26def90a2d6f10d6ff579ea61c267963f6cbfbbe63b0ea7b
@@ -41,7 +41,7 @@ declare -A IMAGES=(
 
 usage() {
     printf "Usage: %s -a <%s|%s> -g <%s|%s> [ -r REGISTRY ] [ -t IMAGE ] [ -v TAG ] [ -d ] [ -h ]\n\n" \
-        "$(basename "$0")" $ARCH_AMD64 $ARCH_386 $GO_112 $GO_110
+        "$(basename "$0")" $ARCH_AMD64 $ARCH_386 $GO_113 $GO_110
     echo "Possible arguments:"
     printf "  -a\ttarget architecture of the image (default: '%s')\n" $ARCH
     printf "  -d\tdon’t build the image, only print the resulting image name and exit\n"
@@ -93,7 +93,7 @@ parse_args() {
         exit 1
     fi
 
-    if [[ "$GO" != "$GO_112" ]] && [[ "$GO" != "$GO_110" ]]; then
+    if [[ "$GO" != "$GO_113" ]] && [[ "$GO" != "$GO_110" ]]; then
         printf "Invalid go version specified: %s\n\n" "$GO"
         exit 1
     fi
@@ -192,7 +192,7 @@ install_packages() {
         protobuf-compiler \
         python-protobuf \
         socat
-    if [[ "$GO" == "$GO_112" ]]; then
+    if [[ "$GO" == "$GO_113" ]]; then
         run apt-get install -y libbtrfs-dev
     fi
     run apt-get clean
@@ -224,8 +224,9 @@ install_cri_tools() {
     for BINARY in "${BINARIES[@]}"; do
         TARBALL=$BINARY-$ARCHIVE
         echo "Downloading $TARBALL"
-        wget $URL/"${VERSIONS["cri-tools"]}"/"$TARBALL"
+        wget -O "$TARBALL" $URL/"${VERSIONS["cri-tools"]}"/"$TARBALL"
         tar xf "$TARBALL" -C "$MOUNT_DIR"/usr/bin
+        run chown root:root /usr/bin/$BINARY # https://circleci.com/docs/2.0/high-uid-error
         run "$BINARY" --version
         rm "$TARBALL"
     done
@@ -240,7 +241,7 @@ install_cni_plugins() {
     TARBALL=cni-plugins-linux-$ARCH-${VERSIONS["cni-plugins"]}.tgz
     CNI_DIR="$MOUNT_DIR"/opt/cni/bin
     mkdir -p "$CNI_DIR"
-    wget $URL/"${VERSIONS["cni-plugins"]}"/"$TARBALL"
+    wget -O "$TARBALL" $URL/"${VERSIONS["cni-plugins"]}"/"$TARBALL"
     tar xf "$TARBALL" -C "$CNI_DIR"
     rm "$TARBALL"
     ls -lah "$CNI_DIR"

--- a/test/critest.bats
+++ b/test/critest.bats
@@ -3,7 +3,7 @@
 load helpers
 
 function setup() {
-	setup_test
+    setup_test
 }
 
 function teardown() {
@@ -20,15 +20,13 @@ function teardown() {
 
     start_crio
 
-    run critest --parallel $JOBS \
+    critest --parallel 8 \
                 --runtime-endpoint "${CRIO_SOCKET}" \
                 --image-endpoint "${CRIO_SOCKET}" \
                 --ginkgo.focus="${CRI_FOCUS}" \
                 --ginkgo.skip="${CRI_SKIP}" \
-                --ginkgo.flakeAttempts=3
+                --ginkgo.flakeAttempts=3 >&3
 
-
-    echo "$output"
     [ "$status" -eq 0 ]
 
     stop_crio

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -212,7 +212,7 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run crictl rm "$ctr_id"
+	run crictl rm -f "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	run crictl stopp "$pod_id"

--- a/test/image.bats
+++ b/test/image.bats
@@ -27,7 +27,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	pod_id="$output"
 	sed -e "s/%VALUE%/$REDIS_IMAGEID/g" "$TESTDATA"/container_config_by_imageid.json > "$TESTDIR"/ctr_by_imageid.json
-	run crictl create "$pod_id" "$TESTDIR"/ctr_by_imageid.json "$TESTDATA"/sandbox_config.json
+	run crictl create --no-pull "$pod_id" "$TESTDIR"/ctr_by_imageid.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
 	ctr_id="$output"
@@ -46,7 +46,7 @@ function teardown() {
 
 	sed -e "s/%VALUE%/$REDIS_IMAGEID/g" "$TESTDATA"/container_config_by_imageid.json > "$TESTDIR"/ctr_by_imageid.json
 
-	run crictl create "$pod_id" "$TESTDIR"/ctr_by_imageid.json "$TESTDATA"/sandbox_config.json
+	run crictl create --no-pull "$pod_id" "$TESTDIR"/ctr_by_imageid.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
 	ctr_id="$output"
@@ -135,14 +135,6 @@ function teardown() {
 	run crictl pull "$SIGNED_IMAGE"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_images
-}
-
-@test "image pull without signature" {
-	start_crio "" "" --no-pause-image
-	run crictl image pull "$UNSIGNED_IMAGE"
-	echo "$output"
-	[ "$status" -ne 0 ]
 	cleanup_images
 }
 


### PR DESCRIPTION
With this commit we also provide three new build images based on go
1.13.4 and go 1.10.8 (legacy build). The following dependencies have
been updated as well:

- cri-tools: v1.15.0 → v1.16.1
- cni-plugins: v0.8.1 → v0.8.2
- conmon: v2.0.0 → v2.0.2
- runc: v1.0.0-rc8 → v1.0.0-rc9