### PR TITLE
sandbox: skip memory check if set to "max"

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -682,7 +682,7 @@ func AddCgroupAnnotation(ctx context.Context, g generate.Generator, mountPath, c
 			} else {
 				// strip off the newline character and convert it to an int
 				strMemory := strings.TrimRight(string(fileData), "\n")
-				if strMemory != "" {
+				if strMemory != "" && strMemory != "max" {
 					memoryLimit, err := strconv.ParseInt(strMemory, 10, 64)
 					if err != nil {
 						return "", errors.Wrapf(err, "error converting cgroup memory value from string to int %q", strMemory)


### PR DESCRIPTION
skip the memory check if the value is set to the string "max".  That
is used on cgroup v2 when no limits are present.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
