### PR TITLE
Mention trace level in documentation

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -69,7 +69,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -l log-dir -r -d 'Default log di
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-filter -r -d 'Filter the log messages by the provided regular expression. For example \'request.\*\' filters all gRPC requests.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-format -r -d 'Set the format used by logs (\'text\' (default), or \'json\')'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-journald -d 'Log to systemd journal (journald) in addition to kubernetes log file (default: false)'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l log-level -s l -r -d 'Log messages above specified level: debug, info, warn, error (default), fatal or panic'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l log-level -s l -r -d 'Log messages above specified level: trace, debug, info, warn, error (default), fatal or panic'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-size-max -r -d 'Maximum log size in bytes for a container. If it is positive, it must be >= 8192 (to match/exceed conmon read buffer) (default: -1, no limit)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l manage-network-ns-lifecycle -d 'Determines whether we pin and remove network namespace and manage its lifecycle (default: false)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l metrics-port -r -d 'Port for the metrics endpoint (default: 9090)'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -204,7 +204,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--log-journald**: Log to systemd journal (journald) in addition to kubernetes log file (default: false)
 
-**--log-level, -l**="": Log messages above specified level: debug, info, warn, error (default), fatal or panic (default: error)
+**--log-level, -l**="": Log messages above specified level: trace, debug, info, warn, error (default), fatal or panic (default: error)
 
 **--log-size-max**="": Maximum log size in bytes for a container. If it is positive, it must be >= 8192 (to match/exceed conmon read buffer) (default: -1, no limit) (default: -1)
 

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -320,7 +320,7 @@ func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext)
 		cli.StringFlag{
 			Name:   "log-level, l",
 			Value:  "error",
-			Usage:  "Log messages above specified level: debug, info, warn, error (default), fatal or panic",
+			Usage:  "Log messages above specified level: trace, debug, info, warn, error (default), fatal or panic",
 			EnvVar: "CONTAINER_LOG_LEVEL",
 		},
 		cli.StringFlag{

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -207,8 +207,8 @@ bind_mount_prefix = ""
 read_only = {{ .ReadOnly }}
 
 # Changes the verbosity of the logs based on the level it is set to. Options
-# are fatal, panic, error, warn, info, and debug. This option supports live
-# configuration reload.
+# are fatal, panic, error, warn, info, debug and trace. This option supports
+# live configuration reload.
 log_level = "{{ .LogLevel }}"
 
 # Filter the log messages by the provided regular expression.


### PR DESCRIPTION
conmon 2.0.3 now fully supports the trace log level.
This means that we also should outline that in our documentation since
we're using this level already.