### PR TITLE
Remove crio-wipe and crio-shutdown systemd units from bundle

### DIFF
--- a/contrib/bundle/Makefile
+++ b/contrib/bundle/Makefile
@@ -56,8 +56,6 @@ install-crio:
 	install $(SELINUX) -D -m 644 -t $(FISHINSTALLDIR) completions/fish/crio.fish
 	install $(SELINUX) -D -m 644 -t $(ZSHINSTALLDIR) completions/zsh/_crio
 	install $(SELINUX) -D -m 644 -t $(CONTAINERS_DIR) contrib/policy.json
-	install $(SELINUX) -D -m 644 -t $(SYSTEMDDIR) contrib/crio-shutdown.service
-	install $(SELINUX) -D -m 644 -t $(SYSTEMDDIR) contrib/crio-wipe.service
 	install $(SELINUX) -D -m 644 -t $(SYSTEMDDIR) contrib/crio.service
 
 .PHONY: install-pinns
@@ -105,8 +103,6 @@ uninstall-crio:
 	rm $(FISHINSTALLDIR)/crio.fish
 	rm $(ZSHINSTALLDIR)/_crio
 	rm $(CONTAINERS_DIR)/policy.json
-	rm $(SYSTEMDDIR)/crio-shutdown.service
-	rm $(SYSTEMDDIR)/crio-wipe.service
 	rm $(SYSTEMDDIR)/crio.service
 
 .PHONY: uninstall-pinns

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -29,8 +29,6 @@ FILES_ETC=(
 FILES_CONTRIB=(
     "$GIT_ROOT/contrib/cni/10-crio-bridge.conf"
     "$GIT_ROOT/contrib/policy.json"
-    "$GIT_ROOT/contrib/systemd/crio-shutdown.service"
-    "$GIT_ROOT/contrib/systemd/crio-wipe.service"
     "$GIT_ROOT/contrib/systemd/crio.service"
 )
 COMPLETIONS="$GIT_ROOT/completions"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:
Both systemd units are not required and therefore should not be part of
the static bundle.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Removed `crio-wipe.service` and `crio-shutdown.service` systemd units from the static bundle since they are not required
```
