### PR TITLE
systemd: use inactive-or-failed for CollectMode

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -533,13 +533,14 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		}
 		specgen.SetLinuxCgroupsPath(cgPath)
 
-		if t, ok := kubeAnnotations[podTerminationGracePeriodLabel]; ok {
-			// currently only supported by systemd, see
-			// https://github.com/opencontainers/runc/pull/2224
-			if useSystemd {
+		if useSystemd {
+			if t, ok := kubeAnnotations[podTerminationGracePeriodLabel]; ok {
+				// currently only supported by systemd, see
+				// https://github.com/opencontainers/runc/pull/2224
 				specgen.AddAnnotation("org.systemd.property.TimeoutStopUSec",
 					"uint64 "+t+"000000") // sec to usec
 			}
+			configureGeneratorWithCollectMode(specgen)
 		}
 
 		if privileged {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -699,6 +699,7 @@ func AddCgroupAnnotation(ctx context.Context, g generate.Generator, mountPath, c
 					}
 				}
 			}
+			configureGeneratorWithCollectMode(g)
 		} else {
 			if strings.HasSuffix(path.Base(cgroupParent), ".slice") {
 				return "", fmt.Errorf("cri-o configured with cgroupfs cgroup manager, but received systemd slice as parent: %s", cgroupParent)
@@ -710,6 +711,12 @@ func AddCgroupAnnotation(ctx context.Context, g generate.Generator, mountPath, c
 	g.AddAnnotation(annotations.CgroupParent, cgroupParent)
 
 	return cgroupParent, nil
+}
+
+func configureGeneratorWithCollectMode(g generate.Generator) {
+	// we always want inactive-or-failed as the collect mode
+	// when using systemd
+	g.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
 }
 
 // PauseCommand returns the pause command for the provided image configuration.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup

#### What this PR does / why we need it:
Configure every container to have its systemd CollectMode set to inactive-or-failed. This tells systemd to cleanup the cgroup if it failed

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
