### PR TITLE
Do not remove existing runtime handler

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -444,18 +444,9 @@ func (c *Config) UpdateFromFile(path string) error {
 	t := new(tomlConfig)
 	t.fromConfig(c)
 
-	metadata, err := toml.Decode(string(data), t)
+	_, err = toml.Decode(string(data), t)
 	if err != nil {
 		return fmt.Errorf("unable to decode configuration %v: %v", path, err)
-	}
-
-	// If the default runtime `runc` provided via DefaultConfig() is not part
-	// of the configuration file, then we have to manually remove it because
-	// the user explicitly removed it
-	runtimesKey := []string{"crio", "runtime", "runtimes"}
-	if metadata.IsDefined(runtimesKey...) &&
-		!metadata.IsDefined(append(runtimesKey, defaultRuntime)...) {
-		delete(c.Runtimes, defaultRuntime)
 	}
 
 	t.toConfig(c)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -752,7 +752,7 @@ var _ = t.Describe("Config", func() {
 
 			// Then
 			Expect(err).To(BeNil())
-			Expect(sut.Runtimes).To(HaveLen(1))
+			Expect(sut.Runtimes).To(HaveLen(2))
 			Expect(sut.Runtimes).To(HaveKey("crun"))
 		})
 


### PR DESCRIPTION
Fixes - #3536

Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

This PR addresses the concerns raised in #3536 about having runtimes other than default `runc` be responsible for making sure the existing `runc` configuration is not broken. For example, please refer to #3536 for additional info on how it affects the users of Kata runtime. 

#### Which issue(s) this PR fixes:

Fixes #3536 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adding additional runtime handler doesn't require the user to copy existing default runtime handler configuration. The existing default runtime handler configuration will be preserved while adding the new runtime handler. 
```
