### PR TITLE
Add target release version to generated notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,9 +176,11 @@ release-notes: ${RELEASE_NOTES}
 		--github-org cri-o \
 		--github-repo cri-o \
 		--required-author "" \
+		--repo-path /tmp/cri-o-repo \
 		--start-rev $$TAG \
 		--end-sha $(COMMIT_NO) \
-		--output $$OUTPATH/$(COMMIT_NO).md
+		--output $$OUTPATH/$(COMMIT_NO).md &&\
+	sed -i '1s;^;# $(VERSION)\n\n;' $$OUTPATH/$(COMMIT_NO).md
 
 clean:
 ifneq ($(GOPATH),)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The release version for which are the notes generated an be part of the
output markdown document.

#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
