### PR TITLE
[1.14] Restore sandbox selinux labels directly from config.json

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -336,15 +336,8 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 
-	dupLabels, err := label.DupSecOpt(m.Process.SelinuxLabel)
-	if err != nil {
-		return err
-	}
-
-	processLabel, mountLabel, err := label.InitLabels(dupLabels)
-	if err != nil {
-		return err
-	}
+	processLabel := m.Process.SelinuxLabel
+	mountLabel := m.Linux.MountLabel
 
 	spp := m.Annotations[annotations.SeccompProfilePath]
 


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

