### PR TITLE
[1.16] Persist exit status 

### DIFF
--- a/internal/lib/wait.go
+++ b/internal/lib/wait.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"fmt"
+
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -35,5 +37,8 @@ func (c *ContainerServer) ContainerWait(container string) (int32, error) {
 	if err := c.ContainerStateToDisk(ctr); err != nil {
 		logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
-	return exitCode, nil
+	if exitCode == nil {
+		return 0, fmt.Errorf("exit code not set")
+	}
+	return *exitCode, nil
 }

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -73,7 +73,7 @@ type ContainerState struct {
 	Created   time.Time `json:"created"`
 	Started   time.Time `json:"started,omitempty"`
 	Finished  time.Time `json:"finished,omitempty"`
-	ExitCode  int32     `json:"exitCode,omitempty"`
+	ExitCode  *int32    `json:"exitCode,omitempty"`
 	OOMKilled bool      `json:"oomKilled,omitempty"`
 	Error     string    `json:"error,omitempty"`
 }

--- a/internal/oci/memory_store_test.go
+++ b/internal/oci/memory_store_test.go
@@ -2,6 +2,7 @@ package oci_test
 
 import (
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -139,7 +140,7 @@ var _ = t.Describe("MemoryStore", func() {
 
 		It("should succeed apply", func() {
 			// Given
-			newContainerState := &oci.ContainerState{ExitCode: -1}
+			newContainerState := &oci.ContainerState{ExitCode: utils.Int32Ptr(-1)}
 			sut.Add(containerID, testContainer)
 			Expect(sut.Get(containerID)).NotTo(BeNil())
 

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -97,6 +97,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 		"-u", c.id,
 		"-r", r.path,
 		"-b", c.bundlePath,
+		"--persist-dir", c.dir,
 		"-p", filepath.Join(c.bundlePath, "pidfile"),
 		"-l", c.logPath,
 		"--exit-dir", r.config.ContainerExitsDir,
@@ -656,7 +657,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 	}
 
 	if c.state.Status == ContainerStateStopped {
-		exitFilePath := filepath.Join(r.config.ContainerExitsDir, c.id)
+		exitFilePath := filepath.Join(c.dir, "exit")
 		var fi os.FileInfo
 		err = kwait.ExponentialBackoff(
 			kwait.Backoff{

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -630,10 +630,37 @@ func (r *runtimeOCI) DeleteContainer(c *Container) error {
 	return err
 }
 
+func updateContainerStatusFromExitFile(c *Container) error {
+	exitFilePath := filepath.Join(c.dir, "exit")
+	fi, err := os.Stat(exitFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to find container exit file for %v: %v", c.id, err)
+	}
+	c.state.Finished, err = getFinishedTime(fi)
+	if err != nil {
+		return fmt.Errorf("failed to get finished time: %v", err)
+	}
+	statusCodeStr, err := ioutil.ReadFile(exitFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read exit file: %v", err)
+	}
+	statusCode, err := strconv.Atoi(string(statusCodeStr))
+	if err != nil {
+		return fmt.Errorf("status code conversion failed: %v", err)
+	}
+	c.state.ExitCode = utils.Int32Ptr(int32(statusCode))
+	return nil
+}
+
 // UpdateContainerStatus refreshes the status of the container.
 func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
+
+	if c.state.ExitCode != nil && !c.state.Finished.IsZero() {
+		logrus.Debugf("Skipping status update for: %+v", c.state)
+		return nil
+	}
 
 	cmd := exec.Command(r.path, rootFlag, r.root, "state", c.id)
 	if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
@@ -648,8 +675,10 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 		// We always populate the fields below so kube can restart/reschedule
 		// containers failing.
 		c.state.Status = ContainerStateStopped
-		c.state.Finished = time.Now()
-		c.state.ExitCode = 255
+		if err := updateContainerStatusFromExitFile(c); err != nil {
+			c.state.Finished = time.Now()
+			c.state.ExitCode = utils.Int32Ptr(255)
+		}
 		return nil
 	}
 	if err := json.NewDecoder(bytes.NewBuffer(out)).Decode(&c.state); err != nil {
@@ -676,7 +705,6 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 			})
 		if err != nil {
 			logrus.Warnf("failed to find container exit file for %v: %v", c.id, err)
-			c.state.ExitCode = -1
 		} else {
 			c.state.Finished, err = getFinishedTime(fi)
 			if err != nil {
@@ -690,7 +718,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 			if err != nil {
 				return fmt.Errorf("status code conversion failed: %v", err)
 			}
-			c.state.ExitCode = int32(statusCode)
+			c.state.ExitCode = utils.Int32Ptr(int32(statusCode))
 		}
 
 		oomFilePath := filepath.Join(c.bundlePath, "oom")

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -580,7 +580,8 @@ func (r *runtimeVM) UpdateContainerStatus(c *Container) error {
 
 	c.state.Status = status
 	c.state.Finished = response.ExitedAt
-	c.state.ExitCode = int32(response.ExitStatus)
+	exitCode := int32(response.ExitStatus)
+	c.state.ExitCode = &exitCode
 
 	return nil
 }

--- a/server/container_status_test.go
+++ b/server/container_status_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -51,11 +52,11 @@ var _ = t.Describe("ContainerStatus", func() {
 				State: specs.State{Status: oci.ContainerStateRunning},
 			}, pb.ContainerState_CONTAINER_RUNNING),
 			Entry("Stopped: ExitCode 0", &oci.ContainerState{
-				ExitCode: 0,
+				ExitCode: utils.Int32Ptr(0),
 				State:    specs.State{Status: oci.ContainerStateStopped},
 			}, pb.ContainerState_CONTAINER_EXITED),
 			Entry("Stopped: ExitCode -1", &oci.ContainerState{
-				ExitCode: -1,
+				ExitCode: utils.Int32Ptr(-1),
 				State:    specs.State{Status: oci.ContainerStateStopped},
 			}, pb.ContainerState_CONTAINER_EXITED),
 			Entry("Stopped: OOMKilled", &oci.ContainerState{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -306,3 +306,8 @@ func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir st
 
 	return passwdFile, nil
 }
+
+// Int32Ptr is a utility function to assign to integer pointer variables
+func Int32Ptr(i int32) *int32 {
+	return &i
+}


### PR DESCRIPTION
conmon will save the exit file of the container under
/var/lib so it gets persisted and available even on reboot.

Fixes to better handle exit code:

1. Change ExitCode to be a pointer to distinguish from
 exit code 0.
2. On reboot if we can't get runc state, then attempt
to read exit code from the persisted exit file.
This handles cases where crio was unable to persist
the state for the container but conmon had written
the exit file for the container.
3. When restoring state during CRI-O startup,
write back the state to disk so that any missed
exit file updates are accounted for.


Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
