### PR TITLE
Add PodSandboxConfig (get/set) to Sandbox interface 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,10 @@ testunit: ${GINKGO}
 		--succinct
 	$(GO) tool cover -html=${COVERAGE_PATH}/coverprofile -o ${COVERAGE_PATH}/coverage.html
 	$(GO) tool cover -func=${COVERAGE_PATH}/coverprofile | sed -n 's/\(total:\).*\([0-9][0-9].[0-9]\)/\1 \2/p'
-	find . -name '*_junit.xml' -exec mv -t ${JUNIT_PATH} {} +
+	for f in $$(find . -name "*_junit.xml"); do \
+		mkdir -p $(JUNIT_PATH)/$$(dirname $$f) ;\
+		mv $$f $(JUNIT_PATH)/$$(dirname $$f) ;\
+	done
 
 testunit-bin:
 	mkdir -p ${TESTBIN_PATH}

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/cri-o/cri-o/pkg/container"
+	"github.com/pkg/errors"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // Sandbox is the interface for managing pod sandboxes
@@ -19,14 +21,50 @@ type Sandbox interface {
 	AddContainer(container.Container) error
 
 	RemoveContainer(container.Container) error
+
+	// SetConfig sets the sandbox configuration and validates it
+	SetConfig(*pb.PodSandboxConfig) error
+
+	// Config returns the sandbox configuration
+	Config() *pb.PodSandboxConfig
 }
 
 // sandbox is the hidden default type behind the Sandbox interface
 type sandbox struct {
-	ctx context.Context
+	ctx    context.Context
+	config *pb.PodSandboxConfig
 }
 
 // New creates a new, empty Sandbox instance
 func New(ctx context.Context) Sandbox {
-	return &sandbox{ctx}
+	return &sandbox{
+		ctx:    ctx,
+		config: nil,
+	}
+}
+
+// SetConfig sets the sandbox configuration and validates it
+func (s *sandbox) SetConfig(config *pb.PodSandboxConfig) error {
+	if s.config != nil {
+		return errors.New("config already set")
+	}
+
+	if config == nil {
+		return errors.New("config is nil")
+	}
+
+	if config.GetMetadata() == nil {
+		return errors.New("metadata is nil")
+	}
+
+	if config.GetMetadata().GetName() == "" {
+		return errors.New("PodSandboxConfig.Name should not be empty")
+	}
+	s.config = config
+	return nil
+}
+
+// Config returns the sandbox configuration
+func (s *sandbox) Config() *pb.PodSandboxConfig {
+	return s.config
 }

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -1,0 +1,78 @@
+package sandbox_test
+
+import (
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Sandbox", func() {
+	t.Describe("SetConfig", func() {
+		It("should succeed", func() {
+			// Given
+			config := &pb.PodSandboxConfig{
+				Metadata: &pb.PodSandboxMetadata{Name: "name"},
+			}
+
+			// When
+			err := sut.SetConfig(config)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.Config()).To(Equal(config))
+		})
+
+		It("should fail with nil config", func() {
+			// Given
+			// When
+			err := sut.SetConfig(nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(sut.Config()).To(BeNil())
+		})
+
+		It("should fail with empty config", func() {
+			// Given
+			config := &pb.PodSandboxConfig{}
+
+			// When
+			err := sut.SetConfig(config)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(sut.Config()).To(BeNil())
+		})
+
+		It("should fail with an empty name", func() {
+			// Given
+			config := &pb.PodSandboxConfig{
+				Metadata: &pb.PodSandboxMetadata{},
+			}
+
+			// When
+			err := sut.SetConfig(config)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(sut.Config()).To(BeNil())
+		})
+
+		It("should fail with config already set", func() {
+			// Given
+			config := &pb.PodSandboxConfig{
+				Metadata: &pb.PodSandboxMetadata{Name: "name"},
+			}
+			err := sut.SetConfig(config)
+			Expect(err).To(BeNil())
+
+			// When
+			err = sut.SetConfig(config)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(sut.Config()).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/sandbox/suite_test.go
+++ b/pkg/sandbox/suite_test.go
@@ -1,0 +1,35 @@
+package sandbox_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cri-o/cri-o/pkg/sandbox"
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestSandbox runs the specs
+func TestSandbox(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "Sandbox")
+}
+
+var (
+	t   *TestFramework
+	sut sandbox.Sandbox
+)
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})
+
+var _ = BeforeEach(func() {
+	sut = sandbox.New(context.Background())
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Similar to what was done for the "Container" interface in PR #3387 this adds set/get methods for the sandbox config to the new "Sandbox" interface. It is used by the RunPodSandbox rpc to
validate and retrieve the configuration.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

//cc @saschagrunert 

#### Does this PR introduce a user-facing change?

```release-note
None
```
