### PR TITLE
Close done channel if the wait for ContainerStateStopped times out

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -146,9 +146,11 @@ func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) (
 		break
 	case <-ctx.Done():
 		close(chControl)
+		close(done)
 		return ctx.Err()
 	case <-time.After(time.Duration(r.config.CtrStopTimeout) * time.Second):
 		close(chControl)
+		close(done)
 		return fmt.Errorf(
 			"failed to get container stopped status: %ds timeout reached",
 			r.config.CtrStopTimeout,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In Runtime#WaitContainerStateStopped, the goroutine waiting for ContainerStateStopped may time out.
In this case, the select statement should close done channel.

#### Which issue(s) this PR fixes:

<!--
None
-->


```release-note
None
```
