### PR TITLE
Use HEAD for runc built from source

### DIFF
--- a/contrib/test/integration/build/runc.yml
+++ b/contrib/test/integration/build/runc.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/opencontainers/runc.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-    version: "13b1603fd0e37db1764433a140d494b2e9f05805"
+    version: "HEAD"
 
 - name: build runc
   make:


### PR DESCRIPTION
This is the master branch and it makes sense to use
the latest runc for CI.

Suggested-by: @mrunalp 

/kind dependency-change

```release-note
NONE
```
