### PR TITLE
Manage ns: manage pid

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -211,35 +211,6 @@ func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 	sb.SetSeccompProfilePath(spp)
 	sb.SetNamespaceOptions(&nsOpts)
 
-	// We add an NS only if we can load a permanent one.
-	// Otherwise, the sandbox will live in the host namespace.
-	if c.config.ManageNSLifecycle {
-		netNsPath, err := configNsPath(&m, rspec.NetworkNamespace)
-		if err == nil {
-			if nsErr := sb.NetNsJoin(netNsPath); nsErr != nil {
-				return nsErr
-			}
-		}
-		ipcNsPath, err := configNsPath(&m, rspec.IPCNamespace)
-		if err == nil {
-			if nsErr := sb.IpcNsJoin(ipcNsPath); nsErr != nil {
-				return nsErr
-			}
-		}
-		utsNsPath, err := configNsPath(&m, rspec.UTSNamespace)
-		if err == nil {
-			if nsErr := sb.UtsNsJoin(utsNsPath); nsErr != nil {
-				return nsErr
-			}
-		}
-		userNsPath, err := configNsPath(&m, rspec.UserNamespace)
-		if err == nil {
-			if nsErr := sb.UserNsJoin(userNsPath); nsErr != nil {
-				return nsErr
-			}
-		}
-	}
-
 	if err := c.AddSandbox(sb); err != nil {
 		return err
 	}
@@ -276,6 +247,44 @@ func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 	if err != nil {
 		return err
 	}
+
+	if err := sb.SetInfraContainer(scontainer); err != nil {
+		return errors.Wrapf(err, "set infra container")
+	}
+
+	if err := c.ContainerStateFromDisk(scontainer); err != nil {
+		return errors.Wrapf(err, "error reading sandbox state from disk %q", scontainer.ID())
+	}
+
+	// We add an NS only if we can load a permanent one.
+	// Otherwise, the sandbox will live in the host namespace.
+	if c.config.ManageNSLifecycle {
+		namespacesToJoin := []struct {
+			rspecNS  rspec.LinuxNamespaceType
+			joinFunc func(string) error
+		}{
+			{rspecNS: rspec.NetworkNamespace, joinFunc: sb.NetNsJoin},
+			{rspecNS: rspec.IPCNamespace, joinFunc: sb.IpcNsJoin},
+			{rspecNS: rspec.UTSNamespace, joinFunc: sb.UtsNsJoin},
+			{rspecNS: rspec.UserNamespace, joinFunc: sb.UserNsJoin},
+		}
+		for _, namespaceToJoin := range namespacesToJoin {
+			path, err := configNsPath(&m, namespaceToJoin.rspecNS)
+			if err == nil {
+				if nsErr := namespaceToJoin.joinFunc(path); err != nil {
+					return nsErr
+				}
+			}
+		}
+		// PidNs needs to be handled differently
+		if err := sb.PidNsJoin(); err != nil {
+			// if the namespace wasn't managed, then we silently skip
+			if !errors.Is(err, sandbox.ErrNamespaceNotManaged) {
+				return err
+			}
+		}
+	}
+
 	scontainer.SetSpec(&m)
 	scontainer.SetMountPoint(m.Annotations[annotations.MountPoint])
 
@@ -289,10 +298,6 @@ func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 		}
 	}
 
