### PR TITLE
Move SystemContext from Server into Config

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 
-	"github.com/containers/image/v5/types"
 	"github.com/cri-o/cri-o/internal/pkg/criocli"
 	"github.com/cri-o/cri-o/pkg/config"
 	"github.com/urfave/cli/v2"
@@ -26,7 +25,6 @@ it later with **--config**. Global options will modify the output.`,
 			return err
 		}
 
-		systemContext := &types.SystemContext{}
 		if c.Bool("default") {
 			conf, err = config.DefaultConfig()
 			if err != nil {
@@ -35,7 +33,7 @@ it later with **--config**. Global options will modify the output.`,
 		}
 
 		// Validate the configuration during generation
-		if err = conf.Validate(systemContext, false); err != nil {
+		if err = conf.Validate(false); err != nil {
 			return err
 		}
 

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/image/v5/types"
 	_ "github.com/containers/libpod/pkg/hooks/0.1.0"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/cri-o/cri-o/internal/pkg/criocli"
@@ -119,10 +118,8 @@ func main() {
 	app.Description = app.Usage
 	app.Version = strings.Join(v, "\n")
 
-	systemContext := &types.SystemContext{}
-
 	var err error
-	app.Flags, app.Metadata, err = criocli.GetFlagsAndMetadata(systemContext)
+	app.Flags, app.Metadata, err = criocli.GetFlagsAndMetadata()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -210,7 +207,7 @@ func main() {
 		}
 
 		// Validate the configuration during runtime
-		if err := config.Validate(systemContext, true); err != nil {
+		if err := config.Validate(true); err != nil {
 			cancel()
 			return err
 		}
@@ -230,7 +227,7 @@ func main() {
 			grpc.MaxRecvMsgSize(config.GRPCMaxRecvMsgSize),
 		)
 
-		service, err := server.New(ctx, systemContext, configPath, config)
+		service, err := server.New(ctx, configPath, config)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containers/image/v5/types"
 	"github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/hooks"
 	"github.com/containers/libpod/pkg/registrar"
@@ -94,7 +93,7 @@ func (c *ContainerServer) StorageRuntimeServer() storage.RuntimeServer {
 }
 
 // New creates a new ContainerServer with options provided
-func New(ctx context.Context, systemContext *types.SystemContext, configIface libconfig.Iface) (*ContainerServer, error) {
+func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, error) {
 	if configIface == nil {
 		return nil, fmt.Errorf("provided config is nil")
 	}
@@ -108,7 +107,7 @@ func New(ctx context.Context, systemContext *types.SystemContext, configIface li
 		return nil, fmt.Errorf("cannot create container server: interface is nil")
 	}
 
-	imageService, err := storage.GetImageService(ctx, systemContext, store, config.DefaultTransport, config.InsecureRegistries, config.Registries)
+	imageService, err := storage.GetImageService(ctx, config.SystemContext, store, config.DefaultTransport, config.InsecureRegistries, config.Registries)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -42,7 +42,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			server, err := lib.New(context.Background(), nil, libMock)
+			server, err := lib.New(context.Background(), libMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -56,7 +56,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			server, err := lib.New(context.Background(), nil, libMock)
+			server, err := lib.New(context.Background(), libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -66,7 +66,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should fail when config is nil", func() {
 			// Given
 			// When
-			server, err := lib.New(context.Background(), nil, nil)
+			server, err := lib.New(context.Background(), nil)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -134,7 +134,7 @@ func beforeEach() {
 	)
 
 	// Setup the sut
-	sut, err = lib.New(context.Background(), nil, libMock)
+	sut, err = lib.New(context.Background(), libMock)
 	Expect(err).To(BeNil())
 	Expect(sut).NotTo(BeNil())
 

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containers/image/v5/types"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
@@ -263,14 +262,14 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) (string, error) {
 	return path, nil
 }
 
-func GetFlagsAndMetadata(systemContext *types.SystemContext) ([]cli.Flag, map[string]interface{}, error) {
+func GetFlagsAndMetadata() ([]cli.Flag, map[string]interface{}, error) {
 	config, err := libconfig.DefaultConfig()
 	if err != nil {
 		return nil, nil, errors.Errorf("error loading server config: %v", err)
 	}
 
 	// TODO FIXME should be crio wipe flags
-	flags := getCrioFlags(config, systemContext)
+	flags := getCrioFlags(config)
 
 	metadata := map[string]interface{}{
 		"config": config,
@@ -278,7 +277,7 @@ func GetFlagsAndMetadata(systemContext *types.SystemContext) ([]cli.Flag, map[st
 	return flags, metadata, nil
 }
 
-func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext) []cli.Flag {
+func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
 			Name:      "config",
@@ -715,7 +714,7 @@ func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext)
 		&cli.StringFlag{
 			Name:        "registries-conf",
 			Usage:       "path to the registries.conf file",
-			Destination: &systemContext.SystemRegistriesConfPath,
+			Destination: &defConf.SystemContext.SystemRegistriesConfPath,
 			Hidden:      true,
 			EnvVars:     []string{"CONTAINER_REGISTRIES_CONF"},
 			TakesFile:   true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/storage"
 	cstorage "github.com/containers/storage"
 	"github.com/cri-o/cri-o/internal/version"
+	"github.com/cri-o/cri-o/server/useragent"
 	"github.com/cri-o/cri-o/utils"
 	units "github.com/docker/go-units"
 	selinux "github.com/opencontainers/selinux/go-selinux"
@@ -51,6 +52,7 @@ type Config struct {
 	ImageConfig
 	NetworkConfig
 	MetricsConfig
+	SystemContext *types.SystemContext
 }
 
 // Iface provides a config interface for data encapsulation
@@ -491,6 +493,9 @@ func DefaultConfig() (*Config, error) {
 		return nil, err
 	}
 	return &Config{
+		SystemContext: &types.SystemContext{
+			DockerRegistryUserAgent: useragent.Get(),
+		},
 		RootConfig: RootConfig{
 			Root:           storeOpts.GraphRoot,
 			RunRoot:        storeOpts.RunRoot,
@@ -567,7 +572,7 @@ func DefaultConfig() (*Config, error) {
 // The parameter `onExecution` specifies if the validation should include
 // execution checks. It returns an `error` on validation failure, otherwise
 // `nil`.
-func (c *Config) Validate(systemContext *types.SystemContext, onExecution bool) error {
+func (c *Config) Validate(onExecution bool) error {
 	switch c.ImageVolumes {
 	case ImageVolumesMkdir:
 	case ImageVolumesIgnore:
@@ -580,7 +585,7 @@ func (c *Config) Validate(systemContext *types.SystemContext, onExecution bool) 
 		return errors.Wrapf(err, "root config")
 	}
 
-	if err := c.RuntimeConfig.Validate(systemContext, onExecution); err != nil {
+	if err := c.RuntimeConfig.Validate(c.SystemContext, onExecution); err != nil {
 		return errors.Wrapf(err, "runtime config")
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -36,7 +36,7 @@ var _ = t.Describe("Config", func() {
 		It("should succeed with default config", func() {
 			// Given
 			// When
-			err := sut.Validate(nil, false)
+			err := sut.Validate(false)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -47,7 +47,7 @@ var _ = t.Describe("Config", func() {
 			sut = runtimeValidConfig()
 
 			// When
-			err := sut.Validate(nil, true)
+			err := sut.Validate(true)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -58,7 +58,7 @@ var _ = t.Describe("Config", func() {
 			sut.RootConfig.LogDir = "/dev/null"
 
 			// When
-			err := sut.Validate(nil, true)
+			err := sut.Validate(true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -70,7 +70,7 @@ var _ = t.Describe("Config", func() {
 			sut.Listen = "/proc"
 
 			// When
-			err := sut.Validate(nil, true)
+			err := sut.Validate(true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -81,7 +81,7 @@ var _ = t.Describe("Config", func() {
 			sut.AdditionalDevices = []string{invalidPath}
 
 			// When
-			err := sut.Validate(nil, true)
+			err := sut.Validate(true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -94,7 +94,7 @@ var _ = t.Describe("Config", func() {
 			sut.NetworkConfig.NetworkDir = invalidPath
 
 			// When
-			err := sut.Validate(nil, true)
+			err := sut.Validate(true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -105,7 +105,7 @@ var _ = t.Describe("Config", func() {
 			sut.ImageVolumes = invalidPath
 
 			// When
-			err := sut.Validate(nil, false)
+			err := sut.Validate(false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -116,7 +116,7 @@ var _ = t.Describe("Config", func() {
 			sut.DefaultUlimits = []string{"invalid=-1:-1"}
 
 			// When
-			err := sut.Validate(nil, false)
+			err := sut.Validate(false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -380,7 +380,7 @@ var _ = t.Describe("Config", func() {
 			sut.ManageNSLifecycle = true
 
 			// When
-			err := sut.Validate(nil, false)
+			err := sut.Validate(false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -392,7 +392,7 @@ var _ = t.Describe("Config", func() {
 			sut.ManageNSLifecycle = true
 
 			// When
-			err := sut.Validate(nil, false)
+			err := sut.Validate(false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -403,7 +403,7 @@ var _ = t.Describe("Config", func() {
 			sut.LogSizeMax = 1
 
 			// When
-			err := sut.Validate(nil, false)
+			err := sut.Validate(false)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -706,7 +706,7 @@ var _ = t.Describe("Config", func() {
 			sut.RootConfig.LogDir = "test"
 
 			// When
-			err := sut.Validate(nil, true)
+			err := sut.Validate(true)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -214,4 +214,39 @@ var _ = t.Describe("Config", func() {
 			Expect(err).NotTo(BeNil())
 		})
 	})
+
+	t.Describe("ReloadRegistries", func() {
+		It("should succeed to reload registries", func() {
+			// Given
+			// When
+			err := sut.ReloadRegistries()
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should fail if registries file does not exist", func() {
+			// Given
+			sut.SystemContext.SystemRegistriesConfPath = invalidPath
+
+			// When
+			err := sut.ReloadRegistries()
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should fail if registries file is invalid", func() {
+			// Given
+			regConf := t.MustTempFile("reload-registries")
+			Expect(ioutil.WriteFile(regConf, []byte("invalid"), 0755)).To(BeNil())
+			sut.SystemContext.SystemRegistriesConfPath = regConf
+
+			// When
+			err := sut.ReloadRegistries()
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+	})
 })

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -280,7 +280,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	if image == "" {
 		return nil, fmt.Errorf("CreateContainerRequest.ContainerConfig.Image.Image is empty")
 	}
-	images, err := s.StorageImageServer().ResolveNames(s.systemContext, image)
+	images, err := s.StorageImageServer().ResolveNames(s.config.SystemContext, image)
 	if err != nil {
 		if err == storage.ErrCannotParseImageID {
 			images = append(images, image)
@@ -295,7 +295,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		imgResultErr error
 	)
 	for _, img := range images {
-		imgResult, imgResultErr = s.StorageImageServer().ImageStatus(s.systemContext, img)
+		imgResult, imgResultErr = s.StorageImageServer().ImageStatus(s.config.SystemContext, img)
 		if imgResultErr == nil {
 			break
 		}
@@ -328,7 +328,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	containerIDMappings := s.defaultIDMappings
 	metadata := containerConfig.GetMetadata()
 
-	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.systemContext,
+	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.config.SystemContext,
 		sb.Name(), sb.ID(),
 		image, imgResult.ID,
 		containerName, containerID,

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -16,7 +16,7 @@ func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (res
 			filter = filterImage.Image
 		}
 	}
-	results, err := s.StorageImageServer().ListImages(s.systemContext, filter)
+	results, err := s.StorageImageServer().ListImages(s.config.SystemContext, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -26,7 +26,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 		image = img.Image
 	}
 
-	sourceCtx := *s.systemContext // A shallow copy we can modify
+	sourceCtx := *s.config.SystemContext // A shallow copy we can modify
 	if req.GetAuth() != nil {
 		username := req.GetAuth().Username
 		password := req.GetAuth().Password
@@ -59,7 +59,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 		images []string
 		pulled string
 	)
-	images, err = s.StorageImageServer().ResolveNames(s.systemContext, image)
+	images, err = s.StorageImageServer().ResolveNames(s.config.SystemContext, image)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 		defer tmpImg.Close()
 
 		var storedImage *storage.ImageResult
-		storedImage, err = s.StorageImageServer().ImageStatus(s.systemContext, img)
+		storedImage, err = s.StorageImageServer().ImageStatus(s.config.SystemContext, img)
 		if err == nil {
 			tmpImgConfigDigest := tmpImg.ConfigInfo().Digest
 			if tmpImgConfigDigest.String() == "" {
@@ -136,9 +136,9 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 				}
 			}
 		}()
-		_, err = s.StorageImageServer().PullImage(s.systemContext, img, &copy.Options{
+		_, err = s.StorageImageServer().PullImage(s.config.SystemContext, img, &copy.Options{
 			SourceCtx:        &sourceCtx,
-			DestinationCtx:   s.systemContext,
+			DestinationCtx:   s.config.SystemContext,
 			OciDecryptConfig: dcc,
 			ProgressInterval: time.Second,
 			Progress:         progress,
@@ -153,7 +153,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 	if pulled == "" && err != nil {
 		return nil, err
 	}
-	status, err := s.StorageImageServer().ImageStatus(s.systemContext, pulled)
+	status, err := s.StorageImageServer().ImageStatus(s.config.SystemContext, pulled)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -23,7 +23,7 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (r
 		images  []string
 		deleted bool
 	)
-	images, err = s.StorageImageServer().ResolveNames(s.systemContext, image)
+	images, err = s.StorageImageServer().ResolveNames(s.config.SystemContext, image)
 	if err != nil {
 		if err == storage.ErrCannotParseImageID {
 			images = append(images, image)
@@ -32,7 +32,7 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (r
 		}
 	}
 	for _, img := range images {
-		err = s.StorageImageServer().UntagImage(s.systemContext, img)
+		err = s.StorageImageServer().UntagImage(s.config.SystemContext, img)
 		if err != nil {
 			log.Debugf(ctx, "error deleting image %s: %v", img, err)
 			continue

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -23,7 +23,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (r
 	if image == "" {
 		return nil, fmt.Errorf("no image specified")
 	}
-	images, err := s.StorageImageServer().ResolveNames(s.systemContext, image)
+	images, err := s.StorageImageServer().ResolveNames(s.config.SystemContext, image)
 	if err != nil {
 		if err == pkgstorage.ErrCannotParseImageID {
 			images = append(images, image)
@@ -36,7 +36,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (r
 		lastErr  error
 	)
 	for _, image := range images {
-		status, err := s.StorageImageServer().ImageStatus(s.systemContext, image)
+		status, err := s.StorageImageServer().ImageStatus(s.config.SystemContext, image)
 		if err != nil {
 			if errors.Cause(err) == storage.ErrImageUnknown {
 				log.Warnf(ctx, "imageStatus: can't find %s", image)

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -73,7 +73,7 @@ func (s *Server) getContainerInfo(id string, getContainerFunc, getInfraContainer
 	}
 	image := ctr.Image()
 	if s.ContainerServer != nil && s.ContainerServer.StorageImageServer() != nil {
-		if status, err := s.ContainerServer.StorageImageServer().ImageStatus(s.systemContext, ctr.ImageRef()); err == nil {
+		if status, err := s.ContainerServer.StorageImageServer().ImageStatus(s.config.SystemContext, ctr.ImageRef()); err == nil {
 			image = status.Name
 		}
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -86,7 +86,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if selinuxConfig != nil {
 		labelOptions = getLabelOptions(selinuxConfig)
 	}
-	podContainer, err := s.StorageRuntimeServer().CreatePodSandbox(s.systemContext,
+	podContainer, err := s.StorageRuntimeServer().CreatePodSandbox(s.config.SystemContext,
 		name, id,
 		s.config.PauseImage,
 		s.config.PauseImageAuthFile,

--- a/server/server.go
+++ b/server/server.go
@@ -18,8 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containers/image/v5/pkg/sysregistriesv2"
-	"github.com/containers/image/v5/types"
 	"github.com/containers/libpod/pkg/apparmor"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/internal/lib"
@@ -29,7 +27,6 @@ import (
 	"github.com/cri-o/cri-o/internal/pkg/storage"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/server/metrics"
-	"github.com/cri-o/cri-o/server/useragent"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
@@ -71,7 +68,6 @@ type Server struct {
 	*lib.ContainerServer
 	monitorsChan      chan struct{}
 	defaultIDMappings *idtools.IDMappings
-	systemContext     *types.SystemContext // Never nil
 
 	updateLock sync.RWMutex
 
@@ -287,11 +283,9 @@ func getIDMappings(config *libconfig.Config) (*idtools.IDMappings, error) {
 	return idtools.NewIDMappingsFromMaps(parsedUIDsMappings, parsedGIDsMappings), nil
 }
 
-// New creates a new Server with the provided context, systemContext,
-// configPath and configuration
+// New creates a new Server with the provided context, configPath and configuration
 func New(
 	ctx context.Context,
-	systemContext *types.SystemContext,
 	configPath string,
 	configIface libconfig.Iface,
 ) (*Server, error) {
@@ -300,16 +294,8 @@ func New(
 	}
 	config := configIface.GetData()
 
-	// Make a copy of systemContext we can safely modify, and which is never nil. (Note that this is a shallow copy!)
-	sc := types.SystemContext{}
-	if systemContext != nil {
-		sc = *systemContext
-	}
-	systemContext = &sc
-
-	systemContext.AuthFilePath = config.GlobalAuthFile
-	systemContext.DockerRegistryUserAgent = useragent.Get(ctx)
-	systemContext.SignaturePolicyPath = config.SignaturePolicyPath
+	config.SystemContext.AuthFilePath = config.GlobalAuthFile
+	config.SystemContext.SignaturePolicyPath = config.SignaturePolicyPath
 
 	if err := os.MkdirAll(config.ContainerAttachSocketDir, 0755); err != nil {
 		return nil, err
@@ -319,7 +305,7 @@ func New(
 	if err := os.MkdirAll(config.ContainerExitsDir, 0755); err != nil {
 		return nil, err
 	}
-	containerServer, err := lib.New(ctx, systemContext, configIface)
+	containerServer, err := lib.New(ctx, configIface)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +335,6 @@ func New(
 		appArmorProfile:   config.ApparmorProfile,
 		monitorsChan:      make(chan struct{}),
 		defaultIDMappings: idMappings,
-		systemContext:     systemContext,
 	}
 
 	s.decryptionKeysPath = config.DecryptionKeysPath
@@ -467,12 +452,6 @@ func New(
 
 	// Start a configuration watcher for the default config
 	if _, err := s.StartConfigWatcher(configPath, s.config.Reload); err != nil {
-		logrus.Infof("unable to start config watcher: %v", err)
-	}
-
-	// Start a configuration watcher for the registries of the SystemContext
-	registriesPath := sysregistriesv2.ConfigPath(s.systemContext)
-	if _, err := s.StartConfigWatcher(registriesPath, s.ReloadRegistries); err != nil {
 		logrus.Infof("unable to start config watcher: %v", err)
 	}
 
@@ -666,17 +645,6 @@ func (s *Server) StartConfigWatcher(
 
 	logrus.Debugf("registered SIGHUP watcher for file %q", fileName)
 	return c, nil
-}
-
-// ReloadRegistries reloads the registry configuration from the servers
-// `SystemContext`. The method errors in case of any update failure.
-func (s *Server) ReloadRegistries(file string) error {
-	registries, err := sysregistriesv2.TryUpdatingCache(s.systemContext)
-	if err != nil {
-		return errors.Wrapf(err, "system registries reload failed: %s", file)
-	}
-	logrus.Infof("applied new registry configuration: %+v", registries)
-	return nil
 }
 
 // ReloadDefaultAppArmorProfile reloads the default AppArmor profile and

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/containers/image/v5/types"
 	cstorage "github.com/containers/storage"
 	"github.com/cri-o/cri-o/internal/pkg/signals"
 	"github.com/cri-o/cri-o/server"
@@ -40,7 +39,7 @@ var _ = t.Describe("Server", func() {
 			mockNewServer()
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -56,7 +55,7 @@ var _ = t.Describe("Server", func() {
 
 			// When
 			server, err := server.New(
-				context.Background(), nil, tmpFile, libMock,
+				context.Background(), tmpFile, libMock,
 			)
 
 			// Then
@@ -72,7 +71,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.GIDMappings = "1:1:1"
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -87,7 +86,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.StreamTLSCert = "../test/testdata/cert.pem"
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -122,7 +121,7 @@ var _ = t.Describe("Server", func() {
 			)
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -132,7 +131,7 @@ var _ = t.Describe("Server", func() {
 		It("should fail when provided config is nil", func() {
 			// Given
 			// When
-			server, err := server.New(context.Background(), nil, "", nil)
+			server, err := server.New(context.Background(), "", nil)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -147,7 +146,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.ContainerAttachSocketDir = invalidDir
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -162,7 +161,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.ContainerExitsDir = invalidDir
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -179,7 +178,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.NetworkDir = invalidDir
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -198,7 +197,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.GIDMappings = g
 
 			// When
-			sut, err := server.New(context.Background(), nil, "", libMock)
+			sut, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -219,7 +218,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.SeccompProfile = invalidDir
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -236,7 +235,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.SeccompProfile = "/dev/null"
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -250,7 +249,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.StreamPort = invalid
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -265,7 +264,7 @@ var _ = t.Describe("Server", func() {
 			serverConfig.StreamTLSKey = invalid
 
 			// When
-			server, err := server.New(context.Background(), nil, "", libMock)
+			server, err := server.New(context.Background(), "", libMock)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -394,49 +393,6 @@ var _ = t.Describe("Server", func() {
 
 			// When
 			_, err := sut.StartConfigWatcher(tmpFile, nil)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-	})
-
-	t.Describe("ReloadRegistries", func() {
-		// The test registries file
-		regConf := ""
-
-		// Prepare the sut
-		BeforeEach(func() {
-			regConf = t.MustTempFile("reload-registries")
-			ctx := &types.SystemContext{SystemRegistriesConfPath: regConf}
-			setupSUTWithContext(ctx)
-		})
-
-		It("should succeed to reload registries", func() {
-			// Given
-			// When
-			err := sut.ReloadRegistries(regConf)
-
-			// Then
-			Expect(err).To(BeNil())
-		})
-
-		It("should fail if registries file got deleted", func() {
-			// Given
-			Expect(os.Remove(regConf)).To(BeNil())
-
-			// When
-			err := sut.ReloadRegistries(regConf)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
-		It("should fail if registries file is invalid", func() {
-			// Given
-			Expect(ioutil.WriteFile(regConf, []byte("invalid"), 0755)).To(BeNil())
-
-			// When
-			err := sut.ReloadRegistries(regConf)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containers/image/v5/types"
 	cstorage "github.com/containers/storage"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
@@ -182,13 +181,9 @@ var afterEach = func() {
 }
 
 var setupSUT = func() {
-	setupSUTWithContext(nil)
-}
-
-var setupSUTWithContext = func(ctx *types.SystemContext) {
 	var err error
 	mockNewServer()
-	sut, err = server.New(context.Background(), ctx, "", libMock)
+	sut, err = server.New(context.Background(), "", libMock)
 	Expect(err).To(BeNil())
 	Expect(sut).NotTo(BeNil())
 

--- a/server/useragent/useragent.go
+++ b/server/useragent/useragent.go
@@ -1,14 +1,13 @@
 package useragent
 
 import (
-	"context"
 	"runtime"
 
 	"github.com/cri-o/cri-o/internal/version"
 )
 
 // Get is the User-Agent the CRI-O daemon uses to identify itself.
-func Get(ctx context.Context) string {
+func Get() string {
 	httpVersion := make([]VersionInfo, 0, 4)
 	httpVersion = append(httpVersion,
 		VersionInfo{Name: "cri-o", Version: version.Version},

--- a/server/useragent/useragent_test.go
+++ b/server/useragent/useragent_test.go
@@ -1,8 +1,6 @@
 package useragent_test
 
 import (
-	"context"
-
 	"github.com/cri-o/cri-o/server/useragent"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,7 +13,7 @@ var _ = t.Describe("Useragent", func() {
 		It("should succeed", func() {
 			// Given
 			// When
-			result := useragent.Get(context.Background())
+			result := useragent.Get()
 
 			// Then
 			Expect(result).To(SatisfyAll(


### PR DESCRIPTION
This allows to simplify the configuration reload strategy as well as
updating parts of the system context during live reload. There are now
fewer locations where the context has to be passed around.