### PR TITLE
Update golangci-lint to v1.23.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,8 @@ endif
 	touch "$(GOPATH)/.gopathok"
 
 lint: .gopathok ${GOLANGCI_LINT}
+	${GOLANGCI_LINT} version
+	${GOLANGCI_LINT} linters
 	${GOLANGCI_LINT} run
 
 bin/pinns:
@@ -235,7 +237,7 @@ ${RELEASE_TOOL}:
 
 ${GOLANGCI_LINT}:
 	export \
-		VERSION=v1.23.1 \
+		VERSION=v1.23.3 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
 	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION


### PR DESCRIPTION
We also print out the enabled/disabled linters as well as the version
for CI debugging purposes.