### PR TITLE
Default manage_network_ns_lifecycle to true

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -71,7 +71,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l log-format -r -d 'Set the 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-journald -d 'Log to systemd journal (journald) in addition to kubernetes log file (default: false)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-level -s l -r -d 'Log messages above specified level: trace, debug, info, warn, error, fatal or panic'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-size-max -r -d 'Maximum log size in bytes for a container. If it is positive, it must be >= 8192 to match/exceed conmon read buffer'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l manage-network-ns-lifecycle -d 'Determines whether we pin and remove network namespace and manage its lifecycle (default: false)'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l manage-network-ns-lifecycle -d 'Determines whether we pin and remove network namespace and manage its lifecycle (default: true)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l metrics-port -r -d 'Port for the metrics endpoint'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l no-pivot -d 'If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE` (default: false)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l pause-command -r -d 'Path to the pause executable in the pause image (default: "/pause")'

--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -29,14 +29,6 @@
     target: install.config
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
 
-- name: set manage network ns lifecycle
-  replace:
-    regexp: 'manage_network_ns_lifecycle.*=.*false'
-    replace: 'manage_network_ns_lifecycle = true'
-    name: /etc/crio/crio.conf
-    backup: yes
-  when: manage_network_ns_lifecycle
-
 - name: install configs
   copy:
     src: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/{{ item.src }}"

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -4,7 +4,6 @@
 integration_selinux_enabled: True
 e2e_selinux_enabled: False
 node_e2e_selinux_enabled: False
-manage_network_ns_lifecycle: False
 
 # For results.yml Paths use rsync 'source' conventions
 artifacts: "/tmp/artifacts"  # Base-directory for collection

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -208,7 +208,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--log-size-max**="": Maximum log size in bytes for a container. If it is positive, it must be >= 8192 to match/exceed conmon read buffer (default: -1)
 
-**--manage-network-ns-lifecycle**: Determines whether we pin and remove network namespace and manage its lifecycle (default: false)
+**--manage-network-ns-lifecycle**: Determines whether we pin and remove network namespace and manage its lifecycle (default: true)
 
 **--metrics-port**="": Port for the metrics endpoint (default: 9090)
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -194,7 +194,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **ctr_stop_timeout**=0
   The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container.
 
-**manage_network_ns_lifecycle**=false
+**manage_network_ns_lifecycle**=true
   ManageNetworkNSLifecycle determines whether we pin and remove network namespace and manage its lifecycle.
 
 ### CRIO.RUNTIME.RUNTIMES TABLE

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -504,6 +504,7 @@ func DefaultConfig() (*Config, error) {
 			DefaultUlimits:           []string{},
 			AdditionalDevices:        []string{},
 			HooksDir:                 []string{hooks.DefaultDir},
+			ManageNetworkNSLifecycle: true,
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport:    defaultTransport,

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -47,8 +47,6 @@ var _ = t.Describe("RunPodSandbox", func() {
 					Return(storage.RuntimeContainerMetadata{}, nil),
 				runtimeServerMock.EXPECT().SetContainerMetadata(gomock.Any(),
 					gomock.Any()).Return(nil),
-				runtimeServerMock.EXPECT().StartContainer(gomock.Any()).
-					Return("", nil),
 				runtimeServerMock.EXPECT().RemovePodSandbox(gomock.Any()).
 					Return(nil),
 			)

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -14,6 +14,7 @@ function teardown() {
 	if test \! -e /proc/self/uid_map; then
 		skip "userNS not available"
 	fi
+    export MANAGE_NETNS_LIFECYCLE=false
 	export CONTAINER_UID_MAPPINGS="0:100000:100000"
 	export CONTAINER_GID_MAPPINGS="0:200000:100000"
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -71,6 +71,8 @@ CONTAINER_LOG_SIZE_MAX=${CONTAINER_LOG_SIZE_MAX:--1}
 STREAM_PORT=${STREAM_PORT:-10010}
 # Metrics Port
 CONTAINER_METRICS_PORT=${CONTAINER_METRICS_PORT:-9090}
+# Manage the network namespace lifecycle
+MANAGE_NETNS_LIFECYCLE=${MANAGE_NETNS_LIFECYCLE:-true}
 
 POD_IPV4_CIDR="10.88.0.0/16"
 POD_IPV4_CIDR_START="10.88"
@@ -275,7 +277,7 @@ function setup_crio() {
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/image-volume-test:latest --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$CRIO_BINARY_PATH" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --registry "quay.io" --registry "docker.io" --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY:$RUNTIME_ROOT" -r "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" $DEVICES $ULIMITS --default-sysctls "$TEST_SYSCTL" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
+	"$CRIO_BINARY_PATH" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --registry "quay.io" --registry "docker.io" --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY:$RUNTIME_ROOT" -r "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" $DEVICES $ULIMITS --default-sysctls "$TEST_SYSCTL" --manage-network-ns-lifecycle="$MANAGE_NETNS_LIFECYCLE" $OVERRIDE_OPTIONS --config /dev/null config >$CRIO_CONFIG
 	sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?default_ulimits = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i $CRIO_CONFIG
 	# make sure we don't run with nodev, or else mounting a readonly rootfs will fail: https://github.com/cri-o/cri-o/issues/1929#issuecomment-474240498
 	sed -r -e 's/nodev(,)?//g' -i $CRIO_CONFIG


### PR DESCRIPTION
It is recommended to set the configuration option `manage_network_ns_lifecycle = true`, which we will now default from the beginning of releases newer than v1.17.x. All test scenarios have been adapted as well.