### PR TITLE
manage ns: don't cleanup top level directories

### DIFF
--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -3,7 +3,6 @@ package sandbox
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/pkg/config"
@@ -170,37 +169,27 @@ func (s *Sandbox) RemoveManagedNamespaces() error {
 	errs := make([]error, 0)
 
 	// use a map as a set to delete each parent directory just once
-	directories := make(map[string]bool)
 	if s.utsns != nil {
-		directories[filepath.Dir(s.utsns.Path())] = true
 		if err := s.utsns.Remove(); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if s.ipcns != nil {
-		directories[filepath.Dir(s.ipcns.Path())] = true
 		if err := s.ipcns.Remove(); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if s.netns != nil {
-		directories[filepath.Dir(s.netns.Path())] = true
 		if err := s.netns.Remove(); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if s.userns != nil {
-		directories[filepath.Dir(s.userns.Path())] = true
 		if err := s.userns.Remove(); err != nil {
 			errs = append(errs, err)
 		}
 	}
 
-	for directory := range directories {
-		if err := os.RemoveAll(directory); err != nil {
-			errs = append(errs, err)
-		}
-	}
 	var err error
 	if len(errs) != 0 {
 		err = errors.Errorf("Removing namespaces encountered the following errors %v", errs)

--- a/internal/lib/sandbox/namespaces_linux.go
+++ b/internal/lib/sandbox/namespaces_linux.go
@@ -15,6 +15,7 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -85,9 +86,14 @@ func pinNamespaces(nsTypes []NSType, cfg *config.Config) ([]NamespaceIface, erro
 			nsType: nsType,
 		})
 	}
-
 	pinns := cfg.PinnsPath
-	if output, err := exec.Command(pinns, pinnsArgs...).Output(); err != nil {
+
+	logrus.Debugf("calling pinns with %v", pinnsArgs)
+	output, err := exec.Command(pinns, pinnsArgs...).Output()
+	if len(output) != 0 {
+		logrus.Debugf("pinns output: %s", string(output))
+	}
+	if err != nil {
 		// cleanup after ourselves
 		failedUmounts := make([]string, 0)
 		for _, info := range mountedNamespaces {

--- a/internal/lib/sandbox/namespaces_test.go
+++ b/internal/lib/sandbox/namespaces_test.go
@@ -145,7 +145,6 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 					nsType := ifaceMock.Type()
 					ifaceMock.EXPECT().Type().Return(nsType)
 					ifaceMock.EXPECT().Path().Return(filepath.Join(tmpDir, string(nsType)))
-					ifaceMock.EXPECT().Path().Return(filepath.Join(tmpDir, string(nsType)))
 					ifaceMock.EXPECT().Remove().Return(nil)
 				},
 			}
@@ -165,8 +164,6 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 
 			// Then
 			Expect(err).To(BeNil())
-			_, err = os.Stat(tmpDir)
-			Expect(os.IsNotExist(err)).To(Equal(true))
 		})
 	})
 	t.Describe("*NsJoin", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
#### What this PR does / why we need it:
now that we bind mount to $dir/$ns/$rand instead of $dir/$rand/$ns, we should not cleanup the middle directory, as it will attempt to cleanup the namespace directory for all pods
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
