### PR TITLE
Add OCI image spec to image stats info

### DIFF
--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/storage"
 	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -47,6 +48,7 @@ type ImageResult struct {
 	User         string
 	PreviousName string
 	Labels       map[string]string
+	OCIConfig    *specs.Image
 }
 
 type indexInfo struct {
@@ -58,7 +60,7 @@ type indexInfo struct {
 // avoid having to reread them every time we need to return information about
 // images.
 type imageCacheItem struct {
-	user         string
+	config       *specs.Image
 	size         *uint64
 	configDigest digest.Digest
 	info         *types.ImageInspectInfo
@@ -196,7 +198,7 @@ func (svc *imageService) buildImageCacheItem(systemContext *types.SystemContext,
 	}
 
 	return imageCacheItem{
-		user:         imageConfig.Config.User,
+		config:       imageConfig,
 		size:         size,
 		configDigest: configDigest,
 		info:         info,
@@ -225,9 +227,10 @@ func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageC
 		Size:         cacheItem.size,
 		Digest:       imageDigest,
 		ConfigDigest: cacheItem.configDigest,
-		User:         cacheItem.user,
+		User:         cacheItem.config.Config.User,
 		PreviousName: previousName,
 		Labels:       cacheItem.info.Labels,
+		OCIConfig:    cacheItem.config,
 	}
 }
 

--- a/server/image_status_test.go
+++ b/server/image_status_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -41,6 +42,47 @@ var _ = t.Describe("ImageStatus", func() {
 			// Then
 			Expect(err).To(BeNil())
 			Expect(response).NotTo(BeNil())
+		})
+
+		It("should succeed verbose", func() {
+			// Given
+			size := uint64(100)
+			gomock.InOrder(
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any(),
+				).Return(
+					[]string{"image"}, nil,
+				),
+				imageServerMock.EXPECT().ImageStatus(
+					gomock.Any(), gomock.Any(),
+				).Return(
+					&storage.ImageResult{
+						ID:   "image",
+						User: "10",
+						Size: &size,
+						OCIConfig: &specs.Image{
+							Architecture: "arch",
+							OS:           "os",
+						},
+					},
+					nil,
+				),
+			)
+
+			// When
+			response, err := sut.ImageStatus(context.Background(),
+				&pb.ImageStatusRequest{
+					Image:   &pb.ImageSpec{Image: "image"},
+					Verbose: true,
+				})
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(response).NotTo(BeNil())
+			Expect(response.Info).To(HaveKey("info"))
+			Expect(response.Info["info"]).To(ContainSubstring(
+				`{"imageSpec":{"architecture":"arch","os":"os","config":{}`,
+			))
 		})
 
 		It("should succeed with wrong image id", func() {

--- a/test/inspecti.bats
+++ b/test/inspecti.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# vim: set syntax=sh:
+
+load helpers
+
+function setup() {
+    setup_test
+    start_crio
+}
+
+function teardown() {
+    cleanup_test
+}
+
+@test "inspect image should succed contain all necessary information" {
+    run crictl inspecti quay.io/crio/redis:alpine | jq -e .status.size
+    run crictl inspecti quay.io/crio/redis:alpine | jq -e .info.imageSpec.config.Cmd
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
Added the full OCI image spec to the verbose `ImageStatusResponse`,
for example when running `crictl inspecti $IMAGE`.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/3567
#### Special notes for your reviewer:
I also added the output only if the request is specified in verbose mode.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added the full OCI image spec to the verbose `ImageStatusResponse`, for example when running `crictl inspecti $IMAGE`.
```
