### PR TITLE
cgroup features detection speedup and simplification

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -45,23 +45,16 @@ const minMemoryLimit = 12582912
 const podTerminationGracePeriodLabel = "io.kubernetes.pod.terminationGracePeriod"
 
 var (
-	_cgroupHasMemorySwapOnce sync.Once
-	_cgroupHasMemorySwap     bool
-
 	_controllerAvailableOnce sync.Once
 	_controllers             map[string]struct{}
 )
 
 func cgroupHasMemorySwap() bool {
-	_cgroupHasMemorySwapOnce.Do(func() {
-		if cgroups.IsCgroup2UnifiedMode() {
-			_cgroupHasMemorySwap = true
-			return
-		}
-		_, err := os.Stat("/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes")
-		_cgroupHasMemorySwap = err == nil
-	})
-	return _cgroupHasMemorySwap
+	if cgroups.IsCgroup2UnifiedMode() {
+		return true
+	}
+	_, err := os.Stat("/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes")
+	return err == nil
 }
 
 type configDevice struct {


### PR DESCRIPTION
One speedup, one fix, and a few simplifications to the code.

The speedup is not calling `cgroups.FindCgroupMountpoint` to test whether the pids controller is available. Believe me, this is huge.

The fix is not calling `cgroups.FindCgroupMountpoint` o test whether the pids controller is available (it will always say "yes, sir").

Simplification number one is reusing the same code to check for hugetlb controller.

Simplification number two is dropping sync.Once use to avoid an os.Stat() call.

Overall result: faster, simpler code.

Side note: this also prepares the codebase for upcoming changes in runc (https://github.com/opencontainers/runc/pull/2411)

---

/kind cleanup

```release-note
NONE
```
