### PR TITLE
Delete container Id from ctrIDIndex if podIDIndex.Add fails

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -308,6 +308,13 @@ func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 	if err := c.ctrIDIndex.Add(scontainer.ID()); err != nil {
 		return err
 	}
+	defer func() {
+		if retErr != nil {
+			if err1 := c.ctrIDIndex.Delete(scontainer.ID()); err1 != nil {
+				logrus.Warnf("could not delete container ID %s: %v", scontainer.ID(), err1)
+			}
+		}
+	}()
 	if err := c.podIDIndex.Add(id); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In ContainerServer#LoadSandbox, if podIDIndex.Add() call fails, we should delete container Id from ctrIDIndex.

#### Which issue(s) this PR fixes:

<!--
None
-->


```release-note
None
```
