### PR TITLE
[1.14] klog: don't write to /tmp

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goflag "flag"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -26,6 +27,7 @@ import (
 	"github.com/urfave/cli"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
+	"k8s.io/klog"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
@@ -77,8 +79,19 @@ func catchShutdown(ctx context.Context, cancel context.CancelFunc, gserver *grpc
 }
 
 func main() {
-	// https://github.com/kubernetes/kubernetes/issues/17162
-	goflag.CommandLine.Parse([]string{})
+	// Unfortunately, there's no way to ask klog to not write to tmp without this kludge.
+	// Until something like https://github.com/kubernetes/klog/pull/100 is merged, this will have to do.
+	klogFlagSet := goflag.NewFlagSet("klog", goflag.ExitOnError)
+	klog.InitFlags(klogFlagSet)
+
+	if err := klogFlagSet.Set("logtostderr", "false"); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to set logtostderr for klog: %v\n", err)
+	}
+	if err := klogFlagSet.Set("alsologtostderr", "false"); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to set alsologtostderr for klog: %v\n", err)
+	}
+
+	klog.SetOutput(ioutil.Discard)
 
 	if reexec.Init() {
 		return

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20191004102930-01520b8320fc+incompatible
 	k8s.io/cloud-provider v0.0.0-20191004111010-9775d7be8494 // indirect
 	k8s.io/csi-api v0.0.0-20191004110013-47566b0fae2b // indirect
-	k8s.io/klog v0.3.3
+	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20190306001800-15615b16d372 // indirect
 	k8s.io/kubernetes v1.14.10-beta.0.0.20191205115033-6b6e640a7aaf
 	k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1163,7 +1163,7 @@ k8s.io/client-go/listers/storage/v1alpha1
 # k8s.io/cloud-provider v0.0.0-20191004111010-9775d7be8494 => k8s.io/cloud-provider v0.0.0-20190314002645-c892ea32361a
 k8s.io/cloud-provider
 k8s.io/cloud-provider/features
-# k8s.io/klog v0.3.3 => k8s.io/klog v0.0.0-20181108234604-8139d8cb77af
+# k8s.io/klog v1.0.0 => k8s.io/klog v0.0.0-20181108234604-8139d8cb77af
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20190306001800-15615b16d372
 k8s.io/kube-openapi/pkg/util/proto


### PR DESCRIPTION
klog currently doesn't have an API to not write to /tmp. One has to "pass" down flags to it.
since cri-o uses libraries that use klog, we need this hack to not write klog logs to /tmp

Signed-off-by: Peter Hunt <pehunt@redhat.com>