### PR TITLE
[1.17] Add the context and network destroy commits back in

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -617,6 +617,10 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		log.Errorf(ctx, "%v", err)
 	}
 
+	if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
+		return nil, ctx.Err()
+	}
+
 	log.Infof(ctx, "Created container: %s", container.Description())
 	resp := &pb.CreateContainerResponse{
 		ContainerId: containerID,

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -626,6 +626,10 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		log.Errorf(ctx, "%v", err)
 	}
 
+	if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
+		return nil, ctx.Err()
+	}
+
 	log.Infof(ctx, "ran pod sandbox with infra container: %s", container.Description())
 	resp = &pb.RunPodSandboxResponse{PodSandboxId: id}
 	return resp, nil


### PR DESCRIPTION
We reverted two commits thinking it was causing a regression, but it prove to not be the cause.
So reverting the revert now.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

