### PR TITLE
Add runtime_type as an option of "--runtimes"

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -106,7 +106,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l read-only -d 'Setup all un
 complete -c crio -n '__fish_crio_no_subcommand' -f -l registry -r -d 'Registry to be prepended when pulling unqualified images, can be specified multiple times'
 complete -c crio -n '__fish_crio_no_subcommand' -l root -s r -r -d 'The CRI-O root directory'
 complete -c crio -n '__fish_crio_no_subcommand' -l runroot -r -d 'The CRI-O state directory'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l runtimes -r -d 'OCI runtimes, format is runtime_name:runtime_path:runtime_root'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l runtimes -r -d 'OCI runtimes, format is runtime_name:runtime_path:runtime_root:runtime_type'
 complete -c crio -n '__fish_crio_no_subcommand' -l seccomp-profile -r -d 'Path to the seccomp.json profile to be used as the runtime\'s default. If not specified, then the internal default seccomp profile will be used. (default: "")'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l selinux -d 'Enable selinux support (default: false)'
 complete -c crio -n '__fish_crio_no_subcommand' -l signature-policy -r -d 'Path to signature policy JSON file. (default: "", to use the system-wide default)'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -265,7 +265,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--runroot**="": The CRI-O state directory (default: /var/run/containers/storage)
 
-**--runtimes**="": OCI runtimes, format is runtime_name:runtime_path:runtime_root (default: [])
+**--runtimes**="": OCI runtimes, format is runtime_name:runtime_path:runtime_root:runtime_type (default: [])
 
 **--seccomp-profile**="": Path to the seccomp.json profile to be used as the runtime's default. If not specified, then the internal default seccomp profile will be used. (default: "")
 

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -128,12 +128,21 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 		runtimes := StringSliceTrySplit(ctx, "runtimes")
 		for _, r := range runtimes {
 			fields := strings.Split(r, ":")
-			if len(fields) != 3 {
+
+			runtimeType := libconfig.DefaultRuntimeType
+
+			switch len(fields) {
+			case 4:
+				runtimeType = fields[3]
+				fallthrough
+			case 3:
+				config.Runtimes[fields[0]] = &libconfig.RuntimeHandler{
+					RuntimePath: fields[1],
+					RuntimeRoot: fields[2],
+					RuntimeType: runtimeType,
+				}
+			default:
 				return fmt.Errorf("wrong format for --runtimes: %q", r)
-			}
-			config.Runtimes[fields[0]] = &libconfig.RuntimeHandler{
-				RuntimePath: fields[1],
-				RuntimeRoot: fields[2],
 			}
 		}
 	}
@@ -484,7 +493,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:    "runtimes",
-			Usage:   "OCI runtimes, format is runtime_name:runtime_path:runtime_root",
+			Usage:   "OCI runtimes, format is runtime_name:runtime_path:runtime_root:runtime_type",
 			EnvVars: []string{"CONTAINER_RUNTIMES"},
 		},
 		&cli.StringFlag{

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -41,6 +41,7 @@ OVERRIDE_OPTIONS=${OVERRIDE_OPTIONS:-}
 RUNTIME_PATH=$(command -v "$CONTAINER_RUNTIME" || true)
 RUNTIME_BINARY=${RUNTIME_PATH:-$(command -v runc)}
 RUNTIME_ROOT=${RUNTIME_ROOT:-/run/runc}
+RUNTIME_TYPE=${RUNTIME_TYPE:-oci}
 # Path of the apparmor_parser binary.
 APPARMOR_PARSER_BINARY=${APPARMOR_PARSER_BINARY:-/sbin/apparmor_parser}
 # Path of the apparmor profile for test.
@@ -303,7 +304,7 @@ function setup_crio() {
         --listen "$CRIO_SOCKET" \
         --registry "quay.io" \
         --registry "docker.io" \
-        --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY:$RUNTIME_ROOT" \
+        --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY:$RUNTIME_ROOT:$RUNTIME_TYPE" \
         -r "$TESTDIR/crio" \
         --runroot "$TESTDIR/crio-run" \
         --cni-default-network "$CNI_DEFAULT_NETWORK" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:

Let's add a new field to the "--runtimes" option, allowing consumers of
the cli to also define the type of the runtime.

This is particularly useful to ease testing of the "vm" runtime, used by
kata-containers.

Mind that this PR does *not* break the command-line backwards
compatibility as we do not mandate 4 fields to be defined, but in case a
4th field is define, it'll be treated as the runtime_type.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #3877

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds a new optional field, runtime_type, to the "--runtimes" option.
```
