### PR TITLE
Fail to start when already listening on socket

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -600,6 +600,10 @@ func (c *APIConfig) Validate(onExecution bool) error {
 
 		// Remove the socket if it already exists
 		if _, err := os.Stat(c.Listen); err == nil {
+			if _, err := net.DialTimeout("unix", c.Listen, 0); err == nil {
+				return errors.Errorf("already existing crio connection on %s", c.Listen)
+			}
+
 			if err := os.Remove(c.Listen); err != nil {
 				return err
 			}


### PR DESCRIPTION
If CRI-O is already listening on a socket, then we should fail to start
the server, which was not the case before this patch.