### PR TITLE
[1.17] server/ContainerStatus: don't lock for c.State()

### DIFF
--- a/server/container_status.go
+++ b/server/container_status.go
@@ -46,7 +46,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	}
 	resp.Status.Mounts = mounts
 
-	cState := c.State()
+	cState := c.StateNoLock()
 	rStatus := pb.ContainerState_CONTAINER_UNKNOWN
 
 	// If we defaulted to exit code not set earlier then we attempt to


### PR DESCRIPTION
Backport of https://github.com/cri-o/cri-o/pull/3457 to 1.17; may fix https://github.com/cri-o/cri-o/issues/3455

c.State() is using opLock which can sometimes be held for minutes
in e.g. runtime.ContainerStop. The opLock is there so that
operations changing the container state won't clash. There
is no reason to wait for the lock here.

The side effect is, ContainerStatus will return immediately,
not e.g. after container has finished starting or stopping,
and show the old, rather than new, state.

/kind bug


```release-note
ContainerStatus no longer waits for a container operation (such as start or stop) to finish.
```