### PR TITLE
Unwrap errors from label.Relabel() before checking for ENOTSUP

### DIFF
--- a/server/label_linux.go
+++ b/server/label_linux.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
 func securityLabel(path, secLabel string, shared bool) error {
-	if err := label.Relabel(path, secLabel, shared); err != nil && err != unix.ENOTSUP {
+	if err := label.Relabel(path, secLabel, shared); err != nil && errors.Cause(err) != unix.ENOTSUP {
 		return fmt.Errorf("relabel failed %s: %v", path, err)
 	}
 	return nil

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -157,7 +157,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			}
 			return nil, err
 		}
-		if err := label.Relabel(resolvPath, mountLabel, false); err != nil && err != unix.ENOTSUP {
+		if err := label.Relabel(resolvPath, mountLabel, false); err != nil && errors.Cause(err) != unix.ENOTSUP {
 			return nil, err
 		}
 		mnt := runtimespec.Mount{
@@ -452,7 +452,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if err := ioutil.WriteFile(hostnamePath, []byte(hostname+"\n"), 0644); err != nil {
 		return nil, err
 	}
-	if err := label.Relabel(hostnamePath, mountLabel, false); err != nil && err != unix.ENOTSUP {
+	if err := label.Relabel(hostnamePath, mountLabel, false); err != nil && errors.Cause(err) != unix.ENOTSUP {
 		return nil, err
 	}
 	mnt = runtimespec.Mount{

--- a/server/secrets.go
+++ b/server/secrets.go
@@ -12,6 +12,7 @@ import (
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 // SecretData info
@@ -143,7 +144,7 @@ func secretMounts(ctx context.Context, defaultMountsPaths []string, mountLabel, 
 				return nil, err
 			}
 		}
-		if err := label.Relabel(ctrDirOnHost, mountLabel, false); err != nil {
+		if err := label.Relabel(ctrDirOnHost, mountLabel, false); err != nil && errors.Cause(err) != unix.ENOTSUP {
 			return nil, err
 		}
 


### PR DESCRIPTION
label.Relabel() can now return wrapped errors, so unwrap them before comparing them to ENOTSUP.  Add a similar check in the path that handles setting up secrets.  Spurred by discussion in https://github.com/cri-o/cri-o/pull/3202#discussion_r375264784.