### PR TITLE
[release-1.18] Cleanup nix derivation for static builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ stdenv: &stdenv
     IMAGE: &image quay.io/crio/crio-build-amd64-go1.14:master-1.3.6
     IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.13:master-1.3.6
     IMAGE386: &image386 quay.io/crio/crio-build-386-go1.14:master-1.3.6
-    IMAGENIX: &imagenix quay.io/crio/nix:1.3.0
+    IMAGENIX: &imagenix quay.io/crio/nix:1.4.0
     JOBS: &jobs 4
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o
     WORKDIR_VM: &workdir_vm /home/circleci/go/src/github.com/cri-o/cri-o
@@ -89,7 +89,7 @@ workflows:
           test_userns: '1'
       - integration:
           name: integration-static
-          crio_binary: crio-static
+          crio_binary: static/crio
           requires:
             - build-static
       - lint
@@ -165,15 +165,15 @@ jobs:
           command: |
             nix-build nix --argstr revision $CIRCLE_SHA1
             mkdir -p bin
-            cp result-*bin/bin/crio-* bin
+            cp -r result/bin bin/static
       - run:
           name: Show CRI-O version for static binaries
           command: |
-            ./bin/crio-static version
+            ./bin/static/crio version
       - persist_to_workspace:
           root: .
           paths:
-            - bin
+            - bin/static
 
   build-test-binaries:
     executor: container

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ coverprofile
 .gdb_history
 *gomock_reflect*
 lib/state.json
-result-*bin
+result
 *_junit.xml
 
 ./Vagrantfile

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,59 +1,44 @@
 { system ? builtins.currentSystem }:
 let
-  pkgs = import ./nixpkgs.nix {
+  pkgs = (import ./nixpkgs.nix {
     config = {
       packageOverrides = pkg: {
-        go_1_12 = pkg.go_1_14;
+        gpgme = (static pkg.gpgme);
+        libassuan = (static pkg.libassuan);
+        libgpgerror = (static pkg.libgpgerror);
+        libseccomp = (static pkg.libseccomp);
       };
     };
-  };
+  });
 
-  static = pkg: pkg.overrideAttrs(old: {
-    configureFlags = (old.configureFlags or []) ++
+  static = pkg: pkg.overrideAttrs(x: {
+    configureFlags = (x.configureFlags or []) ++
       [ "--without-shared" "--disable-shared" ];
     dontDisableStatic = true;
     enableSharedExecutables = false;
     enableStatic = true;
   });
 
-  patchLvm2 = pkg: pkg.overrideAttrs(old: {
-    configureFlags = [
-      "--disable-cmdlib" "--disable-readline" "--disable-udev_rules"
-      "--disable-udev_sync" "--enable-pkgconfig" "--enable-static_link"
-    ];
-    preConfigure = old.preConfigure + ''
-      substituteInPlace libdm/Makefile.in --replace \
-        SUBDIRS=dm-tools SUBDIRS=
-      substituteInPlace tools/Makefile.in --replace \
-        "TARGETS += lvm.static" ""
-      substituteInPlace tools/Makefile.in --replace \
-        "INSTALL_LVM_TARGETS += install_tools_static" ""
-    '';
-    postInstall = "";
-  });
-
-  self = {
-    cri-o-static = (pkgs.cri-o.overrideAttrs(old: {
+  self = with pkgs; {
+    cri-o-static = (cri-o.overrideAttrs(x: {
       name = "cri-o-static";
-      buildInputs = old.buildInputs ++ (with pkgs; [ systemd ]);
       src = ./..;
-      buildPhase = ''
-        pushd go/src/github.com/cri-o/cri-o
-        make BUILDTAGS="apparmor seccomp selinux containers_image_ostree_stub netgo" \
-          bin/crio \
-          bin/crio-status \
-          bin/pinns
+      doCheck = false;
+      buildInputs = [
+        glibc
+        glibc.static
+        gpgme
+        libapparmor
+        libassuan
+        libgpgerror
+        libseccomp
+        libselinux
+      ];
+      prePatch = ''
+        export LDFLAGS='-static-libgcc -static'
+        export EXTRA_LDFLAGS='-linkmode external -extldflags "-static -lm"'
+        export BUILDTAGS='static netgo apparmor selinux seccomp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper'
       '';
-      EXTRA_LDFLAGS = ''-linkmode external -extldflags "-static -lm"'';
-      dontStrip = true;
-      # DEBUG = 1; # Uncomment this line to enable debug symbols in the binary
-    })).override {
-      flavor = "-static";
-      gpgme = (static pkgs.gpgme);
-      libassuan = (static pkgs.libassuan);
-      libgpgerror = (static pkgs.libgpgerror);
-      libseccomp = (static pkgs.libseccomp);
-      lvm2 = (patchLvm2 (static pkgs.lvm2));
-    };
+    }));
   };
 in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,8 +1,9 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "b3412865ce1db90fca65274024395ca00cf13e6d",
-  "date": "2020-03-24T10:00:11+00:00",
-  "sha256": "15n1v50bixkbap3badnkk5p4f3m7qawxvpx65nrvljvb0pgznfiv",
+  "rev": "2b51171fb6eadbe0909dc5f3726371a149044f77",
+  "date": "2020-05-13T14:24:04+02:00",
+  "path": "/nix/store/dnv2wqnkssh7ph5r9gbxv6gxp8ykkqn4-nixpkgs",
+  "sha256": "1f76j4m05sbypc1s9lbdbdp62slryvknsi78ilrb3lnmq17biymi",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
Also see #3804

nix-based static binary could be found from:
- https://github.com/alvistack/cri-o/releases/tag/v1.18.1
- https://github.com/alvistack/cri-o/releases/tag/v1.17.4