### PR TITLE
managed namespaces: batch infra.State() calls

### DIFF
--- a/internal/lib/sandbox/namespaces_test.go
+++ b/internal/lib/sandbox/namespaces_test.go
@@ -116,7 +116,7 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 			Expect(err).To(BeNil())
 			Expect(len(createdNamespaces)).To(Equal(3))
 			for _, ns := range createdNamespaces {
-				_, found := nsFound[ns]
+				_, found := nsFound[ns.Path()]
 				Expect(found).To(Equal(true))
 			}
 		})
@@ -147,8 +147,8 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 			createdNamespaces, err := testSandbox.CreateNamespacesWithFunc(managedNamespaces, "", withTmpDir.pinNamespaces)
 			Expect(err).To(BeNil())
 
-			for _, file := range createdNamespaces {
-				f, err := os.Create(file)
+			for _, ns := range createdNamespaces {
+				f, err := os.Create(ns.Path())
 				f.Close()
 
 				Expect(err).To(BeNil())
@@ -378,9 +378,10 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 			// When
 			nsPaths := testSandbox.NamespacePaths()
 			// Then
-			Expect(nsPaths[sandbox.UTSNS]).To(ContainSubstring("42"))
-			Expect(nsPaths[sandbox.NETNS]).To(ContainSubstring("42"))
-			Expect(nsPaths[sandbox.IPCNS]).To(ContainSubstring("42"))
+			for _, ns := range nsPaths {
+				Expect(ns.Path()).To(ContainSubstring("42"))
+			}
+			Expect(len(nsPaths)).To(Equal(3))
 		})
 		It("should get managed path despite infra set", func() {
 			// Given
@@ -398,9 +399,10 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 			// When
 			nsPaths := testSandbox.NamespacePaths()
 			// Then
-			Expect(nsPaths[sandbox.UTSNS]).NotTo(ContainSubstring("42"))
-			Expect(nsPaths[sandbox.NETNS]).NotTo(ContainSubstring("42"))
-			Expect(nsPaths[sandbox.IPCNS]).NotTo(ContainSubstring("42"))
+			for _, ns := range nsPaths {
+				Expect(ns.Path()).NotTo(ContainSubstring("42"))
+			}
+			Expect(len(nsPaths)).To(Equal(3))
 		})
 	})
 	t.Describe("NamespacePaths without infra", func() {

--- a/internal/lib/sandbox/namespaces_test.go
+++ b/internal/lib/sandbox/namespaces_test.go
@@ -3,11 +3,15 @@ package sandbox_test
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/oci"
 	sandboxmock "github.com/cri-o/cri-o/test/mocks/sandbox"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // pinNamespaceFunctor is a way to generically create a mockable pinNamespaces() function
@@ -348,6 +352,64 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 			path := testSandbox.UtsNsPath()
 			// Then
 			Expect(path).ToNot(Equal(""))
+		})
+	})
+	t.Describe("NamespacePaths with infra", func() {
+		BeforeEach(func() {
+			testContainer, err := oci.NewContainer("testid", "testname", "",
+				"/container/logs", map[string]string{},
+				map[string]string{}, map[string]string{}, "image",
+				"imageName", "imageRef", &pb.ContainerMetadata{},
+				"testsandboxid", false, false, false, false, "",
+				"/root/for/container", time.Now(), "SIGKILL")
+			Expect(err).To(BeNil())
+			Expect(testContainer).NotTo(BeNil())
+
+			cstate := &oci.ContainerState{}
+			cstate.State = specs.State{
+				Pid: 42,
+			}
+			testContainer.SetState(cstate)
+
+			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
+		})
+		It("should get something when infra set", func() {
+			// Given
+			// When
+			nsPaths := testSandbox.NamespacePaths()
+			// Then
+			Expect(nsPaths[sandbox.UTSNS]).To(ContainSubstring("42"))
+			Expect(nsPaths[sandbox.NETNS]).To(ContainSubstring("42"))
+			Expect(nsPaths[sandbox.IPCNS]).To(ContainSubstring("42"))
+		})
+		It("should get managed path despite infra set", func() {
+			// Given
+			managedNamespaces := []string{"ipc", "net", "uts"}
+			getPath := pinNamespacesFunctor{
+				ifaceModifyFunc: func(ifaceMock *sandboxmock.MockNamespaceIface) {
+					nsType := setPathToDir(genericNamespaceParentDir, ifaceMock)
+					ifaceMock.EXPECT().Get().Return(&sandbox.Namespace{})
+					ifaceMock.EXPECT().Path().Return(filepath.Join(genericNamespaceParentDir, nsType))
+				},
+			}
+			// When
+			_, err := testSandbox.CreateNamespacesWithFunc(managedNamespaces, "", getPath.pinNamespaces)
+			Expect(err).To(BeNil())
+			// When
+			nsPaths := testSandbox.NamespacePaths()
+			// Then
+			Expect(nsPaths[sandbox.UTSNS]).NotTo(ContainSubstring("42"))
+			Expect(nsPaths[sandbox.NETNS]).NotTo(ContainSubstring("42"))
+			Expect(nsPaths[sandbox.IPCNS]).NotTo(ContainSubstring("42"))
+		})
+	})
+	t.Describe("NamespacePaths without infra", func() {
+		It("should get nothing", func() {
+			// Given
+			// When
+			nsPaths := testSandbox.NamespacePaths()
+			// Then
+			Expect(len(nsPaths)).To(Equal(0))
 		})
 	})
 })

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -208,6 +208,8 @@ var _ = t.Describe("Sandbox", func() {
 			Expect(testSandbox.InfraContainer()).To(Equal(testContainer))
 			Expect(testSandbox.UserNsPath()).NotTo(Equal(""))
 			Expect(testSandbox.NetNsPath()).NotTo(Equal(""))
+			Expect(testSandbox.UtsNsPath()).NotTo(Equal(""))
+			Expect(testSandbox.IpcNsPath()).NotTo(Equal(""))
 
 			// And When
 			testSandbox.RemoveInfraContainer()
@@ -216,6 +218,8 @@ var _ = t.Describe("Sandbox", func() {
 			Expect(testSandbox.InfraContainer()).To(BeNil())
 			Expect(testSandbox.UserNsPath()).To(Equal(""))
 			Expect(testSandbox.NetNsPath()).To(Equal(""))
+			Expect(testSandbox.UtsNsPath()).To(Equal(""))
+			Expect(testSandbox.IpcNsPath()).To(Equal(""))
 		})
 
 		It("should fail add an infra container twice", func() {

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -53,18 +53,18 @@ func (mr *MockRuntimeImplMockRecorder) AttachContainer(arg0, arg1, arg2, arg3, a
 }
 
 // ContainerStats mocks base method
-func (m *MockRuntimeImpl) ContainerStats(arg0 *oci.Container) (*oci.ContainerStats, error) {
+func (m *MockRuntimeImpl) ContainerStats(arg0 *oci.Container, arg1 string) (*oci.ContainerStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainerStats", arg0)
+	ret := m.ctrl.Call(m, "ContainerStats", arg0, arg1)
 	ret0, _ := ret[0].(*oci.ContainerStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContainerStats indicates an expected call of ContainerStats
-func (mr *MockRuntimeImplMockRecorder) ContainerStats(arg0 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) ContainerStats(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStats", reflect.TypeOf((*MockRuntimeImpl)(nil).ContainerStats), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStats", reflect.TypeOf((*MockRuntimeImpl)(nil).ContainerStats), arg0, arg1)
 }
 
 // CreateContainer mocks base method


### PR DESCRIPTION
to save on holding the sandbox lock for each namespace, introduce NamespacePaths() to get all namespace paths the sandbox or infra container manage
also share a bit more code between infra and container namespace generation
As well as add unit tests and update some old ones
Signed-off-by: Peter Hunt <pehunt@redhat.com>