### PR TITLE
[1.17] oci: check state before stop atomically

### DIFF
--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -204,4 +204,38 @@ var _ = t.Describe("Container", func() {
 		// Then
 		Expect(err).NotTo(BeNil())
 	})
+	It("should fail to stop if already stopped", func() {
+		// Given
+		state := &oci.ContainerState{}
+		state.Status = oci.ContainerStateStopped
+		sut.SetState(state)
+		// When
+		err := sut.ShouldBeStopped()
+
+		// Then
+		Expect(err).To(Equal(oci.ErrContainerStopped))
+	})
+	It("should fail to stop if paused", func() {
+		// Given
+		state := &oci.ContainerState{}
+		state.Status = oci.ContainerStatePaused
+		sut.SetState(state)
+		// When
+		err := sut.ShouldBeStopped()
+
+		// Then
+		Expect(err).NotTo(Equal(oci.ErrContainerStopped))
+		Expect(err).NotTo(BeNil())
+	})
+	It("should succeed to stop if started", func() {
+		// Given
+		state := &oci.ContainerState{}
+		state.Status = oci.ContainerStateRunning
+		sut.SetState(state)
+		// When
+		err := sut.ShouldBeStopped()
+
+		// Then
+		Expect(err).To(BeNil())
+	})
 })

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -596,6 +596,10 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
+	if err := c.ShouldBeStopped(); err != nil {
+		return err
+	}
+
 	// Check if the process is around before sending a signal
 	process, err := findprocess.FindProcess(c.state.Pid)
 	if err == findprocess.ErrNotFound {

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -455,6 +455,10 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
+	if err := c.ShouldBeStopped(); err != nil {
+		return err
+	}
+
 	// Cancel the context before returning to ensure goroutines are stopped.
 	ctx, cancel := context.WithCancel(r.ctx)
 	defer cancel()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind flake

#### What this PR does / why we need it:
in stop, we need to check the pod's status before stopping it.
However, as it stands, we do it in two distinct steps: State() followed by ContainerStop()

There exists a race where:
the State() call happens
followed by an UpdateContainerStatus() (marking the container as stopped)
followed by the Container Stop()

we've hit this race quite a bit in circleCI running 'pod stop idempotent with ctrs already stopped'

fix this by moving the check branching on Status to after we take the opLock()

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
