### PR TITLE
oci: Handle timeouts correctly for probes

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	conmonconfig "github.com/containers/conmon/runner/config"
 	"github.com/cri-o/cri-o/internal/pkg/findprocess"
 	"github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/utils"
@@ -452,6 +453,18 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 	}
 
 	logrus.Debugf("Received container exit code: %v, message: %s", ec.ExitCode, ec.Message)
+
+	// When we timeout the command in conmon then we should return
+	// an ExecSyncResponse with a non-zero exit code because
+	// the prober code in the kubelet checks for it. If we return
+	// a custom error, then the probes transition into Unknown status
+	// and the container isn't restarted as expected.
+	if ec.ExitCode == -1 && ec.Message == conmonconfig.TimedOutMessage {
+		return &ExecSyncResponse{
+			Stderr:   []byte(conmonconfig.TimedOutMessage),
+			ExitCode: -1,
+		}, nil
+	}
 
 	if ec.ExitCode == -1 {
 		return nil, &ExecSyncError{


### PR DESCRIPTION
We shouldn't return a custom error when an exec sync command
times out. Instead, we should return a non-zero exit code.

When the probe code in kubernetes sees a custom error
it goes into Unknown status and doesn't restart containers
on timed out probes as expected.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>
