### PR TITLE
[1.17] oci: handle timeouts correctly for probes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,9 @@ version: 2.1
 stdenv: &stdenv
   environment:
     GOCACHE: &gocache /tmp/go-build
-    IMAGE: &image quay.io/crio/crio-build-amd64-go1.13:master-1.1.4
-    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.10:master-1.1.4
-    IMAGE386: &image386 quay.io/crio/crio-build-386-go1.13:master-1.1.4
+    IMAGE: &image quay.io/crio/crio-build-amd64-go1.13:1.17-1.1.0
+    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.10:1.17-1.1.0
+    IMAGE386: &image386 quay.io/crio/crio-build-386-go1.13:1.17-1.1.0
     IMAGENIX: &imagenix quay.io/crio/nix:1.1.0
     JOBS: &jobs 4
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/containernetworking/cni v0.7.1
 	github.com/containernetworking/plugins v0.8.3
 	github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982
-	github.com/containers/conmon v2.0.8+incompatible
+	github.com/containers/conmon v2.0.9+incompatible
 	github.com/containers/image/v5 v5.1.1-0.20200205121319-c7a29b0b19be
 	github.com/containers/libpod v1.6.3-0.20191101152258-04e8bf3dba50
 	github.com/containers/ocicrypt v0.0.0-20190930154801-b87a4a69c741

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982 h1:5WUe09k2s
 github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982/go.mod h1:eGWB4tLoo0hIBuytQpvgUC0hk2mvl2ofaYBeDsU/qoc=
 github.com/containers/conmon v2.0.8+incompatible h1:8A14aNVSUAQ3hCQpPsMcIm/zczge5o+EOUr1XfY++2I=
 github.com/containers/conmon v2.0.8+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
+github.com/containers/conmon v2.0.9+incompatible h1:YcEgk0Ny1WBdH35M2LKe2cG6FiQqzDdVaURw84XvS7A=
+github.com/containers/conmon v2.0.9+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.0.0/go.mod h1:MgiLzCfIeo8lrHi+4Lb8HP+rh513sm0Mlk6RrhjFOLY=
 github.com/containers/image/v5 v5.1.1-0.20200205121319-c7a29b0b19be h1:9XSPScJUg7KDjqpPGu3DYGCQpMsRsNqrVHi2Pd7rEsI=
 github.com/containers/image/v5 v5.1.1-0.20200205121319-c7a29b0b19be/go.mod h1:BKlMD34WxRo1ruGHHEOrPQP0Qci7SWoPwU6fS7arsCU=

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	conmonconfig "github.com/containers/conmon/runner/config"
 	"github.com/cri-o/cri-o/internal/pkg/findprocess"
 	"github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/utils"
@@ -452,6 +453,18 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 	}
 
 	logrus.Debugf("Received container exit code: %v, message: %s", ec.ExitCode, ec.Message)
+
+	// When we timeout the command in conmon then we should return
+	// an ExecSyncResponse with a non-zero exit code because
+	// the prober code in the kubelet checks for it. If we return
+	// a custom error, then the probes transition into Unknown status
+	// and the container isn't restarted as expected.
+	if ec.ExitCode == -1 && ec.Message == conmonconfig.TimedOutMessage {
+		return &ExecSyncResponse{
+			Stderr:   []byte(conmonconfig.TimedOutMessage),
+			ExitCode: -1,
+		}, nil
+	}
 
 	if ec.ExitCode == -1 {
 		return nil, &ExecSyncError{

--- a/scripts/build-test-image
+++ b/scripts/build-test-image
@@ -8,7 +8,7 @@ fi
 # Versions to be used
 declare -A VERSIONS=(
     ["cni-plugins"]=v0.8.3
-    ["conmon"]=v2.0.8
+    ["conmon"]=v2.0.9
     ["cri-tools"]=v1.17.0
     ["runc"]=v1.0.0-rc9
 )

--- a/vendor/github.com/containers/conmon/runner/config/config.go
+++ b/vendor/github.com/containers/conmon/runner/config/config.go
@@ -13,4 +13,7 @@ const (
 	// ReopenLogsEvent is the event code the caller program will
 	// send along the ctrl fd to signal conmon to reopen the log files
 	ReopenLogsEvent = 2
+	// TimedOutMessage is the message sent back to the caller by conmon
+	// when a container times out
+	TimedOutMessage = "command timed out"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,7 +94,7 @@ github.com/containers/buildah/pkg/secrets
 github.com/containers/buildah/pkg/umask
 github.com/containers/buildah/pkg/unshare
 github.com/containers/buildah/util
-# github.com/containers/conmon v2.0.8+incompatible
+# github.com/containers/conmon v2.0.9+incompatible
 github.com/containers/conmon/runner/config
 # github.com/containers/image/v5 v5.1.1-0.20200205121319-c7a29b0b19be
 github.com/containers/image/v5/copy


### PR DESCRIPTION
 oci: Handle timeouts correctly for probes

We shouldn't return a custom error when an exec sync command
times out. Instead, we should return a non-zero exit code.

When the prober code in kubernetes sees a custom error
it goes into Unknown status and doesn't restart containers
on timed out probes as expected.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

cherry-pick of https://github.com/cri-o/cri-o/pull/3065