### PR TITLE
integration tests: switch to systemd cgroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ sudo curl -v --unix-socket /var/run/crio/crio.sock http://localhost/info | jq
 {
   "storage_driver": "btrfs",
   "storage_root": "/var/lib/containers/storage",
-  "cgroup_driver": "cgroupfs",
+  "cgroup_driver": "systemd",
   "default_id_mappings": { ... }
 }
 ```
@@ -199,7 +199,7 @@ line tool. It supports all API endpoints via the dedicated subcommands `config`,
 
 ```
 $ sudo go run cmd/crio-status/main.go info
-cgroup driver: cgroupfs
+cgroup driver: systemd
 storage driver: btrfs
 storage root: /var/lib/containers/storage
 default GID mappings (format <container>:<host>:<size>):

--- a/bundle/test
+++ b/bundle/test
@@ -17,6 +17,9 @@ cd "$(dirname "$0")"
 tar xfvz "$ARCHIVE"
 pushd "$BUNDLE"
 
+# Install and prepare config
+make install
+
 # Start CRI-O
 systemctl daemon-reload
 systemctl start crio

--- a/bundle/test
+++ b/bundle/test
@@ -17,11 +17,6 @@ cd "$(dirname "$0")"
 tar xfvz "$ARCHIVE"
 pushd "$BUNDLE"
 
-# Install and prepare config
-make install
-printf '[crio.runtime]\ncgroup_manager = "cgroupfs"\n' \
-    >/etc/crio/crio.conf.d/01-override.conf
-
 # Start CRI-O
 systemctl daemon-reload
 systemctl start crio

--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -71,13 +71,6 @@
       [crio]
       storage_driver = "overlay"
 
-- name: run with systemd cgroup manager
-  copy:
-    dest: /etc/crio/crio.conf.d/01-cgroup-manager-systemd.conf
-    content: |
-      [crio.runtime]
-      cgroup_manager = "systemd"
-
 - name: add quay.io and docker.io as default registries
   copy:
     dest: /etc/crio/crio.conf.d/01-registries.conf

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -20,7 +20,7 @@ result_dest_basedir: '{{ lookup("env","WORKSPACE") |
 
 # Environment variables to set when executing integration tests
 int_test_env:
-    CGROUP_MANAGER: "cgroupfs"
+    CGROUP_MANAGER: "systemd"
     STORAGE_OPTIONS: >
         --storage-driver=overlay
 

