### PR TITLE
[1.17] Close image pull progress goroutine after completion

### DIFF
--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -195,6 +195,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 			ProgressInterval: time.Second,
 			Progress:         progress,
 		})
+		close(progress)
 		if err != nil {
 			log.Debugf(ctx, "error pulling image %s: %v", img, err)
 			continue


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
A number of active goroutines are running for an extended period of time:

```
goroutine 6975025 [chan receive, 38 minutes]:
github.com/cri-o/cri-o/server.(*Server).pullImage.func1(0xc0021a3860, 0x562778dc32c0, 0xc0063841e0, 0xc002cd0ff0, 0x562778dee420, 0xc007139a40)
	/builddir/build/BUILD/cri-o-5f5c5e443806e56ce083fa6c40cfc916804fac3d/_output/src/github.com/cri-o/cri-o/server/image_pull.go:157 +0x80
created by github.com/cri-o/cri-o/server.(*Server).pullImage
	/builddir/build/BUILD/cri-o-5f5c5e443806e56ce083fa6c40cfc916804fac3d/_output/src/github.com/cri-o/cri-o/server/image_pull.go:156 +0x575
```

This PR closes the progress channel cleaning up the goroutine.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```
