### PR TITLE
managed_ns: deflake tests

### DIFF
--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -14,10 +14,11 @@ import (
 type NSType string
 
 const (
-	NETNS  NSType = "net"
-	IPCNS  NSType = "ipc"
-	UTSNS  NSType = "uts"
-	USERNS NSType = "user"
+	NETNS         NSType = "net"
+	IPCNS         NSType = "ipc"
+	UTSNS         NSType = "uts"
+	USERNS        NSType = "user"
+	numNamespaces        = 4
 )
 
 // NamespaceIface provides a generic namespace interface
@@ -134,7 +135,7 @@ func (s *Sandbox) CreateNamespacesWithFunc(managedNamespaces []NSType, cfg *conf
 func (s *Sandbox) NamespacePaths() []*ManagedNamespace {
 	pid := infraPid(s.InfraContainer())
 
-	typesAndPaths := make([]*ManagedNamespace, 0, 3)
+	typesAndPaths := make([]*ManagedNamespace, 0, numNamespaces)
 
 	if ipc := nsPathGivenInfraPid(s.ipcns, IPCNS, pid); ipc != "" {
 		typesAndPaths = append(typesAndPaths, &ManagedNamespace{

--- a/test/mocks/containerstorage/containerstorage.go
+++ b/test/mocks/containerstorage/containerstorage.go
@@ -6,12 +6,12 @@ package containerstoragemock
 
 import (
 	storage "github.com/containers/storage"
-	graphdriver "github.com/containers/storage/drivers"
+	drivers "github.com/containers/storage/drivers"
 	archive "github.com/containers/storage/pkg/archive"
 	idtools "github.com/containers/storage/pkg/idtools"
 	lockfile "github.com/containers/storage/pkg/lockfile"
 	gomock "github.com/golang/mock/gomock"
-	digest "github.com/opencontainers/go-digest"
+	go_digest "github.com/opencontainers/go-digest"
 	io "io"
 	reflect "reflect"
 )
@@ -100,10 +100,10 @@ func (mr *MockStoreMockRecorder) ContainerBigData(arg0, arg1 interface{}) *gomoc
 }
 
 // ContainerBigDataDigest mocks base method
-func (m *MockStore) ContainerBigDataDigest(arg0, arg1 string) (digest.Digest, error) {
+func (m *MockStore) ContainerBigDataDigest(arg0, arg1 string) (go_digest.Digest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerBigDataDigest", arg0, arg1)
-	ret0, _ := ret[0].(digest.Digest)
+	ret0, _ := ret[0].(go_digest.Digest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -411,7 +411,7 @@ func (mr *MockStoreMockRecorder) GIDMap() *gomock.Call {
 }
 
 // GetDigestLock mocks base method
-func (m *MockStore) GetDigestLock(arg0 digest.Digest) (lockfile.Locker, error) {
+func (m *MockStore) GetDigestLock(arg0 go_digest.Digest) (lockfile.Locker, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDigestLock", arg0)
 	ret0, _ := ret[0].(lockfile.Locker)
@@ -426,10 +426,10 @@ func (mr *MockStoreMockRecorder) GetDigestLock(arg0 interface{}) *gomock.Call {
 }
 
 // GraphDriver mocks base method
-func (m *MockStore) GraphDriver() (graphdriver.Driver, error) {
+func (m *MockStore) GraphDriver() (drivers.Driver, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GraphDriver")
-	ret0, _ := ret[0].(graphdriver.Driver)
+	ret0, _ := ret[0].(drivers.Driver)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -513,10 +513,10 @@ func (mr *MockStoreMockRecorder) ImageBigData(arg0, arg1 interface{}) *gomock.Ca
 }
 
 // ImageBigDataDigest mocks base method
-func (m *MockStore) ImageBigDataDigest(arg0, arg1 string) (digest.Digest, error) {
+func (m *MockStore) ImageBigDataDigest(arg0, arg1 string) (go_digest.Digest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageBigDataDigest", arg0, arg1)
-	ret0, _ := ret[0].(digest.Digest)
+	ret0, _ := ret[0].(go_digest.Digest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -573,7 +573,7 @@ func (mr *MockStoreMockRecorder) Images() *gomock.Call {
 }
 
 // ImagesByDigest mocks base method
-func (m *MockStore) ImagesByDigest(arg0 digest.Digest) ([]*storage.Image, error) {
+func (m *MockStore) ImagesByDigest(arg0 go_digest.Digest) ([]*storage.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImagesByDigest", arg0)
 	ret0, _ := ret[0].([]*storage.Image)
@@ -664,7 +664,7 @@ func (mr *MockStoreMockRecorder) Layers() *gomock.Call {
 }
 
 // LayersByCompressedDigest mocks base method
-func (m *MockStore) LayersByCompressedDigest(arg0 digest.Digest) ([]storage.Layer, error) {
+func (m *MockStore) LayersByCompressedDigest(arg0 go_digest.Digest) ([]storage.Layer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LayersByCompressedDigest", arg0)
 	ret0, _ := ret[0].([]storage.Layer)
@@ -679,7 +679,7 @@ func (mr *MockStoreMockRecorder) LayersByCompressedDigest(arg0 interface{}) *gom
 }
 
 // LayersByUncompressedDigest mocks base method
-func (m *MockStore) LayersByUncompressedDigest(arg0 digest.Digest) ([]storage.Layer, error) {
+func (m *MockStore) LayersByUncompressedDigest(arg0 go_digest.Digest) ([]storage.Layer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LayersByUncompressedDigest", arg0)
 	ret0, _ := ret[0].([]storage.Layer)
@@ -871,7 +871,7 @@ func (mr *MockStoreMockRecorder) SetContainerRunDirectoryFile(arg0, arg1, arg2 i
 }
 
 // SetImageBigData mocks base method
-func (m *MockStore) SetImageBigData(arg0, arg1 string, arg2 []byte, arg3 func([]byte) (digest.Digest, error)) error {
+func (m *MockStore) SetImageBigData(arg0, arg1 string, arg2 []byte, arg3 func([]byte) (go_digest.Digest, error)) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetImageBigData", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	gomock "github.com/golang/mock/gomock"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	specs_go "github.com/opencontainers/runtime-spec/specs-go"
 	io "io"
 	remotecommand "k8s.io/client-go/tools/remotecommand"
 	reflect "reflect"
@@ -139,17 +139,17 @@ func (mr *MockRuntimeImplMockRecorder) PauseContainer(arg0 interface{}) *gomock.
 }
 
 // PortForwardContainer mocks base method
-func (m *MockRuntimeImpl) PortForwardContainer(arg0 *oci.Container, arg1 int32, arg2 io.ReadWriter) error {
+func (m *MockRuntimeImpl) PortForwardContainer(arg0 context.Context, arg1 *oci.Container, arg2 string, arg3 int32, arg4 io.ReadWriteCloser) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PortForwardContainer", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PortForwardContainer", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PortForwardContainer indicates an expected call of PortForwardContainer
-func (mr *MockRuntimeImplMockRecorder) PortForwardContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) PortForwardContainer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForwardContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).PortForwardContainer), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForwardContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).PortForwardContainer), arg0, arg1, arg2, arg3, arg4)
 }
 
 // ReopenContainerLog mocks base method
@@ -223,7 +223,7 @@ func (mr *MockRuntimeImplMockRecorder) UnpauseContainer(arg0 interface{}) *gomoc
 }
 
 // UpdateContainer mocks base method
-func (m *MockRuntimeImpl) UpdateContainer(arg0 *oci.Container, arg1 *specs.LinuxResources) error {
+func (m *MockRuntimeImpl) UpdateContainer(arg0 *oci.Container, arg1 *specs_go.LinuxResources) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainer", arg0, arg1)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind flake

#### What this PR does / why we need it:
turns out, the PID 42 (as idiomatic a test variable it is) is not the best PID to use.
NamespacePaths() returns /proc entries if the PID is running, so sometimes there was a PID 42 on the system, and the tests returned valid paths, causing the test to fail

This PR updates the tests to use the values 0 (unset pid), 1 (running pid), and 4194305 (never running pid, as it's max_pid+1)

it also fixes a small inconsistency in reserving space for the slice of namespace paths

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
