### PR TITLE
SetLinuxResourcesMemorySwap to the LinuxResourcesMemoryLimit

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -495,6 +495,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 				return nil, fmt.Errorf("set memory limit %v too low; should be at least %v", memoryLimit, minMemoryLimit)
 			}
 			specgen.SetLinuxResourcesMemoryLimit(memoryLimit)
+			specgen.SetLinuxResourcesMemorySwap(memoryLimit)
 
 			specgen.SetProcessOOMScoreAdj(int(resources.GetOomScoreAdj()))
 			specgen.SetLinuxResourcesCPUCpus(resources.GetCpusetCpus())

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -40,6 +40,7 @@ func toOCIResources(r *pb.LinuxContainerResources) *rspec.LinuxResources {
 		},
 		Memory: &rspec.LinuxMemory{
 			Limit: proto.Int64(r.GetMemoryLimitInBytes()),
+			Swap:  proto.Int64(r.GetMemoryLimitInBytes()),
 		},
 		// TODO(runcom): OOMScoreAdj is missing
 	}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1251,6 +1251,16 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "209715200" ]]
 
+	if test -r /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ; then
+		expected=209715200
+	else
+		expected=0
+	fi
+	run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.swap.max 2> /dev/null"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "$output" -eq "$expected" ]
+
 	if test $(stat -f -c%T /sys/fs/cgroup) = cgroup2fs; then
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.max"
 		echo "$output"
@@ -1285,6 +1295,16 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "524288000" ]]
+
+	if test -r /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ; then
+		expected=524288000
+	else
+		expected=0
+	fi
+	run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.swap.max 2> /dev/null"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "$output" -eq "$expected" ]
 
 	if test $(stat -f -c%T /sys/fs/cgroup) = cgroup2fs; then
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.max"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Per https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-limits-are-run, when kubernetes runs a container with a memory usage limit set, it expects results comparable to using `docker run --memory=...`.

Per https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details, if the --memory flag is used, but the --memory-swap flag is _not_ used, the swap space limit value is expected to be equal to the memory limit value.

This swap space limit _includes_ the memory limit, though, so kubernetes effectively expects us to not allow the container to use swap.

CRI-O currently doesn't ask a runtime to set a limit on the amount of swap space a container is allowed to use, but OpenShift has build tests that check for that behavior, so they noticed.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
When setting the limit of memory resource usage in a container's runtime spec, we now disable use of swap by the container.
```