### PR TITLE
Make bin/pinns a PHONY target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,4 +454,5 @@ docs-validation:
 	test-images \
 	test-image-nix \
 	uninstall \
-	vendor
+	vendor \
+	bin/pinns


### PR DESCRIPTION
We have to make the `bin/pinns` target `PHONY` to have a rebuild based
on file system changes (via `pinns/Makefile`), otherwise we would omit
the "file changed check" inside the `pinns` directory.
