### PR TITLE
[1.11] update containers/image

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/gregjones/httpcache 787624de3eb7bd915c329cba748687a3b22666a6
 github.com/json-iterator/go f2b4162afba35581b6d4a50d3b8f34e33c144682
 github.com/peterbourgon/diskv v2.0.1
 github.com/sirupsen/logrus v1.0.0
-github.com/containers/image 8f11f3ad8912d8bc43a7d25992b8f313ffefd430
+github.com/containers/image cri-o-release-1.11
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/ostreedev/ostree-go master
 github.com/containers/storage release-1.11

--- a/vendor/github.com/containers/image/docker/docker_client.go
+++ b/vendor/github.com/containers/image/docker/docker_client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/iolimits"
 	"github.com/containers/image/pkg/docker/config"
 	"github.com/containers/image/pkg/tlsclientconfig"
 	"github.com/containers/image/types"
@@ -497,7 +497,7 @@ func (c *dockerClient) getBearerToken(ctx context.Context, realm, service, scope
 	default:
 		return nil, errors.Errorf("unexpected http code: %d, URL: %s", res.StatusCode, authReq.URL)
 	}
-	tokenBlob, err := ioutil.ReadAll(res.Body)
+	tokenBlob, err := iolimits.ReadAtMost(res.Body, iolimits.MaxAuthTokenBodySize)
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +576,8 @@ func (c *dockerClient) getExtensionsSignatures(ctx context.Context, ref dockerRe
 	if res.StatusCode != http.StatusOK {
 		return nil, errors.Wrapf(client.HandleErrorResponse(res), "Error downloading signatures for %s in %s", manifestDigest, ref.ref.Name())
 	}
-	body, err := ioutil.ReadAll(res.Body)
+
+	body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxSignatureListBodySize)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/iolimits"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/docker/distribution/registry/api/errcode"
@@ -448,7 +449,7 @@ sigExists:
 		}
 		defer res.Body.Close()
 		if res.StatusCode != http.StatusCreated {
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxErrorBodySize)
 			if err == nil {
 				logrus.Debugf("Error body %s", string(body))
 			}

--- a/vendor/github.com/containers/image/docker/docker_image_src.go
+++ b/vendor/github.com/containers/image/docker/docker_image_src.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/iolimits"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/docker/distribution/registry/client"
@@ -97,7 +98,8 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 	if res.StatusCode != http.StatusOK {
 		return nil, "", errors.Wrapf(client.HandleErrorResponse(res), "Error reading manifest %s in %s", tagOrDigest, s.ref.ref.Name())
 	}
-	manblob, err := ioutil.ReadAll(res.Body)
+
+	manblob, err := iolimits.ReadAtMost(res.Body, iolimits.MaxManifestBodySize)
 	if err != nil {
 		return nil, "", err
 	}
@@ -276,7 +278,7 @@ func (s *dockerImageSource) getOneSignature(ctx context.Context, url *url.URL) (
 		} else if res.StatusCode != http.StatusOK {
 			return nil, false, errors.Errorf("Error reading signature from %s: status %d", url.String(), res.StatusCode)
 		}
-		sig, err := ioutil.ReadAll(res.Body)
+		sig, err := iolimits.ReadAtMost(res.Body, iolimits.MaxSignatureBodySize)
 		if err != nil {
 			return nil, false, err
 		}
@@ -337,7 +339,7 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 		return err
 	}
 	defer get.Body.Close()
-	manifestBody, err := ioutil.ReadAll(get.Body)
+	manifestBody, err := iolimits.ReadAtMost(get.Body, iolimits.MaxManifestBodySize)
 	if err != nil {
 		return err
 	}
@@ -360,7 +362,7 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 	}
 	defer delete.Body.Close()
 
-	body, err := ioutil.ReadAll(delete.Body)
+	body, err := iolimits.ReadAtMost(delete.Body, iolimits.MaxErrorBodySize)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/image/docker/tarfile/dest.go
+++ b/vendor/github.com/containers/image/docker/tarfile/dest.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/iolimits"
 	"github.com/containers/image/internal/tmpdir"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
