### PR TITLE
config migrate: add pause image and namespace dir

### DIFF
--- a/internal/config/migrate/from_1_17.go
+++ b/internal/config/migrate/from_1_17.go
@@ -50,5 +50,23 @@ func migrateFrom1_17(cfg *config.Config) error {
 		logrus.Infof(`Changing "ctr_stop_timeout" to %d`, cfg.CtrStopTimeout)
 	}
 
+	// Change namespaces dir to new path
+	// https://github.com/cri-o/cri-o/pull/3509
+	logrus.Infof("Checking for namespaces_dir, which now should be /var/run instead of /var/run/crio/ns")
+	newNamespacesDir := "/var/run"
+	if cfg.NamespacesDir == "/var/run/crio/ns" {
+		cfg.NamespacesDir = newNamespacesDir
+		logrus.Infof(`Changing "namespaces_dir" to %s`, cfg.NamespacesDir)
+	}
+
+	// Upgrade pause image
+	// https://github.com/cri-o/cri-o/pull/3582
+	logrus.Infof("Checking for pause_image, which now should be k8s.gcr.io/pause:3.2 instead of k8s.gcr.io/pause:3.1")
+	newPauseImage := "k8s.gcr.io/pause:3.2"
+	if cfg.PauseImage == "k8s.gcr.io/pause:3.1" {
+		cfg.PauseImage = newPauseImage
+		logrus.Infof(`Changing "pause_image" to %s`, cfg.PauseImage)
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup


#### What this PR does / why we need it:
https://github.com/cri-o/cri-o/pull/3509 and  https://github.com/cri-o/cri-o/pull/3582 changed some defaults from 1.17.0. Add these defaults to config migrate 
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
