### PR TITLE
persist exit status

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -199,7 +199,7 @@ func (c *ContainerServer) Update() error {
 			ctr := c.GetContainer(id)
 			if ctr != nil {
 				// if the container exists, update its state
-				if err := c.ContainerStateFromDisk(c.GetContainer(id)); err != nil {
+				if err := c.ContainerStateFromDisk(ctr); err != nil {
 					logrus.Warnf("unable to retrieve containers %s state from disk: %v", id, err)
 				}
 			}
@@ -437,6 +437,13 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	if err := c.ContainerStateFromDisk(scontainer); err != nil {
 		return fmt.Errorf("error reading sandbox state from disk %q: %v", scontainer.ID(), err)
 	}
+
+	// We write back the state because it is possible that crio did not have a chance to
+	// read the exit file and persist exit code into the state on reboot.
+	if err := c.ContainerStateToDisk(scontainer); err != nil {
+		return fmt.Errorf("failed to write container state to disk %q: %v", scontainer.ID(), err)
+	}
+
 	sb.SetCreated()
 	if err := c.MonitorConmon(scontainer); err != nil {
 		return fmt.Errorf("error adding conmon of sandbox container %s to monitoring loop: %v", scontainer.ID(), err)
@@ -557,6 +564,12 @@ func (c *ContainerServer) LoadContainer(id string) error {
 
 	if err := c.ContainerStateFromDisk(ctr); err != nil {
 		return fmt.Errorf("error reading container state from disk %q: %v", ctr.ID(), err)
+	}
+
+	// We write back the state because it is possible that crio did not have a chance to
+	// read the exit file and persist exit code into the state on reboot.
+	if err := c.ContainerStateToDisk(ctr); err != nil {
+		return fmt.Errorf("failed to write container state to disk %q: %v", ctr.ID(), err)
 	}
 	ctr.SetCreated()
 

--- a/internal/lib/wait.go
+++ b/internal/lib/wait.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"fmt"
+
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -35,5 +37,8 @@ func (c *ContainerServer) ContainerWait(container string) (int32, error) {
 	if err := c.ContainerStateToDisk(ctr); err != nil {
 		logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
-	return exitCode, nil
+	if exitCode == nil {
+		return 0, fmt.Errorf("exit code not set")
+	}
+	return *exitCode, nil
 }

--- a/internal/lib/wait.go
+++ b/internal/lib/wait.go
@@ -1,8 +1,6 @@
 package lib
 
 import (
-	"fmt"
-
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -38,7 +36,7 @@ func (c *ContainerServer) ContainerWait(container string) (int32, error) {
 		logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
 	if exitCode == nil {
-		return 0, fmt.Errorf("exit code not set")
+		return 0, errors.New("exit code not set")
 	}
 	return *exitCode, nil
 }

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -338,3 +338,7 @@ func (c *Container) Description() string {
 func (c *Container) StdinOnce() bool {
 	return c.stdinOnce
 }
+
+func (c *Container) exitFilePath() string {
+	return filepath.Join(c.dir, "exit")
+}

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -72,7 +72,7 @@ type ContainerState struct {
 	Created   time.Time `json:"created"`
 	Started   time.Time `json:"started,omitempty"`
 	Finished  time.Time `json:"finished,omitempty"`
-	ExitCode  int32     `json:"exitCode,omitempty"`
+	ExitCode  *int32    `json:"exitCode,omitempty"`
 	OOMKilled bool      `json:"oomKilled,omitempty"`
 	Error     string    `json:"error,omitempty"`
 }

--- a/internal/oci/memory_store_test.go
+++ b/internal/oci/memory_store_test.go
@@ -2,6 +2,7 @@ package oci_test
 
 import (
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -139,7 +140,7 @@ var _ = t.Describe("MemoryStore", func() {
 
 		It("should succeed apply", func() {
 			// Given
-			newContainerState := &oci.ContainerState{ExitCode: -1}
+			newContainerState := &oci.ContainerState{ExitCode: utils.Int32Ptr(-1)}
 			sut.Add(containerID, testContainer)
 			Expect(sut.Get(containerID)).NotTo(BeNil())
 

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -98,6 +98,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 		"-u", c.id,
 		"-r", r.path,
 		"-b", c.bundlePath,
+		"--persist-dir", c.dir,
 		"-p", filepath.Join(c.bundlePath, "pidfile"),
 		"-P", c.conmonPidFilePath(),
 		"-l", c.logPath,
@@ -657,7 +658,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 	}
 
 	if c.state.Status == ContainerStateStopped {
-		exitFilePath := filepath.Join(r.config.ContainerExitsDir, c.id)
+		exitFilePath := filepath.Join(c.dir, "exit")
 		var fi os.FileInfo
 		err = kwait.ExponentialBackoff(
 			kwait.Backoff{

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -631,10 +631,37 @@ func (r *runtimeOCI) DeleteContainer(c *Container) error {
 	return err
 }
 
+func updateContainerStatusFromExitFile(c *Container) error {
+	exitFilePath := filepath.Join(c.dir, "exit")
+	fi, err := os.Stat(exitFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to find container exit file for %v: %v", c.id, err)
+	}
+	c.state.Finished, err = getFinishedTime(fi)
+	if err != nil {
+		return fmt.Errorf("failed to get finished time: %v", err)
+	}
+	statusCodeStr, err := ioutil.ReadFile(exitFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read exit file: %v", err)
+	}
+	statusCode, err := strconv.Atoi(string(statusCodeStr))
+	if err != nil {
+		return fmt.Errorf("status code conversion failed: %v", err)
+	}
+	c.state.ExitCode = utils.Int32Ptr(int32(statusCode))
+	return nil
+}
+
 // UpdateContainerStatus refreshes the status of the container.
 func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
+
+	if c.state.ExitCode != nil && !c.state.Finished.IsZero() {
+		logrus.Debugf("Skipping status update for: %+v", c.state)
+		return nil
+	}
 
 	cmd := exec.Command(r.path, rootFlag, r.root, "state", c.id) // nolint: gosec
 	if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
@@ -649,8 +676,10 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 		// We always populate the fields below so kube can restart/reschedule
 		// containers failing.
 		c.state.Status = ContainerStateStopped
-		c.state.Finished = time.Now()
-		c.state.ExitCode = 255
+		if err := updateContainerStatusFromExitFile(c); err != nil {
+			c.state.Finished = time.Now()
+			c.state.ExitCode = utils.Int32Ptr(255)
+		}
 		return nil
 	}
 	if err := json.NewDecoder(bytes.NewBuffer(out)).Decode(&c.state); err != nil {
@@ -677,7 +706,6 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 			})
 		if err != nil {
 			logrus.Warnf("failed to find container exit file for %v: %v", c.id, err)
-			c.state.ExitCode = -1
 		} else {
 			c.state.Finished, err = getFinishedTime(fi)
 			if err != nil {
@@ -691,7 +719,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 			if err != nil {
 				return fmt.Errorf("status code conversion failed: %v", err)
 			}
-			c.state.ExitCode = int32(statusCode)
+			c.state.ExitCode = utils.Int32Ptr(int32(statusCode))
 		}
 
 		oomFilePath := filepath.Join(c.bundlePath, "oom")
@@ -981,7 +1009,7 @@ func (r *Runtime) SpoofOOM(c *Container) {
 
 	c.state.Status = ContainerStateStopped
 	c.state.Finished = time.Now()
-	c.state.ExitCode = 137
+	c.state.ExitCode = utils.Int32Ptr(137)
 	c.state.OOMKilled = true
 
 	oomFilePath := filepath.Join(c.bundlePath, "oom")

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -579,7 +579,8 @@ func (r *runtimeVM) UpdateContainerStatus(c *Container) error {
 
 	c.state.Status = status
 	c.state.Finished = response.ExitedAt
-	c.state.ExitCode = int32(response.ExitStatus)
+	exitCode := int32(response.ExitStatus)
+	c.state.ExitCode = &exitCode
 
 	return nil
 }

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -49,9 +49,9 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	cState := c.State()
 	rStatus := pb.ContainerState_CONTAINER_UNKNOWN
 
-	// If we defaulted to exit code -1 earlier then we attempt to
+	// If we defaulted to exit code not set earlier then we attempt to
 	// get the exit code from the exit file again.
-	if cState.ExitCode == -1 {
+	if cState.Status == oci.ContainerStateStopped && cState.ExitCode == nil {
 		err := s.Runtime().UpdateContainerStatus(c)
 		if err != nil {
 			log.Warnf(ctx, "Failed to UpdateStatus of container %s: %v", c.ID(), err)
@@ -76,11 +76,15 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		resp.Status.StartedAt = started
 		finished := cState.Finished.UnixNano()
 		resp.Status.FinishedAt = finished
-		resp.Status.ExitCode = cState.ExitCode
+		if cState.ExitCode == nil {
+			resp.Status.ExitCode = -1
+		} else {
+			resp.Status.ExitCode = *cState.ExitCode
+		}
 		switch {
 		case cState.OOMKilled:
 			resp.Status.Reason = oomKilledReason
-		case cState.ExitCode == 0:
+		case resp.Status.ExitCode == 0:
 			resp.Status.Reason = completedReason
 		default:
 			resp.Status.Reason = errorReason

--- a/server/container_status_test.go
+++ b/server/container_status_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -51,11 +52,11 @@ var _ = t.Describe("ContainerStatus", func() {
 				State: specs.State{Status: oci.ContainerStateRunning},
 			}, pb.ContainerState_CONTAINER_RUNNING),
 			Entry("Stopped: ExitCode 0", &oci.ContainerState{
-				ExitCode: 0,
+				ExitCode: utils.Int32Ptr(0),
 				State:    specs.State{Status: oci.ContainerStateStopped},
 			}, pb.ContainerState_CONTAINER_EXITED),
 			Entry("Stopped: ExitCode -1", &oci.ContainerState{
-				ExitCode: -1,
+				ExitCode: utils.Int32Ptr(-1),
 				State:    specs.State{Status: oci.ContainerStateStopped},
 			}, pb.ContainerState_CONTAINER_EXITED),
 			Entry("Stopped: OOMKilled", &oci.ContainerState{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -306,3 +306,8 @@ func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir st
 
 	return passwdFile, nil
 }
+
+// Int32Ptr is a utility function to assign to integer pointer variables
+func Int32Ptr(i int32) *int32 {
+	return &i
+}


### PR DESCRIPTION
conmon will save the exit file of the container under
/var/lib so it gets persisted and available even on reboot.

Fixes to better handle exit code:

    Change ExitCode to be a pointer to distinguish from
    exit code 0.
    On reboot if we can't get runc state, then attempt
    to read exit code from the persisted exit file.
    This handles cases where crio was unable to persist
    the state for the container but conmon had written
    the exit file for the container.
    When restoring state during CRI-O startup,
    write back the state to disk so that any missed
    exit file updates are accounted for.

Signed-off-by: Mrunal Patel mrunalp@gmail.com
cherry-pick of https://github.com/cri-o/cri-o/pull/3041