### PR TITLE
[1.16] oci: Handle timeouts correctly for probes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ version: 2.1
 stdenv: &stdenv
   environment:
     GOCACHE: &gocache /tmp/go-build
-    IMAGE: &image quay.io/crio/crio-build-amd64-go1.13:1.16-1.1.2
-    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.10:1.16-1.1.2
+    IMAGE: &image quay.io/crio/crio-build-amd64-go1.13:1.16-1.1.3
+    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.10:1.16-1.1.3
     JOBS: &jobs 8
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o
 

--- a/contrib/test/integration/build/conmon.yml
+++ b/contrib/test/integration/build/conmon.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/containers/conmon.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/containers/conmon"
-    version: v2.0.8
+    version: v2.0.9
 
 - name: build conmon
   make:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/containernetworking/cni v0.7.1
 	github.com/containernetworking/plugins v0.8.2
 	github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982
-	github.com/containers/conmon v2.0.8+incompatible
+	github.com/containers/conmon v2.0.9+incompatible
 	github.com/containers/image/v5 v5.0.0
 	github.com/containers/libpod v1.6.3-0.20191101152258-04e8bf3dba50
 	github.com/containers/psgo v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982 h1:5WUe09k2s
 github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982/go.mod h1:eGWB4tLoo0hIBuytQpvgUC0hk2mvl2ofaYBeDsU/qoc=
 github.com/containers/conmon v2.0.8+incompatible h1:8A14aNVSUAQ3hCQpPsMcIm/zczge5o+EOUr1XfY++2I=
 github.com/containers/conmon v2.0.8+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
+github.com/containers/conmon v2.0.9+incompatible h1:YcEgk0Ny1WBdH35M2LKe2cG6FiQqzDdVaURw84XvS7A=
+github.com/containers/conmon v2.0.9+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.0.0 h1:arnXgbt1ucsC/ndtSpiQY87rA0UjhF+/xQnPzqdBDn4=
 github.com/containers/image/v5 v5.0.0/go.mod h1:MgiLzCfIeo8lrHi+4Lb8HP+rh513sm0Mlk6RrhjFOLY=
 github.com/containers/libpod v1.6.3-0.20191101152258-04e8bf3dba50 h1:htMcfTu+mPPx1hcNqxUrGhdaCTGYQ1WB+I7GA/Jiffw=

--- a/scripts/build-test-image
+++ b/scripts/build-test-image
@@ -8,7 +8,7 @@ fi
 # Versions to be used
 declare -A VERSIONS=(
     ["cni-plugins"]=v0.8.2
-    ["conmon"]=v2.0.8
+    ["conmon"]=v2.0.9
     ["cri-tools"]=v1.16.1
     ["runc"]=v1.0.0-rc9
 )

--- a/vendor/github.com/containers/conmon/runner/config/config.go
+++ b/vendor/github.com/containers/conmon/runner/config/config.go
@@ -13,4 +13,7 @@ const (
 	// ReopenLogsEvent is the event code the caller program will
 	// send along the ctrl fd to signal conmon to reopen the log files
 	ReopenLogsEvent = 2
+	// TimedOutMessage is the message sent back to the caller by conmon
+	// when a container times out
+	TimedOutMessage = "command timed out"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -92,7 +92,7 @@ github.com/containers/buildah/pkg/cgroups
 github.com/containers/buildah/pkg/chrootuser
 github.com/containers/buildah/pkg/overlay
 github.com/containers/buildah/pkg/cli
-# github.com/containers/conmon v2.0.8+incompatible
+# github.com/containers/conmon v2.0.9+incompatible
 github.com/containers/conmon/runner/config
 # github.com/containers/image/v5 v5.0.0
 github.com/containers/image/v5/types


### PR DESCRIPTION
We shouldn't return a custom error when an exec sync command
times out. Instead, we should return a non-zero exit code.

When the prober code in kubernetes sees a custom error
it goes into Unknown status and doesn't restart containers
on timed out probes as expected.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>


