### PR TITLE
Streamline how done channel is closed in Runtime#WaitContainerStateStopped

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -126,11 +126,10 @@ func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) (
 				// Check if the container is stopped
 				if err := impl.UpdateContainerStatus(c); err != nil {
 					done <- err
-					close(done)
 					return
 				}
 				if c.State().Status == ContainerStateStopped {
-					close(done)
+					done <- nil
 					return
 				}
 				time.Sleep(100 * time.Millisecond)
@@ -139,6 +138,7 @@ func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) (
 	}()
 	select {
 	case err = <-done:
+		close(done)
 		break
 	case <-ctx.Done():
 		close(chControl)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Currently the done channel may be closed in the goroutine or by the select statement starting on line 139.
We need to consider the following scenario:

* detection of ContainerStateStopped exhausts the timeout, with done channel closed by the select statement starting on line 139
* around the same time, ContainerStateStopped is returned from UpdateContainerStatus call, resulting in the close of done channel on line 132.

This PR moves the close of done channel to the main goroutine of WaitContainerStateStopped.

#### Which issue(s) this PR fixes:

<!--
Fixes #
-->
Fixes #3925

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
