### PR TITLE
Drop support for golang < v1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ stdenv: &stdenv
   environment:
     GOCACHE: &gocache /tmp/go-build
     IMAGE: &image quay.io/crio/crio-build-amd64-go1.13:master-1.2.0
-    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.10:master-1.2.0
+    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.12:master-1.2.0
     IMAGE386: &image386 quay.io/crio/crio-build-386-go1.13:master-1.2.0
     IMAGENIX: &imagenix quay.io/crio/nix:1.2.0
     JOBS: &jobs 4
@@ -59,7 +59,7 @@ workflows:
           filters: *filterAllTags
 
       - build:
-          name: build-go1.10
+          name: build-go1.12
           executor: container-legacy
           filters: *filterAllTags
 

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ local-image:
 test-images:
 	$(TESTIMAGE_SCRIPT) -g 1.13 -a amd64
 	$(TESTIMAGE_SCRIPT) -g 1.13 -a 386
-	$(TESTIMAGE_SCRIPT) -g 1.10 -a amd64
+	$(TESTIMAGE_SCRIPT) -g 1.12 -a amd64
 
 test-image-nix:
 	time $(CONTAINER_RUNTIME) build -t $(TESTIMAGE_NIX) \

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -34,7 +34,10 @@ import (
 )
 
 func writeCrioGoroutineStacks() {
-	path := filepath.Join("/tmp", fmt.Sprintf("crio-goroutine-stacks-%s.log", strings.Replace(time.Now().Format(time.RFC3339), ":", "", -1))) // nolint: gocritic
+	path := filepath.Join("/tmp", fmt.Sprintf(
+		"crio-goroutine-stacks-%s.log",
+		strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", ""),
+	))
 	if err := utils.WriteGoroutineStacksToFile(path); err != nil {
 		logrus.Warnf("Failed to write goroutine stacks: %s", err)
 	}

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -167,7 +167,7 @@ func (r *runtimeVM) startRuntimeDaemon(c *Container) error {
 	args = append(args, "start")
 
 	// Modify the runtime path so that it complies with v2 shim API
-	newRuntimePath := strings.Replace(r.path, "-", ".", -1) // nolint: gocritic
+	newRuntimePath := strings.ReplaceAll(r.path, "-", ".")
 
 	// Setup default namespace
 	r.ctx = namespaces.WithNamespace(r.ctx, namespaces.Default)

--- a/scripts/build-test-image
+++ b/scripts/build-test-image
@@ -6,12 +6,8 @@ if ! command -v buildah >/dev/null; then
 fi
 
 # Versions to be used
-declare -A VERSIONS=(
-    ["cni-plugins"]=v0.8.5
-    ["conmon"]=v2.0.10
-    ["cri-tools"]=v1.17.0
-    ["runc"]=v1.0.0-rc10
-)
+# shellcheck source=versions
+source "$(dirname "${BASH_SOURCE[0]}")"/versions
 
 # Commonly used constants
 ARCH_AMD64=amd64
@@ -151,6 +147,7 @@ install_packages() {
         jq \
         libaio-dev \
         libapparmor-dev \
+        libbtrfs-dev \
         libcap-dev \
         libdevmapper-dev \
         libdevmapper1.02.1 \
@@ -172,9 +169,6 @@ install_packages() {
         protobuf-compiler \
         python-protobuf \
         socat
-    if [[ "$GO" != "1.10" ]]; then
-        run apt-get install -y libbtrfs-dev
-    fi
     run apt-get clean
     rm -rf "$MOUNT_DIR"/var/lib/apt/lists/*
 }

--- a/scripts/circle-setup
+++ b/scripts/circle-setup
@@ -2,12 +2,8 @@
 set -euo pipefail
 
 # Versions to be used
-declare -A VERSIONS=(
-    ["cni-plugins"]=v0.8.4
-    ["conmon"]=v2.0.9
-    ["cri-tools"]=v1.17.0
-    ["runc"]=v1.0.0-rc9
-)
+# shellcheck source=versions
+source "$(dirname "${BASH_SOURCE[0]}")"/versions
 
 main() {
     set -x
@@ -25,8 +21,6 @@ main() {
 
 prepare_system() {
     env
-    go version
-    go env
 
     sudo systemctl stop docker
     sudo ufw disable
@@ -42,12 +36,21 @@ prepare_system() {
 }
 
 install_packages() {
+    # remove old golang version
+    sudo rm -rf /usr/local/go
+    sudo rm -rf /usr/local/bin/go
+
+    # set GOPATH
+    echo "export GOPATH=/home/circleci/go" >>~/.bashrc
+
+    sudo add-apt-repository -y ppa:longsleep/golang-backports
     sudo apt-get update
     sudo apt-get install -y \
         apparmor \
         btrfs-tools \
         conntrack \
         e2fslibs-dev \
+        golang-go \
         jq \
         libaio-dev \
         libapparmor-dev \
@@ -63,6 +66,9 @@ install_packages() {
         libseccomp-dev \
         libsystemd-dev \
         libudev-dev
+
+    go version
+    go env
 }
 
 install_bats() {
@@ -111,8 +117,10 @@ install_cni_plugins() {
 
 install_runc() {
     export GOPATH=/home/circleci/go
-    go get github.com/opencontainers/runc
-    pushd $GOPATH/src/github.com/opencontainers/runc
+    mkdir -p "$GOPATH"/github.com/opencontainers
+    RUNC_PATH=github.com/opencontainers/runc
+    git clone https://"$RUNC_PATH" "$GOPATH"/src/"$RUNC_PATH"
+    pushd "$GOPATH"/src/$RUNC_PATH
     git checkout "${VERSIONS["runc"]}"
     make BUILDTAGS="apparmor selinux seccomp"
     sudo cp runc /usr/sbin

--- a/scripts/versions
+++ b/scripts/versions
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Versions to be used
+declare -A VERSIONS=(
+    ["cni-plugins"]=v0.8.5
+    ["conmon"]=v2.0.10
+    ["cri-tools"]=v1.17.0
+    ["runc"]=v1.0.0-rc10
+)

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -132,7 +132,9 @@ apt-get update -qq && apt-get install -y \
 
 If using an older release or a long-term support release, be careful to double-check that the version of `runc` is new enough (running `runc --version` should produce `spec: 1.0.0`), or else build your own.
 
-Be careful to double-check that the version of golang is new enough, version 1.10.x or higher is required.  If needed, golang kits are available at https://golang.org/dl/
+Be careful to double-check that the version of golang is new enough, version
+1.12.x or higher is required. If needed, newer golang versions are available at
+[the official download website](https://golang.org/dl).
 
 ## Get Source Code
 


### PR DESCRIPTION
To be able to update Kubernetes to the latest release we have to drop
support for go 1.10 and agreed on supporting down to golang v1.12.x.

Needed for https://github.com/cri-o/cri-o/pull/3280