### PR TITLE
Delete container Id only when impl.DeleteContainer(c) passes

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -299,16 +299,18 @@ func (r *Runtime) StopContainer(ctx context.Context, c *Container, timeout int64
 }
 
 // DeleteContainer deletes a container.
-func (r *Runtime) DeleteContainer(c *Container) error {
+func (r *Runtime) DeleteContainer(c *Container) (err error) {
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		r.runtimeImplMapMutex.Lock()
-		delete(r.runtimeImplMap, c.ID())
-		r.runtimeImplMapMutex.Unlock()
+		if err == nil {
+			r.runtimeImplMapMutex.Lock()
+			delete(r.runtimeImplMap, c.ID())
+			r.runtimeImplMapMutex.Unlock()
+		}
 	}()
 
 	return impl.DeleteContainer(c)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In Runtime#DeleteContainer, we should only delete the container Id from runtimeImplMap if the call to impl.DeleteContainer(c) doesn't return non-nil error.

#### Which issue(s) this PR fixes:

<!--
None
-->


```release-note
None
```
