### PR TITLE
Add live configuration reload to seccomp profile

### DIFF
--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -75,6 +75,10 @@ func (c *Config) Reload() error {
 		return err
 	}
 	c.ReloadDecryptionKeyConfig(newConfig)
+	if err := c.ReloadSeccompProfile(newConfig); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -163,4 +167,17 @@ func (c *Config) ReloadDecryptionKeyConfig(newConfig *Config) {
 		logConfig("decryption_keys_path", newConfig.DecryptionKeysPath)
 		c.DecryptionKeysPath = newConfig.DecryptionKeysPath
 	}
+}
+
+// ReloadSeccompProfile reloads the seccomp profile from the new config if
+// their paths differ.
+func (c *Config) ReloadSeccompProfile(newConfig *Config) error {
+	// Reload the seccomp profile in any case because its content could have
+	// changed as well
+	if err := c.Seccomp().LoadProfile(newConfig.SeccompProfile); err != nil {
+		return errors.Wrap(err, "unable to reload seccomp_profile")
+	}
+	c.SeccompProfile = newConfig.SeccompProfile
+	logConfig("seccomp_profile", c.SeccompProfile)
+	return nil
 }

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -66,6 +66,20 @@ var _ = t.Describe("Config", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 		})
+
+		It("should fail with invalid seccomp_profile", func() {
+			// Given
+			modifyDefaultConfig(
+				`seccomp_profile = ""`,
+				`seccomp_profile = "`+invalidPath+`"`,
+			)
+
+			// When
+			err := sut.Reload()
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
 	})
 
 	t.Describe("ReloadLogLevel", func() {
@@ -235,6 +249,45 @@ var _ = t.Describe("Config", func() {
 
 			// When
 			err := sut.ReloadRegistries()
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	t.Describe("ReloadSeccompProfile", func() {
+		It("should succeed without any config change", func() {
+			// Given
+			// When
+			err := sut.ReloadSeccompProfile(sut)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed with config change", func() {
+			// Given
+			filePath := t.MustTempFile("seccomp")
+			Expect(ioutil.WriteFile(filePath, []byte(`{}`), 0644)).To(BeNil())
+
+			newConfig := defaultConfig()
+			newConfig.SeccompProfile = filePath
+
+			// When
+			err := sut.ReloadSeccompProfile(newConfig)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.SeccompProfile).To(Equal(filePath))
+		})
+
+		It("should fail with invalid seccomp_profile", func() {
+			// Given
+			newConfig := defaultConfig()
+			newConfig.SeccompProfile = invalidPath
+
+			// When
+			err := sut.ReloadSeccompProfile(newConfig)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/pkg/config/seccomp/seccomp.go
+++ b/pkg/config/seccomp/seccomp.go
@@ -1,0 +1,66 @@
+package seccomp
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	seccomp "github.com/seccomp/containers-golang"
+	"github.com/sirupsen/logrus"
+)
+
+// Config is the global seccomp configuration type
+type Config struct {
+	enabled bool
+	profile *seccomp.Seccomp
+}
+
+// New creates a new default seccomp configuration instance
+func New() *Config {
+	return &Config{
+		enabled: seccomp.IsEnabled(),
+		profile: seccomp.DefaultProfile(),
+	}
+}
+
+// LoadProfile can be used to load a seccomp profile from the provided path.
+// This method will not fial if seccomp is disabled.
+func (c *Config) LoadProfile(profilePath string) error {
+	if c.IsDisabled() {
+		logrus.Info("Seccomp is disabled by the system or at CRI-O build-time")
+		return nil
+	}
+
+	if profilePath == "" {
+		c.profile = seccomp.DefaultProfile()
+		logrus.Info("No seccomp profile specified, using the internal default")
+		logrus.Debugf("Current seccomp profile content: %+v", c.profile)
+		return nil
+	}
+
+	profile, err := ioutil.ReadFile(profilePath)
+	if err != nil {
+		return errors.Wrapf(err, "open seccomp profile %s failed", profilePath)
+	}
+
+	tmpProfile := &seccomp.Seccomp{}
+	if err := json.Unmarshal(profile, tmpProfile); err != nil {
+		return errors.Wrap(err, "decoding seccomp profile failed")
+	}
+
+	c.profile = tmpProfile
+	logrus.Infof("Successfully loaded seccomp profile %q", profilePath)
+	logrus.Debugf("Current seccomp profile content: %+v", c.profile)
+	return nil
+}
+
+// IsDisabled returns true if seccomp is disabled either via the missing
+// `seccomp` buildtag or globally by the system.
+func (c *Config) IsDisabled() bool {
+	return !c.enabled
+}
+
+// Profile returns the currently loaded seccomp profile
+func (c *Config) Profile() *seccomp.Seccomp {
+	return c.profile
+}

--- a/pkg/config/seccomp/seccomp_test.go
+++ b/pkg/config/seccomp/seccomp_test.go
@@ -1,0 +1,93 @@
+package seccomp_test
+
+import (
+	"io/ioutil"
+
+	"github.com/cri-o/cri-o/pkg/config/seccomp"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	containers_seccomp "github.com/seccomp/containers-golang"
+)
+
+// The actual test suite
+var _ = t.Describe("Config", func() {
+	var sut *seccomp.Config
+
+	BeforeEach(func() {
+		sut = seccomp.New()
+		Expect(sut).NotTo(BeNil())
+	})
+
+	t.Describe("IsDisabled", func() {
+		It("should be false per default", func() {
+			// Given
+			// When
+			res := sut.IsDisabled()
+
+			// Then
+			Expect(res).To(BeFalse())
+		})
+	})
+
+	t.Describe("Profile", func() {
+		It("should be the default without any load", func() {
+			// Given
+			// When
+			res := sut.Profile()
+
+			// Then
+			Expect(res).To(Equal(containers_seccomp.DefaultProfile()))
+		})
+	})
+
+	t.Describe("LoadProfile", func() {
+		It("should succeed with default profile", func() {
+			// Given
+
+			// When
+			err := sut.LoadProfile("")
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed with profile", func() {
+			// Given
+			file := t.MustTempFile("")
+			Expect(ioutil.WriteFile(file, []byte(`{
+				"names": ["clone"],
+				"action": "SCMP_ACT_ALLOW",
+				"args": [
+					{
+					"index": 1,
+					"value": 2080505856,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+					}
+				],
+				"comment": "s390 parameter ordering for clone is different",
+				"includes": {
+					"arches": ["s390", "s390x"]
+				},
+				"excludes": {
+					"caps": ["CAP_SYS_ADMIN"]
+				}
+			}`), 0644)).To(BeNil())
+
+			// When
+			err := sut.LoadProfile(file)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should fail with non-existing profile", func() {
+			// Given
+			// When
+			err := sut.LoadProfile("/proc/not/existing/file")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/config/seccomp/suite_test.go
+++ b/pkg/config/seccomp/suite_test.go
@@ -1,0 +1,26 @@
+package seccomp_test
+
+import (
+	"testing"
+
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestLib runs the created specs
+func TestLibConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "SeccompConfig")
+}
+
+var t *TestFramework
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -130,7 +130,7 @@ selinux = {{ .SELinux }}
 
 # Path to the seccomp.json profile which is used as the default seccomp profile
 # for the runtime. If not specified, then the internal default seccomp profile
-# will be used.
+# will be used. This option supports live configuration reload.
 seccomp_profile = "{{ .SeccompProfile }}"
 
 # Used to change the name of the default AppArmor profile of CRI-O. The default

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -640,7 +640,7 @@ func (s *Server) setupSeccomp(ctx context.Context, specgen *generate.Generator, 
 		specgen.Config.Linux.Seccomp = nil
 		return nil
 	}
-	if !s.seccompEnabled {
+	if s.Config().Seccomp().IsDisabled() {
 		if profile != seccompUnconfined {
 			return fmt.Errorf("seccomp is not enabled in your kernel, cannot run with a profile")
 		}
@@ -654,7 +654,7 @@ func (s *Server) setupSeccomp(ctx context.Context, specgen *generate.Generator, 
 
 	// Load the default seccomp profile from the server if the profile is a default one
 	if profile == seccompRuntimeDefault || profile == seccompDockerDefault {
-		linuxSpecs, err := seccomp.LoadProfileFromConfig(s.seccompProfile, specgen.Config)
+		linuxSpecs, err := seccomp.LoadProfileFromConfig(s.Config().Seccomp().Profile(), specgen.Config)
 		if err != nil {
 			return err
 		}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -439,7 +439,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 
-	if !s.seccompEnabled {
+	if s.Config().Seccomp().IsDisabled() {
 		g.Config.Linux.Seccomp = nil
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -195,40 +195,6 @@ var _ = t.Describe("Server", func() {
 			Entry("sz", "1:1:w", "1:1:w"),
 		)
 
-		It("should fail with inavailable seccomp profile", func() {
-			// Given
-			gomock.InOrder(
-				libMock.EXPECT().GetData().Times(2).Return(serverConfig),
-				libMock.EXPECT().GetStore().Return(storeMock, nil),
-				libMock.EXPECT().GetData().Return(serverConfig),
-			)
-			serverConfig.SeccompProfile = invalidDir
-
-			// When
-			server, err := server.New(context.Background(), libMock)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(server).To(BeNil())
-		})
-
-		It("should fail with wrong seccomp profile", func() {
-			// Given
-			gomock.InOrder(
-				libMock.EXPECT().GetData().Times(2).Return(serverConfig),
-				libMock.EXPECT().GetStore().Return(storeMock, nil),
-				libMock.EXPECT().GetData().Return(serverConfig),
-			)
-			serverConfig.SeccompProfile = "/dev/null"
-
-			// When
-			server, err := server.New(context.Background(), libMock)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(server).To(BeNil())
-		})
-
 		It("should fail with invalid stream address and port", func() {
 			// Given
 			mockNewServer()

--- a/test/docs-validation/main.go
+++ b/test/docs-validation/main.go
@@ -231,8 +231,8 @@ func recursiveEntries(
 ) {
 	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 		if v.Kind() == reflect.Ptr {
-			// Skip recursive data
-			if seen[v.Interface()] {
+			// Skip private or recursive data
+			if !v.CanInterface() || seen[v.Interface()] {
 				return
 			}
 			seen[v.Interface()] = true

--- a/test/reload_config.bats
+++ b/test/reload_config.bats
@@ -155,3 +155,30 @@ function expect_log_failure() {
     # then
     expect_log_success $OPTION $NEW_OPTION
 }
+
+@test "reload config should succeed with 'seccomp_profile'" {
+    # given
+    NEW_SECCOMP_PROFILE="$(mktemp --tmpdir seccomp.XXXXXX.json)"
+    echo "{}" > "$NEW_SECCOMP_PROFILE"
+    OPTION="seccomp_profile"
+
+    # when
+    replace_config $OPTION $NEW_SECCOMP_PROFILE
+    reload_crio
+
+    # then
+    expect_log_success $OPTION $NEW_SECCOMP_PROFILE
+}
+
+@test "reload config should fail with invalid 'seccomp_profile'" {
+    # given
+    NEW_SECCOMP_PROFILE=")"
+    OPTION="seccomp_profile"
+
+    # when
+    replace_config $OPTION $NEW_SECCOMP_PROFILE
+    reload_crio
+
+    # then
+    expect_log_failure "unable to reload seccomp_profile"
+}


### PR DESCRIPTION
The seccomp profile is now processed in a dedicated sub-package of the
`config` package and supports the live config reload feature. Necessary
test have been added as well.