### PR TITLE
server, cgroupv2: do not create cgroupns

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -660,8 +660,8 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		specgen.AddMount(cgroupMnt)
 	}
 
-	// When running on cgroupv2, automatically add a cgroup namespace.
-	if cgroups.IsCgroup2UnifiedMode() {
+	// When running on cgroupv2, automatically add a cgroup namespace for not privileged containers.
+	if !privileged && cgroups.IsCgroup2UnifiedMode() {
 		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.CgroupNamespace), ""); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
give privileged containers a full view on the cgroups.  This reflects
the current status of the cgroupv2 KEP.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
