### PR TITLE
don't set PodIPs on host network pods

### DIFF
--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -17,7 +17,7 @@ import (
 // or an error
 func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs []string, result cnitypes.Result, err error) {
 	if sb.HostNetwork() {
-		return s.hostIPs, nil, nil
+		return nil, nil, nil
 	}
 
 	podNetwork, err := s.newPodNetwork(sb)
@@ -89,7 +89,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 // getSandboxIP retrieves the IP address for the sandbox
 func (s *Server) getSandboxIPs(sb *sandbox.Sandbox) (podIPs []string, err error) {
 	if sb.HostNetwork() {
-		return s.hostIPs, nil
+		return nil, nil
 	}
 
 	podNetwork, err := s.newPodNetwork(sb)

--- a/server/server.go
+++ b/server/server.go
@@ -67,7 +67,6 @@ type Server struct {
 	hostportManager hostport.HostPortManager
 
 	appArmorProfile string
-	hostIPs         []string
 
 	*lib.ContainerServer
 	monitorsChan      chan struct{}
@@ -398,17 +397,11 @@ func New(
 	s.restore()
 	s.cleanupSandboxesOnShutdown(ctx)
 
-	hostIPs := s.getHostIPs(config.HostIP)
 	bindAddress := net.ParseIP(config.StreamAddress)
 	if bindAddress == nil {
+		hostIPs := s.getHostIPs(config.HostIP)
 		bindAddress = hostIPs[0]
 	}
-	ips := []string{}
-	for _, ip := range hostIPs {
-		ips = append(ips, ip.String())
-	}
-	s.hostIPs = ips
-	logrus.Infof("using host IPs: %v", s.hostIPs)
 
 	_, err = net.LookupPort("tcp", config.StreamPort)
 	if err != nil {


### PR DESCRIPTION
If the runtime returns an IP for a HostNetwork pod, then kubelet will accept that IP as the pod's PodIP. But if it returns nothing, kubelet will fill in the PodIP with whatever it considers the correct node IP to be. In particular, on a dual-stack host, letting kubelet decide will ensure that hostNetwork pods end up with the node's "preferred" IP according to kubelet.

(This change means that the `host_ip` config variable and all of the code for detecting it if it's not set is now *mostly* useless, although it still gets used to figure out `bindAddress`... Probably that can be simplified though.)

/cc @mrunalp @haircommander 