### PR TITLE
Improves container memory usage stats

### DIFF
--- a/internal/config/cgmgr/cgmgr.go
+++ b/internal/config/cgmgr/cgmgr.go
@@ -40,6 +40,10 @@ type CgroupManager interface {
 	// the cgroup path for that containerID. If parentCgroup is empty, it
 	// uses the default parent for that particular manager
 	ContainerCgroupPath(string, string) string
+	// ContainerCgroupAbsolutePath takes arguments sandbox parent cgroup and container ID and
+	// returns the cgroup path on disk for that containerID. If parentCgroup is empty, it
+	// uses the default parent for that particular manager
+	ContainerCgroupAbsolutePath(string, string) (string, error)
 	// SandboxCgroupPath takes the sandbox parent, and sandbox ID. It
 	// returns the cgroup parent, cgroup path, and error. For systemd cgroups,
 	// it also checks there is enough memory in the given cgroup

--- a/internal/config/cgmgr/cgmgr_test.go
+++ b/internal/config/cgmgr/cgmgr_test.go
@@ -1,6 +1,8 @@
 package cgmgr_test
 
 import (
+	"path/filepath"
+
 	"github.com/cri-o/cri-o/internal/config/cgmgr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -186,6 +188,34 @@ var _ = t.Describe("Config", func() {
 				Expect(cgroupPath).To(ContainSubstring(cID))
 				Expect(cgroupPath).To(ContainSubstring(genericSandboxParent))
 			})
+		})
+		t.Describe("ContainerCgroupAbsolutePath", func() {
+			It("should contain default system.slice", func() {
+				// Given
+				// When
+				cgroupPath, err := sut.ContainerCgroupAbsolutePath("", cID)
+				// Then
+				Expect(err).To(BeNil())
+				Expect(cgroupPath).To(ContainSubstring(cID))
+				Expect(cgroupPath).To(ContainSubstring("system.slice"))
+			})
+			It("should be an absolute path", func() {
+				// Given
+				// When
+				cgroupPath, err := sut.ContainerCgroupAbsolutePath("", cID)
+				// Then
+				Expect(err).To(BeNil())
+				Expect(filepath.IsAbs(cgroupPath)).To(BeTrue())
+			})
+			It("should fail to expand slice", func() {
+				// Given
+				// When
+				cgroupPath, err := sut.ContainerCgroupAbsolutePath("::::", cID)
+				// Then
+				Expect(err).To(Not(BeNil()))
+				Expect(cgroupPath).To(Equal(""))
+			})
+
 		})
 		t.Describe("SandboxCgroupPath", func() {
 			It("should fail when parent too short", func() {

--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -41,6 +41,12 @@ func (*CgroupfsManager) ContainerCgroupPath(sbParent, containerID string) string
 	return filepath.Join(parent, crioPrefix+"-"+containerID)
 }
 
+// ContainerCgroupAbsolutePath just calls ContainerCgroupPath,
+// because they both return the absolute path
+func (m *CgroupfsManager) ContainerCgroupAbsolutePath(sbParent, containerID string) (string, error) {
+	return m.ContainerCgroupPath(sbParent, containerID), nil
+}
+
 // SandboxCgroupPath takes the sandbox parent, and sandbox ID. It
 // returns the cgroup parent, cgroup path, and error.
 func (*CgroupfsManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgPath string, _ error) {

--- a/test/stats.bats
+++ b/test/stats.bats
@@ -24,18 +24,63 @@ function teardown() {
 
     # then
     JSON="$output"
-    echo $JSON | jq -e '.stats[0].attributes.id != ""'
+    run echo $JSON | jq -e '.stats[0].attributes.id != ""'
     [ "$status" -eq 0 ]
 
-    echo $JSON | jq -e '.stats[0].cpu.timestamp > 0'
+    run echo $JSON | jq -e '.stats[0].cpu.timestamp > 0'
     [ "$status" -eq 0 ]
 
-    echo $JSON | jq -e '.stats[0].cpu.usageCoreNanoSeconds.value > 0'
+    run echo $JSON | jq -e '.stats[0].cpu.usageCoreNanoSeconds.value > 0'
     [ "$status" -eq 0 ]
 
-    echo $JSON | jq -e '.stats[0].memory.timestamp > 0'
+    run echo $JSON | jq -e '.stats[0].memory.timestamp > 0'
     [ "$status" -eq 0 ]
 
-    echo $JSON | jq -e '.stats[0].memory.workingSetBytes.value > 0'
+    run echo $JSON | jq -e '.stats[0].memory.workingSetBytes.value > 0'
+    [ "$status" -eq 0 ]
+}
+
+@test "container stats" {
+    # given
+    container2config=$(cat "$TESTDATA"/container_redis.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["name"] = ["podsandbox1-redis2"];obj["metadata"]["name"] = "podsandbox1-redis2"; json.dump(obj, sys.stdout)')
+    echo "$container2config" > "$TESTDIR"/container_redis2.json
+    run crictl runp "$TESTDATA"/sandbox_config.json
+    echo "$output"
+    [ "$status" -eq 0 ]
+    pod_id="$output"
+    run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+    echo "$output"
+    [ "$status" -eq 0 ]
+    ctr1_id="$output"
+    run crictl create "$pod_id" "$TESTDIR"/container_redis2.json "$TESTDATA"/sandbox_config.json
+    echo "$output"
+    [ "$status" -eq 0 ]
+    ctr2_id="$output"
+    run crictl start "$ctr1_id"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run crictl start "$ctr2_id"
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    # when
+    run crictl stats -o json "$ctr1_id"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    ctr1_stats_JSON="$output"
+
+    run crictl stats -o json "$crt2_id"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    ctr2_stats_JSON="$output"
+
+    run echo $ctr1_stats_JSON | jq -e '.stats[0].memory.workingSetBytes.value'
+    [ "$status" -eq 0 ]
+    ctr1_memory_bytes="$output"
+    run echo $ctr2_stats_JSON | jq -e '.stats[0].memory.workingSetBytes.value'
+    [ "$status" -eq 0 ]
+    ctr2_memory_bytes="$output"
+
+    run echo $ctr1_memory_bytes != $ctr2_memory_bytes
     [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
Allows viewing of stats by individual container instead of the whole pod
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3580 
<!--

or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
How the stats display for containers

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fixed a bug where crictl only showed pod level stats, not container level stats.

```
