### PR TITLE
Cleanup sandbox shared memory before removing it

### DIFF
--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -88,6 +88,10 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 		}
 	}
 
+	if err := sb.UnmountShm(); err != nil {
+		return nil, err
+	}
+
 	if err := s.StorageRuntimeServer().RemovePodSandbox(sb.ID()); err != nil && err != pkgstorage.ErrInvalidSandboxID {
 		return nil, fmt.Errorf("failed to remove pod sandbox %s: %v", sb.ID(), err)
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -242,12 +242,12 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.SetLinuxMountLabel(mountLabel)
 
 	// Remove the default /dev/shm mount to ensure we overwrite it
-	g.RemoveMount("/dev/shm")
+	g.RemoveMount(sandbox.DevShmPath)
 
 	// create shm mount for the pod containers.
 	var shmPath string
 	if hostIPC {
-		shmPath = "/dev/shm"
+		shmPath = sandbox.DevShmPath
 	} else {
 		shmPath, err = setupShm(podContainer.RunDir, mountLabel)
 		if err != nil {
@@ -266,7 +266,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	mnt := runtimespec.Mount{
 		Type:        "bind",
 		Source:      shmPath,
-		Destination: "/dev/shm",
+		Destination: sandbox.DevShmPath,
 		Options:     []string{"rw", "bind"},
 	}
 	// bind mount the pod shm


### PR DESCRIPTION
If conmon gets killed either with running or without running CRI-O, then
we have no way to cleanup the shared memory for the pod. This will cause
an unlinkat failure, which is now fixed by removing the SHM before
actually touching the sandbox.

Reproduce via:

```bash
> sudo crictl runp test/testdata/sandbox_config.json
> sudo pkill conmon
> sudo crictl rmp -fa
7e4148565ae9430830515329a0cc3578c55fb041232bda4d77a9b3e11a0580d6
ERRO[0000] removing the pod sandbox "7e4148565ae9430830515329a0cc3578c55fb041232bda4d77a9b3e11a0580d6" failed: \
  rpc error: code = Unknown desc = failed to remove pod sandbox 7e4148565ae9430830515329a0cc3578c55fb041232bda4d77a9b3e11a0580d6: \
  unlinkat /var/run/containers/storage/overlay-containers/7e4148565ae9430830515329a0cc3578c55fb041232bda4d77a9b3e11a0580d6/userdata/shm: device or resource busy
FATA[0000] unable to remove sandbox(es)
> sudo crictl pods
POD ID              CREATED             STATE               NAME                NAMESPACE           ATTEMPT
7e4148565ae94       5 seconds ago       NotReady            podsandbox1         redhat.test.crio    1
```

Now:
```
> sudo crictl runp test/testdata/sandbox_config.json && sudo pkill conmon && sudo crictl rmp -fa
746c3b35b02e7c4eb80a4fd9440e7d718217ee61bb039acb638127176721d0c7
Removed sandbox 746c3b35b02e7c4eb80a4fd9440e7d718217ee61bb039acb638127176721d0c7
```

