### PR TITLE
Fix possible branch condition evaluates to a garbage value

### DIFF
--- a/pinns/pinns.c
+++ b/pinns/pinns.c
@@ -41,9 +41,9 @@ int main(int argc, char **argv) {
   int unshare_flags = 0;
   int c;
   char *pin_path = NULL;
-  bool bind_net;
-  bool bind_uts;
-  bool bind_ipc;
+  bool bind_net = false;
+  bool bind_uts = false;
+  bool bind_ipc = false;
 
   static const struct option long_options[] = {
       {"help", no_argument, NULL, 'h'},


### PR DESCRIPTION
The clang static analyzer complains that the variables
`bind_uts`, `bind_ipc` and `bind_net` may be uninitialized on certain
conditions, which is now fixed.

Reproducible via:

```
> scan-build make
scan-build: Using '/usr/bin/clang-9.0.0' for static analysis
/usr/bin/ccc-analyzer -std=c99 -Os -Wall -Wextra -static   -c -o pinns.o pinns.c
pinns.c:105:7: warning: Branch condition evaluates to a garbage value
  if (bind_uts) {
      ^~~~~~~~
pinns.c:111:7: warning: Branch condition evaluates to a garbage value
  if (bind_ipc) {
      ^~~~~~~~
pinns.c:117:7: warning: Branch condition evaluates to a garbage value
  if (bind_net) {
      ^~~~~~~~
3 warnings generated.
/usr/bin/ccc-analyzer -o ../bin/pinns pinns.o -std=c99 -Os -Wall -Wextra -static
scan-build: 3 bugs found.
scan-build: Run 'scan-view /tmp/scan-build-2019-11-26-121307-20385-1' to examine bug reports.
```