### PR TITLE
server: create cgroupns when running on cgroup v2

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -640,6 +640,13 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		specgen.AddMount(cgroupMnt)
 	}
 
+	// When running on cgroupv2, automatically add a cgroup namespace.
+	if cgroups.IsCgroup2UnifiedMode() {
+		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.CgroupNamespace), ""); err != nil {
+			return nil, err
+		}
+	}
+
 	for idx, ip := range sb.IPs() {
 		specgen.AddAnnotation(fmt.Sprintf("%s.%d", annotations.IP, idx), ip)
 	}


### PR DESCRIPTION
when running on a cgroup 2 host, create automatically the cgroupns.

This is being discussed as part of the cgroup v2 support KEP

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
