### PR TITLE
[1.11] conmon: make un-OOM-killable

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -137,7 +137,7 @@ static GOptionEntry opt_entries[] = {
 #define TSBUFLEN 44
 
 #define CGROUP_ROOT "/sys/fs/cgroup"
-#define OOM_SCORE "-999"
+#define OOM_SCORE "-1000"
 
 static int log_fd = -1;
 


### PR DESCRIPTION
There are no situations that conmon should be OOM killed. In all situations conmon would be OOM killed, it is from a poorly acting container in conmon's cgroup. Even with -999, if conmon allocates memory at the wrong time, it will be OOM killed. If conmon is made un-OOM-killable, the container will be the one to be killed, as is correct.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

/kind bug