### PR TITLE
Update golangci-lint to v1.23.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - gofmt
     - goimports
     - golint
+    - goprintffuncname
     - gosec
     - gosimple
     - govet
@@ -36,6 +37,7 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - rowserrcheck
     - scopelint
     - staticcheck
     - structcheck

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ ${RELEASE_TOOL}:
 
 ${GOLANGCI_LINT}:
 	export \
-		VERSION=v1.22.1 \
+		VERSION=v1.23.1 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
 	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION


### PR DESCRIPTION
This also enables two new linters which do not complain out of the box.