### PR TITLE
Remove the protocol filter from the portMappings constructor

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -74,9 +74,6 @@ func convertPortMappings(in []*pb.PortMapping) []*hostport.PortMapping {
 		if v.HostPort <= 0 {
 			continue
 		}
-		if v.Protocol != pb.Protocol_TCP && v.Protocol != pb.Protocol_UDP {
-			continue
-		}
 		out = append(out, &hostport.PortMapping{
 			HostPort:      v.HostPort,
 			ContainerPort: v.ContainerPort,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

#### What this PR does / why we need it:
There is a protocol filter in the current code that filters out all host ports that do not have TCP or UDP as protocol defined. Originally this protocol filter was introduced to prevent the loading of the SCTP kernel module on the nodes. But the iptables chain creation alone does not load the kernel module. The module would be loaded if an SCTP socket was created. The host port manager imported by CRI-O already filters out the SCTP ports from the set of ports on which it starts listening. As there is no socket operation (listening) on the SCTP ports the kernel module is not loaded. We can remove this filter here so the iptables chains will be created for SCTP host ports.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Container HostPort with SCTP protocol is supported.
```
