### PR TITLE
add conmonmon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/containers/conmon v2.0.3+incompatible
 	github.com/containers/image/v5 v5.0.0
 	github.com/containers/libpod v1.6.3-0.20191101152258-04e8bf3dba50
+	github.com/containers/psgo v1.4.0
 	github.com/containers/storage v1.15.2
 	github.com/coreos/go-systemd/v22 v22.0.0
 	github.com/cpuguy83/go-md2man v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/containers/psgo v1.3.1 h1:1kE+jJ9Ou5f9zQT/M2IdeSclsKWsXrSFlOcnqc+F2TA
 github.com/containers/psgo v1.3.1/go.mod h1:LLiRMmxZ6FWP4bB/fOUu6kDT+4okk/ZCeeykqh0O5Ns=
 github.com/containers/psgo v1.3.2 h1:jYfppPih3S/j2Yi5O14AXjd8GfCx1ph9L3YsoK3adko=
 github.com/containers/psgo v1.3.2/go.mod h1:ENXXLQ5E1At4K0EUsGogXBJi/C28gwqkONWeLPI9fJ8=
+github.com/containers/psgo v1.4.0 h1:D8B4fZCCZhYgc8hDyMPCiShOinmOB1TP1qe46sSC19k=
+github.com/containers/psgo v1.4.0/go.mod h1:ENXXLQ5E1At4K0EUsGogXBJi/C28gwqkONWeLPI9fJ8=
 github.com/containers/storage v1.12.10/go.mod h1:+RirK6VQAqskQlaTBrOG6ulDvn4si2QjFE1NZCn06MM=
 github.com/containers/storage v1.12.12 h1:gao0GNzjmSX4Ai/StOHtUVIrBguC0OKyvx/ZMwBdyuY=
 github.com/containers/storage v1.12.12/go.mod h1:+RirK6VQAqskQlaTBrOG6ulDvn4si2QjFE1NZCn06MM=

