### PR TITLE
[1.17] port forward: drain the stream on error

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -866,6 +866,15 @@ func (r *runtimeOCI) AttachContainer(c *Container, inputStream io.Reader, output
 
 // PortForwardContainer forwards the specified port provides statistics of a container.
 func (r *runtimeOCI) PortForwardContainer(c *Container, port int32, stream io.ReadWriter) error {
+	emptyStreamOnError := true
+	defer func() {
+		if emptyStreamOnError {
+			go func() {
+				_, copyError := pools.Copy(ioutil.Discard, stream)
+				logrus.Errorf("error closing port forward stream after other error: %v", copyError)
+			}()
+		}
+	}()
 	containerPid := c.State().Pid
 	socatPath, lookupErr := exec.LookPath("socat")
 	if lookupErr != nil {
@@ -906,6 +915,7 @@ func (r *runtimeOCI) PortForwardContainer(c *Container, port int32, stream io.Re
 	}
 	var copyError error
 	go func() {
+		emptyStreamOnError = false
 		_, copyError = pools.Copy(inPipe, stream)
 		inPipe.Close()
 	}()

--- a/server/container_portforward.go
+++ b/server/container_portforward.go
@@ -28,7 +28,7 @@ func (s StreamService) PortForward(podSandboxID string, port int32, stream io.Re
 	// ref https://bugzilla.redhat.com/show_bug.cgi?id=1798193
 	emptyStreamOnError := true
 	defer func() {
-		if emptyStreamOnError {
+		if emptyStreamOnError && stream != nil {
 			go func() {
 				_, copyError := pools.Copy(ioutil.Discard, stream)
 				logrus.Errorf("error closing port forward stream after other error: %v", copyError)

--- a/server/container_portforward.go
+++ b/server/container_portforward.go
@@ -3,8 +3,11 @@ package server
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/docker/docker/pkg/pools"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -20,7 +23,21 @@ func (s *Server) PortForward(ctx context.Context, req *pb.PortForwardRequest) (r
 }
 
 func (s StreamService) PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+	// if we error in this function before Copying all of the content out of the stream,
+	// this stream will eventually get full, which causes leakages and can eventually brick CRI-O
+	// ref https://bugzilla.redhat.com/show_bug.cgi?id=1798193
+	emptyStreamOnError := true
+	defer func() {
+		if emptyStreamOnError {
+			go func() {
+				_, copyError := pools.Copy(ioutil.Discard, stream)
+				logrus.Errorf("error closing port forward stream after other error: %v", copyError)
+			}()
+		}
+	}()
+
 	sandboxID, err := s.runtimeServer.PodIDIndex().Get(podSandboxID)
+
 	if err != nil {
 		return fmt.Errorf("PodSandbox with ID starting with %s not found: %v", podSandboxID, err)
 	}
@@ -39,5 +56,6 @@ func (s StreamService) PortForward(podSandboxID string, port int32, stream io.Re
 		return fmt.Errorf("container is not created or running")
 	}
 
+	emptyStreamOnError = false
 	return s.runtimeServer.Runtime().PortForwardContainer(c, port, stream)
 }


### PR DESCRIPTION
Before, we never drained the stream when we failed before calling pools.Copy(). A failure like this could happen if socat is not installed, or there is an invalid id found.

The problem is: if we never drain the streams, they stay open, and will cause kubelet to hang when trying to allocate one of its streams. If we don't drain on error, we can leak

fix this by draining the streams on error, until we actually want to copy data out of it

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
