### PR TITLE
Fix possible segmentation fault in namespace removal

### DIFF
--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -218,9 +218,13 @@ func (s *Sandbox) NetNsPath() string {
 
 // NetNsJoin attempts to join the sandbox to an existing network namespace
 // This will fail if the sandbox is already part of a network namespace
-func (s *Sandbox) NetNsJoin(nspath string) (err error) {
-	s.netns, err = nsJoin(nspath, NETNS, s.netns)
-	return err
+func (s *Sandbox) NetNsJoin(nspath string) error {
+	ns, err := nsJoin(nspath, NETNS, s.netns)
+	if err != nil {
+		return err
+	}
+	s.netns = ns
+	return nil
 }
 
 // IpcNs specific functions
@@ -233,8 +237,12 @@ func (s *Sandbox) IpcNsPath() string {
 
 // IpcNsJoin attempts to join the sandbox to an existing IPC namespace
 // This will fail if the sandbox is already part of a IPC namespace
-func (s *Sandbox) IpcNsJoin(nspath string) (err error) {
-	s.ipcns, err = nsJoin(nspath, IPCNS, s.ipcns)
+func (s *Sandbox) IpcNsJoin(nspath string) error {
+	ns, err := nsJoin(nspath, IPCNS, s.ipcns)
+	if err != nil {
+		return err
+	}
+	s.ipcns = ns
 	return err
 }
 
@@ -248,8 +256,12 @@ func (s *Sandbox) UtsNsPath() string {
 
 // UtsNsJoin attempts to join the sandbox to an existing UTS namespace
 // This will fail if the sandbox is already part of a UTS namespace
-func (s *Sandbox) UtsNsJoin(nspath string) (err error) {
-	s.utsns, err = nsJoin(nspath, UTSNS, s.utsns)
+func (s *Sandbox) UtsNsJoin(nspath string) error {
+	ns, err := nsJoin(nspath, UTSNS, s.utsns)
+	if err != nil {
+		return err
+	}
+	s.utsns = ns
 	return err
 }
 
@@ -263,8 +275,12 @@ func (s *Sandbox) UserNsPath() string {
 
 // UserNsJoin attempts to join the sandbox to an existing User namespace
 // This will fail if the sandbox is already part of a User namespace
-func (s *Sandbox) UserNsJoin(nspath string) (err error) {
-	s.userns, err = nsJoin(nspath, USERNS, s.userns)
+func (s *Sandbox) UserNsJoin(nspath string) error {
+	ns, err := nsJoin(nspath, USERNS, s.userns)
+	if err != nil {
+		return err
+	}
+	s.userns = ns
 	return err
 }
 


### PR DESCRIPTION
Before this patch, if the namespace is closed or not retrievable, then
we still assign `nil` to it. In this case the interface checks for `nil`
will not work any more on removal and will trigger a segmentation fault.

This is now fixed by only touching pointers when necessary. Reproducible
via:

```bash
> sudo ./bin/crio &
> sudo crictl runp test/testdata/sandbox_config.json
> sudo pkill crio
> sudo pkill conmon
> sudo umount /run/crio/ns/*/*
> sudo ./bin/crio &
> sudo crictl rmp -fa
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x19840d9]

goroutine 73 [running]:
sync.(*Mutex).Lock(...)
        /usr/lib64/go/1.13/src/sync/mutex.go:74
github.com/cri-o/cri-o/internal/lib/sandbox.(*Namespace).Remove(0x0, 0x0, 0x0)
        /home/sascha/go/src/github.com/cri-o/cri-o/internal/lib/sandbox/namespaces_linux.go:167 +0x49
github.com/cri-o/cri-o/internal/lib/sandbox.(*Sandbox).RemoveManagedNamespaces(0xc0001956c0, 0xc0004a6d40, 0x40)
        /home/sascha/go/src/github.com/cri-o/cri-o/internal/lib/sandbox/namespaces.go:176 +0x84e
github.com/cri-o/cri-o/server.(*Server).RemovePodSandbox(0xc0003f4d80, 0x2251c60, 0xc0006a8000, 0xc00053b0e0, 0xc0003f4d80, 0x1, 0x1)
        /home/sascha/go/src/github.com/cri-o/cri-o/server/sandbox_remove.go:99 +0x1445
```

More background information are available here:
https://www.calhoun.io/when-nil-isnt-equal-to-nil/