### PR TITLE
oci: Don't return early for non-tty attach if there is no stdin

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -885,7 +885,12 @@ func (r *runtimeOCI) AttachContainer(c *Container, inputStream io.Reader, output
 	case err := <-receiveStdout:
 		return err
 	case err := <-stdinDone:
-		if !c.StdinOnce() && !tty {
+		// This particular case is for when we get a non-tty attach
+		// with --leave-stdin-open=true. We want to return as soon
+		// as we receive EOF from the client. However, we should do
+		// this only when stdin is enabled. If there is no stdin
+		// enabled then we wait for output as usual.
+		if c.stdin && !c.StdinOnce() && !tty {
 			return nil
 		}
 		if _, ok := err.(utils.DetachError); ok {


### PR DESCRIPTION
We want to return early from a non-tty attach only if stdin is
enabled otherwise we want to wait for the output as well.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>



#### What type of PR is this?


 /kind failing-test


#### What this PR does / why we need it:
This PR fixes a race exposed by recent changes in https://github.com/kubernetes/kubernetes/pull/91227





#### Does this PR introduce a user-facing change?



```release-note
None
```
