### PR TITLE
[1.18] Automatically label containers running systemd with the correct label

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/containers/common v0.9.1
 	github.com/containers/conmon v2.0.15+incompatible
 	github.com/containers/image/v5 v5.4.3
-	github.com/containers/libpod v1.9.0
+	github.com/containers/libpod v1.9.2
 	github.com/containers/ocicrypt v1.0.2
 	github.com/containers/storage v1.18.2
 	github.com/coreos/go-systemd/v22 v22.0.0

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,7 @@ github.com/containers/buildah v1.14.8 h1:JbMI0QSOmyZ30Mr2633uCXAj+Fajgh/EFS9xX/Y
 github.com/containers/buildah v1.14.8/go.mod h1:ytEjHJQnRXC1ygXMyc0FqYkjcoCydqBQkOdxbH563QU=
 github.com/containers/common v0.8.1 h1:1IUwAtZ4mC7GYRr4AC23cHf2oXCuoLzTUoSzIkSgnYw=
 github.com/containers/common v0.8.1/go.mod h1:VxDJbaA1k6N1TNv9Rt6bQEF4hyKVHNfOfGA5L91ADEs=
+github.com/containers/common v0.8.4/go.mod h1:VxDJbaA1k6N1TNv9Rt6bQEF4hyKVHNfOfGA5L91ADEs=
 github.com/containers/common v0.9.1 h1:S5lkpnycTI29YzpNJ4RLv49g8sksgYNRNsugPmzQCR8=
 github.com/containers/common v0.9.1/go.mod h1:9YGKPwu6NFYQG2NtSP9bRhNGA8mgd1mUCCkOU2tr+Pc=
 github.com/containers/conmon v2.0.14+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
@@ -149,6 +150,8 @@ github.com/containers/image/v5 v5.4.3 h1:zn2HR7uu4hpvT5QQHgjqonOzKDuM1I1UHUEmzZT
 github.com/containers/image/v5 v5.4.3/go.mod h1:pN0tvp3YbDd7BWavK2aE0mvJUqVd2HmhPjekyWSFm0U=
 github.com/containers/libpod v1.9.0 h1:zxk/7Q9fVv0NL0JTg5JPev7Q/ON6kPkYEh13U9fvOmQ=
 github.com/containers/libpod v1.9.0/go.mod h1:xNGAWfRxLe0R8abmfa0yIZYEtiE/pf58Ty3g6OlThlI=
+github.com/containers/libpod v1.9.2 h1:h1ZD0OJ2wORmq0of0TZqomQdLtLd/M3dP6fJsuHt+B0=
+github.com/containers/libpod v1.9.2/go.mod h1:dwuETW8bj8zjrLFFEIZgTXHJVkvUFAefKRZLFxdScds=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.2 h1:Q0/IPs8ohfbXNxEfyJ2pFVmvJu5BhqJUAmc6ES9NKbo=

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -17,7 +17,7 @@ import (
 	"github.com/containers/buildah/pkg/secrets"
 	"github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/rootless"
-	"github.com/containers/libpod/pkg/selinux"
+	selinux "github.com/containers/libpod/pkg/selinux"
 	createconfig "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/cri-o/cri-o/internal/lib"
@@ -716,7 +716,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	specgen.SetProcessArgs(processArgs)
 
 	if strings.Contains(processArgs[0], "/sbin/init") || (filepath.Base(processArgs[0]) == oci.SystemdCgroupsManager) {
-		processLabel, err = selinux.InitLabel(processLabel)
+		processLabel, err = selinux.SELinuxInitLabel(processLabel)
 		if err != nil {
 			return nil, err
 		}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/buildah/pkg/secrets"
 	"github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/libpod/pkg/selinux"
 	createconfig "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/cri-o/cri-o/internal/lib"
@@ -395,6 +396,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	if err != nil {
 		return nil, err
 	}
+
 	mountLabel := containerInfo.MountLabel
 	var processLabel string
 	if !privileged {
@@ -422,8 +424,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 			}
 		}
 	}()
