### PR TITLE
[WIP-Rebase] *: Add --pid-namespace=[container|pod|pod-container]

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -58,6 +58,7 @@ crio
 [--pause-command]=[value]
 [--pause-image-auth-file]=[value]
 [--pause-image]=[value]
+[--pid-namespace]=[value]
 [--pids-limit]=[value]
 [--pinns-path]=[value]
 [--profile-port]=[value]
@@ -243,6 +244,8 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 **--pause-image-auth-file**="": Path to a config file containing credentials for --pause-image (default: "")
 
 **--pids-limit**="": Maximum number of processes allowed in a container (default: 1024)
+
+**--pid-namespace**="": Select the PID namespace scope.  Choose from `container` for all containers (including pod infra containers) to have sibling PID namespaces (the default), `pod` for all containers to share a single, per-pod namespace, or `pod-container` to have the pod's infra container in one PID namespace with the non-infra containers in per-container PID namespaces that are children of the pod's infra PID namespace.  A `hostPID` Kubernetes pod specification overrides this setting.
 
 **--pinns-path**="": The path to find the pinns binary, which is needed to manage namespace lifecycle. Will be searched for in $PATH if empty (default: "")
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -171,6 +171,9 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **pids_limit**=1024
   Maximum number of processes allowed in a container.
 
+**pid_namespace**=""
+  Select the PID namespace scope.  Choose from `container` for all containers (including pod infra containers) to have sibling PID namespaces (the default), `pod` for all containers to share a single, per-pod namespace, or `pod-container` to have the pod's infra container in one PID namespace with the non-infra containers in per-container PID namespaces that are children of the pod's infra PID namespace.  A `hostPID` Kubernetes pod specification overrides this setting.
+
 **log_filter**=""
   Filter the log messages by the provided regular expression. This option supports live configuration reload. For example 'request:.*' filters all gRPC requests.
 

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -242,6 +242,9 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 	if ctx.IsSet("stream-tls-cert") {
 		config.StreamTLSCert = ctx.String("stream-tls-cert")
 	}
+	if ctx.IsSet("pid-namespace") {
+		config.PidNamespace = libconfig.PidNamespaceType(ctx.String("pid-namespace"))
+	}
 	if ctx.IsSet("stream-tls-key") {
 		config.StreamTLSKey = ctx.String("stream-tls-key")
 	}
@@ -715,6 +718,11 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 			Usage:     fmt.Sprintf("Path to the x509 certificate file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes (default: %q)", defConf.StreamTLSCert),
 			EnvVars:   []string{"CONTAINER_TLS_CERT"},
 			TakesFile: true,
