### PR TITLE
Introduce state lock for finer grained access control

### DIFF
--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -386,12 +386,7 @@ func (s *Sandbox) Ready(takeLock bool) bool {
 		// isn't running
 		return true
 	}
-	var cState *oci.ContainerState
-	if takeLock {
-		cState = podInfraContainer.State()
-	} else {
-		cState = podInfraContainer.StateNoLock()
-	}
+	cState := podInfraContainer.State()
 
 	return cState.Status == oci.ContainerStateRunning
 }

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -50,6 +50,7 @@ type Container struct {
 	state              *ContainerState
 	metadata           *pb.ContainerMetadata
 	opLock             sync.RWMutex
+	stateLock          sync.RWMutex
 	spec               *specs.Spec
 	idMappings         *idtools.IDMappings
 	terminal           bool
@@ -157,8 +158,15 @@ func (c *Container) FromDisk() error {
 	}
 	defer jsonSource.Close()
 
+	var state ContainerState
 	dec := json.NewDecoder(jsonSource)
-	return dec.Decode(c.state)
+	if err := dec.Decode(&state); err != nil {
+		return err
+	}
+	c.stateLock.Lock()
+	c.state = &state
+	c.stateLock.Unlock()
+	return nil
 }
 
 // StatePath returns the containers state.json path
@@ -267,14 +275,17 @@ func (c *Container) Metadata() *pb.ContainerMetadata {
 
 // State returns the state of the running container
 func (c *Container) State() *ContainerState {
-	c.opLock.RLock()
-	defer c.opLock.RUnlock()
-	return c.state
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+	if c.state != nil {
+		cs := *c.state
+		return &cs
+	}
+	return nil
 }
 
-// StateNoLock returns the state of a container without using a lock.
-func (c *Container) StateNoLock() *ContainerState {
-	return c.state
+func (c *Container) Pid() int {
+	return c.state.Pid
 }
 
 // AddVolume adds a volume to list of container volumes.
@@ -319,13 +330,19 @@ func (c *Container) Created() bool {
 
 // SetStartFailed sets the container state appropriately after a start failure
 func (c *Container) SetStartFailed(err error) {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
 	// adjust finished and started times
 	c.state.Finished, c.state.Started = c.state.Created, c.state.Created
 	if err != nil {
 		c.state.Error = err.Error()
 	}
+}
+
+func (c *Container) SetFinished(t time.Time) {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	c.state.Finished = t
 }
 
 // Description returns a description for the container

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -43,7 +43,7 @@ var _ = t.Describe("Container", func() {
 		Expect(sut.Dir()).To(Equal("dir"))
 		Expect(sut.StatePath()).To(Equal("dir/state.json"))
 		Expect(sut.Metadata()).To(Equal(&pb.ContainerMetadata{}))
-		Expect(sut.StateNoLock().Version).To(BeEmpty())
+		Expect(sut.State().Version).To(BeEmpty())
 		Expect(sut.GetStopSignal()).To(Equal("15"))
 		Expect(sut.CreatedAt().UnixNano()).
 			To(BeNumerically("<", time.Now().UnixNano()))

--- a/internal/oci/container_test_inject.go
+++ b/internal/oci/container_test_inject.go
@@ -6,5 +6,7 @@ package oci
 
 // SetState sets the container state
 func (c *Container) SetState(state *ContainerState) {
+	c.stateLock.Lock()
 	c.state = state
+	c.stateLock.Unlock()
 }

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -551,8 +551,8 @@ func (r *runtimeVM) UpdateContainerStatus(c *Container) error {
 	defer logrus.Debug("runtimeVM.UpdateContainerStatus() end")
 
 	// Lock the container
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
 
 	// This can happen on restore, for example if we switch the runtime type
 	// for a container from "oci" to "vm" for the same runtime.

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -79,8 +79,8 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 			continue
 		}
 		podSandboxID := ctr.Sandbox()
-		cState := ctr.StateNoLock()
-		created := ctr.CreatedAt().UnixNano()
+		cState := ctr.State()
+		created := cState.Created.UnixNano()
 		rState := pb.ContainerState_CONTAINER_UNKNOWN
 		cID := ctr.ID()
 		img := &pb.ImageSpec{

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -50,7 +50,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	}
 	resp.Status.Mounts = mounts
 
-	cState := c.StateNoLock()
+	cState := c.State()
 	rStatus := pb.ContainerState_CONTAINER_UNKNOWN
 
 	// If we defaulted to exit code not set earlier then we attempt to
@@ -63,7 +63,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		cState = c.State()
 	}
 
-	created := c.CreatedAt().UnixNano()
+	created := cState.Created.UnixNano()
 	switch cState.Status {
 	case oci.ContainerStateCreated:
 		rStatus = pb.ContainerState_CONTAINER_CREATED


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Some of the deadlock situation (recently fixed) seemed to be caused by contention between container op and access to Container.State (since they use the same lock).

This PR introduces state lock which is used to guard access to Container.State.

One benefit is that UpdateContainerStatus no longer takes opLock:
```
// UpdateContainerStatus refreshes the status of the container.
func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
	c.stateLock.Lock()
```

StateNoLock() is not needed and is removed.

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
