### PR TITLE
[1.17] Fix server restore to not remove podman containers

### DIFF
--- a/cmd/crio/wipe.go
+++ b/cmd/crio/wipe.go
@@ -89,8 +89,7 @@ func (c ContainerStore) getCrioContainersAndImages() (crioContainers, crioImages
 		if err := json.Unmarshal([]byte(metadataString), &metadata); err != nil {
 			continue
 		}
-		// CRI-O pods differ from libpod pods because they contain a PodName and PodID annotation
-		if metadata.PodName == "" || metadata.PodID == "" {
+		if !storage.IsCrioContainer(&metadata) {
 			continue
 		}
 		crioContainers = append(crioContainers, id)

--- a/go.sum
+++ b/go.sum
@@ -125,10 +125,7 @@ github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982 h1:5WUe09k2s
 github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982/go.mod h1:eGWB4tLoo0hIBuytQpvgUC0hk2mvl2ofaYBeDsU/qoc=
 github.com/containers/conmon v2.0.8+incompatible h1:8A14aNVSUAQ3hCQpPsMcIm/zczge5o+EOUr1XfY++2I=
 github.com/containers/conmon v2.0.8+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/image/v5 v5.0.0 h1:arnXgbt1ucsC/ndtSpiQY87rA0UjhF+/xQnPzqdBDn4=
 github.com/containers/image/v5 v5.0.0/go.mod h1:MgiLzCfIeo8lrHi+4Lb8HP+rh513sm0Mlk6RrhjFOLY=
-github.com/containers/image/v5 v5.1.0 h1:5FjAvPJniamuNNIQHkh4PnsL+n+xzs6Aonzaz5dqTEo=
-github.com/containers/image/v5 v5.1.0/go.mod h1:BKlMD34WxRo1ruGHHEOrPQP0Qci7SWoPwU6fS7arsCU=
 github.com/containers/image/v5 v5.1.1-0.20200205121319-c7a29b0b19be h1:9XSPScJUg7KDjqpPGu3DYGCQpMsRsNqrVHi2Pd7rEsI=
 github.com/containers/image/v5 v5.1.1-0.20200205121319-c7a29b0b19be/go.mod h1:BKlMD34WxRo1ruGHHEOrPQP0Qci7SWoPwU6fS7arsCU=
 github.com/containers/libpod v1.6.3-0.20191101152258-04e8bf3dba50 h1:htMcfTu+mPPx1hcNqxUrGhdaCTGYQ1WB+I7GA/Jiffw=
@@ -142,7 +139,6 @@ github.com/containers/psgo v1.4.0 h1:D8B4fZCCZhYgc8hDyMPCiShOinmOB1TP1qe46sSC19k
 github.com/containers/psgo v1.4.0/go.mod h1:ENXXLQ5E1At4K0EUsGogXBJi/C28gwqkONWeLPI9fJ8=
 github.com/containers/storage v1.13.4/go.mod h1:6D8nK2sU9V7nEmAraINRs88ZEscM5C5DK+8Npp27GeA=
 github.com/containers/storage v1.13.5/go.mod h1:HELz8Sn+UVbPaUZMI8RvIG9doD4y4z6Gtg4k7xdd2ZY=
-github.com/containers/storage v1.15.3 h1:+lFSQZnnKUFyUEtguIgdoQLJfWSuYz+j/wg5GxLtsN4=
 github.com/containers/storage v1.15.3/go.mod h1:v0lq/3f+cXH3Y/HiDaFYRR0zilwDve7I4W7U5xQxvF8=
 github.com/containers/storage v1.15.4-0.20191218193401-e18327c57107 h1:p6uPxazL30wwtXqTYFgV2mRQ+1PjQV1izzN8VpwyAxE=
 github.com/containers/storage v1.15.4-0.20191218193401-e18327c57107/go.mod h1:v0lq/3f+cXH3Y/HiDaFYRR0zilwDve7I4W7U5xQxvF8=
@@ -424,7 +420,6 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -502,7 +497,6 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
@@ -537,7 +531,6 @@ github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mozilla/tls-observatory v0.0.0-20180409132520-8791a200eb40/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
-github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618 h1:7InQ7/zrOh6SlFjaXFubv0xX0HsuC9qJsdqm7bNQpYM=
 github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
 github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c h1:xa+eQWKuJ9MbB9FBL/eoNvDFvveAkz2LQoz8PzX7Q/4=
 github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c/go.mod h1:GhAqVMEWnTcW2dxoD/SO3n2enrgWl3y6Dnx4m59GvcA=
@@ -583,7 +576,6 @@ github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rm
 github.com/opencontainers/runtime-spec v0.1.2-0.20190408193819-a1b50f621a48 h1:7IFBPtDtiQr5iUxv4CSJ62K25ENfu2/JVXlOmIH1RKY=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190408193819-a1b50f621a48/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/opencontainers/runtime-tools v0.9.0 h1:FYgwVsKRI/H9hU32MJ/4MLOzXWodKK5zsQavY8NPMkU=
 github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/runtime-tools v0.9.1-0.20200121211434-d1bf3e66ff0a h1:sf61qNtb7rsTAzYjwV7sqSXoksDyazZn2uHi8nj4GlM=
 github.com/opencontainers/runtime-tools v0.9.1-0.20200121211434-d1bf3e66ff0a/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
@@ -724,8 +716,6 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli/v2 v2.0.0 h1:+HU9SCbu8GnEUFtIBfuUNXN39ofWViIEJIp6SURMpCg=
-github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.1.1 h1:Qt8FeAtxE/vfdrLmR3rxR6JRE0RoVmbXu8+6kZtYU4k=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
@@ -795,7 +785,6 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad h1:5E5raQxcv+6CZ11RrBYQe5WRbUIWpScjh0kvHZkZIrQ=
 golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 h1:pXVtWnwHkrWD9ru3sDxY/qFK/bfc0egRovX91EjWjf4=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -28,6 +28,11 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
 )
 
+// ContainerManagerCRIO specifies an annotation value which indicates that the
+// container has been created by CRI-O. Usually used together with the key
+// `io.container.manager`.
+const ContainerManagerCRIO = "cri-o"
+
 // ContainerServer implements the ImageServer
 type ContainerServer struct {
 	runtime              *oci.Runtime
@@ -259,7 +264,11 @@ func (c *ContainerServer) Update() error {
 	for containerID := range newPodContainers {
 		// load this container
 		if err = c.LoadContainer(containerID); err != nil {
-			logrus.Warnf("could not load new sandbox container %s: %v, ignoring", containerID, err)
+			if err == ErrIsNonCrioContainer {
+				logrus.Infof("ignoring non CRI-O container %s", containerID)
+			} else {
+				logrus.Warnf("could not load new sandbox container %s: %v, ignoring", containerID, err)
+			}
 		} else {
 			logrus.Debugf("loaded new pod container %s: %v", containerID, err)
 		}
@@ -464,6 +473,8 @@ func configNsPath(spec *rspec.Spec, nsType rspec.LinuxNamespaceType) (string, er
 	return "", fmt.Errorf("missing networking namespace")
 }
 
+var ErrIsNonCrioContainer = errors.New("non CRI-O container")
+
 // LoadContainer loads a container from the disk into the container store
 func (c *ContainerServer) LoadContainer(id string) error {
 	config, err := c.store.FromContainerDirectory(id, "config.json")
@@ -474,6 +485,12 @@ func (c *ContainerServer) LoadContainer(id string) error {
 	if err := json.Unmarshal(config, &m); err != nil {
 		return err
 	}
+
+	// Do not interact with containers of others
+	if manager, ok := m.Annotations[annotations.ContainerManager]; ok && manager != ContainerManagerCRIO {
+		return ErrIsNonCrioContainer
+	}
+
 	labels := make(map[string]string)
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.Labels]), &labels); err != nil {
 		return err

--- a/internal/pkg/storage/utils.go
+++ b/internal/pkg/storage/utils.go
@@ -1,0 +1,8 @@
+package storage
+
+// IsCrioContainer returns whether a container coming from storage was created
+// by CRI-O CRI-O sandboxes and containers differ from libpod container and
+// pods because they require a PodName and PodID annotation
+func IsCrioContainer(md *RuntimeContainerMetadata) bool {
+	return md.PodName != "" && md.PodID != ""
+}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/rootless"
 	createconfig "github.com/containers/libpod/pkg/spec"
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/pkg/log"
@@ -713,6 +714,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	specgen.AddAnnotation(annotations.Stdin, fmt.Sprintf("%v", containerConfig.Stdin))
 	specgen.AddAnnotation(annotations.StdinOnce, fmt.Sprintf("%v", containerConfig.StdinOnce))
 	specgen.AddAnnotation(annotations.ResolvPath, sb.InfraContainer().CrioAnnotations()[annotations.ResolvPath])
+	specgen.AddAnnotation(annotations.ContainerManager, lib.ContainerManagerCRIO)
 
 	created := time.Now()
 	specgen.AddAnnotation(annotations.Created, created.Format(time.RFC3339Nano))

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/cgroups"
 	"github.com/containers/storage"
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/pkg/log"
@@ -329,6 +330,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation(annotations.NamespaceOptions, string(nsOptsJSON))
 	g.AddAnnotation(annotations.KubeName, kubeName)
 	g.AddAnnotation(annotations.HostNetwork, fmt.Sprintf("%v", hostNetwork))
+	g.AddAnnotation(annotations.ContainerManager, lib.ContainerManagerCRIO)
 	if podContainer.Config.Config.StopSignal != "" {
 		// this key is defined in image-spec conversion document at https://github.com/opencontainers/image-spec/pull/492/files#diff-8aafbe2c3690162540381b8cdb157112R57
 		g.AddAnnotation("org.opencontainers.image.stopSignal", podContainer.Config.Config.StopSignal)

--- a/server/server.go
+++ b/server/server.go
@@ -155,6 +155,10 @@ func (s *Server) restore(ctx context.Context) {
 			logrus.Warnf("error parsing metadata for %s: %v, ignoring", containers[i].ID, err2)
 			continue
 		}
+		if !storage.IsCrioContainer(&metadata) {
+			logrus.Debugf("container %s determined to not be a CRI-O container or sandbox", containers[i].ID)
+			continue
+		}
 		names[containers[i].ID] = containers[i].Names
 		if metadata.Pod {
 			pods[containers[i].ID] = &metadata
@@ -202,13 +206,18 @@ func (s *Server) restore(ctx context.Context) {
 	// release the name associated with you.
 	for containerID := range podContainers {
 		if err := s.LoadContainer(containerID); err != nil {
-			logrus.Warnf("could not restore container %s: %v", containerID, err)
-			for _, n := range names[containerID] {
-				if err := s.Store().DeleteContainer(n); err != nil {
-					logrus.Warnf("unable to delete container %s: %v", n, err)
+			// containers of other runtimes should not be deleted
+			if err == lib.ErrIsNonCrioContainer {
+				logrus.Infof("ignoring non CRI-O container %s", containerID)
+			} else {
+				logrus.Warnf("could not restore container %s: %v", containerID, err)
+				for _, n := range names[containerID] {
+					if err := s.Store().DeleteContainer(n); err != nil {
+						logrus.Warnf("unable to delete container %s: %v", n, err)
+					}
+					// Release the container name
+					s.ReleaseContainerName(n)
 				}
-				// Release the container name
-				s.ReleaseContainerName(n)
 			}
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -108,9 +108,9 @@ var _ = t.Describe("Server", func() {
 						{},
 					}, testError),
 				storeMock.EXPECT().Metadata(gomock.Any()).
-					Return(`{"Pod": false}`, nil),
+					Return(`{"Pod": false, "pod-name": "name", "pod-id": "id" }`, nil),
 				storeMock.EXPECT().Metadata(gomock.Any()).
-					Return(`{"Pod": true}`, nil),
+					Return(`{"Pod": true, "pod-name": "name", "pod-id": "id" }`, nil),
 				storeMock.EXPECT().Metadata(gomock.Any()).
 					Return("", t.TestError),
 				storeMock.EXPECT().


### PR DESCRIPTION
The previous behavior was that CRI-O forcely tried to remove running
podman containers on startup, which only succeeded for the container
storage but not the running process. The result was was a running
container process in podman, which got broken because its storage got
removed.

This is now fixed by excluding podman containers on restore, discovered
by the new podman annotation.

A dedicated unit test has been added as well.

Signed-off-by: Sascha Grunert <sgrunert@suse.com>