### PR TITLE
logs: fix some problems

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -710,6 +710,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 		}
 		out, err := cmd.Output()
 		if err != nil {
+			logrus.Errorf("Failed to update container state for %s: %v", c.id, err)
 			// there are many code paths that could lead to have a bad state in the
 			// underlying runtime.
 			// On any error like a container went away or we rebooted and containers

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -3,7 +3,6 @@ package server
 import (
 	"fmt"
 
-	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -42,6 +41,5 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *p
 		ExitCode: execResp.ExitCode,
 	}
 
-	log.Infof(ctx, "exec'd %s in %s", cmd, c.Description())
 	return resp, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup


#### What this PR does / why we need it:
logging "Exec'd..." for every exec sync is too much, especially on Info
if we fail to decode state, we should log why the `$runtime state` command failed

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
