### PR TITLE
[1.18] oci: repeat $runtime state calls if appropriate

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -344,6 +344,24 @@ func (c *Container) exitFilePath() string {
 	return filepath.Join(c.dir, "exit")
 }
 
+// IsRunning is a function that checks if a specific pid is running
+// it is used to check a container state when we don't want (or don't trust) a `$runtime state` call
+func (c *Container) IsRunning() bool {
+	pid := c.state.Pid
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		logrus.Infof("container %s not found: %v", c.id, err)
+		return false
+	}
+
+	if err := process.Signal(syscall.Signal(0)); err != nil {
+		logrus.Errorf("container %s not running %v", c.id, err)
+		return false
+	}
+
+	return true
+}
+
 // ShouldBeStopped checks whether the container state is in a place
 // where attempting to stop it makes sense
 // a container is not stoppable if it's paused or stopped

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -238,4 +238,38 @@ var _ = t.Describe("Container", func() {
 		// Then
 		Expect(err).To(BeNil())
 	})
+	It("should be false if pid unintialized", func() {
+		// Given
+		state := &oci.ContainerState{}
+		state.Pid = 0
+		sut.SetState(state)
+		// When
+		err := sut.IsRunning()
+
+		// Then
+		Expect(err).To(Equal(false))
+	})
+	It("should succeed if pid is running", func() {
+		// Given
+		state := &oci.ContainerState{}
+		state.Pid = 1
+		sut.SetState(state)
+		// When
+		err := sut.IsRunning()
+
+		// Then
+		Expect(err).To(Equal(true))
+	})
+	It("should be false if pid is not running", func() {
+		// Given
+		state := &oci.ContainerState{}
+		// the highest allowed pid + 1
+		state.Pid = 4194305
+		sut.SetState(state)
+		// When
+		err := sut.IsRunning()
+
+		// Then
+		Expect(err).To(Equal(false))
+	})
 })

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -711,6 +711,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 		// went away we do not error out stopping kubernetes to recover.
 		// We always populate the fields below so kube can restart/reschedule
 		// containers failing.
+		logrus.Errorf("Failed to update container state for %s: %v", c.id, err)
 		c.state.Status = ContainerStateStopped
 		if err := updateContainerStatusFromExitFile(c); err != nil {
 			c.state.Finished = time.Now()

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -3,7 +3,6 @@ package server
 import (
 	"fmt"
 
-	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -42,6 +41,5 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *p
 		ExitCode: execResp.ExitCode,
 	}
 
-	log.Infof(ctx, "exec'd %s in %s", cmd, c.Description())
 	return resp, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

 /kind bug


#### What this PR does / why we need it:
we have seen cases where `$runtime state` calls fail supriously, but succeed later
this is not great, though, we shouldn't incorrectly label pods if this happens.

We now retry state calls up to three times if we determine the container is still running (by calling kill on its pid)

also carry https://github.com/cri-o/cri-o/pull/3853
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
