### PR TITLE
Avoid removing container twice

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -759,6 +759,9 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 	if err2 != nil {
 		return err2
 	}
+	if state == nil {
+		return fmt.Errorf("state command returned nil")
+	}
 	*c.state = *state
 	if err != nil {
 		logrus.Warnf("failed to find container exit file for %v: %v", c.id, err)

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -413,9 +413,11 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 		return -1, errors.Errorf("ExecSyncContainer timeout (%v)", timeoutDuration)
 	}
 
-	// Delete the process
-	if err := r.remove(ctx, c.ID(), execID); err != nil {
-		return -1, err
+	if err == nil {
+		// Delete the process
+		if err := r.remove(ctx, c.ID(), execID); err != nil {
+			logrus.Debugf("unable to remove container %s: %v", c.ID(), err)
+		}
 	}
 
 	return exitCode, err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In runtimeVM#execContainerCommon, if err is nil after select statement finishes, we call r.remove().
However, if the remove call returns error, the deferred func would try to call r.remove() again (almost certain to fail).

This PR avoids calling remove() a second time.

#### Which issue(s) this PR fixes:

<!--
None
-->


```release-note
None
```
