### PR TITLE
Fix unit tests for rootless runs

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,6 +19,8 @@ var _ = t.Describe("Config", func() {
 		sut.Runtimes["runc"] = &config.RuntimeHandler{
 			RuntimePath: validFilePath, RuntimeType: config.DefaultRuntimeType,
 		}
+		sut.PinnsPath = validFilePath
+		sut.NamespacesDir = os.TempDir()
 		sut.Conmon = validFilePath
 		tmpDir := t.MustTempDir("cni-test")
 		sut.NetworkConfig.PluginDirs = []string{tmpDir}
@@ -232,6 +234,8 @@ var _ = t.Describe("Config", func() {
 				RuntimePath: validFilePath,
 				RuntimeType: config.DefaultRuntimeType,
 			}
+			sut.PinnsPath = validFilePath
+			sut.NamespacesDir = os.TempDir()
 			sut.Conmon = validFilePath
 			sut.HooksDir = []string{validDirPath}
 


### PR DESCRIPTION
Running unit tests locally require a valid namespace path as well as pinns which can be faked around.