### PR TITLE
[1.14] Add config to run conmon under a custom cgroup slice    

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -105,6 +105,9 @@ no_pivot = {{ .NoPivot }}
 # Path to the conmon binary, used for monitoring the OCI runtime.
 conmon = "{{ .Conmon }}"
 
+# Cgroup setting for conmon
+conmon_cgroup = "{{ .ConmonCgroup }}"
+
 # Environment variable list for the conmon process, used for passing necessary
 # environment variables to conmon or the runtime.
 conmon_env = [

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -83,6 +83,9 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **conmon**="/usr/local/libexec/crio/conmon"
   Path to the conmon binary, used for monitoring the OCI runtime.
 
+**conmon_cgroup**="system.slice"
+  Cgroup setting for conmon
+
 **conmon_env**=["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
   Environment variable list for the conmon process, used for passing necessary environment variables to conmon or the runtime.
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -175,6 +175,9 @@ type RuntimeConfig struct {
 	// Conmon is the path to conmon binary, used for managing the runtime.
 	Conmon string `toml:"conmon"`
 
+	// ConmonCgroup is the cgroup setting used for conmon.
+	ConmonCgroup string `toml:"conmon_cgroup"`
+
 	// SeccompProfile is the seccomp json profile path which is used as the
 	// default for the runtime.
 	SeccompProfile string `toml:"seccomp_profile"`
@@ -408,6 +411,7 @@ func DefaultConfig() (*Config, error) {
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
+			ConmonCgroup:             "pod",
 			SELinux:                  selinuxEnabled(),
 			SeccompProfile:           seccompProfilePath,
 			ApparmorProfile:          apparmorProfileName,
@@ -501,6 +505,10 @@ func (c *RuntimeConfig) Validate(onExecution bool) error {
 		} else {
 			return fmt.Errorf("default_runtime set to %q, but no runtime path is set for it", c.DefaultRuntime)
 		}
+	}
+
+	if !(c.ConmonCgroup == "pod" || strings.HasSuffix(c.ConmonCgroup, ".slice")) {
+		return errors.New("conmon cgroup should be 'pod' or a systemd slice")
 	}
 
 	// check for validation on execution

--- a/lib/config.go
+++ b/lib/config.go
@@ -411,7 +411,7 @@ func DefaultConfig() (*Config, error) {
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
-			ConmonCgroup:             "pod",
+			ConmonCgroup:             "system.slice",
 			SELinux:                  selinuxEnabled(),
 			SeccompProfile:           seccompProfilePath,
 			ApparmorProfile:          apparmorProfileName,

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -124,7 +124,7 @@ func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error)
 
 	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.GlobalAuthFile, config.PauseImage, config.PauseImageAuthFile)
 
-	runtime, err := oci.New(config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.LogToJournald, config.NoPivot, config.CtrStopTimeout)
+	runtime, err := oci.New(config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.ConmonCgroup, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.LogToJournald, config.NoPivot, config.CtrStopTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -50,6 +50,7 @@ type Runtime struct {
 	runtimes                 map[string]RuntimeHandler
 	conmonPath               string
 	conmonEnv                []string
+	conmonCgroup             string
 	cgroupManager            string
 	containerExitsDir        string
 	containerAttachSocketDir string
@@ -102,6 +103,7 @@ func New(defaultRuntime string,
 	runtimes map[string]RuntimeHandler,
 	conmonPath string,
 	conmonEnv []string,
+	conmonCgroup string,
 	cgroupManager string,
 	containerExitsDir string,
 	containerAttachSocketDir string,
@@ -123,6 +125,7 @@ func New(defaultRuntime string,
 		runtimes:                 runtimes,
 		conmonPath:               conmonPath,
 		conmonEnv:                conmonEnv,
+		conmonCgroup:             conmonCgroup,
 		cgroupManager:            cgroupManager,
 		containerExitsDir:        containerExitsDir,
 		containerAttachSocketDir: containerAttachSocketDir,

--- a/oci/oci_linux.go
+++ b/oci/oci_linux.go
@@ -22,38 +22,41 @@ func createUnitName(prefix string, name string) string {
 	return fmt.Sprintf("%s-%s.scope", prefix, name)
 }
 
+func createConmonUnitName(name string) string {
+	return createUnitName("crio-conmon", name)
+}
+
 func (r *runtimeOCI) createContainerPlatform(c *Container, cgroupParent string, pid int) {
 	// Move conmon to specified cgroup
-	switch r.cgroupManager {
-	case SystemdCgroupsManager:
-		logrus.Debugf("Running conmon under slice %s and unitName %s", cgroupParent, createUnitName("crio-conmon", c.id))
-		if err := utils.RunUnderSystemdScope(pid, cgroupParent, createUnitName("crio-conmon", c.id)); err != nil {
-			logrus.Warnf("Failed to add conmon to systemd sandbox cgroup: %v", err)
+	if r.conmonCgroup == "pod" || r.conmonCgroup == "" {
+		if r.cgroupManager == SystemdCgroupsManager {
+			logrus.Debugf("Running conmon under slice %s and unitName %s", cgroupParent, createConmonUnitName(c.id))
+			if err := utils.RunUnderSystemdScope(pid, cgroupParent, createConmonUnitName(c.id)); err != nil {
+				logrus.Warnf("Failed to add conmon to systemd sandbox cgroup: %v", err)
+			}
 		}
-	case CgroupfsCgroupsManager:
-		cgroupPath := filepath.Join(cgroupParent, "/crio-conmon-"+c.id)
-		control, err := cgroups.New(cgroups.V1, cgroups.StaticPath(cgroupPath), &rspec.LinuxResources{})
+
+		control, err := cgroups.New(cgroups.V1, cgroups.StaticPath(filepath.Join(cgroupParent, "/crio-conmon-"+c.id)), &rspec.LinuxResources{})
 		if err != nil {
 			logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
 		}
 
-		if control == nil {
-			break
+		if control != nil {
+			// Here we should defer a crio-connmon- cgroup hierarchy deletion, but it will
+			// always fail as conmon's pid is still there.
+			// Fortunately, kubelet takes care of deleting this for us, so the leak will
+			// only happens in corner case where one does a manual deletion of the container
+			// through e.g. runc. This should be handled by implementing a conmon monitoring
+			// routine that does the cgroup cleanup once conmon is terminated.
+			if err := control.Add(cgroups.Process{Pid: pid}); err != nil {
+				logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
+			}
 		}
-
-		// Here we should defer a crio-connmon- cgroup hierarchy deletion, but it will
-		// always fail as conmon's pid is still there.
-		// Fortunately, kubelet takes care of deleting this for us, so the leak will
-		// only happens in corner case where one does a manual deletion of the container
-		// through e.g. runc. This should be handled by implementing a conmon monitoring
-		// routine that does the cgroup cleanup once conmon is terminated.
-		if err := control.Add(cgroups.Process{Pid: pid}); err != nil {
-			logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
+	} else if strings.HasSuffix(r.conmonCgroup, ".slice") {
+		logrus.Debugf("Running conmon under custom slice %s and unitName %s", r.conmonCgroup, createConmonUnitName(c.id))
+		if err := utils.RunUnderSystemdScope(pid, r.conmonCgroup, createConmonUnitName(c.id)); err != nil {
+			logrus.Warnf("Failed to add conmon to custom systemd sandbox cgroup: %v", err)
 		}
-
-		// Record conmon's cgroup path in the container, so we can properly
-		// clean it up when removing the container.
-		c.conmonCgroupfsPath = cgroupPath
 	}
 }
 

--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -14,7 +14,7 @@ var _ = t.Describe("Oci", func() {
 			// When
 			runtime, err := oci.New("runc",
 				map[string]oci.RuntimeHandler{"runc": {"/bin/sh", ""}},
-				"", []string{}, "", "", "", 0, false, false, 0)
+				"", []string{}, "", "", "", "", 0, false, false, 0)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -26,7 +26,7 @@ var _ = t.Describe("Oci", func() {
 			// When
 			runtime, err := oci.New("",
 				map[string]oci.RuntimeHandler{}, "", []string{},
-				"", "", "", 0, false, false, 0)
+				"", "", "", "", 0, false, false, 0)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -51,7 +51,7 @@ var _ = t.Describe("Oci", func() {
 			var err error
 			sut, err = oci.New(defaultRuntime,
 				runtimes,
-				"", []string{}, "", "", "", 0, false, false, 0)
+				"", []string{}, "", "", "", "", 0, false, false, 0)
 
 			Expect(err).To(BeNil())
 			Expect(sut).NotTo(BeNil())

--- a/pkg/criocli/criocli.go
+++ b/pkg/criocli/criocli.go
@@ -131,6 +131,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("cgroup-manager") {
 		config.CgroupManager = ctx.GlobalString("cgroup-manager")
 	}
+	if ctx.GlobalIsSet("conmon-cgroup") {
+		config.ConmonCgroup = ctx.GlobalString("conmon-cgroup")
+	}
 	if ctx.GlobalIsSet("hooks-dir") {
 		config.HooksDir = ctx.GlobalStringSlice("hooks-dir")
 	}
@@ -217,6 +220,10 @@ func getCrioFlags(defConf *server.Config) []cli.Flag {
 		cli.StringFlag{
 			Name:  "conmon",
 			Usage: "path to the conmon executable",
+		},
+		cli.StringFlag{
+			Name:  "conmon-cgroup",
+			Usage: fmt.Sprintf("cgroup used for conmon process (default: %q)", defConf.ConmonCgroup),
 		},
 		cli.StringFlag{
 			Name:  "listen",

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -16,6 +16,8 @@ CRICTL_PATH=$(command -v crictl || true)
 CRICTL_BINARY=${CRICTL_PATH:-/usr/bin/crictl}
 # Path of the conmon binary.
 CONMON_BINARY=${CONMON_BINARY:-${CRIO_ROOT}/cri-o/bin/conmon}
+# Cgroup for the conmon process
+CONMON_CGROUP=${CONMON_CGROUP:-pod}
 # Path of the pause binary.
 PAUSE_BINARY=${PAUSE_BINARY:-${CRIO_ROOT}/cri-o/bin/pause}
 # Path of the default seccomp profile.
@@ -244,7 +246,7 @@ function setup_crio() {
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/image-volume-test:latest --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --default-capabilities "$capabilities" --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --stream-port "$STREAM_PORT" --cgroup-manager "$CGROUP_MANAGER" --default-mounts-file "$TESTDIR/containers/mounts.conf" --registry "quay.io" --default-runtime $DEFAULT_RUNTIME --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" $DEVICES $ULIMITS --uid-mappings "$UID_MAPPINGS" --gid-mappings "$GID_MAPPINGS" --default-sysctls "$TEST_SYSCTL" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
+	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --default-capabilities "$capabilities" --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --stream-port "$STREAM_PORT" --cgroup-manager "$CGROUP_MANAGER" --conmon-cgroup "$CONMON_CGROUP" --default-mounts-file "$TESTDIR/containers/mounts.conf" --registry "quay.io" --default-runtime $DEFAULT_RUNTIME --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" $DEVICES $ULIMITS --uid-mappings "$UID_MAPPINGS" --gid-mappings "$GID_MAPPINGS" --default-sysctls "$TEST_SYSCTL" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
 	sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?default_ulimits = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i $CRIO_CONFIG
 	# make sure we don't run with nodev, or else mounting a readonly rootfs will fail: https://github.com/cri-o/cri-o/issues/1929#issuecomment-474240498
 	sed -r -e 's/nodev(,)?//g' -i $CRIO_CONFIG


### PR DESCRIPTION
    Including:
            add config value to run conmon under a custom cgroup slice
            add cli flag for --conmon-cgroup
            add config validation for conmon cgroup
            test: add test for conmon cgroup
            sandbox_run: log warning if we can't find the slice
            default to system.slice
