### PR TITLE
Add live configuration reload to AppArmor profile

### DIFF
--- a/internal/config/apparmor/apparmor.go
+++ b/internal/config/apparmor/apparmor.go
@@ -1,0 +1,134 @@
+package apparmor
+
+import (
+	"strings"
+
+	"github.com/containers/libpod/pkg/apparmor"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	k8sAppArmor "k8s.io/kubernetes/pkg/security/apparmor"
+)
+
+const (
+	// DefaultProfile is the default profile name
+	DefaultProfile = "crio-default"
+
+	unconfined = "unconfined"
+)
+
+// Config is the global AppArmor configuration type
+type Config struct {
+	enabled        bool
+	defaultProfile string
+}
+
+// New creates a new default AppArmor configuration instance
+func New() *Config {
+	return &Config{
+		enabled:        apparmor.IsEnabled(),
+		defaultProfile: DefaultProfile,
+	}
+}
+
+// LoadProfile can be used to load a AppArmor profile from the provided path.
+// This method will not fail if AppArmor is disabled.
+func (c *Config) LoadProfile(profile string) error {
+	if !c.IsEnabled() {
+		logrus.Info("AppArmor is disabled by the system or at CRI-O build-time")
+		return nil
+	}
+
+	if profile == unconfined {
+		logrus.Info("AppArmor profile is unconfined which basically disables it")
+		c.defaultProfile = unconfined
+		return nil
+	}
+
+	// Load the default profile
+	if profile == "" || profile == DefaultProfile {
+		logrus.Infof("Installing default AppArmor profile: %v", DefaultProfile)
+
+		if err := apparmor.InstallDefault(DefaultProfile); err != nil {
+			return errors.Wrapf(err,
+				"installing default AppArmor profile %q failed",
+				DefaultProfile,
+			)
+		}
+
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			c, err := apparmor.DefaultContent(DefaultProfile)
+			if err != nil {
+				return errors.Wrapf(err,
+					"retrieving default AppArmor profile %q content failed",
+					DefaultProfile,
+				)
+			}
+			logrus.Tracef("Default AppArmor profile contents: %s", c)
+		}
+
+		c.defaultProfile = DefaultProfile
+		return nil
+	}
+
+	// Load a custom profile
+	logrus.Infof("Assuming user-provided AppArmor profile: %v", profile)
+	isLoaded, err := apparmor.IsLoaded(profile)
+	if err != nil {
+		return errors.Wrapf(err,
+			"checking if AppArmor profile %s is loaded", profile,
+		)
+	}
+
+	if !isLoaded {
+		return errors.Errorf(
+			"config provided AppArmor profile %q not loaded", profile,
+		)
+	}
+
+	c.defaultProfile = profile
+	return nil
+}
+
+// IsEnabled returns true if AppArmor is enabled via the `apparmor` buildtag
+// and globally by the system.
+func (c *Config) IsEnabled() bool {
+	return c.enabled
+}
+
+// Apply returns the trimmed AppArmor profile to be used and reloads if the
+// default profile is specified
+func (c *Config) Apply(profile string) (string, error) {
+	if profile == "" || profile == k8sAppArmor.ProfileRuntimeDefault {
+		return c.defaultProfile, nil
+	}
+	profile = strings.TrimPrefix(profile, k8sAppArmor.ProfileNamePrefix)
+
+	// reload the profile if default
+	if profile == DefaultProfile {
+		if err := reloadDefaultProfile(); err != nil {
+			return "", errors.Wrap(err, "reloading default profile")
+		}
+	}
+
+	return profile, nil
+}
+
+// reloadDefaultProfile reloads the default AppArmor profile and returns an
+// error on any failure.
+func reloadDefaultProfile() error {
+	isLoaded, err := apparmor.IsLoaded(DefaultProfile)
+	if err != nil {
+		return errors.Wrapf(err,
+			"checking if default AppArmor profile %s is loaded", DefaultProfile,
+		)
+	}
+	if !isLoaded {
+		if err := apparmor.InstallDefault(DefaultProfile); err != nil {
+			return errors.Wrapf(err,
+				"installing default AppArmor profile %q failed",
+				DefaultProfile,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/config/apparmor/apparmor_test.go
+++ b/internal/config/apparmor/apparmor_test.go
@@ -1,0 +1,43 @@
+package apparmor_test
+
+import (
+	"github.com/cri-o/cri-o/internal/config/apparmor"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The actual test suite
+var _ = t.Describe("Config", func() {
+	var sut *apparmor.Config
+
+	BeforeEach(func() {
+		sut = apparmor.New()
+		Expect(sut).NotTo(BeNil())
+
+		if !sut.IsEnabled() {
+			Skip("AppArmor is disabled")
+		}
+	})
+
+	t.Describe("IsEnabled", func() {
+		It("should be true per default", func() {
+			// Given
+			// When
+			res := sut.IsEnabled()
+
+			// Then
+			Expect(res).To(BeTrue())
+		})
+	})
+
+	t.Describe("LoadProfile", func() {
+		It("should succeed with unconfied", func() {
+			// Given
+			// When
+			err := sut.LoadProfile("unconfied")
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/internal/config/apparmor/suite_test.go
+++ b/internal/config/apparmor/suite_test.go
@@ -1,0 +1,26 @@
+package apparmor_test
+
+import (
+	"testing"
+
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestLib runs the created specs
+func TestLibConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "AppArmorConfig")
+}
+
+var t *TestFramework
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})

--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -78,6 +78,9 @@ func (c *Config) Reload() error {
 	if err := c.ReloadSeccompProfile(newConfig); err != nil {
 		return err
 	}
+	if err := c.ReloadAppArmorProfile(newConfig); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -179,5 +182,18 @@ func (c *Config) ReloadSeccompProfile(newConfig *Config) error {
 	}
 	c.SeccompProfile = newConfig.SeccompProfile
 	logConfig("seccomp_profile", c.SeccompProfile)
+	return nil
+}
+
+// ReloadAppArmorProfile reloads the AppArmor profile from the new config if
+// they differ.
+func (c *Config) ReloadAppArmorProfile(newConfig *Config) error {
+	if c.ApparmorProfile != newConfig.ApparmorProfile {
+		if err := c.AppArmor().LoadProfile(newConfig.ApparmorProfile); err != nil {
+			return errors.Wrap(err, "unable to reload apparmor_profile")
+		}
+		c.ApparmorProfile = newConfig.ApparmorProfile
+		logConfig("apparmor_profile", c.ApparmorProfile)
+	}
 	return nil
 }

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/containers/libpod/pkg/apparmor"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -291,6 +292,37 @@ var _ = t.Describe("Config", func() {
 
 			// Then
 			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	t.Describe("ReloadAppArmorProfile", func() {
+		BeforeEach(func() {
+			if !apparmor.IsEnabled() {
+				Skip("AppArmor is disabled")
+			}
+		})
+
+		It("should succeed without any config change", func() {
+			// Given
+			// When
+			err := sut.ReloadAppArmorProfile(sut)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed with config change", func() {
+			// Given
+			const profile = "unconfined"
+			newConfig := defaultConfig()
+			newConfig.ApparmorProfile = profile
+
+			// When
+			err := sut.ReloadAppArmorProfile(newConfig)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.ApparmorProfile).To(Equal(profile))
 		})
 	})
 })

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -135,7 +135,9 @@ seccomp_profile = "{{ .SeccompProfile }}"
 
 # Used to change the name of the default AppArmor profile of CRI-O. The default
 # profile name is "crio-default". This profile only takes effect if the user
-# does not specify a profile via the Kubernetes Pod's metadata annotation.
+# does not specify a profile via the Kubernetes Pod's metadata annotation. If
+# the profile is set to "unconfined", then this equals to disabling AppArmor.
+# This option supports live configuration reload.
 apparmor_profile = "{{ .ApparmorProfile }}"
 
 # Cgroup management implementation used for the runtime.

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -23,7 +23,6 @@ import (
 	"github.com/opencontainers/runtime-tools/generate"
 	seccomp "github.com/seccomp/containers-golang"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
-	"k8s.io/kubernetes/pkg/security/apparmor"
 )
 
 const (
@@ -677,13 +676,4 @@ func (s *Server) setupSeccomp(ctx context.Context, specgen *generate.Generator, 
 	}
 	specgen.Config.Linux.Seccomp = linuxSpecs
 	return nil
-}
-
-// containerAppArmorProfile gets the trimmed profile name for the given profile
-// string and falls back to the server’s default on empty and runtime/default profiles.
-func (s *Server) containerAppArmorProfile(profile string) string {
-	if profile == "" || profile == apparmor.ProfileRuntimeDefault {
-		return s.appArmorProfile
-	}
-	return strings.TrimPrefix(profile, apparmor.ProfileNamePrefix)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containers/libpod/pkg/apparmor"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
@@ -57,15 +56,11 @@ type Server struct {
 	netPlugin       ocicni.CNIPlugin
 	hostportManager hostport.HostPortManager
 
-	appArmorProfile string
-
 	*lib.ContainerServer
 	monitorsChan      chan struct{}
 	defaultIDMappings *idtools.IDMappings
 
 	updateLock sync.RWMutex
-
-	appArmorEnabled bool
 }
 
 type certConfigCache struct {
@@ -333,44 +328,8 @@ func New(
 		netPlugin:         netPlugin,
 		hostportManager:   hostportManager,
 		config:            *config,
-		appArmorEnabled:   apparmor.IsEnabled(),
-		appArmorProfile:   config.ApparmorProfile,
 		monitorsChan:      make(chan struct{}),
 		defaultIDMappings: idMappings,
-	}
-
-	if s.appArmorEnabled {
-		if config.ApparmorProfile == "" || config.ApparmorProfile == libconfig.DefaultApparmorProfile {
-			logrus.Infof("installing default apparmor profile: %v", libconfig.DefaultApparmorProfile)
-			if err := apparmor.InstallDefault(libconfig.DefaultApparmorProfile); err != nil {
-				return nil, errors.Wrapf(err,
-					"installing default apparmor profile %q failed",
-					libconfig.DefaultApparmorProfile,
-				)
-			}
-			if logrus.IsLevelEnabled(logrus.TraceLevel) {
-				profileContent, err := apparmor.DefaultContent(libconfig.DefaultApparmorProfile)
-				if err != nil {
-					return nil, errors.Wrapf(err,
-						"retrieving default apparmor profile %q content failed",
-						libconfig.DefaultApparmorProfile,
-					)
-				}
-				logrus.Tracef("default apparmor profile contents: %s", profileContent)
-			}
-		} else if config.ApparmorProfile != "unconfined" {
-			logrus.Infof("assuming user-provided apparmor profile: %v", config.ApparmorProfile)
-			isLoaded, err := apparmor.IsLoaded(config.ApparmorProfile)
-			if err != nil {
-				return nil, err
-			}
-			if !isLoaded {
-				return nil, errors.Errorf(
-					"config provided AppArmor profile %q not loaded",
-					config.ApparmorProfile,
-				)
-			}
-		}
 	}
 
 	if err := configureMaxThreads(); err != nil {
@@ -586,19 +545,4 @@ func (s *Server) StartExitMonitor() {
 		close(done)
 	}
 	<-done
-}
-
-// ReloadDefaultAppArmorProfile reloads the default AppArmor profile and
-// returns an error on any failure.
-func (s *Server) ReloadDefaultAppArmorProfile() error {
-	isLoaded, err := apparmor.IsLoaded(libconfig.DefaultApparmorProfile)
-	if err != nil {
-		return err
-	}
-	if !isLoaded {
-		if err := apparmor.InstallDefault(libconfig.DefaultApparmorProfile); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/test/reload_config.bats
+++ b/test/reload_config.bats
@@ -182,3 +182,37 @@ function expect_log_failure() {
     # then
     expect_log_failure "unable to reload seccomp_profile"
 }
+
+@test "reload config should succeed with 'apparmor_profile'" {
+    if [[ $(is_apparmor_enabled) -eq 0 ]]; then
+        skip "skip test since AppArmor is not enabled."
+    fi
+
+    # given
+    NEW_APPARMOR_PROFILE="unconfined"
+    OPTION="apparmor_profile"
+
+    # when
+    replace_config $OPTION $NEW_APPARMOR_PROFILE
+    reload_crio
+
+    # then
+    expect_log_success $OPTION $NEW_APPARMOR_PROFILE
+}
+
+@test "reload config should fail with invalid 'apparmor_profile'" {
+    if [[ $(is_apparmor_enabled) -eq 0 ]]; then
+        skip "skip test since AppArmor is not enabled."
+    fi
+
+    # given
+    NEW_APPARMOR_PROFILE=")"
+    OPTION="apparmor_profile"
+
+    # when
+    replace_config $OPTION $NEW_APPARMOR_PROFILE
+    reload_crio
+
+    # then
+    expect_log_failure "unable to reload apparmor_profile"
+}


### PR DESCRIPTION
The apparmor profile is now processed in a dedicated sub-package of the
`config` package and supports the live config reload feature. Necessary
test have been added as well.