@@ -129,7 +130,7 @@ func (d *Destination) PutBlob(ctx context.Context, stream io.Reader, inputInfo t
 	}
 
 	if isConfig {
-		buf, err := ioutil.ReadAll(stream)
+		buf, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
 		if err != nil {
 			return types.BlobInfo{}, errors.Wrap(err, "Error reading Config file stream")
 		}

--- a/vendor/github.com/containers/image/docker/tarfile/src.go
+++ b/vendor/github.com/containers/image/docker/tarfile/src.go
@@ -11,6 +11,7 @@ import (
 	"path"
 
 	"github.com/containers/image/internal/tmpdir"
+	"github.com/containers/image/internal/iolimits"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/pkg/compression"
 	"github.com/containers/image/types"
@@ -184,13 +185,13 @@ func findTarComponent(inputFile io.Reader, path string) (*tar.Reader, *tar.Heade
 }
 
 // readTarComponent returns full contents of componentPath.
-func (s *Source) readTarComponent(path string) ([]byte, error) {
+func (s *Source) readTarComponent(path string, limit int) ([]byte, error) {
 	file, err := s.openTarComponent(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error loading tar component %s", path)
 	}
 	defer file.Close()
-	bytes, err := ioutil.ReadAll(file)
+	bytes, err := iolimits.ReadAtMost(file, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -213,9 +214,8 @@ func (s *Source) ensureCachedDataIsPresent() error {
 	if len(tarManifest) != 1 {
 		return errors.Errorf("Unexpected tar manifest.json: expected 1 item, got %d", len(tarManifest))
 	}
-
 	// Read and parse config.
-	configBytes, err := s.readTarComponent(tarManifest[0].Config)
+	configBytes, err := s.readTarComponent(tarManifest[0].Config, iolimits.MaxConfigBodySize)
 	if err != nil {
 		return err
 	}
@@ -241,7 +241,7 @@ func (s *Source) ensureCachedDataIsPresent() error {
 // loadTarManifest loads and decodes the manifest.json.
 func (s *Source) loadTarManifest() ([]ManifestItem, error) {
 	// FIXME? Do we need to deal with the legacy format?
-	bytes, err := s.readTarComponent(manifestFileName)
+	bytes, err := s.readTarComponent(manifestFileName, iolimits.MaxTarFileManifestSize)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/image/image/docker_schema2.go
+++ b/vendor/github.com/containers/image/image/docker_schema2.go
@@ -6,10 +6,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
 	"strings"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/iolimits"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
@@ -100,7 +100,7 @@ func (m *manifestSchema2) ConfigBlob(ctx context.Context) ([]byte, error) {
 			return nil, err
 		}
 		defer stream.Close()
-		blob, err := ioutil.ReadAll(stream)
+		blob, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/containers/image/image/oci.go
+++ b/vendor/github.com/containers/image/image/oci.go
@@ -3,9 +3,9 @@ package image
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/iolimits"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
@@ -65,7 +65,7 @@ func (m *manifestOCI1) ConfigBlob(ctx context.Context) ([]byte, error) {
 			return nil, err
 		}
 		defer stream.Close()
-		blob, err := ioutil.ReadAll(stream)
+		blob, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/containers/image/internal/iolimits/iolimits.go
+++ b/vendor/github.com/containers/image/internal/iolimits/iolimits.go
@@ -1,0 +1,60 @@
+package iolimits
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+// All constants below are intended to be used as limits for `ReadAtMost`. The
+// immediate use-case for limiting the size of in-memory copied data is to
+// protect against OOM DOS attacks as described inCVE-2020-1702. Instead of
+// copying data until running out of memory, we error out after hitting the
+// specified limit.
+const (
+	// megaByte denotes one megabyte and is intended to be used as a limit in
+	// `ReadAtMost`.
+	megaByte = 1 << 20
+	// MaxManifestBodySize is the maximum allowed size of a manifest. The limit
+	// of 4 MB aligns with the one of a Docker registry:
+	// https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/registry/handlers/manifests.go#L30
+	MaxManifestBodySize = 4 * megaByte
+	// MaxAuthTokenBodySize is the maximum allowed size of an auth token.
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxAuthTokenBodySize = megaByte
+	// MaxSignatureListBodySize is the maximum allowed size of a signature list.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxSignatureListBodySize = 4 * megaByte
+	// MaxSignatureBodySize is the maximum allowed size of a signature.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxSignatureBodySize = 4 * megaByte
+	// MaxErrorBodySize is the maximum allowed size of an error-response body.
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxErrorBodySize = megaByte
+	// MaxConfigBodySize is the maximum allowed size of a config blob.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxConfigBodySize = 4 * megaByte
+	// MaxOpenShiftStatusBody is the maximum allowed size of an OpenShift status body.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxOpenShiftStatusBody = 4 * megaByte
+	// MaxTarFileManifestSize is the maximum allowed size of a (docker save)-like manifest (which may contain multiple images)
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxTarFileManifestSize = megaByte
+)
+
+// ReadAtMost reads from reader and errors out if the specified limit (in bytes) is exceeded.
+func ReadAtMost(reader io.Reader, limit int) ([]byte, error) {
+	limitedReader := io.LimitReader(reader, int64(limit+1))
+
+	res, err := ioutil.ReadAll(limitedReader)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res) > limit {
+		return nil, errors.Errorf("exceeded maximum allowed size of %d bytes", limit)
+	}
+
+	return res, nil
+}

--- a/vendor/github.com/containers/image/openshift/openshift.go
+++ b/vendor/github.com/containers/image/openshift/openshift.go
@@ -7,13 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/containers/image/docker"
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/iolimits"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/containers/image/version"
@@ -102,7 +102,7 @@ func (c *openshiftClient) doRequest(ctx context.Context, method, path string, re
 		return nil, err
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxOpenShiftStatusBody)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Pulls in fixes for CVE-2020-1702 from the new cri-o-release-1.11 branch
from containers/image.

Fixes: CVE-2020-1702
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>