### PR TITLE
man page for crio.conf.d

### DIFF
--- a/bundle/Makefile
+++ b/bundle/Makefile
@@ -32,6 +32,7 @@ install:
 	install $(SELINUX) -D -m 644 -t $(OCIDIR) etc/crio-umount.conf
 	install $(SELINUX) -D -m 644 -t $(ETCDIR)/crio etc/crio.conf
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man5 man/crio.conf.5
+	install $(SELINUX) -D -m 644 -t $(MANDIR)/man5 man/crio.conf.d.5
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man8 man/crio.8
 	install $(SELINUX) -D -m 644 -t $(BASHINSTALLDIR) completions/bash/crio
 	install $(SELINUX) -D -m 644 -t $(FISHINSTALLDIR) completions/fish/crio.fish
@@ -54,6 +55,7 @@ uninstall:
 	rm $(OCIDIR)/crio-umount.conf
 	rm $(ETCDIR)/crio/crio.conf
 	rm $(MANDIR)/man5/crio.conf.5
+	rm $(MANDIR)/man5/crio.conf.d.5
 	rm $(MANDIR)/man8/crio.8
 	rm $(BASHINSTALLDIR)/crio
 	rm $(FISHINSTALLDIR)/crio.fish

--- a/bundle/build
+++ b/bundle/build
@@ -17,6 +17,7 @@ FILES_BIN=(
 FILES_MAN=(
     "../docs/crio.8"
     "../docs/crio.conf.5"
+    "../docs/crio.conf.d.5"
 )
 FILES_ETC=(
     "../crictl.yaml"

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -22,10 +22,10 @@ complete -c crio -n '__fish_crio_no_subcommand' -l config-dir -s d -r -d 'Path t
     configuration file named \'00-default\' has a lower priority than a file
     named \'01-my-overwrite\'.
     The global config file, provided via \'--config,-c\' or per default in
-	/etc/crio/crio.conf, always has a lower priority than the files in the directory specified
-	by \'--config-dir,-d\'.
-	Beside that, provided command line parameters still have a higher priority
-	than any configuration file.'
+    /etc/crio/crio.conf, always has a lower priority than the files in the directory specified
+    by \'--config-dir,-d\'.
+    Besides that, provided command line parameters have a higher priority
+    than any configuration file.'
 complete -c crio -n '__fish_crio_no_subcommand' -l conmon -r -d 'Path to the conmon binary, used for monitoring the OCI runtime. Will be searched for using $PATH if empty. (default: "")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l conmon-cgroup -r -d 'cgroup to be used for conmon process (default: "system.slice")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l conmon-env -r -d 'Environment variable list for the conmon process, used for passing necessary environment variables to conmon or the runtime'

--- a/docs/crio-status.8.md
+++ b/docs/crio-status.8.md
@@ -87,4 +87,5 @@ Shows a list of commands or help for one command
 
 # SEE ALSO
 
-crio.conf(5), oci-hooks(5), policy.json(5), registries.conf(5), storage.conf(5)
+crio.conf(5), crio.conf.d(5), oci-hooks(5), policy.json(5), registries.conf(5),
+storage.conf(5)

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -127,10 +127,10 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
     configuration file named '00-default' has a lower priority than a file
     named '01-my-overwrite'.
     The global config file, provided via '--config,-c' or per default in
-	/etc/crio/crio.conf, always has a lower priority than the files in the directory specified
-	by '--config-dir,-d'.
-	Beside that, provided command line parameters still have a higher priority
-	than any configuration file. (default: /etc/crio/crio.conf.d)
+    /etc/crio/crio.conf, always has a lower priority than the files in the directory specified
+    by '--config-dir,-d'.
+    Besides that, provided command line parameters have a higher priority
+    than any configuration file. (default: /etc/crio/crio.conf.d)
 
 **--conmon**="": Path to the conmon binary, used for monitoring the OCI runtime. Will be searched for using $PATH if empty. (default: "")
 
@@ -351,4 +351,5 @@ Shows a list of commands or help for one command
 
 # SEE ALSO
 
-crio.conf(5), oci-hooks(5), policy.json(5), registries.conf(5), storage.conf(5)
+crio.conf(5), crio.conf.d(5), oci-hooks(5), policy.json(5), registries.conf(5),
+storage.conf(5)

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -264,7 +264,7 @@ The `crio.metrics` table containers settings pertaining to the Prometheus based 
   The port on which the metrics server will listen.
 
 # SEE ALSO
-containers-storage.conf(5), containers-policy.json(5), containers-registries.conf(5), crio(8)
+crio.conf.d(5), containers-storage.conf(5), containers-policy.json(5), containers-registries.conf(5), crio(8)
 
 # HISTORY
 Aug 2018, Update to the latest state by Valentin Rothberg <vrothberg@suse.com>

--- a/docs/crio.conf.d.5.md
+++ b/docs/crio.conf.d.5.md
@@ -1,0 +1,25 @@
+% crio.conf.d(5)
+
+# NAME
+crio.conf.d - directory for drop-in configuration files for CRI-O
+
+# DESCRIPTION
+Additionally to configuration in crio.conf(5), CRI-O allows to drop configuration
+snippets into the crio.conf.d directory. The default directory is /etc/crio/crio.conf.d/.
+The path can be changed via CRIO's **--config-dir** command line option.
+
+# CONFIGURATION PRECEDENCE
+When it exists, the main configuration file (/etc/crio/crio.conf by default) is
+read before any file in the configuration directory (/etc/crio/crio.conf.d).
+Settings in that file have the lowest precedence.
+
+Files in the configuration directory are sorted by name in lexical order and
+applied in that order. If multiple configuration files specify the same
+configuration option the setting specified in file sorted last takes
+precedence over any other value. That is if both 00-default.conf and
+10-custom.conf exist in crio.conf.d and both specify different values for a
+certain configuration option the value from 10-custom.conf will be applied.
+
+# SEE ALSO
+
+crio.conf(5), crio(8)

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -293,10 +293,10 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
     configuration file named '00-default' has a lower priority than a file
     named '01-my-overwrite'.
     The global config file, provided via '--config,-c' or per default in
-	%s, always has a lower priority than the files in the directory specified
-	by '--config-dir,-d'.
-	Beside that, provided command line parameters still have a higher priority
-	than any configuration file.`, libconfig.CrioConfigPath),
+    %s, always has a lower priority than the files in the directory specified
+    by '--config-dir,-d'.
+    Beside that, provided command line parameters still have a higher priority
+    than any configuration file.`, libconfig.CrioConfigPath),
 			EnvVars:   []string{"CONTAINER_CONFIG_DIR"},
 			TakesFile: true,
 		},

