### PR TITLE
vendor: update github.com/containernetworking/cni to v0.7.2-0.20200304161608-4fae32b84921

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/containerd/containerd v1.3.3
 	github.com/containerd/release-tool v0.0.0-20200218161915-2230b10b5f0b
 	github.com/containerd/ttrpc v0.0.0-20200121165050-0be804eadb15
-	github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784
+	github.com/containernetworking/cni v0.7.2-0.20200304161608-4fae32b84921
 	github.com/containernetworking/plugins v0.8.5
 	github.com/containers/buildah v1.14.0
 	github.com/containers/conmon v2.0.10+incompatible

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784 h1:rqUVL
 github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.7.2-0.20200219164625-56ace59a9e7f h1:MvUTRn2S2Ql4s/q+ruVq0n33tQlhsyM8bTbKM575G7k=
 github.com/containernetworking/cni v0.7.2-0.20200219164625-56ace59a9e7f/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/containernetworking/cni v0.7.2-0.20200304161608-4fae32b84921 h1:eUMd8hlGasYcg1tBqETZtxaW3a7EIxqY7Z1g65gcKQg=
+github.com/containernetworking/cni v0.7.2-0.20200304161608-4fae32b84921/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.2/go.mod h1:TxALKWZpWL79BC3GOYKJzzXr7U8R23PdhwaLp6F3adc=
 github.com/containernetworking/plugins v0.8.5 h1:pCvEMrFf7yzJI8+/D/7jkvE96KD52b7/Eu+jpahihy8=
 github.com/containernetworking/plugins v0.8.5/go.mod h1:UZ2539umj8djuRQmBxuazHeJbYrLV8BSBejkk+she6o=

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -529,9 +529,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		if err != nil {
 			return nil, err
 		}
-		if result != nil {
-			g.AddAnnotation(annotations.CNIResult, result.String())
-		}
 		defer func() {
 			if err != nil {
 				if err2 := s.networkStop(ctx, sb); err2 != nil {
@@ -539,6 +536,14 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 				}
 			}
 		}()
