### PR TITLE
[release-1.17] Use proper variable for error return in Server#createSandboxContainer

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -207,7 +207,7 @@ func makeAccessible(path string, uid, gid int) error {
 }
 
 // nolint:gocyclo
-func (s *Server) createSandboxContainer(ctx context.Context, containerID, containerName string, sb *sandbox.Sandbox, sandboxConfig *pb.PodSandboxConfig, containerConfig *pb.ContainerConfig) (*oci.Container, error) {
+func (s *Server) createSandboxContainer(ctx context.Context, containerID, containerName string, sb *sandbox.Sandbox, sandboxConfig *pb.PodSandboxConfig, containerConfig *pb.ContainerConfig) (cntr *oci.Container, errRet error) {
 	if sb == nil {
 		return nil, errors.New("createSandboxContainer needs a sandbox")
 	}
@@ -373,7 +373,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	}
 
 	defer func() {
-		if err != nil {
+		if errRet != nil {
 			err2 := s.StorageRuntimeServer().DeleteContainer(containerInfo.ID)
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
In Server#createSandboxContainer, the deferred func calls DeleteContainer if there is error.
Subsequently, some error is not assigned to the error variable which is checked by the deferred func.

This PR names the error return and checks this error in deferred func.

#### Which issue(s) this PR fixes:

Fixes #3558


```release-note
None
```
