### PR TITLE
[1.16] Use vendored go modules when running unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,7 @@ testunit: ${GINKGO}
 		-r \
 		--trace \
 		--cover \
+		--mod=vendor \
 		--covermode atomic \
 		--outputdir ${COVERAGE_PATH} \
 		--coverprofile coverprofile \

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -430,19 +430,5 @@ var _ = t.Describe("Sandbox", func() {
 			Expect(err).NotTo(BeNil())
 			Expect(ns).To(BeNil())
 		})
-
-		It("should fail on invalid permissions", func() {
-			// Given
-			Expect(os.MkdirAll("/tmp/noperm", 0000)).To(BeNil())
-			defer os.RemoveAll("/tmp/noperm")
-
-			// When
-			ns, err := testSandbox.NetNsGet("/proc/self/ns",
-				"../../../tmp/noperm/test")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(ns).To(BeNil())
-		})
 	})
 })

--- a/pkg/config/suite_test.go
+++ b/pkg/config/suite_test.go
@@ -23,7 +23,7 @@ var (
 
 const (
 	validFilePath = "/bin/sh"
-	invalidPath   = "/wrong"
+	invalidPath   = "/proc/invalid"
 )
 
 var _ = BeforeSuite(func() {

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -226,32 +226,19 @@ var _ = t.Describe("RunPodSandbox", func() {
 			Expect(res).To(Equal(""))
 		})
 
-		var prepareCgroupDirs = func(perm os.FileMode, content string) (string, string) {
+		var prepareCgroupDirs = func(content string) (string, string) {
 			const cgroup = "some.slice"
 			tmpDir := t.MustTempDir("cgroup")
 			Expect(os.MkdirAll(filepath.Join(tmpDir, cgroup), 0755)).To(BeNil())
 			Expect(ioutil.WriteFile(
 				filepath.Join(tmpDir, cgroup, "memory.limit_in_bytes"),
-				[]byte(content), perm)).To(BeNil())
+				[]byte(content), 0644)).To(BeNil())
 			return cgroup, tmpDir
 		}
 
-		It("should fail with systemd manager if memory read fails", func() {
-			// Given
-			cgroup, tmpDir := prepareCgroupDirs(0222, "")
-
-			// When
-			res, err := server.AddCgroupAnnotation(context.Background(), g,
-				tmpDir, oci.SystemdCgroupsManager, cgroup, "id")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(res).To(Equal(""))
-		})
-
 		It("should succeed with systemd manager if memory string empty", func() {
 			// Given
-			cgroup, tmpDir := prepareCgroupDirs(0644, "")
+			cgroup, tmpDir := prepareCgroupDirs("")
 
 			// When
 			res, err := server.AddCgroupAnnotation(context.Background(), g,
@@ -264,7 +251,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 
 		It("should succeed with systemd manager with valid memory ", func() {
 			// Given
-			cgroup, tmpDir := prepareCgroupDirs(0644, "13000000")
+			cgroup, tmpDir := prepareCgroupDirs("13000000")
 
 			// When
 			res, err := server.AddCgroupAnnotation(context.Background(), g,
@@ -277,7 +264,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 
 		It("should fail with systemd manager with too low memory", func() {
 			// Given
-			cgroup, tmpDir := prepareCgroupDirs(0644, "10")
+			cgroup, tmpDir := prepareCgroupDirs("10")
 
 			// When
 			res, err := server.AddCgroupAnnotation(context.Background(), g,
@@ -290,7 +277,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 
 		It("should fail with systemd manager with invalid memory ", func() {
 			// Given
-			cgroup, tmpDir := prepareCgroupDirs(0644, "invalid")
+			cgroup, tmpDir := prepareCgroupDirs("invalid")
 
 			// When
 			res, err := server.AddCgroupAnnotation(context.Background(), g,

--- a/server/secrets_test.go
+++ b/server/secrets_test.go
@@ -34,8 +34,7 @@ var _ = t.Describe("Secrets", func() {
 		It("should fail with invalid dir", func() {
 			// Given
 			sut := server.SecretData{}
-			secretsDir := "/invalid"
-			defer os.RemoveAll(secretsDir)
+			secretsDir := "/proc/invalid" // nolint: gosec
 
 			// When
 			err := sut.SaveTo(secretsDir)


### PR DESCRIPTION
We also remove two flaking unit tests in conjunction with the new test
images (running as root user).