+		},
+		&cli.StringFlag{
+			Name:      "pid-namespace",
+			Usage:     fmt.Sprintf("Select the PID namespace scope (\"container\" default, \"pod\", or \"pod-container\")"),
+			EnvVars:   []string{"CONTAINER_PID_NAMESPACE"},
 		},
 		&cli.StringFlag{
 			Name:      "stream-tls-key",

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -268,7 +268,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 
-	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, privileged, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], "", labels, m.Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, privileged, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}
@@ -412,7 +412,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, img, imgName, imgRef, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.Privileged(), sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], "", labels, m.Annotations, kubeAnnotations, img, imgName, imgRef, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.Privileged(), sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -45,6 +45,7 @@ type Container struct {
 	seccompProfilePath string
 	conmonCgroupfsPath string
 	labels             fields.Set
+	pidNamespace       string
 	annotations        fields.Set
 	crioAnnotations    fields.Set
 	state              *ContainerState
@@ -78,7 +79,7 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, image, imageName, imageRef string, metadata *pb.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce, privileged bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
+func NewContainer(id, name, bundlePath, logPath string, pidNamespace string, labels, crioAnnotations, annotations map[string]string, image, imageName, imageRef string, metadata *pb.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce, privileged bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
 	c := &Container{
@@ -87,6 +88,7 @@ func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations,
 		bundlePath:      bundlePath,
 		logPath:         logPath,
 		labels:          labels,
+		pidNamespace:    pidNamespace,
 		sandbox:         sandbox,
 		terminal:        terminal,
 		stdin:           stdin,

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -117,6 +117,9 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 	if r.config.NoPivot {
 		args = append(args, "--no-pivot")
 	}
+	if c.pidNamespace != "" {
+		args = append(args, "--pid-namespace", c.pidNamespace)
+	}
 	if c.terminal {
 		args = append(args, "-t")
 	} else if c.stdin {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,24 @@ const (
 	ImageVolumesBind ImageVolumesType = "bind"
 )
 
+// PIDNamespaceType describes pod PID namespace strategies.
+type PidNamespaceType string
+
+const (
+	// PIDNamespaceContainer is for all containers (including pod infra
+	// containers) to have sibling PID namespaces.
+	PidNamespaceContainer PidNamespaceType = "container"
+
+	// PIDNamespacePod is for all containers to share a single, per-pod
+	// namespace.
+	PidNamespacePod PidNamespaceType = "pod"
+
+	// PIDNamespacePodContainer is for the pod's infra container in one
+	// PID namespace with the non-infra container in per-container PID
+	// namespaces that are children of the pod's infra PID namespace.
+	PidNamespacePodContainer PidNamespaceType = "pod-container"
+)
+
 const (
 	// DefaultPidsLimit is the default value for maximum number of processes
 	// allowed inside a container
@@ -257,6 +275,16 @@ type RuntimeConfig struct {
 	// PidsLimit is the number of processes each container is restricted to
 	// by the cgroup process number controller.
 	PidsLimit int64 `toml:"pids_limit"`
+
+	// Select the PID namespace scope.  Choose from 'container' for all
+	// containers (including pod infra containers) to have sibling PID
+	// namespaces (the default), 'pod' for all containers to share a
+	// single, per-pod namespace, or 'pod-container' to have the pod's
+	// infra container in one PID namespace with the non-infra containers
+	// in per-container PID namespaces that are children of the pod's infra
+	// PID namespace .  A 'hostPID' Kubernetes pod specification overrides
+	// this setting.
+	PidNamespace PidNamespaceType `toml:"pid_namespace"`
 
 	// LogSizeMax is the maximum number of bytes after which the log file
 	// will be truncated. It can be expressed as a human-friendly string

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -47,7 +47,7 @@ func TestGetContainerInfo(t *testing.T) {
 		"io.kubernetes.test1": "value1",
 	}
 	getContainerFunc := func(id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", "", labels, annotations, annotations, "image", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -164,7 +164,7 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", "", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -195,7 +195,7 @@ func TestGetContainerInfoSandboxNotFound(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", "", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -466,7 +466,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation(annotations.HostnamePath, hostnamePath)
 	sb.AddHostnamePath(hostnamePath)
 
-	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, sb.Privileged(), sb.RuntimeHandler(), podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, "", labels, g.Config.Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, sb.Privileged(), sb.RuntimeHandler(), podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/test/namespaces.bats
+++ b/test/namespaces.bats
@@ -34,4 +34,28 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+
+
+	run crictl exec --sync "$pod_id" cat /proc/*/cmdline
+	echo "$output"
+	[ "$status" -eq 0 ]
+	if [ -n "${REDIS_IN_INFRA}" ]
+	then
+		[[ "$output" =~ "redis" ]]
+	else
+		! [[ "$output" =~ "redis" ]]
+	fi
+
+}
+
+@test "container pid namespace" {
+	ADDITIONAL_CRIO_OPTIONS=--pid-namespace=container pid_namespace_test
+}
+
+@test "pod pid namespace" {
+	ADDITIONAL_CRIO_OPTIONS=--pid-namespace=pod REDIS_IN_INFRA=1 EXPECTED_INIT=pause pid_namespace_test
+}
+
+@test "pod-container pid namespace" {
+	ADDITIONAL_CRIO_OPTIONS=--pid-namespace=pod-container REDIS_IN_INFRA=1 pid_namespace_test
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

So crio callers can pick their PID namespace approach.  This seems
like something that folks might want to configure per-pod, or possibly
even per-container, but for now follow --enable-shared-pid-namespace
and make it per-crio-daemon.

The "Deprecated:" paragraph approach in Go comments is recommended in
[1].

I tried to find a more compact form for the REDIS_IN_INFRA test, but:

* =~ is not in POSIX [2], so we need to use Bash's internal [[.
* '[ ! {expression} ]' is in POSIX [2], but Bash's [[ seems to look
  for ! before doing variable expansion.

Because of those, we can't use POSIX's ${parameter:+word} [3]:

  NOT="!"
  [[ ${REDIS_IN_INFRA:+${NOT}} "$output" =~ "redis" ]]

and the best alternative I can find is the if/else that I've gone with
in this commit.

The ADDITIONAL_CRIO_OPTIONS approach is easier to maintain than the
old approach with settings for every option, because we no longer need
to maintain defaults in two locations (lib/config.go and
test/helpers.bash).  For this commit, I've only dropped
ENABLE_SHARED_PID_NAMESPACE, but we may want to extend this approach
to more variables in the future.

PIDNamespaceType follows the ImageVolumes pattern at Mrunal's
recommendation [4].

[1]: https://blog.golang.org/godoc-documenting-go-code
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html
[3]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02
[4]: #1280 (comment)

Based on: https://github.com/cri-o/cri-o/pull/1280/

Signed-off-by: W. Trevor King <wking@tremily.us>
Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>