### PR TITLE
Close the done channel in waitContainerStop

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -557,6 +557,7 @@ func waitContainerStop(ctx context.Context, c *Container, timeout time.Duration,
 		for {
 			select {
 			case <-chControl:
+				close(done)
 				return
 			default:
 				process, err := findprocess.FindProcess(c.state.Pid)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In waitContainerStop, done channel should be closed by the goroutine.
```
case <-chControl:
   return
```
The close of channel was missing in the above case.

#### Which issue(s) this PR fixes:

<!--
None
-->

```release-note
None
```