--- a/internal/lib/conmonmon.go
+++ b/internal/lib/conmonmon.go
@@ -1,0 +1,178 @@
+package lib
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/containers/psgo"
+	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/pkg/config"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// the time between checking the registered conmons
+var sleepTime = 5 * time.Minute
+
+// conmonmon is a struct responsible for monitoring conmons
+// it contains a map of containers -> info on conmons, and sleeps on
+// a loop, waiting for a conmon to die. if it has, it kills the associated
+// container.
+type conmonmon struct {
+	conmons   map[*oci.Container]*conmonInfo
+	closeChan chan bool
+	runtime   *oci.Runtime
+	server    *ContainerServer
+	lock      sync.Mutex
+}
+
+// conmonInfo contains all necessary state to verify
+// the conmon the container was originally spawned from is still running
+type conmonInfo struct {
+	conmonPID int
+	startTime string
+}
+
+// newConmonmon creates a new conmonmon instance given a runtime.
+// It also starts the monitoring routine
+func (c *ContainerServer) newConmonmon(r *oci.Runtime) *conmonmon {
+	cmm := conmonmon{
+		conmons:   make(map[*oci.Container]*conmonInfo),
+		runtime:   r,
+		server:    c,
+		closeChan: make(chan bool, 2),
+	}
+	go cmm.monitorConmons()
+	return &cmm
+}
+
+// monitorConmons sits on a loop and sleeps.
+// after waking, it signals to the conmons, checking if they're still alive.
+func (c *conmonmon) monitorConmons() {
+	for {
+		select {
+		case <-time.After(sleepTime):
+			c.signalConmons()
+		case <-c.closeChan:
+			return
+		}
+	}
+}
+
+// signalConmons loops through all available conmons and they are verified as still alive
+// if they're not, the container is killed and we spoof an OOM event for the container
+func (c *conmonmon) signalConmons() {
+	c.lock.Lock()
+	for ctr, info := range c.conmons {
+		if ctr.State().Status == oci.ContainerStateRunning {
+			if err := c.verifyConmonValid(info.startTime, info.conmonPID); err != nil {
+				logrus.Debugf("conmon pid %d invalid: %v. Killing container %s", info.conmonPID, err, ctr.ID())
+				delete(c.conmons, ctr)
+				// kill container in separate thread to hold the conmonmon lock as little as possible
+				go c.oomKillContainer(ctr)
+			}
+		}
+	}
+	c.lock.Unlock()
+}
+
+// verifyConmonValid checks if the conmon we have saved as being associated with the container
+// matches the pid. We first check if the pid is running, then check against the start time
+// we originally recorded.
+// These two checks should verify we are looking at the same conmon
+func (c *conmonmon) verifyConmonValid(savedStart string, pid int) error {
+	// check the start time is the same as we recorded (to prevent pid wrap from tricking us)
+	startTime, err := getProcessStartTime(pid)
+	if err != nil {
+		return err
+	}
+	if startTime != savedStart {
+		return errors.Errorf("pids found to differ in stime: recorded %s found %s", savedStart, startTime)
+	}
+
+	return nil
+}
+
+// oomKillContainer does everything required to pretend as though the container OOM'd
+// this includes killing, setting its state, and writing that state to disk
+func (c *conmonmon) oomKillContainer(ctr *oci.Container) {
+	if err := c.runtime.SignalContainer(ctr, unix.SIGKILL); err != nil {
+		logrus.Debugf(err.Error())
+	}
+	c.runtime.SpoofOOM(ctr)
+	if err := c.server.ContainerStateToDisk(ctr); err != nil {
+		logrus.Debugf(err.Error())
+	}
+}
+
+// MonitorConmon adds a container's conmon to map of those watched
+func (c *conmonmon) MonitorConmon(ctr *oci.Container) error {
+	// silently return if we are asked to monitor a
+	// runtime type that doesn't use conmon
+	if runtimeType, err := c.runtime.ContainerRuntimeType(ctr); runtimeType == config.RuntimeTypeVM {
+		if err != nil {
+			logrus.Debugf("error when adding conmon of %s to monitoring loop: %v", ctr.ID(), err)
+		}
+		return nil
+	}
+
+	status := ctr.State().Status
+	if status != oci.ContainerStateRunning && status != oci.ContainerStateCreated {
+		return nil
+	}
+
+	conmonPID, err := oci.ReadConmonPidFile(ctr)
+	if err != nil {
+		return err
+	}
+
+	startTime, err := getProcessStartTime(conmonPID)
+	if err != nil {
+		return err
+	}
+
+	ci := &conmonInfo{
+		conmonPID: conmonPID,
+		startTime: startTime,
+	}
+
+	c.lock.Lock()
+	if _, found := c.conmons[ctr]; found {
+		c.lock.Unlock()
+		return errors.Errorf("container ID: %s already has a registered conmon", ctr.ID())
+	}
+	c.conmons[ctr] = ci
+	c.lock.Unlock()
+
+	return nil
+}
+
+// getProcessStartTime takes a pid and runs ps against it, filtering for stime
+func getProcessStartTime(pid int) (string, error) {
+	psInfo, err := psgo.ProcessInfoByPids([]string{strconv.Itoa(pid)}, []string{"stime"})
+	if err != nil {
+		return "", err
+	}
+	if len(psInfo) != 2 || len(psInfo[1]) != 1 {
+		return "", errors.Errorf("insufficient ps information; pid likely stopped")
+	}
+
+	return psInfo[1][0], nil
+}
+
+// StopMonitoringConmon removes a container's conmon to map of those watched
+func (c *conmonmon) StopMonitoringConmon(ctr *oci.Container) {
+	c.lock.Lock()
+	// we can be idempotent here, because there are multiple ways a container can
+	// not be tracked anymore
+	delete(c.conmons, ctr)
+	c.lock.Unlock()
+}
+
+// ShutdownConmonmon tells conmonmon to stop sleeping on a loop,
+// and to stop monitoring
+func (c *conmonmon) ShutdownConmonmon() {
+	c.closeChan <- true
+}

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -203,6 +203,18 @@ func (r *Runtime) PrivilegedWithoutHostDevices(handler string) (bool, error) {
 	return rh.PrivilegedWithoutHostDevices, nil
 }
 
