### PR TITLE
Cleanup and update nix derivation for static builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ stdenv: &stdenv
     IMAGE: &image quay.io/crio/crio-build-amd64-go1.14:master-1.3.7
     IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.13:master-1.3.7
     IMAGE386: &image386 quay.io/crio/crio-build-386-go1.14:master-1.3.7
-    IMAGENIX: &imagenix quay.io/crio/nix:1.4.0
     JOBS: &jobs 4
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o
     WORKDIR_VM: &workdir_vm /home/circleci/go/src/github.com/cri-o/cri-o
@@ -36,10 +35,6 @@ executors:
       - image: golang:1.14
     <<: *stdenv
     working_directory: *workdir
-
-  nix:
-    docker:
-      - image: *imagenix
 
   machine:
     machine:
@@ -155,18 +150,18 @@ jobs:
             - docs
 
   build-static:
-    executor: nix
+    executor: machine
     steps:
       - checkout
-      - run:
-          name: Add remote to fetch all tags
-          command: |
-            git remote add base https://github.com/cri-o/cri-o
-            git fetch base
+      - attach_workspace:
+          at: .
       - run:
           name: build
           command: |
-            nix-build nix --argstr revision $CIRCLE_SHA1
+            set -ex
+            sudo mkdir -p /nix
+            sudo docker run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix
+            sudo docker run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
             mkdir -p bin
             cp -r result/bin bin/static
       - run:
@@ -177,6 +172,12 @@ jobs:
           root: .
           paths:
             - bin/static
+      - store_artifacts:
+          path: result/bin/crio
+      - store_artifacts:
+          path: result/bin/crio-status
+      - store_artifacts:
+          path: result/bin/pinns
 
   build-test-binaries:
     executor: container

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ test-images:
 	$(TESTIMAGE_SCRIPT) -g 1.13 -a amd64
 
 nixpkgs:
-	@nix run -f channel:nixpkgs-unstable nix-prefetch-git -c nix-prefetch-git \
+	@nix run -f channel:nixos-20.03 nix-prefetch-git -c nix-prefetch-git \
 		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json
 
 test-image-nix:

--- a/contrib/test/integration/build/crun.yml
+++ b/contrib/test/integration/build/crun.yml
@@ -5,7 +5,7 @@
     repo: "https://github.com/containers/crun.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/containers/crun"
     force: "{{ force_clone | default(False) | bool}}"
-    version: "4ad44b872b09a244dd7b2848952f4db0d0b968f4"
+    version: "88886aef25302adfd40a9335372bbc2b970c8ae5"
 
 - name: Install crun dependencies
   raw: >

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,10 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "2b51171fb6eadbe0909dc5f3726371a149044f77",
-  "date": "2020-05-13T14:24:04+02:00",
-  "path": "/nix/store/dnv2wqnkssh7ph5r9gbxv6gxp8ykkqn4-nixpkgs",
-  "sha256": "1f76j4m05sbypc1s9lbdbdp62slryvknsi78ilrb3lnmq17biymi",
-  "fetchSubmodules": false,
-  "deepClone": false,
-  "leaveDotGit": false
+  "rev": "02591d02a910b3b92092153c5f3419a8d696aa1d",
+  "date": "2020-07-09T03:52:28+02:00",
+  "sha256": "1pp9v4rqmgx1b298gxix8b79m8pvxy1rcf8l25rxxxxnkr5ls1ng",
+  "fetchSubmodules": false
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind cleanup
> /kind dependency-change

#### What this PR does / why we need it:

Similar PR goes for crun/conmon/libpod/cri-o/etc, too.

Also see:
  - ~~https://github.com/containers/crun/pull/372~~
  - ~~https://github.com/containers/conmon/pull/161~~
  - ~~https://github.com/containers/skopeo/pull/932~~
  - ~~https://github.com/containers/buildah/pull/2380~~
  - ~~https://github.com/containers/libpod/pull/6402~~
  - https://github.com/cri-o/cri-o/pull/3804


Static binaries:
  - [crun-0.13-linux-amd64](https://github.com/alvistack/crun/releases/download/0.13/crun-0.13-linux-amd64)
  - [conmon-v2.0.17-linux-amd64](https://github.com/alvistack/conmon/releases/download/v2.0.17/conmon-v2.0.17-linux-amd64)
  - [skopeo-v1.1.0-linux-amd64](https://github.com/alvistack/skopeo/releases/download/v1.1.0/skopeo-v1.1.0-linux-amd64)
  - [buildah-v1.15.0-linux-amd64](https://github.com/alvistack/buildah/releases/download/v1.15.0/buildah-v1.15.0-linux-amd64)
  - [podman-v1.9.3-linux-amd64](https://github.com/alvistack/libpod/releases/download/v1.9.3/podman-v1.9.3-linux-amd64)
  - [cri-o-v1.17.4-linux-amd64.tar.gz](https://github.com/alvistack/cri-o/releases/download/v1.17.4/cri-o-v1.17.4-linux-amd64.tar.gz)
  - [cri-o-v1.18.2-linux-amd64.tar.gz](https://github.com/alvistack/cri-o/releases/download/v1.18.2/cri-o-v1.18.2-linux-amd64.tar.gz)

Ansible Roles:
  - https://github.com/alvistack/ansible-role-crun
  - https://github.com/alvistack/ansible-role-conmon
  - https://github.com/alvistack/ansible-role-skopeo
  - https://github.com/alvistack/ansible-role-buildah 
  - https://github.com/alvistack/ansible-role-podman
  - https://github.com/alvistack/ansible-role-cri_o


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:


Here I skip the btrfs and lvm2 support for static binary, because:
1. btrfs will not support in CentOS 8
2. With skopeo experience both btrfs and lvm2 are not easy for compile as static binary

Also see:
- https://github.com/containers/libpod/pull/6402#discussion_r431398382

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Cleanup and update nix derivation for static builds
```
