### PR TITLE
[1.17] fail on network stop

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -438,6 +438,9 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	if err := sb.SetInfraContainer(scontainer); err != nil {
 		return err
 	}
+
+	sb.RestoreStopped()
+
 	if err := c.ctrIDIndex.Add(scontainer.ID()); err != nil {
 		return err
 	}

--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -327,5 +327,13 @@ func nsPathGivenInfraPid(ns NamespaceIface, nsType NSType, infraPid int) string 
 // infraNsPath returns the namespace path of type nsType for infra
 // with pid infraContainerPid
 func infraNsPath(nsType NSType, infraContainerPid int) string {
-	return fmt.Sprintf("/proc/%d/ns/%s", infraContainerPid, nsType)
+	// verify nsPath exists on the host. This will prevent us from fatally erroring
+	// on network tear down if the path doesn't exist
+	// Technically, this is pretty racy, but so is every check using the infra container PID.
+	// Without managing the namespaces, this is the best we can do
+	nsPath := fmt.Sprintf("/proc/%d/ns/%s", infraContainerPid, nsType)
+	if _, err := os.Stat(nsPath); err != nil {
+		return ""
+	}
+	return nsPath
 }

--- a/internal/lib/sandbox/namespaces_test.go
+++ b/internal/lib/sandbox/namespaces_test.go
@@ -441,16 +441,6 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 
 			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
 		})
-		It("should get something when infra set", func() {
-			// Given
-			// When
-			nsPaths := testSandbox.NamespacePaths()
-			// Then
-			for _, ns := range nsPaths {
-				Expect(ns.Path()).To(ContainSubstring("42"))
-			}
-			Expect(len(nsPaths)).To(Equal(numManagedNamespaces))
-		})
 		It("should get managed path despite infra set", func() {
 			// Given
 			getPath := pinNamespacesFunctor{

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -219,8 +219,8 @@ var _ = t.Describe("Sandbox", func() {
 			// Then
 			Expect(err).To(BeNil())
 			Expect(testSandbox.InfraContainer()).To(Equal(testContainer))
-			Expect(testSandbox.UserNsPath()).NotTo(Equal(""))
 			// while we have a sandbox, it does not have a valid network namespace
+			Expect(testSandbox.UserNsPath()).To(Equal(""))
 			Expect(testSandbox.NetNsPath()).To(Equal(""))
 			Expect(testSandbox.UtsNsPath()).To(Equal(""))
 			Expect(testSandbox.IpcNsPath()).To(Equal(""))

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -104,10 +104,23 @@ var _ = t.Describe("Sandbox", func() {
 			Expect(testSandbox.Stopped()).To(BeFalse())
 
 			// When
-			testSandbox.SetStopped()
+			testSandbox.SetStopped(false)
 
 			// Then
 			Expect(testSandbox.Stopped()).To(BeTrue())
+		})
+	})
+
+	t.Describe("NetworkStopped", func() {
+		It("should succeed", func() {
+			// Given
+			Expect(testSandbox.NetworkStopped()).To(BeFalse())
+
+			// When
+			Expect(testSandbox.SetNetworkStopped(false)).To(BeNil())
+
+			// Then
+			Expect(testSandbox.NetworkStopped()).To(BeTrue())
 		})
 	})
 
@@ -207,9 +220,10 @@ var _ = t.Describe("Sandbox", func() {
 			Expect(err).To(BeNil())
 			Expect(testSandbox.InfraContainer()).To(Equal(testContainer))
 			Expect(testSandbox.UserNsPath()).NotTo(Equal(""))
-			Expect(testSandbox.NetNsPath()).NotTo(Equal(""))
-			Expect(testSandbox.UtsNsPath()).NotTo(Equal(""))
-			Expect(testSandbox.IpcNsPath()).NotTo(Equal(""))
+			// while we have a sandbox, it does not have a valid network namespace
+			Expect(testSandbox.NetNsPath()).To(Equal(""))
+			Expect(testSandbox.UtsNsPath()).To(Equal(""))
+			Expect(testSandbox.IpcNsPath()).To(Equal(""))
 
 			// And When
 			testSandbox.RemoveInfraContainer()

--- a/server/container_create_test.go
+++ b/server/container_create_test.go
@@ -83,7 +83,7 @@ var _ = t.Describe("ContainerCreate", func() {
 		It("should fail when container is stopped", func() {
 			// Given
 			addContainerAndSandbox()
-			testSandbox.SetStopped()
+			testSandbox.SetStopped(false)
 
 			// When
 			response, err := sut.CreateContainer(context.Background(),

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -532,7 +532,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 		defer func() {
 			if err != nil {
-				s.networkStop(ctx, sb)
+				if err2 := s.networkStop(ctx, sb); err2 != nil {
+					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
+				}
 			}
 		}()
 	}
@@ -614,7 +616,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 		defer func() {
 			if err != nil {
-				s.networkStop(ctx, sb)
+				if err2 := s.networkStop(ctx, sb); err2 != nil {
+					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
+				}
 			}
 		}()
 	}

--- a/server/sandbox_stop_test.go
+++ b/server/sandbox_stop_test.go
@@ -23,7 +23,8 @@ var _ = t.Describe("PodSandboxStatus", func() {
 		It("should succeed with already stopped sandbox", func() {
 			// Given
 			addContainerAndSandbox()
-			testSandbox.SetStopped()
+			testSandbox.SetStopped(false)
+			Expect(testSandbox.SetNetworkStopped(false)).To(BeNil())
 
 			// When
 			response, err := sut.StopPodSandbox(context.Background(),

--- a/server/server.go
+++ b/server/server.go
@@ -218,7 +218,9 @@ func (s *Server) restore(ctx context.Context) {
 	for _, sb := range s.ListSandboxes() {
 		// Clean up networking if pod couldn't be restored and was deleted
 		if ok := deletedPods[sb.ID()]; ok {
-			s.networkStop(ctx, sb)
+			if err := s.networkStop(ctx, sb); err != nil {
+				logrus.Warnf("error stopping network on restore cleanup %v:", err)
+			}
 			continue
 		}
 		ips, err := s.getSandboxIPs(sb)


### PR DESCRIPTION
Move stopNetwork call to earlier in sandbox stop function. This means we unconditionally stop the network.
Add sb.*NetworkStopped functions
Create files in infra's persistent dir to restore {,network}Stopped state
update tests accordingly

cherry-pick-of: #3127 

Signed-off-by: Peter Hunt <pehunt@redhat.com>