### PR TITLE
[1.14] Destroy the pod's network when it can't be restored

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -215,8 +215,9 @@ func (s *Server) restore() {
 
 	// Restore sandbox IPs
 	for _, sb := range s.ListSandboxes() {
-		// Move on if pod was deleted
-		if ok, _ := deletedPods[sb.ID()]; ok {
+		// Clean up networking if pod couldn't be restored and was deleted
+		if ok := deletedPods[sb.ID()]; ok {
+			s.networkStop(sb)
 			continue
 		}
 		ip, err := s.getSandboxIP(sb)


### PR DESCRIPTION
If a pod cannot be restored after restart, destroy the
pod network and release the IPs for fututre use

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>