### PR TITLE
docs: improve setup.md

### DIFF
--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -21,7 +21,6 @@ Fedora, RHEL<=7, CentOS and related distributions:
 
 ```bash
 yum install -y \
-  btrfs-progs-devel \
   containers-common \
   device-mapper-devel \
   git \
@@ -35,7 +34,15 @@ yum install -y \
   libseccomp-devel \
   libselinux-devel \
   pkgconfig \
+  make \
   runc
+```
+
+**Please note**:
+- ```CentOS 8``` (or higher): ```pkgconfig``` package is replaced by ```pkgconf-pkg-config```
+- By default btrfs is not enabled. To add the btrfs support, install the following package:
+```
+  btrfs-progs-devel
 ```
 
 RHEL 8 distributions:\
@@ -89,7 +96,7 @@ The following dependencies:
   libgpg-error \
   libseccomp \
   libselinux \
-  pkgconfig \
+  pkgconf-pkg-config \
 ```
 
 On Ubuntu distributions, there is a dedicated PPA provided by


### PR DESCRIPTION
This patch improve the following in setup.md:

  - Do not set btrfs-progs-devel package as required
    package for installation.

  - For Fedora/CentOS steps: add make as requirement.

  - Add to RHEL8 steps: pkgconf-pkg-config package
    (replacement for pkgconfig).

  - Add a note about btrfs-progs-devel and pkgconfig
    replacement.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

**- What I did** Improved setup.md

**- How I did it** Testing in local machines, based on the info provided in #3130

**- How to verify it** RHEL8 and Fedora