### PR TITLE
[1.18] Fix static binary integration tests

### DIFF
--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -28,7 +28,7 @@ function teardown() {
 
 # run crio_wipe calls crio_wipe and tests it succeeded
 function run_crio_wipe() {
-	run $CRIO_BINARY --config "$CRIO_CONFIG" wipe
+	run $CRIO_BINARY_PATH --config "$CRIO_CONFIG" wipe
 	echo "$status"
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -75,6 +75,8 @@ CONTAINER_LOG_SIZE_MAX=${CONTAINER_LOG_SIZE_MAX:--1}
 STREAM_PORT=${STREAM_PORT:-10010}
 # Metrics Port
 CONTAINER_METRICS_PORT=${CONTAINER_METRICS_PORT:-9090}
+# CNI binary dir
+CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin}
 
 POD_IPV4_CIDR="10.88.0.0/16"
 POD_IPV4_CIDR_START="10.88"
@@ -212,7 +214,8 @@ function setup_test() {
     # Copy all the CNI dependencies around to ensure encapsulated tests
     CRIO_CNI_PLUGIN="$TESTDIR/cni-bin"
     mkdir "$CRIO_CNI_PLUGIN"
-    cp /opt/cni/bin/* "$CRIO_CNI_PLUGIN"
+    cp "$CNI_BIN_DIR/bridge" "$CRIO_CNI_PLUGIN"
+    cp "$CNI_BIN_DIR/host-local" "$CRIO_CNI_PLUGIN"
     cp "$INTEGRATION_ROOT"/cni_plugin_helper.bash "$CRIO_CNI_PLUGIN"
     sed -i "s;%TEST_DIR%;$TESTDIR;" "$CRIO_CNI_PLUGIN"/cni_plugin_helper.bash
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The selected binary in the crio wipe integration tests had the wrong
path, which should be now fixed.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