+		if result != nil {
+			var data []byte
+			data, err = json.Marshal(result)
+			if err != nil {
+				return nil, err
+			}
+			g.AddAnnotation(annotations.CNIResult, string(data))
+		}
 	}
 
 	for idx, ip := range ips {

--- a/vendor/github.com/containernetworking/cni/libcni/api.go
+++ b/vendor/github.com/containernetworking/cni/libcni/api.go
@@ -409,6 +409,9 @@ func (c *CNIConfig) addNetwork(ctx context.Context, name, cniVersion string, net
 	if err := utils.ValidateNetworkName(name); err != nil {
 		return nil, err
 	}
+	if err := utils.ValidateInterfaceName(rt.IfName); err != nil {
+		return nil, err
+	}
 
 	newConf, err := buildOneConfig(name, cniVersion, net, prevResult, rt)
 	if err != nil {
@@ -628,6 +631,9 @@ func (c *CNIConfig) validatePlugin(ctx context.Context, pluginName, expectedVers
 	pluginPath, err := c.exec.FindInPath(pluginName, c.Path)
 	if err != nil {
 		return err
+	}
+	if expectedVersion == "" {
+		expectedVersion = "0.1.0"
 	}
 
 	vi, err := invoke.GetVersionInfo(ctx, pluginPath, c.exec)

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/args.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/args.go
@@ -60,8 +60,8 @@ func (args *Args) AsEnv() []string {
 		pluginArgsStr = stringify(args.PluginArgs)
 	}
 
-	// Duplicated values which come first will be overrided, so we must put the
-	// custom values in the end to avoid being overrided by the process environments.
+	// Duplicated values which come first will be overridden, so we must put the
+	// custom values in the end to avoid being overridden by the process environments.
 	env = append(env,
 		"CNI_COMMAND="+args.Command,
 		"CNI_CONTAINERID="+args.ContainerID,

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec.go
@@ -44,10 +44,14 @@ func (e *RawExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData [
 }
 
 func pluginErr(err error, output []byte) error {
-	if _, ok := err.(*exec.ExitError); ok {
+	if exitError, ok := err.(*exec.ExitError); ok {
 		emsg := types.Error{}
 		if len(output) == 0 {
-			emsg.Msg = "netplugin failed with no error message"
+			if len(exitError.Stderr) == 0 {
+				emsg.Msg = "netplugin failed with no error message"
+			} else {
+				emsg.Msg = fmt.Sprintf("netplugin failed: %q", string(exitError.Stderr))
+			}
 		} else if perr := json.Unmarshal(output, &emsg); perr != nil {
 			emsg.Msg = fmt.Sprintf("netplugin failed but error parsing its diagnostic message %q: %v", string(output), perr)
 		}

--- a/vendor/github.com/containernetworking/cni/pkg/types/020/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/020/types.go
@@ -86,20 +86,6 @@ func (r *Result) PrintTo(writer io.Writer) error {
 	return err
 }
 
-// String returns a formatted string in the form of "[IP4: $1,][ IP6: $2,] DNS: $3" where
-// $1 represents the receiver's IPv4, $2 represents the receiver's IPv6 and $3 the
-// receiver's DNS. If $1 or $2 are nil, they won't be present in the returned string.
-func (r *Result) String() string {
-	var str string
-	if r.IP4 != nil {
-		str = fmt.Sprintf("IP4:%+v, ", *r.IP4)
-	}
-	if r.IP6 != nil {
-		str += fmt.Sprintf("IP6:%+v, ", *r.IP6)
-	}
-	return fmt.Sprintf("%sDNS:%+v", str, r.DNS)
-}
-
 // IPConfig contains values necessary to configure an interface
 type IPConfig struct {
 	IP      net.IPNet

--- a/vendor/github.com/containernetworking/cni/pkg/types/current/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/current/types.go
@@ -207,23 +207,6 @@ func (r *Result) PrintTo(writer io.Writer) error {
 	return err
 }
 
-// String returns a formatted string in the form of "[Interfaces: $1,][ IP: $2,] DNS: $3" where
-// $1 represents the receiver's Interfaces, $2 represents the receiver's IP addresses and $3 the
-// receiver's DNS. If $1 or $2 are nil, they won't be present in the returned string.
-func (r *Result) String() string {
-	var str string
-	if len(r.Interfaces) > 0 {
-		str += fmt.Sprintf("Interfaces:%+v, ", r.Interfaces)
-	}
-	if len(r.IPs) > 0 {
-		str += fmt.Sprintf("IP:%+v, ", r.IPs)
-	}
-	if len(r.Routes) > 0 {
-		str += fmt.Sprintf("Routes:%+v, ", r.Routes)
-	}
-	return fmt.Sprintf("%sDNS:%+v", str, r.DNS)
-}
-
 // Convert this old version result to the current CNI version result
 func (r *Result) Convert() (*Result, error) {
 	return r, nil

--- a/vendor/github.com/containernetworking/cni/pkg/types/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/types.go
@@ -100,9 +100,6 @@ type Result interface {
 
 	// Prints the result in JSON format to provided writer
 	PrintTo(writer io.Writer) error
-
-	// Returns a JSON string representation of the result
-	String() string
 }
 
 func PrintResult(result Result, version string) error {

--- a/vendor/github.com/containers/libpod/libpod/networking_linux.go
+++ b/vendor/github.com/containers/libpod/libpod/networking_linux.go
@@ -117,10 +117,10 @@ func (r *Runtime) configureNetNS(ctr *Container, ctrNS ns.NetNS) ([]*cnitypes.Re
 
 	networkStatus := make([]*cnitypes.Result, 0)
 	for idx, r := range results {
-		logrus.Debugf("[%d] CNI result: %v", idx, r.Result.String())
+		logrus.Debugf("[%d] CNI result: %v", idx, r.Result)
 		resultCurrent, err := cnitypes.GetResult(r.Result)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing CNI plugin result %q: %v", r.Result.String(), err)
+			return nil, errors.Wrapf(err, "error parsing CNI plugin result %q: %v", r.Result, err)
 		}
 		networkStatus = append(networkStatus, resultCurrent)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -77,7 +77,7 @@ github.com/containerd/release-tool
 github.com/containerd/ttrpc
 # github.com/containerd/typeurl v0.0.0-20190228175220-2a93cfde8c20
 github.com/containerd/typeurl
-# github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784
+# github.com/containernetworking/cni v0.7.2-0.20200304161608-4fae32b84921
 ## explicit
 github.com/containernetworking/cni/libcni
 github.com/containernetworking/cni/pkg/invoke


### PR DESCRIPTION
Specifically to get:

https://github.com/containernetworking/cni/pull/735
6f29b0165883b2b52ccd4dcb937162ea4c86927b intercept netplugin std err

But also pulls in some interface name validation and a compatibility
fix for configurations that don't set a CNI version.

Signed-off-by: Dan Williams <dcbw@redhat.com>

/kind bug

```release-note
NONE
```
