### PR TITLE
config: move default version file location to tmpfs

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -115,7 +115,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -l stream-tls-ca -r -d 'Path to 
 complete -c crio -n '__fish_crio_no_subcommand' -l stream-tls-cert -r -d 'Path to the x509 certificate file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: "")'
 complete -c crio -n '__fish_crio_no_subcommand' -l stream-tls-key -r -d 'Path to the key file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: "")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l uid-mappings -r -d 'Specify the UID mappings to use for the user namespace (default: "")'
-complete -c crio -n '__fish_crio_no_subcommand' -l version-file -r -d 'Location for CRI-O to lay down the version file (default: /var/lib/crio/version)'
+complete -c crio -n '__fish_crio_no_subcommand' -l version-file -r -d 'Location for CRI-O to lay down the version file (default: /var/run/crio/version)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l help -s h -d 'show help'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l version -s v -d 'print the version'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l help -s h -d 'show help'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -284,7 +284,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--version, -v**: print the version
 
-**--version-file**="": Location for CRI-O to lay down the version file (default: /var/lib/crio/version)
+**--version-file**="": Location for CRI-O to lay down the version file (default: /var/run/crio/version)
 
 
 # COMMANDS

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -44,7 +44,7 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
 **log_dir**="/var/log/crio/pods"
   The default log directory where all logs will go unless directly specified by the kubelet. The log directory specified must be an absolute directory.
 
-**version_file**="/var/lib/crio/version"
+**version_file**="/var/run/crio/version"
   Location for crio to lay down the version file.
 
 ## CRIO.API TABLE

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -19,5 +19,5 @@ const (
 	CrioSocketPath = "/var/run/crio/crio.sock"
 
 	// CrioVersionPath is where the CRI-O version file is located
-	CrioVersionPath = "/var/lib/crio/version"
+	CrioVersionPath = "/var/run/crio/version"
 )


### PR DESCRIPTION
move default version file location to /var/run/crio/version instead of /var/lib/crio/version

as we should really wipe crio after every reboot, so let's put it on a tmpfs

Signed-off-by: Peter Hunt <pehunt@redhat.com>