### PR TITLE
Close the done channel when there is watcher error

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -581,6 +581,7 @@ func (s *Server) StartExitMonitor() {
 				}
 			case err := <-watcher.Errors:
 				logrus.Debugf("watch error: %v", err)
+				close(done)
 				return
 			case <-s.monitorsChan:
 				logrus.Debug("closing exit monitor...")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
When the following case is triggered, done channel is not closed.
```
case err := <-watcher.Errors:
   logrus.Debugf("watch error: %v", err)
   return
```
This PR closes the done channel before returning.

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
