### PR TITLE
[1.16] fail on network stop

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -10,7 +10,7 @@ function __fish_crio_no_subcommand --description 'Test if there has been any sub
 end
 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l additional-devices -r -d 'devices to add to the containers (default: [])'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l apparmor-profile -r -d 'default apparmor profile name (default: "crio-default-1.16.1")'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l apparmor-profile -r -d 'default apparmor profile name (default: "crio-default-1.16.2")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l bind-mount-prefix -r -d 'specify a prefix to prepend to the source of a bind mount (default: "")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l cgroup-manager -r -d 'cgroup manager (cgroupfs or systemd) (default: "cgroupfs")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l cni-config-dir -r -d 'CNI configuration files directory (default: "/etc/cni/net.d/")'

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -428,6 +428,9 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	if err := sb.SetInfraContainer(scontainer); err != nil {
 		return err
 	}
+
+	sb.RestoreStopped()
+
 	if err := c.ctrIDIndex.Add(scontainer.ID()); err != nil {
 		return err
 	}

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -107,10 +107,23 @@ var _ = t.Describe("Sandbox", func() {
 			Expect(testSandbox.Stopped()).To(BeFalse())
 
 			// When
-			testSandbox.SetStopped()
+			testSandbox.SetStopped(false)
 
 			// Then
 			Expect(testSandbox.Stopped()).To(BeTrue())
+		})
+	})
+
+	t.Describe("NetworkStopped", func() {
+		It("should succeed", func() {
+			// Given
+			Expect(testSandbox.NetworkStopped()).To(BeFalse())
+
+			// When
+			Expect(testSandbox.SetNetworkStopped(false)).To(BeNil())
+
+			// Then
+			Expect(testSandbox.NetworkStopped()).To(BeTrue())
 		})
 	})
 
@@ -210,7 +223,8 @@ var _ = t.Describe("Sandbox", func() {
 			Expect(err).To(BeNil())
 			Expect(testSandbox.InfraContainer()).To(Equal(testContainer))
 			Expect(testSandbox.UserNsPath()).NotTo(Equal(""))
-			Expect(testSandbox.NetNsPath()).NotTo(Equal(""))
+			// while we have a sandbox, it does not have a valid network namespace
+			Expect(testSandbox.NetNsPath()).To(Equal(""))
 
 			// And When
 			testSandbox.RemoveInfraContainer()

--- a/server/container_create_test.go
+++ b/server/container_create_test.go
@@ -83,7 +83,7 @@ var _ = t.Describe("ContainerCreate", func() {
 		It("should fail when container is stopped", func() {
 			// Given
 			addContainerAndSandbox()
-			testSandbox.SetStopped()
+			testSandbox.SetStopped(false)
 
 			// When
 			response, err := sut.CreateContainer(context.Background(),

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -10,6 +10,7 @@ import (
 	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/pkg/log"
+	"github.com/pkg/errors"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
 )
 
@@ -29,7 +30,9 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 	// but an error happened between plugin success and the end of networkStart()
 	defer func() {
 		if err != nil {
-			s.networkStop(ctx, sb)
+			if err2 := s.networkStop(ctx, sb); err2 != nil {
+				log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
+			}
 		}
 	}()
 
@@ -115,9 +118,9 @@ func (s *Server) getSandboxIPs(sb *sandbox.Sandbox) (podIPs []string, err error)
 
 // networkStop cleans up and removes a pod's network.  It is best-effort and
 // must call the network plugin even if the network namespace is already gone
-func (s *Server) networkStop(ctx context.Context, sb *sandbox.Sandbox) {
-	if sb.HostNetwork() {
-		return
+func (s *Server) networkStop(ctx context.Context, sb *sandbox.Sandbox) error {
+	if sb.HostNetwork() || sb.NetworkStopped() {
+		return nil
 	}
 
 	if err := s.hostportManager.Remove(sb.ID(), &hostport.PodPortMapping{
@@ -131,11 +134,11 @@ func (s *Server) networkStop(ctx context.Context, sb *sandbox.Sandbox) {
 
 	podNetwork, err := s.newPodNetwork(sb)
 	if err != nil {
-		log.Warnf(ctx, err.Error())
-		return
+		return err
 	}
 	if err := s.netPlugin.TearDownPod(podNetwork); err != nil {
-		log.Warnf(ctx, "failed to destroy network for pod sandbox %s(%s): %v",
-			sb.Name(), sb.ID(), err)
+		return errors.Wrapf(err, "failed to destroy network for pod sandbox %s(%s)", sb.Name(), sb.ID())
 	}
+
+	return sb.SetNetworkStopped(true)
 }

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -578,7 +578,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 		defer func() {
 			if err != nil {
-				s.networkStop(ctx, sb)
+				if err2 := s.networkStop(ctx, sb); err2 != nil {
+					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
+				}
 			}
 		}()
 	}
@@ -661,7 +663,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 		defer func() {
 			if err != nil {
-				s.networkStop(ctx, sb)
+				if err2 := s.networkStop(ctx, sb); err2 != nil {
+					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
+				}
 			}
 		}()
 	}

--- a/server/sandbox_stop_test.go
+++ b/server/sandbox_stop_test.go
@@ -23,7 +23,8 @@ var _ = t.Describe("PodSandboxStatus", func() {
 		It("should succeed with already stopped sandbox", func() {
 			// Given
 			addContainerAndSandbox()
-			testSandbox.SetStopped()
+			testSandbox.SetStopped(false)
+			Expect(testSandbox.SetNetworkStopped(false)).To(BeNil())
 
 			// When
 			response, err := sut.StopPodSandbox(context.Background(),

--- a/server/server.go
+++ b/server/server.go
@@ -228,7 +228,9 @@ func (s *Server) restore(ctx context.Context) {
 	for _, sb := range s.ListSandboxes() {
 		// Clean up networking if pod couldn't be restored and was deleted
 		if ok := deletedPods[sb.ID()]; ok {
-			s.networkStop(ctx, sb)
+			if err := s.networkStop(ctx, sb); err != nil {
+				logrus.Warnf("error stopping network on restore cleanup %v:", err)
+			}
 			continue
 		}
 		ips, err := s.getSandboxIPs(sb)


### PR DESCRIPTION
Move stopNetwork call to earlier in sandbox stop function. This means we unconditionally stop the network.
Add sb.*NetworkStopped functions
Create files in infra's persistent dir to restore {,network}Stopped state
update tests accordingly

Signed-off-by: Peter Hunt <pehunt@redhat.com>
