### PR TITLE
Add crun to config template

### DIFF
--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -289,6 +289,10 @@ runtime_type = "{{ $runtime_handler.RuntimeType }}"
 runtime_root = "{{ $runtime_handler.RuntimeRoot }}"
 {{ end }}
 
+# crun is a fast and lightweight fully featured OCI runtime and C library for
+# running containers
+#[crio.runtime.runtimes.crun]
+
 # Kata Containers is an OCI runtime, where containers are run inside lightweight
 # VMs. Kata provides additional isolation towards the host, minimizing the host attack
 # surface and mitigating the consequences of containers breakout.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
It makes sense to have crun in the config template to give users a hint
that there is another drop-in OCI runtime available.
#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `crun` container runtime to `crio.conf` (commented out per default)
```
