### PR TITLE
[1.11] oci: handle timeouts correctly for probes

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -609,7 +609,10 @@ function teardown() {
 	run crictl exec --sync --timeout 1 "$ctr_id" sleep 3
 	echo "$output"
 	[[ "$output" =~ "command timed out" ]]
-	[ "$status" -ne 0 ]
+	# in 1.11, the exit code is non-zero only when ExecSyncError is returned
+	# In later versions, the exit code is non-zero if ExecSyncResponse returns
+	# a non-zero code
+	[ "$status" -eq 0 ]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:
We shouldn't return a custom error when an exec sync command
times out. Instead, we should return a non-zero exit code.

When the prober code in kubernetes sees a custom error
it goes into Unknown status and doesn't restart containers
on timed out probes as expected.

Signed-off-by: Mrunal Patel mrunalp@gmail.com
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
