### PR TITLE
Allow release notes for release branches

### DIFF
--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -65,6 +65,17 @@ func run() error {
 	}
 	logrus.Infof("Using HEAD commit %s", head)
 
+	targetBranch := git.Master
+	currentBranch, err := repo.CurrentBranch()
+	if err != nil {
+		return errors.Wrap(err, "get current branch")
+	}
+	logrus.Infof("Found current branch %s", currentBranch)
+	if git.IsReleaseBranch(currentBranch) && currentBranch != git.Master {
+		targetBranch = currentBranch
+	}
+	logrus.Infof("Using target branch %s", targetBranch)
+
 	templateFile, err := ioutil.TempFile("", "")
 	if err != nil {
 		return errors.Wrap(err, "writing template file")
@@ -117,6 +128,7 @@ Download the static release bundle via our Google Cloud Bucket:
 		"./build/bin/release-notes",
 		"--github-org=cri-o",
 		"--github-repo=cri-o",
+		"--branch="+targetBranch,
 		"--repo-path=/tmp/cri-o-repo",
 		"--required-author=",
 		"--start-rev="+startTag,
@@ -133,11 +145,6 @@ Download the static release bundle via our Google Cloud Bucket:
 		content, err := ioutil.ReadFile(outputFilePath)
 		if err != nil {
 			return errors.Wrap(err, "open generated release notes")
-		}
-
-		currentBranch, err := repo.CurrentBranch()
-		if err != nil {
-			return errors.Wrap(err, "get current branch")
 		}
 
 		logrus.Infof("Checking out branch %s", branch)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This changes the release notes generation script to also work for
release branches.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Forward-port of https://github.com/cri-o/cri-o/pull/3766
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
