### PR TITLE
Check whether seccomp is enabled before making assertion

### DIFF
--- a/internal/config/seccomp/seccomp_test.go
+++ b/internal/config/seccomp/seccomp_test.go
@@ -18,17 +18,6 @@ var _ = t.Describe("Config", func() {
 		Expect(sut).NotTo(BeNil())
 	})
 
-	t.Describe("IsDisabled", func() {
-		It("should be false per default", func() {
-			// Given
-			// When
-			res := sut.IsDisabled()
-
-			// Then
-			Expect(res).To(BeFalse())
-		})
-	})
-
 	t.Describe("Profile", func() {
 		It("should be the default without any load", func() {
 			// Given
@@ -81,13 +70,15 @@ var _ = t.Describe("Config", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should fail with non-existing profile", func() {
-			// Given
-			// When
-			err := sut.LoadProfile("/proc/not/existing/file")
+		if sut != nil && !sut.IsDisabled() {
+			It("should fail with non-existing profile", func() {
+				// Given
+				// When
+				err := sut.LoadProfile("/proc/not/existing/file")
 
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
+				// Then
+				Expect(err).NotTo(BeNil())
+			})
+		}
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When I run tests on Fedora, I got the following failure:
```
cri-o: Config cri-o: IsDisabled [It] should be false per default
/home/zyu/cri-o/internal/config/seccomp/seccomp_test.go:22

  Expected
      <bool>: true
  to be false

  /home/zyu/cri-o/internal/config/seccomp/seccomp_test.go:28

  Full Stack Trace
  github.com/cri-o/cri-o/internal/config/seccomp_test.glob..func1.2.1()
  /home/zyu/cri-o/internal/config/seccomp/seccomp_test.go:28 +0xfc
  github.com/cri-o/cri-o/test/framework.RunFrameworkSpecs(0xc000178500, 0x88fbb4, 0xd)
  /home/zyu/cri-o/test/framework/framework.go:99 +0x15a
  github.com/cri-o/cri-o/internal/config/seccomp_test.TestLibConfig(0xc000178500)
  /home/zyu/cri-o/internal/config/seccomp/suite_test.go:14 +0x8a
```
Looking at vendor/github.com/seccomp/containers-golang/seccomp_linux.go :
```
func IsEnabled() bool {
        // Check if Seccomp is supported, via CONFIG_SECCOMP.
        if err := unix.Prctl(unix.PR_GET_SECCOMP, 0, 0, 0, 0); err != unix.EINVAL {
```
It is uncertain that seccomp is disabled on Linux.

This PR makes seccomp related assertion conditional.

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
