### PR TITLE
[1.16] Don't check for closed namespaces

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -348,10 +348,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		netNsPath, err := configNetNsPath(&m)
 		if err == nil {
 			nsErr := sb.NetNsJoin(netNsPath, sb.Name())
-			// If we can't load the networking namespace
-			// because it's closed, we just set the sb netns
-			// pointer to nil. Otherwise we return an error.
-			if nsErr != nil && nsErr != sandbox.ErrClosedNetNS {
+			if nsErr != nil {
 				return nsErr
 			}
 		}


### PR DESCRIPTION
This is a minimal change backported for 1.16 to solve the issues seen in https://github.com/openshift/containernetworking-plugins/pull/15 and https://bugzilla.redhat.com/show_bug.cgi?id=1754154#c11 as discussed here: https://github.com/cri-o/cri-o/pull/3048#pullrequestreview-339880592

#3086 is a more comprehensive solution for future versions

Signed-off-by: Richard Brown rbrownccb@opensuse.org
