### PR TITLE
Add sandbox IPs if there is no error in IP retrieval

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -244,6 +244,7 @@ func (s *Server) restore(ctx context.Context) {
 		ips, err := s.getSandboxIPs(sb)
 		if err != nil {
 			logrus.Warnf("could not restore sandbox IP for %v: %v", sb.ID(), err)
+			continue
 		}
 		sb.AddIPs(ips)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In Server#restore() 
```
ips, err := s.getSandboxIPs(sb)
if err != nil {
   logrus.Warnf("could not restore sandbox IP for %v: %v", sb.ID(), err)
}
sb.AddIPs(ips)
```
sb.AddIPs() should only be called when err return from getSandboxIPs() is nil.

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
