### PR TITLE
runtime_vm: Ignore ttrpc.ErrClosed when shutting the container down

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -540,7 +540,7 @@ func (r *runtimeVM) DeleteContainer(c *Container) error {
 		return err
 	}
 
-	if _, err := r.task.Shutdown(r.ctx, &task.ShutdownRequest{ID: c.ID()}); err != nil {
+	if _, err := r.task.Shutdown(r.ctx, &task.ShutdownRequest{ID: c.ID()}); err != nil && !errors.Is(err, ttrpc.ErrClosed) {
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

When shutting the container down, we're dealing with the following piece
of code on Kata side:
https://github.com/kata-containers/runtime/blob/master/containerd-shim-v2/service.go#L785
```
func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (_ *ptypes.Empty, err error) {
	defer func() {
		err = toGRPC(err)
	}()

	s.mu.Lock()
	if len(s.containers) != 0 {
		s.mu.Unlock()
		return empty, nil
	}
	s.mu.Unlock()

	s.cancel()

	os.Exit(0)

	// This will never be called, but this is only there to make sure the
	// program can compile.
	return empty, nil
}
```

The code shown above will simply stop the service, closing the ttrpc
channel, raising then the "ErrClosed" error, which is returned by the
Shutdown.

Differently from containerd code, which simply igores the error, CRI-O
propagates the error, leaving a bunch of processes behind that will
never ever be closed.

Here's what containerd does:
https://github.com/containerd/containerd/blob/master/runtime/v2/shim.go#L194
```
        _, err := s.task.Shutdown(ctx, &task.ShutdownRequest{
                ID: s.ID(),
        })
        if err != nil && !errors.Is(err, ttrpc.ErrClosed) {
                return errdefs.FromGRPC(err)
        }
```

Knowing that, let's mimic what's been done by containerd and ignore the
error in this specific case.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Again, not so trivial case to reproduce. If needed, I have an OCP cluster already setup that could be loaned for validating this issue.

#### Does this PR introduce a user-facing change?
```release-note
None
```
