### PR TITLE
[1.13] Pass down the integer value of the stop signal

### DIFF
--- a/lib/kill.go
+++ b/lib/kill.go
@@ -1,22 +1,24 @@
 package lib
 
 import (
+	"os"
+	"strconv"
+	"syscall"
+
 	"github.com/cri-o/cri-o/oci"
 	"github.com/cri-o/cri-o/utils"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/pkg/errors"
-	"os"
-	"syscall"
 )
 
-// Reverse lookup signal string from its map
-func findStringInSignalMap(killSignal syscall.Signal) (string, error) {
-	for k, v := range signal.SignalMap {
+// Check if killSignal exists in the signal map
+func inSignalMap(killSignal syscall.Signal) bool {
+	for _, v := range signal.SignalMap {
 		if v == killSignal {
-			return k, nil
+			return true
 		}
 	}
-	return "", errors.Errorf("unable to convert signal to string")
+	return false
 
 }
 
@@ -33,15 +35,14 @@ func (c *ContainerServer) ContainerKill(container string, killSignal syscall.Sig
 	if cStatus.Status != oci.ContainerStateRunning {
 		return "", errors.Errorf("cannot kill container %s: it is not running", container)
 	}
-	signalString, err := findStringInSignalMap(killSignal)
-	if err != nil {
-		return "", err
+	if !inSignalMap(killSignal) {
+		return "", errors.Errorf("unable to find %s in the signal map", killSignal.String())
 	}
 	rPath, err := c.runtime.Path(ctr)
 	if err != nil {
 		return "", err
 	}
-	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "kill", ctr.ID(), signalString); err != nil {
+	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "kill", ctr.ID(), strconv.Itoa(int(killSignal))); err != nil {
 		return "", err
 	}
 	c.ContainerStateToDisk(ctr)

--- a/oci/container.go
+++ b/oci/container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,7 +19,7 @@ import (
 )
 
 const (
-	defaultStopSignal = "TERM"
+	defaultStopSignal = "15"
 )
 
 // Container represents a runtime container.
@@ -124,11 +125,13 @@ func (c *Container) GetStopSignal() string {
 		return defaultStopSignal
 	}
 	cleanSignal := strings.TrimPrefix(strings.ToUpper(c.stopSignal), "SIG")
-	_, ok := signal.SignalMap[cleanSignal]
+	val, ok := signal.SignalMap[cleanSignal]
 	if !ok {
 		return defaultStopSignal
 	}
-	return cleanSignal
+	// return the stop signal in the form of its int converted to a string
+	// i.e stop signal 34 is returned as "34" to avoid back and forth conversion
+	return strconv.Itoa(int(val))
 }
 
 // FromDisk restores container's state from disk


### PR DESCRIPTION
Instead of converting the stop signal from int to its
string name, i.e sig 15 to "TERM", send down the int value
converted to a string instead i.e sig 15 to "15". This avoids
doing a look up for the signal in the sigMap in both cri-o
and runc and double back and forth conversion from int to string.
The sigMap in the runc code for example didn't have all the
signals that the sigMap in cri-o does. So when a container
with the ubi8-init image was run and stopped, a SIGRTMIN+3
is used, which wasn't being recognized by runc causing the
container to fail to stop.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
