### PR TITLE
[1.16] Add info logs where needed

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -377,6 +377,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 
 	defer func() {
 		if errRet != nil {
+			log.Infof(ctx, "createCtrLinux: deleting container %s from storage", containerInfo.ID)
 			err2 := s.StorageRuntimeServer().DeleteContainer(containerInfo.ID)
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
@@ -796,6 +797,14 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount container %s(%s): %v", containerName, containerID, err)
 	}
+	defer func() {
+		if errRet != nil {
+			log.Infof(ctx, "createCtrLinux: stopping storage container %s", containerID)
+			if err := s.StorageRuntimeServer().StopContainer(containerID); err != nil {
+				log.Warnf(ctx, "couldn't stop storage container: %v: %v", containerID, err)
+			}
+		}
+	}()
 	specgen.AddAnnotation(annotations.MountPoint, mountPoint)
 
 	if containerImageConfig.Config.StopSignal != "" {

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -11,6 +11,8 @@ import (
 // RemoveContainer removes the container. If the container is running, the container
 // should be force removed.
 func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (resp *pb.RemoveContainerResponse, err error) {
+	log.Infof(ctx, "Attempting to remove container: %s", req.GetContainerId())
+
 	const operation = "remove_container"
 	defer func() {
 		recordOperation(operation, time.Now())

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -10,6 +10,8 @@ import (
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
 func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest) (resp *pb.StopContainerResponse, err error) {
+	log.Infof(ctx, "Attempting to stop container: %s", req.GetContainerId())
+
 	const operation = "stop_container"
 	defer func() {
 		recordOperation(operation, time.Now())

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -35,7 +35,8 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 	// but an error happened between plugin success and the end of networkStart()
 	defer func() {
 		if err != nil {
-			if err2 := s.networkStop(startCtx, sb); err2 != nil {
+			log.Infof(ctx, "networkStart: stopping network for sandbox %s", sb.ID())
+			if err2 := s.networkStop(ctx, sb); err2 != nil {
 				log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
 			}
 		}

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -19,6 +19,8 @@ import (
 // RemovePodSandbox deletes the sandbox. If there are any running containers in the
 // sandbox, they should be force deleted.
 func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxRequest) (resp *pb.RemovePodSandboxResponse, err error) {
+	log.Infof(ctx, "Attempting to remove pod sandbox: %s", req.GetPodSandboxId())
+
 	const operation = "remove_pod_sandbox"
 	defer func() {
 		recordOperation(operation, time.Now())

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -58,6 +58,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	// we need to fill in the container name, as it is not present in the request. Luckily, it is a constant.
 	log.Infof(ctx, "attempting to run pod sandbox with infra container: %s%s", translateLabelsToDescription(req.GetConfig().GetLabels()), leaky.PodInfraContainerName)
+
 	var processLabel, mountLabel, resolvPath string
 	// process req.Name
 	kubeName := req.GetConfig().GetMetadata().GetName()
@@ -74,6 +75,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: releasing pod sandbox name: %s", name)
 			s.ReleasePodName(name)
 		}
 	}()
@@ -84,6 +86,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: releasing container name: %s", containerName)
 			s.ReleaseContainerName(containerName)
 		}
 	}()
@@ -117,6 +120,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: removing pod sandbox from storage: %s", id)
 			if err2 := s.StorageRuntimeServer().RemovePodSandbox(id); err2 != nil {
 				log.Warnf(ctx, "couldn't cleanup pod sandbox %q: %v", id, err2)
 			}
@@ -263,6 +267,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		pathsToChown = append(pathsToChown, shmPath)
 		defer func() {
 			if err != nil {
+				log.Infof(ctx, "runSandbox: unmounting shmPath for sandbox %s", id)
 				if err2 := unix.Unmount(shmPath, unix.MNT_DETACH); err2 != nil {
 					log.Warnf(ctx, "failed to unmount shm for pod: %v", err2)
 				}
@@ -290,6 +295,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: deleting container ID from idIndex for sandbox %s", id)
 			if err2 := s.CtrIDIndex().Delete(id); err2 != nil {
 				log.Warnf(ctx, "couldn't delete ctr id %s from idIndex", id)
 			}
@@ -390,6 +396,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: removing pod sandbox %s", id)
 			if err := s.removeSandbox(id); err != nil {
 				log.Warnf(ctx, "could not remove pod sandbox: %v", err)
 			}
@@ -402,6 +409,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: deleting pod ID %s from idIndex", id)
 			if err := s.PodIDIndex().Delete(id); err != nil {
 				log.Warnf(ctx, "couldn't delete pod id %s from idIndex", id)
 			}
@@ -457,6 +465,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 				return
 			}
 
+			log.Infof(ctx, "runSandbox: cleaning up namespaces after failing to run sandbox %s", id)
 			if netnsErr := sb.NetNsRemove(); netnsErr != nil {
 				log.Warnf(ctx, "Failed to remove networking namespace: %v", netnsErr)
 			}
@@ -494,6 +503,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: stopping storage container for sandbox %s", id)
 			if err2 := s.StorageRuntimeServer().StopContainer(id); err2 != nil {
 				log.Warnf(ctx, "couldn't stop storage container: %v: %v", id, err2)
 			}
@@ -585,6 +595,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 		defer func() {
 			if err != nil {
+				log.Infof(ctx, "runSandbox: in manageNSLifecycle, stopping network for sandbox %s", sb.ID())
 				if err2 := s.networkStop(ctx, sb); err2 != nil {
 					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
 				}
@@ -618,6 +629,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	s.addInfraContainer(container)
 	defer func() {
 		if err != nil {
+			log.Infof(ctx, "runSandbox: removing infra container %s", container.ID())
 			s.removeInfraContainer(container)
 		}
 	}()
@@ -643,16 +655,18 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	defer func() {
 		if err != nil {
 			// Clean-up steps from RemovePodSanbox
-			timeout := int64(10)
-			if err2 := s.Runtime().StopContainer(ctx, container, timeout); err2 != nil {
+			log.Infof(ctx, "runSandbox: stopping container %s", container.ID())
+			if err2 := s.Runtime().StopContainer(ctx, container, int64(10)); err2 != nil {
 				log.Warnf(ctx, "failed to stop container %s: %v", container.Name(), err2)
 			}
 			if err2 := s.Runtime().WaitContainerStateStopped(ctx, container); err2 != nil {
 				log.Warnf(ctx, "failed to get container 'stopped' status %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
 			}
+			log.Infof(ctx, "runSandbox: deleting container %s", container.ID())
 			if err2 := s.Runtime().DeleteContainer(container); err2 != nil {
 				log.Warnf(ctx, "failed to delete container %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
 			}
+			log.Infof(ctx, "runSandbox: writing container %s state to disk", container.ID())
 			if err2 := s.ContainerStateToDisk(container); err2 != nil {
 				log.Warnf(ctx, "failed to write container state %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
 			}
@@ -670,6 +684,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 		defer func() {
 			if err != nil {
+				log.Infof(ctx, "runSandbox: in not manageNSLifecycle, stopping network for sandbox %s", sb.ID())
 				if err2 := s.networkStop(ctx, sb); err2 != nil {
 					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
 				}
@@ -681,6 +696,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	sb.SetCreated()
 
 	if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
+		log.Infof(ctx, "runSandbox: context was either canceled or the deadline was exceeded: %v", ctx.Err())
 		return nil, ctx.Err()
 	}
 

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -20,6 +20,8 @@ import (
 )
 
 func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxRequest) (resp *pb.StopPodSandboxResponse, err error) {
+	log.Infof(ctx, "Attempting to stop pod sandbox: %s", req.GetPodSandboxId())
+
 	const operation = "stop_pod_sandbox"
 	defer func() {
 		recordOperation(operation, time.Now())


### PR DESCRIPTION



<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:
Add info logs to all the defers in container and sandbox create.
Add logs for when we get a request from kubelet to stop and remove
a container and sandbox.
And add a storage stop container in container create as a defer so
we clean up if we fail to start the container.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>