### PR TITLE
Container should only be added once after passing filter

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -601,6 +601,7 @@ func (c *ContainerServer) ListContainers(filters ...func(*oci.Container) bool) (
 		for _, filter := range filters {
 			if filter(container) {
 				filteredContainers = append(filteredContainers, container)
+				break
 			}
 		}
 	}

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -809,6 +809,9 @@ var _ = t.Describe("ContainerServer", func() {
 			containers, err := sut.ListContainers(
 				func(container *oci.Container) bool {
 					return true
+				},
+				func(container *oci.Container) bool {
+					return true
 				})
 
 			// Then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In ContainerServer#ListContainers, we should only include container once even if there are two filters which the container passes.

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
