### PR TITLE
[1.16] add error to reservation printed error

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -576,7 +576,7 @@ func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
 // ReserveContainerName holds a name for a container that is being created
 func (c *ContainerServer) ReserveContainerName(id, name string) (string, error) {
 	if err := c.ctrNameIndex.Reserve(name, id); err != nil {
-		err = fmt.Errorf("error reserving ctr name %s for id %s", name, id)
+		err = fmt.Errorf("error reserving ctr name %s for id %s: %v", name, id, err)
 		logrus.Warn(err)
 		return "", err
 	}
@@ -592,7 +592,7 @@ func (c *ContainerServer) ReleaseContainerName(name string) {
 // ReservePodName holds a name for a pod that is being created
 func (c *ContainerServer) ReservePodName(id, name string) (string, error) {
 	if err := c.podNameIndex.Reserve(name, id); err != nil {
-		err = fmt.Errorf("error reserving pod name %s for id %s", name, id)
+		err = fmt.Errorf("error reserving pod name %s for id %s: %v", name, id, err)
 		logrus.Warn(err)
 		return "", err
 	}


### PR DESCRIPTION
this error pops up every once in a while, but without the printed error, we don't actually know what happened. add the error to the logging call so we know what went wrong.

Signed-off-by: Peter Hunt <pehunt@redhat.com>