### PR TITLE
Add crun to static binary bundle

### DIFF
--- a/contrib/bundle/Makefile
+++ b/contrib/bundle/Makefile
@@ -21,7 +21,8 @@ install: \
 	install-crio \
 	install-crictl \
 	install-pinns \
-	install-runc
+	install-runc \
+	install-crun
 
 .PHONY: install-cni
 install-cni:
@@ -65,6 +66,10 @@ install-pinns:
 install-runc:
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/runc
 
+.PHONY: install-crun
+install-crun:
+	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/crun
+
 .PHONY: uninstall
 uninstall: \
 	uninstall-cni \
@@ -72,7 +77,8 @@ uninstall: \
 	uninstall-crio \
 	uninstall-crictl \
 	uninstall-pinns \
-	uninstall-runc
+	uninstall-runc \
+	uninstall-crun
 
 .PHONY: uninstall-cni
 uninstall-cni:
@@ -110,3 +116,7 @@ uninstall-pinns:
 .PHONY: uninstall-runc
 uninstall-runc:
 	rm $(BINDIR)/runc
+
+.PHONY: uninstall-crun
+uninstall-crun:
+	rm $(BINDIR)/crun

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -104,6 +104,11 @@ curl_to "$TMP_BIN/runc" \
     https://github.com/opencontainers/runc/releases/download/"${VERSIONS["runc"]}"/runc.amd64
 chmod +x "$TMP_BIN/runc"
 
+# crun
+curl_to "$TMP_BIN/crun" \
+    https://github.com/containers/crun/releases/download/"${VERSIONS["crun"]}"/crun-"${VERSIONS["crun"]}"-static-x86_64
+chmod +x "$TMP_BIN/crun"
+
 # CNI plugins
 mkdir -p "$TMPDIR/cni-plugins"
 set -x

--- a/scripts/versions
+++ b/scripts/versions
@@ -7,6 +7,7 @@ declare -A VERSIONS=(
     ["conmon"]=v2.0.15
     ["cri-tools"]=v1.18.0
     ["runc"]=v1.0.0-rc10
+    ["crun"]=0.13
     ["bats"]=v1.2.0
 )
 export VERSIONS


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This allows us to give users the possibility to use crun instead of runc.


#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes-sigs/cri-tools/issues/613

#### Special notes for your reviewer:

@giuseppe do we need to have crun as drop-in for runc? Because I always see that it gets symlinked as runc and not used as stand-alone `crun`.

#### Does this PR introduce a user-facing change?

```release-note
- Added latest `crun` version to static binary bundle
```
