### PR TITLE
WIP [1.16] Revert "Fixes to better handle exit code"

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -204,7 +204,7 @@ func (c *ContainerServer) Update() error {
 			ctr := c.GetContainer(id)
 			if ctr != nil {
 				// if the container exists, update its state
-				if err := c.ContainerStateFromDisk(ctr); err != nil {
+				if err := c.ContainerStateFromDisk(c.GetContainer(id)); err != nil {
 					logrus.Warnf("unable to retrieve containers %s state from disk: %v", id, err)
 				}
 			}
@@ -411,13 +411,6 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	if err := c.ContainerStateFromDisk(scontainer); err != nil {
 		return fmt.Errorf("error reading sandbox state from disk %q: %v", scontainer.ID(), err)
 	}
-
-	// We write back the state because it is possible that crio did not have a chance to
-	// read the exit file and persist exit code into the state on reboot.
-	if err := c.ContainerStateToDisk(scontainer); err != nil {
-		return fmt.Errorf("failed to write container state to disk %q: %v", scontainer.ID(), err)
-	}
-
 	sb.SetCreated()
 	if err := c.MonitorConmon(scontainer); err != nil {
 		return fmt.Errorf("error adding conmon of sandbox container %s to monitoring loop: %v", scontainer.ID(), err)
@@ -546,12 +539,6 @@ func (c *ContainerServer) LoadContainer(id string) error {
 
 	if err := c.ContainerStateFromDisk(ctr); err != nil {
 		return fmt.Errorf("error reading container state from disk %q: %v", ctr.ID(), err)
-	}
-
-	// We write back the state because it is possible that crio did not have a chance to
-	// read the exit file and persist exit code into the state on reboot.
-	if err := c.ContainerStateToDisk(ctr); err != nil {
-		return fmt.Errorf("failed to write container state to disk %q: %v", ctr.ID(), err)
 	}
 	ctr.SetCreated()
 

--- a/internal/lib/wait.go
+++ b/internal/lib/wait.go
@@ -1,8 +1,6 @@
 package lib
 
 import (
-	"fmt"
-
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -37,8 +35,5 @@ func (c *ContainerServer) ContainerWait(container string) (int32, error) {
 	if err := c.ContainerStateToDisk(ctr); err != nil {
 		logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
-	if exitCode == nil {
-		return 0, fmt.Errorf("exit code not set")
-	}
-	return *exitCode, nil
+	return exitCode, nil
 }

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -73,7 +73,7 @@ type ContainerState struct {
 	Created   time.Time `json:"created"`
 	Started   time.Time `json:"started,omitempty"`
 	Finished  time.Time `json:"finished,omitempty"`
-	ExitCode  *int32    `json:"exitCode,omitempty"`
+	ExitCode  int32     `json:"exitCode,omitempty"`
 	OOMKilled bool      `json:"oomKilled,omitempty"`
 	Error     string    `json:"error,omitempty"`
 }

--- a/internal/oci/memory_store_test.go
+++ b/internal/oci/memory_store_test.go
@@ -2,7 +2,6 @@ package oci_test
 
 import (
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/cri-o/cri-o/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -140,7 +139,7 @@ var _ = t.Describe("MemoryStore", func() {
 
 		It("should succeed apply", func() {
 			// Given
-			newContainerState := &oci.ContainerState{ExitCode: utils.Int32Ptr(-1)}
+			newContainerState := &oci.ContainerState{ExitCode: -1}
 			sut.Add(containerID, testContainer)
 			Expect(sut.Get(containerID)).NotTo(BeNil())
 

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -580,8 +580,7 @@ func (r *runtimeVM) UpdateContainerStatus(c *Container) error {
 
 	c.state.Status = status
 	c.state.Finished = response.ExitedAt
-	exitCode := int32(response.ExitStatus)
-	c.state.ExitCode = &exitCode
+	c.state.ExitCode = int32(response.ExitStatus)
 
 	return nil
 }

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -55,9 +55,9 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	cState := c.State()
 	rStatus := pb.ContainerState_CONTAINER_UNKNOWN
 
-	// If we defaulted to exit code not set earlier then we attempt to
+	// If we defaulted to exit code -1 earlier then we attempt to
 	// get the exit code from the exit file again.
-	if cState.Status == oci.ContainerStateStopped && cState.ExitCode == nil {
+	if cState.ExitCode == -1 {
 		err := s.Runtime().UpdateContainerStatus(c)
 		if err != nil {
 			log.Warnf(ctx, "Failed to UpdateStatus of container %s: %v", c.ID(), err)
@@ -82,15 +82,11 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		resp.Status.StartedAt = started
 		finished := cState.Finished.UnixNano()
 		resp.Status.FinishedAt = finished
-		if cState.ExitCode == nil {
-			resp.Status.ExitCode = -1
-		} else {
-			resp.Status.ExitCode = *cState.ExitCode
-		}
+		resp.Status.ExitCode = cState.ExitCode
 		switch {
 		case cState.OOMKilled:
 			resp.Status.Reason = oomKilledReason
-		case resp.Status.ExitCode == 0:
+		case cState.ExitCode == 0:
 			resp.Status.Reason = completedReason
 		default:
 			resp.Status.Reason = errorReason

--- a/server/container_status_test.go
+++ b/server/container_status_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/cri-o/cri-o/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -52,11 +51,11 @@ var _ = t.Describe("ContainerStatus", func() {
 				State: specs.State{Status: oci.ContainerStateRunning},
 			}, pb.ContainerState_CONTAINER_RUNNING),
 			Entry("Stopped: ExitCode 0", &oci.ContainerState{
-				ExitCode: utils.Int32Ptr(0),
+				ExitCode: 0,
 				State:    specs.State{Status: oci.ContainerStateStopped},
 			}, pb.ContainerState_CONTAINER_EXITED),
 			Entry("Stopped: ExitCode -1", &oci.ContainerState{
-				ExitCode: utils.Int32Ptr(-1),
+				ExitCode: -1,
 				State:    specs.State{Status: oci.ContainerStateStopped},
 			}, pb.ContainerState_CONTAINER_EXITED),
 			Entry("Stopped: OOMKilled", &oci.ContainerState{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -306,8 +306,3 @@ func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir st
 
 	return passwdFile, nil
 }
-
-// Int32Ptr is a utility function to assign to integer pointer variables
-func Int32Ptr(i int32) *int32 {
-	return &i
-}


### PR DESCRIPTION
This reverts commit fe74f7602d56ae54623f6481800f47ea04e1f9a7.

This is a testing commit to verify this is the commit that broke kata in 1.16 (it very likely is)