### PR TITLE
fix segfault with errors.Cause()

### DIFF
--- a/cmd/crio/wipe.go
+++ b/cmd/crio/wipe.go
@@ -106,7 +106,7 @@ func (c ContainerStore) wipeCrio(shouldWipeImages bool) error {
 func (c ContainerStore) getCrioContainersAndImages() (crioContainers, crioImages []string, _ error) {
 	containers, err := c.store.Containers()
 	if err != nil {
-		if os.IsNotExist(errors.Cause(err)) {
+		if errors.Is(err, os.ErrNotExist) {
 			return crioContainers, crioImages, err
 		}
 		logrus.Errorf("could not read containers and sandboxes: %v", err)

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -524,7 +524,7 @@ func recoverLogError() {
 func (c *ContainerServer) Shutdown() error {
 	defer recoverLogError()
 	_, err := c.store.Shutdown(false)
-	if err != nil && errors.Cause(err) != cstorage.ErrLayerUsedByContainer {
+	if err != nil && !errors.Is(err, cstorage.ErrLayerUsedByContainer) {
 		return err
 	}
 	return nil

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -606,7 +606,7 @@ func (r *runtimeVM) updateContainerStatus(c *Container) error {
 		ID: c.ID(),
 	})
 	if err != nil {
-		if errors.Cause(err) != ttrpc.ErrClosed {
+		if errors.Is(err, ttrpc.ErrClosed) {
 			return errdefs.FromGRPC(err)
 		}
 		return errdefs.ErrNotFound

--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -180,7 +180,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		}
 	}
 	img, err := istorage.Transport.GetStoreImage(r.storageImageServer.GetStore(), ref)
-	if img == nil && errors.Cause(err) == storage.ErrImageUnknown && isPauseImage {
+	if img == nil && errors.Is(err, storage.ErrImageUnknown) && isPauseImage {
 		image := imageID
 		if imageName != "" {
 			image = imageName
@@ -209,7 +209,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		}
 		logrus.Debugf("successfully pulled image %q", image)
 	}
-	if img == nil && errors.Cause(err) == storage.ErrImageUnknown {
+	if img == nil && errors.Is(err, storage.ErrImageUnknown) {
 		if imageID == "" {
 			return ContainerInfo{}, fmt.Errorf("image %q not present in image store", imageName)
 		}
@@ -357,7 +357,7 @@ func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, pod
 func (r *runtimeService) RemovePodSandbox(idOrName string) error {
 	container, err := r.storageImageServer.GetStore().Container(idOrName)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Is(err, storage.ErrContainerUnknown) {
 			return ErrInvalidSandboxID
 		}
 		return err
@@ -410,7 +410,7 @@ func (r *runtimeService) GetContainerMetadata(idOrName string) (RuntimeContainer
 func (r *runtimeService) StartContainer(idOrName string) (string, error) {
 	container, err := r.storageImageServer.GetStore().Container(idOrName)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Is(err, storage.ErrContainerUnknown) {
 			return "", ErrInvalidContainerID
 		}
 		return "", err
@@ -448,7 +448,7 @@ func (r *runtimeService) StopContainer(idOrName string) error {
 func (r *runtimeService) GetWorkDir(id string) (string, error) {
 	container, err := r.storageImageServer.GetStore().Container(id)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Is(err, storage.ErrContainerUnknown) {
 			return "", ErrInvalidContainerID
 		}
 		return "", err
@@ -459,7 +459,7 @@ func (r *runtimeService) GetWorkDir(id string) (string, error) {
 func (r *runtimeService) GetRunDir(id string) (string, error) {
 	container, err := r.storageImageServer.GetStore().Container(id)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Is(err, storage.ErrContainerUnknown) {
 			return "", ErrInvalidContainerID
 		}
 		return "", err

--- a/server/label_linux.go
+++ b/server/label_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 func securityLabel(path, secLabel string, shared bool) error {
-	if err := label.Relabel(path, secLabel, shared); err != nil && errors.Cause(err) != unix.ENOTSUP {
+	if err := label.Relabel(path, secLabel, shared); err != nil && !errors.Is(err, unix.ENOTSUP) {
 		return fmt.Errorf("relabel failed %s: %v", path, err)
 	}
 	return nil

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -81,7 +81,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 		s.removeInfraContainer(podInfraContainer)
 		podInfraContainer.CleanupConmonCgroup()
 
-		if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
+		if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
 			log.Warnf(ctx, "failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 		}
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -108,7 +108,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	mountLabel := podContainer.MountLabel
 	processLabel := podContainer.ProcessLabel
 
-	if errors.Cause(err) == storage.ErrDuplicateName {
+	if errors.Is(err, storage.ErrDuplicateName) {
 		return nil, fmt.Errorf("pod sandbox with name %q already exists", sbox.Name())
 	}
 	if err != nil {
@@ -174,11 +174,10 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			}
 			return nil, err
 		}
-		if err := label.Relabel(resolvPath, mountLabel, false); err != nil && errors.Cause(err) != unix.ENOTSUP {
+		if err := label.Relabel(resolvPath, mountLabel, false); err != nil && !errors.Is(err, unix.ENOTSUP) {
 			if err1 := removeFile(resolvPath); err1 != nil {
 				return nil, fmt.Errorf("%v; failed to remove %s: %v", err, resolvPath, err1)
 			}
-			return nil, err
 		}
 		mnt := spec.Mount{
 			Type:        "bind",
@@ -468,7 +467,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if err := ioutil.WriteFile(hostnamePath, []byte(hostname+"\n"), 0o644); err != nil {
 		return nil, err
 	}
-	if err := label.Relabel(hostnamePath, mountLabel, false); err != nil && errors.Cause(err) != unix.ENOTSUP {
+	if err := label.Relabel(hostnamePath, mountLabel, false); err != nil && !errors.Is(err, unix.ENOTSUP) {
 		return nil, err
 	}
 	mnt = spec.Mount{

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -70,7 +70,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 					if err := s.StopContainerAndWait(ctx, c, int64(10)); err != nil {
 						return fmt.Errorf("failed to stop container for pod sandbox %s: %v", sb.ID(), err)
 					}
-					if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
+					if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
 						// assume container already umounted
 						log.Warnf(ctx, "failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 					}
@@ -99,7 +99,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		return nil, err
 	}
 
-	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
+	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
 		log.Warnf(ctx, "failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
 	if err := s.ContainerStateToDisk(podInfraContainer); err != nil {

--- a/server/secrets.go
+++ b/server/secrets.go
@@ -144,7 +144,7 @@ func secretMounts(ctx context.Context, defaultMountsPaths []string, mountLabel, 
 				return nil, err
 			}
 		}
-		if err := label.Relabel(ctrDirOnHost, mountLabel, false); err != nil && errors.Cause(err) != unix.ENOTSUP {
+		if err := label.Relabel(ctrDirOnHost, mountLabel, false); err != nil && !errors.Is(err, unix.ENOTSUP) {
 			return nil, err
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -153,7 +153,7 @@ func (s *Server) getPortForward(req *pb.PortForwardRequest) (*pb.PortForwardResp
 
 func (s *Server) restore(ctx context.Context) {
 	containers, err := s.Store().Containers()
-	if err != nil && !os.IsNotExist(errors.Cause(err)) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		logrus.Warnf("could not read containers and sandboxes: %v", err)
 	}
 	pods := map[string]*storage.RuntimeContainerMetadata{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug

#### What this PR does / why we need it:
a strange interaction between the go compiler and errors.Cause() seems to happen.
Sometimes, the condition `err != nil` is checked after `errors.Cause(err)...`
since errors.Cause(err) segfaults if err == nil, we need to put the second check in a new block

it sucks, but we've seen a segfault like in https://storage.googleapis.com/origin-federated-results/pr-logs/pull/cri-o_cri-o/3887/test_pull_request_crio_e2e_fedora/13716/artifacts/journals/crio.service once already

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
