### PR TITLE
Use named error return for container_server

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -144,7 +144,7 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 }
 
 // LoadSandbox loads a sandbox from the disk into the sandbox store
-func (c *ContainerServer) LoadSandbox(id string) error {
+func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 	config, err := c.store.FromContainerDirectory(id, "config.json")
 	if err != nil {
 		return err
@@ -163,7 +163,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			c.ReleasePodName(name)
 		}
 	}()
@@ -236,7 +236,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			if err := c.RemoveSandbox(sb.ID()); err != nil {
 				logrus.Warnf("could not remove sandbox ID %s: %v", sb.ID(), err)
 			}
@@ -258,7 +258,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			c.ReleaseContainerName(cname)
 		}
 	}()
@@ -333,7 +333,7 @@ func configNsPath(spec *rspec.Spec, nsType rspec.LinuxNamespaceType) (string, er
 var ErrIsNonCrioContainer = errors.New("non CRI-O container")
 
 // LoadContainer loads a container from the disk into the container store
-func (c *ContainerServer) LoadContainer(id string) error {
+func (c *ContainerServer) LoadContainer(id string) (retErr error) {
 	config, err := c.store.FromContainerDirectory(id, "config.json")
 	if err != nil {
 		return err
@@ -359,7 +359,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			c.ReleaseContainerName(name)
 		}
 	}()

--- a/internal/lib/rename.go
+++ b/internal/lib/rename.go
@@ -15,7 +15,7 @@ import (
 const configFile = "config.json"
 
 // ContainerRename renames the given container
-func (c *ContainerServer) ContainerRename(container, name string) error {
+func (c *ContainerServer) ContainerRename(container, name string) (retErr error) {
 	ctr, err := c.LookupContainer(container)
 	if err != nil {
 		return err
@@ -27,7 +27,7 @@ func (c *ContainerServer) ContainerRename(container, name string) error {
 		return err
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			c.ReleaseContainerName(name)
 		} else {
 			c.ReleaseContainerName(oldName)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR names error return variable to cover all possible error return code paths.

#### Which issue(s) this PR fixes:


None

```release-note
None
```
