### PR TITLE
Drop musl build from nix to update to go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ stdenv: &stdenv
     IMAGE: &image quay.io/crio/crio-build-amd64-go1.14:master-1.3.2
     IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.12:master-1.3.2
     IMAGE386: &image386 quay.io/crio/crio-build-386-go1.14:master-1.3.2
-    IMAGENIX: &imagenix quay.io/crio/nix:1.2.0
+    IMAGENIX: &imagenix quay.io/crio/nix:1.3.0
     JOBS: &jobs 4
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o
     WORKDIR_VM: &workdir_vm /home/circleci/go/src/github.com/cri-o/cri-o
@@ -117,15 +117,8 @@ workflows:
           filters: *filterAllTags
 
       - integration:
-          name: integration-static-glibc
-          crio_binary: crio-x86_64-static-glibc
-          requires:
-            - build-static
-          filters: *filterAllTags
-
-      - integration:
-          name: integration-static-musl
-          crio_binary: crio-x86_64-static-musl
+          name: integration-static
+          crio_binary: crio-static
           requires:
             - build-static
           filters: *filterAllTags
@@ -141,8 +134,7 @@ workflows:
             - bundle-test
             - integration
             - integration-critest
-            - integration-static-glibc
-            - integration-static-musl
+            - integration-static
             - integration-userns
             - release-notes
             - unit-tests
@@ -194,7 +186,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: add remote go fetch all tags
+          name: Add remote to fetch all tags
           command: |
             git remote add base https://github.com/cri-o/cri-o
             git fetch base
@@ -207,8 +199,7 @@ jobs:
       - run:
           name: Show CRI-O version for static binaries
           command: |
-            ./bin/crio-x86_64-static-glibc version
-            ./bin/crio-x86_64-static-musl version
+            ./bin/crio-static version
       - persist_to_workspace:
           root: .
           paths:

--- a/Dockerfile-nix
+++ b/Dockerfile-nix
@@ -2,8 +2,7 @@
 FROM nixos/nix
 RUN apk add git
 COPY . /cri-o
-ARG COMMIT
 WORKDIR cri-o/nix
-RUN nix-build --argstr revision ${COMMIT}
+RUN nix-build
 WORKDIR /
 RUN rm -rf cri-o

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ TESTIMAGE_REGISTRY := quay.io/crio
 TESTIMAGE_SCRIPT := scripts/build-test-image -r $(TESTIMAGE_REGISTRY) -v $(TESTIMAGE_VERSION)
 TESTIMAGE_NAME ?= $(shell $(TESTIMAGE_SCRIPT) -d)
 
-TESTIMAGE_NIX ?= $(TESTIMAGE_REGISTRY)/nix:1.2.0
+TESTIMAGE_NIX ?= $(TESTIMAGE_REGISTRY)/nix:1.3.0
 
 all: binaries config docs
 
@@ -152,9 +152,9 @@ bin/crio-status: $(GO_FILES) .gopathok
 
 build-static:
 	$(CONTAINER_RUNTIME) run --rm -it -v $(shell pwd):/cri-o $(TESTIMAGE_NIX) sh -c \
-		"nix build -f cri-o/nix --argstr revision $(COMMIT_NO) && \
+		"nix build -f cri-o/nix && \
 		mkdir -p cri-o/bin && \
-		cp result-*bin/bin/crio-* cri-o/bin"
+		cp result-bin/bin/crio-* cri-o/bin"
 
 release-bundle: clean bin/pinns build-static docs config bundle
 
@@ -208,6 +208,10 @@ test-images:
 	$(TESTIMAGE_SCRIPT) -g 1.14 -a amd64
 	$(TESTIMAGE_SCRIPT) -g 1.14 -a 386
 	$(TESTIMAGE_SCRIPT) -g 1.12 -a amd64
+
+nixpkgs:
+	@nix run -f channel:nixpkgs-unstable nix-prefetch-git -c nix-prefetch-git \
+		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json
 
 test-image-nix:
 	time $(CONTAINER_RUNTIME) build -t $(TESTIMAGE_NIX) \
@@ -481,6 +485,7 @@ docs-validation:
 	install \
 	lint \
 	local-cross \
+	nixpkgs \
 	release-bundle \
 	testunit \
 	testunit-bin \

--- a/contrib/bundle/Makefile
+++ b/contrib/bundle/Makefile
@@ -12,8 +12,6 @@ ZSHINSTALLDIR ?= $(PREFIX)/share/zsh/site-functions
 SYSTEMDDIR ?= $(PREFIX)/lib/systemd/system
 OPT_CNI_BIN_DIR ?= /opt/cni/bin
 
-DEFAULT_BINARY ?= crio-x86_64-static-musl
-
 all: install
 
 .PHONY: install
@@ -45,11 +43,9 @@ install-crio:
 	install $(SELINUX) -d -m 755 $(FISHINSTALLDIR)
 	install $(SELINUX) -d -m 755 $(ZSHINSTALLDIR)
 	install $(SELINUX) -d -m 755 $(CONTAINERS_DIR)
