### PR TITLE
Add gRPC method name to logs

### DIFF
--- a/internal/log/interceptors.go
+++ b/internal/log/interceptors.go
@@ -30,7 +30,9 @@ func StreamInterceptor() grpc.StreamServerInterceptor {
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		newCtx := addRequestID(stream.Context())
+		newCtx := addRequestName(
+			addRequestID(stream.Context()), info.FullMethod,
+		)
 		newStream := NewServerStream(stream)
 		newStream.NewContext = newCtx
 
@@ -51,7 +53,9 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		newCtx := addRequestID(ctx)
+		newCtx := addRequestName(
+			addRequestID(ctx), info.FullMethod,
+		)
 		Debugf(newCtx, "request: %+v", req)
 
 		resp, err := handler(newCtx, req)
@@ -68,4 +72,8 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 
 func addRequestID(ctx context.Context) context.Context {
 	return context.WithValue(ctx, ID{}, uuid.New().String())
+}
+
+func addRequestName(ctx context.Context, req string) context.Context {
+	return context.WithValue(ctx, Name{}, req)
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -8,6 +8,7 @@ import (
 )
 
 type ID struct{}
+type Name struct{}
 
 func Debugf(ctx context.Context, format string, args ...interface{}) {
 	entry(ctx).Debugf(format, args...)
@@ -31,9 +32,10 @@ func entry(ctx context.Context) *logrus.Entry {
 		return logrus.NewEntry(logger)
 	}
 
-	idValue := ctx.Value(ID{})
-	if ret, ok := idValue.(string); ok {
-		return logger.WithField("id", ret)
+	id, idOk := ctx.Value(ID{}).(string)
+	name, nameOk := ctx.Value(Name{}).(string)
+	if idOk && nameOk {
+		return logger.WithField("id", id).WithField("name", name)
 	}
 
 	return logrus.NewEntry(logger)

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -14,14 +14,19 @@ var _ = t.Describe("Log", func() {
 	var ctx context.Context
 
 	const (
-		msg = "Hello world"
-		id  = "some-id"
+		msg  = "Hello world"
+		id   = "some-id"
+		name = "some-name"
 	)
 
 	idEntry := "id=" + id
+	nameEntry := "name=" + name
 
 	BeforeEach(func() {
-		ctx = context.WithValue(context.Background(), log.ID{}, id)
+		ctx = context.WithValue(
+			context.WithValue(context.Background(), log.ID{}, id),
+			log.Name{}, name,
+		)
 	})
 
 	t.Describe("Debugf", func() {
@@ -35,6 +40,7 @@ var _ = t.Describe("Log", func() {
 			// Then
 			Expect(buf.String()).To(ContainSubstring(msg))
 			Expect(buf.String()).To(ContainSubstring(idEntry))
+			Expect(buf.String()).To(ContainSubstring(nameEntry))
 		})
 
 		It("should succeed to debug on empty context", func() {
@@ -45,6 +51,7 @@ var _ = t.Describe("Log", func() {
 			// Then
 			Expect(buf.String()).To(ContainSubstring(msg))
 			Expect(buf.String()).ToNot(ContainSubstring(idEntry))
+			Expect(buf.String()).ToNot(ContainSubstring(nameEntry))
 		})
 
 		It("should succeed to debug on nil context", func() {
@@ -55,6 +62,7 @@ var _ = t.Describe("Log", func() {
 			// Then
 			Expect(buf.String()).To(ContainSubstring(msg))
 			Expect(buf.String()).ToNot(ContainSubstring(idEntry))
+			Expect(buf.String()).ToNot(ContainSubstring(nameEntry))
 		})
 	})
 
@@ -69,6 +77,7 @@ var _ = t.Describe("Log", func() {
 			// Then
 			Expect(buf.String()).To(ContainSubstring(msg))
 			Expect(buf.String()).To(ContainSubstring(idEntry))
+			Expect(buf.String()).To(ContainSubstring(nameEntry))
 		})
 
 		It("should not debug log", func() {
@@ -92,6 +101,7 @@ var _ = t.Describe("Log", func() {
 			// Then
 			Expect(buf.String()).To(ContainSubstring(msg))
 			Expect(buf.String()).To(ContainSubstring(idEntry))
+			Expect(buf.String()).To(ContainSubstring(nameEntry))
 		})
 
 		It("should not info log", func() {
@@ -115,6 +125,7 @@ var _ = t.Describe("Log", func() {
 			// Then
 			Expect(buf.String()).To(ContainSubstring(msg))
 			Expect(buf.String()).To(ContainSubstring(idEntry))
+			Expect(buf.String()).To(ContainSubstring(nameEntry))
 		})
 
 		It("should not warn log", func() {

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -39,11 +39,11 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (r
 		status, err := s.StorageImageServer().ImageStatus(s.config.SystemContext, image)
 		if err != nil {
 			if errors.Cause(err) == storage.ErrImageUnknown {
-				log.Warnf(ctx, "imageStatus: can't find %s", image)
+				log.Debugf(ctx, "can't find %s", image)
 				notfound = true
 				continue
 			}
-			log.Warnf(ctx, "imageStatus: error getting status from %s: %v", image, err)
+			log.Warnf(ctx, "error getting status from %s: %v", image, err)
 			lastErr = err
 			continue
 		}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:

Beside the unique ID we now add the full gRPC method name to the logs,
which allow better traceability and removes the necessity to prefix the
logs with hard-coded method names.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
We now have an additional `name` field ad the end of the logs:
```
DEBU[2020-03-10 10:59:23.041438456+01:00] Response: &ListContainersResponse{Containers:[]*Container{},}  file="go-grpc-middleware/chain.go:25" id=420e073d-2d14-4126-a6d7-d3a79db698a1 name=/runtime.v1alpha2.RuntimeService/ListContainers
DEBU[2020-03-10 10:59:50.426689794+01:00] Request: &ListImagesRequest{Filter:&ImageFilter{Image:&ImageSpec{Image:,},},}  file="go-grpc-middleware/chain.go:25" id=5b73c5ba-0b32-47b6-bc44-456c7005e233 name=/runtime.v1alpha2.ImageService/ListImages
```
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added gRPC method names to log entries to increase trace-ablity
```