### PR TITLE
WIP: set "readonly_rootfs" and "privileged" in the right places in tests

### DIFF
--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -37,7 +37,6 @@
 		"owner": "dragon",
 		"daemon": "crio"
 	},
-	"privileged": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -58,6 +57,7 @@
 				"pid": 1
 			},
 			"readonly_rootfs": false,
+			"privileged": true,
 			"selinux_options": {
 				"user": "system_u",
 				"role": "system_r",

--- a/test/testdata/container_config_by_imageid.json
+++ b/test/testdata/container_config_by_imageid.json
@@ -37,8 +37,6 @@
 		"owner": "dragon",
 		"daemon": "crio"
 	},
-	"privileged": true,
-	"readonly_rootfs": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -55,6 +53,8 @@
 			"namespace_options": {
 				"pid": 1
 			},
+			"readonly_rootfs": true,
+			"privileged": true,
 			"capabilities": {
 				"add_capabilities": [
 					"setuid",

--- a/test/testdata/container_config_hostport.json
+++ b/test/testdata/container_config_hostport.json
@@ -39,8 +39,6 @@
 		"owner": "dragon",
 		"daemon": "crio"
 	},
-	"privileged": true,
-	"readonly_rootfs": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -57,6 +55,8 @@
 			"namespace_options": {
 				"pid": 1
 			},
+			"readonly_rootfs": true,
+			"privileged": true,
 			"capabilities": {
 				"add_capabilities": [
 					"setuid",

--- a/test/testdata/container_config_logging.json
+++ b/test/testdata/container_config_logging.json
@@ -39,8 +39,6 @@
 		"owner": "dragon",
 		"daemon": "crio"
 	},
-	"privileged": true,
-	"readonly_rootfs": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -57,6 +55,8 @@
 			"namespace_options": {
 				"pid": 1
 			},
+			"readonly_rootfs": true,
+			"privileged": true,
 			"capabilities": {
 				"add_capabilities": [
 					"setuid",

--- a/test/testdata/container_config_privileged.json
+++ b/test/testdata/container_config_privileged.json
@@ -42,7 +42,6 @@
 	"stdin_once": false,
 	"tty": false,
 	"linux": {
-		"privileged": true,
 		"resources": {
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
@@ -55,6 +54,7 @@
 				"pid": 1
 			},
 			"readonly_rootfs": false,
+			"privileged": true,
 			"selinux_options": {
 				"user": "system_u",
 				"role": "system_r",

--- a/test/testdata/container_config_resolvconf.json
+++ b/test/testdata/container_config_resolvconf.json
@@ -39,7 +39,6 @@
 		"owner": "dragon",
 		"daemon": "crio"
 	},
-	"privileged": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -57,6 +56,7 @@
 				"pid": 1
 			},
 			"readonly_rootfs": false,
+			"privileged": true,
 			"capabilities": {
 				"add_capabilities": [
 					"setuid",

--- a/test/testdata/container_config_resolvconf_ro.json
+++ b/test/testdata/container_config_resolvconf_ro.json
@@ -39,7 +39,6 @@
 		"owner": "dragon",
 		"daemon": "crio"
 	},
-	"privileged": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -57,6 +56,7 @@
 				"pid": 1
 			},
 			"readonly_rootfs": true,
+			"privileged": true,
 			"capabilities": {
 				"add_capabilities": [
 					"setuid",

--- a/test/testdata/container_config_seccomp.json
+++ b/test/testdata/container_config_seccomp.json
@@ -37,8 +37,6 @@
 		"owner": "dragon",
 		"daemon": "crio"
 	},
-	"privileged": true,
-	"readonly_rootfs": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -55,6 +53,8 @@
 			"namespace_options": {
 				"pid": 1
 			},
+			"privileged": true,
+			"readonly_rootfs": true,
 			"seccomp_profile_path": "%VALUE%",
 			"capabilities": {
 				"add_capabilities": [

--- a/test/testdata/container_config_sleep.json
+++ b/test/testdata/container_config_sleep.json
@@ -38,7 +38,6 @@
 		"owner": "dragon",
 		"daemon": "crio"
 	},
-	"privileged": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -55,6 +54,7 @@
 			"namespace_options": {
 				"pid": 1
 			},
+			"privileged": true,
 			"readonly_rootfs": false,
 			"selinux_options": {
 				"user": "system_u",

--- a/test/testdata/container_exit_test.json
+++ b/test/testdata/container_exit_test.json
@@ -14,7 +14,6 @@
 			"value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 		}
 	],
-	"readonly_rootfs": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -23,7 +22,8 @@
 		"security_context": {
 			"namespace_options": {
 				"pid": 1
-			}
+			},
+			"readonly_rootfs": true
 		}
 	}
 }

--- a/test/testdata/container_redis.json
+++ b/test/testdata/container_redis.json
@@ -38,7 +38,6 @@
 	"annotations": {
 		"pod": "podsandbox1"
 	},
-	"readonly_rootfs": false,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -57,6 +56,7 @@
 			"namespace_options": {
 				"pid": 1
 			},
+			"readonly_rootfs": false,
 			"capabilities": {
 				"add_capabilities": [
 					"sys_admin"

--- a/test/testdata/container_redis_apparmor.json
+++ b/test/testdata/container_redis_apparmor.json
@@ -35,7 +35,6 @@
   "annotations": {
     "pod": "podsandbox1"
   },
-  "readonly_rootfs": false,
   "log_path": "",
   "stdin": false,
   "stdin_once": false,
@@ -55,6 +54,7 @@
       "namespace_options": {
         "pid": 1
       },
+      "readonly_rootfs": false,
       "capabilities": {
         "add_capabilities": ["sys_admin"]
       }

--- a/test/testdata/container_redis_default_mounts.json
+++ b/test/testdata/container_redis_default_mounts.json
@@ -44,7 +44,6 @@
 	"annotations": {
 		"pod": "podsandbox1"
 	},
-	"readonly_rootfs": false,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -61,6 +60,7 @@
 			"namespace_options": {
 				"pid": 1
 			},
+			"readonly_rootfs": false,
 			"capabilities": {
 				"add_capabilities": [
 					"sys_admin"

--- a/test/testdata/container_redis_device.json
+++ b/test/testdata/container_redis_device.json
@@ -45,7 +45,6 @@
 	"annotations": {
 		"pod": "podsandbox1"
 	},
-	"readonly_rootfs": false,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -59,6 +58,7 @@
 			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
+			"readonly_rootfs": false,
 			"privileged": "%privilegedboolean%",
 			"namespace_options": {
 				"pid": 1

--- a/test/testdata/container_redis_env_custom.json
+++ b/test/testdata/container_redis_env_custom.json
@@ -38,7 +38,6 @@
 	"annotations": {
 		"pod": "podsandbox1"
 	},
-	"readonly_rootfs": false,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -55,6 +54,7 @@
 			"namespace_options": {
 				"pid": 1
 			},
+			"readonly_rootfs": false,
 			"capabilities": {
 				"add_capabilities": [
 					"sys_admin"

--- a/test/testdata/container_redis_namespace.json
+++ b/test/testdata/container_redis_namespace.json
@@ -38,7 +38,6 @@
 	"annotations": {
 		"pod": "podsandbox1"
 	},
-	"readonly_rootfs": false,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -58,7 +57,8 @@
 				"add_capabilities": [
 					"sys_admin"
 				]
-			}
+			},
+			"readonly_rootfs": false
 		}
 	}
 }

--- a/test/testdata/container_sleep.json
+++ b/test/testdata/container_sleep.json
@@ -21,7 +21,6 @@
 	"annotations": {
 		"pod": "podsandbox"
 	},
-	"readonly_rootfs": false,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -30,7 +29,8 @@
 		"security_context": {
 			"namespace_options": {
 				"pid": 1
-			}
+			},
+			"readonly_rootfs": false
 		},
 		"resources": {
 			"cpu_period": 10000,

--- a/test/testdata/template_container_config.json
+++ b/test/testdata/template_container_config.json
@@ -35,7 +35,6 @@
 		"owner": "dragon",
 		"daemon": "crio"
 	},
-	"privileged": true,
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
@@ -49,6 +48,7 @@
 			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
+			"privileged": true,
 			"readonly_rootfs": false,
 			"selinux_options": {
 				"user": "system_u",


### PR DESCRIPTION
The `readonly_rootfs` and `privileged` options are part of Linux-specific security context information ([definition](https://github.com/cri-o/cri-o/blob/release-1.16/vendor/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.pb.go#L2431)).  Setting them anywhere else doesn't appear to have any effect.