### PR TITLE
Fix generated docs formatting

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -41,29 +41,34 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l hooks-dir -r -d 'Set the O
     the semantics of hook injection, see \'oci-hooks(5)\'. CRI-O
     currently support both the 1.0.0 and 0.1.0 hook schemas, although
     the 0.1.0 schema is deprecated.
-
     This option may be set multiple times; paths from later options
     have higher precedence (\'oci-hooks(5)\' discusses directory
     precedence).
-
-	For the annotation conditions, CRI-O uses the Kubernetes
+    For the annotation conditions, CRI-O uses the Kubernetes
     annotations, which are a subset of the annotations passed to the
     OCI runtime. For example, \'io.kubernetes.cri-o.Volumes\' is part of
     the OCI runtime configuration annotations, but it is not part of
     the Kubernetes annotations being matched for hooks.
-
     For the bind-mount conditions, only mounts explicitly requested by
     Kubernetes configuration are considered. Bind mounts that CRI-O
     inserts by default (e.g. \'/dev/shm\') are not considered.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l host-ip -r -d 'Host IPs are the addresses to be used for the host network and can be specified up to two times'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l image-volumes -r -d 'Image volume handling (\'mkdir\', \'bind\', or \'ignore\')
-    1. mkdir: A directory is created inside the container root filesystem for the volumes.
-    2. bind: A directory is created inside container state directory and bind mounted into the container for the volumes.
-    3. ignore: All volumes are just ignored and no action is taken.'
+    1. mkdir: A directory is created inside the container root filesystem for
+       the volumes.
+    2. bind: A directory is created inside container state directory and bind
+       mounted into the container for the volumes.
+	3. ignore: All volumes are just ignored and no action is taken.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l insecure-registry -r -d 'Enable insecure registry communication, i.e., enable un-encrypted and/or untrusted communication.
-    1. List of insecure registries can contain an element with CIDR notation to specify a whole subnet.
-    2. Insecure registries accept HTTP or accept HTTPS with certificates from unknown CAs.
-    3. Enabling \'--insecure-registry\' is useful when running a local registry. However, because its use creates security vulnerabilities, **it should ONLY be enabled for testing purposes**. For increased security, users should add their CA to their system\'s list of trusted CAs instead of using \'--insecure-registry\'.'
+    1. List of insecure registries can contain an element with CIDR notation to
+       specify a whole subnet.
+    2. Insecure registries accept HTTP or accept HTTPS with certificates from
+       unknown CAs.
+    3. Enabling \'--insecure-registry\' is useful when running a local registry.
+       However, because its use creates security vulnerabilities, **it should ONLY
+       be enabled for testing purposes**. For increased security, users should add
+       their CA to their system\'s list of trusted CAs instead of using
+       \'--insecure-registry\'.'
 complete -c crio -n '__fish_crio_no_subcommand' -l listen -r -d 'Path to the CRI-O socket (default: "/var/run/crio/crio.sock")'
 complete -c crio -n '__fish_crio_no_subcommand' -l log -r -d 'Set the log file path where internal debug information is written'
 complete -c crio -n '__fish_crio_no_subcommand' -l log-dir -r -d 'Default log directory where all logs will go unless directly specified by the kubelet'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -171,17 +171,14 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
     the semantics of hook injection, see 'oci-hooks(5)'. CRI-O
     currently support both the 1.0.0 and 0.1.0 hook schemas, although
     the 0.1.0 schema is deprecated.
-
     This option may be set multiple times; paths from later options
     have higher precedence ('oci-hooks(5)' discusses directory
     precedence).
-
-	For the annotation conditions, CRI-O uses the Kubernetes
+    For the annotation conditions, CRI-O uses the Kubernetes
     annotations, which are a subset of the annotations passed to the
     OCI runtime. For example, 'io.kubernetes.cri-o.Volumes' is part of
     the OCI runtime configuration annotations, but it is not part of
     the Kubernetes annotations being matched for hooks.
-
     For the bind-mount conditions, only mounts explicitly requested by
     Kubernetes configuration are considered. Bind mounts that CRI-O
     inserts by default (e.g. '/dev/shm') are not considered. (default: [])
@@ -189,14 +186,22 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 **--host-ip**="": Host IPs are the addresses to be used for the host network and can be specified up to two times (default: [])
 
 **--image-volumes**="": Image volume handling ('mkdir', 'bind', or 'ignore')
-    1. mkdir: A directory is created inside the container root filesystem for the volumes.
-    2. bind: A directory is created inside container state directory and bind mounted into the container for the volumes.
-    3. ignore: All volumes are just ignored and no action is taken. (default: mkdir)
+    1. mkdir: A directory is created inside the container root filesystem for
+       the volumes.
+    2. bind: A directory is created inside container state directory and bind
+       mounted into the container for the volumes.
+	3. ignore: All volumes are just ignored and no action is taken. (default: mkdir)
 
 **--insecure-registry**="": Enable insecure registry communication, i.e., enable un-encrypted and/or untrusted communication.
-    1. List of insecure registries can contain an element with CIDR notation to specify a whole subnet.
-    2. Insecure registries accept HTTP or accept HTTPS with certificates from unknown CAs.
-    3. Enabling '--insecure-registry' is useful when running a local registry. However, because its use creates security vulnerabilities, **it should ONLY be enabled for testing purposes**. For increased security, users should add their CA to their system's list of trusted CAs instead of using '--insecure-registry'. (default: [])
+    1. List of insecure registries can contain an element with CIDR notation to
+       specify a whole subnet.
+    2. Insecure registries accept HTTP or accept HTTPS with certificates from
+       unknown CAs.
+    3. Enabling '--insecure-registry' is useful when running a local registry.
+       However, because its use creates security vulnerabilities, **it should ONLY
+       be enabled for testing purposes**. For increased security, users should add
+       their CA to their system's list of trusted CAs instead of using
+       '--insecure-registry'. (default: [])
 
 **--listen**="": Path to the CRI-O socket (default: "/var/run/crio/crio.sock")
 

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -405,9 +405,15 @@ func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext)
 			Name:  "insecure-registry",
 			Value: cli.NewStringSlice(defConf.InsecureRegistries...),
 			Usage: "Enable insecure registry communication, i.e., enable un-encrypted and/or untrusted communication." + `
-    1. List of insecure registries can contain an element with CIDR notation to specify a whole subnet.
-    2. Insecure registries accept HTTP or accept HTTPS with certificates from unknown CAs.
-    3. Enabling '--insecure-registry' is useful when running a local registry. However, because its use creates security vulnerabilities, **it should ONLY be enabled for testing purposes**. For increased security, users should add their CA to their system's list of trusted CAs instead of using '--insecure-registry'.`,
+    1. List of insecure registries can contain an element with CIDR notation to
+       specify a whole subnet.
+    2. Insecure registries accept HTTP or accept HTTPS with certificates from
+       unknown CAs.
+    3. Enabling '--insecure-registry' is useful when running a local registry.
+       However, because its use creates security vulnerabilities, **it should ONLY
+       be enabled for testing purposes**. For increased security, users should add
+       their CA to their system's list of trusted CAs instead of using
+       '--insecure-registry'.`,
 			EnvVars: []string{"CONTAINER_INSECURE_REGISTRY"},
 		},
 		&cli.StringSliceFlag{
@@ -496,9 +502,11 @@ func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext)
 			Name:  "image-volumes",
 			Value: string(libconfig.ImageVolumesMkdir),
 			Usage: "Image volume handling ('mkdir', 'bind', or 'ignore')" + `
-    1. mkdir: A directory is created inside the container root filesystem for the volumes.
-    2. bind: A directory is created inside container state directory and bind mounted into the container for the volumes.
-    3. ignore: All volumes are just ignored and no action is taken.`,
+    1. mkdir: A directory is created inside the container root filesystem for
+       the volumes.
+    2. bind: A directory is created inside container state directory and bind
+       mounted into the container for the volumes.
+	3. ignore: All volumes are just ignored and no action is taken.`,
 			EnvVars: []string{"CONTAINER_IMAGE_VOLUMES"},
 		},
 		&cli.StringSliceFlag{
@@ -509,17 +517,14 @@ func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext)
     the semantics of hook injection, see 'oci-hooks(5)'. CRI-O
     currently support both the 1.0.0 and 0.1.0 hook schemas, although
     the 0.1.0 schema is deprecated.
-
     This option may be set multiple times; paths from later options
     have higher precedence ('oci-hooks(5)' discusses directory
     precedence).
-
-	For the annotation conditions, CRI-O uses the Kubernetes
+    For the annotation conditions, CRI-O uses the Kubernetes
     annotations, which are a subset of the annotations passed to the
     OCI runtime. For example, 'io.kubernetes.cri-o.Volumes' is part of
     the OCI runtime configuration annotations, but it is not part of
     the Kubernetes annotations being matched for hooks.
-
     For the bind-mount conditions, only mounts explicitly requested by
     Kubernetes configuration are considered. Bind mounts that CRI-O
     inserts by default (e.g. '/dev/shm') are not considered.`,


### PR DESCRIPTION
This fixes the markdown as well as the man page formatting for the CLI
documentation.