### PR TITLE
Use crictl for crio wipe

### DIFF
--- a/cmd/crio/wipe.go
+++ b/cmd/crio/wipe.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 
-	cstorage "github.com/containers/storage"
 	"github.com/cri-o/cri-o/internal/criocli"
-	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/internal/version"
+	"github.com/cri-o/cri-o/pkg/config"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	"k8s.io/release/pkg/command"
 )
+
+const crictl = "crictl"
 
 var wipeCommand = &cli.Command{
 	Name:   "wipe",
@@ -28,7 +28,7 @@ var wipeCommand = &cli.Command{
 }
 
 func crioWipe(c *cli.Context) error {
-	config, err := criocli.GetConfigFromContext(c)
+	cfg, err := criocli.GetConfigFromContext(c)
 	if err != nil {
 		return err
 	}
@@ -36,94 +36,35 @@ func crioWipe(c *cli.Context) error {
 	shouldWipe := true
 	// First, check if we need to upgrade at all
 	if !c.IsSet("force") {
-		shouldWipe, err = version.ShouldCrioWipe(config.VersionFile)
+		shouldWipe, err = version.ShouldCrioWipe(cfg.VersionFile)
 		if err != nil {
-			fmt.Fprint(os.Stderr, err.Error())
+			logrus.Warnf("%v", err)
 		}
 	}
 
 	// if we should not wipe, exit with no error
 	if !shouldWipe {
-		fmt.Println("major and minor version unchanged; no wipe needed")
+		logrus.Info("Major and minor version unchanged; no wipe needed")
 		return nil
 	}
 
-	store, err := config.GetStore()
-	if err != nil {
-		return err
+	if !command.Available(crictl) {
+		return errors.Errorf("%s not found in $PATH", crictl)
 	}
 
-	cstore := ContainerStore{store}
-	if err := cstore.wipeCrio(); err != nil {
-		return err
-	}
-
-	return nil
+	return removeContainersAndImages(cfg)
 }
 
-type ContainerStore struct {
-	store cstorage.Store
-}
+func removeContainersAndImages(c *config.Config) error {
+	logrus.Info("Removing all containers and pods")
+	e := fmt.Sprintf("--runtime-endpoint=unix://%s", c.Listen)
+	if err := command.New(crictl, e, "rmp", "-fa").RunSuccess(); err != nil {
+		return errors.Wrap(err, "removing all containers and pods")
+	}
 
-func (c ContainerStore) wipeCrio() error {
-	crioContainers, crioImages, err := c.getCrioContainersAndImages()
-	if err != nil {
-		return err
-	}
-	for _, id := range crioContainers {
-		c.deleteContainer(id)
-	}
-	for _, id := range crioImages {
-		c.deleteImage(id)
+	logrus.Info("Removing all images")
+	if err := command.New(crictl, e, "rmi", "-a").RunSuccess(); err != nil {
+		return errors.Wrap(err, "removing all images")
 	}
 	return nil
-}
-
-func (c ContainerStore) getCrioContainersAndImages() (crioContainers, crioImages []string, err error) {
-	containers, err := c.store.Containers()
-	if err != nil {
-		if os.IsNotExist(errors.Cause(err)) {
-			return crioContainers, crioImages, err
-		}
-		logrus.Warnf("could not read containers and sandboxes: %v", err)
-	}
-
-	for i := range containers {
-		id := containers[i].ID
-		metadataString, err := c.store.Metadata(id)
-		if err != nil {
-			continue
-		}
-
-		metadata := storage.RuntimeContainerMetadata{}
-		if err := json.Unmarshal([]byte(metadataString), &metadata); err != nil {
-			continue
-		}
-		if !storage.IsCrioContainer(&metadata) {
-			continue
-		}
-		crioContainers = append(crioContainers, id)
-		crioImages = append(crioImages, containers[i].ImageID)
-	}
-	return crioContainers, crioImages, nil
-}
-
-func (c ContainerStore) deleteContainer(id string) {
-	if mounted, err := c.store.Unmount(id, true); err != nil || mounted {
-		logrus.Warnf("unable to unmount container %s: %v", id, err)
-		return
-	}
-	if err := c.store.DeleteContainer(id); err != nil {
-		logrus.Warnf("unable to delete container %s: %v", id, err)
-		return
-	}
-	logrus.Infof("deleted container %s", id)
-}
-
-func (c ContainerStore) deleteImage(id string) {
-	if _, err := c.store.DeleteImage(id, true); err != nil {
-		logrus.Warnf("unable to delete image %s: %v", id, err)
-		return
-	}
-	logrus.Infof("deleted image %s", id)
 }

--- a/contrib/systemd/crio-wipe.service
+++ b/contrib/systemd/crio-wipe.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CRI-O Auto Update Script
-Before=crio.service
+After=crio.service
 RequiresMountsFor=/var/lib/containers
 
 [Service]

--- a/contrib/systemd/crio.service
+++ b/contrib/systemd/crio.service
@@ -3,7 +3,7 @@ Description=Container Runtime Interface for OCI (CRI-O)
 Documentation=https://github.com/cri-o/cri-o
 Wants=network-online.target
 After=network-online.target
-After=crio-wipe.service
+Before=crio-wipe.service
 Requires=crio-wipe.service
 
 [Service]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
We encountered multiple issues with crio wipe, for example that the
containers storage got not properly unmounted or processes are still
alive. To avoid such pitfalls, we can now utilize crictl to remove all
pods (including containers) and images via two simple commands. This now
requires to have a working crio instance running before executing `crio
wipe`.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
@haircommander would this work for OpenShift too?
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed `crio wipe` to use `crictl` for container and image removal. This means that we now
  require `crictl` to be available in `$PATH` as well as changing the execution order of the
  `crio-wipe.service` systemd unit.
```
