### PR TITLE
Add release branch forward to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,14 @@ workflows:
       - lint:
           filters: *filterAllTags
 
+      - release-branch-forward:
+          requires:
+            - results
+          filters:
+            branches:
+              only:
+                - master
+
       - release-notes:
           filters: *filterAllTags
 
@@ -382,6 +390,26 @@ jobs:
           command: make lint
       - save_cache:
           key: v4-lint-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+
+  release-branch-forward:
+    executor: container
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-release-branch-forward-{{ checksum "go.sum" }}
+      - add_ssh_keys:
+          fingerprints:
+            - bd:a6:4b:50:1b:2a:a4:1d:79:67:64:05:66:c4:3a:10
+      - run:
+          name: Forward Latest Release Branch
+          command: make release-branch-forward
+          environment:
+            DRY_RUN: false
+      - save_cache:
+          key: v1-release-branch-forward-{{ checksum "go.sum" }}
           paths:
             - *gocache
 

--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,9 @@ git-validation: .gopathok ${GIT_VALIDATION}
 docs-validation:
 	$(GO_RUN) -tags "$(BUILDTAGS)" ./test/docs-validation
 
+release-branch-forward:
+	$(GO_RUN) ./scripts/release-branch-forward
+
 .PHONY: \
 	${CRIO_CONFD_DIR} \
 	.explicit_phony \
@@ -496,6 +499,7 @@ docs-validation:
 	nixpkgs \
 	release-bundle \
 	shfmt \
+	release-branch-forward \
 	testunit \
 	testunit-bin \
 	test-images \

--- a/scripts/release-branch-forward/release_branch_forward.go
+++ b/scripts/release-branch-forward/release_branch_forward.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/release/pkg/command"
 	kgit "k8s.io/release/pkg/git"
+	"k8s.io/release/pkg/util"
 )
 
 const (
@@ -19,6 +20,7 @@ const (
 	grep                = "grep"
 	tail                = "tail"
 	releaseBranchPrefix = "release-"
+	dryRunEnv           = "DRY_RUN"
 )
 
 var dryRun bool
@@ -27,7 +29,7 @@ func main() {
 	flag.BoolVar(
 		&dryRun,
 		"dry-run",
-		true,
+		!util.IsEnvSet(dryRunEnv),
 		"do not really push, just do a dry run",
 	)
 	flag.Parse()
@@ -43,6 +45,15 @@ func run() error {
 		return errors.Errorf(
 			"please ensure that %s are available in $PATH",
 			strings.Join([]string{git, grep, tail}, ", "),
+		)
+	}
+
+	if dryRun {
+		logrus.Warnf("Please note that this is only a dry-run and will not "+
+			"result in any real git push to the remote location. "+
+			"To enable a real git push, export the environment "+
+			"variable %s=false",
+			dryRunEnv,
 		)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now add the release branch forward script to CircleCI, which will on
on every master branch push.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
