### PR TITLE
Uppercase first log char per default

### DIFF
--- a/internal/pkg/log/hook_filter.go
+++ b/internal/pkg/log/hook_filter.go
@@ -3,6 +3,7 @@ package log
 import (
 	"io/ioutil"
 	"regexp"
+	"unicode"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -50,5 +51,13 @@ func (f *FilterHook) Fire(entry *logrus.Entry) error {
 	if entry.Level == logrus.DebugLevel {
 		entry.Message = f.predefined.ReplaceAllString(entry.Message, "[FILTERED]")
 	}
+
+	// Uppercase every first character for each log just for better optics
+	if len(entry.Message) > 0 {
+		messageBytes := []byte(entry.Message)
+		messageBytes[0] = byte(unicode.ToUpper(rune(messageBytes[0])))
+		entry.Message = string(messageBytes)
+	}
+
 	return nil
 }

--- a/internal/pkg/log/hook_filter_test.go
+++ b/internal/pkg/log/hook_filter_test.go
@@ -77,7 +77,7 @@ var _ = t.Describe("HookFilter", func() {
 
 			// Then
 			Expect(res).To(BeNil())
-			Expect(entry.Message).To(Equal("a slice: [FILTERED]"))
+			Expect(entry.Message).To(Equal("A slice: [FILTERED]"))
 		})
 	})
 })

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -646,7 +646,7 @@ function wait_for_log() {
             exit 1
         fi
 
-        if grep -q "$1" "$CRIO_LOG"; then
+        if grep -iq "$1" "$CRIO_LOG"; then
             break
         fi
 


### PR DESCRIPTION
Just for sake of the general beautifulness of our logs, we now uppercase the
first character of them:

```
DEBU[…] Using runtime executable from …
DEBU[…] Found valid runtime "runc" for…
DEBU[…] Using  hooks directory: /usr/s…
DEBU[…] Using conmon from $PATH: /usr/…
DEBU[…] Using pinns from $PATH: /usr/b…
DEBU[…] Cached value indicated that ov…
DEBU[…] Cached value indicated that me…
DEBU[…] Cached value indicated that na…
DEBU[…] BackingFs=btrfs, projectQuotaS…
INFO[…] [graphdriver] using prior stor…
DEBU[…] Reading hooks from /usr/share/…
INFO[…] Found CNI network crio-bridge …
INFO[…] Found CNI network podman (type…
INFO[…] Update default CNI network nam…
INFO[…] No seccomp profile specified, …
INFO[…] Installing default apparmor pr…
DEBU[…] Golang's threads limit set to …
INFO[…] Got pod network &{Name:podsand…
INFO[…] About to check CNI network cri…
DEBU[…] Sandboxes: [0xc0001f6a80]     …
DEBU[…] Registered SIGHUP watcher for …
DEBU[…] Monitoring "/usr/share/contain…
```
