### PR TITLE
SetLinuxResourcesMemorySwap to the LinuxResourcesMemoryLimit

### DIFF
--- a/contrib/test/integration/build/crun.yml
+++ b/contrib/test/integration/build/crun.yml
@@ -5,7 +5,7 @@
     repo: "https://github.com/containers/crun.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/containers/crun"
     force: "{{ force_clone | default(False) | bool}}"
-    version: "0.13"
+    version: "4ad44b872b09a244dd7b2848952f4db0d0b968f4"
 
 - name: Install crun dependencies
   raw: >
@@ -23,6 +23,9 @@
       go-md2man \
       glibc-static \
       python3-libmount \
+      libtool \
+      pkgconf-pkg-config \
+      gperf \
       libtool
 
 - name: Run autogen.sh
@@ -33,6 +36,11 @@
 - name: Run configure
   command: "{{ ansible_env.GOPATH }}/src/github.com/containers/crun/configure"
   args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/containers/crun"
+
+- name: run crun clean
+  make:
+    target: clean
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/containers/crun"
 
 - name: build crun

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -506,11 +506,12 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 			specgen.SetLinuxResourcesCPUShares(uint64(resources.GetCpuShares()))
 
 			memoryLimit := resources.GetMemoryLimitInBytes()
-			if memoryLimit != 0 && memoryLimit < minMemoryLimit {
-				return nil, fmt.Errorf("set memory limit %v too low; should be at least %v", memoryLimit, minMemoryLimit)
-			}
 			if memoryLimit != 0 {
+				if memoryLimit < minMemoryLimit {
+					return nil, fmt.Errorf("set memory limit %v too low; should be at least %v", memoryLimit, minMemoryLimit)
+				}
 				specgen.SetLinuxResourcesMemoryLimit(memoryLimit)
+				specgen.SetLinuxResourcesMemorySwap(memoryLimit)
 			}
 
 			specgen.SetProcessOOMScoreAdj(int(resources.GetOomScoreAdj()))

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -51,6 +51,9 @@ var (
 	_cgroupv2HasHugetlbOnce sync.Once
 	_cgroupv2HasHugetlb     bool
 	_cgroupv2HasHugetlbErr  error
+
+	_cgroupHasMemorySwapOnce sync.Once
+	_cgroupHasMemorySwap     bool
 )
 
 // cgroupv1HasHugetlb returns whether the hugetlb controller is present on
@@ -80,6 +83,18 @@ func cgroupv2HasHugetlb() (bool, error) {
 		_cgroupv2HasHugetlb = strings.Contains(string(controllers), "hugetlb")
 	})
 	return _cgroupv2HasHugetlb, _cgroupv2HasHugetlbErr
+}
+
+func cgroupHasMemorySwap() bool {
+	_cgroupHasMemorySwapOnce.Do(func() {
+		if cgroups.IsCgroup2UnifiedMode() {
+			_cgroupHasMemorySwap = true
+			return
+		}
+		_, err := os.Stat("/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes")
+		_cgroupHasMemorySwap = err == nil
+	})
+	return _cgroupHasMemorySwap
 }
 
 type configDevice struct {
@@ -511,7 +526,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 					return nil, fmt.Errorf("set memory limit %v too low; should be at least %v", memoryLimit, minMemoryLimit)
 				}
 				specgen.SetLinuxResourcesMemoryLimit(memoryLimit)
-				specgen.SetLinuxResourcesMemorySwap(memoryLimit)
+				if cgroupHasMemorySwap() {
+					specgen.SetLinuxResourcesMemorySwap(memoryLimit)
+				}
 			}
 
 			specgen.SetProcessOOMScoreAdj(int(resources.GetOomScoreAdj()))

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -40,6 +40,7 @@ func toOCIResources(r *pb.LinuxContainerResources) *rspec.LinuxResources {
 		},
 		Memory: &rspec.LinuxMemory{
 			Limit: proto.Int64(r.GetMemoryLimitInBytes()),
+			Swap:  proto.Int64(r.GetMemoryLimitInBytes()),
 		},
 		// TODO(runcom): OOMScoreAdj is missing
 	}

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -30,6 +30,11 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *pb.UpdateCon
 
 // toOCIResources converts CRI resource constraints to OCI.
 func toOCIResources(r *pb.LinuxContainerResources) *rspec.LinuxResources {
+	var swap int64
+	memory := r.GetMemoryLimitInBytes()
+	if cgroupHasMemorySwap() {
+		swap = memory
+	}
 	return &rspec.LinuxResources{
 		CPU: &rspec.LinuxCPU{
 			Shares: proto.Uint64(uint64(r.GetCpuShares())),
@@ -39,8 +44,8 @@ func toOCIResources(r *pb.LinuxContainerResources) *rspec.LinuxResources {
 			Mems:   r.GetCpusetMems(),
 		},
 		Memory: &rspec.LinuxMemory{
-			Limit: proto.Int64(r.GetMemoryLimitInBytes()),
-			Swap:  proto.Int64(r.GetMemoryLimitInBytes()),
+			Limit: proto.Int64(memory),
+			Swap:  proto.Int64(swap),
 		},
 		// TODO(runcom): OOMScoreAdj is missing
 	}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1276,6 +1276,16 @@ function wait_until_exit() {
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "209715200" ]]
 
+	if test -r /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ; then
+		expected=209715200
+	else
+		expected=0
+	fi
+	run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.swap.max 2> /dev/null"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "$output" -eq "$expected" ]
+
 	if test $(stat -f -c%T /sys/fs/cgroup) = cgroup2fs; then
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.max"
 		echo "$output"
@@ -1310,6 +1320,16 @@ function wait_until_exit() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "524288000" ]]
+
+	if test -r /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ; then
+		expected=524288000
+	else
+		expected=0
+	fi
+	run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes 2> /dev/null || cat /sys/fs/cgroup/memory.swap.max 2> /dev/null"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "$output" -eq "$expected" ]
 
 	if test $(stat -f -c%T /sys/fs/cgroup) = cgroup2fs; then
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.max"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
Per https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-limits-are-run, when kubernetes runs a container with a memory usage limit set, it expects results comparable to using docker run --memory=....

Per https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details, if the --memory flag is used, but the --memory-swap flag is not used, the swap space limit value is expected to be equal to the memory limit value.

This swap space limit includes the memory limit, though, so kubernetes effectively expects us to not allow the container to use swap.

CRI-O currently doesn't ask a runtime to set a limit on the amount of swap space a container is allowed to use, but OpenShift has build tests that check for that behavior, so they noticed.

This PR also checks to make sure we have cgroup memory swap enabled. If we don't, we don't set this value, as it will error in the runtime

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
this is carrying https://github.com/cri-o/cri-o/pull/3349, but adds the check for memsw
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When setting the limit of memory resource usage in a container's runtime spec, we now disable use of swap by the container.
```
