### PR TITLE
Pass down the integer value of the stop signal

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -21,7 +22,7 @@ import (
 )
 
 const (
-	defaultStopSignal    = "TERM"
+	defaultStopSignal    = "15"
 	defaultStopSignalInt = 15
 )
 
@@ -129,11 +130,13 @@ func (c *Container) GetStopSignal() string {
 		return defaultStopSignal
 	}
 	cleanSignal := strings.TrimPrefix(strings.ToUpper(c.stopSignal), "SIG")
-	_, ok := signal.SignalMap[cleanSignal]
+	val, ok := signal.SignalMap[cleanSignal]
 	if !ok {
 		return defaultStopSignal
 	}
-	return cleanSignal
+	// return the stop signal in the form of its int converted to a string
+	// i.e stop signal 34 is returned as "34" to avoid back and forth conversion
+	return strconv.Itoa(int(val))
 }
 
 // StopSignal returns the container's own stop signal configured from

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -44,7 +44,7 @@ var _ = t.Describe("Container", func() {
 		Expect(sut.StatePath()).To(Equal("dir/state.json"))
 		Expect(sut.Metadata()).To(Equal(&pb.ContainerMetadata{}))
 		Expect(sut.StateNoLock().Version).To(BeEmpty())
-		Expect(sut.GetStopSignal()).To(Equal("TERM"))
+		Expect(sut.GetStopSignal()).To(Equal("15"))
 		Expect(sut.CreatedAt().UnixNano()).
 			To(BeNumerically("<", time.Now().UnixNano()))
 	})
@@ -149,7 +149,7 @@ var _ = t.Describe("Container", func() {
 		signal := container.GetStopSignal()
 
 		// Then
-		Expect(signal).To(Equal("TERM"))
+		Expect(signal).To(Equal("15"))
 	})
 
 	It("should succeed get the non default stop signal", func() {
@@ -165,7 +165,7 @@ var _ = t.Describe("Container", func() {
 		signal := container.GetStopSignal()
 
 		// Then
-		Expect(signal).To(Equal("TRAP"))
+		Expect(signal).To(Equal("5"))
 	})
 
 	It("should succeed to get the state from disk", func() {

--- a/internal/oci/kill.go
+++ b/internal/oci/kill.go
@@ -4,15 +4,14 @@ import (
 	"syscall"
 
 	"github.com/docker/docker/pkg/signal"
-	"github.com/pkg/errors"
 )
 
-// Reverse lookup signal string from its map
-func findStringInSignalMap(killSignal syscall.Signal) (string, error) {
-	for k, v := range signal.SignalMap {
+// Check if killSignal exists in the signal map
+func inSignalMap(killSignal syscall.Signal) bool {
+	for _, v := range signal.SignalMap {
 		if v == killSignal {
-			return k, nil
+			return true
 		}
 	}
-	return "", errors.Errorf("unable to convert signal to string")
+	return false
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -779,13 +779,12 @@ func (r *runtimeOCI) SignalContainer(c *Container, sig syscall.Signal) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	signalString, err := findStringInSignalMap(sig)
-	if err != nil {
-		return err
+	if !inSignalMap(sig) {
+		return errors.Errorf("unable to find %s in the signal map", sig.String())
 	}
 
 	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.path,
-		rootFlag, r.root, "kill", c.ID(), signalString)
+		rootFlag, r.root, "kill", c.ID(), strconv.Itoa(int(sig)))
 }
 
 // AttachContainer attaches IO to a running container.


### PR DESCRIPTION
Instead of converting the stop signal from int to its
string name, i.e sig 15 to "TERM", send down the int value
converted to a string instead i.e sig 15 to "15". This avoids
doing a look up for the signal in the sigMap in both cri-o
and runc and double back and forth conversion from int to string.
The sigMap in the runc code for example didn't have all the
signals that the sigMap in cri-o does. So when a container
with the ubi8-init image was run and stopped, a SIGRTMIN+3
is used, which wasn't being recognized by runc causing the
container to fail to stop.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1800107

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

