### PR TITLE
Add image pull success and failure metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/creack/pty v1.1.9
 	github.com/cri-o/ocicni v0.2.1-0.20200422173648-513ef787b8c9
 	github.com/cyphar/filepath-securejoin v0.2.2
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-zoo/bone v1.3.0

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -26,8 +26,11 @@ const (
 	// CRIOImagePullsByNameSkippedKey is the key for CRI-O skipped image pull metrics by name (skipped).
 	CRIOImagePullsByNameSkippedKey = "crio_image_pulls_by_name_skipped"
 
-	// TODO(runcom):
-	// timeouts
+	// CRIOImagePullsFailuresKey is the key for failed image downloads in CRI-O.
+	CRIOImagePullsFailuresKey = "crio_image_pulls_failures"
+
+	// CRIOImagePullsSuccessesKey is the key for successful image downloads in CRI-O.
+	CRIOImagePullsSuccessesKey = "crio_image_pulls_successes"
 
 	subsystem = "container_runtime"
 )
@@ -94,6 +97,26 @@ var (
 		},
 		[]string{"name"},
 	)
+
+	// CRIOImagePullsFailures collects image pull failures
+	CRIOImagePullsFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      CRIOImagePullsFailuresKey,
+			Help:      "Cumulative number of CRI-O image pull failures by error.",
+		},
+		[]string{"name", "error"},
+	)
+
+	// CRIOImagePullsSuccesses collects image pull successes
+	CRIOImagePullsSuccesses = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      CRIOImagePullsSuccessesKey,
+			Help:      "Cumulative number of CRI-O image pull successes.",
+		},
+		[]string{"name"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -107,6 +130,8 @@ func Register() {
 		prometheus.MustRegister(CRIOImagePullsByDigest)
 		prometheus.MustRegister(CRIOImagePullsByName)
 		prometheus.MustRegister(CRIOImagePullsByNameSkipped)
+		prometheus.MustRegister(CRIOImagePullsFailures)
+		prometheus.MustRegister(CRIOImagePullsSuccesses)
 	})
 }
 

--- a/tutorials/metrics.md
+++ b/tutorials/metrics.md
@@ -36,14 +36,64 @@ Beside the [default golang based metrics][2], CRI-O provides the following addit
 | `crio_image_pulls_by_digest`           | `name`, `digest`, `mediatype`, `size`                                                                                                   | Counter | Bytes transferred by CRI-O image pulls by digest.                        |
 | `crio_image_pulls_by_name`             | `name`, `size`                                                                                                                          | Counter | Bytes transferred by CRI-O image pulls by name.                          |
 | `crio_image_pulls_by_name_skipped`     | `name`                                                                                                                                  | Counter | Bytes skipped by CRI-O image pulls by name.                              |
+| `crio_image_pulls_successes`           | `name`                                                                                                                                  | Counter | Successful image pulls by image name                                     |
+| `crio_image_pulls_failures`            | `name`, `error`                                                                                                                         | Counter | Failed image pulls by image name and their error category.               |
 
-\* Available CRI-O RPC's from the [gRPC API][3]: `Attach`, `ContainerStats`, `ContainerStatus`,
-`CreateContainer`, `Exec`, `ExecSync`, `ImageFsInfo`, `ImageStatus`,
-`ListContainerStats`, `ListContainers`, `ListImages`, `ListPodSandbox`,
-`PodSandboxStatus`, `PortForward`, `PullImage`, `RemoveContainer`,
-`RemoveImage`, `RemovePodSandbox`, `ReopenContainerLog`, `RunPodSandbox`,
-`StartContainer`, `Status`, `StopContainer`, `StopPodSandbox`,
-`UpdateContainerResources`, `UpdateRuntimeConfig`, `Version`
+- Available CRI-O RPC's from the [gRPC API][3]: `Attach`, `ContainerStats`, `ContainerStatus`,
+  `CreateContainer`, `Exec`, `ExecSync`, `ImageFsInfo`, `ImageStatus`,
+  `ListContainerStats`, `ListContainers`, `ListImages`, `ListPodSandbox`,
+  `PodSandboxStatus`, `PortForward`, `PullImage`, `RemoveContainer`,
+  `RemoveImage`, `RemovePodSandbox`, `ReopenContainerLog`, `RunPodSandbox`,
+  `StartContainer`, `Status`, `StopContainer`, `StopPodSandbox`,
+  `UpdateContainerResources`, `UpdateRuntimeConfig`, `Version`
+
+- Available error categories for `crio_image_pulls_failures`:
+  - `UNKNOWN`: The default label which gets applied if the error is not known
+  - `CONNECTION_REFUSED`: The local network is down or the registry refused the
+    connection.
+  - `CONNECTION_TIMEOUT`: The connection timed out during the image download.
+  - `NOT_FOUND`: The registry does not exist at the specified resource
+  - `BLOB_UNKNOWN`: This error may be returned when a blob is unknown to the
+    registry in a specified repository. This can be returned with a standard get
+    or if a manifest references an unknown layer during upload.
+  - `BLOB_UPLOAD_INVALID`: The blob upload encountered an error and can no
+    longer proceed.
+  - `BLOB_UPLOAD_UNKNOWN`: If a blob upload has been cancelled or was never
+    started, this error code may be returned.
+  - `DENIED`: The access controller denied access for the operation on a
+    resource.
+  - `DIGEST_INVALID`: When a blob is uploaded, the registry will check that the
+    content matches the digest provided by the client. The error may include a
+    detail structure with the key "digest", including the invalid digest string.
+    This error may also be returned when a manifest includes an invalid layer
+    digest.
+  - `MANIFEST_BLOB_UNKNOWN`: This error may be returned when a manifest blob is
+    unknown to the registry.
+  - `MANIFEST_INVALID`: During upload, manifests undergo several checks ensuring
+    validity. If those checks fail, this error may be returned, unless a more
+    specific error is included. The detail will contain information the failed
+    validation.
+  - `MANIFEST_UNKNOWN`: This error is returned when the manifest, identified by
+    name and tag is unknown to the repository.
+  - `MANIFEST_UNVERIFIED`: During manifest upload, if the manifest fails
+    signature verification, this error will be returned.
+  - `NAME_INVALID`: Invalid repository name encountered either during manifest.
+    validation or any API operation.
+  - `NAME_UNKNOWN`: This is returned if the name used during an operation is
+    unknown to the registry.
+  - `SIZE_INVALID`: When a layer is uploaded, the provided size will be checked
+    against the uploaded content. If they do not match, this error will be
+    returned.
+  - `TAG_INVALID`: During a manifest upload, if the tag in the manifest does not
+    match the uri tag, this error will be returned.
+  - `TOOMANYREQUESTS`: Returned when a client attempts to contact a service too
+    many times.
+  - `UNAUTHORIZED`: The access controller was unable to authenticate the client.
+    Often this will be accompanied by a Www-Authenticate HTTP response header
+    indicating how to authenticate.
+  - `UNAVAILABLE`: Returned when a service is not available.
+  - `UNSUPPORTED`: The operation was unsupported due to a missing implementation
+    or invalid set of parameters.
 
 [0]: https://prometheus.io
 [1]: https://github.com/curl/curl

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -311,6 +311,7 @@ github.com/cyphar/filepath-securejoin
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/docker/distribution v2.7.1+incompatible
+## explicit
 github.com/docker/distribution
 github.com/docker/distribution/digestset
 github.com/docker/distribution/metrics


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This commit adds two new metrics `crio_image_pulls_failures` and
`crio_image_pulls_successes`.

