### PR TITLE
conmonmon: errorf when OOM killing

### DIFF
--- a/internal/lib/conmonmon.go
+++ b/internal/lib/conmonmon.go
@@ -68,7 +68,7 @@ func (c *conmonmon) signalConmons() {
 	for ctr, info := range c.conmons {
 		if ctr.State().Status == oci.ContainerStateRunning {
 			if err := c.verifyConmonValid(info.startTime, info.conmonPID); err != nil {
-				logrus.Debugf("conmon pid %d invalid: %v. Killing container %s", info.conmonPID, err, ctr.ID())
+				logrus.Errorf("conmon pid %d invalid: %v. Killing container %s", info.conmonPID, err, ctr.ID())
 				delete(c.conmons, ctr)
 				// kill container in separate thread to hold the conmonmon lock as little as possible
 				go c.oomKillContainer(ctr)


### PR DESCRIPTION
when conmonmon decides a conmon is gone, and its container should have oom kill spoofed, that's a big deal.
As an admin, we'd typically want that feedback.
Error is a standard value for log level, so this message is more likely to show up. Error is more representative of the severity of the situation

Signed-off-by: Peter Hunt <pehunt@redhat.com>
