### PR TITLE
[1.18] Pin runc for CI

### DIFF
--- a/contrib/test/integration/build/runc.yml
+++ b/contrib/test/integration/build/runc.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/opencontainers/runc.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-    version: "HEAD"
+    version: "2b9a36ee8c82b580f09ed853dc72388aadca9ea9" # v1.0.0-rc10-307-g2b9a36ee
 
 - name: build runc
   make:


### PR DESCRIPTION
We should only use HEAD in master branch (see #3493), not in release branches. This is to prevent possible CI failures caused by changes in upstream runc.

/kind flake

```release-note
NONE
```