-	if err := c.ContainerStateFromDisk(scontainer); err != nil {
-		return fmt.Errorf("error reading sandbox state from disk %q: %v", scontainer.ID(), err)
-	}
-
 	// We write back the state because it is possible that crio did not have a chance to
 	// read the exit file and persist exit code into the state on reboot.
 	if err := c.ContainerStateToDisk(scontainer); err != nil {
@@ -301,9 +306,6 @@ func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 
 	sb.SetCreated()
 	if err := label.ReserveLabel(processLabel); err != nil {
-		return err
-	}
-	if err := sb.SetInfraContainer(scontainer); err != nil {
 		return err
 	}
 

--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -2,7 +2,9 @@ package sandbox
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/internal/oci"
@@ -22,6 +24,8 @@ const (
 	PIDNS         NSType = "pid"
 	numNamespaces        = 4
 )
+
+var ErrNamespaceNotManaged = errors.New("sandbox namespace not managed")
 
 // NamespaceIface provides a generic namespace interface
 type NamespaceIface interface {
@@ -73,7 +77,7 @@ func (s *Sandbox) CreateManagedNamespaces(managedNamespaces []NSType, idMappings
 	return s.CreateNamespacesWithFunc(managedNamespaces, idMappings, cfg, pinNamespaces)
 }
 
-// CreateManagedNamespacesWithFunc is mainly added for testing purposes. There's no point in actually calling the pinns binary
+// CreateNamespacesWithFunc is mainly added for testing purposes. There's no point in actually calling the pinns binary
 // in unit tests, so this function allows the actual pin func to be abstracted out. Every other caller should use CreateManagedNamespaces
 func (s *Sandbox) CreateNamespacesWithFunc(managedNamespaces []NSType, idMappings *idtools.IDMappings, cfg *config.Config, pinFunc func([]NSType, *config.Config, *idtools.IDMappings) ([]NamespaceIface, error)) (mns []*ManagedNamespace, retErr error) {
 	typesAndPaths := make([]*ManagedNamespace, 0, 4)
@@ -189,6 +193,11 @@ func (s *Sandbox) RemoveManagedNamespaces() error {
 			errs = append(errs, err)
 		}
 	}
+	if s.pidns != nil {
+		if err := s.pidns.Remove(); err != nil {
+			errs = append(errs, err)
+		}
+	}
 	if s.userns != nil {
 		if err := s.userns.Remove(); err != nil {
 			errs = append(errs, err)
@@ -279,11 +288,103 @@ func (s *Sandbox) UserNsJoin(nspath string) error {
 }
 
 // PidNs specific functions
+// CreateManagedPidNamespace creates a managed pid namespace
+// it is separate from the other namespaces because pid namespaces need special handling
+// We cannot tell the runtime: "here is your pid namespace!", because it gets created
+// when the container is created and it would would be a bother having conmon (the parent of the container process)
+// unshare and then do the bind mount
+// instead, we mount the sandbox's pid namespace after the infra container is created
+// and from then on refer to it for each container create
+// thus, this should be called after the infra container has been created in the runtime
+func (s *Sandbox) CreateManagedPidNamespace(cfg *config.Config) error {
+	return s.CreateManagedPidNamespaceWithFunc(cfg, pinPidNamespace)
+}
+
+func (s *Sandbox) CreateManagedPidNamespaceWithFunc(cfg *config.Config, pinFunc func(*config.Config, string) (NamespaceIface, error)) (retErr error) {
+	if cfg == nil {
+		return errors.New("cannot create a managed pid namespace with a nil config")
+	}
+
+	podPidnsProc := s.nsPath(nil, PIDNS)
+	// pid must have stopped or be incorrect, report error
+	if podPidnsProc == "" {
+		return errors.Errorf("proc entry for sandbox %s is gone; pid not created or stopped", s.id)
+	}
+
+	// since this is the first time the sandbox's pidns
+	// has been requested, we need to bind mount it to a new spot
+	// this will allow us to pay less attention to the infra pid for future calls
+	pidnsIface, err := pinFunc(cfg, podPidnsProc)
+	if err != nil {
+		return err
+	}
+
+	// if we fail the below write, we need to clean up the mount we created
+	defer func() {
+		if retErr != nil {
+			if err := pidnsIface.Remove(); err != nil {
+				logrus.Errorf("failed to clean up pidns after we failed to create it: %v", err)
+			}
+		}
+	}()
+
+	if err := s.writePidNsLocation(pidnsIface.Path()); err != nil {
+		return errors.Wrapf(err, "failed to write persistent location of pid")
+	}
+	s.pidns = pidnsIface
+
+	return nil
+}
 
 // PidNsPath returns the path to the pid namespace of the sandbox.
-// If the sandbox uses the host namespace, the empty string is returned.
+// If the sandbox uses the host namespace, the empty string is returned
+// We need the cri-o config to make sure we get the namespace
+// mounted in the correct spot.
 func (s *Sandbox) PidNsPath() string {
-	return s.nsPath(nil, PIDNS)
+	return s.nsPath(s.pidns, PIDNS)
+}
+
+// Attempts to join the pid namespace, whose location is saved in
+// the infra container's run dir.
+// if the location cannot be found (cri-o was restarted from not managing namespaces
+// to managing namespaces), an error ErrNamespaceNotManaged is returned
+func (s *Sandbox) PidNsJoin() error {
+	path, err := s.pidNsLocation()
+	if err != nil {
+		return err
+	}
+	ns, err := nsJoin(path, PIDNS, s.pidns)
+	if err != nil {
+		return err
+	}
+	s.pidns = ns
+	return err
+}
+
+func (s *Sandbox) writePidNsLocation(path string) error {
+	if err := ioutil.WriteFile(s.pidNsLocationFile(), []byte(path), 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Sandbox) pidNsLocation() (string, error) {
+	contents, err := ioutil.ReadFile(s.pidNsLocationFile())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", ErrNamespaceNotManaged
+		}
+		return "", err
+	}
+	return string(contents), nil
+}
+
+func (s *Sandbox) pidNsLocationFile() string {
+	infra := s.InfraContainer()
+	if infra == nil {
+		return ""
+	}
+	return filepath.Join(infra.Dir(), "pid-location")
 }
 
 // nsJoin checks if the current iface is nil, and if so gets the namespace at nsPath

--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -40,6 +40,7 @@ type Sandbox struct {
 	mountLabel     string
 	netns          NamespaceIface
 	ipcns          NamespaceIface
+	pidns          NamespaceIface
 	utsns          NamespaceIface
 	userns         NamespaceIface
 	shmPath        string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

 /kind bug

#### What this PR does / why we need it:
pid namespaces were special cased as a namespace that was not managed, because they function differently

For the other namespaces, we can pass a new namespace to the runtime when that namespace is private to the pod
However, it would be a bother creating a new pid namespace (conmon would have to unshare the namespace, then do the bind mount)

Instead, mount the pid namespace *after* the sandbox is created. This way, the infra container's runtime config doesn't list the namespace (more on that below)
but subsequent containers created can join the namespace, instead of the proc entry. This further protects us from pid wrap

A consequence of not adding the file to the config is the restore case is a bit odd. The other namespaces can join the namespace listed in the restored config.json,
but the pid namespace is not saved in its config json.

Work around this by saving the pidns location to the infra container's runDir

this PR also adds unit tests, and refactors a couple of things to make tests pass


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
build on top of https://github.com/cri-o/cri-o/pull/3868
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
CRI-O now manages the lifecycle of sandbox's PID namespace when manage_ns_lifecycle is enabled
```
