### PR TITLE
[1.16] Set log-dir to default value if it is empty

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ const (
 	defaultRuntime         = "runc"
 	DefaultRuntimeType     = "oci"
 	DefaultRuntimeRoot     = "/run/runc"
+	defaultLogDir          = "/var/log/crio/pods"
 	cgroupManager          = "cgroupfs"
 	DefaultApparmorProfile = "crio-default-" + version.Version
 	defaultGRPCMaxMsgSize  = 16 * 1024 * 1024
@@ -465,7 +466,7 @@ func DefaultConfig() (*Config, error) {
 			RunRoot:        storeOpts.RunRoot,
 			Storage:        storeOpts.GraphDriverName,
 			StorageOptions: storeOpts.GraphDriverOptions,
-			LogDir:         "/var/log/crio/pods",
+			LogDir:         defaultLogDir,
 			VersionFile:    CrioVersionPath,
 		},
 		APIConfig: APIConfig{
@@ -598,6 +599,10 @@ func (c *APIConfig) Validate(onExecution bool) error {
 // `nil`.
 func (c *RootConfig) Validate(onExecution bool) error {
 	if onExecution {
+		if c.LogDir == "" {
+			logrus.Debugf("Defaulting to %q as the log-dir since log_dir is not set", defaultLogDir)
+			c.LogDir = defaultLogDir
+		}
 		if !filepath.IsAbs(c.LogDir) {
 			return errors.New("log_dir is not an absolute path")
 		}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

 /kind bug

#### What this PR does / why we need it:
If the log_dir value from crio.conf is empty, set it
to the default value of /var/log/crio/pods. This helps
fix a bug we hit when upgrading from 4.2 to 4.3 as 4.2
did not have the log_dir option in crio.conf. When we have
ctrcfg CR already created in a 4.2 cluster and try upgrading
to 4.3, cri-o breaks because log_dir in crio.conf ends up
being "".

#### Which issue(s) this PR fixes:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1838606

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
