### PR TITLE
build: make install providing systemd and config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ docs-generation:
 bundle:
 	bundle/build
 
-install: .gopathok install.bin install.man install.completions
+install: .gopathok install.bin install.man install.completions install.systemd install.config
 
 install.bin: binaries
 	install ${SELINUXOPT} -D -m 755 bin/crio $(BINDIR)/crio


### PR DESCRIPTION
Currently, make install is not installing systemd files and configs.
Based on that, the environment is incomplete when building and
installing the project manually.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

**- What I did**: Improved Makefile

**- How I did it**: Changing the install target from Makefile

**- How to verify it**: make && make install (Now I see config and systemd files in the env)
