### PR TITLE
Update Makefile targets and docs to crio.conf.d

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
           name: Show CRI-O version
           command: ./bin/crio version
       - run:
-          command: make crio.conf
+          command: make crio.conf.d
       - run:
           command: make docs -j $JOBS
       - save_cache:
@@ -182,7 +182,7 @@ jobs:
           root: .
           paths:
             - bin
-            - crio.conf
+            - build/crio.conf.d/00-default.conf
             - docs
 
   build-static:

--- a/bundle/Makefile
+++ b/bundle/Makefile
@@ -30,7 +30,7 @@ install:
 	ln -sf $(BINDIR)/$(DEFAULT_BINARY) $(BINDIR)/crio
 	install $(SELINUX) -D -m 644 -t $(ETCDIR) etc/crictl.yaml
 	install $(SELINUX) -D -m 644 -t $(OCIDIR) etc/crio-umount.conf
-	install $(SELINUX) -D -m 644 -t $(ETCDIR)/crio etc/crio.conf
+	install $(SELINUX) -D -m 644 -t $(ETCDIR)/crio/crio.conf.d etc/00-default.conf
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man5 man/crio.conf.5
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man5 man/crio.conf.d.5
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man8 man/crio.8
@@ -53,7 +53,7 @@ uninstall:
 	rm $(BINDIR)/pinns
 	rm $(ETCDIR)/crictl.yaml
 	rm $(OCIDIR)/crio-umount.conf
-	rm $(ETCDIR)/crio/crio.conf
+	rm $(ETCDIR)/crio/crio.conf.d/00-default.conf
 	rm $(MANDIR)/man5/crio.conf.5
 	rm $(MANDIR)/man5/crio.conf.d.5
 	rm $(MANDIR)/man8/crio.8

