### PR TITLE
[release-1.17] Cleanup nix derivation for static builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ version: 2.1
 stdenv: &stdenv
   environment:
     GOCACHE: &gocache /tmp/go-build
-    IMAGE: &image quay.io/crio/crio-build-amd64-go1.13:1.17-1.1.3
-    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.10:1.17-1.1.3
-    IMAGE386: &image386 quay.io/crio/crio-build-386-go1.13:1.17-1.1.3
-    IMAGENIX: &imagenix quay.io/crio/nix:1.1.0
+    IMAGE: &image quay.io/crio/crio-build-amd64-go1.14:master-1.3.6
+    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.13:master-1.3.6
+    IMAGE386: &image386 quay.io/crio/crio-build-386-go1.14:master-1.3.6
+    IMAGENIX: &imagenix quay.io/crio/nix:1.4.0
     JOBS: &jobs 4
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o
     WORKDIR_VM: &workdir_vm /home/circleci/go/src/github.com/cri-o/cri-o
@@ -33,7 +33,7 @@ executors:
 
   container-base:
     docker:
-      - image: circleci/golang:1.13
+      - image: golang:1.14
     <<: *stdenv
     working_directory: *workdir
 
@@ -53,7 +53,7 @@ workflows:
     jobs:
       - build
       - build:
-          name: build-go1.10
+          name: build-go1.13
           executor: container-legacy
       - build:
           name: build-386
@@ -64,9 +64,15 @@ workflows:
           requires:
             - build
             - build-static
+      - bundle-test:
+          requires:
+            - bundle
       - completions-validation:
           requires:
             - build
+      - dependencies:
+          requires:
+            - release-notes
       - docs-generation:
           requires:
             - build
@@ -82,25 +88,31 @@ workflows:
           name: integration-userns
           test_userns: '1'
       - integration:
-          name: integration-static-glibc
-          crio_binary: crio-x86_64-static-glibc
-          requires:
-            - build-static
-      - integration:
-          name: integration-static-musl
-          crio_binary: crio-x86_64-static-musl
+          name: integration-static
+          crio_binary: static/crio
           requires:
             - build-static
       - lint
+      - release-branch-forward:
+          requires:
+            - results
+          filters:
+            branches:
+              only:
+                - master
+      - release-notes:
+          requires:
+            - results
       - results:
           requires:
-            - bundle
+            - bundle-test
             - integration
             - integration-critest
-            - integration-static-glibc
-            - integration-static-musl
+            - integration-static
             - integration-userns
             - unit-tests
+      - shellcheck
+      - shfmt
       - unit-tests
       - vendor
 
@@ -120,6 +132,9 @@ jobs:
       - run: go env
       - run:
           command: make binaries -j $JOBS
+      - run:
+          name: Show CRI-O version
+          command: ./bin/crio version
       - run:
           command: make crio.conf
       - run:
@@ -141,15 +156,24 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Add remote to fetch all tags
+          command: |
+            git remote add base https://github.com/cri-o/cri-o
+            git fetch base
+      - run:
           name: build
           command: |
             nix-build nix --argstr revision $CIRCLE_SHA1
             mkdir -p bin
-            cp result-*bin/bin/crio-* bin
+            cp -r result/bin bin/static
+      - run:
+          name: Show CRI-O version for static binaries
+          command: |
+            ./bin/static/crio version
       - persist_to_workspace:
           root: .
           paths:
-            - bin
+            - bin/static
 
   build-test-binaries:
     executor: container
