### PR TITLE
Cleanup go modules and vendor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/creack/pty v1.1.9
 	github.com/cri-o/ocicni v0.2.1-0.20200422173648-513ef787b8c9
 	github.com/cyphar/filepath-securejoin v0.2.2
-	github.com/docker/docker v1.4.2-0.20191219165747-a9416c67da9f // indirect
 	github.com/docker/go-units v0.4.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-zoo/bone v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,6 @@ github.com/containers/conmon v2.0.15+incompatible h1:3CdToyAu/XEiXO2Se/HaOv3TEc1
 github.com/containers/conmon v2.0.15+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.4.3 h1:zn2HR7uu4hpvT5QQHgjqonOzKDuM1I1UHUEmzZT5sbs=
 github.com/containers/image/v5 v5.4.3/go.mod h1:pN0tvp3YbDd7BWavK2aE0mvJUqVd2HmhPjekyWSFm0U=
-github.com/containers/libpod v1.9.0 h1:zxk/7Q9fVv0NL0JTg5JPev7Q/ON6kPkYEh13U9fvOmQ=
-github.com/containers/libpod v1.9.0/go.mod h1:xNGAWfRxLe0R8abmfa0yIZYEtiE/pf58Ty3g6OlThlI=
 github.com/containers/libpod v1.9.1 h1:uimXDEWJfeihzNosPtJ9f7njYZ4RmYD4KPXbwavw020=
 github.com/containers/libpod v1.9.1/go.mod h1:70h+znEanYLSS+qDBgD6eIdQ7xMXVfWYnUDq264UZno=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
@@ -189,8 +187,6 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cri-o/ocicni v0.1.1-0.20190920040751-deac903fd99b/go.mod h1:ZOuIEOp/3MB1eCBWANnNxM3zUA3NWh76wSRCsnKAg2c=
-github.com/cri-o/ocicni v0.2.1-0.20200409131010-b197cd13855b h1:L894Tw4cIPW2Job8YfKqV1P8sA4vxlnxrU9vysxlA+k=
-github.com/cri-o/ocicni v0.2.1-0.20200409131010-b197cd13855b/go.mod h1:839vrWpNBb3HiYh5seMM7H1vTB1iVn23B0jvoa7IFOk=
 github.com/cri-o/ocicni v0.2.1-0.20200422173648-513ef787b8c9 h1:dAbtJnDldXrdkhcumFHVaA/XBDJkWrI8Z3enj/DW07Q=
 github.com/cri-o/ocicni v0.2.1-0.20200422173648-513ef787b8c9/go.mod h1:839vrWpNBb3HiYh5seMM7H1vTB1iVn23B0jvoa7IFOk=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,6 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 # github.com/docker/docker v1.4.2-0.20191219165747-a9416c67da9f
-## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Running `go mod tidy` and `go mod vendor` cleaned up these files.

#### Which issue(s) this PR fixes:
gopls choking up on CRI-O master.



#### Does this PR introduce a user-facing change?
No

```release-note
Cleanup go module and vendor files.
```
