### PR TITLE
branch foward: skip release candidates

### DIFF
--- a/scripts/release-branch-forward/release_branch_forward.go
+++ b/scripts/release-branch-forward/release_branch_forward.go
@@ -73,7 +73,7 @@ func run() error {
 	tagPrefix := strings.TrimPrefix(latestReleaseBranch, releaseBranchPrefix)
 	lsRemoteTags, err := command.
 		New(git, "ls-remote", "--sort=v:refname", "--tags", remote).
-		Pipe(grep, "-Eo", "v"+tagPrefix+".*").
+		Pipe(grep, "-Eo", "v"+tagPrefix+".[0-9]*$").
 		RunSilentSuccessOutput()
 	if err == nil {
 		logrus.Warnf(


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug

#### What this PR does / why we need it:
skips tags that don't fit the form [version].[0-9]*$ (i.e. 1.18.0-rc1)
we shouldn't consider release candidates as reason to not forward master. We should stop forwarding from master once we cut a sub-minor release

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
