### PR TITLE
Add crio config --migrate feature

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -134,6 +134,18 @@ complete -r -c crio -n '__fish_crio_no_subcommand' -a 'config' -d 'Outputs a com
 by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.'
 complete -c crio -n '__fish_seen_subcommand_from config' -f -l default -d 'Output the default configuration (without taking into account any configuration options).'
+complete -c crio -n '__fish_seen_subcommand_from config' -f -l migrate-defaults -s m -r -d 'Migrate the default config from a specified version.
+    To run a config migration, just select the input config via the global
+    \'--config,-c\' command line argument, for example:
+    ```
+    crio -c /etc/crio/crio.conf.d/00-default.conf config -m 1.17
+    ```
+    The migration will print converted configuration options to stderr and will
+    output the resulting configuration to stdout.
+    Please note that the migration will overwrite any fields that have changed
+    defaults between versions. To save a custom configuration change, it should
+    be in a drop-in configuration file instead.
+    Possible values: "1.17"'
 complete -c crio -n '__fish_seen_subcommand_from version' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'version' -d 'display detailed version information'
 complete -c crio -n '__fish_seen_subcommand_from version' -f -l json -s j -d 'print JSON instead of text'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -313,6 +313,19 @@ it later with **--config**. Global options will modify the output.
 
 **--default**: Output the default configuration (without taking into account any configuration options).
 
+**--migrate-defaults, -m**="": Migrate the default config from a specified version.
+    To run a config migration, just select the input config via the global
+    '--config,-c' command line argument, for example:
+    ```
+    crio -c /etc/crio/crio.conf.d/00-default.conf config -m 1.17
+    ```
+    The migration will print converted configuration options to stderr and will
+    output the resulting configuration to stdout.
+    Please note that the migration will overwrite any fields that have changed
+    defaults between versions. To save a custom configuration change, it should
+    be in a drop-in configuration file instead.
+    Possible values: "1.17" (default: 1.17)
+
 ## version
 
 display detailed version information

