### PR TITLE
make all operations read state atomically

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -26,6 +26,7 @@ const defaultStopSignalInt = 15
 
 var defaultStopSignal = strconv.Itoa(defaultStopSignalInt)
 var ErrContainerStopped = errors.New("container is already stopped")
+var ErrContainerNotCreated = errors.New("container is not in created state")
 
 // Container represents a runtime container.
 type Container struct {
@@ -356,4 +357,11 @@ func (c *Container) ShouldBeStopped() error {
 		return errors.New("cannot stop paused container")
 	}
 	return nil
+}
+
+func (c *Container) ShouldBeStarted() error {
+	if c.state.Status == ContainerStateCreated {
+		return nil
+	}
+	return errors.Wrapf(ErrContainerNotCreated, "invalid state %s for %s", c.state.Status, c.id)
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -232,6 +232,10 @@ func (r *runtimeOCI) StartContainer(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
+	if err := c.ShouldBeStarted(); err != nil {
+		return err
+	}
+
 	if _, err := utils.ExecCmd(
 		r.path, rootFlag, r.root, "start", c.id,
 	); err != nil {

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -237,6 +237,10 @@ func (r *runtimeVM) StartContainer(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
+	if err := c.ShouldBeStarted(); err != nil {
+		return err
+	}
+
 	if err := r.start(r.ctx, c.ID(), ""); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:
there are still two cases where the container state isn't checked atomically: container start and sandbox remove

fix these cases, so we don't risk updating state based on stale data

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
