### PR TITLE
Automatically label containers running systemd with the correct label

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -17,7 +17,7 @@ import (
 	"github.com/containers/buildah/pkg/secrets"
 	"github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/rootless"
-	"github.com/containers/libpod/pkg/selinux"
+	selinux "github.com/containers/libpod/pkg/selinux"
 	createconfig "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/cri-o/cri-o/internal/lib"
@@ -722,7 +722,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	specgen.SetProcessArgs(processArgs)
 
 	if strings.Contains(processArgs[0], "/sbin/init") || (filepath.Base(processArgs[0]) == oci.SystemdCgroupsManager) {
-		processLabel, err = selinux.InitLabel(processLabel)
+		processLabel, err = selinux.SELinuxInitLabel(processLabel)
 		if err != nil {
 			return nil, err
 		}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/buildah/pkg/secrets"
 	"github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/libpod/pkg/selinux"
 	createconfig "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/cri-o/cri-o/internal/lib"
@@ -398,6 +399,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	if err != nil {
 		return nil, err
 	}
+
 	mountLabel := containerInfo.MountLabel
 	var processLabel string
 	if !privileged {
@@ -425,8 +427,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 			}
 		}
 	}()
-	specgen.SetLinuxMountLabel(mountLabel)
-	specgen.SetProcessSelinuxLabel(processLabel)
 
 	containerVolumes, ociMounts, err := addOCIBindMounts(ctx, mountLabel, containerConfig, &specgen, s.config.RuntimeConfig.BindMountPrefix)
 	if err != nil {
@@ -722,6 +722,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	specgen.SetProcessArgs(processArgs)
 
 	if strings.Contains(processArgs[0], "/sbin/init") || (filepath.Base(processArgs[0]) == oci.SystemdCgroupsManager) {
+		processLabel, err = selinux.InitLabel(processLabel)
+		if err != nil {
+			return nil, err
+		}
 		setupSystemd(specgen.Mounts(), specgen)
 	}
 
@@ -962,6 +966,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	if err != nil {
 		return nil, err
 	}
+
+	specgen.SetLinuxMountLabel(mountLabel)
+	specgen.SetProcessSelinuxLabel(processLabel)
 
 	container.SetIDMappings(containerIDMappings)
 	if s.defaultIDMappings != nil && !s.defaultIDMappings.Empty() {

--- a/vendor/github.com/containers/libpod/pkg/selinux/selinux.go
+++ b/vendor/github.com/containers/libpod/pkg/selinux/selinux.go
@@ -1,0 +1,40 @@
+package selinux
+
+import (
+	"github.com/opencontainers/selinux/go-selinux"
+)
+
+// KVMLabel returns labels for running kvm isolated containers
+func KVMLabel(cLabel string) (string, error) {
+	if cLabel == "" {
+		// selinux is disabled
+		return "", nil
+	}
+	processLabel, _ := selinux.KVMContainerLabels()
+	selinux.ReleaseLabel(processLabel)
+	return swapSELinuxLabel(cLabel, processLabel)
+}
+
+// InitLabel returns labels for running systemd based containers
+func InitLabel(cLabel string) (string, error) {
+	if cLabel == "" {
+		// selinux is disabled
+		return "", nil
+	}
+	processLabel, _ := selinux.InitContainerLabels()
+	selinux.ReleaseLabel(processLabel)
+	return swapSELinuxLabel(cLabel, processLabel)
+}
+
+func swapSELinuxLabel(cLabel, processLabel string) (string, error) {
+	dcon, err := selinux.NewContext(cLabel)
+	if err != nil {
+		return "", err
+	}
+	scon, err := selinux.NewContext(processLabel)
+	if err != nil {
+		return "", err
+	}
+	dcon["type"] = scon["type"]
+	return dcon.Get(), nil
+}

--- a/vendor/github.com/containers/libpod/pkg/selinux/selinux.go
+++ b/vendor/github.com/containers/libpod/pkg/selinux/selinux.go
@@ -1,11 +1,11 @@
-package selinux
+package util
 
 import (
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
-// KVMLabel returns labels for running kvm isolated containers
-func KVMLabel(cLabel string) (string, error) {
+// SELinuxKVMLabel returns labels for running kvm isolated containers
+func SELinuxKVMLabel(cLabel string) (string, error) {
 	if cLabel == "" {
 		// selinux is disabled
 		return "", nil
@@ -15,8 +15,8 @@ func KVMLabel(cLabel string) (string, error) {
 	return swapSELinuxLabel(cLabel, processLabel)
 }
 
-// InitLabel returns labels for running systemd based containers
-func InitLabel(cLabel string) (string, error) {
+// SELinuxInitLabel returns labels for running systemd based containers
+func SELinuxInitLabel(cLabel string) (string, error) {
 	if cLabel == "" {
 		// selinux is disabled
 		return "", nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -210,6 +210,7 @@ github.com/containers/libpod/pkg/resolvconf/dns
 github.com/containers/libpod/pkg/rootless
 github.com/containers/libpod/pkg/rootlessport
 github.com/containers/libpod/pkg/seccomp
+github.com/containers/libpod/pkg/selinux
 github.com/containers/libpod/pkg/signal
 github.com/containers/libpod/pkg/spec
 github.com/containers/libpod/pkg/sysinfo


### PR DESCRIPTION
/kind Feature

Newer versions of container-selinux, container-selinux-2.132.0 or newer,
supply a `container_init_t` label.  If CRI-O is running systemd or init inside
of the container, then the container will require different SELinux privs
to run the container.

By using the new SELinux label, we can run ordinary containers with a tighter
selinux policy then those running the init system, makeing the overlay system
more secure.

The eliminates the need to turn on the container_manage_cgroup SELinux boolean.

Ie. no need to execute

```
setsebool -P container_manage_cgroup 1
```

Any longer. On systems without the updated container-selnux package, the containers will still
attempt to run the standard container type `container_t`, and still require the boolean.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
containers running `init` or `systemd` are now given a new selinux label `container_init_t`, giving it selinux privileges more appropriate for the workload
```
