### PR TITLE
managed namespaces: remove ErrClosedNS

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -340,41 +340,25 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	if c.config.ManageNSLifecycle {
 		netNsPath, err := configNsPath(&m, rspec.NetworkNamespace)
 		if err == nil {
-			nsErr := sb.NetNsJoin(netNsPath)
-			// If we can't load the networking namespace
-			// because it's closed, we just set the sb netns
-			// pointer to nil. Otherwise we return an error.
-			if nsErr != nil && nsErr != sandbox.ErrClosedNS {
+			if nsErr := sb.NetNsJoin(netNsPath); nsErr != nil {
 				return nsErr
 			}
 		}
 		ipcNsPath, err := configNsPath(&m, rspec.IPCNamespace)
 		if err == nil {
-			nsErr := sb.IpcNsJoin(ipcNsPath)
-			// If we can't load the IPC namespace
-			// because it's closed, we just set the sb ipcns
-			// pointer to nil. Otherwise we return an error.
-			if nsErr != nil && nsErr != sandbox.ErrClosedNS {
+			if nsErr := sb.IpcNsJoin(ipcNsPath); nsErr != nil {
 				return nsErr
 			}
 		}
 		utsNsPath, err := configNsPath(&m, rspec.UTSNamespace)
 		if err == nil {
-			nsErr := sb.UtsNsJoin(utsNsPath)
-			// If we can't load the UTS namespace
-			// because it's closed, we just set the sb utsns
-			// pointer to nil. Otherwise we return an error.
-			if nsErr != nil && nsErr != sandbox.ErrClosedNS {
+			if nsErr := sb.UtsNsJoin(utsNsPath); nsErr != nil {
 				return nsErr
 			}
 		}
 		userNsPath, err := configNsPath(&m, rspec.UserNamespace)
 		if err == nil {
-			nsErr := sb.UserNsJoin(userNsPath)
-			// If we can't load the User namespace
-			// because it's closed, we just set the sb userns
-			// pointer to nil. Otherwise we return an error.
-			if nsErr != nil && nsErr != sandbox.ErrClosedNS {
+			if nsErr := sb.UserNsJoin(userNsPath); nsErr != nil {
 				return nsErr
 			}
 		}

--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -17,10 +17,6 @@ const (
 	USERNS = "user"
 )
 
-// ErrClosedNS is the error returned when the network namespace of the
-// sandbox is closed
-var ErrClosedNS = errors.New("PodSandbox namespace is closed")
-
 // NamespaceIface provides a generic namespace interface
 type NamespaceIface interface {
 	// Close closes this network namespace

--- a/internal/lib/sandbox/namespaces_linux.go
+++ b/internal/lib/sandbox/namespaces_linux.go
@@ -130,7 +130,7 @@ func pinNamespaces(nsTypes []string, pinnsPath string) ([]NamespaceIface, error)
 // returns a Namespace
 func getNamespace(nsPath string) (*Namespace, error) {
 	if err := nspkg.IsNSorErr(nsPath); err != nil {
-		return nil, ErrClosedNS
+		return nil, err
 	}
 
 	ns, err := nspkg.GetNS(nsPath)


### PR DESCRIPTION
we only returned this error if IsNSorError fails, which means the namespace either doesn't exist, or the path is not a namespace.

Both of these errors means the saved spec doesn't accurately describe the pod being created, which is cause for dropping the pod and starting over (a failed restore).

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
