### PR TITLE
Default to system.slice for conmon cgroup

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -95,7 +95,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **conmon**=""
   Path to the conmon binary, used for monitoring the OCI runtime. Will be searched for using $PATH if empty.
 
-**conmon_cgroup**="pod"
+**conmon_cgroup**="system.slice"
   Cgroup setting for conmon
 
 **conmon_env**=["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]

--- a/internal/lib/config/config.go
+++ b/internal/lib/config/config.go
@@ -483,7 +483,7 @@ func DefaultConfig() (*Config, error) {
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
-			ConmonCgroup:             "pod",
+			ConmonCgroup:             "system.slice",
 			SELinux:                  selinuxEnabled(),
 			SeccompProfile:           "",
 			ApparmorProfile:          DefaultApparmorProfile,


### PR DESCRIPTION
Move from "pod" to "system.slice" for the conmon cgroup.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>