### PR TITLE
Downgrade golangci-lint to v1.23.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,20 +380,17 @@ jobs:
             - *gocache
 
   lint:
-    executor: machine
+    executor: container
     steps:
       - checkout
-      - run:
-          name: setup environment
-          command: scripts/circle-setup
       - restore_cache:
           keys:
-            - v3-lint-{{ checksum "go.sum" }}
+            - v4-lint-{{ checksum "go.sum" }}
       - run:
           name: lint
           command: make lint
       - save_cache:
-          key: v3-lint-{{ checksum "go.sum" }}
+          key: v4-lint-{{ checksum "go.sum" }}
           paths:
             - *gocache
 

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ ${SHFMT}:
 
 ${GOLANGCI_LINT}:
 	export \
-		VERSION=v1.24.0 \
+		VERSION=v1.23.8 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
 	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
This is a workaround to stabilize our CI and reduce to out of memory
kills in CircleCI.
#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
