### PR TITLE
stats: skipped stopped containers on container list stats

### DIFF
--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -2,13 +2,18 @@ package server
 
 import (
 	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // ListContainerStats returns stats of all running containers.
 func (s *Server) ListContainerStats(ctx context.Context, req *pb.ListContainerStatsRequest) (*pb.ListContainerStatsResponse, error) {
-	ctrList, err := s.ContainerServer.ListContainers()
+	ctrList, err := s.ContainerServer.ListContainers(
+		func(container *oci.Container) bool {
+			return container.StateNoLock().Status != oci.ContainerStateStopped
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_stats_test.go
+++ b/server/container_stats_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"context"
 
+	"github.com/cri-o/cri-o/internal/oci"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -28,6 +29,66 @@ var _ = t.Describe("ContainerStats", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 			Expect(response).To(BeNil())
+		})
+	})
+})
+
+var _ = t.Describe("ContainerStatsList", func() {
+	// Prepare the sut
+	BeforeEach(func() {
+		beforeEach()
+		setupSUT()
+	})
+
+	AfterEach(afterEach)
+
+	t.Describe("ContainerStatsList", func() {
+		It("should succeed", func() {
+			// Given
+			addContainerAndSandbox()
+			// When
+			response, err := sut.ListContainerStats(context.Background(),
+				&pb.ListContainerStatsRequest{})
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(response).NotTo(BeNil())
+			Expect(len(response.Stats)).To(Equal(1))
+		})
+		It("should filter stopped container", func() {
+			// Given
+			state := oci.ContainerState{}
+			state.Status = oci.ContainerStateStopped
+			testContainer.SetState(&state)
+			addContainerAndSandbox()
+
+			// When
+			response, err := sut.ListContainerStats(context.Background(),
+				&pb.ListContainerStatsRequest{},
+			)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(response).NotTo(BeNil())
+			Expect(len(response.Stats)).To(Equal(0))
+		})
+		It("should filter by id", func() {
+			// Given
+			addContainerAndSandbox()
+
+			// When
+			response, err := sut.ListContainerStats(context.Background(),
+				&pb.ListContainerStatsRequest{
+					Filter: &pb.ContainerStatsFilter{
+						Id: "invalid",
+					},
+				},
+			)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(response).NotTo(BeNil())
+			Expect(len(response.Stats)).To(Equal(0))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:
skip stopped containers when reporting stats

we have run into situations where cri-o reports a cgroup is deleted on list container stats calls, and it takes a while for cri-o to actually remove the container from the state. Stopped containers shouldn't matter with reporting stats, so we can skip them.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
should fix spammed logs [here](https://storage.googleapis.com/origin-federated-results/pr-logs/pull/cri-o_cri-o/3477/test_pull_request_crio_e2e_crun_fedora/2405/artifacts/journals/crio.service) 
<!--
Fixes #
or
None
-->
also fixes https://github.com/cri-o/cri-o/issues/3259
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
