### PR TITLE
Use correct upload URL for binary uploads

### DIFF
--- a/scripts/upload-artifacts
+++ b/scripts/upload-artifacts
@@ -20,12 +20,15 @@ if TAG=$(git describe --exact-match --tags 2>/dev/null); then
     if [[ -z $GITHUB_TOKEN ]]; then
         echo GITHUB_TOKEN not set, skipping artifact upload to GitHub
     else
+        UPLOAD_URL=$(curl -sfL https://api.github.com/repos/cri-o/cri-o/releases |
+            jq -r ".[] | select(.tag_name == \"$TAG\") | .upload_url")
+        UPLOAD_URL=${UPLOAD_URL%"{?name,label}"}
         FILE=build/bundle/crio-$TAG.tar.gz
         curl -f \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Content-Type: $(file -b --mime-type "$FILE")" \
             --data-binary @"$FILE" \
-            "https://uploads.github.com/repos/cri-o/cri-o/releases/$TAG/assets?name=$(basename "$FILE")"
+            "$UPLOAD_URL?name=$(basename "$FILE")"
     fi
 else
     echo "Skipping artifact upload to GitHub (not on a tag)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The upload URL has to be retrieved before doing an upload to GitHub.
With this fix we will do this now.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
