### PR TITLE
Refactor sysctl handling and add unit tests

### DIFF
--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -162,7 +162,7 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) (string, error) {
 		config.DefaultCapabilities = strings.Split(ctx.String("default-capabilities"), ",")
 	}
 	if ctx.IsSet("default-sysctls") {
-		config.DefaultSysctls = strings.Split(ctx.String("default-sysctls"), ",")
+		config.DefaultSysctls = ctx.StringSlice("default-sysctls")
 	}
 	if ctx.IsSet("default-ulimits") {
 		config.DefaultUlimits = ctx.StringSlice("default-ulimits")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -725,6 +725,10 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 		return fmt.Errorf("log size max should be negative or >= %d", OCIBufSize)
 	}
 
+	if _, err := c.Sysctls(); err != nil {
+		return errors.Wrapf(err, "invalid default_sysctls")
+	}
+
 	// check for validation on execution
 	if onExecution {
 		if err := c.ValidateRuntimes(); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -439,6 +439,17 @@ var _ = t.Describe("Config", func() {
 			Expect(err).To(BeNil())
 			Expect(sut.DefaultRuntime).To(Equal("runc"))
 		})
+
+		It("should fail on invalid default_sysctls", func() {
+			// Given
+			sut.DefaultSysctls = []string{"invalid"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
 	})
 
 	t.Describe("ValidateRuntimes", func() {

--- a/pkg/config/sysctl.go
+++ b/pkg/config/sysctl.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Sysctl is a generic abstraction over key value based sysctls
+type Sysctl struct {
+	key, value string
+}
+
+// Key returns the key of the sysctl (key=value format)
+func (s *Sysctl) Key() string {
+	return s.key
+}
+
+// Value returns the value of the sysctl (key=value format)
+func (s *Sysctl) Value() string {
+	return s.value
+}
+
+// Sysctls returns the parsed sysctl slice and an error if not parsable
+func (c *RuntimeConfig) Sysctls() (sysctls []Sysctl, err error) {
+	for _, sysctl := range c.DefaultSysctls {
+		// skip empty values for sake of backwards compatibility
+		if sysctl == "" {
+			continue
+		}
+		split := strings.SplitN(sysctl, "=", 2)
+		if len(split) == 2 {
+			sysctls = append(sysctls, Sysctl{key: split[0], value: split[1]})
+		} else {
+			return nil, errors.Errorf("%q is not in key=value format", sysctl)
+		}
+	}
+	return sysctls, nil
+}
+
+// Namespace represents a kernel namespace name.
+type Namespace string
+
+const (
+	// IpcNamespace is the Linux IPC namespace
+	IpcNamespace = Namespace("ipc")
+
+	// NetNamespace is the network namespace
+	NetNamespace = Namespace("net")
+
+	// UnknownNamespace is the zero value if no namespace is known
+	UnknownNamespace = Namespace("")
+)
+
+var namespaces = map[string]Namespace{
+	"kernel.sem": IpcNamespace,
+}
+
+var prefixNamespaces = map[string]Namespace{
+	"kernel.shm": IpcNamespace,
+	"kernel.msg": IpcNamespace,
+	"fs.mqueue.": IpcNamespace,
+	"net.":       NetNamespace,
+}
+
+// Validate checks that a sysctl is whitelisted because it is known to be
+// namespaced by the Linux kernel. The parameters hostNet and hostIPC are used
+// to forbid sysctls for pod sharing the respective namespaces with the host.
+// This check is only used on sysctls defined by the user in the crio.conf
+// file.
+func (s *Sysctl) Validate(hostNet, hostIPC bool) error {
+	nsErrorFmt := "%q not allowed with host %s enabled"
+	if ns, found := namespaces[s.Key()]; found {
+		if ns == IpcNamespace && hostIPC {
+			return errors.Errorf(nsErrorFmt, s.Key(), ns)
+		}
+		return nil
+	}
+	for p, ns := range prefixNamespaces {
+		if strings.HasPrefix(s.Key(), p) {
+			if ns == IpcNamespace && hostIPC {
+				return errors.Errorf(nsErrorFmt, s.Key(), ns)
+			}
+			if ns == NetNamespace && hostNet {
+				return errors.Errorf(nsErrorFmt, s.Key(), ns)
+			}
+			return nil
+		}
+	}
+	return errors.Errorf("%s not whitelisted", s.Key())
+}

--- a/pkg/config/sysctl_test.go
+++ b/pkg/config/sysctl_test.go
@@ -1,0 +1,147 @@
+package config_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The actual test suite
+var _ = t.Describe("Sysctl", func() {
+	BeforeEach(beforeEach)
+
+	It("should succeed to parse sysctls in default config", func() {
+		// Given
+		// When
+		sysctls, err := sut.Sysctls()
+
+		// Then
+		Expect(err).To(BeNil())
+		Expect(sysctls).To(BeEmpty())
+	})
+
+	It("should succeed to parse sysctls in key=value format", func() {
+		// Given
+		sut.DefaultSysctls = []string{
+			"a=b",
+			"",
+			"key=value",
+			"some-fancy-foo=some-other-bar",
+		}
+
+		// When
+		sysctls, err := sut.Sysctls()
+
+		// Then
+		Expect(err).To(BeNil())
+		Expect(sysctls).To(HaveLen(3))
+		Expect(sysctls[0].Key()).To(Equal("a"))
+		Expect(sysctls[0].Value()).To(Equal("b"))
+		Expect(sysctls[1].Key()).To(Equal("key"))
+		Expect(sysctls[1].Value()).To(Equal("value"))
+		Expect(sysctls[2].Key()).To(Equal("some-fancy-foo"))
+		Expect(sysctls[2].Value()).To(Equal("some-other-bar"))
+	})
+
+	It("should fail to parse sysctls in wrong format", func() {
+		// Given
+		sut.DefaultSysctls = []string{"wrong-format"}
+
+		// When
+		sysctls, err := sut.Sysctls()
+
+		// Then
+		Expect(err).NotTo(BeNil())
+		Expect(sysctls).To(BeNil())
+	})
+
+	It("should fail to validate not whitelisted sysctl with host NET and IPC namespaces", func() {
+		// Given
+		sut.DefaultSysctls = []string{"a=b"}
+		sysctls, err := sut.Sysctls()
+		Expect(err).To(BeNil())
+
+		// When
+		err = sysctls[0].Validate(true, true)
+
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+
+	It("should fail to validate not whitelisted sysctl without host NET and IPC namespaces", func() {
+		// Given
+		sut.DefaultSysctls = []string{"a=b"}
+		sysctls, err := sut.Sysctls()
+		Expect(err).To(BeNil())
+
+		// When
+		err = sysctls[0].Validate(false, false)
+
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+
+	It("should fail to validate whitelisted sysctl with enabled host NET namespace", func() {
+		// Given
+		sut.DefaultSysctls = []string{"net.ipv4.ip_forward=1"}
+		sysctls, err := sut.Sysctls()
+		Expect(err).To(BeNil())
+
+		// When
+		err = sysctls[0].Validate(true, false)
+
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+
+	It("should fail to validate whitelisted sysctl with enabled host IPC namespace", func() {
+		// Given
+		sut.DefaultSysctls = []string{"kernel.shmmax=100"}
+		sysctls, err := sut.Sysctls()
+		Expect(err).To(BeNil())
+
+		// When
+		err = sysctls[0].Validate(false, true)
+
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+
+	It("should succeed to validate whitelisted sysctl with disabled host NET namespace", func() {
+		// Given
+		sut.DefaultSysctls = []string{"net.ipv4.ip_forward=1"}
+		sysctls, err := sut.Sysctls()
+		Expect(err).To(BeNil())
+
+		// When
+		err = sysctls[0].Validate(false, true)
+
+		// Then
+		Expect(err).To(BeNil())
+	})
+
+	It("should succeed to validate whitelisted kernel sysctl with disabled host NET and IPC namespaces", func() {
+		// Given
+		sut.DefaultSysctls = []string{"kernel.sem=32001 1 1"}
+		sysctls, err := sut.Sysctls()
+		Expect(err).To(BeNil())
+
+		// When
+		err = sysctls[0].Validate(false, false)
+
+		// Then
+		Expect(err).To(BeNil())
+	})
+
+	It("should fail to validate whitelisted kernel sysctl with enabled host IPC namespace", func() {
+		// Given
+		sut.DefaultSysctls = []string{"kernel.sem=32001 1 1"}
+		sysctls, err := sut.Sysctls()
+		Expect(err).To(BeNil())
+
+		// When
+		err = sysctls[0].Validate(false, true)
+
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+})

--- a/server/utils.go
+++ b/server/utils.go
@@ -228,61 +228,6 @@ func mergeEnvs(imageConfig *v1.Image, kubeEnvs []*pb.KeyValue) []string {
 	return envs
 }
 
-// Namespace represents a kernel namespace name.
-type Namespace string
-
-const (
-	// IpcNamespace is the Linux IPC namespace
-	IpcNamespace = Namespace("ipc")
-
-	// NetNamespace is the network namespace
-	NetNamespace = Namespace("net")
-
-	// UnknownNamespace is the zero value if no namespace is known
-	UnknownNamespace = Namespace("")
-)
-
-var namespaces = map[string]Namespace{
-	"kernel.sem": IpcNamespace,
-}
-
-var prefixNamespaces = map[string]Namespace{
-	"kernel.shm": IpcNamespace,
-	"kernel.msg": IpcNamespace,
-	"fs.mqueue.": IpcNamespace,
-	"net.":       NetNamespace,
-}
-
-// validateSysctl checks that a sysctl is whitelisted because it is known
-// to be namespaced by the Linux kernel.
-// The parameters hostNet and hostIPC are used to forbid sysctls for pod sharing the
-// respective namespaces with the host. This check is only used on sysctls defined by
-// the user in the crio.conf file.
-func validateSysctl(sysctl string, hostNet, hostIPC bool) error {
-	nsErrorFmt := "%q not allowed with host %s enabled"
-	if ns, found := namespaces[sysctl]; found {
-		if ns == IpcNamespace && hostIPC {
-			return errors.Errorf(nsErrorFmt, sysctl, ns)
-		}
-		if ns == NetNamespace && hostNet {
-			return errors.Errorf(nsErrorFmt, sysctl, ns)
-		}
-		return nil
-	}
-	for p, ns := range prefixNamespaces {
-		if strings.HasPrefix(sysctl, p) {
-			if ns == IpcNamespace && hostIPC {
-				return errors.Errorf(nsErrorFmt, sysctl, ns)
-			}
-			if ns == NetNamespace && hostNet {
-				return errors.Errorf(nsErrorFmt, sysctl, ns)
-			}
-			return nil
-		}
-	}
-	return errors.Errorf("%q not whitelisted", sysctl)
-}
-
 type ulimit struct {
 	name string
 	hard uint64


### PR DESCRIPTION
This fixes the CLI default_sysctl string slice handling and refactors
the validation/parsing of the sysctls in to the config package. We now
pre-check if the sysctls are parsable via the CLI to reduce the error
surface. Unit tests for all parsing and validation cases have been added
as well.