### PR TITLE
Use correct format for logPath removal log

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -502,7 +502,7 @@ func ensureSaneLogPath(logPath string) error {
 	if os.IsNotExist(err) {
 		err = os.RemoveAll(logPath)
 		if err != nil {
-			return fmt.Errorf("ensureSaneLogPath remove bad logPath: %s", err)
+			return fmt.Errorf("failed to remove bad log path %s: %v", logPath, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In ensureSaneLogPath(), if the call to os.RemoveAll fails, we log the error.
However, the format string is wrong. '%s' shouldn't be used with err.

This PR corrects the mistake.

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
