### PR TITLE
Validate capabilities on CRI-O start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/containernetworking/cni v0.7.2-0.20200304161608-4fae32b84921
 	github.com/containernetworking/plugins v0.8.5
 	github.com/containers/buildah v1.14.8
+	github.com/containers/common v0.9.1
 	github.com/containers/conmon v2.0.15+incompatible
 	github.com/containers/image/v5 v5.4.3
 	github.com/containers/libpod v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/containers/common v0.7.0 h1:wlcHuOa8CcsreCMd0BlvKUubIVzkLy8EMLtJ0JO+Y
 github.com/containers/common v0.7.0/go.mod h1:UmhIdvSkhTR0hWR01AnuZGNufm80+A0s8isb05eTmz0=
 github.com/containers/common v0.8.1 h1:1IUwAtZ4mC7GYRr4AC23cHf2oXCuoLzTUoSzIkSgnYw=
 github.com/containers/common v0.8.1/go.mod h1:VxDJbaA1k6N1TNv9Rt6bQEF4hyKVHNfOfGA5L91ADEs=
+github.com/containers/common v0.9.1 h1:S5lkpnycTI29YzpNJ4RLv49g8sksgYNRNsugPmzQCR8=
+github.com/containers/common v0.9.1/go.mod h1:9YGKPwu6NFYQG2NtSP9bRhNGA8mgd1mUCCkOU2tr+Pc=
 github.com/containers/conmon v2.0.10+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon v2.0.14+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon v2.0.15+incompatible h1:3CdToyAu/XEiXO2Se/HaOv3TEc1pbk2YaZCZbTLIFUs=

