### PR TITLE
Allow server to start without config

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -215,7 +215,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--log-journald**: Log to systemd journal (journald) in addition to kubernetes log file (default: false)
 
-**--log-level, -l**="": Log messages above specified level: trace, debug, info, warn, error, fatal or panic (default: error)
+**--log-level, -l**="": Log messages above specified level: trace, debug, info, warn, error, fatal or panic (default: info)
 
 **--log-size-max**="": Maximum log size in bytes for a container. If it is positive, it must be >= 8192 to match/exceed conmon read buffer (default: -1)
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -167,7 +167,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **log_filter**=""
   Filter the log messages by the provided regular expression. This option supports live configuration reload. For example 'request:.*' filters all gRPC requests.
 
-**log_level**="error"
+**log_level**="info"
   Changes the verbosity of the logs based on the level it is set to. Options are fatal, panic, error, warn, info, and debug. This option supports live configuration reload.
 
 **log_size_max**=-1

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/image/v5/types"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -53,11 +52,6 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) (string, error) {
 					}
 				}
 			}
-
-			// We don't error out if --config wasn't explicitly set and the
-			// default doesn't exist. But we will log a warning about it, so
-			// the user doesn't miss it.
-			logrus.Warnf("default configuration file does not exist: %s", path)
 		}
 	}
 
@@ -332,7 +326,7 @@ func getCrioFlags(defConf *libconfig.Config, systemContext *types.SystemContext)
 		&cli.StringFlag{
 			Name:    "log-level",
 			Aliases: []string{"l"},
-			Value:   "error",
+			Value:   "info",
 			Usage:   "Log messages above specified level: trace, debug, info, warn, error, fatal or panic",
 			EnvVars: []string{"CONTAINER_LOG_LEVEL"},
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -514,7 +514,7 @@ func DefaultConfig() (*Config, error) {
 			LogSizeMax:               DefaultLogSizeMax,
 			LogToJournald:            DefaultLogToJournald,
 			DefaultCapabilities:      DefaultCapabilities,
-			LogLevel:                 "error",
+			LogLevel:                 "info",
 			DefaultSysctls:           []string{},
 			DefaultUlimits:           []string{},
 			AdditionalDevices:        []string{},

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -51,7 +51,7 @@ var _ = t.Describe("Config", func() {
 		It("should fail with invalid log_level", func() {
 			// Given
 			filePath := modifyDefaultConfig(
-				`log_level = "error"`,
+				`log_level = "info"`,
 				`log_level = "invalid"`,
 			)
 

--- a/server/server.go
+++ b/server/server.go
@@ -465,15 +465,13 @@ func New(
 
 	// Start a configuration watcher for the default config
 	if _, err := s.StartConfigWatcher(configPath, s.config.Reload); err != nil {
-		logrus.Warnf("unable to start config watcher for file %q: %v",
-			configPath, err)
+		logrus.Infof("unable to start config watcher: %v", err)
 	}
 
 	// Start a configuration watcher for the registries of the SystemContext
 	registriesPath := sysregistriesv2.ConfigPath(s.systemContext)
 	if _, err := s.StartConfigWatcher(registriesPath, s.ReloadRegistries); err != nil {
-		logrus.Warnf("unable to start config watcher for file %q: %v",
-			registriesPath, err)
+		logrus.Infof("unable to start config watcher: %v", err)
 	}
 
 	// Start the metrics server if configured to be enabled


### PR DESCRIPTION
We already search required runtime dependencies inside paths so the
existence of global `crio.conf` is not necessary in all cases. We will
now not warn any more if the configuration file does not exist on the
system as well as set default the `log_level` to `info` to provide a
better default startup context.