### PR TITLE
[1.16] Check for context errors before returning from longer requests

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -623,6 +623,10 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		log.Errorf(ctx, "%v", err)
 	}
 
+	if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
+		return nil, ctx.Err()
+	}
+
 	log.Infof(ctx, "Created container: %s", container.Description())
 	resp := &pb.CreateContainerResponse{
 		ContainerId: containerID,

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -673,6 +673,10 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		log.Errorf(ctx, "%v", err)
 	}
 
+	if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
+		return nil, ctx.Err()
+	}
+
 	log.Infof(ctx, "ran pod sandbox with infra container: %s", container.Description())
 	resp = &pb.RunPodSandboxResponse{PodSandboxId: id}
 	return resp, nil


### PR DESCRIPTION
This is a possible fix for #2984 

The issue seems to be that the kubelet times out on the create request but crio doesn't error out when kubelet client times out. So, we end up with the pod being created and then kubelet keeps on trying to create the pod again and it can't since the name is reserved.

With the change, we error out on timeouts so the pod creation fails and the name is unreserved so later attempts by the kubelet to create a pod or container may succeed.

We may want to add more of these checks around long running operations rather than just at the end in follow-ups. 

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