--- a/internal/config/capabilities/capabilities.go
+++ b/internal/config/capabilities/capabilities.go
@@ -1,0 +1,40 @@
+package capabilities
+
+import (
+	"strings"
+
+	common "github.com/containers/common/pkg/capabilities"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// Capabilities is the default representation for capabilities
+type Capabilities []string
+
+// Default returns the default capabilities as string slice
+func Default() Capabilities {
+	return []string{
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FSETID",
+		"FOWNER",
+		"SETGID",
+		"SETUID",
+		"SETPCAP",
+		"NET_BIND_SERVICE",
+		"KILL",
+	}
+}
+
+// Validate checks if the provided capabilities are available on the system
+func (c Capabilities) Validate() error {
+	caps := Capabilities{}
+	for _, cap := range c {
+		caps = append(caps, "CAP_"+strings.ToUpper(cap))
+	}
+	if err := common.ValidateCapabilities(caps); err != nil {
+		return errors.Wrap(err, "validating capabilities")
+	}
+	logrus.Infof("Using default capabilities: %s", strings.Join(caps, ", "))
+	return nil
+}

--- a/internal/config/capabilities/capabilities_test.go
+++ b/internal/config/capabilities/capabilities_test.go
@@ -1,0 +1,43 @@
+package capabilities_test
+
+import (
+	"github.com/cri-o/cri-o/internal/config/capabilities"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The actual test suite
+var _ = t.Describe("Capabilities", func() {
+	It("should succeed to validate the default capabilities", func() {
+		// Given
+		sut := capabilities.Default()
+
+		// When
+		err := sut.Validate()
+
+		// Then
+		Expect(err).To(BeNil())
+	})
+
+	It("should succeed to validate wrong case capabilities", func() {
+		// Given
+		sut := capabilities.Capabilities{"chOwn", "setGID", "NET_raw"}
+
+		// When
+		err := sut.Validate()
+
+		// Then
+		Expect(err).To(BeNil())
+	})
+
+	It("should fail to validate wrong capabilities", func() {
+		// Given
+		sut := capabilities.Capabilities{"wrong"}
+
+		// When
+		err := sut.Validate()
+
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+})

--- a/internal/config/capabilities/suite_test.go
+++ b/internal/config/capabilities/suite_test.go
@@ -1,0 +1,26 @@
+package capabilities_test
+
+import (
+	"testing"
+
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestLib runs the created specs
+func TestLibConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "Capabilities")
+}
+
+var t *TestFramework
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -87,6 +87,9 @@ type ContainersConfig struct {
 	// Default way to create a cgroup namespace for the container
 	CgroupNS string `toml:"cgroupns"`
 
+	// Default cgroup configuration
+	Cgroups string `toml:"cgroups"`
+
 	// Capabilities to add to all containers.
 	DefaultCapabilities []string `toml:"default_capabilities"`
 
@@ -270,6 +273,10 @@ type EngineConfig struct {
 	// RuntimeSupportsNoCgroups is a list of OCI runtimes that support
 	// running containers without CGroups.
 	RuntimeSupportsNoCgroups []string `toml:"runtime_supports_nocgroupv2"`
+
+	// RuntimeSupportsKVM is a list of OCI runtimes that support
+	// KVM separation for conatainers.
+	RuntimeSupportsKVM []string `toml:"runtime_supports_kvm"`
 
 	// SetOptions contains a subset of config options. It's used to indicate if
 	// a given option has either been set by the user or by the parsed

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -47,6 +47,15 @@
 #
 # cgroupns = "private"
 
+# Control container cgroup configuration
+# Determines  whether  the  container will create CGroups.
+# Options are:
+# `enabled`   Enable cgroup support within container
+# `disabled`  Disable cgroup support, will inherit cgroups from parent
+# `no-conmon` Container engine runs run without conmon
+#
+# cgroups = "enabled"
+
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #
@@ -347,6 +356,14 @@
 #
 # runtime_supports_json = ["crun", "runc", "kata"]
 
+# List of the OCI runtimes that supports running containers without cgroups.
+#
+# runtime_supports_nocgroups = ["crun"]
+
+# List of the OCI runtimes that supports running containers with KVM Separation.
+#
+# runtime_supports_kvm = ["kata"]
+
 # Paths to look for a valid OCI runtime (runc, runv, kata, etc)
 [engine.runtimes]
 # runc = [
@@ -376,6 +393,8 @@
 #            "/usr/local/sbin/kata-runtime",
 #            "/sbin/kata-runtime",
 #            "/bin/kata-runtime",
+#            "/usr/bin/kata-qemu",
+#            "/usr/bin/kata-fc",
 # ]
 
 # Number of seconds to wait for container to exit before sending kill signal.

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -148,6 +148,7 @@ func DefaultConfig() (*Config, error) {
 			Annotations:         []string{},
 			ApparmorProfile:     DefaultApparmorProfile,
 			CgroupNS:            "private",
+			Cgroups:             "enabled",
 			DefaultCapabilities: DefaultCapabilities,
 			DefaultSysctls:      []string{},
 			DefaultUlimits:      getDefaultProcessLimits(),
@@ -246,6 +247,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			"/usr/local/sbin/kata-runtime",
 			"/sbin/kata-runtime",
 			"/bin/kata-runtime",
+			"/usr/bin/kata-qemu",
+			"/usr/bin/kata-fc",
 		},
 	}
 	c.ConmonEnvVars = []string{
@@ -267,6 +270,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		"runc",
 	}
 	c.RuntimeSupportsNoCgroups = []string{"crun"}
+	c.RuntimeSupportsKVM = []string{"kata", "kata-runtime", "kata-qemu", "kata-fc"}
 	c.InitPath = DefaultInitPath
 	c.NoPivotRoot = false
 
@@ -434,6 +438,11 @@ func (c *Config) PidNS() string {
 // CgroupNS returns the default Cgroup Namespace configuration to run containers with
 func (c *Config) CgroupNS() string {
 	return c.Containers.CgroupNS
+}
+
+// Cgroups returns whether to containers with cgroup confinement
+func (c *Config) Cgroups() string {
+	return c.Containers.Cgroups
 }
 
 // UTSNS returns the default UTS Namespace configuration to run containers with

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,7 +108,8 @@ github.com/containers/buildah/pkg/secrets
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/pkg/umask
 github.com/containers/buildah/util
-# github.com/containers/common v0.8.1
+# github.com/containers/common v0.9.1
+## explicit
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/capabilities
 github.com/containers/common/pkg/cgroupv2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now validate the provided capabilities on config validation to give
users more feedback about their input.
#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added verification of provided `--default-capabilities`/`default_capabilities` on configuration validation (CRI-O startup)
```
