### PR TITLE
[1.18] version: small tweaks

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -152,9 +152,11 @@ func (i *Info) String() string {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		value := v.FieldByName(field.Name).String()
-		fmt.Fprintf(w, "%s:\t%s", field.Name, value)
-		if i+1 < t.NumField() {
-			fmt.Fprintf(w, "\n")
+		if value != "" {
+			fmt.Fprintf(w, "%s:\t%s", field.Name, value)
+			if i+1 < t.NumField() {
+				fmt.Fprintf(w, "\n")
+			}
 		}
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,10 +13,10 @@ import (
 	"text/tabwriter"
 
 	"github.com/blang/semver"
+	"github.com/cri-o/cri-o/utils"
 	"github.com/google/renameio"
 	"github.com/pkg/errors"
-
-	"github.com/cri-o/cri-o/utils"
+	"github.com/sirupsen/logrus"
 )
 
 // Version is the version of the build.
@@ -167,14 +167,16 @@ func (i *Info) String() string {
 func getLinkmode() string {
 	abspath, err := os.Executable()
 	if err != nil {
-		return fmt.Sprintf("unknown: %v", err)
+		logrus.Warnf("Encountered error finding binary to detect link mode: %v", err)
+		return ""
 	}
 
 	if _, err := utils.ExecCmd("ldd", abspath); err != nil {
 		if strings.Contains(err.Error(), "not a dynamic executable") {
 			return "static"
 		}
-		return fmt.Sprintf("unknown: %v", err)
+		logrus.Warnf("Encountered error detecting link mode of binary: %v", err)
+		return ""
 	}
 
 	return "dynamic"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:
omitempty on String(), as we already have set omitempty on the JSON version, but the String() method left in empty strings
also return empty string when we fail to check the ldd status of the binary (as opposed to setting the field as the error)

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix some `crio version` oddities
```
