### PR TITLE
Fail to start when stream server port already allocated

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -457,7 +457,7 @@ func New(
 	go func() {
 		defer close(s.stream.streamServerCloseCh)
 		if err := s.stream.streamServer.Start(true); err != nil && err != http.ErrServerClosed {
-			logrus.Errorf("Failed to start streaming server: %v", err)
+			logrus.Fatalf("Failed to start streaming server: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
If the streaming server port is already used then we should fail on
CRI-O startup.