### PR TITLE
[1.18] Fix CI by re-generating mocks

### DIFF
--- a/test/mocks/ocicni/types.go
+++ b/test/mocks/ocicni/types.go
@@ -64,18 +64,18 @@ func (mr *MockCNIPluginMockRecorder) GetPodNetworkStatus(arg0 interface{}) *gomo
 }
 
 // GetPodNetworkStatusWithContext mocks base method
-func (m *MockCNIPlugin) GetPodNetworkStatusWithContext(ctx context.Context, arg0 ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+func (m *MockCNIPlugin) GetPodNetworkStatusWithContext(arg0 context.Context, arg1 ocicni.PodNetwork) ([]ocicni.NetResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPodNetworkStatusWithContext", ctx, arg0)
+	ret := m.ctrl.Call(m, "GetPodNetworkStatusWithContext", arg0, arg1)
 	ret0, _ := ret[0].([]ocicni.NetResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPodNetworkStatusWithContext indicates an expected call of GetPodNetworkStatusWithContext
-func (mr *MockCNIPluginMockRecorder) GetPodNetworkStatusWithContext(ctx context.Context, arg0 interface{}) *gomock.Call {
+func (mr *MockCNIPluginMockRecorder) GetPodNetworkStatusWithContext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodNetworkStatusWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).GetPodNetworkStatusWithContext), ctx, arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodNetworkStatusWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).GetPodNetworkStatusWithContext), arg0, arg1)
 }
 
 // Name mocks base method
@@ -108,18 +108,18 @@ func (mr *MockCNIPluginMockRecorder) SetUpPod(arg0 interface{}) *gomock.Call {
 }
 
 // SetUpPodWithContext mocks base method
-func (m *MockCNIPlugin) SetUpPodWithContext(ctx context.Context, arg0 ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+func (m *MockCNIPlugin) SetUpPodWithContext(arg0 context.Context, arg1 ocicni.PodNetwork) ([]ocicni.NetResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUpPodWithContext", ctx, arg0)
+	ret := m.ctrl.Call(m, "SetUpPodWithContext", arg0, arg1)
 	ret0, _ := ret[0].([]ocicni.NetResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SetUpPodWithContext indicates an expected call of SetUpPodWithContext
-func (mr *MockCNIPluginMockRecorder) SetUpPodWithContext(ctx context.Context, arg0 interface{}) *gomock.Call {
+func (mr *MockCNIPluginMockRecorder) SetUpPodWithContext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpPodWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).SetUpPodWithContext), ctx, arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpPodWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).SetUpPodWithContext), arg0, arg1)
 }
 
 // Shutdown mocks base method
@@ -165,15 +165,15 @@ func (mr *MockCNIPluginMockRecorder) TearDownPod(arg0 interface{}) *gomock.Call 
 }
 
 // TearDownPodWithContext mocks base method
-func (m *MockCNIPlugin) TearDownPodWithContext(ctx context.Context, arg0 ocicni.PodNetwork) error {
+func (m *MockCNIPlugin) TearDownPodWithContext(arg0 context.Context, arg1 ocicni.PodNetwork) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TearDownPodWithContext", ctx, arg0)
+	ret := m.ctrl.Call(m, "TearDownPodWithContext", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TearDownPodWithContext indicates an expected call of TearDownPodWithContext
-func (mr *MockCNIPluginMockRecorder) TearDownPodWithContext(ctx context.Context, arg0 interface{}) *gomock.Call {
+func (mr *MockCNIPluginMockRecorder) TearDownPodWithContext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TearDownPodWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).TearDownPodWithContext), ctx, arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TearDownPodWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).TearDownPodWithContext), arg0, arg1)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
Re-generation of the mocks should make lint and unit tests work again.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
