### PR TITLE
Obtain lock before storing decoded state

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -141,6 +141,7 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err erro
 
 	select {
 	case err = <-createdCh:
+		f.Close()
 		if err != nil {
 			return errors.Errorf("CreateContainer failed: %v", err)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR adds locking around the state decoding in Container#FromDisk

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