--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -41,7 +41,7 @@ function teardown() {
 }
 
 @test "conmon custom cgroup" {
-	CONTAINER_CONMON_CGROUP="customcrioconmon.slice" CONTAINER_CGROUP_MANAGER="systemd" start_crio
+	CONTAINER_CONMON_CGROUP="customcrioconmon.slice" start_crio
 	cgroup_parent_config=$(cat "$TESTDATA"/sandbox_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["cgroup_parent"] = "Burstablecriotest123.slice"; json.dump(obj, sys.stdout)')
 	echo "$cgroup_parent_config" > "$TESTDIR"/sandbox_config_slice.json
 	run crictl runp "$TESTDIR"/sandbox_config_slice.json

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -63,7 +63,7 @@ CHECKSECCOMP_BINARY=${CHECKSECCOMP_BINARY:-${CRIO_ROOT}/test/checkseccomp/checks
 # The default log directory where all logs will go unless directly specified by the kubelet
 DEFAULT_LOG_PATH=${DEFAULT_LOG_PATH:-/var/log/crio/pods}
 # Cgroup manager to be used
-CONTAINER_CGROUP_MANAGER=${CONTAINER_CGROUP_MANAGER:-cgroupfs}
+CONTAINER_CGROUP_MANAGER=${CONTAINER_CGROUP_MANAGER:-systemd}
 # Image volumes handling
 CONTAINER_IMAGE_VOLUMES=${CONTAINER_IMAGE_VOLUMES:-mkdir}
 # Container pids limit

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -319,7 +319,7 @@ function teardown() {
 		skip "need systemd cgroup manager"
 	fi
 
-	cgroup_parent_config=$(cat "$TESTDATA"/sandbox_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["cgroup_parent"] = "/Burstable/pod_integration_tests-123"; json.dump(obj, sys.stdout)')
+	cgroup_parent_config=$(cat "$TESTDATA"/sandbox_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["cgroup_parent"] = "Burstable-pod_integration_tests-123.slice"; json.dump(obj, sys.stdout)')
 	echo "$cgroup_parent_config" > "$TESTDIR"/sandbox_systemd_cgroup_parent.json
 
 	start_crio
@@ -331,7 +331,7 @@ function teardown() {
 	run systemctl list-units --type=slice
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "Burstable-pod_integration_tests_123.slice" ]]
+	[[ "$output" =~ "Burstable-pod_integration_tests-123.slice" ]]
 }
 
 @test "kubernetes pod terminationGracePeriod passthru" {

--- a/test/testdata/sandbox1_config.json
+++ b/test/testdata/sandbox1_config.json
@@ -33,7 +33,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 0,

--- a/test/testdata/sandbox2_config.json
+++ b/test/testdata/sandbox2_config.json
@@ -33,7 +33,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 0,

--- a/test/testdata/sandbox3_config.json
+++ b/test/testdata/sandbox3_config.json
@@ -33,7 +33,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 0,

--- a/test/testdata/sandbox_config.json
+++ b/test/testdata/sandbox_config.json
@@ -31,7 +31,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 0,

--- a/test/testdata/sandbox_config_apparmor.json
+++ b/test/testdata/sandbox_config_apparmor.json
@@ -29,7 +29,7 @@
     "owner": "hmeng"
   },
   "linux": {
-    "cgroup_parent": "/Burstable/pod_123-456",
+    "cgroup_parent": "pod_123-456.slice",
     "security_context": {
       "apparmor_profile": "%VALUE%",
       "namespace_options": {

--- a/test/testdata/sandbox_config_hostnet.json
+++ b/test/testdata/sandbox_config_hostnet.json
@@ -35,7 +35,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 2,

--- a/test/testdata/sandbox_config_hostport.json
+++ b/test/testdata/sandbox_config_hostport.json
@@ -41,7 +41,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 0,

--- a/test/testdata/sandbox_config_privileged.json
+++ b/test/testdata/sandbox_config_privileged.json
@@ -31,7 +31,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 0,

--- a/test/testdata/sandbox_config_seccomp.json
+++ b/test/testdata/sandbox_config_seccomp.json
@@ -34,7 +34,7 @@
 		"owner": "hmeng"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"seccomp_profile_path": "%VALUE%",
 			"namespace_options": {

--- a/test/testdata/sandbox_config_selinux.json
+++ b/test/testdata/sandbox_config_selinux.json
@@ -31,7 +31,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 0,

--- a/test/testdata/sandbox_config_sysctl.json
+++ b/test/testdata/sandbox_config_sysctl.json
@@ -36,7 +36,7 @@
 			"net.ipv4.ip_local_port_range": "1024 65000",
 			"kernel.msgmax": "8192"
 		},
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 0,

--- a/test/testdata/sandbox_pidnamespacemode_config.json
+++ b/test/testdata/sandbox_pidnamespacemode_config.json
@@ -34,7 +34,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"host_network": false,

--- a/test/testdata/template_sandbox_config.json
+++ b/test/testdata/template_sandbox_config.json
@@ -31,7 +31,7 @@
 		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
 	},
 	"linux": {
-		"cgroup_parent": "/Burstable/pod_123-456",
+		"cgroup_parent": "pod_123-456.slice",
 		"security_context": {
 			"namespace_options": {
 				"network": 0,


### PR DESCRIPTION
Considering it's the default and has been for a while

closes the open portion of https://github.com/cri-o/cri-o/issues/3301

Also fix a bug where using systemd as a cgroup_manager would cause stats to return nothing

Signed-off-by: Peter Hunt <pehunt@redhat.com>