+// ContainerRuntimeType returns the type of runtime configured.
+// This is needed when callers need to do specific work for oci vs vm
+// containers, like monitor an oci container's conmon.
+func (r *Runtime) ContainerRuntimeType(c *Container) (string, error) {
+	rh, err := r.getRuntimeHandler(c.runtimeHandler)
+	if err != nil {
+		return "", err
+	}
+
+	return rh.RuntimeType, nil
+}
+
 func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
 	rh, err := r.getRuntimeHandler(c.runtimeHandler)
 	if err != nil {

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -53,6 +53,7 @@ func newRuntimeOCI(r *Runtime, handler *config.RuntimeHandler) RuntimeImpl {
 	if handler.RuntimeRoot != "" {
 		runRoot = handler.RuntimeRoot
 	}
+
 	return &runtimeOCI{
 		Runtime: r,
 		path:    handler.RuntimePath,
@@ -98,6 +99,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 		"-r", r.path,
 		"-b", c.bundlePath,
 		"-p", filepath.Join(c.bundlePath, "pidfile"),
+		"-P", c.conmonPidFilePath(),
 		"-l", c.logPath,
 		"--exit-dir", r.config.ContainerExitsDir,
 		"--socket-dir-path", r.config.ContainerAttachSocketDir,
@@ -214,6 +216,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 		logrus.Errorf("Container creation timeout (%v)", ContainerCreateTimeout)
 		return fmt.Errorf("create container timeout")
 	}
+
 	return nil
 }
 
@@ -623,6 +626,7 @@ func (r *runtimeOCI) DeleteContainer(c *Container) error {
 	defer c.opLock.Unlock()
 
 	_, err := utils.ExecCmd(r.path, rootFlag, r.root, "delete", "--force", c.id)
+
 	return err
 }
 
@@ -943,4 +947,61 @@ func prepareProcessExec(c *Container, cmd []string, tty bool) (*os.File, error) 
 		return nil, err
 	}
 	return f, nil
+}
+
+// ReadConmonPidFile attempts to read conmon's pid from its pid file
+// This function makes no verification that this file should exist
+// it is up to the caller to verify that this container has a conmon
+func ReadConmonPidFile(c *Container) (int, error) {
+	contents, err := ioutil.ReadFile(c.conmonPidFilePath())
+	if err != nil {
+		return -1, err
+	}
+	// Convert it to an int
+	conmonPID, err := strconv.Atoi(string(contents))
+	if err != nil {
+		return -1, err
+	}
+	return conmonPID, nil
+}
+
+func (c *Container) conmonPidFilePath() string {
+	return filepath.Join(c.bundlePath, "conmon-pidfile")
+}
+
+// SpoofOOM is a function that sets a container state as though it OOM'd. It's used in situations
+// where another process in the container's cgroup (like conmon) OOM'd when it wasn't supposed to,
+// allowing us to report to the kubelet that the container OOM'd instead.
+func (r *Runtime) SpoofOOM(c *Container) {
+	ecBytes := []byte{'1', '3', '7'}
+
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	c.state.Status = ContainerStateStopped
+	c.state.Finished = time.Now()
+	c.state.ExitCode = 137
+	c.state.OOMKilled = true
+
+	oomFilePath := filepath.Join(c.bundlePath, "oom")
+	oomFile, err := os.Create(oomFilePath)
+	if err != nil {
+		logrus.Debugf("unable to write to oom file path %s: %v", oomFilePath, err)
+	}
+	oomFile.Close()
+
+	exitFilePath := filepath.Join(r.config.ContainerExitsDir, c.id)
+	exitFile, err := os.Create(exitFilePath)
+	if err != nil {
+		logrus.Debugf("unable to write exit file path %s: %v", exitFilePath, err)
+		return
+	}
+	if _, err := exitFile.Write(ecBytes); err != nil {
+		logrus.Debugf("failed to write exit code to file %s: %v", exitFilePath, err)
+	}
+	exitFile.Close()
+}
+
+func ConmonPath(r *Runtime) string {
+	return r.config.Conmon
 }

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -613,6 +613,10 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 
 	container.SetCreated()
 
+	if err := s.MonitorConmon(container); err != nil {
+		log.Errorf(ctx, "%v", err)
+	}
+
 	log.Infof(ctx, "Created container: %s", container.Description())
 	resp := &pb.CreateContainerResponse{
 		ContainerId: containerID,

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -20,6 +20,8 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		return nil, err
 	}
 
+	s.StopMonitoringConmon(c)
+
 	log.Infof(ctx, "Removed container %s", c.Description())
 	resp = &pb.RemoveContainerResponse{}
 	return resp, nil

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -33,6 +33,14 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 		}
 	}()
 
+	// in the event a container is created, conmon is oom killed, then the container
+	// is started, we want to start the watcher on it, and appropriately kill it.
+	// this situation is VERY unlikely, but conmonmon exists because the kernel OOM killer
+	// can't be trusted
+	if err := s.MonitorConmon(c); err != nil {
+		log.Debugf(ctx, "failed to add conmon for %s to monitor: %v", c.ID(), err)
+	}
+
 	err = s.Runtime().StartContainer(c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start container %s: %v", c.ID(), err)

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -74,6 +74,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 		if err := s.CtrIDIndex().Delete(c.ID()); err != nil {
 			return nil, fmt.Errorf("failed to delete container %s in pod sandbox %s from index: %v", c.Name(), sb.ID(), err)
 		}
+		s.StopMonitoringConmon(c)
 	}
 
 	s.removeInfraContainer(podInfraContainer)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -660,6 +660,10 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	sb.SetCreated()
 
