### PR TITLE
only set cpu period and quota when both are defined

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -517,8 +517,11 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	if linux != nil {
 		resources := linux.GetResources()
 		if resources != nil {
-			specgen.SetLinuxResourcesCPUPeriod(uint64(resources.GetCpuPeriod()))
-			specgen.SetLinuxResourcesCPUQuota(resources.GetCpuQuota())
+			// only set period or quota if both are configured, or else the runtime will fail
+			if resources.GetCpuPeriod() != 0 && resources.GetCpuQuota() != 0 {
+				specgen.SetLinuxResourcesCPUPeriod(uint64(resources.GetCpuPeriod()))
+				specgen.SetLinuxResourcesCPUQuota(resources.GetCpuQuota())
+			}
 			specgen.SetLinuxResourcesCPUShares(uint64(resources.GetCpuShares()))
 
 			memoryLimit := resources.GetMemoryLimitInBytes()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:
runc was previously doing this for us, but has since changed behavior. Now, we're responsible for not setting quota or period when either are undefined

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
fixes https://github.com/cri-o/cri-o/issues/3792
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
