### PR TITLE
Mention starting cri-o for running with kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ Bucket][bucket]. This means that the latest master commit can be downloaded via:
 > curl -f https://storage.googleapis.com/k8s-conform-cri-o/artifacts/crio-$(git ls-remote https://github.com/cri-o/cri-o master | cut -c1-9).tar.gz -o crio.tar.gz
 ```
 
-### Running CRI-O
+### Running kubernetes with CRI-O
+
+You need to start `CRI-O` first (tutorials/setup.md#starting-cri-o).
 
 You can run a local version of Kubernetes with `CRI-O` using `local-up-cluster.sh`:
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Starting cri-o is required for running kubernetes with cri-o. Otherwise you would see:
```
W0318 08:26:30.130587   36467 clientconn.go:1208] grpc: addrConn.createTransport failed to connect to {/var/run/crio/crio.sock  <nil> 0 <nil>}. Err :connection error: desc = "transport: Error while dialing dial unix /var/run/crio/crio.sock: connect: no such file or directory". Reconnecting...
```
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None
```release-note

```
