### PR TITLE
Fix unit tests for locally configured registries

### DIFF
--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -2,7 +2,6 @@ package storage_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	"github.com/containers/image/v5/copy"
@@ -33,10 +32,13 @@ var _ = t.Describe("Image", func() {
 	var (
 		mockCtrl  *gomock.Controller
 		storeMock *containerstoragemock.MockStore
-	)
 
-	// The system under test
-	var sut storage.ImageServer
+		// The system under test
+		sut storage.ImageServer
+
+		// The empty system context
+		ctx *types.SystemContext
+	)
 
 	// Prepare the system under test
 	BeforeEach(func() {
@@ -44,9 +46,14 @@ var _ = t.Describe("Image", func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 		storeMock = containerstoragemock.NewMockStore(mockCtrl)
 
+		// Setup the SUT
 		var err error
+		ctx = &types.SystemContext{
+			SystemRegistriesConfPath: t.MustTempFile("registries"),
+		}
+
 		sut, err = storage.GetImageService(
-			context.Background(), nil, storeMock, "docker://",
+			context.Background(), ctx, storeMock, "docker://",
 			[]string{}, []string{testDockerRegistry, testExampleRegistry},
 		)
 		Expect(err).To(BeNil())
@@ -54,6 +61,7 @@ var _ = t.Describe("Image", func() {
 	})
 	AfterEach(func() {
 		mockCtrl.Finish()
+		Expect(os.Remove(ctx.SystemRegistriesConfPath)).To(BeNil())
 	})
 
 	mockGetRef := func() mockSequence {
@@ -149,7 +157,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(nil, testImageName)
+			names, err := sut.ResolveNames(ctx, testImageName)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -168,7 +176,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(nil, imageName)
+			names, err := sut.ResolveNames(ctx, imageName)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -184,7 +192,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(nil, testImageWithTagAndDigest)
+			names, err := sut.ResolveNames(ctx, testImageWithTagAndDigest)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -202,7 +210,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(nil, testNormalizedImageWithTagAndDigest)
+			names, err := sut.ResolveNames(ctx, testNormalizedImageWithTagAndDigest)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -235,7 +243,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(nil, testSHA256)
+			names, err := sut.ResolveNames(ctx, testSHA256)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -251,7 +259,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			names, err := sut.ResolveNames(nil, "camelCaseName")
+			names, err := sut.ResolveNames(ctx, "camelCaseName")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -266,18 +274,14 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// Create an empty file for the registries config path
-			file, err := ioutil.TempFile(".", "registries")
-			Expect(err).To(BeNil())
-			defer os.Remove(file.Name())
-
 			sut, err := storage.GetImageService(context.Background(),
-				&types.SystemContext{SystemRegistriesConfPath: file.Name()},
-				storeMock, "", []string{}, []string{})
+				ctx, storeMock, "", []string{}, []string{},
+			)
 			Expect(err).To(BeNil())
 			Expect(sut).NotTo(BeNil())
 
 			// When
-			names, err := sut.ResolveNames(nil, testImageName)
+			names, err := sut.ResolveNames(ctx, testImageName)
 
 			// Then
 			Expect(err).NotTo(BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The system context is not stored any more in the image server, which
means that we cannot pass `nil` to sysregistries, because this will
access the host configured registries and might cause the unit tests to
fail.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
`make testunit` should now work with any configuration in `/etc/containers/registries.conf`
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
/cc @rhafer 