-	specgen.SetLinuxMountLabel(mountLabel)
-	specgen.SetProcessSelinuxLabel(processLabel)
 
 	containerVolumes, ociMounts, err := addOCIBindMounts(ctx, mountLabel, containerConfig, &specgen, s.config.RuntimeConfig.BindMountPrefix)
 	if err != nil {
@@ -716,6 +716,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	specgen.SetProcessArgs(processArgs)
 
 	if strings.Contains(processArgs[0], "/sbin/init") || (filepath.Base(processArgs[0]) == oci.SystemdCgroupsManager) {
+		processLabel, err = selinux.InitLabel(processLabel)
+		if err != nil {
+			return nil, err
+		}
 		setupSystemd(specgen.Mounts(), specgen)
 	}
 
@@ -956,6 +960,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	if err != nil {
 		return nil, err
 	}
+
+	specgen.SetLinuxMountLabel(mountLabel)
+	specgen.SetProcessSelinuxLabel(processLabel)
 
 	container.SetIDMappings(containerIDMappings)
 	if s.defaultIDMappings != nil && !s.defaultIDMappings.Empty() {

--- a/vendor/github.com/containers/libpod/cmd/podman/cliconfig/config.go
+++ b/vendor/github.com/containers/libpod/cmd/podman/cliconfig/config.go
@@ -708,7 +708,6 @@ type UntagValues struct {
 func GetDefaultConfig() *config.Config {
 	var err error
 	conf, err := config.NewConfig("")
-	conf.CheckCgroupsAndAdjustConfig()
 	if err != nil {
 		logrus.Errorf("Error loading container config %v\n", err)
 		os.Exit(1)

--- a/vendor/github.com/containers/libpod/libpod/healthcheck.go
+++ b/vendor/github.com/containers/libpod/libpod/healthcheck.go
@@ -238,7 +238,7 @@ func (c *Container) updateHealthCheckLog(hcl define.HealthCheckLog, inStartPerio
 
 // HealthCheckLogPath returns the path for where the health check log is
 func (c *Container) healthCheckLogPath() string {
-	return filepath.Join(filepath.Dir(c.LogPath()), "healthcheck.log")
+	return filepath.Join(filepath.Dir(c.state.RunDir), "healthcheck.log")
 }
 
 // GetHealthCheckLog returns HealthCheck results by reading the container's

--- a/vendor/github.com/containers/libpod/libpod/runtime.go
+++ b/vendor/github.com/containers/libpod/libpod/runtime.go
@@ -131,8 +131,9 @@ func NewRuntime(ctx context.Context, options ...RuntimeOption) (runtime *Runtime
 	if err != nil {
 		return nil, err
 	}
+	runtime, err = newRuntimeFromConfig(ctx, conf, options...)
 	conf.CheckCgroupsAndAdjustConfig()
-	return newRuntimeFromConfig(ctx, conf, options...)
+	return runtime, err
 }
 
 // NewRuntimeFromConfig creates a new container runtime using the given
@@ -762,7 +763,7 @@ type DBConfig struct {
 // mergeDBConfig merges the configuration from the database.
 func (r *Runtime) mergeDBConfig(dbConfig *DBConfig) error {
 
-	c := r.config.Engine
+	c := &r.config.Engine
 	if !r.storageSet.RunRootSet && dbConfig.StorageTmp != "" {
 		if r.storageConfig.RunRoot != dbConfig.StorageTmp &&
 			r.storageConfig.RunRoot != "" {

--- a/vendor/github.com/containers/libpod/pkg/cgroups/cgroups.go
+++ b/vendor/github.com/containers/libpod/pkg/cgroups/cgroups.go
@@ -517,6 +517,10 @@ func (c *CgroupControl) AddPid(pid int) error {
 	}
 
 	for _, n := range names {
+		// If we aren't using cgroup2, we won't write correctly to unified hierarchy
+		if !c.cgroup2 && n == "unified" {
+			continue
+		}
 		p := filepath.Join(c.getCgroupv1Path(n), "tasks")
 		if err := ioutil.WriteFile(p, pidString, 0644); err != nil {
 			return errors.Wrapf(err, "write %s", p)

--- a/vendor/github.com/containers/libpod/pkg/rootless/rootless_linux.go
+++ b/vendor/github.com/containers/libpod/pkg/rootless/rootless_linux.go
@@ -31,7 +31,7 @@ extern uid_t rootless_uid();
 extern uid_t rootless_gid();
 extern int reexec_in_user_namespace(int ready, char *pause_pid_file_path, char *file_to_read, int fd);
 extern int reexec_in_user_namespace_wait(int pid, int options);
-extern int reexec_userns_join(int userns, int mountns, char *pause_pid_file_path);
+extern int reexec_userns_join(int pid, char *pause_pid_file_path);
 */
 import "C"
 
@@ -124,91 +124,6 @@ func tryMappingTool(tool string, pid int, hostID int, mappings []idtools.IDMap) 
 	return nil
 }
 
-func readUserNs(path string) (string, error) {
-	b := make([]byte, 256)
-	_, err := unix.Readlink(path, b)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
-}
-
-func readUserNsFd(fd uintptr) (string, error) {
-	return readUserNs(fmt.Sprintf("/proc/self/fd/%d", fd))
-}
-
-func getParentUserNs(fd uintptr) (uintptr, error) {
-	const nsGetParent = 0xb702
-	ret, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, uintptr(nsGetParent), 0)
-	if errno != 0 {
-		return 0, errno
-	}
-	return (uintptr)(unsafe.Pointer(ret)), nil
-}
-
-// getUserNSFirstChild returns an open FD for the first direct child user namespace that created the process
-// Each container creates a new user namespace where the runtime runs.  The current process in the container
-// might have created new user namespaces that are child of the initial namespace we created.
-// This function finds the initial namespace created for the container that is a child of the current namespace.
-//
-//                                     current ns
-//                                       /     \
-//                           TARGET ->  a   [other containers]
-//                                     /
-//                                    b
-//                                   /
-//        NS READ USING THE PID ->  c
-func getUserNSFirstChild(fd uintptr) (*os.File, error) {
-	currentNS, err := readUserNs("/proc/self/ns/user")
-	if err != nil {
-		return nil, err
-	}
-
-	ns, err := readUserNsFd(fd)
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot read user namespace")
-	}
-	if ns == currentNS {
-		return nil, errors.New("process running in the same user namespace")
-	}
-
-	for {
-		nextFd, err := getParentUserNs(fd)
-		if err != nil {
-			if err == unix.ENOTTY {
-				return os.NewFile(fd, "userns child"), nil
-			}
-			return nil, errors.Wrapf(err, "cannot get parent user namespace")
-		}
-
-		ns, err = readUserNsFd(nextFd)
-		if err != nil {
-			return nil, errors.Wrapf(err, "cannot read user namespace")
-		}
-
-		if ns == currentNS {
-			if err := unix.Close(int(nextFd)); err != nil {
-				return nil, err
-			}
-
-			// Drop O_CLOEXEC for the fd.
-			_, _, errno := unix.Syscall(unix.SYS_FCNTL, fd, unix.F_SETFD, 0)
-			if errno != 0 {
-				if err := unix.Close(int(fd)); err != nil {
-					logrus.Errorf("failed to close file descriptor %d", fd)
-				}
-				return nil, errno
-			}
-
-			return os.NewFile(fd, "userns child"), nil
-		}
-		if err := unix.Close(int(fd)); err != nil {
-			return nil, err
-		}
-		fd = nextFd
-	}
-}
-
 // joinUserAndMountNS re-exec podman in a new userNS and join the user and mount
 // namespace of the specified PID without looking up its parent.  Useful to join directly
 // the conmon process.
@@ -220,31 +135,7 @@ func joinUserAndMountNS(pid uint, pausePid string) (bool, int, error) {
 	cPausePid := C.CString(pausePid)
 	defer C.free(unsafe.Pointer(cPausePid))
 
-	userNS, err := os.Open(fmt.Sprintf("/proc/%d/ns/user", pid))
-	if err != nil {
-		return false, -1, err
-	}
-	defer func() {
-		if err := userNS.Close(); err != nil {
-			logrus.Errorf("unable to close namespace: %q", err)
-		}
-	}()
-
-	mountNS, err := os.Open(fmt.Sprintf("/proc/%d/ns/mnt", pid))
-	if err != nil {
-		return false, -1, err
-	}
-	defer func() {
-		if err := mountNS.Close(); err != nil {
-			logrus.Errorf("unable to close namespace: %q", err)
-		}
-	}()
-
-	fd, err := getUserNSFirstChild(userNS.Fd())
-	if err != nil {
-		return false, -1, err
-	}
-	pidC := C.reexec_userns_join(C.int(fd.Fd()), C.int(mountNS.Fd()), cPausePid)
+	pidC := C.reexec_userns_join(C.int(pid), cPausePid)
 	if int(pidC) < 0 {
 		return false, -1, errors.Errorf("cannot re-exec process")
 	}

--- a/vendor/github.com/containers/libpod/pkg/selinux/selinux.go
+++ b/vendor/github.com/containers/libpod/pkg/selinux/selinux.go
@@ -1,0 +1,40 @@
+package selinux
+
+import (
+	"github.com/opencontainers/selinux/go-selinux"
+)
+
+// KVMLabel returns labels for running kvm isolated containers
+func KVMLabel(cLabel string) (string, error) {
+	if cLabel == "" {
+		// selinux is disabled
+		return "", nil
+	}
+	processLabel, _ := selinux.KVMContainerLabels()
+	selinux.ReleaseLabel(processLabel)
+	return swapSELinuxLabel(cLabel, processLabel)
+}
+
+// InitLabel returns labels for running systemd based containers
+func InitLabel(cLabel string) (string, error) {
+	if cLabel == "" {
+		// selinux is disabled
+		return "", nil
+	}
+	processLabel, _ := selinux.InitContainerLabels()
+	selinux.ReleaseLabel(processLabel)
+	return swapSELinuxLabel(cLabel, processLabel)
+}
+
+func swapSELinuxLabel(cLabel, processLabel string) (string, error) {
+	dcon, err := selinux.NewContext(cLabel)
+	if err != nil {
+		return "", err
+	}
+	scon, err := selinux.NewContext(processLabel)
+	if err != nil {
+		return "", err
+	}
+	dcon["type"] = scon["type"]
+	return dcon.Get(), nil
+}

--- a/vendor/github.com/containers/libpod/pkg/selinux/selinux.go
+++ b/vendor/github.com/containers/libpod/pkg/selinux/selinux.go
@@ -1,11 +1,11 @@
-package selinux
+package util
 
 import (
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
-// KVMLabel returns labels for running kvm isolated containers
-func KVMLabel(cLabel string) (string, error) {
+// SELinuxKVMLabel returns labels for running kvm isolated containers
+func SELinuxKVMLabel(cLabel string) (string, error) {
 	if cLabel == "" {
 		// selinux is disabled
 		return "", nil
@@ -15,8 +15,8 @@ func KVMLabel(cLabel string) (string, error) {
 	return swapSELinuxLabel(cLabel, processLabel)
 }
 
-// InitLabel returns labels for running systemd based containers
-func InitLabel(cLabel string) (string, error) {
+// SELinuxInitLabel returns labels for running systemd based containers
+func SELinuxInitLabel(cLabel string) (string, error) {
 	if cLabel == "" {
 		// selinux is disabled
 		return "", nil

--- a/vendor/github.com/containers/libpod/pkg/spec/config_linux.go
+++ b/vendor/github.com/containers/libpod/pkg/spec/config_linux.go
@@ -16,6 +16,7 @@ import (
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -365,4 +366,28 @@ func GetStatFromPath(path string) (unix.Stat_t, error) {
 	s := unix.Stat_t{}
 	err := unix.Stat(path, &s)
 	return s, err
+}
+
+func getNOFILESettings() (uint64, uint64) {
+	if rootless.IsRootless() {
+		var rlimit unix.Rlimit
+		if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err == nil {
+			return rlimit.Cur, rlimit.Max
+		} else {
+			logrus.Warnf("failed to return RLIMIT_NOFILE ulimit %q", err)
+		}
+	}
+	return kernelMax, kernelMax
+}
+
+func getNPROCSettings() (uint64, uint64) {
+	if rootless.IsRootless() {
+		var rlimit unix.Rlimit
+		if err := unix.Getrlimit(unix.RLIMIT_NPROC, &rlimit); err == nil {
+			return rlimit.Cur, rlimit.Max
+		} else {
+			logrus.Warnf("failed to return RLIMIT_NPROC ulimit %q", err)
+		}
+	}
+	return kernelMax, kernelMax
 }

--- a/vendor/github.com/containers/libpod/pkg/spec/config_unsupported.go
+++ b/vendor/github.com/containers/libpod/pkg/spec/config_unsupported.go
@@ -34,3 +34,11 @@ func DevicesFromPath(g *generate.Generator, devicePath string) error {
 func deviceCgroupRules(g *generate.Generator, deviceCgroupRules []string) error {
 	return errors.New("function not implemented")
 }
+
+func getNOFILESettings() (uint64, uint64) {
+	return kernelMax, kernelMax
+}
+
+func getNPROCSettings() (uint64, uint64) {
+	return kernelMax, kernelMax
+}

--- a/vendor/github.com/containers/libpod/pkg/spec/spec.go
+++ b/vendor/github.com/containers/libpod/pkg/spec/spec.go
@@ -18,7 +18,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const CpuPeriod = 100000
+const (
+	CpuPeriod        = 100000
+	kernelMax uint64 = 1048576
+)
 
 func GetAvailableGids() (int64, error) {
 	idMap, err := user.ParseIDMapFile("/proc/self/gid_map")
@@ -326,10 +329,6 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 		}
 		defaultEnv = env.Join(env.DefaultEnvVariables, defaultEnv)
 	}
-	config.Env = env.Join(defaultEnv, config.Env)
-	for name, val := range config.Env {
-		g.AddProcessEnv(name, val)
-	}
 
 	if err := addRlimits(config, &g); err != nil {
 		return nil, err
@@ -359,6 +358,11 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 
 	if err := config.Cgroup.ConfigureGenerator(&g); err != nil {
 		return nil, err
+	}
+
+	config.Env = env.Join(defaultEnv, config.Env)
+	for name, val := range config.Env {
+		g.AddProcessEnv(name, val)
 	}
 	configSpec := g.Config
 
@@ -501,10 +505,8 @@ func BlockAccessToKernelFilesystems(privileged, pidModeIsHost bool, g *generate.
 
 func addRlimits(config *CreateConfig, g *generate.Generator) error {
 	var (
-		kernelMax  uint64 = 1048576
-		isRootless        = rootless.IsRootless()
-		nofileSet         = false
-		nprocSet          = false
+		nofileSet = false
+		nprocSet  = false
 	)
 
 	for _, u := range config.Resources.Ulimit {
@@ -533,11 +535,13 @@ func addRlimits(config *CreateConfig, g *generate.Generator) error {
 	// If not explicitly overridden by the user, default number of open
 	// files and number of processes to the maximum they can be set to
 	// (without overriding a sysctl)
-	if !nofileSet && !isRootless {
-		g.AddProcessRlimits("RLIMIT_NOFILE", kernelMax, kernelMax)
+	if !nofileSet {
+		current, max := getNOFILESettings()
+		g.AddProcessRlimits("RLIMIT_NOFILE", current, max)
 	}
-	if !nprocSet && !isRootless {
-		g.AddProcessRlimits("RLIMIT_NPROC", kernelMax, kernelMax)
+	if !nprocSet {
+		current, max := getNPROCSettings()
+		g.AddProcessRlimits("RLIMIT_NPROC", current, max)
 	}
 
 	return nil

--- a/vendor/github.com/containers/libpod/version/version.go
+++ b/vendor/github.com/containers/libpod/version/version.go
@@ -4,7 +4,7 @@ package version
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-const Version = "1.9.0"
+const Version = "1.9.2"
 
 // RemoteAPIVersion is the version for the remote
 // client API.  It is used to determine compatibility

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,7 +159,7 @@ github.com/containers/image/v5/transports
 github.com/containers/image/v5/transports/alltransports
 github.com/containers/image/v5/types
 github.com/containers/image/v5/version
-# github.com/containers/libpod v1.9.0
+# github.com/containers/libpod v1.9.2
 ## explicit
 github.com/containers/libpod/cmd/podman/cliconfig
 github.com/containers/libpod/libpod
@@ -196,6 +196,7 @@ github.com/containers/libpod/pkg/resolvconf/dns
 github.com/containers/libpod/pkg/rootless
 github.com/containers/libpod/pkg/rootlessport
 github.com/containers/libpod/pkg/seccomp
+github.com/containers/libpod/pkg/selinux
 github.com/containers/libpod/pkg/signal
 github.com/containers/libpod/pkg/spec
 github.com/containers/libpod/pkg/sysinfo


### PR DESCRIPTION
/kind Feature

Newer versions of container-selinux, container-selinux-2.132.0 or newer,
supply a `container_init_t` label.  If CRI-O is running systemd or init inside
of the container, then the container will require different SELinux privs
to run the container.

By using the new SELinux label, we can run ordinary containers with a tighter
selinux policy then those running the init system, makeing the overlay system
more secure.

The eliminates the need to turn on the container_manage_cgroup SELinux boolean.

Ie. no need to execute

```
setsebool -P container_manage_cgroup 1
```

Any longer. On systems without the updated container-selnux package, the containers will still
attempt to run the standard container type `container_t`, and still require the boolean.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
containers running `init` or `systemd` are now given a new selinux label `container_init_t`, giving it selinux privileges more appropriate for the workload
```
