### PR TITLE
Take total_inactive_file into consideration for memory usage

### DIFF
--- a/internal/oci/stats.go
+++ b/internal/oci/stats.go
@@ -13,18 +13,19 @@ import (
 
 // ContainerStats contains the statistics information for a running container
 type ContainerStats struct {
-	Container   string
-	CPU         float64
-	CPUNano     uint64
-	SystemNano  int64
-	MemUsage    uint64
-	MemLimit    uint64
-	MemPerc     float64
-	NetInput    uint64
-	NetOutput   uint64
-	BlockInput  uint64
-	BlockOutput uint64
-	PIDs        uint64
+	Container       string
+	CPU             float64
+	CPUNano         uint64
+	SystemNano      int64
+	MemUsage        uint64
+	MemLimit        uint64
+	MemPerc         float64
+	NetInput        uint64
+	NetOutput       uint64
+	BlockInput      uint64
+	BlockOutput     uint64
+	PIDs            uint64
+	WorkingSetBytes uint64
 }
 
 // Returns the total number of bytes transmitted and received for the given container stats

--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -39,7 +39,7 @@ func (s *Server) buildContainerStats(stats *oci.ContainerStats, container *oci.C
 		},
 		Memory: &pb.MemoryUsage{
 			Timestamp:       stats.SystemNano,
-			WorkingSetBytes: &pb.UInt64Value{Value: stats.MemUsage},
+			WorkingSetBytes: &pb.UInt64Value{Value: stats.WorkingSetBytes},
 		},
 		WritableLayer: writableLayer,
 	}


### PR DESCRIPTION
We should take the `total_inactive_file` into consideration
when providing the `WorkingSetBytes` to align with other
container runtimes.

Closes #3106