### PR TITLE
Fix possible segmentation fault in error handling

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -427,7 +427,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	for idx := range cleanupFuncs {
 		defer func(currentFunc int) {
 			if err != nil {
-				if err2 := cleanupFuncs[currentFunc](); err != nil {
+				if err2 := cleanupFuncs[currentFunc](); err2 != nil {
 					log.Debugf(ctx, err2.Error())
 				}
 			}


### PR DESCRIPTION
The check for `err` instead of `err2` will cause a segmentation fault if
`err2 == nil`.

Reproducible by:

```
> sudo ./bin/crio --cni-config-dir=/empty/path
```

```
> sudo crictl run test/testdata/container_redis.json test/testdata/sandbox_config.json
FATA[0000] Running container failed: run pod sandbox failed: rpc error: code = Unavailable desc = transport is closing
```

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1a1fd17]

goroutine 57 [running]:
github.com/cri-o/cri-o/server.(*Server).runPodSandbox.func8(0xc0006b5f90, 0xc0000e4210, 0x1, 0x1, 0x224be20, 0xc00067a690, 0x0)
        /go/src/github.com/cri-o/cri-o/server/sandbox_run_linux.go:431 +0x67
github.com/cri-o/cri-o/server.(*Server).runPodSandbox(0xc0001ee000, 0x224be20, 0xc00067a690, 0xc0005b8260, 0x0, 0x1b95100, 0x228e320)
        /go/src/github.com/cri-o/cri-o/server/sandbox_run_linux.go:528 +0x60ae
github.com/cri-o/cri-o/server.(*Server).RunPodSandbox(0xc0001ee000, 0x224be20, 0xc00067a690, 0xc0005b8260, 0xc0001ee000, 0x1, 0x1)
        /go/src/github.com/cri-o/cri-o/server/sandbox_run.go:69 +0x49
```
