### PR TITLE
Make release notes require results in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,8 @@ workflows:
           filters: *filterAllTags
 
       - release-notes:
+          requires:
+            - results
           filters: *filterAllTags
 
       - results:
@@ -144,7 +146,6 @@ workflows:
             - integration-static-glibc
             - integration-static-musl
             - integration-userns
-            - release-notes
             - unit-tests
           filters: *filterAllTags
 
@@ -409,14 +410,12 @@ jobs:
           command: |
             if [[ -z $GITHUB_TOKEN ]]; then
               echo Skipping release notes generation
-              mkdir -p build/release-notes
             else
               make release-notes
             fi
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build/release-notes
+      - store_artifacts:
+          path: build/release-notes
+          destination: release-notes
       - save_cache:
           key: v1-release-notes-{{ checksum "go.sum" }}
           paths:

--- a/scripts/latest-version/latest_version.go
+++ b/scripts/latest-version/latest_version.go
@@ -66,7 +66,7 @@ func main() {
 			branch = strings.TrimSpace(branchRes.Output())
 		}
 		versionScope := ""
-		if strings.HasPrefix(branch, "release-") {
+		if isReleaseBranch(branch) {
 			versionScope = strings.TrimPrefix(branch, "release-")
 		}
 
@@ -108,7 +108,7 @@ func incVersion(tag, branch string) string {
 	if err != nil {
 		panic(err)
 	}
-	isReleaseBranch := kgit.IsReleaseBranch(branch) && branch != kgit.Master
+	isReleaseBranch := isReleaseBranch(branch)
 
 	// Do nothing if no version bump is required
 	if noBumpVersion {
@@ -129,6 +129,10 @@ func incVersion(tag, branch string) string {
 	sv.Pre = []semver.PRVersion{{VersionStr: "dev"}}
 
 	return sv.String()
+}
+
+func isReleaseBranch(branch string) bool {
+	return kgit.IsReleaseBranch(branch) && branch != kgit.Master
 }
 
 func decVersion(tag string) string {


### PR DESCRIPTION

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
We should not publish the release notes if no binary bundle has been
uploaded. To fix that scenario, we now only allow notes generation if
the `results` step has been finished.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
