### PR TITLE
Check that SecurityContext is not nil before dereferencing

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -111,7 +111,7 @@ func findCgroupMountpoint(name string) error {
 
 func addDevicesPlatform(ctx context.Context, sb *sandbox.Sandbox, containerConfig *pb.ContainerConfig, privilegedWithoutHostDevices bool, specgen *generate.Generator) error {
 	sp := specgen.Config
-	if containerConfig.GetLinux().GetSecurityContext().GetPrivileged() && !privilegedWithoutHostDevices {
+	if containerConfig.GetLinux().GetSecurityContext() != nil && containerConfig.GetLinux().GetSecurityContext().GetPrivileged() && !privilegedWithoutHostDevices {
 		hostDevices, err := devices.HostDevices()
 		if err != nil {
 			return err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR adds check for containerConfig.GetLinux().GetSecurityContext() not to be nil before dereferencing.
This would give the if statement parity consistent with how GetPrivileged() is called in other parts of the file.

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
