### PR TITLE
Switch back to machine executor for CI lint stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,9 +377,12 @@ jobs:
             - *gocache
 
   lint:
-    executor: container
+    executor: machine
     steps:
       - checkout
+      - run:
+          name: setup environment
+          command: scripts/circle-setup
       - restore_cache:
           keys:
             - v2-lint-{{ checksum "go.sum" }}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
The container executor was hit by OOM kills because golangci-lint uses a
tremendous amount of memory. We now switch back to the machine executor
to have better memory constraints.
#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
