### PR TITLE
Remove utils.ExecCmdWithStdStreams in favor of utils.ExecCmd

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -227,8 +227,9 @@ func (r *runtimeOCI) StartContainer(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr,
-		r.path, rootFlag, r.root, "start", c.id); err != nil {
+	if _, err := utils.ExecCmd(
+		r.path, rootFlag, r.root, "start", c.id,
+	); err != nil {
 		return err
 	}
 	c.state.Started = time.Now()
@@ -612,8 +613,9 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 	}
 
 	if timeout > 0 {
-		if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr,
-			r.path, rootFlag, r.root, "kill", c.id, c.GetStopSignal()); err != nil {
+		if _, err := utils.ExecCmd(
+			r.path, rootFlag, r.root, "kill", c.id, c.GetStopSignal(),
+		); err != nil {
 			if err := checkProcessGone(c); err != nil {
 				return fmt.Errorf("failed to stop container %q: %v", c.id, err)
 			}
@@ -625,8 +627,9 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 		logrus.Warnf("Stop container %q timed out: %v", c.id, err)
 	}
 
-	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr,
-		r.path, rootFlag, r.root, "kill", c.id, "KILL"); err != nil {
+	if _, err := utils.ExecCmd(
+		r.path, rootFlag, r.root, "kill", c.id, "KILL",
+	); err != nil {
 		if err := checkProcessGone(c); err != nil {
 			return fmt.Errorf("failed to stop container %q: %v", c.id, err)
 		}
@@ -656,7 +659,6 @@ func (r *runtimeOCI) DeleteContainer(c *Container) error {
 	defer c.opLock.Unlock()
 
 	_, err := utils.ExecCmd(r.path, rootFlag, r.root, "delete", "--force", c.id)
-
 	return err
 }
 
@@ -799,8 +801,10 @@ func (r *runtimeOCI) SignalContainer(c *Container, sig syscall.Signal) error {
 		return errors.Errorf("unable to find %s in the signal map", sig.String())
 	}
 
-	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.path,
-		rootFlag, r.root, "kill", c.ID(), strconv.Itoa(int(sig)))
+	_, err := utils.ExecCmd(
+		r.path, rootFlag, r.root, "kill", c.ID(), strconv.Itoa(int(sig)),
+	)
+	return err
 }
 
 // AttachContainer attaches IO to a running container.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -45,24 +45,6 @@ func ExecCmd(name string, args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
-// ExecCmdWithStdStreams execute a command with the specified standard streams.
-func ExecCmdWithStdStreams(stdin io.Reader, stdout, stderr io.Writer, name string, args ...string) error {
-	cmd := exec.Command(name, args...)
-	cmd.Stdin = stdin
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", v))
-	}
-
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("`%v %v` failed: %v", name, strings.Join(args, " "), err)
-	}
-
-	return nil
-}
-
 // StatusToExitCode converts wait status code to an exit code
 func StatusToExitCode(status int) int {
 	return ((status) & 0xff00) >> 8

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -47,36 +47,6 @@ var _ = t.Describe("Utils", func() {
 		})
 	})
 
-	t.Describe("ExecCmdWithStdStreams", func() {
-		It("should succeed", func() {
-			// Given
-			stdout := &bytes.Buffer{}
-			stderr := &bytes.Buffer{}
-
-			// When
-			err := utils.ExecCmdWithStdStreams(nil, stdout, stderr, "ls")
-
-			// Then
-			Expect(err).To(BeNil())
-			Expect(stdout.String()).NotTo(BeEmpty())
-			Expect(stderr.String()).To(BeEmpty())
-		})
-
-		It("should fail on wrong command", func() {
-			// Given
-			stdout := &bytes.Buffer{}
-			stderr := &bytes.Buffer{}
-
-			// When
-			err := utils.ExecCmdWithStdStreams(nil, stdout, stderr, "not-existing")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(stdout.String()).To(BeEmpty())
-			Expect(stderr.String()).To(BeEmpty())
-		})
-	})
-
 	t.Describe("StatusToExitCode", func() {
 		It("should succeed", func() {
 			// Given


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup


#### What this PR does / why we need it:
We only use standard streams so we can fallback to the `utils.ExecCmd`
function. Beside that, we printed results of lower level runtimes (like
runc) directly to stdout/err which is annoying when triaging the CRI-O logs.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Removed annoying logs coming directly from lower level runtimes like runc
```
