### PR TITLE
build: clean generated bin/ dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,8 +187,7 @@ endif
 	rm -fr test/testdata/redis-image
 	find . -name \*~ -delete
 	find . -name \#\* -delete
-	rm -f bin/crio
-	rm -f bin/crio.cross.*
+	rm -rf bin/
 	$(MAKE) -C pinns clean
 	rm -f test/copyimg/copyimg
 	rm -f test/checkseccomp/checkseccomp


### PR DESCRIPTION
Previously, make clean command was not cleaning
bin/crio-status and bin/ dir. This patch make sure
the generated bin/ is cleaned.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix make clean