### PR TITLE
[1.17] sandbox: Make sure the label annotation is proper JSON

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -277,11 +277,11 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	}
 	var m rspec.Spec
 	if err := json.Unmarshal(config, &m); err != nil {
-		return err
+		return errors.Wrap(err, "error unmarshalling sandbox spec")
 	}
 	labels := make(map[string]string)
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.Labels]), &labels); err != nil {
-		return err
+		return errors.Wrapf(err, "error unmarshalling %s annotation", annotations.Labels)
 	}
 	name := m.Annotations[annotations.Name]
 	name, err = c.ReservePodName(id, name)
@@ -295,7 +295,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	}()
 	var metadata pb.PodSandboxMetadata
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.Metadata]), &metadata); err != nil {
-		return err
+		return errors.Wrapf(err, "error unmarshalling %s annotation", annotations.Metadata)
 	}
 
 	processLabel := m.Process.SelinuxLabel
@@ -305,19 +305,19 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 
 	kubeAnnotations := make(map[string]string)
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.Annotations]), &kubeAnnotations); err != nil {
-		return err
+		return errors.Wrapf(err, "error unmarshalling %s annotation", annotations.Annotations)
 	}
 
 	portMappings := []*hostport.PortMapping{}
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.PortMappings]), &portMappings); err != nil {
-		return err
+		return errors.Wrapf(err, "error unmarshalling %s annotation", annotations.PortMappings)
 	}
 
 	privileged := isTrue(m.Annotations[annotations.PrivilegedRuntime])
 	hostNetwork := isTrue(m.Annotations[annotations.HostNetwork])
 	nsOpts := pb.NamespaceOption{}
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.NamespaceOptions]), &nsOpts); err != nil {
-		return err
+		return errors.Wrapf(err, "error unmarshalling %s annotation", annotations.NamespaceOptions)
 	}
 
 	sb, err := sandbox.New(id, m.Annotations[annotations.Namespace], name, m.Annotations[annotations.KubeName], filepath.Dir(m.Annotations[annotations.LogPath]), labels, kubeAnnotations, processLabel, mountLabel, &metadata, m.Annotations[annotations.ShmPath], m.Annotations[annotations.CgroupParent], privileged, m.Annotations[annotations.RuntimeHandler], m.Annotations[annotations.ResolvPath], m.Annotations[annotations.HostName], portMappings, hostNetwork)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -187,13 +187,12 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 
 	// Add special container name label for the infra container
-	labelsJSON := []byte{}
 	if labels != nil {
 		labels[types.KubernetesContainerNameLabel] = leaky.PodInfraContainerName
-		labelsJSON, err = json.Marshal(labels)
-		if err != nil {
-			return nil, err
-		}
+	}
+	labelsJSON, err := json.Marshal(labels)
+	if err != nil {
+		return nil, err
 	}
 
 	// add annotations


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

sandbox: Make sure the label annotation is proper JSON

The io.kubernetes.cri-o.Labels annotation is supposed to contain a JSON formatted string. Make sure that we set a proper JSON value (null) even if there are no labels. The empty string '' that was used before is not valid JSON.


#### Which issue(s) this PR fixes:

Fixes #3511

#### Special notes for your reviewer:

backport of https://github.com/cri-o/cri-o/pull/3523

#### Does this PR introduce a user-facing change?

```release-note
- Empty sandbox labels are now serialized into proper JSON (`null`)
```
