### PR TITLE
Check error return from os.Create before closing file

### DIFF
--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -344,7 +344,9 @@ func (s *Sandbox) SetNetworkStopped(createFile bool) error {
 func (s *Sandbox) createFileInInfraDir(filename string) error {
 	infra := s.InfraContainer()
 	f, err := os.Create(filepath.Join(infra.Dir(), filename))
-	f.Close()
+	if err == nil {
+		f.Close()
+	}
 	return err
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In Sandbox#SetNetworkStopped, we shouldn't close f without checking error return from os.Create

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
