### PR TITLE
WIP: Auto inject CRI-O version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ stdenv: &stdenv
     IMAGE: &image quay.io/crio/crio-build-amd64-go1.13:master-1.1.6
     IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.10:master-1.1.6
     IMAGE386: &image386 quay.io/crio/crio-build-386-go1.13:master-1.1.6
-    IMAGENIX: &imagenix quay.io/crio/nix:1.1.0
+    IMAGENIX: &imagenix quay.io/crio/nix:1.2.0
     JOBS: &jobs 4
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o
     WORKDIR_VM: &workdir_vm /home/circleci/go/src/github.com/cri-o/cri-o
@@ -120,6 +120,9 @@ jobs:
       - run: go env
       - run:
           command: make binaries -j $JOBS
+      - run:
+          name: Show CRI-O version
+          command: ./bin/crio version
       - run:
           command: make crio.conf
       - run:

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,12 @@ ifeq ($(shell bash -c '[[ `command -v git` && `git rev-parse --git-dir 2>/dev/nu
 	COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 	GIT_TREE_STATE := $(if $(shell git status --porcelain --untracked-files=no),dirty,clean)
 	GIT_MERGE_BASE := $(shell git merge-base origin/master $(shell git rev-parse --abbrev-ref HEAD))
+	VERSION := $(shell hack/git_tag.sh)
 else
 	COMMIT_NO := unknown
 	GIT_TREE_STATE := unknown
 	GIT_MERGE_BASE := HEAD^
+	VERSION := unknown
 endif
 
 # pass crio CLI options to generate custom crio.conf build time
@@ -90,14 +92,14 @@ BASE_LDFLAGS = ${SHRINKFLAGS} \
     -X ${PROJECT}/internal/version.GitCommit=${COMMIT_NO} \
     -X ${PROJECT}/internal/version.gitTreeState=${GIT_TREE_STATE}
 
-LDFLAGS = -ldflags '${BASE_LDFLAGS}'
+LDFLAGS = -ldflags '${BASE_LDFLAGS} ${EXTRA_LDFLAGS}'
 
 TESTIMAGE_VERSION := master-1.1.6
 TESTIMAGE_REGISTRY := quay.io/crio
 TESTIMAGE_SCRIPT := scripts/build-test-image -r $(TESTIMAGE_REGISTRY) -v $(TESTIMAGE_VERSION)
 TESTIMAGE_NAME ?= $(shell $(TESTIMAGE_SCRIPT) -d)
 
-TESTIMAGE_NIX ?= $(TESTIMAGE_REGISTRY)/nix:1.1.0
+TESTIMAGE_NIX ?= $(TESTIMAGE_REGISTRY)/nix:1.2.0
 
 all: binaries crio.conf docs
 

--- a/bundle/Makefile
+++ b/bundle/Makefile
@@ -23,6 +23,8 @@ install:
 	install $(SELINUX) -d -m 755 $(CONTAINERS_DIR)
 	install $(SELINUX) -d -m 755 $(CNIDIR)
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/pinns
+	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-status-x86_64-static-glibc
+	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-status-x86_64-static-musl
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-x86_64-static-glibc
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-x86_64-static-musl
 	ln -sf $(BINDIR)/$(DEFAULT_BINARY) $(BINDIR)/crio
@@ -43,6 +45,8 @@ install:
 .PHONY: uninstall
 uninstall:
 	rm $(BINDIR)/crio
+	rm $(BINDIR)/crio-status-x86_64-static-glibc
+	rm $(BINDIR)/crio-status-x86_64-static-musl
 	rm $(BINDIR)/crio-x86_64-static-glibc
 	rm $(BINDIR)/crio-x86_64-static-musl
 	rm $(BINDIR)/pinns

--- a/bundle/build
+++ b/bundle/build
@@ -4,6 +4,8 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 FILES_BIN=(
+    "../bin/crio-status-x86_64-static-glibc"
+    "../bin/crio-status-x86_64-static-musl"
     "../bin/crio-x86_64-static-glibc"
     "../bin/crio-x86_64-static-musl"
     "../bin/pinns"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -50,33 +50,11 @@ let
   self = {
     cri-o-static-musl = (muslPkgs.cri-o.overrideAttrs(old: {
       name = "cri-o-x86_64-static-musl-${revision}";
-      buildInputs = old.buildInputs ++ [ muslPkgs.systemd ];
+      buildInputs = old.buildInputs ++ (with muslPkgs; [ systemd ]);
       src = ./..;
-
-      # TODO: remove the build phase patch after CRI-O 1.17.0 release in nixpkgs
-      buildPhase = ''
-        pushd go/src/${old.goPackagePath}
-
-        # Build the crio binaries
-        function build() {
-          go build \
-            -tags "apparmor seccomp selinux containers_image_ostree_stub" \
-            -o bin/"$1" \
-            -buildmode=pie \
-            -ldflags '-s -w -linkmode external -extldflags "-static"' \
-            ${old.goPackagePath}/cmd/"$1"
-        }
-        build crio
-        build crio-status
-      '';
-      installPhase = ''
-        install -Dm755 bin/crio $bin/bin/crio-x86_64-static-musl
-        install -Dm755 bin/crio-status $bin/bin/crio-status-x86_64-static-musl
-      '';
+      EXTRA_LDFLAGS = ''-linkmode external -extldflags "-static"'';
     })).override {
       flavor = "-x86_64-static-musl";
-      ldflags = ''-linkmode external -extldflags "-static"'';
-
       glibc = null;
       gpgme = (static muslPkgs.gpgme);
       libassuan = (static muslPkgs.libassuan);
@@ -86,33 +64,11 @@ let
     };
     cri-o-static-glibc = (glibcPkgs.cri-o.overrideAttrs(old: {
       name = "cri-o-x86_64-static-glibc-${revision}";
-      buildInputs = old.buildInputs ++ [ glibcPkgs.systemd ];
+      buildInputs = old.buildInputs ++ (with glibcPkgs; [ systemd ]);
       src = ./..;
-
-      # TODO: remove the build phase patch after CRI-O 1.17.0 release in nixpkgs
-      buildPhase = ''
-        pushd go/src/${old.goPackagePath}
-
-        # Build the crio binaries
-        function build() {
-          go build \
-            -tags "apparmor seccomp selinux containers_image_ostree_stub" \
-            -o bin/"$1" \
-            -buildmode=pie \
-            -ldflags '-s -w -linkmode external -extldflags "-static -lm"' \
-            ${old.goPackagePath}/cmd/"$1"
-        }
-        build crio
-        build crio-status
-      '';
-      installPhase = ''
-        install -Dm755 bin/crio $bin/bin/crio-x86_64-static-glibc
-        install -Dm755 bin/crio-status $bin/bin/crio-status-x86_64-static-glibc
-      '';
+      EXTRA_LDFLAGS = ''-linkmode external -extldflags "-static -lm"'';
     })).override {
       flavor = "-x86_64-static-glibc";
-      ldflags = ''-linkmode external -extldflags "-static -lm"'';
-
       gpgme = (static glibcPkgs.gpgme);
       libassuan = (static glibcPkgs.libassuan);
       libgpgerror = (static glibcPkgs.libgpgerror);

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -2,8 +2,8 @@ let
   nixpkgs = builtins.fetchTarball {
     name = "nixos-unstable";
     url = "https://github.com/nixos/nixpkgs/archive/" +
-      "f28fad5e2fe777534f1c2719a40e69812085dfe5.tar.gz";
-    sha256 = "0qb021c3y2k1ai0vvadv9cd6vacj0lsd5xv2a4ir1hhn0pnc5g59";
+      "221274e1552fdb84e8caf0831dbd9140b111131e.tar.gz";
+    sha256 = "1ic9d9c27qpcrx5n5dn1mak3hrbbdq1is24p11rqrj9xas79lf89";
   };
   nixpkgsMuslSystemd = builtins.fetchTarball {
     name = "nixos-systemd-musl";


### PR DESCRIPTION
We now automatically inject the `Version` variable during build. This
allows us to cut releases without having the need for bumping this
constant.
