### PR TITLE
Skip invalid hooks directories by default

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -46,6 +46,8 @@ complete -c crio -n '__fish_crio_no_subcommand' -l global-auth-file -r -d 'Path 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l grpc-max-recv-msg-size -r -d 'Maximum grpc receive message size in bytes'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l grpc-max-send-msg-size -r -d 'Maximum grpc receive message size'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l hooks-dir -r -d 'Set the OCI hooks directory path (may be set multiple times) (default: ["/usr/share/containers/oci/hooks.d"])
+    If one of the directories does not exist, then CRI-O will automatically
+    skip them.
     Each \'\*.json\' file in the path configures a hook for CRI-O
     containers. For more details on the syntax of the JSON files and
     the semantics of hook injection, see \'oci-hooks(5)\'. CRI-O

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -173,6 +173,8 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 **--help, -h**: show help
 
 **--hooks-dir**="": Set the OCI hooks directory path (may be set multiple times) (default: ["/usr/share/containers/oci/hooks.d"])
+    If one of the directories does not exist, then CRI-O will automatically
+    skip them.
     Each '\*.json' file in the path configures a hook for CRI-O
     containers. For more details on the syntax of the JSON files and
     the semantics of hook injection, see 'oci-hooks(5)'. CRI-O

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -524,6 +524,8 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		&cli.StringSliceFlag{
 			Name: "hooks-dir",
 			Usage: fmt.Sprintf("Set the OCI hooks directory path (may be set multiple times) (default: %q)", defConf.HooksDir) + `
+    If one of the directories does not exist, then CRI-O will automatically
+    skip them.
     Each '\*.json' file in the path configures a hook for CRI-O
     containers. For more details on the syntax of the JSON files and
     the semantics of hook injection, see 'oci-hooks(5)'. CRI-O

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -750,11 +750,17 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 			return errors.Wrapf(err, "invalid registries")
 		}
 
+		// Sort out invalid hooks directories
+		hooksDirs := []string{}
 		for _, hooksDir := range c.HooksDir {
 			if err := utils.IsDirectory(hooksDir); err != nil {
-				return errors.Wrapf(err, "invalid hooks_dir: %s", err)
+				logrus.Warnf("skipping invalid hooks directory: %v", err)
+				continue
 			}
+			logrus.Debugf("using  hooks directory: %s", hooksDir)
+			hooksDirs = append(hooksDirs, hooksDir)
 		}
+		c.HooksDir = hooksDirs
 
 		// Validate the conmon path
 		if err := c.ValidateConmonPath("conmon"); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -214,39 +214,30 @@ var _ = t.Describe("Config", func() {
 			sut.PinnsPath = validFilePath
 			sut.NamespacesDir = os.TempDir()
 			sut.Conmon = validFilePath
-			sut.HooksDir = []string{validDirPath}
+			sut.HooksDir = []string{validDirPath, validDirPath, validDirPath}
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, true)
 
 			// Then
 			Expect(err).To(BeNil())
+			Expect(sut.HooksDir).To(HaveLen(3))
 		})
 
-		It("should fail on invalid hooks directory", func() {
+		It("should sort out invalid hooks directories", func() {
 			// Given
 			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validFilePath}
 			sut.Conmon = validFilePath
-			sut.HooksDir = []string{invalidPath}
+			sut.PinnsPath = validFilePath
+			sut.NamespacesDir = os.TempDir()
+			sut.HooksDir = []string{invalidPath, validDirPath, validDirPath}
 
 			// When
 			err := sut.RuntimeConfig.Validate(nil, true)
 
 			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
-		It("should fail if the hooks directory is not a directory", func() {
-			// Given
-			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validFilePath}
-			sut.Conmon = validFilePath
-			sut.HooksDir = []string{validFilePath}
-
-			// When
-			err := sut.RuntimeConfig.Validate(nil, true)
-
-			// Then
-			Expect(err).NotTo(BeNil())
+			Expect(err).To(BeNil())
+			Expect(sut.HooksDir).To(HaveLen(2))
 		})
 
 		It("should fail on invalid conmon path", func() {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -160,7 +160,8 @@ default_sysctls = [
 additional_devices = [
 {{ range $device := .AdditionalDevices}}{{ printf "\t%q, \n" $device}}{{ end }}]
 
-# Path to OCI hooks directories for automatically executed hooks.
+# Path to OCI hooks directories for automatically executed hooks. If one of the
+# directories does not exist, then CRI-O will automatically skip them.
 hooks_dir = [
 {{ range $hooksDir := .HooksDir }}{{ printf "\t%q, \n" $hooksDir}}{{ end }}]
 


### PR DESCRIPTION
If a specified or the default hooks directory is not available, then we
warn the user but do not fail any more.

Fixes: #3179