### PR TITLE
Bump golangci-lint to v1.22.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters:
     # - gochecknoglobals
     # - gocognit
     # - godox
+    # - gomnd
     # - lll
     # - wsl
 linters-settings:

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ ${RELEASE_TOOL}:
 
 ${GOLANGCI_LINT}:
 	export \
-		VERSION=v1.21.0 \
+		VERSION=v1.22.1 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
 	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION


### PR DESCRIPTION
Updating golangci lint to the latest version.