### PR TITLE
test/conmonmon: fix getting conmon pid

### DIFF
--- a/test/conmonmon.bats
+++ b/test/conmonmon.bats
@@ -14,7 +14,7 @@ function teardown() {
 function kill_conmon() {
 	ctr_id="$1"
 
-	conmon_pid=$(ps -eo "%p %a" | grep conmon | grep "$ctr_id" | cut -d' ' -f1)
+	conmon_pid=$(pgrep -f "conmon .* -c $ctr_id ")
 	if [ -z "$conmon_pid" ]; then
 		skip "conmon pid found empty; probably kata containers"
 	fi


### PR DESCRIPTION
I ran tests on my laptop and saw this:

> ok 12 conmonmon cleans up running conmon # skip conmon pid found empty; probably kata containers

Looking into it, I found out that `ps -eo "%p %a"` formats its output
into columns, and the PID column is right-aligned, e.g.

```
 100763 /usr/local/bin/conmon <....>
```

(note the extra space before the PID). This results in `cut -d' ' -f1`
printing nothing instead of a PID.

Replacing `cut` with `awk '{print $1}'` would solve the issue, but
it will be even better to use `pgrep` which allows to filter by command
name and does not do fancy whitespace formatting. It can also filter by
the complete command line, making other greps and cuts redundant.

Tested with pgrep from procps-ng-3.3.15, as well as busybox-1.30.1.

Fixes: ec3187b3e

/kind bug
/release-note-none