### PR TITLE
[1.18] sandbox iface: don't fail if uid is not specified

### DIFF
--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -92,10 +92,6 @@ func (s *sandbox) SetNameAndID() error {
 		return errors.New("cannot generate pod name without name in metadata")
 	}
 
-	if s.config.GetMetadata().GetUid() == "" {
-		return errors.New("cannot generate pod name without uid in metadata")
-	}
-
 	s.id = stringid.GenerateNonCryptoID()
 	s.name = strings.Join([]string{
 		"k8s",

--- a/pkg/sandbox/sandbox_setnameandid_test.go
+++ b/pkg/sandbox/sandbox_setnameandid_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Sandbox:SetNameAndID", func() {
 			Expect(sut.ID()).To(Equal(""))
 			Expect(sut.Name()).To(Equal(""))
 		})
-		It("should fail with empty uid in metadata", func() {
+		It("should succeed with empty uid in metadata", func() {
 			// Given
 			config := &pb.PodSandboxConfig{
 				Metadata: &pb.PodSandboxMetadata{
@@ -92,9 +92,9 @@ var _ = Describe("Sandbox:SetNameAndID", func() {
 			err := sut.SetNameAndID()
 
 			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(sut.ID()).To(Equal(""))
-			Expect(sut.Name()).To(Equal(""))
+			Expect(err).To(BeNil())
+			Expect(sut.ID()).NotTo(Equal(""))
+			Expect(sut.Name()).NotTo(Equal(""))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:
It is not strictly needed, just a namespace is
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where Pod creation would fail if Uid was not specified in Metadata of sandbox config passed in a run pod sandbox request
```
