### PR TITLE
[1.18] StringSliceTrySplit: return a copy of the underlying slice

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -144,7 +144,7 @@ func main() {
 	}...)
 
 	app.Before = func(c *cli.Context) (err error) {
-		config, err := criocli.GetConfigFromContext(c)
+		config, err := criocli.GetAndMergeConfigFromContext(c)
 		if err != nil {
 			return err
 		}

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -780,6 +780,9 @@ func StringSliceTrySplit(ctx *cli.Context, name string) []string {
 			"Parsed commma separated CLI flag %q into dedicated values %v",
 			name, values,
 		)
+	} else {
+		// Copy the slice to avoid the cli flags being overwritten
+		values = append(values[:0:0], values...)
 	}
 
 	return values

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -27,6 +27,14 @@ func GetConfigFromContext(c *cli.Context) (*libconfig.Config, error) {
 	if !ok {
 		return nil, fmt.Errorf("type assertion error when accessing server config")
 	}
+	return config, nil
+}
+
+func GetAndMergeConfigFromContext(c *cli.Context) (*libconfig.Config, error) {
+	config, err := GetConfigFromContext(c)
+	if err != nil {
+		return nil, err
+	}
 	if err := mergeConfig(config, c); err != nil {
 		return nil, err
 	}

--- a/internal/criocli/criocli_test.go
+++ b/internal/criocli/criocli_test.go
@@ -46,4 +46,16 @@ var _ = t.Describe("CLI", func() {
 		Entry("separated", "a", "b", "c"),
 	)
 
+	It("should return a copy of the slice", func() {
+		// Given
+		slice.Set("value1")
+		slice.Set("value2")
+
+		// When
+		res := criocli.StringSliceTrySplit(ctx, flagName)
+		res[0] = "value3"
+
+		// Then
+		Expect(slice.Value()[0]).To(Equal("value1"))
+	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:

Fixes #3862

#### Special notes for your reviewer:

1.18 Backport of PR #3870 

#### Does this PR introduce a user-facing change?

```release-note
Make StringSliceTrySplit return a copy of the underlying slice as otherwise the underlying flags in the ctx might be overriden, which can cause issue when the config is reloaded (GetConfigFromContext() is called more than once).
```
