### PR TITLE
Move CNI plugin into NetworkConfig

### DIFF
--- a/pkg/config/config_test_inject.go
+++ b/pkg/config/config_test_inject.go
@@ -1,0 +1,21 @@
+// +build test
+// All *_inject.go files are meant to be used by tests only. Purpose of this
+// files is to provide a way to inject mocked data into the current setup.
+
+package config
+
+import (
+	"github.com/cri-o/ocicni/pkg/ocicni"
+)
+
+// SetCNIPlugin sets the network plugin for the Configuration. The function
+// errors if a sane shutdown of the initially created network plugin failed.
+func (c *NetworkConfig) SetCNIPlugin(plugin ocicni.CNIPlugin) error {
+	if c.CNIPlugin() != nil {
+		if err := c.CNIPlugin().Shutdown(); err != nil {
+			return err
+		}
+	}
+	c.cniPlugin = plugin
+	return nil
+}

--- a/server/runtime_status.go
+++ b/server/runtime_status.go
@@ -21,7 +21,7 @@ func (s *Server) Status(ctx context.Context, req *pb.StatusRequest) (resp *pb.St
 		Status: true,
 	}
 
-	if err := s.netPlugin.Status(); err != nil {
+	if err := s.config.CNIPlugin().Status(); err != nil {
 		networkCondition.Status = false
 		networkCondition.Reason = networkNotReadyReason
 		networkCondition.Message = fmt.Sprintf("Network plugin returns error: %v", err)

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -41,7 +41,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 	}()
 
 	podSetUpStart := time.Now()
-	_, err = s.netPlugin.SetUpPod(podNetwork)
+	_, err = s.config.CNIPlugin().SetUpPod(podNetwork)
 	if err != nil {
 		err = fmt.Errorf("failed to create pod network sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 		return
@@ -50,7 +50,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 	metrics.CRIOOperationsLatency.WithLabelValues("network_setup_pod").
 		Observe(metrics.SinceInMicroseconds(podSetUpStart))
 
-	podNetworkStatus, err := s.netPlugin.GetPodNetworkStatus(podNetwork)
+	podNetworkStatus, err := s.config.CNIPlugin().GetPodNetworkStatus(podNetwork)
 	if err != nil {
 		err = fmt.Errorf("failed to get network status for pod sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 		return
@@ -111,7 +111,7 @@ func (s *Server) getSandboxIPs(sb *sandbox.Sandbox) (podIPs []string, err error)
 	if err != nil {
 		return nil, err
 	}
-	podNetworkStatus, err := s.netPlugin.GetPodNetworkStatus(podNetwork)
+	podNetworkStatus, err := s.config.CNIPlugin().GetPodNetworkStatus(podNetwork)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get network status for pod sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 	}
@@ -148,7 +148,7 @@ func (s *Server) networkStop(ctx context.Context, sb *sandbox.Sandbox) error {
 	if err != nil {
 		return err
 	}
-	if err := s.netPlugin.TearDownPod(podNetwork); err != nil {
+	if err := s.config.CNIPlugin().TearDownPod(podNetwork); err != nil {
 		return errors.Wrapf(err, "failed to destroy network for pod sandbox %s(%s)", sb.Name(), sb.ID())
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -155,23 +155,6 @@ var _ = t.Describe("Server", func() {
 			Expect(server).To(BeNil())
 		})
 
-		It("should fail when CNI init errors", func() {
-			// Given
-			gomock.InOrder(
-				libMock.EXPECT().GetData().Times(2).Return(serverConfig),
-				libMock.EXPECT().GetStore().Return(storeMock, nil),
-				libMock.EXPECT().GetData().Return(serverConfig),
-			)
-			serverConfig.NetworkDir = invalidDir
-
-			// When
-			server, err := server.New(context.Background(), libMock)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(server).To(BeNil())
-		})
-
 		DescribeTable("should fail with wrong ID mappings", func(u, g string) {
 			// Given
 			gomock.InOrder(

--- a/server/server_test_inject.go
+++ b/server/server_test_inject.go
@@ -18,12 +18,8 @@ func (s *StreamService) SetRuntimeServer(server *Server) {
 	s.runtimeServer = server
 }
 
-// SetNetPlugin sets the network plugin for the ContainerServer. The function
+// SetCNIPlugin sets the network plugin for the ContainerServer. The function
 // errors if a sane shutdown of the initially created network plugin failed.
-func (s *Server) SetNetPlugin(plugin ocicni.CNIPlugin) error {
-	if err := s.netPlugin.Shutdown(); err != nil {
-		return err
-	}
-	s.netPlugin = plugin
-	return nil
+func (s *Server) SetCNIPlugin(plugin ocicni.CNIPlugin) error {
+	return s.config.SetCNIPlugin(plugin)
 }

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -190,7 +190,7 @@ var setupSUT = func() {
 	// Inject the mock
 	sut.SetStorageImageServer(imageServerMock)
 	sut.SetStorageRuntimeServer(runtimeServerMock)
-	Expect(sut.SetNetPlugin(cniPluginMock)).To(BeNil())
+	Expect(sut.SetCNIPlugin(cniPluginMock)).To(BeNil())
 }
 
 func mockNewServer() {

--- a/server/utils.go
+++ b/server/utils.go
@@ -139,7 +139,7 @@ func (s *Server) newPodNetwork(sb *sandbox.Sandbox) (ocicni.PodNetwork, error) {
 		}
 	}
 
-	network := s.netPlugin.GetDefaultNetworkName()
+	network := s.config.CNIPlugin().GetDefaultNetworkName()
 	return ocicni.PodNetwork{
 		Name:      sb.KubeName(),
 		Namespace: sb.Namespace(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup

#### What this PR does / why we need it:
The network configuration validation seems to be the right place to init
the CNI plugin, because after that we have all necessary information for
it.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
