### PR TITLE
Add container config (set/get) to Container interface

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1,5 +1,58 @@
 package container
 
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+// Container is the main public container interface
 type Container interface {
-	/* TODO: add methods */
+	// SetConfig sets the configuration to the container and validates it
+	SetConfig(*pb.ContainerConfig) error
+
+	// Config returns the container configuration
+	Config() *pb.ContainerConfig
+}
+
+// container is the hidden default type behind the Container interface
+type container struct {
+	ctx    context.Context
+	config *pb.ContainerConfig
+}
+
+// New creates a new, empty Sandbox instance
+func New(ctx context.Context) Container {
+	return &container{
+		ctx:    ctx,
+		config: nil,
+	}
+}
+
+// SetConfig sets the configuration to the container and validates it
+func (c *container) SetConfig(config *pb.ContainerConfig) error {
+	if c.config != nil {
+		return errors.New("config already set")
+	}
+
+	if config == nil {
+		return errors.New("config is nil")
+	}
+
+	if config.GetMetadata() == nil {
+		return errors.New("metadata is nil")
+	}
+
+	if config.GetMetadata().GetName() == "" {
+		return errors.New("name is nil")
+	}
+
+	c.config = config
+	return nil
+}
+
+// Config returns the container configuration
+func (c *container) Config() *pb.ContainerConfig {
+	return c.config
 }

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -1,0 +1,79 @@
+package container_test
+
+import (
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The actual test suite
+var _ = t.Describe("Container", func() {
+	t.Describe("SetConfig", func() {
+		It("should succeed", func() {
+			// Given
+			config := &pb.ContainerConfig{
+				Metadata: &pb.ContainerMetadata{Name: "name"},
+			}
+
+			// When
+			err := sut.SetConfig(config)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.Config()).To(Equal(config))
+		})
+
+		It("should fail with nil config", func() {
+			// Given
+			// When
+			err := sut.SetConfig(nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(sut.Config()).To(BeNil())
+		})
+
+		It("should fail with empty config", func() {
+			// Given
+			config := &pb.ContainerConfig{}
+
+			// When
+			err := sut.SetConfig(config)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(sut.Config()).To(BeNil())
+		})
+
+		It("should fail with empty name", func() {
+			// Given
+			config := &pb.ContainerConfig{
+				Metadata: &pb.ContainerMetadata{},
+			}
+
+			// When
+			err := sut.SetConfig(config)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(sut.Config()).To(BeNil())
+		})
+
+		It("should fail with already set config", func() {
+			// Given
+			config := &pb.ContainerConfig{
+				Metadata: &pb.ContainerMetadata{Name: "name"},
+			}
+			err := sut.SetConfig(config)
+			Expect(err).To(BeNil())
+
+			// When
+			err = sut.SetConfig(config)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(sut.Config()).To(Equal(config))
+		})
+	})
+})

--- a/pkg/container/suite_test.go
+++ b/pkg/container/suite_test.go
@@ -1,0 +1,35 @@
+package container_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cri-o/cri-o/pkg/container"
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestContainer runs the specs
+func TestContainer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "Container")
+}
+
+var (
+	t   *TestFramework
+	sut container.Container
+)
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})
+
+var _ = BeforeEach(func() {
+	sut = container.New(context.Background())
+})


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This commit adds a configuration setter and getter to the new
`Container` interface, which can be used as a base for further
refactorings. The container creation RPC now uses the new interface to
validate and retrieve the config. Unit tests have been added as well.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
/cc @rhafer 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
