### PR TITLE
Bump go.mod to use go 1.13

### DIFF
--- a/contrib/test/integration/golang.yml
+++ b/contrib/test/integration/golang.yml
@@ -51,8 +51,6 @@
 - name: install Go tools and dependencies
   shell: /usr/bin/go get -u "github.com/{{ item }}"
   with_items:
-    - tools/godep
     - onsi/ginkgo/ginkgo
     - onsi/gomega
-    - cloudflare/cfssl/cmd/...
     - jteeuwen/go-bindata/go-bindata

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.12
+go 1.13
 
 module github.com/cri-o/cri-o
 


### PR DESCRIPTION
To avoid inconsistent behavior between go versions we now use go 1.13 per
default.