### PR TITLE
Simplify container log path handling

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -453,19 +453,16 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		specgen.SetProcessApparmorProfile(profile)
 	}
 
-	logPath := containerConfig.GetLogPath()
 	sboxLogDir := sandboxConfig.GetLogDirectory()
 	if sboxLogDir == "" {
 		sboxLogDir = sb.LogDir()
 	}
+
+	logPath := containerConfig.GetLogPath()
 	if logPath == "" {
 		logPath = filepath.Join(sboxLogDir, containerID+".log")
-	}
-	if !filepath.IsAbs(logPath) {
-		// XXX: It's not really clear what this should be versus the sbox logDirectory.
-		log.Warnf(ctx, "requested logPath for ctr id %s is a relative path: %s", containerID, logPath)
+	} else {
 		logPath = filepath.Join(sboxLogDir, logPath)
-		log.Warnf(ctx, "logPath from relative path is now absolute: %s", logPath)
 	}
 
 	// Handle https://issues.k8s.io/44043


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
The `LogPath` inside the container config should be mostly relative
according to:

https://github.com/kubernetes/kubernetes/blob/84dc7046797aad80f258b6740a98e79199c8bb4d/pkg/kubelet/kuberuntime/helpers.go#L167-L170

This means we can remove the annoying warning for every container and
just fallback to a default log path if empty.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Removed warning about non-absolute container log paths when creating a container
```