--- a/internal/config/migrate/from_1_17.go
+++ b/internal/config/migrate/from_1_17.go
@@ -1,0 +1,54 @@
+package migrate
+
+import (
+	"strings"
+
+	"github.com/cri-o/cri-o/internal/config/apparmor"
+	"github.com/cri-o/cri-o/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+// migrateFrom1_17 migrates a config from the 1.17.x version
+func migrateFrom1_17(cfg *config.Config) error {
+	// Remove NET_RAW and SYS_CHROOT capability by default
+	// https://github.com/cri-o/cri-o/pull/3119
+	newDefaultCapabilities := []string{}
+	logrus.Infof("Checking for NET_RAW and SYS_CHROOT capabilities, which have been removed per default")
+	for _, cap := range cfg.DefaultCapabilities {
+		if cap == "NET_RAW" || cap == "SYS_CHROOT" {
+			logrus.Infof(`Removing "default_capabilities" entry %q`, cap)
+			continue
+		}
+		newDefaultCapabilities = append(newDefaultCapabilities, cap)
+	}
+	cfg.DefaultCapabilities = newDefaultCapabilities
+
+	// Change AppArmor profile to not contain version info any more
+	// https://github.com/cri-o/cri-o/pull/3287
+	logrus.Infof("Checking for default AppArmor profile, which does not contain the version number any more")
+	if cfg.ApparmorProfile != apparmor.DefaultProfile && strings.Contains(
+		cfg.ApparmorProfile, apparmor.DefaultProfile,
+	) {
+		cfg.ApparmorProfile = apparmor.DefaultProfile
+		logrus.Infof(`Changing "apparmor_profile" to %q`, cfg.ApparmorProfile)
+	}
+
+	// Changing the default error log level to info
+	const newLogLevel = "info"
+	logrus.Infof("Checking for the log level, which has changed from error to info")
+	if cfg.LogLevel == "error" {
+		cfg.LogLevel = newLogLevel
+		logrus.Infof(`Changing "log_level" to %q`, newLogLevel)
+	}
+
+	// Change CtrStopTimeout to the new minimum value
+	// https://github.com/cri-o/cri-o/pull/3282
+	logrus.Infof("Checking for ctr_stop_timeout, which now has a minimum value of 30")
+	const newCtrStopTimeout = 30
+	if cfg.CtrStopTimeout < newCtrStopTimeout {
+		cfg.CtrStopTimeout = newCtrStopTimeout
+		logrus.Infof(`Changing "ctr_stop_timeout" to %d`, cfg.CtrStopTimeout)
+	}
+
+	return nil
+}

--- a/internal/config/migrate/migrate.go
+++ b/internal/config/migrate/migrate.go
@@ -1,0 +1,23 @@
+package migrate
+
+import (
+	"github.com/cri-o/cri-o/pkg/config"
+	"github.com/pkg/errors"
+)
+
+// All possible migration scenarios
+const (
+	FromPrevious = From1_17
+	From1_17     = "1.17"
+)
+
+// Config migrates the provided config from the provided scenario to the
+// current one.
+func Config(cfg *config.Config, from string) error {
+	// 1.17 specific settings
+	if from == From1_17 {
+		return migrateFrom1_17(cfg)
+	}
+
+	return errors.Errorf("unsupported migration version %q", from)
+}

--- a/test/config_migrate.bats
+++ b/test/config_migrate.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# vim: set syntax=sh:
+
+load helpers
+
+@test "config migrate should succeed with default config" {
+    # when
+    run crio -c "" -d "" config -m 1.17 2>&1
+
+    # then
+    [[ "$output" != *"Changing"* ]]
+    [ "$status" -eq 0 ]
+}
+
+@test "config migrate should succeed with 1.17 config" {
+    # when
+    run crio -c "$TESTDATA/config/config-v1.17.0.toml" -d "" config -m 1.17 2>&1
+
+    # then
+    [[ "$output" == *'Changing \"apparmor_profile\" to \"crio-default\"'* ]]
+    [[ "$output" == *'apparmor_profile = "crio-default"'* ]]
+
+    [[ "$output" == *'Removing \"default_capabilities\" entry \"NET_RAW\"'* ]]
+    [[ "$output" == *'Removing \"default_capabilities\" entry \"SYS_CHROOT\"'* ]]
+
+    [[ "$output" == *'Changing \"log_level\" to \"info\"'* ]]
+    [[ "$output" == *'log_level = "info"'* ]]
+
+    [[ "$output" == *'Changing \"ctr_stop_timeout\" to 30'* ]]
+    [[ "$output" == *'ctr_stop_timeout = 30'* ]]
+    [ "$status" -eq 0 ]
+}
+
+@test "config migrate should fail on invalid version" {
+    # when
+    run crio -c "" -d "" config -m 1.16
+
+    # then
+    [[ "$output" == *"unsupported migration version"* ]]
+    [ "$status" -eq 1 ]
+}

--- a/test/testdata/config/config-v1.17.0.toml
+++ b/test/testdata/config/config-v1.17.0.toml
@@ -1,0 +1,357 @@
+# The CRI-O configuration file specifies all of the available configuration
+# options and command-line flags for the crio(8) OCI Kubernetes Container Runtime
+# daemon, but in a TOML format that can be more easily modified and versioned.
+#
+# Please refer to crio.conf(5) for details of all configuration options.
+
+# CRI-O supports partial configuration reload during runtime, which can be
+# done by sending SIGHUP to the running process. Currently supported options
+# are explicitly mentioned with: 'This option supports live configuration
+# reload'.
+
+# CRI-O reads its storage defaults from the containers-storage.conf(5) file
+# located at /etc/containers/storage.conf. Modify this storage configuration if
+# you want to change the system's defaults. If you want to modify storage just
+# for CRI-O, you can change the storage configuration options here.
+[crio]
+
+# Path to the "root directory". CRI-O stores all of its data, including
+# containers images, in this directory.
+#root = "/var/lib/containers/storage"
+
+# Path to the "run directory". CRI-O stores all of its state in this directory.
+#runroot = "/var/run/containers/storage"
+
+# Storage driver used to manage the storage of images and containers. Please
+# refer to containers-storage.conf(5) to see all available storage drivers.
+#storage_driver = ""
+
+# List to pass options to the storage driver. Please refer to
+# containers-storage.conf(5) to see all available storage options.
+#storage_option = [
+#]
+
+# The default log directory where all logs will go unless directly specified by
+# the kubelet. The log directory specified must be an absolute directory.
+log_dir = "/var/log/crio/pods"
+
+# Location for CRI-O to lay down the version file
+version_file = "/var/run/crio/version"
+
+# The crio.api table contains settings for the kubelet/gRPC interface.
+[crio.api]
+
+# Path to AF_LOCAL socket on which CRI-O will listen.
+listen = "/var/run/crio/crio.sock"
+
+# IP address on which the stream server will listen.
+stream_address = "127.0.0.1"
+
+# The port on which the stream server will listen.
+stream_port = "0"
+
+# Enable encrypted TLS transport of the stream server.
+stream_enable_tls = false
+
+# Path to the x509 certificate file used to serve the encrypted stream. This
+# file can change, and CRI-O will automatically pick up the changes within 5
+# minutes.
+stream_tls_cert = ""
+
+# Path to the key file used to serve the encrypted stream. This file can
+# change and CRI-O will automatically pick up the changes within 5 minutes.
+stream_tls_key = ""
+
+# Path to the x509 CA(s) file used to verify and authenticate client
+# communication with the encrypted stream. This file can change and CRI-O will
+# automatically pick up the changes within 5 minutes.
+stream_tls_ca = ""
+
+# Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 16 * 1024 * 1024.
+grpc_max_send_msg_size = 16777216
+
+# Maximum grpc receive message size. If not set or <= 0, then CRI-O will default to 16 * 1024 * 1024.
+grpc_max_recv_msg_size = 16777216
+
+# The crio.runtime table contains settings pertaining to the OCI runtime used
+# and options for how to set up and manage the OCI runtime.
+[crio.runtime]
+
+# A list of ulimits to be set in containers by default, specified as
+# "<ulimit name>=<soft limit>:<hard limit>", for example:
+# "nofile=1024:2048"
+# If nothing is set here, settings will be inherited from the CRI-O daemon
+#default_ulimits = [
+#]
+
+# default_runtime is the _name_ of the OCI runtime to be used as the default.
+# The name is matched against the runtimes map below.
+default_runtime = "runc"
+
+# If true, the runtime will not use pivot_root, but instead use MS_MOVE.
+no_pivot = false
+
+# decryption_keys_path is the path where the keys required for
+# image decryption are stored.
+decryption_keys_path = "/etc/crio/keys/"
+
+# Path to the conmon binary, used for monitoring the OCI runtime.
+# Will be searched for using $PATH if empty.
+conmon = ""
+
+# Cgroup setting for conmon
+conmon_cgroup = "system.slice"
+
+# Environment variable list for the conmon process, used for passing necessary
+# environment variables to conmon or the runtime.
+conmon_env = [
+	"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+]
+
+# If true, SELinux will be used for pod separation on the host.
+selinux = false
+
+# Path to the seccomp.json profile which is used as the default seccomp profile
+# for the runtime. If not specified, then the internal default seccomp profile
+# will be used.
+seccomp_profile = ""
+
+# Used to change the name of the default AppArmor profile of CRI-O. The default
+# profile name is "crio-default-" followed by the version string of CRI-O.
+apparmor_profile = "crio-default-1.17.0"
+
+# Cgroup management implementation used for the runtime.
+cgroup_manager = "cgroupfs"
+
+# List of default capabilities for containers. If it is empty or commented out,
+# only the capabilities defined in the containers json file by the user/kube
+# will be added.
+default_capabilities = [
+	"CHOWN",
+	"DAC_OVERRIDE",
+	"FSETID",
+	"FOWNER",
+	"NET_RAW",
+	"SETGID",
+	"SETUID",
+	"SETPCAP",
+	"NET_BIND_SERVICE",
+	"SYS_CHROOT",
+	"KILL",
+]
+
+# List of default sysctls. If it is empty or commented out, only the sysctls
+# defined in the container json file by the user/kube will be added.
+default_sysctls = [
+]
+
+# List of additional devices. specified as
+# "<device-on-host>:<device-on-container>:<permissions>", for example: "--device=/dev/sdc:/dev/xvdc:rwm".
+#If it is empty or commented out, only the devices
+# defined in the container json file by the user/kube will be added.
+additional_devices = [
+]
+
+# Path to OCI hooks directories for automatically executed hooks.
+hooks_dir = [
+	"/usr/share/containers/oci/hooks.d",
+]
+
+# List of default mounts for each container. **Deprecated:** this option will
+# be removed in future versions in favor of default_mounts_file.
+default_mounts = [
+]
+
+# Path to the file specifying the defaults mounts for each container. The
+# format of the config is /SRC:/DST, one mount per line. Notice that CRI-O reads
+# its default mounts from the following two files:
+#
+#   1) /etc/containers/mounts.conf (i.e., default_mounts_file): This is the
+#      override file, where users can either add in their own default mounts, or
+#      override the default mounts shipped with the package.
+#
+#   2) /usr/share/containers/mounts.conf: This is the default file read for
+#      mounts. If you want CRI-O to read from a different, specific mounts file,
+#      you can change the default_mounts_file. Note, if this is done, CRI-O will
+#      only add mounts it finds in this file.
+#
+#default_mounts_file = ""
+
+# Maximum number of processes allowed in a container.
+pids_limit = 1024
+
+# Maximum sized allowed for the container log file. Negative numbers indicate
+# that no size limit is imposed. If it is positive, it must be >= 8192 to
+# match/exceed conmon's read buffer. The file is truncated and re-opened so the
+# limit is never exceeded.
+log_size_max = -1
+
+# Whether container output should be logged to journald in addition to the kuberentes log file
+log_to_journald = false
+
+# Path to directory in which container exit files are written to by conmon.
+container_exits_dir = "/var/run/crio/exits"
+
+# Path to directory for container attach sockets.
+container_attach_socket_dir = "/var/run/crio"
+
+# The prefix to use for the source of the bind mounts.
+bind_mount_prefix = ""
+
+# If set to true, all containers will run in read-only mode.
+read_only = false
+
+# Changes the verbosity of the logs based on the level it is set to. Options
+# are fatal, panic, error, warn, info, debug and trace. This option supports
+# live configuration reload.
+log_level = "error"
+
+# Filter the log messages by the provided regular expression.
+# This option supports live configuration reload.
+log_filter = ""
+
+# The UID mappings for the user namespace of each container. A range is
+# specified in the form containerUID:HostUID:Size. Multiple ranges must be
+# separated by comma.
+uid_mappings = ""
+
+# The GID mappings for the user namespace of each container. A range is
+# specified in the form containerGID:HostGID:Size. Multiple ranges must be
+# separated by comma.
+gid_mappings = ""
+
+# The minimal amount of time in seconds to wait before issuing a timeout
+# regarding the proper termination of the container.
+ctr_stop_timeout = 0
+
+# **DEPRECATED** this option is being replaced by manage_ns_lifecycle, which is described below.
+# manage_network_ns_lifecycle = false
+
+# manage_ns_lifecycle determines whether we pin and remove namespaces
+# and manage their lifecycle
+manage_ns_lifecycle = false
+
+# The directory where the state of the managed namespaces gets tracked.
+# Only used when manage_ns_lifecycle is true.
+namespaces_dir = "/var/run/crio/ns"
+
+# pinns_path is the path to find the pinns binary, which is needed to manage namespace lifecycle
+pinns_path = ""
+
+# The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
+# The runtime to use is picked based on the runtime_handler provided by the CRI.
+# If no runtime_handler is provided, the runtime will be picked based on the level
+# of trust of the workload. Each entry in the table should follow the format:
+#
+#[crio.runtime.runtimes.runtime-handler]
+#  runtime_path = "/path/to/the/executable"
+#  runtime_type = "oci"
+#  runtime_root = "/path/to/the/root"
+#
+# Where:
+# - runtime-handler: name used to identify the runtime
+# - runtime_path (optional, string): absolute path to the runtime executable in
+#   the host filesystem. If omitted, the runtime-handler identifier should match
+#   the runtime executable name, and the runtime executable should be placed
+#   in $PATH.
+# - runtime_type (optional, string): type of runtime, one of: "oci", "vm". If
+#   omitted, an "oci" runtime is assumed.
+# - runtime_root (optional, string): root directory for storage of containers
+#   state.
+
+
+[crio.runtime.runtimes.runc]
+runtime_path = ""
+runtime_type = "oci"
+runtime_root = "/run/runc"
+
+
+# Kata Containers is an OCI runtime, where containers are run inside lightweight
+# VMs. Kata provides additional isolation towards the host, minimizing the host attack
+# surface and mitigating the consequences of containers breakout.
+
+# Kata Containers with the default configured VMM
+#[crio.runtime.runtimes.kata-runtime]
+
+# Kata Containers with the QEMU VMM
+#[crio.runtime.runtimes.kata-qemu]
+
+# Kata Containers with the Firecracker VMM
+#[crio.runtime.runtimes.kata-fc]
+
+# The crio.image table contains settings pertaining to the management of OCI images.
+#
+# CRI-O reads its configured registries defaults from the system wide
+# containers-registries.conf(5) located in /etc/containers/registries.conf. If
+# you want to modify just CRI-O, you can change the registries configuration in
+# this file. Otherwise, leave insecure_registries and registries commented out to
+# use the system's defaults from /etc/containers/registries.conf.
+[crio.image]
+
+# Default transport for pulling images from a remote container storage.
+default_transport = "docker://"
+
+# The path to a file containing credentials necessary for pulling images from
+# secure registries. The file is similar to that of /var/lib/kubelet/config.json
+global_auth_file = ""
+
+# The image used to instantiate infra containers.
+# This option supports live configuration reload.
+pause_image = "k8s.gcr.io/pause:3.1"
+
+# The path to a file containing credentials specific for pulling the pause_image from
+# above. The file is similar to that of /var/lib/kubelet/config.json
+# This option supports live configuration reload.
+pause_image_auth_file = ""
+
+# The command to run to have a container stay in the paused state.
+# When explicitly set to "", it will fallback to the entrypoint and command
+# specified in the pause image. When commented out, it will fallback to the
+# default: "/pause". This option supports live configuration reload.
+pause_command = "/pause"
+
+# Path to the file which decides what sort of policy we use when deciding
+# whether or not to trust an image that we've pulled. It is not recommended that
+# this option be used, as the default behavior of using the system-wide default
+# policy (i.e., /etc/containers/policy.json) is most often preferred. Please
+# refer to containers-policy.json(5) for more details.
+signature_policy = ""
+
+# List of registries to skip TLS verification for pulling images. Please
+# consider configuring the registries via /etc/containers/registries.conf before
+# changing them here.
+#insecure_registries = "[]"
+
+# Controls how image volumes are handled. The valid values are mkdir, bind and
+# ignore; the latter will ignore volumes entirely.
+image_volumes = "mkdir"
+
+# List of registries to be used when pulling an unqualified image (e.g.,
+# "alpine:latest"). By default, registries is set to "docker.io" for
+# compatibility reasons. Depending on your workload and usecase you may add more
+# registries (e.g., "quay.io", "registry.fedoraproject.org",
+# "registry.opensuse.org", etc.).
+#registries = [
+# ]
+
+
+# The crio.network table containers settings pertaining to the management of
+# CNI plugins.
+[crio.network]
+
+# Path to the directory where CNI configuration files are located.
+network_dir = "/etc/cni/net.d/"
+
+# Paths to directories where CNI plugin binaries are located.
+plugin_dirs = [
+	"/opt/cni/bin/",
+]
+
+# A necessary configuration for Prometheus based metrics retrieval
+[crio.metrics]
+
+# Globally enable or disable metrics support.
+enable_metrics = false
+
+# The port on which the metrics server will listen.
+metrics_port = 9090


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

We now offer a new option `crio config -m/--migrate` to migrate the current provided config to the latest version. The feature also logs which changes will be done to the config before printing the result:

```console
> sudo ./bin/crio config -m 1.17
INFO Migrating config from 1.17
INFO Checking for NET_RAW and SYS_CHROOT capabilities, which have been removed per default
INFO Removing "default_capabilities" entry "NET_RAW"
INFO Removing "default_capabilities" entry "SYS_CHROOT"
INFO Checking for default AppArmor profile, which does not contain the version number any more
INFO Checking for the log level, which has changed from error to info
INFO Checking for ctr_stop_timeout, which now has a minimum value of 30
INFO Changing "ctr_stop_timeout" to 30
# The CRI-O configuration file specifies all of the available configuration
# options and command-line flags for the crio(8) OCI Kubernetes Container Runtime
# daemon, but in a TOML format that can be more easily modified and versioned.
#
# Please refer to crio.conf(5) for details of all configuration options.
…
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I will add tests if we agree that this is useful for users.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Add `crio config -m/--migrate` option which supports migrating a v1.17.0 configuration file to the latest version.
```
