### PR TITLE
Add the mounts that are required by systemd

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -665,6 +665,22 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		specgen.AddMount(cgroupMnt)
 	}
 
+	containerImageConfig := containerInfo.Config
+	if containerImageConfig == nil {
+		err = fmt.Errorf("empty image config for %s", image)
+		return nil, err
+	}
+
+	processArgs, err := buildOCIProcessArgs(ctx, containerConfig, containerImageConfig)
+	if err != nil {
+		return nil, err
+	}
+	specgen.SetProcessArgs(processArgs)
+
+	if strings.Contains(processArgs[0], "/sbin/init") || (filepath.Base(processArgs[0]) == oci.SystemdCgroupsManager) {
+		setupSystemd(specgen.Mounts(), specgen)
+	}
+
 	// When running on cgroupv2, automatically add a cgroup namespace for not privileged containers.
 	if !privileged && cgroups.IsCgroup2UnifiedMode() {
 		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.CgroupNamespace), ""); err != nil {
@@ -787,12 +803,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	}
 	specgen.AddAnnotation(annotations.MountPoint, mountPoint)
 
-	containerImageConfig := containerInfo.Config
-	if containerImageConfig == nil {
-		err = fmt.Errorf("empty image config for %s", image)
-		return nil, err
-	}
-
 	if containerImageConfig.Config.StopSignal != "" {
 		// this key is defined in image-spec conversion document at https://github.com/opencontainers/image-spec/pull/492/files#diff-8aafbe2c3690162540381b8cdb157112R57
 		specgen.AddAnnotation("org.opencontainers.image.stopSignal", containerImageConfig.Config.StopSignal)
@@ -817,12 +827,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	if err != nil {
 		return nil, err
 	}
-
-	processArgs, err := buildOCIProcessArgs(ctx, containerConfig, containerImageConfig)
-	if err != nil {
-		return nil, err
-	}
-	specgen.SetProcessArgs(processArgs)
 
 	// Set working directory
 	// Pick it up from image config first and override if specified in CRI
@@ -1149,4 +1153,65 @@ func getDevicesFromConfig(ctx context.Context, config *libconfig.Config) ([]conf
 	}
 
 	return linuxdevs, nil
+}
+
+// mountExists returns true if dest exists in the list of mounts
+func mountExists(specMounts []rspec.Mount, dest string) bool {
+	for _, m := range specMounts {
+		if m.Destination == dest {
+			return true
+		}
+	}
+	return false
+}
+
+// systemd expects to have /run, /run/lock and /tmp on tmpfs
+// It also expects to be able to write to /sys/fs/cgroup/systemd and /var/log/journal
+func setupSystemd(mounts []rspec.Mount, g generate.Generator) {
+	options := []string{"rw", "rprivate", "noexec", "nosuid", "nodev"}
+	for _, dest := range []string{"/run", "/run/lock"} {
+		if mountExists(mounts, dest) {
+			continue
+		}
+		tmpfsMnt := rspec.Mount{
+			Destination: dest,
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     append(options, "tmpcopyup", "size=65536k"),
+		}
+		g.AddMount(tmpfsMnt)
+	}
+	for _, dest := range []string{"/tmp", "/var/log/journal"} {
+		if mountExists(mounts, dest) {
+			continue
+		}
+		tmpfsMnt := rspec.Mount{
+			Destination: dest,
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     append(options, "tmpcopyup"),
+		}
+		g.AddMount(tmpfsMnt)
+	}
+
+	if cgroups.IsCgroup2UnifiedMode() {
+		g.RemoveMount("/sys/fs/cgroup")
+
+		systemdMnt := rspec.Mount{
+			Destination: "/sys/fs/cgroup",
+			Type:        "cgroup",
+			Source:      "cgroup",
+			Options:     []string{"private", "rw"},
+		}
+		g.AddMount(systemdMnt)
+	} else {
+		systemdMnt := rspec.Mount{
+			Destination: "/sys/fs/cgroup/systemd",
+			Type:        "bind",
+			Source:      "/sys/fs/cgroup/systemd",
+			Options:     []string{"bind", "nodev", "noexec", "nosuid"},
+		}
+		g.AddMount(systemdMnt)
+		g.AddLinuxMaskedPaths("/sys/fs/cgroup/systemd/release_agent")
+	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

 /kind bug

#### What this PR does / why we need it:

Systemd expects to have /run, /run/lock, and /tmp
on tmpfs. It also expects to be able to write to
/sys/fs/cgroup/systemd and /var/log/journal.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

None

Signed-off-by: Urvashi Mohnani umohnani@redhat.com
