### PR TITLE
Add user-notice about minimal ctr_stop_timeout

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -31,7 +31,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l conmon-cgroup -r -d 'cgrou
 complete -c crio -n '__fish_crio_no_subcommand' -f -l conmon-env -r -d 'Environment variable list for the conmon process, used for passing necessary environment variables to conmon or the runtime'
 complete -c crio -n '__fish_crio_no_subcommand' -l container-attach-socket-dir -r -d 'Path to directory for container attach sockets (default: "/var/run/crio")'
 complete -c crio -n '__fish_crio_no_subcommand' -l container-exits-dir -r -d 'Path to directory in which container exit files are written to by conmon (default: "/var/run/crio/exits")'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l ctr-stop-timeout -r -d 'The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l ctr-stop-timeout -r -d 'The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container. The lowest possible value is 30s, whereas lower values are not considered by CRI-O'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l decryption-keys-path -r -d 'Path to load keys for image decryption. (default: "/etc/crio/keys/")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l default-capabilities -r -d 'Capabilities to add to the containers (default: ["CHOWN" "DAC_OVERRIDE" "FSETID" "FOWNER" "NET_RAW" "SETGID" "SETUID" "SETPCAP" "NET_BIND_SERVICE" "SYS_CHROOT" "KILL"])'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l default-mounts -r -d 'Add one or more default mount paths in the form host:container (deprecated) (default: [])'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -142,7 +142,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--container-exits-dir**="": Path to directory in which container exit files are written to by conmon (default: "/var/run/crio/exits")
 
-**--ctr-stop-timeout**="": The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container (default: 0)
+**--ctr-stop-timeout**="": The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container. The lowest possible value is 30s, whereas lower values are not considered by CRI-O (default: 30)
 
 **--decryption-keys-path**="": Path to load keys for image decryption. (default: "/etc/crio/keys/")
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -191,7 +191,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **gid_mappings**=""
   The GID mappings for the user namespace of each container. A range is specified in the form containerGID:HostGID:Size. Multiple ranges must be separated by comma.
 
-**ctr_stop_timeout**=0
+**ctr_stop_timeout**=30
   The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container.
 
 **manage_network_ns_lifecycle**=false

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -639,7 +639,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.Int64Flag{
 			Name:    "ctr-stop-timeout",
-			Usage:   "The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container",
+			Usage:   "The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container. The lowest possible value is 30s, whereas lower values are not considered by CRI-O",
 			Value:   defConf.CtrStopTimeout,
 			EnvVars: []string{"CONTAINER_STOP_TIMEOUT"},
 		},

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -229,7 +229,8 @@ uid_mappings = "{{ .UIDMappings }}"
 gid_mappings = "{{ .GIDMappings }}"
 
 # The minimal amount of time in seconds to wait before issuing a timeout
-# regarding the proper termination of the container.
+# regarding the proper termination of the container. The lowest possible
+# value is 30s, whereas lower values are not considered by CRI-O.
 ctr_stop_timeout = {{ .CtrStopTimeout }}
 
 # **DEPRECATED** this option is being replaced by manage_ns_lifecycle, which is described below.


### PR DESCRIPTION
We now mention in the documentation that the lowest possible value for
the ctr_stop_timeout is 30seconds. We also move the validation of this
fact into the config validation part of the library.