+	if err := s.MonitorConmon(container); err != nil {
+		log.Errorf(ctx, "%v", err)
+	}
+
 	log.Infof(ctx, "ran pod sandbox with infra container: %s", container.Description())
 	resp = &pb.RunPodSandboxResponse{PodSandboxId: id}
 	return resp, nil

--- a/server/server.go
+++ b/server/server.go
@@ -247,6 +247,8 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	// notice this won't trigger just on system halt but also on normal
 	// crio.service restart!!!
 	s.cleanupSandboxesOnShutdown(ctx)
+
+	s.ShutdownConmonmon()
 	return s.ContainerServer.Shutdown()
 }
 

--- a/test/conmonmon.bats
+++ b/test/conmonmon.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_test
+	start_crio
+}
+
+function teardown() {
+	cleanup_test
+}
+
+function kill_conmon() {
+	ctr_id="$1"
+
+	conmon_pid=$(ps -eo "%p %a" | grep conmon | grep "$ctr_id" | cut -d' ' -f1)
+	if [ -z "$conmon_pid" ]; then
+		skip "conmon pid found empty; probably kata containers"
+	fi
+
+	run sudo kill -9 $conmon_pid
+	echo "$output"
+	[ "$status" -eq 0 ]
+}
+
+function wait_and_check_for_oom() {
+	attempt=0
+	while [ $attempt -le 100 ]; do
+		attempt=$((attempt+1))
+		run crictl inspect --output yaml "$ctr_id"
+		echo "$output"
+		[ "$status" -eq 0 ]
+		if [[ "$output" =~ "OOMKilled" ]]; then
+			break
+		fi
+		sleep 10
+	done
+	[[ "$output" =~ "OOMKilled" ]]
+}
+
+function wait_and_check_for_sandbox_oom() {
+	attempt=0
+	while [ $attempt -le 100 ]; do
+		attempt=$((attempt+1))
+		run crictl inspectp --output yaml "$pod_id"
+		echo "$output"
+		[ "$status" -eq 0 ]
+		if [[ "$output" =~ "SANDBOX_NOTREADY" ]]; then
+			break
+		fi
+		sleep 10
+	done
+	[[ "$output" =~ "SANDBOX_NOTREADY" ]]
+}
+
+@test "conmonmon cleans up running conmon" {
+	if [[ "$CI" == "true" ]]; then
+		skip "CI container tests don't support conmonmon"
+	fi
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run crictl create "$pod_id" "$TESTDATA"/container_config_sleep.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+
+	run crictl start "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	kill_conmon "$ctr_id"
+
+	wait_and_check_for_oom "$ctr_id"
+}
+
+@test "conmonmon cleans up created conmon once it runs" {
+	if [[ "$CI" == "true" ]]; then
+		skip "CI container tests don't support conmonmon"
+	fi
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run crictl create "$pod_id" "$TESTDATA"/container_config_sleep.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+
+	kill_conmon "$ctr_id"
+
+	run crictl start "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	wait_and_check_for_oom "$ctr_id"
+}
+
+@test "conmonmon cleans up created conmon after restart" {
+	if [[ "$CI" == "true" ]]; then
+		skip "CI container tests don't support conmonmon"
+	fi
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run crictl create "$pod_id" "$TESTDATA"/container_config_sleep.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+
+	restart_crio
+
+	kill_conmon "$ctr_id"
+
+	run crictl start "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	wait_and_check_for_oom "$ctr_id"
+}
+
+@test "conmonmon cleans up started conmon after restart" {
+	if [[ "$CI" == "true" ]]; then
+		skip "CI container tests don't support conmonmon"
+	fi
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run crictl create "$pod_id" "$TESTDATA"/container_config_sleep.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+
+	run crictl start "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	restart_crio
+
+	kill_conmon "$ctr_id"
+
+	wait_and_check_for_oom "$ctr_id"
+}
+
+@test "conmonmon cleans up running sandbox conmon" {
+	if [[ "$CI" == "true" ]]; then
+		skip "CI container tests don't support conmonmon"
+	fi
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	kill_conmon "$pod_id"
+
+	wait_and_check_for_sandbox_oom "$pod_id"
+}
+
+@test "conmonmon cleans up started sandbox conmon after restart" {
+	if [[ "$CI" == "true" ]]; then
+		skip "CI container tests don't support conmonmon"
+	fi
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	restart_crio
+
+	kill_conmon "$pod_id"
+
+	wait_and_check_for_sandbox_oom "$pod_id"
+}

