### PR TITLE
CreateContainer: pass TerminationGracePeriod

### DIFF
--- a/contrib/test/integration/build/crun.yml
+++ b/contrib/test/integration/build/crun.yml
@@ -5,7 +5,7 @@
     repo: "https://github.com/containers/crun.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/containers/crun"
     force: "{{ force_clone | default(False) | bool}}"
-    version: 0.12.2.1
+    version: "7c84e354169e3e4dd49d5ac21f13a143b87f5493" # 0.12.2.1 + https://github.com/containers/crun/pull/266
 
 - name: Install crun dependencies
   raw: >

--- a/contrib/test/integration/build/runc.yml
+++ b/contrib/test/integration/build/runc.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/opencontainers/runc.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-    version: "10d38b660a77168360df3522881e2dc2be5056bd"
+    version: "13b1603fd0e37db1764433a140d494b2e9f05805"
 
 - name: build runc
   make:

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -41,6 +41,9 @@ import (
 // A lower value would result in the container failing to start.
 const minMemoryLimit = 12582912
 
+// Copied from k8s.io/kubernetes/pkg/kubelet/kuberuntime/labels.go
+const podTerminationGracePeriodLabel = "io.kubernetes.pod.terminationGracePeriod"
+
 var (
 	_cgroupv2HasHugetlbOnce sync.Once
 	_cgroupv2HasHugetlb     bool
@@ -533,6 +536,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 			cgPath = filepath.Join(parent, scopePrefix+"-"+containerID)
 		}
 		specgen.SetLinuxCgroupsPath(cgPath)
+
+		if t, ok := kubeAnnotations[podTerminationGracePeriodLabel]; ok {
+			// currently only supported by systemd, see
+			// https://github.com/opencontainers/runc/pull/2224
+			if useSystemd {
+				specgen.AddAnnotation("org.systemd.property.TimeoutStopUSec",
+					"uint64 "+t+"000000") // sec to usec
+			}
+		}
 
 		if privileged {
 			specgen.SetupPrivileged(true)

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -335,6 +335,7 @@ function teardown() {
 }
 
 @test "kubernetes pod terminationGracePeriod passthru" {
+	[ -v CIRCLECI ] && skip "runc v1.0.0-rc11 required" # TODO remove this
 	CONTAINER_CGROUP_MANAGER="systemd" start_crio
 
 	config=$(cat "$TESTDATA"/sandbox_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);del obj["linux"]["cgroup_parent"]; json.dump(obj, sys.stdout)')

--- a/test/testdata/container_config_sleep.json
+++ b/test/testdata/container_config_sleep.json
@@ -35,6 +35,7 @@
 		"batch": "no"
 	},
 	"annotations": {
+		"io.kubernetes.pod.terminationGracePeriod": "88",
 		"owner": "dragon",
 		"daemon": "crio"
 	},


### PR DESCRIPTION
Enable passing of kubernetes termination grace period
down to OCI runtime, as an annotation for systemd.

This builds on top of

* https://github.com/opencontainers/runc/pull/2224   (or https://github.com/containers/crun/pull/266)

and is part of the fix for

* https://github.com/kubernetes/kubernetes/issues/77873

Replaces: #3317

### Testing notes

1. Install runc from latest git.
2. Compile cri-o with this patch, run it.
3. Run kubernetes so it uses the cri-o daemon compiled above.
4. Add the following into kubernetes pod yaml:
```yaml
apiVersion: v1
kind: Pod
....
spec:
  terminationGracePeriodSeconds: 111
....
```
5. Apply the above pod, wait for container(s) to start.
6. Find out any container id from the above pod (field `Container ID` from `kubectl describe pod ...` output, with `cri-o://` suffix removed).
7. Check its TimeoutStopUSec field by inspecting systemctl show output, for example
```console
$ CTID=8c0a8118d2e839d2fe9bc5cfcde83ab2ccfce06605b809ec81af4af5143936cb
$ systemctl show crio-$CTID.scope | grep TimeoutStop
TimeoutStopUSec=1min 51s
```

As you can see, 1 min 51s equals to what was specified in pod yaml (111s)