### PR TITLE
test: set cri-o systemd restart policy to no

### DIFF
--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -20,25 +20,15 @@
     dest: "/bin/pinns"
     state: link
 
-- name: install cri-o
-  make:
-    target: install
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
-
 - name: set RestartPolicy in systemd unit appropriate for tests
   lineinfile:
     path: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/contrib/systemd/crio.service"
     regexp: '^Restart='
-    line: '^Restart=no'
+    line: 'Restart=no'
 
-- name: install cri-o systemd files
+- name: install cri-o
   make:
-    target: install.systemd
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
-
-- name: install cri-o config
-  make:
-    target: install.config
+    target: install
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
 
 - name: set manage network ns lifecycle

--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -25,6 +25,12 @@
     target: install
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
 
+- name: set RestartPolicy in systemd unit appropriate for tests
+  lineinfile:
+    path: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/contrib/systemd/crio.service"
+    regexp: '^Restart='
+    line: '^Restart=no'
+
 - name: install cri-o systemd files
   make:
     target: install.systemd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind failing-test

#### What this PR does / why we need it:
While in production we want cri-o to restart when it crashes, when we're testing we'd like to catch panics and crashes. Set restart policy in the systemd unit file to never restart, so we fail tests that make cri-o panic

also drop make install.{systemd,config} when building cri-o, as the targets are already hit when running make install

I consider this a failing test because we are failing to catch when CRI-O crashes
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
