### PR TITLE
Generate dependencies file in gh-pages root

### DIFF
--- a/scripts/dependencies/dependencies.go
+++ b/scripts/dependencies/dependencies.go
@@ -16,9 +16,8 @@ import (
 )
 
 const (
-	branch   = "gh-pages"
-	postsDir = "_posts"
-	file     = "dependencies.md"
+	branch = "gh-pages"
+	file   = "dependencies.md"
 )
 
 var outputPath string
@@ -130,15 +129,11 @@ _Generated on %s for commit [%s][0]._
 		defer func() { err = repo.Checkout(currentBranch) }()
 
 		// Write the target file
-		if err := os.MkdirAll(postsDir, 0o755); err != nil {
-			return errors.Wrap(err, "creating posts directory")
-		}
-		postsFile := filepath.Join(postsDir, file)
-		if err := ioutil.WriteFile(postsFile, []byte(content), 0o644); err != nil {
+		if err := ioutil.WriteFile(file, []byte(content), 0o644); err != nil {
 			return errors.Wrap(err, "write content to file")
 		}
 
-		if err := repo.Add(postsFile); err != nil {
+		if err := repo.Add(file); err != nil {
 			return errors.Wrap(err, "add file to repo")
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind documentation

#### What this PR does / why we need it:
Using the `_posts` directory was not optimal (they have not been
rendered to HTML) so we're switching to the repo root for the generated
reports.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
