### PR TITLE
[1.16] Add the container IDs that cri-o assigns to various logs

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -623,7 +623,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		log.Errorf(ctx, "%v", err)
 	}
 
-	log.Infof(ctx, "Created container: %s", container.Description())
+	log.Infof(ctx, "Created container %s: %s", container.ID(), container.Description())
 	resp := &pb.CreateContainerResponse{
 		ContainerId: containerID,
 	}

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -30,7 +30,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 
 	s.StopMonitoringConmon(c)
 
-	log.Infof(ctx, "Removed container %s", c.Description())
+	log.Infof(ctx, "Removed container %s: %s", c.ID(), c.Description())
 	resp = &pb.RemoveContainerResponse{}
 	return resp, nil
 }

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -52,7 +52,7 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 		return nil, fmt.Errorf("failed to start container %s: %v", c.ID(), err)
 	}
 
-	log.Infof(ctx, "Started container: %s", c.Description())
+	log.Infof(ctx, "Started container %s: %s", c.ID(), c.Description())
 	resp = &pb.StartContainerResponse{}
 	return resp, nil
 }

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -21,14 +21,13 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 	if err != nil {
 		return nil, err
 	}
-	description := c.Description()
 
 	_, err = s.ContainerServer.ContainerStop(ctx, req.ContainerId, req.Timeout)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Infof(ctx, "stopped container: %s", description)
+	log.Infof(ctx, "stopped container %s: %s", c.ID(), c.Description())
 	resp = &pb.StopContainerResponse{}
 	return resp, nil
 }

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -677,7 +677,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		log.Errorf(ctx, "%v", err)
 	}
 
-	log.Infof(ctx, "ran pod sandbox with infra container: %s", container.Description())
+	log.Infof(ctx, "ran pod sandbox %s with infra container: %s", container.ID(), container.Description())
 	resp = &pb.RunPodSandboxResponse{PodSandboxId: id}
 	return resp, nil
 }

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -139,7 +139,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		log.Warnf(ctx, "error writing pod infra container %q state to disk: %v", podInfraContainer.ID(), err)
 	}
 
-	log.Infof(ctx, "stopped pod sandbox: %s", podInfraContainer.Description())
+	log.Infof(ctx, "stopped pod sandbox: %s", sb.ID())
 	sb.SetStopped(true)
 	resp = &pb.StopPodSandboxResponse{}
 	return resp, nil


### PR DESCRIPTION
Having the extra container/pod ID in the logs helpw with
debugging. Fix the stop sandbox log to save "stopped" instead
of "removed".

cherry-pick of https://github.com/cri-o/cri-o/pull/3185

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

