### PR TITLE
[1.17] Revert "infra: remove unneeded uses of infra container"

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -233,14 +233,12 @@ func (c *ContainerServer) Update() error {
 			continue
 		}
 		podInfraContainer := sb.InfraContainer()
-		if podInfraContainer != nil {
-			c.ReleaseContainerName(podInfraContainer.Name())
-			c.RemoveContainer(podInfraContainer)
-			if err := c.ctrIDIndex.Delete(podInfraContainer.ID()); err != nil {
-				return err
-			}
-			sb.RemoveInfraContainer()
+		c.ReleaseContainerName(podInfraContainer.Name())
+		c.RemoveContainer(podInfraContainer)
+		if err := c.ctrIDIndex.Delete(podInfraContainer.ID()); err != nil {
+			return err
 		}
+		sb.RemoveInfraContainer()
 		c.ReleasePodName(sb.Name())
 		if err := c.RemoveSandbox(sb.ID()); err != nil {
 			logrus.Warnf("failed to remove sandbox ID %s: %v", sb.ID(), err)
@@ -588,9 +586,6 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 // ContainerStateToDisk writes the container's state information to a JSON file
 // on disk
 func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
-	if ctr == nil {
-		return nil
-	}
 	if err := c.Runtime().UpdateContainerStatus(ctr); err != nil {
 		logrus.Warnf("error updating the container status %q: %v", ctr.ID(), err)
 	}
@@ -779,15 +774,4 @@ func (c *ContainerServer) RemoveSandbox(id string) error {
 // ListSandboxes lists all sandboxes in the state store
 func (c *ContainerServer) ListSandboxes() []*sandbox.Sandbox {
 	return c.state.sandboxes.List()
-}
-
-// StopContainerAndWait is a wrapping function that stops a container and waits for the container state to be stopped
-func (c *ContainerServer) StopContainerAndWait(ctx context.Context, ctr *oci.Container, timeout int64) error {
-	if err := c.Runtime().StopContainer(ctx, ctr, timeout); err != nil {
-		return fmt.Errorf("failed to stop container %s: %v", ctr.Name(), err)
-	}
-	if err := c.Runtime().WaitContainerStateStopped(ctx, ctr); err != nil {
-		return fmt.Errorf("failed to get container 'stopped' status %s: %v", ctr.Name(), err)
-	}
-	return nil
 }

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -179,9 +179,6 @@ func (c *Container) Name() string {
 
 // ID returns the id of the container.
 func (c *Container) ID() string {
-	if c == nil {
-		return ""
-	}
 	return c.id
 }
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -603,7 +603,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		}
 	}()
 
-	if err := s.createContainerPlatform(container, sb.CgroupParent()); err != nil {
+	if err := s.createContainerPlatform(container, sb.InfraContainer(), sb.CgroupParent()); err != nil {
 		return nil, err
 	}
 

--- a/server/container_create_generic.go
+++ b/server/container_create_generic.go
@@ -5,6 +5,6 @@ package server
 import "github.com/cri-o/cri-o/internal/oci"
 
 // createContainerPlatform performs platform dependent intermediate steps before calling the container's oci.Runtime().CreateContainer()
-func (s *Server) createContainerPlatform(container *oci.Container, cgroupParent string) error {
+func (s *Server) createContainerPlatform(container *oci.Container, infraContainer *oci.Container, cgroupParent string) error {
 	return s.Runtime().CreateContainer(container, cgroupParent)
 }

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -167,7 +167,7 @@ func addDevicesPlatform(ctx context.Context, sb *sandbox.Sandbox, containerConfi
 }
 
 // createContainerPlatform performs platform dependent intermediate steps before calling the container's oci.Runtime().CreateContainer()
-func (s *Server) createContainerPlatform(container *oci.Container, cgroupParent string) error {
+func (s *Server) createContainerPlatform(container, infraContainer *oci.Container, cgroupParent string) error {
 	if s.defaultIDMappings != nil && !s.defaultIDMappings.Empty() {
 		rootPair := s.defaultIDMappings.RootPair()
 
@@ -706,13 +706,13 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	specgen.AddAnnotation(annotations.Name, containerName)
 	specgen.AddAnnotation(annotations.ContainerID, containerID)
 	specgen.AddAnnotation(annotations.SandboxID, sb.ID())
-	specgen.AddAnnotation(annotations.SandboxName, sb.Name())
+	specgen.AddAnnotation(annotations.SandboxName, sb.InfraContainer().Name())
 	specgen.AddAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer)
 	specgen.AddAnnotation(annotations.LogPath, logPath)
 	specgen.AddAnnotation(annotations.TTY, fmt.Sprintf("%v", containerConfig.Tty))
 	specgen.AddAnnotation(annotations.Stdin, fmt.Sprintf("%v", containerConfig.Stdin))
 	specgen.AddAnnotation(annotations.StdinOnce, fmt.Sprintf("%v", containerConfig.StdinOnce))
-	specgen.AddAnnotation(annotations.ResolvPath, sb.ResolvPath())
+	specgen.AddAnnotation(annotations.ResolvPath, sb.InfraContainer().CrioAnnotations()[annotations.ResolvPath])
 
 	created := time.Now()
 	specgen.AddAnnotation(annotations.Created, created.Format(time.RFC3339Nano))

--- a/server/sandbox_list_test.go
+++ b/server/sandbox_list_test.go
@@ -52,8 +52,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 			// Then
 			Expect(err).To(BeNil())
 			Expect(response).NotTo(BeNil())
-			// the sandbox is created, and even though it has no infra container, it should be displayed
-			Expect(len(response.Items)).To(Equal(1))
+			Expect(len(response.Items)).To(BeZero())
 		})
 
 		It("should skip not created sandboxes", func() {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -578,7 +578,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}
 
-	if err := s.createContainerPlatform(container, sb.CgroupParent()); err != nil {
+	if err := s.createContainerPlatform(container, nil, sb.CgroupParent()); err != nil {
 		return nil, err
 	}
 

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -66,8 +66,12 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 				}
 				c := ctr
 				waitGroup.Go(func() error {
-					if err := s.StopContainerAndWait(ctx, c, int64(10)); err != nil {
-						return fmt.Errorf("failed to stop container for pod sandbox %s: %v", sb.ID(), err)
+					timeout := int64(10)
+					if err := s.Runtime().StopContainer(ctx, c, timeout); err != nil {
+						return fmt.Errorf("failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
+					}
+					if err := s.Runtime().WaitContainerStateStopped(ctx, c); err != nil {
+						return fmt.Errorf("failed to get container 'stopped' status %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 					}
 					if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
 						// assume container already umounted
@@ -85,15 +89,16 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		}
 	}
 
-	if podInfraContainer != nil {
-		podInfraStatus := podInfraContainer.State()
-		if podInfraStatus.Status != oci.ContainerStateStopped {
-			if err := s.StopContainerAndWait(ctx, podInfraContainer, int64(10)); err != nil {
-				return nil, fmt.Errorf("failed to stop infra container for pod sandbox %s: %v", sb.ID(), err)
-			}
+	podInfraStatus := podInfraContainer.State()
+	if podInfraStatus.Status != oci.ContainerStateStopped {
+		timeout := int64(10)
+		if err := s.Runtime().StopContainer(ctx, podInfraContainer, timeout); err != nil {
+			return nil, fmt.Errorf("failed to stop infra container %s in pod sandbox %s: %v", podInfraContainer.Name(), sb.ID(), err)
+		}
+		if err := s.Runtime().WaitContainerStateStopped(ctx, podInfraContainer); err != nil {
+			return nil, fmt.Errorf("failed to get infra container 'stopped' status %s in pod sandbox %s: %v", podInfraContainer.Name(), sb.ID(), err)
 		}
 	}
-
 	if s.config.ManageNSLifecycle {
 		if err := sb.RemoveManagedNamespaces(); err != nil {
 			return nil, err
@@ -111,8 +116,10 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		log.Warnf(ctx, "error writing pod infra container %q state to disk: %v", podInfraContainer.ID(), err)
 	}
 
-	log.Infof(ctx, "stopped pod sandbox: %s", sb.ID())
+	log.Infof(ctx, "stopped pod sandbox: %s", podInfraContainer.Description())
+
 	sb.SetStopped(true)
+
 	resp = &pb.StopPodSandboxResponse{}
 	return resp, nil
 }


### PR DESCRIPTION
This reverts commit 1d7d97192c031f02c05a025de80ac319c070f987.

This revert is needed because 1.17 is not ready to remove infra containers, and this  code is incomplete (the Ready() check wasn't correct). as such, revert it until we actually drop the infra container

Signed-off-by: Peter Hunt <pehunt@redhat.com>