--- a/internal/pkg/criocli/criocli.go
+++ b/internal/pkg/criocli/criocli.go
@@ -295,7 +295,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
     The global config file, provided via '--config,-c' or per default in
     %s, always has a lower priority than the files in the directory specified
     by '--config-dir,-d'.
-    Beside that, provided command line parameters still have a higher priority
+    Besides that, provided command line parameters have a higher priority
     than any configuration file.`, libconfig.CrioConfigPath),
 			EnvVars:   []string{"CONTAINER_CONFIG_DIR"},
 			TakesFile: true,

--- a/internal/pkg/criocli/documentation.go
+++ b/internal/pkg/criocli/documentation.go
@@ -62,7 +62,8 @@ const markdownDocTemplate = `
 
 # SEE ALSO
 
-crio.conf(5), oci-hooks(5), policy.json(5), registries.conf(5), storage.conf(5)`
+crio.conf(5), crio.conf.d(5), oci-hooks(5), policy.json(5), registries.conf(5),
+storage.conf(5)`
 
 func man() *cli.Command {
 	return &cli.Command{


### PR DESCRIPTION
#### What type of PR is this?

> /kind documentation

#### What this PR does / why we need it:

This adds a small man page about the usage of the configuration directory `crio.conf.d`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Added man page for crio.conf.d(5)
```
