### PR TITLE
Make SIGHUP reload for drop-in config dir work

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -20,7 +20,7 @@ it later with **--config**. Global options will modify the output.`,
 		},
 	},
 	Action: func(c *cli.Context) error {
-		_, conf, err := criocli.GetConfigFromContext(c)
+		conf, err := criocli.GetConfigFromContext(c)
 		if err != nil {
 			return err
 		}

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -131,10 +131,8 @@ func main() {
 		wipeCommand,
 	}...)
 
-	var configPath string
 	app.Before = func(c *cli.Context) (err error) {
-		var config *libconfig.Config
-		configPath, config, err = criocli.GetConfigFromContext(c)
+		config, err := criocli.GetConfigFromContext(c)
 		if err != nil {
 			return err
 		}
@@ -224,7 +222,7 @@ func main() {
 			grpc.MaxRecvMsgSize(config.GRPCMaxRecvMsgSize),
 		)
 
-		service, err := server.New(ctx, configPath, config)
+		service, err := server.New(ctx, config)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/crio/wipe.go
+++ b/cmd/crio/wipe.go
@@ -21,7 +21,7 @@ var wipeCommand = &cli.Command{
 }
 
 func crioWipe(c *cli.Context) error {
-	_, config, err := criocli.GetConfigFromContext(c)
+	config, err := criocli.GetConfigFromContext(c)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -13,9 +13,10 @@ var _ = t.Describe("Config", func() {
 	BeforeEach(beforeEach)
 
 	t.Describe("Reload", func() {
-		var modifyDefaultConfig = func(old, new string) string {
+		var modifyDefaultConfig = func(old, new string) {
 			filePath := t.MustTempFile("config")
 			Expect(sut.ToFile(filePath)).To(BeNil())
+			Expect(sut.UpdateFromFile(filePath)).To(BeNil())
 
 			read, err := ioutil.ReadFile(filePath)
 			Expect(err).To(BeNil())
@@ -23,40 +24,30 @@ var _ = t.Describe("Config", func() {
 			newContents := strings.ReplaceAll(string(read), old, new)
 			err = ioutil.WriteFile(filePath, []byte(newContents), 0)
 			Expect(err).To(BeNil())
-
-			return filePath
 		}
 
 		It("should succeed without any config change", func() {
 			// Given
 			filePath := t.MustTempFile("config")
 			Expect(sut.ToFile(filePath)).To(BeNil())
+			Expect(sut.UpdateFromFile(filePath)).To(BeNil())
 
 			// When
-			err := sut.Reload(filePath)
+			err := sut.Reload()
 
 			// Then
 			Expect(err).To(BeNil())
 		})
 
-		It("should fail with invalid config path", func() {
-			// Given
-			// When
-			err := sut.Reload("")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
 		It("should fail with invalid log_level", func() {
 			// Given
-			filePath := modifyDefaultConfig(
+			modifyDefaultConfig(
 				`log_level = "info"`,
 				`log_level = "invalid"`,
 			)
 
 			// When
-			err := sut.Reload(filePath)
+			err := sut.Reload()
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -64,13 +55,13 @@ var _ = t.Describe("Config", func() {
 
 		It("should fail with invalid pause_image_auth_file", func() {
 			// Given
-			filePath := modifyDefaultConfig(
+			modifyDefaultConfig(
 				`pause_image_auth_file = ""`,
 				`pause_image_auth_file = "`+invalidPath+`"`,
 			)
 
 			// When
-			err := sut.Reload(filePath)
+			err := sut.Reload()
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -183,7 +183,7 @@ var afterEach = func() {
 var setupSUT = func() {
 	var err error
 	mockNewServer()
-	sut, err = server.New(context.Background(), "", libMock)
+	sut, err = server.New(context.Background(), libMock)
 	Expect(err).To(BeNil())
 	Expect(sut).NotTo(BeNil())
 


### PR DESCRIPTION
We now store the config dir and path locations directly at the `Config`
structure, which allows us to use that information on SIGHUP reload to
check both locations for possible new configuration files.