`crio_image_pulls_successes` counts every successful image pull
operation by the image name, wheras `crio_image_pulls_failures` contains
an additional `error` label. Possible error labels are:

- `UNKNOWN`:
  The default label which gets applied if the error is not known

- `CONNECTION_REFUSED`:
  The local network is down or the registry refused the connection

- `CONNECTION_TIMEOUT`:
  The connection timed out during the image download

- `404_NOT_FOUND`:
  The registry does not exist at the specified resource

- `BLOB_UNKNOWN`:
  This error may be returned when a blob is unknown to the registry in a
  specified repository. This can be returned with a standard get or if a
  manifest references an unknown layer during upload.

- `BLOB_UPLOAD_INVALID`:
  The blob upload encountered an error and can no longer proceed.

- `BLOB_UPLOAD_UNKNOWN`:
  If a blob upload has been cancelled or was never started, this error
  code may be returned.

- `DENIED`:
  The access controller denied access for the operation on a resource.

- `DIGEST_INVALID`:
  When a blob is uploaded, the registry will check that the content
  matches the digest provided by the client. The error may include a
  detail structure with the key "digest", including the invalid digest
  string. This error may also be returned when a manifest includes an
  invalid layer digest.

- `MANIFEST_BLOB_UNKNOWN`:
  This error may be returned when a manifest blob is unknown to the
  registry.

- `MANIFEST_INVALID`:
  During upload, manifests undergo several checks ensuring validity. If
  those checks fail, this error may be returned, unless a more specific
  error is included. The detail will contain information the failed
  validation.

- `MANIFEST_UNKNOWN`:
  This error is returned when the manifest, identified by name and tag
  is unknown to the repository.

- `MANIFEST_UNVERIFIED`:
  During manifest upload, if the manifest fails signature verification,
  this error will be returned.

- `NAME_INVALID`:
  Invalid repository name encountered either during manifest validation
  or any API operation.

- `NAME_UNKNOWN`:
  This is returned if the name used during an operation is unknown to
  the registry.

- `SIZE_INVALID`:
  When a layer is uploaded, the provided size will be checked against
  the uploaded content. If they do not match, this error will be
  returned.

- `TAG_INVALID`:
  During a manifest upload, if the tag in the manifest does not match
  the uri tag, this error will be returned.

- `TOOMANYREQUESTS`:
  Returned when a client attempts to contact a service too many times

- `UNAUTHORIZED`:
  The access controller was unable to authenticate the client. Often
  this will be accompanied by a Www-Authenticate HTTP response header
  indicating how to authenticate.

- `UNAVAILABLE`:
  Returned when a service is not available

- `UNSUPPORTED`:
  The operation was unsupported due to a missing implementation or
  invalid set of parameters.

#### Which issue(s) this PR fixes:
Fixes https://github.com/cri-o/cri-o/issues/3807
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added new metrics `crio_image_pulls_failures` and `crio_image_pulls_successes`. For more information please refer to the [CRI-O metrics guide](https://github.com/cri-o/cri-o/blob/master/tutorials/metrics.md)
```
