### PR TITLE
server: Return grpc code NotFound when we can't find a container or pod

### DIFF
--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/client-go/tools/remotecommand"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -24,7 +26,7 @@ func (s *Server) Attach(ctx context.Context, req *pb.AttachRequest) (resp *pb.At
 func (s StreamService) Attach(containerID string, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	c, err := s.runtimeServer.GetContainerFromShortID(containerID)
 	if err != nil {
-		return fmt.Errorf("could not find container %q: %v", containerID, err)
+		return status.Errorf(codes.NotFound, "could not find container %q: %v", containerID, err)
 	}
 
 	if err := s.runtimeServer.Runtime().UpdateContainerStatus(c); err != nil {

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/client-go/tools/remotecommand"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -24,7 +26,7 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (resp *pb.ExecRe
 func (s StreamService) Exec(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	c, err := s.runtimeServer.GetContainerFromShortID(containerID)
 	if err != nil {
-		return fmt.Errorf("could not find container %q: %v", containerID, err)
+		return status.Errorf(codes.NotFound, "could not find container %q: %v", containerID, err)
 	}
 
 	if err := s.runtimeServer.Runtime().UpdateContainerStatus(c); err != nil {

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -13,7 +15,7 @@ import (
 func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *pb.ExecSyncResponse, err error) {
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
 	if err := s.Runtime().UpdateContainerStatus(c); err != nil {

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -3,6 +3,8 @@ package server
 import (
 	"github.com/cri-o/cri-o/internal/log"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -12,7 +14,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 	// save container description to print
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
 	_, err = s.ContainerServer.Remove(ctx, req.ContainerId, true)

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -13,7 +15,7 @@ import (
 func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerRequest) (resp *pb.StartContainerResponse, err error) {
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 	state := c.State()
 	if state.Status != oci.ContainerStateCreated {

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -19,7 +21,7 @@ const (
 func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusRequest) (resp *pb.ContainerStatusResponse, err error) {
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
 	containerID := c.ID()

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -3,6 +3,8 @@ package server
 import (
 	"github.com/cri-o/cri-o/internal/log"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -11,7 +13,7 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 	// save container description to print
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
 	_, err = s.ContainerServer.ContainerStop(ctx, req.ContainerId, req.Timeout)

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -9,7 +11,7 @@ import (
 func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusRequest) (resp *pb.PodSandboxStatusResponse, err error) {
 	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, "could not find pod %q: %v", req.PodSandboxId, err)
 	}
 
 	rStatus := pb.PodSandboxState_SANDBOX_NOTREADY


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>



/kind cleanup


#### What this PR does / why we need it:
Returns grpc code NotFound when we can't find a container or a pod.

#### Which issue(s) this PR fixes:



#### Special notes for your reviewer:
This will help the kubelet as it will be able to distinguish from other errors.
We want to make use of other grpc codes as well but this is a first step.

#### Does this PR introduce a user-facing change?
No.

```release-note
Return grpc code NotFound when we can't find a container or pod
```
