### PR TITLE
drop host_ip from crio.conf.5.md

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -50,9 +50,6 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
 ## CRIO.API TABLE
 The `crio.api` table contains settings for the kubelet/gRPC interface.
 
-**host_ips**=[]
-  Host IPs are the addresses to be used for the host network. It is not possible to assign more than two addresses right now.
-
 **listen**="/var/run/crio/crio.sock"
   Path to AF_LOCAL socket on which CRI-O will listen.
 


### PR DESCRIPTION
as we don't support setting that option in the crio.conf anymore

Signed-off-by: Peter Hunt <pehunt@redhat.com>