### PR TITLE
[1.16] klog: don't write to /tmp

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goflag "flag"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -29,6 +30,7 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"k8s.io/klog"
 )
 
 // gitCommit is the commit that the binary is being built from.
@@ -81,11 +83,19 @@ func catchShutdown(ctx context.Context, cancel context.CancelFunc, gserver *grpc
 }
 
 func main() {
-	// https://github.com/kubernetes/kubernetes/issues/17162
-	if err := goflag.CommandLine.Parse([]string{}); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to parse command line flags\n")
-		os.Exit(-1)
+	// Unfortunately, there's no way to ask klog to not write to tmp without this kludge.
+	// Until something like https://github.com/kubernetes/klog/pull/100 is merged, this will have to do.
+	klogFlagSet := goflag.NewFlagSet("klog", goflag.ExitOnError)
+	klog.InitFlags(klogFlagSet)
+
+	if err := klogFlagSet.Set("logtostderr", "false"); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to set logtostderr for klog: %v\n", err)
 	}
+	if err := klogFlagSet.Set("alsologtostderr", "false"); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to set alsologtostderr for klog: %v\n", err)
+	}
+
+	klog.SetOutput(ioutil.Discard)
 
 	if reexec.Init() {
 		fmt.Fprintf(os.Stderr, "unable to initialize container storage\n")

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/cri-api v0.0.0
+	k8s.io/klog v1.0.0
 	k8s.io/kubernetes v1.13.0
 	k8s.io/utils v0.0.0-20190920012459-5008bf6f8cd6
 )


### PR DESCRIPTION
klog currently doesn't have an API to not write to /tmp. One has to "pass" down flags to it.
since cri-o uses libraries that use klog, we need this hack to not write klog logs to /tmp

Signed-off-by: Peter Hunt <pehunt@redhat.com>