### PR TITLE
Add info logs where needed and check for context erroring

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -546,6 +547,13 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	if sb.Stopped() {
 		return nil, fmt.Errorf("CreateContainer failed as the sandbox was stopped: %v", sbID)
 	}
+
+	defer func() {
+		if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
+			log.Infof(ctx, "createCtr: context was either canceled or the deadline was exceeded: %v", ctx.Err())
+			debug.PrintStack()
+		}
+	}()
 
 	ctr := container.New(ctx)
 	if err := ctr.SetConfig(req.GetConfig()); err != nil {

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -562,6 +562,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "createCtr: releasing container name %s", ctr.Name())
 			s.ReleaseContainerName(ctr.Name())
 		}
 	}()
@@ -572,6 +573,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "createCtr: deleting container %s from storage", ctr.ID())
 			err2 := s.StorageRuntimeServer().DeleteContainer(ctr.ID())
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
@@ -582,6 +584,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	s.addContainer(newContainer)
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "createCtr: removing container %s", newContainer.ID())
 			s.removeContainer(newContainer)
 		}
 	}()
@@ -591,6 +594,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "createCtr: deleting container ID %s from idIndex", ctr.ID())
 			if err2 := s.CtrIDIndex().Delete(ctr.ID()); err2 != nil {
 				log.Warnf(ctx, "couldn't delete ctr id %s from idIndex", ctr.ID())
 			}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -418,6 +418,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 
 	defer func() {
 		if errRet != nil {
+			log.Infof(ctx, "createCtrLinux: deleting container %s from storage", containerInfo.ID)
 			err2 := s.StorageRuntimeServer().DeleteContainer(containerInfo.ID)
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
@@ -846,6 +847,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	}
 	defer func() {
 		if errRet != nil {
+			log.Infof(ctx, "createCtrLinux: stopping storage container %s", containerID)
 			if err := s.StorageRuntimeServer().StopContainer(containerID); err != nil {
 				log.Warnf(ctx, "couldn't stop storage container: %v: %v", containerID, err)
 			}

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -11,6 +11,7 @@ import (
 // RemoveContainer removes the container. If the container is running, the container
 // should be force removed.
 func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (resp *pb.RemoveContainerResponse, err error) {
+	log.Infof(ctx, "Attempting to remove container: %s", req.GetContainerId())
 	// save container description to print
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -10,6 +10,7 @@ import (
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
 func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest) (resp *pb.StopContainerResponse, err error) {
+	log.Infof(ctx, "Attempting to stop container: %s", req.GetContainerId())
 	// save container description to print
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -34,6 +34,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 	// but an error happened between plugin success and the end of networkStart()
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "networkStart: stopping network for sandbox %s", sb.ID())
 			if err2 := s.networkStop(ctx, sb); err2 != nil {
 				log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
 			}

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -16,6 +16,7 @@ import (
 // RemovePodSandbox deletes the sandbox. If there are any running containers in the
 // sandbox, they should be force deleted.
 func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxRequest) (resp *pb.RemovePodSandboxResponse, err error) {
+	log.Infof(ctx, "Attempting to remove pod sandbox: %s", req.GetPodSandboxId())
 	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
 	if err != nil {
 		if err == sandbox.ErrIDEmpty {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -68,6 +68,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: releasing pod sandbox name: %s", sbox.Name())
 			s.ReleasePodName(sbox.Name())
 		}
 	}()
@@ -78,6 +79,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: releasing container name: %s", containerName)
 			s.ReleaseContainerName(containerName)
 		}
 	}()
@@ -112,6 +114,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: removing pod sandbox from storage: %s", sbox.ID())
 			if err2 := s.StorageRuntimeServer().RemovePodSandbox(sbox.ID()); err2 != nil {
 				log.Warnf(ctx, "couldn't cleanup pod sandbox %q: %v", sbox.ID(), err2)
 			}
@@ -259,6 +262,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		pathsToChown = append(pathsToChown, shmPath)
 		defer func() {
 			if err != nil {
+				log.Infof(ctx, "runSandbox: unmounting shmPath for sandbox %s", sbox.ID())
 				if err2 := unix.Unmount(shmPath, unix.MNT_DETACH); err2 != nil {
 					log.Warnf(ctx, "failed to unmount shm for pod: %v", err2)
 				}
@@ -286,6 +290,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: deleting container ID from idIndex for sandbox %s", sbox.ID())
 			if err2 := s.CtrIDIndex().Delete(sbox.ID()); err2 != nil {
 				log.Warnf(ctx, "couldn't delete ctr id %s from idIndex", sbox.ID())
 			}
@@ -386,6 +391,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: removing pod sandbox %s", sbox.ID())
 			if err := s.removeSandbox(sbox.ID()); err != nil {
 				log.Warnf(ctx, "could not remove pod sandbox: %v", err)
 			}
@@ -398,6 +404,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: deleting pod ID %s from idIndex", sbox.ID())
 			if err := s.PodIDIndex().Delete(sbox.ID()); err != nil {
 				log.Warnf(ctx, "couldn't delete pod id %s from idIndex", sbox.ID())
 			}
@@ -431,6 +438,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	for idx := range cleanupFuncs {
 		defer func(currentFunc int) {
 			if err != nil {
+				log.Infof(ctx, "runSandbox: cleaning up namespaces after failing to run sandbox %s", sbox.ID())
 				if err2 := cleanupFuncs[currentFunc](); err2 != nil {
 					log.Debugf(ctx, err2.Error())
 				}
@@ -452,6 +460,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: stopping storage container for sandbox %s", sbox.ID())
 			if err2 := s.StorageRuntimeServer().StopContainer(sbox.ID()); err2 != nil {
 				log.Warnf(ctx, "couldn't stop storage container: %v: %v", sbox.ID(), err2)
 			}
@@ -551,6 +560,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 		defer func() {
 			if err != nil {
+				log.Infof(ctx, "runSandbox: in manageNSLifecycle, stopping network for sandbox %s", sb.ID())
 				if err2 := s.networkStop(ctx, sb); err2 != nil {
 					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
 				}
@@ -584,6 +594,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	s.addInfraContainer(container)
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: removing infra container %s", container.ID())
 			s.removeInfraContainer(container)
 		}
 	}()
@@ -608,16 +619,18 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	defer func() {
 		if err != nil {
 			// Clean-up steps from RemovePodSanbox
-			timeout := int64(10)
-			if err2 := s.Runtime().StopContainer(ctx, container, timeout); err2 != nil {
+			log.Infof(ctx, "runSandbox: stopping container %s", container.ID())
+			if err2 := s.Runtime().StopContainer(ctx, container, int64(10)); err2 != nil {
 				log.Warnf(ctx, "failed to stop container %s: %v", container.Name(), err2)
 			}
 			if err2 := s.Runtime().WaitContainerStateStopped(ctx, container); err2 != nil {
 				log.Warnf(ctx, "failed to get container 'stopped' status %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
 			}
+			log.Infof(ctx, "runSandbox: deleting container %s", container.ID())
 			if err2 := s.Runtime().DeleteContainer(container); err2 != nil {
 				log.Warnf(ctx, "failed to delete container %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
 			}
+			log.Infof(ctx, "runSandbox: writing container %s state to disk", container.ID())
 			if err2 := s.ContainerStateToDisk(container); err2 != nil {
 				log.Warnf(ctx, "failed to write container state %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
 			}
@@ -635,6 +648,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 		defer func() {
 			if err != nil {
+				log.Infof(ctx, "runSandbox: in not manageNSLifecycle, stopping network for sandbox %s", sb.ID())
 				if err2 := s.networkStop(ctx, sb); err2 != nil {
 					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
 				}

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -16,6 +16,7 @@ import (
 )
 
 func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxRequest) (resp *pb.StopPodSandboxResponse, err error) {
+	log.Infof(ctx, "Attempting to stop pod sandbox: %s", req.GetPodSandboxId())
 	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
 	if err != nil {
 		if err == sandbox.ErrIDEmpty {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind cleanup

#### What this PR does / why we need it:
Add info logs to all the defers in container and sandbox create.
Add logs for when we get a request from kubelet to stop and remove
a container and sandbox.
And Check for context erroring before returning from longer requests
The kubelet times out on the create request but crio doesn't error out
when kubelet client times out. So, we end up with the pod being created
and then kubelet keeps on trying to create the pod again and it can't
since the name is reserved.
With the change, we error out on timeouts so the pod creation fails and
the name is unreserved so later attempts by the kubelet to create a pod
or container may succeed.


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>