### PR TITLE
[1.15] port forward: drain the stream on error

### DIFF
--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -822,6 +822,15 @@ func (r *runtimeOCI) AttachContainer(c *Container, inputStream io.Reader, output
 
 // PortForwardContainer forwards the specified port provides statistics of a container.
 func (r *runtimeOCI) PortForwardContainer(c *Container, port int32, stream io.ReadWriter) error {
+	emptyStreamOnError := true
+	defer func() {
+		if emptyStreamOnError {
+			go func() {
+				_, copyError := pools.Copy(ioutil.Discard, stream)
+				logrus.Errorf("error closing port forward stream after other error: %v", copyError)
+			}()
+		}
+	}()
 	containerPid := c.State().Pid
 	socatPath, lookupErr := exec.LookPath("socat")
 	if lookupErr != nil {
@@ -862,6 +871,7 @@ func (r *runtimeOCI) PortForwardContainer(c *Container, port int32, stream io.Re
 	}
 	var copyError error
 	go func() {
+		emptyStreamOnError = false
 		_, copyError = pools.Copy(inPipe, stream)
 		inPipe.Close()
 	}()


### PR DESCRIPTION
Before, we never drained the stream when we failed before calling pools.Copy(). A failure like this could happen if socat is not installed, or there is an invalid id found.

The problem is: if we never drain the streams, they stay open, and will cause kubelet to hang when trying to allocate one of its streams. If we don't drain on error, we can leak

fix this by draining the streams on error, until we actually want to copy data out of it

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
