### PR TITLE
Add `privileged` indicator to container status

### DIFF
--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -567,7 +567,8 @@ var _ = t.Describe("Runtime", func() {
 					"podName", "podID", "imagename",
 					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 					"containerName", "containerID", "",
-					0, &idtools.IDMappings{}, []string{"mountLabel"})
+					0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+				)
 			})
 
 			It("should succeed to create a pod sandbox", func() {
@@ -576,7 +577,8 @@ var _ = t.Describe("Runtime", func() {
 					"podName", "podID", "imagename", "",
 					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 					"containerName", "metadataName",
-					"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"})
+					"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+				)
 
 			})
 
@@ -597,7 +599,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, &idtools.IDMappings{}, []string{"mountLabel"})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -611,7 +614,8 @@ var _ = t.Describe("Runtime", func() {
 				"", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, &idtools.IDMappings{}, []string{"mountLabel"})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -624,7 +628,8 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "", "",
 				"containerName", "containerID", "metadataName",
-				0, &idtools.IDMappings{}, []string{"mountLabel"})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -637,7 +642,8 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "imagename", "imageID",
 				"", "containerID", "metadataName",
-				0, &idtools.IDMappings{}, []string{"mountLabel"})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -670,7 +676,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, &idtools.IDMappings{}, []string{"mountLabel"})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -699,7 +706,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, &idtools.IDMappings{}, []string{"mountLabel"})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -726,7 +734,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename", "",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -751,7 +760,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename", "",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -771,7 +781,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename", "",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -791,7 +802,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, &idtools.IDMappings{}, []string{"mountLabel"})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -819,7 +831,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "imagename",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "containerID", "metadataName",
-				0, &idtools.IDMappings{}, []string{"mountLabel"})
+				0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -877,7 +890,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "pauseimagename", "",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 		})
 
 		It("should pull pauseImage if not available locally, using provided credential file", func() {
@@ -896,7 +910,8 @@ var _ = t.Describe("Runtime", func() {
 				"podName", "podID", "pauseimagename", "/var/non-default/credentials.json",
 				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"})
+				"uid", "namespace", 0, &idtools.IDMappings{}, []string{"mountLabel"}, false,
+			)
 		})
 
 		AfterEach(func() {

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -395,7 +395,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		metadata.Name,
 		metadata.Attempt,
 		containerIDMappings,
-		labelOptions)
+		labelOptions,
+		privileged,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -602,8 +604,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		}
 		specgen.SetProcessNoNewPrivileges(linux.GetSecurityContext().GetNoNewPrivs())
 
-		if containerConfig.GetLinux().GetSecurityContext() != nil &&
-			!containerConfig.GetLinux().GetSecurityContext().Privileged {
+		if !privileged {
 			// TODO(runcom): have just one of this var at the top of the function
 			securityContext := containerConfig.GetLinux().GetSecurityContext()
 			for _, mp := range []string{

--- a/server/container_status_test.go
+++ b/server/container_status_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/utils"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -32,6 +34,11 @@ var _ = t.Describe("ContainerStatus", func() {
 			testContainer.AddVolume(oci.ContainerVolume{})
 			testContainer.SetState(givenState)
 			testContainer.SetSpec(&specs.Spec{Version: "1.0.0"})
+
+			gomock.InOrder(
+				runtimeServerMock.EXPECT().GetContainerMetadata(gomock.Any()).
+					Return(storage.RuntimeContainerMetadata{}, nil),
+			)
 
 			// When
 			response, err := sut.ContainerStatus(context.Background(),

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -38,7 +38,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 				runtimeServerMock.EXPECT().CreatePodSandbox(gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).
 					Return(storage.ContainerInfo{
 						RunDir: "/tmp",
 						Config: &v1.Image{Config: v1.ImageConfig{}},
@@ -120,7 +121,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 				runtimeServerMock.EXPECT().CreatePodSandbox(gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).
 					Return(storage.ContainerInfo{}, nil),
 				runtimeServerMock.EXPECT().RemovePodSandbox(gomock.Any()).
 					Return(nil),

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -265,6 +265,9 @@ function wait_until_exit() {
 	run crictl inspect "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+	run crictl inspect "$ctr_id" | jq -e ".info.privileged == false"
+	echo "$output"
+	[ "$status" -eq 0 ]
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -1564,6 +1567,10 @@ function wait_until_exit() {
 	[ "$status" -eq 0 ]
 	ctr_id="$output"
 	run crictl start "$ctr_id"
+	[ "$status" -eq 0 ]
+
+	run crictl inspect "$ctr_id" | jq -e ".info.privileged == true"
+	echo "$output"
 	[ "$status" -eq 0 ]
 
 	# TODO there seems to be a difference in behavior between runc and crun

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -164,33 +164,33 @@ func (m *MockRuntimeServer) EXPECT() *MockRuntimeServerMockRecorder {
 }
 
 // CreateContainer mocks base method
-func (m *MockRuntimeServer) CreateContainer(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7 string, arg8 uint32, arg9 *idtools.IDMappings, arg10 []string) (storage0.ContainerInfo, error) {
+func (m *MockRuntimeServer) CreateContainer(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7 string, arg8 uint32, arg9 *idtools.IDMappings, arg10 []string, arg11 bool) (storage0.ContainerInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
+	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
 	ret0, _ := ret[0].(storage0.ContainerInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateContainer indicates an expected call of CreateContainer
-func (mr *MockRuntimeServerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 interface{}) *gomock.Call {
+func (mr *MockRuntimeServerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockRuntimeServer)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockRuntimeServer)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
 }
 
 // CreatePodSandbox mocks base method
-func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 string, arg10 uint32, arg11 *idtools.IDMappings, arg12 []string) (storage0.ContainerInfo, error) {
+func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 string, arg10 uint32, arg11 *idtools.IDMappings, arg12 []string, arg13 bool) (storage0.ContainerInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePodSandbox", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
+	ret := m.ctrl.Call(m, "CreatePodSandbox", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
 	ret0, _ := ret[0].(storage0.ContainerInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePodSandbox indicates an expected call of CreatePodSandbox
-func (mr *MockRuntimeServerMockRecorder) CreatePodSandbox(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12 interface{}) *gomock.Call {
+func (mr *MockRuntimeServerMockRecorder) CreatePodSandbox(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePodSandbox", reflect.TypeOf((*MockRuntimeServer)(nil).CreatePodSandbox), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePodSandbox", reflect.TypeOf((*MockRuntimeServer)(nil).CreatePodSandbox), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
 }
 
 // DeleteContainer mocks base method


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind feature

#### What this PR does / why we need it:
We now add an additional field to the `info` of the container status
indicating if a container is running in privileged mode or not.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/3769
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `privileged` field to container status `info`
```
