### PR TITLE
Add new NSType for available namespaces

### DIFF
--- a/internal/lib/sandbox/namespaces_linux.go
+++ b/internal/lib/sandbox/namespaces_linux.go
@@ -23,7 +23,7 @@ type Namespace struct {
 	ns          NS
 	closed      bool
 	initialized bool
-	nsType      string
+	nsType      NSType
 	nsPath      string
 }
 
@@ -54,8 +54,8 @@ func (n *Namespace) Initialize() NamespaceIface {
 
 // Creates a new persistent namespace and returns an object
 // representing that namespace, without switching to it
-func pinNamespaces(nsTypes []string, pinnsPath string) ([]NamespaceIface, error) {
-	typeToArg := map[string]string{
+func pinNamespaces(nsTypes []NSType, pinnsPath string) ([]NamespaceIface, error) {
+	typeToArg := map[NSType]string{
 		IPCNS:  "-i",
 		UTSNS:  "-u",
 		USERNS: "-U",
@@ -80,7 +80,7 @@ func pinNamespaces(nsTypes []string, pinnsPath string) ([]NamespaceIface, error)
 	pinnsArgs := []string{"-d", pinDir}
 	type namespaceInfo struct {
 		path   string
-		nsType string
+		nsType NSType
 	}
 
 	mountedNamespaces := make([]namespaceInfo, 0, len(nsTypes))
@@ -91,7 +91,7 @@ func pinNamespaces(nsTypes []string, pinnsPath string) ([]NamespaceIface, error)
 		}
 		pinnsArgs = append(pinnsArgs, arg)
 		mountedNamespaces = append(mountedNamespaces, namespaceInfo{
-			path:   filepath.Join(pinDir, nsType),
+			path:   filepath.Join(pinDir, string(nsType)),
 			nsType: nsType,
 		})
 	}
@@ -150,7 +150,7 @@ func (n *Namespace) Path() string {
 }
 
 // Type returns which namespace this structure represents
-func (n *Namespace) Type() string {
+func (n *Namespace) Type() NSType {
 	return n.nsType
 }
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -751,7 +751,7 @@ func (s *Server) configureGeneratorForSysctls(ctx context.Context, g generate.Ge
 // it returns a slice of cleanup funcs, all of which are the respective NamespaceRemove() for the sandbox.
 // The caller should defer the cleanup funcs if there is an error, to make sure each namespace we are managing is properly cleaned up.
 func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, hostPID bool, sb *sandbox.Sandbox, g generate.Generator) (cleanupFuncs []func() error, err error) {
-	managedNamespaces := make([]string, 0, 3)
+	managedNamespaces := make([]sandbox.NSType, 0, 3)
 	if hostNetwork {
 		err = g.RemoveLinuxNamespace(string(runtimespec.NetworkNamespace))
 		if err != nil {
@@ -801,7 +801,7 @@ func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, ho
 // configureGeneratorGivenNamespacePaths takes a map of nsType -> nsPath. It configures the generator
 // to add or replace the defaults to these paths
 func configureGeneratorGivenNamespacePaths(managedNamespaces []*sandbox.ManagedNamespace, g generate.Generator) error {
-	typeToSpec := map[string]string{
+	typeToSpec := map[sandbox.NSType]string{
 		sandbox.IPCNS:  runtimespec.IPCNamespace,
 		sandbox.NETNS:  runtimespec.NetworkNamespace,
 		sandbox.UTSNS:  runtimespec.UTSNamespace,

--- a/test/mocks/sandbox/sandbox.go
+++ b/test/mocks/sandbox/sandbox.go
@@ -118,10 +118,10 @@ func (mr *MockNamespaceIfaceMockRecorder) Remove() *gomock.Call {
 }
 
 // Type mocks base method
-func (m *MockNamespaceIface) Type() string {
+func (m *MockNamespaceIface) Type() sandbox.NSType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(sandbox.NSType)
 	return ret0
 }
 


### PR DESCRIPTION
We now add an additional abstraction layer on of of available namespace
types by defining a new type `NSType`, which is basically just a string.
This ensures that we (from a programming perspective) only can pass
around the available namespaces defined in `namespaces.go`.