### PR TITLE
Update kubeadm.md

### DIFF
--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -5,10 +5,7 @@ It also assumes you've set up your system to use kubeadm. If you haven't done so
 
 ### Configuring CNI
 
-First, CRI-O and `kubeadm reset` don't play well together, as `kubeadm reset` empties `/etc/cni/net.d/`.
-Therefore, it is good to add an overwrite of the `crio.network.network_dir` in `/etc/crio/crio.conf.d/01-overwrite-cni.conf` to somewhere kubeadm won't touch.
-
-Further, you'll need to use your plugins to figure out your pod-network-cidr. If you use the default bridge plugin defined [here](/contrib/cni/10-crio-bridge.conf), set
+You'll need to use your plugins to figure out your pod-network-cidr. If you use the default bridge plugin defined [here](/contrib/cni/10-crio-bridge.conf), set
 ```CIDR=10.88.0.0/16```
 If you're using a flannel network, set
 ```CIDR=10.244.0.0/16```


### PR DESCRIPTION
Kubeadm no longer deletes files in /etc/cni/net.d

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind documentation

#### What this PR does / why we need it:

I can see there was a long [discussion](https://github.com/kubernetes/kubeadm/issues/1822) about how kubeadm used to delete files in `/etc/cni/net.d`. Even the docs this commit modifies are mentioned there.

However, kubeadm merged this [PR](https://github.com/kubernetes/kubernetes/pull/83950) to solve the issue and it no longer deletes files in `/etc/cni/net.d`

In fact, when reseting a kubeadm cluster, there is this piece of information in the terminal:

```
The reset process does not clean CNI configuration. To do so, you must remove /etc/cni/net.d
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
