### PR TITLE
[1.14] Add the container IDs that cri-o assigns to various logs

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -611,7 +611,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 
 	container.SetCreated()
 
-	logrus.Infof("Created container: %s", container.Description())
+	logrus.Infof("Created container %s: %s", container.ID(), container.Description())
 	resp := &pb.CreateContainerResponse{
 		ContainerId: containerID,
 	}

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -29,7 +29,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		return nil, err
 	}
 
-	logrus.Infof("Removed container %s", c.Description())
+	logrus.Infof("Removed container %s: %s", c.ID(), c.Description())
 	resp = &pb.RemoveContainerResponse{}
 	logrus.Debugf("RemoveContainerResponse: %+v", resp)
 	return resp, nil

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -43,7 +43,7 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 		return nil, fmt.Errorf("failed to start container %s: %v", c.ID(), err)
 	}
 
-	logrus.Infof("Started container: %s", c.Description())
+	logrus.Infof("Started container %s: %s", c.ID(), c.Description())
 	resp = &pb.StartContainerResponse{}
 	logrus.Debugf("StartContainerResponse %+v", resp)
 	return resp, nil

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -22,14 +22,13 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 	if err != nil {
 		return nil, err
 	}
-	description := c.Description()
 
 	_, err = s.ContainerServer.ContainerStop(ctx, req.ContainerId, req.Timeout)
 	if err != nil {
 		return nil, err
 	}
 
-	logrus.Infof("Stopped container %s", description)
+	logrus.Infof("Stopped container %s: %s", c.ID(), c.Description())
 	resp = &pb.StopContainerResponse{}
 	logrus.Debugf("StopContainerResponse %s: %+v", req.ContainerId, resp)
 	return resp, nil

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -699,7 +699,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	sb.SetCreated()
 
-	logrus.Infof("Ran pod sandbox with infra container: %s", container.Description())
+	logrus.Infof("Ran pod sandbox %s with infra container: %s", container.ID(), container.Description())
 	resp = &pb.RunPodSandboxResponse{PodSandboxId: id}
 	logrus.Debugf("RunPodSandboxResponse: %+v", resp)
 	return resp, nil

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -140,7 +140,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	}
 	s.ContainerStateToDisk(podInfraContainer)
 
-	logrus.Infof("Stopped pod sandbox: %s", podInfraContainer.Description())
+	logrus.Infof("Stopped pod sandbox: %s", sb.ID())
 	sb.SetStopped()
 	resp = &pb.StopPodSandboxResponse{}
 	logrus.Debugf("StopPodSandboxResponse %s: %+v", sb.ID(), resp)


### PR DESCRIPTION
Having the extra container/pod ID in the logs helpw with
debugging. Fix the stop sandbox log to save "stopped" instead
of "removed".

Cherry pick of https://github.com/cri-o/cri-o/pull/3185

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>