### PR TITLE
Improve crio --version / version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,10 @@ SHRINKFLAGS := -s -w
 VERSION := $(shell $(GO) run ./scripts/latest_version.go)
 
 BASE_LDFLAGS = ${SHRINKFLAGS} \
-	-X ${PROJECT}/internal/version.buildInfo=${SOURCE_DATE_EPOCH} \
 	-X ${PROJECT}/internal/version.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
-	-X ${PROJECT}/internal/version.GitCommit=${COMMIT_NO} \
+	-X ${PROJECT}/internal/version.gitCommit=${COMMIT_NO} \
 	-X ${PROJECT}/internal/version.gitTreeState=${GIT_TREE_STATE} \
-	-X ${PROJECT}/internal/version.Version=${VERSION}
+	-X ${PROJECT}/internal/version.version=${VERSION}
 
 LDFLAGS = -ldflags '${BASE_LDFLAGS} ${EXTRA_LDFLAGS}'
 

--- a/cmd/crio-status/main.go
+++ b/cmd/crio-status/main.go
@@ -23,7 +23,7 @@ func main() {
 	app.Authors = []*cli.Author{{Name: "The CRI-O Maintainers"}}
 	app.Usage = "A tool for CRI-O status retrieval"
 	app.Description = app.Usage
-	app.Version = version.Version
+	app.Version = version.Get().Version
 	app.CommandNotFound = func(*cli.Context, string) { os.Exit(1) }
 	app.OnUsageError = func(c *cli.Context, e error, b bool) error { return e }
 	app.Action = func(c *cli.Context) error {

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -115,17 +115,12 @@ func main() {
 	}
 	app := cli.NewApp()
 
-	var v []string
-	v = append(v, version.Version)
-	if version.GitCommit != "" && version.GitCommit != "unknown" {
-		v = append(v, fmt.Sprintf("commit: %s", version.GitCommit))
-	}
 	app.Name = "crio"
 	app.Usage = "OCI-based implementation of Kubernetes Container Runtime Interface"
 	app.Authors = []*cli.Author{{Name: "The CRI-O Maintainers"}}
 	app.UsageText = usage
 	app.Description = app.Usage
-	app.Version = strings.Join(v, "\n")
+	app.Version = "\n" + version.Get().String()
 
 	var err error
 	app.Flags, app.Metadata, err = criocli.GetFlagsAndMetadata()
@@ -241,7 +236,7 @@ func main() {
 		}
 
 		// Immediately upon start up, write our new version file
-		if err := version.WriteVersionFile(config.VersionFile, version.GitCommit); err != nil {
+		if err := version.WriteVersionFile(config.VersionFile); err != nil {
 			logrus.Fatal(err)
 		}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,11 +16,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Variables injected during build-time
 var (
-	GitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
+	version      string // Version is the version of the build.
+	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string // state of git tree, either "clean" or "dirty"
 	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
-	Version      string // Version is the version of the build.
 )
 
 type Info struct {
@@ -39,7 +40,7 @@ type Info struct {
 // and returns whether the major and minor versions are the same.
 // If they differ, then crio should wipe.
 func ShouldCrioWipe(versionFileName string) (bool, error) {
-	return shouldCrioWipe(versionFileName, Version)
+	return shouldCrioWipe(versionFileName, version)
 }
 
 // shouldCrioWipe is an internal function for testing purposes
@@ -76,8 +77,8 @@ func shouldCrioWipe(versionFileName, versionString string) (bool, error) {
 // file is the location of the old version file
 // gitCommit is the current git commit version. It will be added to the file
 // to aid in debugging, but will not be used to compare versions
-func WriteVersionFile(file, gitCommit string) error {
-	return writeVersionFile(file, gitCommit, Version)
+func WriteVersionFile(file string) error {
+	return writeVersionFile(file, gitCommit, version)
 }
 
 // writeVersionFile is an internal function for testing purposes
@@ -124,8 +125,8 @@ func parseVersionConstant(versionString, gitCommit string) (*semver.Version, err
 
 func Get() *Info {
 	return &Info{
-		Version:      Version,
-		GitCommit:    GitCommit,
+		Version:      version,
+		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
 		BuildDate:    buildDate,
 		GoVersion:    runtime.Version(),
@@ -145,7 +146,7 @@ func (i *Info) String() string {
 	fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
 	fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
 	fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
-	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+	fmt.Fprintf(w, "Platform:\t%s", i.Platform)
 
 	w.Flush()
 	return b.String()

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -97,8 +97,7 @@ func TestParseVersionBadVersion(t *testing.T) {
 }
 
 func TestParseVersionWithCurrentVersion(t *testing.T) {
-	Version = "1.17.0"
-	_, err := parseVersionConstant(Version, "")
+	_, err := parseVersionConstant("1.17.0", "")
 	must(t, err)
 }
 

--- a/server/useragent/useragent.go
+++ b/server/useragent/useragent.go
@@ -8,10 +8,11 @@ import (
 
 // Get is the User-Agent the CRI-O daemon uses to identify itself.
 func Get() string {
+	info := version.Get()
 	httpVersion := make([]VersionInfo, 0, 4)
 	httpVersion = append(httpVersion,
-		VersionInfo{Name: "cri-o", Version: version.Version},
-		VersionInfo{Name: "go", Version: runtime.Version()},
+		VersionInfo{Name: "cri-o", Version: info.Version},
+		VersionInfo{Name: "go", Version: info.GoVersion},
 		VersionInfo{Name: "os", Version: runtime.GOOS},
 		VersionInfo{Name: "arch", Version: runtime.GOARCH})
 

--- a/server/version.go
+++ b/server/version.go
@@ -21,7 +21,7 @@ func (s *Server) Version(ctx context.Context, req *pb.VersionRequest) (resp *pb.
 	return &pb.VersionResponse{
 		Version:           kubeAPIVersion,
 		RuntimeName:       containerName,
-		RuntimeVersion:    version.Version,
+		RuntimeVersion:    version.Get().Version,
 		RuntimeApiVersion: runtimeAPIVersion,
 	}, nil
 }


### PR DESCRIPTION
We now make the unnecessary public variables `version.GitCommit` and
`version.Version` private again.

The output of `crio -v` and the `VERSION` section of `crio -h` now show
the full version details, equally to `crio version`.

We can use the newly introduced `version.Get()` API to retrieve the
version information, for example in `useragent.go` and
`server/version.go`.

Refers to https://github.com/cri-o/cri-o/issues/2979