### PR TITLE
Remove container if the process fails to start

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -361,7 +361,7 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 	}()
 
 	// Start the process
-	if err := r.start(ctx, c.ID(), execID); err != nil {
+	if err = r.start(ctx, c.ID(), execID); err != nil {
 		return -1, err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In runtimeVM#execContainerCommon, when r.start() fails, we should remove the container.

#### Which issue(s) this PR fixes:

<!--
None
-->


```release-note
None
```
