### PR TITLE
Apply Kubernetes PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,72 @@
-<!--
-Please make sure you've read and understood our contributing guidelines;
-https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md
+<!--  Thanks for sending a pull request!
 
-** Make sure all your commits include a signature generated with `git commit -s` **
+Please be aware that we're following the Kubernetes guidelines of contributing
+to this project. This means that we have to use this mandatory template for all
+of our pull requests.
 
-If this is a bug fix, make sure your description includes "fixes #xxxx", or
-"closes #xxxx"
+Please also make sure you've read and understood our contributing guidelines
+(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
+that all your commits are signed with `git commit -s`.
 
-Please provide the following information:
+Here are some additional tips for you:
+
+- If this is your first time, please read our contributor guidelines:
+  https://git.k8s.io/community/contributors/guide#your-first-contribution and
+  developer guide
+  https://git.k8s.io/community/contributors/devel/development.md#development-guide
+- Please label this pull request according to what type of issue you are
+  addressing, especially if this is a release targeted pull request. For
+  reference on required PR/issue labels, read here:
+  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
+- If you want *faster* PR reviews, read how:
+  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+- If the PR is unfinished, see how to mark it:
+  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
 -->
 
-**- What I did**
+#### What type of PR is this?
 
-**- How I did it**
-
-**- How to verify it**
-
-**- Description for the changelog**
 <!--
-Write a short (one line) summary that describes the changes in this
-pull request for inclusion in the changelog:
+Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
+remove leading whitespace from that line:
 -->
+
+> /kind bug
+> /kind cleanup
+> /kind deprecation
+> /kind design
+> /kind documentation
+> /kind feature
+
+#### What this PR does / why we need it:
+
+#### Which issue(s) this PR fixes:
+
+<!--
+Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+-->
+
+<!--
+Fixes #
+or
+None
+-->
+
+#### Special notes for your reviewer:
+
+#### Does this PR introduce a user-facing change?
+
+<!--
+If no, just write `None` in the release-note block below. If yes, a release note
+is required: Enter your extended release note in the block below. If the PR
+requires additional action from users switching to the new release, include the
+string "action required".
+
+For more information on release notes see:
+https://git.k8s.io/community/contributors/guide/release-notes.md
+-->
+
+```release-note
+
+```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
We could generate the release notes (automatically via [the release notes generator](https://github.com/kubernetes/release/tree/master/cmd/release-notes)) from the PR’s as well as applying proper labels via the kinds.

What do you think? This would also mean that we have to follow the PR template, but I'm not sure if we already have the plugins (like for the kinds) in flight.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


