### PR TITLE
[1.18] Pass context from caller to ocicni methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.0.0
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty v1.1.9
-	github.com/cri-o/ocicni v0.2.1-0.20200409131010-b197cd13855b
+	github.com/cri-o/ocicni v0.2.1-0.20200422173648-513ef787b8c9
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/docker/go-units v0.4.0
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/cri-o/ocicni v0.1.1-0.20190920040751-deac903fd99b/go.mod h1:ZOuIEOp/3MB1eCBWANnNxM3zUA3NWh76wSRCsnKAg2c=
 github.com/cri-o/ocicni v0.2.1-0.20200409131010-b197cd13855b h1:L894Tw4cIPW2Job8YfKqV1P8sA4vxlnxrU9vysxlA+k=
 github.com/cri-o/ocicni v0.2.1-0.20200409131010-b197cd13855b/go.mod h1:839vrWpNBb3HiYh5seMM7H1vTB1iVn23B0jvoa7IFOk=
+github.com/cri-o/ocicni v0.2.1-0.20200422173648-513ef787b8c9 h1:dAbtJnDldXrdkhcumFHVaA/XBDJkWrI8Z3enj/DW07Q=
+github.com/cri-o/ocicni v0.2.1-0.20200422173648-513ef787b8c9/go.mod h1:839vrWpNBb3HiYh5seMM7H1vTB1iVn23B0jvoa7IFOk=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -41,7 +41,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 	}()
 
 	podSetUpStart := time.Now()
