### PR TITLE
[1.18] fix naming test panic

### DIFF
--- a/server/naming_test.go
+++ b/server/naming_test.go
@@ -9,7 +9,10 @@ import (
 // The actual test suite
 var _ = t.Describe("Server", func() {
 	// Prepare the sut
-	BeforeEach(beforeEach)
+	BeforeEach(func() {
+		beforeEach()
+		setupSUT()
+	})
 	AfterEach(afterEach)
 
 	t.Describe("ReserveSandboxContainerIDAndName", func() {


### PR DESCRIPTION
This is supposed to fix the following panic in "ci/circleci: unit-tests" job observed in https://github.com/cri-o/cri-o/pull/3752:
    

    •! Panic [0.008 seconds]
    cri-o: Server cri-o: ReserveSandboxContainerIDAndName [It] should succeed
    /go/src/github.com/cri-o/cri-o/server/naming_test.go:16
    
      Test Panicked
      runtime error: invalid memory address or nil pointer dereference
      /usr/local/go/src/runtime/panic.go:212
    
      Full Stack Trace
      github.com/cri-o/cri-o/server.(*Server).ReserveSandboxContainerIDAndName(0x0, 0xc00053d3a8, 0x0, 0x3, 0x0, 0xc0006c2960)
            /go/src/github.com/cri-o/cri-o/server/naming.go:34 +0xfa
      github.com/cri-o/cri-o/server_test.glob..func22.1.1()
            /go/src/github.com/cri-o/cri-o/server/naming_test.go:19 +0x10c
      github.com/cri-o/cri-o/test/framework.RunFrameworkSpecs(0xc00029a7e0, 0x1f305cd, 0x6)
            /go/src/github.com/cri-o/cri-o/test/framework/framework.go:99 +0x15a
      github.com/cri-o/cri-o/server_test.TestServer(0xc00029a7e0)
            /go/src/github.com/cri-o/cri-o/server/suite_test.go:36 +0x8a
      testing.tRunner(0xc00029a7e0, 0x203c040)
            /usr/local/go/src/testing/testing.go:991 +0xdc
      created by testing.(*T).Run
            /usr/local/go/src/testing/testing.go:1042 +0x357

    
and another similar one with
    
> cri-o: Server cri-o: ReserveSandboxContainerIDAndName [It] should fail if name is already reserved


/kind failing-test

```release-note
NONE
```