--- a/vendor/github.com/containers/psgo/README.md
+++ b/vendor/github.com/containers/psgo/README.md
@@ -85,6 +85,8 @@ The ps library is compatible with all AIX format descriptors of the ps command-l
   - Seccomp mode of the process (i.e., disabled, strict or filter). See seccomp(2) for more information.
 - **state**
   - Process state codes (e.g, **R** for *running*, **S** for *sleeping*). See proc(5) for more information.
+- **stime**
+  - Process start time (e.g, "2019-12-09 10:50:36 +0100 CET).
 
 We can try out different format descriptors with the psgo binary:
 

--- a/vendor/github.com/containers/psgo/internal/process/process.go
+++ b/vendor/github.com/containers/psgo/internal/process/process.go
@@ -188,23 +188,30 @@ func (p *Process) SetHostData() error {
 
 // ElapsedTime returns the time.Duration since process p was created.
 func (p *Process) ElapsedTime() (time.Duration, error) {
-	sinceBoot, err := strconv.ParseInt(p.Stat.Starttime, 10, 64)
+	startTime, err := p.StartTime()
 	if err != nil {
 		return 0, err
+	}
+	return (time.Now()).Sub(startTime), nil
+}
+
+// StarTime returns the time.Time when process p was started.
+func (p *Process) StartTime() (time.Time, error) {
+	sinceBoot, err := strconv.ParseInt(p.Stat.Starttime, 10, 64)
+	if err != nil {
+		return time.Time{}, err
 	}
 	clockTicks, err := host.ClockTicks()
 	if err != nil {
-		return 0, err
+		return time.Time{}, err
+	}
+	bootTime, err := host.BootTime()
+	if err != nil {
+		return time.Time{}, err
 	}
 
 	sinceBoot = sinceBoot / clockTicks
-
-	bootTime, err := host.BootTime()
-	if err != nil {
-		return 0, err
-	}
-	created := time.Unix(sinceBoot+bootTime, 0)
-	return (time.Now()).Sub(created), nil
+	return time.Unix(sinceBoot+bootTime, 0), nil
 }
 
 // CPUTime returns the cumlative CPU time of process p as a time.Duration.

--- a/vendor/github.com/containers/psgo/psgo.go
+++ b/vendor/github.com/containers/psgo/psgo.go
@@ -310,6 +310,11 @@ var (
 			header: "STATE",
 			procFn: processState,
 		},
+		{
+			normal: "stime",
+			header: "STIME",
+			procFn: processStartTime,
+		},
 	}
 )
 
@@ -713,6 +718,15 @@ func processTIME(p *process.Process, ctx *psContext) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%v", cpu), nil
+}
+
+// processStartTime returns the start time of process p.
+func processStartTime(p *process.Process, ctx *psContext) (string, error) {
+	sTime, err := p.StartTime()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%v", sTime), nil
 }
 
 // processTTY returns the controlling tty (terminal) of process p.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,7 +174,7 @@ github.com/containers/libpod/utils
 github.com/containers/libpod/version
 # github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b
 github.com/containers/libtrust
-# github.com/containers/psgo v1.3.2
+# github.com/containers/psgo v1.4.0
 github.com/containers/psgo
 github.com/containers/psgo/internal/capabilities
 github.com/containers/psgo/internal/cgroups


### PR DESCRIPTION
One of the many shortcomings of kernel space OOM killing is there isn't very much a process can do to prevent itself from being OOM killed. Even adjusting its score doesn't prevent the kernel from killing it.

Unforuntately for CRI-O, conmon being OOM killed is very bad. A container can be orphaned and left running, with no way to report it state to CRI-O. At worst, it could keep PIDs in CRI-O that really should have gone away.

Introducing conmonmon, a conmon monitor. conmonmon loops in a routine and intermittantly calls `kill 0` on conmon, seeing if its still alive. If it has for some reason been killed, then conmonmon kills its associated container, and sets the container's state as though it OOM'd. This way, we can report to the kubelet that the container OOM'd, even though there is no one listening to it.

Signed-off-by: Peter Hunt <pehunt@redhat.com>