### PR TITLE
version 1.13.11

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.13.11-dev"
+const Version = "1.13.11"


### PR DESCRIPTION
This commit bumps the version of 1.13 to 1.13.11. we are dropping the `-dev` suffix like in the newer branches. this will allow for automatic building of packages.

Signed-off-by: Peter Hunt <pehunt@redhat.com>
