### PR TITLE
[1.17] stats fixes

### DIFF
--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/oci"
 	crioStorage "github.com/cri-o/cri-o/utils"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -52,7 +53,11 @@ func (s *Server) ContainerStats(ctx context.Context, req *pb.ContainerStatsReque
 	if err != nil {
 		return nil, err
 	}
-	cgroup := s.GetSandbox(container.Sandbox()).CgroupParent()
+	sb := s.GetSandbox(container.Sandbox())
+	if sb == nil {
+		return nil, errors.Errorf("unable to get stats for container %s: sandbox %s not found", container.ID(), container.Sandbox())
+	}
+	cgroup := sb.CgroupParent()
 
 	stats, err := s.Runtime().ContainerStats(container, cgroup)
 	if err != nil {

--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -24,7 +24,12 @@ func (s *Server) ListContainerStats(ctx context.Context, req *pb.ListContainerSt
 
 	allStats := make([]*pb.ContainerStats, 0, len(ctrList))
 	for _, container := range ctrList {
-		cgroup := s.GetSandbox(container.Sandbox()).CgroupParent()
+		sb := s.GetSandbox(container.Sandbox())
+		if sb == nil {
+			log.Warnf(ctx, "unable to get stats for container %s: sandbox %s not found", container.ID(), container.Sandbox())
+			continue
+		}
+		cgroup := sb.CgroupParent()
 		stats, err := s.Runtime().ContainerStats(container, cgroup)
 		if err != nil {
 			log.Warnf(ctx, "unable to get stats for container %s: %v", container.ID(), err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
this pulls two stats fixes into 1.17:
https://github.com/cri-o/cri-o/pull/3425 and https://github.com/cri-o/cri-o/pull/3398
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fixes bug where stats when CRI-O uses systemd cgroups are incorrectly reported 
```
