### PR TITLE
oci: wait for stdout also if StdInOnce

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -873,9 +873,9 @@ func (r *runtimeOCI) AttachContainer(c *Container, inputStream io.Reader, output
 		var err error
 		if inputStream != nil {
 			_, err = utils.CopyDetachable(conn, inputStream, nil)
-			if closeErr := conn.CloseWrite(); closeErr != nil {
-				stdinDone <- closeErr
-			}
+		}
+		if closeErr := conn.CloseWrite(); closeErr != nil {
+			stdinDone <- closeErr
 		}
 		stdinDone <- err
 		close(stdinDone)
@@ -885,9 +885,6 @@ func (r *runtimeOCI) AttachContainer(c *Container, inputStream io.Reader, output
 	case err := <-receiveStdout:
 		return err
 	case err := <-stdinDone:
-		if !c.StdinOnce() && !tty {
-			return nil
-		}
 		if _, ok := err.(utils.DetachError); ok {
 			return nil
 		}


### PR DESCRIPTION
kubernetes commit a0f0e58373e5fccb6d96b135f3f0d352b566c034 changed
the attach test adding a sleep before printing to stdout.

The race condition already existed in CRI-O as it didn't wait for
stdout to be fully copied, the new test behaviour just made the
failure consistent.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
