### PR TITLE
Add release-branch-forward script

### DIFF
--- a/scripts/release-branch-forward/release-branch-forward.go
+++ b/scripts/release-branch-forward/release-branch-forward.go
@@ -1,0 +1,114 @@
+// This tools automatically finds the latest CRI-O release branch and merges
+// the latest master branch into it. This happens only if there is no
+// tag present on the release branch.
+package main
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/release/pkg/command"
+	kgit "k8s.io/release/pkg/git"
+)
+
+const (
+	remote              = "https://github.com/cri-o/cri-o"
+	git                 = "git"
+	grep                = "grep"
+	tail                = "tail"
+	releaseBranchPrefix = "release-"
+)
+
+var dryRun bool
+
+func main() {
+	flag.BoolVar(
+		&dryRun,
+		"dry-run",
+		true,
+		"do not really push, just do a dry run",
+	)
+	flag.Parse()
+
+	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	if err := run(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func run() error {
+	if !command.Available(git, grep, tail) {
+		return errors.Errorf(
+			"please ensure that %s are available in $PATH",
+			strings.Join([]string{git, grep, tail}, ", "),
+		)
+	}
+
+	// Get the latest release branch
+	lsRemoteHeads, err := command.
+		New(git, "ls-remote", "--sort=v:refname", "--heads", remote).
+		Pipe(grep, "-Eo", releaseBranchPrefix+".*").
+		Pipe(tail, "-1").
+		RunSilentSuccessOutput()
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve latest release branch")
+	}
+	latestReleaseBranch := lsRemoteHeads.OutputTrimNL()
+	logrus.Infof("Latest release branch: %s", latestReleaseBranch)
+
+	// Check if a release has been done on that branch
+	tagPrefix := strings.TrimPrefix(latestReleaseBranch, releaseBranchPrefix)
+	lsRemoteTags, err := command.
+		New(git, "ls-remote", "--sort=v:refname", "--tags", remote).
+		Pipe(grep, "-Eo", "v"+tagPrefix+".*").
+		RunSilentSuccessOutput()
+	if err == nil {
+		logrus.Warnf(
+			"Found existing tag(s) on release branch: %v",
+			strings.Join(strings.Fields(lsRemoteTags.OutputTrimNL()), ", "),
+		)
+		logrus.Infof("We’re all set, doing nothing")
+		return nil
+	}
+
+	// Checkout the release branch
+	repo, err := kgit.OpenRepo(".")
+	if err != nil {
+		return errors.Wrap(err, "unable to open this repository")
+	}
+	if dryRun {
+		logrus.Info("Setting repository to only do a dry-run")
+		repo.SetDry()
+	}
+	currentBranch, err := repo.CurrentBranch()
+	if err != nil {
+		return errors.Wrap(err, "unable to get current branch")
+	}
+	logrus.Infof("Checking out branch: %s", latestReleaseBranch)
+	if err := repo.Checkout(latestReleaseBranch); err != nil {
+		return errors.Wrapf(err,
+			"unable to checkout release branch %s", latestReleaseBranch,
+		)
+	}
+	defer func() {
+		logrus.Infof("Checking out branch: %s", currentBranch)
+		err = repo.Checkout(currentBranch)
+	}()
+
+	// Merge the latest master
+	mergeTarget := kgit.Remotify(kgit.Master)
+	if err := repo.Merge(mergeTarget); err != nil {
+		return errors.Wrapf(err,
+			"unable to merge %s into release branch", mergeTarget,
+		)
+	}
+
+	// Push the changes
+	if err := repo.Push(latestReleaseBranch); err != nil {
+		return errors.Wrap(err, "unable to push to remote branch")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind design

#### What this PR does / why we need it:
Add a first golang based script for release branch automation.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Maybe we can try the tool manually in the first place to see if it fits our requirements. 
/cc @haircommander @mrunalp 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
