### PR TITLE
[1.14] conmon: bump to 2.0.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN set -x \
        && rm -rf "$GOPATH"
 
 # Install conmon
-RUN VERSION=v2.0.0 &&\
+RUN VERSION=v2.0.11 &&\
     git clone https://github.com/containers/conmon &&\
 	cd conmon && git checkout $VERSION &&\
 	make && make PREFIX=/ install && cd .. && rm -rf conmon/

--- a/contrib/test/integration/build/conmon.yml
+++ b/contrib/test/integration/build/conmon.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/containers/conmon.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/containers/conmon"
-    version: "6f3572558b97bc60dd8f8c7f0807748e6ce2c440"
+    version: "v2.0.11"
 
 - name: build conmon
   make:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784
 	github.com/containernetworking/plugins v0.8.2
 	github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982
-	github.com/containers/conmon v2.0.2+incompatible
+	github.com/containers/conmon v2.0.11+incompatible
 	github.com/containers/image/v5 v5.0.1-0.20200205124631-82291c45f2b0
 	github.com/containers/libpod v1.6.3-0.20191111140219-de32b89eff09
 	github.com/containers/storage v1.13.6

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/containers/buildah v1.11.5-0.20191031204705-20e92ffe0982/go.mod h1:eG
 github.com/containers/conmon v2.0.0+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon v2.0.2+incompatible h1:h2HCdd/EBpwFn7RT82Y2GyXnVUHWxk1Jm4cESSZG4P8=
 github.com/containers/conmon v2.0.2+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
+github.com/containers/conmon v2.0.11+incompatible h1:6GsjGxxobNEQrVsxRrosI33Vm8nS1Gk4n5Tp1B1yETE=
+github.com/containers/conmon v2.0.11+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.0.0/go.mod h1:MgiLzCfIeo8lrHi+4Lb8HP+rh513sm0Mlk6RrhjFOLY=
 github.com/containers/image/v5 v5.0.1-0.20200205124631-82291c45f2b0 h1:iV4aHKRoPcHp5BISsuiPMyaCjGJfLKp/FUMAG1NeqvE=
 github.com/containers/image/v5 v5.0.1-0.20200205124631-82291c45f2b0/go.mod h1:MgiLzCfIeo8lrHi+4Lb8HP+rh513sm0Mlk6RrhjFOLY=

--- a/vendor/github.com/containers/conmon/runner/config/config.go
+++ b/vendor/github.com/containers/conmon/runner/config/config.go
@@ -6,4 +6,14 @@ const (
 	// ConnSockBufSize is the size of the socket used for
 	// to attach to the container
 	ConnSockBufSize = 32768
+	// WinResizeEvent is the event code the caller program will
+	// send along the ctrl fd to signal conmon to resize
+	// the pty window
+	WinResizeEvent = 1
+	// ReopenLogsEvent is the event code the caller program will
+	// send along the ctrl fd to signal conmon to reopen the log files
+	ReopenLogsEvent = 2
+	// TimedOutMessage is the message sent back to the caller by conmon
+	// when a container times out
+	TimedOutMessage = "command timed out"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,7 +95,7 @@ github.com/containers/buildah/pkg/cgroups
 github.com/containers/buildah/pkg/chrootuser
 github.com/containers/buildah/pkg/overlay
 github.com/containers/buildah/pkg/cli
-# github.com/containers/conmon v2.0.2+incompatible
+# github.com/containers/conmon v2.0.11+incompatible
 github.com/containers/conmon/runner/config
 # github.com/containers/image/v5 v5.0.1-0.20200205124631-82291c45f2b0
 github.com/containers/image/v5/pkg/sysregistriesv2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup

#### What this PR does / why we need it:
bumps conmon to 2.0.11

Not only do we want to test against the latest and greatest, conmon 2.0.11 also reduces the chance of incorrectly reporting a container OOM, and also is protected against conmon OOMs. This prevents then need for conmonmon and other tools to protect this branch from incorrect OOM reporting
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
