### PR TITLE
Add DEFAULTS_PATH to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,10 @@ GO_FILES := $(shell find . -type f -name '*.go' -not -name '*_test.go')
 VPATH := $(VPATH):$(GOPATH)
 SHRINKFLAGS := -s -w
 VERSION := $(shell $(GO_RUN) ./scripts/latest_version.go)
+DEFAULTS_PATH := ""
 
 BASE_LDFLAGS = ${SHRINKFLAGS} \
+	-X ${PROJECT}/internal/pkg/criocli.DefaultsPath=${DEFAULTS_PATH} \
 	-X ${PROJECT}/internal/version.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 	-X ${PROJECT}/internal/version.gitCommit=${COMMIT_NO} \
 	-X ${PROJECT}/internal/version.gitTreeState=${GIT_TREE_STATE} \


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This allows user to easily inject the `criocli.DefaultsPath` variable
via `make DEFAULTS_PATH=<PATH>`. 

#### Which issue(s) this PR fixes:
Fixes #2979

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
- Provide the possibility to set the default config path via `make DEFAULTS_PATH=<PATH>`
```