--- a/bundle/build
+++ b/bundle/build
@@ -22,7 +22,7 @@ FILES_MAN=(
 FILES_ETC=(
     "../crictl.yaml"
     "../crio-umount.conf"
-    "../crio.conf"
+    "../build/crio.conf.d/00-default.conf"
 )
 FILES_CONTRIB=(
     "../contrib/cni/10-crio-bridge.conf"

--- a/bundle/test
+++ b/bundle/test
@@ -19,7 +19,6 @@ pushd "$BUNDLE"
 
 # Install and prepare config
 make install
-mkdir /etc/crio/crio.conf.d
 printf '[crio.runtime]\ncgroup_manager = "cgroupfs"\n' \
     >/etc/crio/crio.conf.d/01-override.conf
 

--- a/contrib/cni/README.md
+++ b/contrib/cni/README.md
@@ -6,7 +6,7 @@ basis for your own configurations (distributions should package these files in
 example directories).
 
 To use these configurations, place them in `/etc/cni/net.d` (or the directory
-specified by `crio.network.network_dir` in your `crio.conf`).
+specified by `crio.network.network_dir` in your overwrite of `/etc/crio/crio.conf.d`).
 
 In addition, you need to install the [CNI plugins][cni] necessary into
 `/opt/cni/bin` (or the directories specified by `crio.network.plugin_dir`). The

--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -36,18 +36,19 @@
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
 
 - name: set manage network ns lifecycle
-  replace:
-    regexp: 'manage_ns_lifecycle.*=.*false'
-    replace: 'manage_ns_lifecycle = true'
-    name: /etc/crio/crio.conf
-    backup: yes
+  copy:
+    dest: /etc/crio/crio.conf.d/01-ns-lifecycle.conf
+    content: |
+      [crio.runtime]
+      manage_ns_lifecycle = true
 
 - name: use crun
-  replace:
-    regexp: 'runc'
-    replace: 'crun'
-    name: /etc/crio/crio.conf
-    backup: yes
+  copy:
+    dest: /etc/crio/crio.conf.d/01-crun.conf
+    content: |
+      [crio.runtime]
+      default_runtime = "crun"
+      [crio.runtime.runtimes.crun]
   when: "build_crun | default(False) | bool"
 
 - name: install configs
@@ -64,25 +65,22 @@
       dest: /etc/containers/registries.d/registry.access.redhat.com.yaml
 
 - name: run with overlay
-  replace:
-    regexp: 'storage_driver = ""'
-    replace: 'storage_driver = "overlay"'
-    name: /etc/crio/crio.conf
-    backup: yes
+  copy:
+    dest: /etc/crio/crio.conf.d/01-overlay.conf
+    content: |
+      [crio]
+      storage_driver = "overlay"
 
 - name: run with systemd cgroup manager
-  replace:
-    regexp: 'cgroup_manager = "cgroupfs"'
-    replace: 'cgroup_manager = "systemd"'
-    name: /etc/crio/crio.conf
-    backup: yes
+  copy:
+    dest: /etc/crio/crio.conf.d/01-cgroup-manager-systemd.conf
+    content: |
+      [crio.runtime]
+      cgroup_manager = "systemd"
 
 - name: add quay.io and docker.io as default registries
-  lineinfile:
-    dest: /etc/crio/crio.conf
-    line: |
-          # Added by Ansible from build/cri-o.yml
-          registries = [ "quay.io", "docker.io" ]
-    insertafter: 'registries = \['
-    regexp: 'quay\.io, docker\.io'
-    state: present
+  copy:
+    dest: /etc/crio/crio.conf.d/01-registries.conf
+    content: |
+      [crio.image]
+      registries = [ "quay.io", "docker.io" ]

--- a/contrib/test/integration/e2e-base.yml
+++ b/contrib/test/integration/e2e-base.yml
@@ -2,7 +2,7 @@
 # only fixup paths for e2e tests which expect to be able to pass 'test-handler' as the runtime handler
 - name: add test-handler runtime handler for Runtimes test
   blockinfile:
-    path: /etc/crio/crio.conf
+    path: /etc/crio/crio.conf.d/00-default.conf
     insertbefore: .*crio.runtime.runtimes.runc.*
     backup: yes
     block: |

--- a/tutorials/decryption.md
+++ b/tutorials/decryption.md
@@ -16,9 +16,10 @@ Encryption ties trust to an entity based on the model in which a key is associat
 
 ## Configuring Image Decryption for **Node** key model
 
-In order to set up image decryption support, modify `/etc/crio/crio.conf` as follows:
+In order to set up image decryption support, add an overwrite to `/etc/crio/crio.conf.d/01-decrypt.conf` as follows:
 
 ```toml
+[crio.runtime]
 # decryption_keys_path is the path where the keys required for
 # image decryption are located
 decryption_keys_path = "/etc/crio/keys/"

--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -6,7 +6,7 @@ It also assumes you've set up your system to use kubeadm. If you haven't done so
 ### Configuring CNI
 
 First, CRI-O and `kubeadm reset` don't play well together, as `kubeadm reset` empties `/etc/cni/net.d/`.
-Therefore, it is good to change the `crio.network.network_dir` in `crio.conf` to somewhere kubeadm won't touch.
+Therefore, it is good to add an overwrite of the `crio.network.network_dir` in `/etc/crio/crio.conf.d/01-overwrite-cni.conf` to somewhere kubeadm won't touch.
 
 Further, you'll need to use your plugins to figure out your pod-network-cidr. If you use the default bridge plugin defined [here](/contrib/cni/10-crio-bridge.conf), set
 ```CIDR=10.88.0.0/16```

--- a/tutorials/metrics.md
+++ b/tutorials/metrics.md
@@ -1,8 +1,8 @@
 # CRI-O Metrics
 
 To enable the [Prometheus][0] metrics exporter for CRI-O, either start `crio`
-with `--metrics-enable` or set the corresponding option in
-`/etc/crio/crio.conf`:
+with `--metrics-enable` or add the corresponding option to a config overwrite,
+for example `/etc/crio/crio.conf.d/01-metrics.conf`:
 
 ```toml
 [crio.metrics]

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -39,11 +39,9 @@ yum install -y \
 ```
 
 **Please note**:
-- ```CentOS 8``` (or higher): ```pkgconfig``` package is replaced by ```pkgconf-pkg-config```
-- By default btrfs is not enabled. To add the btrfs support, install the following package:
-```
-  btrfs-progs-devel
-```
+- `CentOS 8` (or higher): `pkgconfig` package is replaced by `pkgconf-pkg-config`
+- By default btrfs is not enabled. To add the btrfs support, install the
+  following package: `btrfs-progs-devel`
 
 RHEL 8 distributions:\
 Make sure you are subscribed to the following repositories: \
@@ -264,12 +262,12 @@ The resulting binary should be now available in `result-bin/bin` and
 ### Creating a release archive
 
 A release bundle consists of all static binaries, the man pages and
-configuration files like `crio.conf`. The `release-bundle` target can be used to
-build a new release archive within the current repository:
+configuration files like `00-default.conf`. The `release-bundle` target can be
+used to build a new release archive within the current repository:
 
 ```
 make release-bundle
-...
+…
 Created ./bundle/crio-v1.15.0.tar.gz
 ```
 
@@ -321,19 +319,24 @@ For more information about this file see [registries.conf(5)](https://github.com
 
 ### Recommended - Use systemd cgroups.
 
-By default, CRI-O uses cgroupfs as a cgroup manager. However, we recommend using systemd as a cgroup manager. You can change your cgroup manager in crio.conf:
+By default, CRI-O uses cgroupfs as a cgroup manager. However, we recommend using
+systemd as a cgroup manager. You can change your cgroup manager by adding an
+overwrite to `/etc/crio/crio.conf.d/01-cgroup-manager.conf`:
 
 ```
+[crio.runtime]
 cgroup_manager = "systemd"
 ```
 
-### Optional - Modify verbosity of logs in /etc/crio/crio.conf
+### Optional - Modify verbosity of logs
 
-Users can modify the `log_level` field in `/etc/crio/crio.conf` to change the verbosity of
-the logs.
-Options are fatal, panic, error (default), warn, info, and debug.
+Users can modify the `log_level` by specifying an overwrite like
+`/etc/crio/crio.conf.d/01-log-level.conf` to change the verbosity of
+the logs. Options are fatal, panic, error, warn, info (default), debug and
+trace.
 
 ```
+[crio.runtime]
 log_level = "info"
 ```
 
@@ -361,7 +364,7 @@ default_sysctls = [
 ]
 ```
 
-Users can change either default by editing `/etc/crio/crio.conf`.
+Users can change either default by adding overwrites to `/etc/crio/crio.conf.d`.
 
 ## Starting CRI-O
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This updates the Makefile targets for the general builds and the bundle
to use the net `crio.conf.d` configuration directory. The documentation
has been adapted as well as the tests.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```