### PR TITLE
Close the channel for syncStruct

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -200,6 +200,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 			return
 		}
 		ch <- syncStruct{si: si}
+		close(ch)
 	}()
 
 	select {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In runtimeOCI#CreateContainer, the channel for syncStruct is not closed.

This PR closes the channel after sending syncStruct to it.

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
