### PR TITLE
docs: remove mention to RHEL-8 beta repo in setup.md

### DIFF
--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -91,8 +91,6 @@ The following dependencies:
   libselinux \
   pkgconfig \
 ```
-are found on the following page: \
-Link: https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/source/Packages/
 
 On Ubuntu distributions, there is a dedicated PPA provided by
 [Project Atomic](https://www.projectatomic.io/):


### PR DESCRIPTION
RHEL-8 beta is outdated. The repo mentioned was last updated
at 15-Nov-2018. Users with RHEL-8 subscription can
have all dependencies installed with no problem.

Signed-off-by: Douglas Schilling Landgraf <dougsland@gmail.com>

**- What I did** Remove old ref. to RHEL-8 beta repo

**- How I did it**  Updating tutorials/setup.md

**- How to verify it**  Double check the last time the repo was updated. Additionally, 8 beta repo is old bits.