### PR TITLE
docs: add gcc as build requirement for CRI-O

### DIFF
--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -35,6 +35,7 @@ yum install -y \
   libselinux-devel \
   pkgconfig \
   make \
+  gcc \
   runc
 ```
 


### PR DESCRIPTION
Fedora/RHEL requires gcc as the others distros to build CRI-O.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Fix the documentation how to build CRI-O on Fedora/RHEL.