### PR TITLE
Add log context to container stats

### DIFF
--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -30,7 +30,7 @@ func (s *Server) ListContainerStats(ctx context.Context, req *pb.ListContainerSt
 			log.Warnf(ctx, "unable to get stats for container %s: %v", container.ID(), err)
 			continue
 		}
-		response := s.buildContainerStats(stats, container)
+		response := s.buildContainerStats(ctx, stats, container)
 		allStats = append(allStats, response)
 	}
 


### PR DESCRIPTION
This adds the logging context to the container stats function to provide
more detailed request tracing.