### PR TITLE
Add `crio version` subcommand

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -32,10 +32,6 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-// gitCommit is the commit that the binary is being built from.
-// It will be populated by the Makefile.
-var gitCommit = ""
-
 func writeCrioGoroutineStacks() {
 	path := filepath.Join("/tmp", fmt.Sprintf("crio-goroutine-stacks-%s.log", strings.Replace(time.Now().Format(time.RFC3339), ":", "", -1))) // nolint: gocritic
 	if err := utils.WriteGoroutineStacksToFile(path); err != nil {
@@ -109,8 +105,8 @@ func main() {
 
 	var v []string
 	v = append(v, version.Version)
-	if gitCommit != "" && gitCommit != "unknown" {
-		v = append(v, fmt.Sprintf("commit: %s", gitCommit))
+	if version.GitCommit != "" && version.GitCommit != "unknown" {
+		v = append(v, fmt.Sprintf("commit: %s", version.GitCommit))
 	}
 	app.Name = "crio"
 	app.Usage = "OCI-based implementation of Kubernetes Container Runtime Interface"
@@ -134,6 +130,7 @@ func main() {
 	app.Commands = criocli.DefaultCommands
 	app.Commands = append(app.Commands, []*cli.Command{
 		configCommand,
+		versionCommand,
 		wipeCommand,
 	}...)
 
@@ -236,7 +233,7 @@ func main() {
 		}
 
 		// Immediately upon start up, write our new version file
-		if err := version.WriteVersionFile(config.VersionFile, gitCommit); err != nil {
+		if err := version.WriteVersionFile(config.VersionFile, version.GitCommit); err != nil {
 			logrus.Fatal(err)
 		}
 

--- a/cmd/crio/version.go
+++ b/cmd/crio/version.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cri-o/cri-o/internal/version"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+)
+
+const jsonFlag = "json"
+
+var versionCommand = &cli.Command{
+	Name:  "version",
+	Usage: "display detailed version information",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    jsonFlag,
+			Aliases: []string{"j"},
+			Usage:   "print JSON instead of text",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		v := version.Get()
+		res := v.String()
+		if c.Bool(jsonFlag) {
+			j, err := v.JSONString()
+			if err != nil {
+				return errors.Wrap(err, "unable to generate JSON from version info")
+			}
+			res = j
+
+		}
+		fmt.Println(res)
+		return nil
+	},
+}

--- a/completions/bash/crio
+++ b/completions/bash/crio
@@ -8,6 +8,7 @@ man
 markdown
 md
 config
+version
 wipe
 help
 h

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -2,7 +2,7 @@
 
 function __fish_crio_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i complete completion man markdown md config wipe help h
+        if contains -- $i complete completion man markdown md config version wipe help h
             return 1
         end
     end
@@ -133,6 +133,9 @@ complete -r -c crio -n '__fish_crio_no_subcommand' -a 'config' -d 'Outputs a com
 by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.'
 complete -c crio -n '__fish_seen_subcommand_from config' -f -l default -d 'Output the default configuration (without taking into account any configuration options).'
+complete -c crio -n '__fish_seen_subcommand_from version' -f -l help -s h -d 'show help'
+complete -r -c crio -n '__fish_crio_no_subcommand' -a 'version' -d 'display detailed version information'
+complete -c crio -n '__fish_seen_subcommand_from version' -f -l json -s j -d 'print JSON instead of text'
 complete -c crio -n '__fish_seen_subcommand_from wipe' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'wipe' -d 'wipe CRI-O\'s container and image storage'
 complete -c crio -n '__fish_seen_subcommand_from help h' -f -l help -s h -d 'show help'

--- a/completions/zsh/_crio
+++ b/completions/zsh/_crio
@@ -3,7 +3,7 @@ _cli_zsh_autocomplete() {
   local -a cmds
   cmds=('complete:Generate bash, fish or zsh completions.' 'completion:Generate bash, fish or zsh completions.' 'man:Generate the man page documentation.' 'markdown:Generate the markdown documentation.' 'md:Generate the markdown documentation.' 'config:Outputs a commented version of the configuration file that could be used
 by CRI-O. This allows you to save you current configuration setup and then load
-it later with **--config**. Global options will modify the output.' 'wipe:wipe CRI-O's container and image storage' 'help:Shows a list of commands or help for one command' 'h:Shows a list of commands or help for one command')
+it later with **--config**. Global options will modify the output.' 'version:display detailed version information' 'wipe:wipe CRI-O's container and image storage' 'help:Shows a list of commands or help for one command' 'h:Shows a list of commands or help for one command')
   _describe 'commands' cmds
 
   local -a opts

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -320,6 +320,12 @@ it later with **--config**. Global options will modify the output.
 
 **--default**: Output the default configuration (without taking into account any configuration options).
 
+## version
+
+display detailed version information
+
+**--json, -j**: print JSON instead of text
+
 ## wipe
 
 wipe CRI-O's container and image storage

--- a/test/version.bats
+++ b/test/version.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# vim: set syntax=sh:
+
+load helpers
+
+@test "version should succeed" {
+    # when
+    run $CRIO_BINARY_PATH version
+    echo "$output"
+
+    # then
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Version:" ]]
+    [[ "$output" =~ "GitCommit:" ]]
+    [[ "$output" =~ "GitTreeState:" ]]
+    [[ "$output" =~ "BuildDate:" ]]
+    [[ "$output" =~ "GoVersion:" ]]
+    [[ "$output" =~ "Compiler:" ]]
+    [[ "$output" =~ "Platform:" ]]
+}
+
+@test "version should succeed with JSON" {
+    # when
+    run $CRIO_BINARY_PATH version -j
+    echo "$output"
+
+    # then
+    JSON="$output"
+    echo $JSON | jq --exit-status '.gitCommit != ""'
+    [ "$status" -eq 0 ]
+
+    echo $JSON | jq --exit-status '.buildDate != ""'
+    [ "$status" -eq 0 ]
+
+    echo $JSON | jq --exit-status '.goVersion != ""'
+    [ "$status" -eq 0 ]
+
+    echo $JSON | jq --exit-status '.compiler != ""'
+    [ "$status" -eq 0 ]
+
+    echo $JSON | jq --exit-status '.platform != ""'
+    [ "$status" -eq 0 ]
+
+    echo $JSON | jq --exit-status '.gitTreeState != ""'
+    [ "$status" -eq 0 ]
+
+    echo $JSON | jq --exit-status '.version != ""'
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
This adds the ability to display detailed version information about CRI-O.

Demo:
```
> ./bin/crio version
GitVersion:    1.17.0-dev
GitCommit:     ca6e4a06c2d2ce4d583df6190666276837a9052b
GitTreeState:  dirty
BuildDate:     2020-02-04T08:53:50Z
GoVersion:     go1.13.7
Compiler:      gc
Platform:      linux/amd64
```
```
> ./bin/crio version -h
NAME:
   crio version - display detailed version information

USAGE:
   crio version [command options] [arguments...]

OPTIONS:
   --json, -j  print JSON instead of text (default: false)
   --help, -h  show help (default: false)
```
```
> ./bin/crio version -j
{
  "gitCommit": "ca6e4a06c2d2ce4d583df6190666276837a9052b",
  "gitTreeState": "dirty",
  "buildDate": "2020-02-04T08:53:50Z",
  "goVersion": "go1.13.7",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```