### PR TITLE
port forward: drain the stream on error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/creack/pty v1.1.9
 	github.com/cri-o/ocicni v0.2.1-0.20200409131010-b197cd13855b
 	github.com/cyphar/filepath-securejoin v0.2.2
+	github.com/docker/docker v1.4.2-0.20191219165747-a9416c67da9f // indirect
 	github.com/docker/go-units v0.4.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-zoo/bone v1.3.0

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -904,8 +904,9 @@ func (r *runtimeOCI) PortForwardContainer(c *Container, port int32, stream io.Re
 	defer func() {
 		if emptyStreamOnError {
 			go func() {
-				_, copyError := pools.Copy(ioutil.Discard, stream)
-				logrus.Errorf("error closing port forward stream after other error: %v", copyError)
+				if _, copyError := pools.Copy(ioutil.Discard, stream); copyError != nil {
+					logrus.Errorf("error closing port forward stream after other error: %v", copyError)
+				}
 			}()
 		}
 	}()

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -900,6 +900,15 @@ func (r *runtimeOCI) AttachContainer(c *Container, inputStream io.Reader, output
 
 // PortForwardContainer forwards the specified port provides statistics of a container.
 func (r *runtimeOCI) PortForwardContainer(c *Container, port int32, stream io.ReadWriter) error {
+	emptyStreamOnError := true
+	defer func() {
+		if emptyStreamOnError {
+			go func() {
+				_, copyError := pools.Copy(ioutil.Discard, stream)
+				logrus.Errorf("error closing port forward stream after other error: %v", copyError)
+			}()
+		}
+	}()
 	containerPid := c.State().Pid
 	socatPath, lookupErr := exec.LookPath("socat")
 	if lookupErr != nil {
@@ -940,6 +949,7 @@ func (r *runtimeOCI) PortForwardContainer(c *Container, port int32, stream io.Re
 	}
 	var copyError error
 	go func() {
+		emptyStreamOnError = false
 		_, copyError = pools.Copy(inPipe, stream)
 		inPipe.Close()
 	}()

--- a/server/container_portforward.go
+++ b/server/container_portforward.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/containers/storage/pkg/pools"
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/docker/docker/pkg/pools"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -28,7 +28,7 @@ func (s StreamService) PortForward(podSandboxID string, port int32, stream io.Re
 	// ref https://bugzilla.redhat.com/show_bug.cgi?id=1798193
 	emptyStreamOnError := true
 	defer func() {
-		if emptyStreamOnError {
+		if emptyStreamOnError && stream != nil {
 			go func() {
 				_, copyError := pools.Copy(ioutil.Discard, stream)
 				logrus.Errorf("error closing port forward stream after other error: %v", copyError)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,6 +307,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 # github.com/docker/docker v1.4.2-0.20191219165747-a9416c67da9f
+## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev


### PR DESCRIPTION
Before, we never drained the stream when we failed before calling pools.Copy(). A failure like this could happen if socat is not installed, or there is an invalid id found.

The problem is: if we never drain the streams, they stay open, and will cause kubelet to hang when trying to allocate one of its streams. If we don't drain on error, we can leak

fix this by draining the streams on error, until we actually want to copy data out of it

Signed-off-by: Peter Hunt <pehunt@redhat.com>