-	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-status-x86_64-static-glibc
-	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-status-x86_64-static-musl
-	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-x86_64-static-glibc
-	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-x86_64-static-musl
-	ln -sf $(BINDIR)/$(DEFAULT_BINARY) $(BINDIR)/crio
+	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-status-static
+	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crio-static
+	ln -sf $(BINDIR)/crio-static $(BINDIR)/crio
 	install $(SELINUX) -D -m 644 -t $(ETCDIR) etc/crictl.yaml
 	install $(SELINUX) -D -m 644 -t $(OCIDIR) etc/crio-umount.conf
 	install $(SELINUX) -D -m 644 -t $(ETCDIR)/crio/crio.conf.d etc/00-default.conf
@@ -97,10 +93,8 @@ uninstall-crictl:
 .PHONY: uninstall-crio
 uninstall-crio:
 	rm $(BINDIR)/crio
-	rm $(BINDIR)/crio-status-x86_64-static-glibc
-	rm $(BINDIR)/crio-status-x86_64-static-musl
-	rm $(BINDIR)/crio-x86_64-static-glibc
-	rm $(BINDIR)/crio-x86_64-static-musl
+	rm $(BINDIR)/crio-status-static
+	rm $(BINDIR)/crio-static
 	rm $(ETCDIR)/crictl.yaml
 	rm $(OCIDIR)/crio-umount.conf
 	rm $(ETCDIR)/crio/crio.conf.d/00-default.conf

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -12,10 +12,8 @@ cd "$(dirname "$0")"
 source "$GIT_ROOT/scripts/versions"
 
 FILES_BIN=(
-    "$GIT_ROOT/bin/crio-status-x86_64-static-glibc"
-    "$GIT_ROOT/bin/crio-status-x86_64-static-musl"
-    "$GIT_ROOT/bin/crio-x86_64-static-glibc"
-    "$GIT_ROOT/bin/crio-x86_64-static-musl"
+    "$GIT_ROOT/bin/crio-status-static"
+    "$GIT_ROOT/bin/crio-static"
     "$GIT_ROOT/bin/pinns"
 )
 FILES_MAN=(

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,9 @@
+{
+  "url": "https://github.com/nixos/nixpkgs",
+  "rev": "b3412865ce1db90fca65274024395ca00cf13e6d",
+  "date": "2020-03-24T10:00:11+00:00",
+  "sha256": "15n1v50bixkbap3badnkk5p4f3m7qawxvpx65nrvljvb0pgznfiv",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,14 +1,8 @@
 let
-  nixpkgs = builtins.fetchTarball {
+  json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = import (builtins.fetchTarball {
     name = "nixos-unstable";
-    url = "https://github.com/nixos/nixpkgs/archive/" +
-      "221274e1552fdb84e8caf0831dbd9140b111131e.tar.gz";
-    sha256 = "1ic9d9c27qpcrx5n5dn1mak3hrbbdq1is24p11rqrj9xas79lf89";
-  };
-  nixpkgsMuslSystemd = builtins.fetchTarball {
-    name = "nixos-systemd-musl";
-    url = "https://github.com/dtzWill/nixpkgs/archive/" +
-      "13510d3dbe08e5bfc5454faf3fe543991dbf6e29.tar.gz";
-    sha256 = "090zagbw39fa8fgwvzcmbcr204pxcfrq1rfw7ip5z44naj6gp7qb";
-  };
-in [ nixpkgs nixpkgsMuslSystemd ]
+    url = "${json.url}/archive/${json.rev}.tar.gz";
+    inherit (json) sha256;
+  });
+in nixpkgs

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -226,10 +226,9 @@ make BUILDTAGS='seccomp apparmor'
 It is possible to build a statically linked binary of CRI-O by using the
 officially provided [nix](https://nixos.org/nix) package and the derivation of
 it [within this repository](../nix). The builds are completely reproducible and
-will create a `x86_64`/`amd64` stripped ELF binary for
-[glibc](https://www.gnu.org/software/libc) and [musl
-libc](https://www.musl-libc.org).  These binaries are integration tested as well
-and support the following features:
+will create a `x86_64`/`amd64` stripped ELF binary for the standard
+[glibc](https://www.gnu.org/software/libc) toolchain. These binaries are
+integration tested as well and support the following features:
 
 - apparmor
 - btrfs
@@ -270,8 +269,7 @@ image before.
 Note that the container runtime and nix image can be specified here, too. The
 resulting binaries should now be available within:
 
-- `bin/crio-x86_64-static-glibc`
-- `bin/crio-x86_64-static-musl`
+- `bin/crio-static`
 
 To build the binaries without any prepared container and via the already
 installed nix package manager, simply run the following command from the root
@@ -281,8 +279,7 @@ directory of this repository:
 nix build -f nix
 ```
 
-The resulting binary should be now available in `result-bin/bin` and
-`result-2-bin/bin`.
+The resulting binary should be now available in `result-bin/bin`.
 
 ### Creating a release archive
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:
We have to drop the musl toolchain which increases the image build time
as well as gives us the opportunity to update to go 1.14. Build and test
scripts have been adapted as well.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Removed the musl libc build target from the static binary bundle in favor of the existing glibc variant
```
