### PR TITLE
[release-1.16] add stop container for StorageRuntimeServer on error

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -39,6 +39,7 @@ import (
 const cgroupMemorySubsystemMountPathV1 = "/sys/fs/cgroup/memory"
 const cgroupMemorySubsystemMountPathV2 = "/sys/fs/cgroup"
 
+// nolint:gocyclo
 func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (resp *pb.RunPodSandboxResponse, err error) {
 	const operation = "run_pod_sandbox"
 	defer func() {
@@ -491,6 +492,13 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %v", containerName, sb.Name(), id, err)
 	}
+	defer func() {
+		if err != nil {
+			if err2 := s.StorageRuntimeServer().StopContainer(id); err2 != nil {
+				log.Warnf(ctx, "couldn't stop storage container: %v: %v", id, err2)
+			}
+		}
+	}()
 	g.AddAnnotation(annotations.MountPoint, mountPoint)
 
 	hostnamePath := fmt.Sprintf("%s/hostname", podContainer.RunDir)

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -49,6 +49,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 					gomock.Any()).Return(nil),
 				runtimeServerMock.EXPECT().StartContainer(gomock.Any()).
 					Return("", nil),
+				runtimeServerMock.EXPECT().StopContainer(gomock.Any()).
+					Return(nil),
 				runtimeServerMock.EXPECT().RemovePodSandbox(gomock.Any()).
 					Return(nil),
 			)


### PR DESCRIPTION
Backports https://github.com/cri-o/cri-o/pull/3588 and replaces the bot backport https://github.com/cri-o/cri-o/pull/3595

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```