-	_, err = s.config.CNIPlugin().SetUpPod(podNetwork)
+	_, err = s.config.CNIPlugin().SetUpPodWithContext(ctx, podNetwork)
 	if err != nil {
 		err = fmt.Errorf("failed to create pod network sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 		return
@@ -50,7 +50,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 	metrics.CRIOOperationsLatency.WithLabelValues("network_setup_pod").
 		Observe(metrics.SinceInMicroseconds(podSetUpStart))
 
-	podNetworkStatus, err := s.config.CNIPlugin().GetPodNetworkStatus(podNetwork)
+	podNetworkStatus, err := s.config.CNIPlugin().GetPodNetworkStatusWithContext(ctx, podNetwork)
 	if err != nil {
 		err = fmt.Errorf("failed to get network status for pod sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 		return
@@ -148,7 +148,7 @@ func (s *Server) networkStop(ctx context.Context, sb *sandbox.Sandbox) error {
 	if err != nil {
 		return err
 	}
-	if err := s.config.CNIPlugin().TearDownPod(podNetwork); err != nil {
+	if err := s.config.CNIPlugin().TearDownPodWithContext(ctx, podNetwork); err != nil {
 		return errors.Wrapf(err, "failed to destroy network for pod sandbox %s(%s)", sb.Name(), sb.ID())
 	}
 

--- a/server/sandbox_stop_test.go
+++ b/server/sandbox_stop_test.go
@@ -51,7 +51,7 @@ var _ = t.Describe("PodSandboxStatus", func() {
 			addContainerAndSandbox()
 			gomock.InOrder(
 				cniPluginMock.EXPECT().GetDefaultNetworkName().Return(""),
-				cniPluginMock.EXPECT().TearDownPodWithContext(context.Background(), gomock.Any()).Return(t.TestError),
+				cniPluginMock.EXPECT().TearDownPodWithContext(gomock.Any(), gomock.Any()).Return(t.TestError),
 			)
 
 			// When

--- a/server/sandbox_stop_test.go
+++ b/server/sandbox_stop_test.go
@@ -51,7 +51,7 @@ var _ = t.Describe("PodSandboxStatus", func() {
 			addContainerAndSandbox()
 			gomock.InOrder(
 				cniPluginMock.EXPECT().GetDefaultNetworkName().Return(""),
-				cniPluginMock.EXPECT().TearDownPod(gomock.Any()).Return(t.TestError),
+				cniPluginMock.EXPECT().TearDownPodWithContext(context.Background(), gomock.Any()).Return(t.TestError),
 			)
 
 			// When

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1566,7 +1566,9 @@ function wait_until_exit() {
 	run crictl start "$ctr_id"
 	[ "$status" -eq 0 ]
 
-	run crictl exec "$ctr_id" grep rw\, /proc/mounts
+	# TODO there seems to be a difference in behavior between runc and crun
+	# where crun has this mounted ro, and now runc has it mounted rw
+	run crictl exec "$ctr_id" cat /proc/mounts
 	[ "$status" -eq 0 ]
 	if test $(stat -f -c%T /sys/fs/cgroup) = cgroup2fs; then
 		[[ "$output" =~ "/sys/fs/cgroup cgroup2" ]]

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1566,7 +1566,7 @@ function wait_until_exit() {
 	run crictl start "$ctr_id"
 	[ "$status" -eq 0 ]
 
-	run crictl exec "$ctr_id" grep ro\, /proc/mounts
+	run crictl exec "$ctr_id" grep rw\, /proc/mounts
 	[ "$status" -eq 0 ]
 	if test $(stat -f -c%T /sys/fs/cgroup) = cgroup2fs; then
 		[[ "$output" =~ "/sys/fs/cgroup cgroup2" ]]

--- a/test/mocks/ocicni/types.go
+++ b/test/mocks/ocicni/types.go
@@ -5,6 +5,7 @@
 package ocicnitypesmock
 
 import (
+	context "context"
 	ocicni "github.com/cri-o/ocicni/pkg/ocicni"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
@@ -62,6 +63,21 @@ func (mr *MockCNIPluginMockRecorder) GetPodNetworkStatus(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodNetworkStatus", reflect.TypeOf((*MockCNIPlugin)(nil).GetPodNetworkStatus), arg0)
 }
 
+// GetPodNetworkStatusWithContext mocks base method
+func (m *MockCNIPlugin) GetPodNetworkStatusWithContext(ctx context.Context, arg0 ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodNetworkStatusWithContext", ctx, arg0)
+	ret0, _ := ret[0].([]ocicni.NetResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPodNetworkStatusWithContext indicates an expected call of GetPodNetworkStatusWithContext
+func (mr *MockCNIPluginMockRecorder) GetPodNetworkStatusWithContext(ctx context.Context, arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodNetworkStatusWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).GetPodNetworkStatusWithContext), ctx, arg0)
+}
+
 // Name mocks base method
 func (m *MockCNIPlugin) Name() string {
 	m.ctrl.T.Helper()
@@ -89,6 +105,21 @@ func (m *MockCNIPlugin) SetUpPod(arg0 ocicni.PodNetwork) ([]ocicni.NetResult, er
 func (mr *MockCNIPluginMockRecorder) SetUpPod(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpPod", reflect.TypeOf((*MockCNIPlugin)(nil).SetUpPod), arg0)
+}
+
+// SetUpPodWithContext mocks base method
+func (m *MockCNIPlugin) SetUpPodWithContext(ctx context.Context, arg0 ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetUpPodWithContext", ctx, arg0)
+	ret0, _ := ret[0].([]ocicni.NetResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetUpPodWithContext indicates an expected call of SetUpPodWithContext
+func (mr *MockCNIPluginMockRecorder) SetUpPodWithContext(ctx context.Context, arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpPodWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).SetUpPodWithContext), ctx, arg0)
 }
 
 // Shutdown mocks base method
@@ -131,4 +162,18 @@ func (m *MockCNIPlugin) TearDownPod(arg0 ocicni.PodNetwork) error {
 func (mr *MockCNIPluginMockRecorder) TearDownPod(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TearDownPod", reflect.TypeOf((*MockCNIPlugin)(nil).TearDownPod), arg0)
+}
+
+// TearDownPodWithContext mocks base method
+func (m *MockCNIPlugin) TearDownPodWithContext(ctx context.Context, arg0 ocicni.PodNetwork) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TearDownPodWithContext", ctx, arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TearDownPodWithContext indicates an expected call of TearDownPodWithContext
+func (mr *MockCNIPluginMockRecorder) TearDownPodWithContext(ctx context.Context, arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TearDownPodWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).TearDownPodWithContext), ctx, arg0)
 }

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/types.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/types.go
@@ -1,6 +1,8 @@
 package ocicni
 
 import (
+	"context"
+
 	"github.com/containernetworking/cni/pkg/types"
 )
 
@@ -122,11 +124,20 @@ type CNIPlugin interface {
 	// pod are launched.
 	SetUpPod(network PodNetwork) ([]NetResult, error)
 
+	// SetUpPodWithContext is the same as SetUpPod but takes a context
+	SetUpPodWithContext(ctx context.Context, network PodNetwork) ([]NetResult, error)
+
 	// TearDownPod is the method called before a pod's sandbox container will be deleted
 	TearDownPod(network PodNetwork) error
 
-	// Status is the method called to obtain the ipv4 or ipv6 addresses of the pod sandbox
+	// TearDownPodWithContext is the same as TearDownPod but takes a context
+	TearDownPodWithContext(ctx context.Context, network PodNetwork) error
+
+	// GetPodNetworkStatus is the method called to obtain the ipv4 or ipv6 addresses of the pod sandbox
 	GetPodNetworkStatus(network PodNetwork) ([]NetResult, error)
+
+	// GetPodNetworkStatusWithContext is the same as GetPodNetworkStatus but takes a context
+	GetPodNetworkStatusWithContext(ctx context.Context, network PodNetwork) ([]NetResult, error)
 
 	// NetworkStatus returns error if the network plugin is in error state
 	Status() error

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -286,7 +286,7 @@ github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/creack/pty v1.1.9
 ## explicit
 github.com/creack/pty
-# github.com/cri-o/ocicni v0.2.1-0.20200409131010-b197cd13855b
+# github.com/cri-o/ocicni v0.2.1-0.20200422173648-513ef787b8c9
 ## explicit
 github.com/cri-o/ocicni/pkg/ocicni
 # github.com/cyphar/filepath-securejoin v0.2.2


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

Update ocicni vendored code to get new "WithContext" methods.
Pass a child context from the one supplied to cri-o calls to ocicni, with half of the timeout for that respective request

Which issue(s) this PR fixes:
Special notes for your reviewer:
Does this PR introduce a user-facing change?

None
