### PR TITLE
Remove socat runtime dependency

### DIFF
--- a/internal/log/interceptors.go
+++ b/internal/log/interceptors.go
@@ -30,9 +30,7 @@ func StreamInterceptor() grpc.StreamServerInterceptor {
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		newCtx := addRequestName(
-			addRequestID(stream.Context()), info.FullMethod,
-		)
+		newCtx := AddRequestNameAndID(stream.Context(), info.FullMethod)
 		newStream := NewServerStream(stream)
 		newStream.NewContext = newCtx
 
@@ -53,9 +51,7 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		newCtx := addRequestName(
-			addRequestID(ctx), info.FullMethod,
-		)
+		newCtx := AddRequestNameAndID(ctx, info.FullMethod)
 		Debugf(newCtx, "request: %+v", req)
 
 		resp, err := handler(newCtx, req)
@@ -68,6 +64,10 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 
 		return resp, err
 	}
+}
+
+func AddRequestNameAndID(ctx context.Context, name string) context.Context {
+	return addRequestName(addRequestID(ctx), name)
 }
 
 func addRequestID(ctx context.Context) context.Context {

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -67,7 +67,8 @@ type RuntimeImpl interface {
 	SignalContainer(*Container, syscall.Signal) error
 	AttachContainer(*Container, io.Reader, io.WriteCloser, io.WriteCloser,
 		bool, <-chan remotecommand.TerminalSize) error
-	PortForwardContainer(*Container, int32, io.ReadWriter) error
+	PortForwardContainer(context.Context, *Container, string,
+		int32, io.ReadWriteCloser) error
 	ReopenContainerLog(*Container) error
 	WaitContainerStateStopped(context.Context, *Container) error
 }
@@ -383,13 +384,13 @@ func (r *Runtime) AttachContainer(c *Container, inputStream io.Reader, outputStr
 }
 
 // PortForwardContainer forwards the specified port provides statistics of a container.
-func (r *Runtime) PortForwardContainer(c *Container, port int32, stream io.ReadWriter) error {
+func (r *Runtime) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
 	}
 
-	return impl.PortForwardContainer(c, port, stream)
+	return impl.PortForwardContainer(ctx, c, netNsPath, port, stream)
 }
 
 // ReopenContainerLog reopens the log file of a container.

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -704,7 +704,7 @@ func (r *runtimeVM) AttachContainer(c *Container, inputStream io.Reader, outputS
 }
 
 // PortForwardContainer forwards the specified port provides statistics of a container.
-func (r *runtimeVM) PortForwardContainer(c *Container, port int32, stream io.ReadWriter) error {
+func (r *runtimeVM) PortForwardContainer(context.Context, *Container, string, int32, io.ReadWriteCloser) error {
 	logrus.Debug("runtimeVM.PortForwardContainer() start")
 	defer logrus.Debug("runtimeVM.PortForwardContainer() end")
 

--- a/tutorials/setup.md
+++ b/tutorials/setup.md
@@ -31,7 +31,6 @@ This guide will walk you through the installation of [CRI-O](https://github.com/
 ## Runtime dependencies
 
 - runc, Clear Containers runtime, or any other OCI compatible runtime
-- socat
 - iproute
 - iptables
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
This is the analogous implementation to
https://github.com/containerd/cri/pull/1470 to remove the socat runtime
dependency from CRI-O.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Removed `socat` runtime dependency which was needed for pod port forwarding
```
