### PR TITLE
[1.16] add default hooks dir to crio.conf

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -10,7 +10,7 @@ function __fish_crio_no_subcommand --description 'Test if there has been any sub
 end
 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l additional-devices -r -d 'devices to add to the containers (default: [])'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l apparmor-profile -r -d 'default apparmor profile name (default: "crio-default-1.16.0")'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l apparmor-profile -r -d 'default apparmor profile name (default: "crio-default-1.16.1")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l bind-mount-prefix -r -d 'specify a prefix to prepend to the source of a bind mount (default: "")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l cgroup-manager -r -d 'cgroup manager (cgroupfs or systemd) (default: "cgroupfs")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l cni-config-dir -r -d 'CNI configuration files directory (default: "/etc/cni/net.d/")'
@@ -34,7 +34,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l gid-mappings -r -d 'specif
 complete -c crio -n '__fish_crio_no_subcommand' -f -l global-auth-file -r -d 'path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries (default: "")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l grpc-max-recv-msg-size -r -d 'maximum grpc receive message size in bytes (default: %!q(int=16777216))'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l grpc-max-send-msg-size -r -d 'maximum grpc receive message size (default: %!q(int=16777216))'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l hooks-dir -r -d 'set the OCI hooks directory path (may be set multiple times) (default: [])'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l hooks-dir -r -d 'set the OCI hooks directory path (may be set multiple times) (default: ["/usr/share/containers/oci/hooks.d"])'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l host-ip -r -d 'host IP considered as the primary IP to use by CRI-O for things such as host network IP (default: "")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l image-volumes -r -d 'image volume handling (\'mkdir\', \'bind\', or \'ignore\')'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l insecure-registry -r -d 'whether to disable TLS verification for the given registry'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 	conmonconfig "github.com/containers/conmon/runner/config"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
+	"github.com/containers/libpod/pkg/hooks"
 	"github.com/containers/libpod/pkg/rootless"
 	createconfig "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/storage"
@@ -497,6 +498,7 @@ func DefaultConfig() (*Config, error) {
 			LogLevel:                 "error",
 			DefaultSysctls:           []string{},
 			DefaultUlimits:           []string{},
+			HooksDir:                 []string{hooks.DefaultDir},
 			AdditionalDevices:        []string{},
 		},
 		ImageConfig: ImageConfig{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,6 +25,7 @@ var _ = t.Describe("Config", func() {
 		sut.NetworkDir = os.TempDir()
 		sut.LogDir = "/"
 		sut.Listen = t.MustTempFile("crio.sock")
+		sut.HooksDir = []string{}
 		return sut
 	}
 
@@ -180,11 +181,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed during runtime", func() {
 			// Given
-			sut.Runtimes["runc"] = &config.RuntimeHandler{
-				RuntimePath: validFilePath,
-				RuntimeType: config.DefaultRuntimeType,
-			}
-			sut.Conmon = validFilePath
+			sut = runtimeValidConfig()
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, true)
@@ -195,12 +192,8 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed with additional devices", func() {
 			// Given
+			sut = runtimeValidConfig()
 			sut.AdditionalDevices = []string{"/dev/null:/dev/null:rw"}
-			sut.Runtimes["runc"] = &config.RuntimeHandler{
-				RuntimePath: validFilePath,
-				RuntimeType: config.DefaultRuntimeType,
-			}
-			sut.Conmon = validFilePath
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, true)
@@ -543,10 +536,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed during runtime", func() {
 			// Given
-			sut.NetworkConfig.NetworkDir = validDirPath
-			tmpDir := path.Join(os.TempDir(), "cni-test")
-			sut.NetworkConfig.PluginDirs = []string{tmpDir}
-			defer os.RemoveAll(tmpDir)
+			sut = runtimeValidConfig()
 
 			// When
 			err := sut.NetworkConfig.Validate(true)


### PR DESCRIPTION
In removing the implicit hooks dir, we also don't have any hooks dirs we ship by default. Given we'd like some sane defaults, we should add hooks.DefaultDir in the default config.

(replace: https://github.com/cri-o/cri-o/pull/3011, hopefully fixing the test issues)

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