@@ -183,7 +207,17 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - bundle/*.tar.gz
+            - build/bundle/*.tar.gz
+
+  bundle-test:
+    executor: machine
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: test
+          command: make bundle-test
 
   completions-validation:
     executor: container
@@ -254,6 +288,33 @@ jobs:
             - *gocache
             - build/bin/git-validation
 
+  dependencies:
+    executor: container
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "go.sum" }}
+      - add_ssh_keys:
+          fingerprints:
+            - bd:a6:4b:50:1b:2a:a4:1d:79:67:64:05:66:c4:3a:10
+      - run:
+          name: Generate Dependency Report
+          command: |
+            if [[ -z $GITHUB_TOKEN ]]; then
+              echo Skipping dependencies generation
+            else
+              make dependencies
+            fi
+      - store_artifacts:
+          path: build/dependencies/dependencies.md
+          destination: dependencies.md
+      - save_cache:
+          key: v1-dependencies-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+            - build/bin/go-mod-outdated
+
   integration:
     executor: machine
     parameters:
@@ -296,8 +357,6 @@ jobs:
             RUN_CRITEST: "<< parameters.run_critest >>"
             TEST_ARGS: "<< parameters.test_args >>"
             TEST_USERNS: "<< parameters.test_userns >>"
-            # TODO: fix this failing CRI test
-            CRI_SKIP: "should fail with with an unloaded profile"
       - save_cache:
           key: v1-integration-{{ checksum "go.sum" }}
           paths:
@@ -309,20 +368,71 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-lint-{{ checksum "go.sum" }}
+            - v4-lint-{{ checksum "go.sum" }}
       - run:
           name: lint
           command: make lint
       - save_cache:
-          key: v2-lint-{{ checksum "go.sum" }}
+          key: v4-lint-{{ checksum "go.sum" }}
           paths:
             - *gocache
 
-  results:
-    executor: container-base
+  release-branch-forward:
+    executor: container
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-release-branch-forward-{{ checksum "go.sum" }}
+      - add_ssh_keys:
+          fingerprints:
+            - bd:a6:4b:50:1b:2a:a4:1d:79:67:64:05:66:c4:3a:10
+      - run:
+          name: Forward Latest Release Branch
+          command: make release-branch-forward
+          environment:
+            DRY_RUN: false
+      - save_cache:
+          key: v1-release-branch-forward-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+
+  release-notes:
+    executor: container
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-release-notes-{{ checksum "go.sum" }}
+      - add_ssh_keys:
+          fingerprints:
+            - bd:a6:4b:50:1b:2a:a4:1d:79:67:64:05:66:c4:3a:10
+      - run:
+          name: Generate Release Notes
+          command: |
+            if [[ -z $GITHUB_TOKEN ]]; then
+              echo Skipping release notes generation
+            else
+              make release-notes
+            fi
+      - store_artifacts:
+          path: build/release-notes
+          destination: release-notes
+      - save_cache:
+          key: v1-release-notes-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+            - build/bin/release-notes
+
+  results:
+    executor: container
+    steps:
+      - checkout
       - attach_workspace:
           at: .
+      - run:
+          name: Upload artifacts
+          command: make upload-artifacts
       - store_test_results:
           path: build/junit
       - store_artifacts:
@@ -330,10 +440,42 @@ jobs:
           destination: bin
       - store_artifacts:
           path: build
-          destination: test
+          destination: build
       - store_artifacts:
           path: bundle
           destination: bundle
+
+  shellcheck:
+    executor: container
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-shellcheck-{{ checksum "go.sum" }}
+      - run:
+          name: Check shell files
+          command: make shellcheck
+      - save_cache:
+          key: v1-shellcheck-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+            - build/bin/shellcheck
+
+  shfmt:
+    executor: container
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-shfmt-{{ checksum "go.sum" }}
+      - run:
+          name: Format shell files
+          command: make shfmt
+      - save_cache:
+          key: v1-shfmt-{{ checksum "go.sum" }}
+          paths:
+            - *gocache
+            - build/bin/shfmt
 
   unit-tests:
     executor: container

--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,8 @@ coverprofile
 .gdb_history
 *gomock_reflect*
 lib/state.json
-result-*bin
+result
 *_junit.xml
-bundle/tmp
-bundle/*.tar.gz
 
 ./Vagrantfile
 .vagrant/

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,123 +1,44 @@
-{ revision ? "HEAD", system ? builtins.currentSystem }:
+{ system ? builtins.currentSystem }:
 let
-  nixpkgs = import ./nixpkgs.nix;
-  glibcPkgs = import (builtins.head nixpkgs) {};
-  muslPkgs = (import (builtins.head nixpkgs) {
+  pkgs = (import ./nixpkgs.nix {
     config = {
       packageOverrides = pkg: {
-        go_1_13 = muslPkgs.go_1_12;
-        go_1_12 = pkg.go_1_12.overrideAttrs (old: {
-          prePatch = ''
-            sed -i 's/TestChown/testChown/' src/os/os_unix_test.go
-            sed -i 's/TestFileChown/testFileChown/' src/os/os_unix_test.go
-            sed -i 's/TestLchown/testLchown/' src/os/os_unix_test.go
-            sed -i 's/TestCoverageUsesAtomicModeForRace/testCoverageUsesAtomicModeForRace/' src/cmd/go/go_test.go
-            sed -i 's/TestTestRaceInstall/testTestRaceInstall/' src/cmd/go/go_test.go
-            sed -i 's/TestGoTestRaceFailures/testGoTestRaceFailures/' src/cmd/go/go_test.go
-            sed -i '/func cmdtest/a return' src/cmd/dist/test.go
-          '' + old.prePatch;
-        });
-        gnupg = glibcPkgs.gnupg;
-        systemd = (import (builtins.elemAt nixpkgs 1) {}).systemd;
+        gpgme = (static pkg.gpgme);
+        libassuan = (static pkg.libassuan);
+        libgpgerror = (static pkg.libgpgerror);
+        libseccomp = (static pkg.libseccomp);
       };
     };
-  }).pkgsMusl;
+  });
 
-  static = pkg: pkg.overrideAttrs(old: {
-    configureFlags = (old.configureFlags or []) ++
+  static = pkg: pkg.overrideAttrs(x: {
+    configureFlags = (x.configureFlags or []) ++
       [ "--without-shared" "--disable-shared" ];
     dontDisableStatic = true;
     enableSharedExecutables = false;
     enableStatic = true;
   });
 
-  patchLvm2 = pkg: pkg.overrideAttrs(old: {
-    configureFlags = [
-      "--disable-cmdlib" "--disable-readline" "--disable-udev_rules"
-      "--disable-udev_sync" "--enable-pkgconfig" "--enable-static_link"
-    ];
-    preConfigure = old.preConfigure + ''
-      substituteInPlace libdm/Makefile.in --replace \
-        SUBDIRS=dm-tools SUBDIRS=
-      substituteInPlace tools/Makefile.in --replace \
-        "TARGETS += lvm.static" ""
-      substituteInPlace tools/Makefile.in --replace \
-        "INSTALL_LVM_TARGETS += install_tools_static" ""
-    '';
-    postInstall = "";
-  });
-
-  self = {
-    cri-o-static-musl = (muslPkgs.cri-o.overrideAttrs(old: {
-      name = "cri-o-x86_64-static-musl-${revision}";
-      buildInputs = old.buildInputs ++ [ muslPkgs.systemd ];
+  self = with pkgs; {
+    cri-o-static = (cri-o.overrideAttrs(x: {
+      name = "cri-o-static";
       src = ./..;
-
-      # TODO: remove the build phase patch after CRI-O 1.17.0 release in nixpkgs
-      buildPhase = ''
-        pushd go/src/${old.goPackagePath}
-
-        # Build the crio binaries
-        function build() {
-          go build \
-            -tags ${old.makeFlags} \
-            -o bin/"$1" \
-            -buildmode=pie \
-            -ldflags '-s -w -linkmode external -extldflags "-static"' \
-            ${old.goPackagePath}/cmd/"$1"
-        }
-        build crio
-        build crio-status
+      doCheck = false;
+      buildInputs = [
+        glibc
+        glibc.static
+        gpgme
+        libapparmor
+        libassuan
+        libgpgerror
+        libseccomp
+        libselinux
+      ];
+      prePatch = ''
+        export LDFLAGS='-static-libgcc -static'
+        export EXTRA_LDFLAGS='-linkmode external -extldflags "-static -lm"'
+        export BUILDTAGS='static netgo apparmor selinux seccomp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper'
       '';
-      installPhase = ''
-        install -Dm755 bin/crio $bin/bin/crio-x86_64-static-musl
-        install -Dm755 bin/crio-status $bin/bin/crio-status-x86_64-static-musl
-      '';
-    })).override {
-      flavor = "-x86_64-static-musl";
-      ldflags = ''-linkmode external -extldflags "-static"'';
-
-      glibc = null;
-      gpgme = (static muslPkgs.gpgme);
-      libassuan = (static muslPkgs.libassuan);
-      libgpgerror = (static muslPkgs.libgpgerror);
-      libseccomp = (static muslPkgs.libseccomp);
-      lvm2 = (patchLvm2 (static muslPkgs.lvm2));
-    };
-    cri-o-static-glibc = (glibcPkgs.cri-o.overrideAttrs(old: {
-      name = "cri-o-x86_64-static-glibc-${revision}";
-      buildInputs = old.buildInputs ++ [ glibcPkgs.systemd ];
-      src = ./..;
-
-      # TODO: remove the build phase patch after CRI-O 1.17.0 release in nixpkgs
-      buildPhase = ''
-        pushd go/src/${old.goPackagePath}
-
-        # Build the crio binaries
-        function build() {
-          go build \
-            -tags ${old.makeFlags} \
-            -o bin/"$1" \
-            -buildmode=pie \
-            -ldflags '-s -w -linkmode external -extldflags "-static -lm"' \
-            ${old.goPackagePath}/cmd/"$1"
-        }
-        build crio
-        build crio-status
-      '';
-      installPhase = ''
-        install -Dm755 bin/crio $bin/bin/crio-x86_64-static-glibc
-        install -Dm755 bin/crio-status $bin/bin/crio-status-x86_64-static-glibc
-      '';
-    })).override {
-      flavor = "-x86_64-static-glibc";
-      ldflags = ''-linkmode external -extldflags "-static -lm"'';
-
-      gpgme = (static glibcPkgs.gpgme);
-      libassuan = (static glibcPkgs.libassuan);
-      libgpgerror = (static glibcPkgs.libgpgerror);
-      libseccomp = (static glibcPkgs.libseccomp);
-      lvm2 = (patchLvm2 (static glibcPkgs.lvm2));
-    };
+    }));
   };
 in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs",
+  "rev": "2b51171fb6eadbe0909dc5f3726371a149044f77",
+  "date": "2020-05-13T14:24:04+02:00",
+  "path": "/nix/store/dnv2wqnkssh7ph5r9gbxv6gxp8ykkqn4-nixpkgs",
+  "sha256": "1f76j4m05sbypc1s9lbdbdp62slryvknsi78ilrb3lnmq17biymi",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,14 +1,8 @@
 let
-  nixpkgs = builtins.fetchTarball {
+  json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = import (builtins.fetchTarball {
     name = "nixos-unstable";
-    url = "https://github.com/nixos/nixpkgs/archive/" +
-      "f28fad5e2fe777534f1c2719a40e69812085dfe5.tar.gz";
-    sha256 = "0qb021c3y2k1ai0vvadv9cd6vacj0lsd5xv2a4ir1hhn0pnc5g59";
-  };
-  nixpkgsMuslSystemd = builtins.fetchTarball {
-    name = "nixos-systemd-musl";
-    url = "https://github.com/dtzWill/nixpkgs/archive/" +
-      "13510d3dbe08e5bfc5454faf3fe543991dbf6e29.tar.gz";
-    sha256 = "090zagbw39fa8fgwvzcmbcr204pxcfrq1rfw7ip5z44naj6gp7qb";
-  };
-in [ nixpkgs nixpkgsMuslSystemd ]
+    url = "${json.url}/archive/${json.rev}.tar.gz";
+    inherit (json) sha256;
+  });
+in nixpkgs


### PR DESCRIPTION
Also see #3804

nix-based static binary could be found from:
- https://github.com/alvistack/cri-o/releases/tag/v1.18.1
- https://github.com/alvistack/cri-o/releases/tag/v1.17.4