### PR TITLE
Fixed cni setup link in crictl.md

### DIFF
--- a/tutorials/crictl.md
+++ b/tutorials/crictl.md
@@ -3,7 +3,7 @@
 This tutorial will walk you through the creation of [Redis](https://redis.io/) server running in a [Pod](http://kubernetes.io/docs/user-guide/pods/) using [crictl](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md)
 
 It assumes you've already downloaded and configured `CRI-O`. If not, see [here for CRI-O](setup.md).
-It also assumes you've set up CNI, and are using the default plugins as described [here](contrib/cni/README.md). If you are using a different configuration, results may vary.
+It also assumes you've set up CNI, and are using the default plugins as described [here](/contrib/cni/README.md). If you are using a different configuration, results may vary.
 
 ## Installation
 


### PR DESCRIPTION
The linked needs to point to the root of project dir, not
the tutorial dir.

Signed-off-by: yihuaf <fang.yihua.eric@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a link to CNI setup in `tutorial/crictl.md`
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
