### PR TITLE
Add live reload to DecryptionKeysPath

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -587,19 +587,19 @@ func (c *Config) Validate(onExecution bool) error {
 	}
 
 	if err := c.RootConfig.Validate(onExecution); err != nil {
-		return errors.Wrapf(err, "root config")
+		return errors.Wrapf(err, "validating root config")
 	}
 
 	if err := c.RuntimeConfig.Validate(c.SystemContext, onExecution); err != nil {
-		return errors.Wrapf(err, "runtime config")
+		return errors.Wrapf(err, "validating runtime config")
 	}
 
 	if err := c.NetworkConfig.Validate(onExecution); err != nil {
-		return errors.Wrapf(err, "network config")
+		return errors.Wrapf(err, "validating network config")
 	}
 
 	if err := c.APIConfig.Validate(onExecution); err != nil {
-		return errors.Wrapf(err, "api config")
+		return errors.Wrapf(err, "validating api config")
 	}
 
 	if !c.SELinux {

--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -74,7 +74,7 @@ func (c *Config) Reload() error {
 	if err := c.ReloadRegistries(); err != nil {
 		return err
 	}
-
+	c.ReloadDecryptionKeyConfig(newConfig)
 	return nil
 }
 
@@ -154,4 +154,13 @@ func (c *Config) ReloadRegistries() error {
 	}
 	logrus.Infof("applied new registry configuration: %+v", registries)
 	return nil
+}
+
+// ReloadDecryptionKeyConfig updates the DecryptionKeysPath with the provided
+// `newConfig`.
+func (c *Config) ReloadDecryptionKeyConfig(newConfig *Config) {
+	if c.DecryptionKeysPath != newConfig.DecryptionKeysPath {
+		logConfig("decryption_keys_path", newConfig.DecryptionKeysPath)
+		c.DecryptionKeysPath = newConfig.DecryptionKeysPath
+	}
 }

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -110,7 +110,7 @@ default_runtime = "{{ .DefaultRuntime }}"
 no_pivot = {{ .NoPivot }}
 
 # decryption_keys_path is the path where the keys required for
-# image decryption are stored.
+# image decryption are stored. This option supports live configuration reload.
 decryption_keys_path = "{{ .DecryptionKeysPath }}"
 
 # Path to the conmon binary, used for monitoring the OCI runtime.

--- a/server/server.go
+++ b/server/server.go
@@ -60,8 +60,7 @@ type Server struct {
 	netPlugin       ocicni.CNIPlugin
 	hostportManager hostport.HostPortManager
 
-	appArmorProfile    string
-	decryptionKeysPath string
+	appArmorProfile string
 
 	*lib.ContainerServer
 	monitorsChan      chan struct{}
@@ -344,8 +343,6 @@ func New(
 		monitorsChan:      make(chan struct{}),
 		defaultIDMappings: idMappings,
 	}
-
-	s.decryptionKeysPath = config.DecryptionKeysPath
 
 	if s.seccompEnabled {
 		if config.SeccompProfile != "" {

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -105,7 +105,7 @@ func TestGetDecryptionKeys(t *testing.T) {
 
 	cc, err := getDecryptionKeys(keysDir)
 
-	if err != nil && cc.DecryptConfig != nil {
+	if err != nil && cc != nil {
 		t.Fatalf("Unable to find the expected keys")
 	}
 }

--- a/test/reload_config.bats
+++ b/test/reload_config.bats
@@ -142,3 +142,16 @@ function expect_log_failure() {
     # then
     expect_log_failure "custom log level filter does not compile"
 }
+
+@test "reload config should succeed with 'decryption_keys_path'" {
+    # given
+    NEW_OPTION="/etc/crio"
+    OPTION="decryption_keys_path"
+
+    # when
+    replace_config $OPTION $NEW_OPTION
+    reload_crio
+
+    # then
+    expect_log_success $OPTION $NEW_OPTION
+}


### PR DESCRIPTION
This adds the live configuration reload feature to the
`decryption_keys_path`. We still check per-pull if the path exists and
decide if the key should be loaded or not.