### PR TITLE
Fix naming unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ BASE_LDFLAGS = ${SHRINKFLAGS} \
 	-X ${PROJECT}/internal/pkg/criocli.DefaultsPath=${DEFAULTS_PATH} \
 	-X ${PROJECT}/internal/version.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 	-X ${PROJECT}/internal/version.gitCommit=${COMMIT_NO} \
-	-X ${PROJECT}/internal/version.gitTreeState=${GIT_TREE_STATE} \
+	-X ${PROJECT}/internal/version.gitTreeState=${GIT_TREE_STATE}
 
 LDFLAGS = -ldflags '${BASE_LDFLAGS} ${EXTRA_LDFLAGS}'
 

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -97,7 +97,7 @@ func TestParseVersionBadVersion(t *testing.T) {
 }
 
 func TestParseVersionWithCurrentVersion(t *testing.T) {
-	_, err := parseVersionConstant("1.17.0", "")
+	_, err := parseVersionConstant(Version, "")
 	must(t, err)
 }
 

--- a/server/naming_test.go
+++ b/server/naming_test.go
@@ -9,7 +9,10 @@ import (
 // The actual test suite
 var _ = t.Describe("Server", func() {
 	// Prepare the sut
-	BeforeEach(beforeEach)
+	BeforeEach(func() {
+		beforeEach()
+		setupSUT()
+	})
 	AfterEach(afterEach)
 
 	t.Describe("ReserveSandboxContainerIDAndName", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind failing-test

#### What this PR does / why we need it:
By using the right before-each function.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
