### PR TITLE
klog: don't write to /tmp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/cri-api v0.0.0
+	k8s.io/klog v1.0.0
 	k8s.io/kubernetes v1.13.0
 	k8s.io/utils v0.0.0-20191217005138-9e5e9d854fcc
 )


### PR DESCRIPTION
klog currently doesn't have an API to not write to /tmp. One has to "pass" down flags to it.
since cri-o uses libraries that use klog, we need this hack to not write klog logs to /tmp

fixes: https://github.com/cri-o/cri-o/issues/1879

Signed-off-by: Peter Hunt <pehunt@redhat.com>
