### PR TITLE
Allow comma separated string slice parsing

### DIFF
--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -8,6 +8,7 @@ import (
 
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -87,13 +88,13 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 		config.Storage = ctx.String("storage-driver")
 	}
 	if ctx.IsSet("storage-opt") {
-		config.StorageOptions = ctx.StringSlice("storage-opt")
+		config.StorageOptions = StringSliceTrySplit(ctx, "storage-opt")
 	}
 	if ctx.IsSet("insecure-registry") {
-		config.InsecureRegistries = ctx.StringSlice("insecure-registry")
+		config.InsecureRegistries = StringSliceTrySplit(ctx, "insecure-registry")
 	}
 	if ctx.IsSet("registry") {
-		config.Registries = ctx.StringSlice("registry")
+		config.Registries = StringSliceTrySplit(ctx, "registry")
 	}
 	if ctx.IsSet("default-transport") {
 		config.DefaultTransport = ctx.String("default-transport")
@@ -116,7 +117,7 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 	}
 
 	if ctx.IsSet("runtimes") {
-		runtimes := ctx.StringSlice("runtimes")
+		runtimes := StringSliceTrySplit(ctx, "runtimes")
 		for _, r := range runtimes {
 			fields := strings.Split(r, ":")
 			if len(fields) != 3 {
@@ -144,19 +145,19 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 		config.ConmonCgroup = ctx.String("conmon-cgroup")
 	}
 	if ctx.IsSet("hooks-dir") {
-		config.HooksDir = ctx.StringSlice("hooks-dir")
+		config.HooksDir = StringSliceTrySplit(ctx, "hooks-dir")
 	}
 	if ctx.IsSet("default-mounts-file") {
 		config.DefaultMountsFile = ctx.String("default-mounts-file")
 	}
 	if ctx.IsSet("default-capabilities") {
-		config.DefaultCapabilities = ctx.StringSlice("default-capabilities")
+		config.DefaultCapabilities = StringSliceTrySplit(ctx, "default-capabilities")
 	}
 	if ctx.IsSet("default-sysctls") {
-		config.DefaultSysctls = ctx.StringSlice("default-sysctls")
+		config.DefaultSysctls = StringSliceTrySplit(ctx, "default-sysctls")
 	}
 	if ctx.IsSet("default-ulimits") {
-		config.DefaultUlimits = ctx.StringSlice("default-ulimits")
+		config.DefaultUlimits = StringSliceTrySplit(ctx, "default-ulimits")
 	}
 	if ctx.IsSet("pids-limit") {
 		config.PidsLimit = ctx.Int64("pids-limit")
@@ -174,7 +175,7 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 		config.NetworkDir = ctx.String("cni-config-dir")
 	}
 	if ctx.IsSet("cni-plugin-dir") {
-		config.PluginDirs = ctx.StringSlice("cni-plugin-dir")
+		config.PluginDirs = StringSliceTrySplit(ctx, "cni-plugin-dir")
 	}
 	if ctx.IsSet("image-volumes") {
 		config.ImageVolumes = libconfig.ImageVolumesType(ctx.String("image-volumes"))
@@ -201,13 +202,13 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 		config.LogDir = ctx.String("log-dir")
 	}
 	if ctx.IsSet("additional-devices") {
-		config.AdditionalDevices = ctx.StringSlice("additional-devices")
+		config.AdditionalDevices = StringSliceTrySplit(ctx, "additional-devices")
 	}
 	if ctx.IsSet("conmon-env") {
-		config.ConmonEnv = ctx.StringSlice("conmon-env")
+		config.ConmonEnv = StringSliceTrySplit(ctx, "conmon-env")
 	}
 	if ctx.IsSet("default-env") {
-		config.DefaultEnv = ctx.StringSlice("default-env")
+		config.DefaultEnv = StringSliceTrySplit(ctx, "default-env")
 	}
 	if ctx.IsSet("container-attach-socket-dir") {
 		config.ContainerAttachSocketDir = ctx.String("container-attach-socket-dir")
@@ -747,4 +748,29 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 			TakesFile: true,
 		},
 	}
+}
+
+// StringSliceTrySplit parses the string slice from the CLI context.
+// If the parsing returns just a single item, then we try to parse them by `,`
+// to allow users to provide their flags comma separated.
+func StringSliceTrySplit(ctx *cli.Context, name string) []string {
+	values := ctx.StringSlice(name)
+	separator := ","
+
+	// It looks like we only parsed one item, let's see if there are more
+	if len(values) == 1 && strings.Contains(values[0], separator) {
+		values = strings.Split(values[0], separator)
+
+		// Trim whitespace
+		for i := range values {
+			values[i] = strings.TrimSpace(values[i])
+		}
+
+		logrus.Infof(
+			"Parsed commma separated CLI flag %q into dedicated values %v",
+			name, values,
+		)
+	}
+
+	return values
 }

--- a/internal/criocli/criocli_test.go
+++ b/internal/criocli/criocli_test.go
@@ -1,0 +1,49 @@
+package criocli_test
+
+import (
+	"flag"
+
+	"github.com/cri-o/cri-o/internal/criocli"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/urfave/cli/v2"
+)
+
+// The actual test suite
+var _ = t.Describe("CLI", func() {
+
+	const flagName = "flag"
+
+	var (
+		slice *cli.StringSlice
+		ctx   *cli.Context
+	)
+
+	BeforeEach(func() {
+		flagSet := flag.NewFlagSet(flagName, flag.ExitOnError)
+		slice = cli.NewStringSlice()
+		flagSet.Var(slice, flagName, "")
+		ctx = cli.NewContext(nil, flagSet, nil)
+	})
+
+	DescribeTable("should parse comma separated flags", func(values ...string) {
+		// Given
+		for _, v := range values {
+			Expect(slice.Set(v)).To(BeNil())
+		}
+
+		// When
+		res := criocli.StringSliceTrySplit(ctx, flagName)
+
+		// Then
+		Expect(res).NotTo(BeNil())
+		Expect(res).To(HaveLen(3))
+		Expect(res).To(ContainElements("a", "b", "c"))
+	},
+		Entry("dense", "a,b,c"),
+		Entry("trim", "   a   , b   ,    c"),
+		Entry("separated", "a", "b", "c"),
+	)
+
+})

--- a/internal/criocli/suite_test.go
+++ b/internal/criocli/suite_test.go
@@ -1,0 +1,26 @@
+package criocli_test
+
+import (
+	"testing"
+
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestLib runs the created specs
+func TestLibConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "CLIConfig")
+}
+
+var t *TestFramework
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
The string slice parser of urfave/cli takes arguments like this:
`--flag value1 --flag value2`. We now re-add the removed behavior to
parse comma separated values like `--flag value1,value2` as a fallback
to the current one.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Re-add the behavior that string slices can be passed to the CLI comma separated, for example `--default-capabilities CHOWN,KILL`
```
