### PR TITLE
Add runtimeSpec field to container stats info

### DIFF
--- a/server/container_status_test.go
+++ b/server/container_status_test.go
@@ -31,6 +31,7 @@ var _ = t.Describe("ContainerStatus", func() {
 			addContainerAndSandbox()
 			testContainer.AddVolume(oci.ContainerVolume{})
 			testContainer.SetState(givenState)
+			testContainer.SetSpec(&specs.Spec{Version: "1.0.0"})
 
 			// When
 			response, err := sut.ContainerStatus(context.Background(),
@@ -44,6 +45,7 @@ var _ = t.Describe("ContainerStatus", func() {
 			Expect(response).NotTo(BeNil())
 			Expect(len(response.Status.Mounts)).To(BeEquivalentTo(1))
 			Expect(response.Status.State).To(Equal(expectedState))
+			Expect(response.Info["info"]).To(ContainSubstring(`"ociVersion":"1.0.0"`))
 		},
 			Entry("Created", &oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateCreated},

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -40,7 +40,7 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	state=$(crictl inspect "$ctr_id")
-	pid=$(echo $state | python -c 'import json; import sys; d=json.load(sys.stdin); print(d["pid"])')
+	pid=$(echo $state | jq .info.pid)
 	grep 100000 /proc/$pid/uid_map
 	[ "$status" -eq 0 ]
 	grep 200000 /proc/$pid/gid_map


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
Added the full OCI runtime spec to the verbose `ContainerStatusResponse`, for example when running `crictl inspect $CONTAINER_ID`

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes #3568
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added the full OCI runtime spec to the verbose `ContainerStatusResponse`, for example when running `crictl inspect $CONTAINER_ID`
```
