### PR TITLE
[release-1.17] add stop container for StorageRuntimeServer on error

### DIFF
--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -49,6 +49,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 					gomock.Any()).Return(nil),
 				runtimeServerMock.EXPECT().StartContainer(gomock.Any()).
 					Return("", nil),
+				runtimeServerMock.EXPECT().StopContainer(gomock.Any()).
+					Return(nil),
 				runtimeServerMock.EXPECT().RemovePodSandbox(gomock.Any()).
 					Return(nil),
 			)


### PR DESCRIPTION
Backports https://github.com/cri-o/cri-o/pull/3588 and replaces the bot backport https://github.com/cri-o/cri-o/pull/3594

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```
