### PR TITLE
Add support for making reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,16 @@ endif
 
 DEFAULTS_PATH := ""
 
+DATE_FMT = +'%Y-%m-%dT%H:%M:%SZ'
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date -u "$(DATE_FMT)")
+endif
+
 BASE_LDFLAGS = ${SHRINKFLAGS} \
 	-X ${PROJECT}/internal/pkg/criocli.DefaultsPath=${DEFAULTS_PATH} \
-	-X ${PROJECT}/internal/version.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+	-X ${PROJECT}/internal/version.buildDate=${BUILD_DATE} \
 	-X ${PROJECT}/internal/version.gitCommit=${COMMIT_NO} \
 	-X ${PROJECT}/internal/version.gitTreeState=${GIT_TREE_STATE}
 


### PR DESCRIPTION
Add support for setting SOURCE_DATE_EPOCH

See: https://reproducible-builds.org/specs/source-date-epoch/

Also make BUILD_DATE into a make variable

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Makes it possible to reproduce builds.

#### Which issue(s) this PR fixes:

Fixes #3702

#### Special notes for your reviewer:

Code is from https://reproducible-builds.org/docs/source-date-epoch/#Makefile

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add build support for setting SOURCE_DATE_EPOCH
```
