### PR TITLE
Update pinns build and add small cleanups

### DIFF
--- a/pinns/Makefile
+++ b/pinns/Makefile
@@ -2,11 +2,14 @@ src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
 override LIBS +=
-CFLAGS ?= -std=c99 -Os -Wall -Wextra
+CFLAGS ?= -std=c99 -Os -Wall -Werror -Wextra
 override CFLAGS += -static
+
+all: ../bin/pinns
 
 ../bin/pinns: $(obj) | ../bin
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+	strip -s $@
 
 ../bin:
 	mkdir -p $@

--- a/pinns/pinns.c
+++ b/pinns/pinns.c
@@ -14,7 +14,7 @@
 
 #include "utils.h"
 
-int bind_ns(const char *pin_path, const char *ns_name) {
+static int bind_ns(const char *pin_path, const char *ns_name) {
   char bind_path[PATH_MAX];
   char ns_path[PATH_MAX];
   int fd;
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
   }
 
   if (!pin_path) {
-    pexit("Path for pinning namespaces not specified.");
+    pexit("Path for pinning namespaces not specified");
   }
 
   struct stat sb;

--- a/pinns/utils.h
+++ b/pinns/utils.h
@@ -12,31 +12,31 @@
 
 #define _pexit(s)                                                              \
   do {                                                                         \
-    fprintf(stderr, "[pinns:e]: %s %s\n", s, strerror(errno));                 \
+    fprintf(stderr, "[pinns:e]: %s: %s\n", s, strerror(errno));                \
     _exit(EXIT_FAILURE);                                                       \
   } while (0)
 
 #define pexit(s)                                                               \
   do {                                                                         \
-    fprintf(stderr, "[pinns:e]: %s %s\n", s, strerror(errno));                 \
+    fprintf(stderr, "[pinns:e]: %s: %s\n", s, strerror(errno));                \
     exit(EXIT_FAILURE);                                                        \
   } while (0)
 
 #define pexitf(fmt, ...)                                                       \
   do {                                                                         \
-    fprintf(stderr, "[pinns:e]: " fmt " %s\n", ##__VA_ARGS__,                  \
+    fprintf(stderr, "[pinns:e]: " fmt ": %s\n", ##__VA_ARGS__,                 \
             strerror(errno));                                                  \
     exit(EXIT_FAILURE);                                                        \
   } while (0)
 
 #define pwarn(s)                                                               \
   do {                                                                         \
-    fprintf(stderr, "[pinns:w]: %s %s\n", s, strerror(errno));                 \
+    fprintf(stderr, "[pinns:w]: %s: %s\n", s, strerror(errno));                \
   } while (0)
 
 #define pwarnf(fmt, ...)                                                       \
   do {                                                                         \
-    fprintf(stderr, "[pinns:e]: " fmt " %s\n", ##__VA_ARGS__,                  \
+    fprintf(stderr, "[pinns:e]: " fmt ": %s\n", ##__VA_ARGS__,                 \
             strerror(errno));                                                  \
   } while (0)
 


### PR DESCRIPTION
Just a couple of enhancements to pinns:

- Strip the binary to reduce its size
- Make `bind_ns()` static to scope to single object
- Print a `:` separator on logging errno
