### PR TITLE
retErr all the things

### DIFF
--- a/cmd/crio/wipe.go
+++ b/cmd/crio/wipe.go
@@ -103,7 +103,7 @@ func (c ContainerStore) wipeCrio(shouldWipeImages bool) error {
 	return nil
 }
 
-func (c ContainerStore) getCrioContainersAndImages() (crioContainers, crioImages []string, err error) {
+func (c ContainerStore) getCrioContainersAndImages() (crioContainers, crioImages []string, _ error) {
 	containers, err := c.store.Containers()
 	if err != nil {
 		if os.IsNotExist(errors.Cause(err)) {

--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -43,7 +43,7 @@ func (*CgroupfsManager) ContainerCgroupPath(sbParent, containerID string) string
 
 // SandboxCgroupPath takes the sandbox parent, and sandbox ID. It
 // returns the cgroup parent, cgroup path, and error.
-func (*CgroupfsManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgPath string, err error) {
+func (*CgroupfsManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgPath string, _ error) {
 	if strings.HasSuffix(path.Base(sbParent), ".slice") {
 		return "", "", fmt.Errorf("cri-o configured with cgroupfs cgroup manager, but received systemd slice as parent: %s", sbParent)
 	}

--- a/internal/config/cgmgr/systemd.go
+++ b/internal/config/cgmgr/systemd.go
@@ -51,7 +51,7 @@ func (*SystemdManager) ContainerCgroupPath(sbParent, containerID string) string 
 // cgroupPathToClean should always be returned empty. It is part of the interface to return the cgroup path
 // that cri-o is responsible for cleaning up upon the container's death.
 // Systemd takes care of this cleaning for us, so return an empty string
-func (*SystemdManager) MoveConmonToCgroup(cid, cgroupParent, conmonCgroup string, pid int) (cgroupPathToClean string, err error) {
+func (*SystemdManager) MoveConmonToCgroup(cid, cgroupParent, conmonCgroup string, pid int) (cgroupPathToClean string, _ error) {
 	if strings.HasSuffix(conmonCgroup, ".slice") {
 		cgroupParent = conmonCgroup
 	}
@@ -67,7 +67,7 @@ func (*SystemdManager) MoveConmonToCgroup(cid, cgroupParent, conmonCgroup string
 // SandboxCgroupPath takes the sandbox parent, and sandbox ID. It
 // returns the cgroup parent, cgroup path, and error.
 // It also checks there is enough memory in the given cgroup
-func (m *SystemdManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgPath string, err error) {
+func (m *SystemdManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgPath string, _ error) {
 	if sbParent == "" {
 		return "", "", nil
 	}

--- a/internal/findprocess/findprocess.go
+++ b/internal/findprocess/findprocess.go
@@ -17,8 +17,8 @@ var ErrNotFound = errors.New("process not found")
 // and only if the returned err is non-nil.
 //
 // [1]: https://golang.org/pkg/os/#FindProcess
-func FindProcess(pid int) (process *os.Process, err error) {
-	process, err = findProcess(pid)
+func FindProcess(pid int) (*os.Process, error) {
+	process, err := findProcess(pid)
 	if err != nil {
 		releaseErr := process.Release()
 		process = nil

--- a/internal/findprocess/findprocess_unix.go
+++ b/internal/findprocess/findprocess_unix.go
@@ -7,8 +7,8 @@ import (
 	"syscall"
 )
 
-func findProcess(pid int) (process *os.Process, err error) {
-	process, err = os.FindProcess(pid)
+func findProcess(pid int) (*os.Process, error) {
+	process, err := os.FindProcess(pid)
 	if err != nil {
 		return process, err
 	}

--- a/internal/findprocess/findprocess_windows.go
+++ b/internal/findprocess/findprocess_windows.go
@@ -4,8 +4,8 @@ import (
 	"os"
 )
 
-func findProcess(pid int) (process *os.Process, err error) {
-	process, err = os.FindProcess(pid)
+func findProcess(pid int) (*os.Process, error) {
+	process, err := os.FindProcess(pid)
 	if err != nil {
 		// FIXME: is there an analog to POSIX's ESRCH we can check for?
 		return process, err

--- a/internal/log/hook_filter.go
+++ b/internal/log/hook_filter.go
@@ -15,8 +15,11 @@ type FilterHook struct {
 }
 
 // NewFilterHook creates a new default FilterHook
-func NewFilterHook(filter string) (hook *FilterHook, err error) {
-	var custom *regexp.Regexp
+func NewFilterHook(filter string) (*FilterHook, error) {
+	var (
+		custom *regexp.Regexp
+		err    error
+	)
 	if filter != "" {
 		custom, err = regexp.Compile(filter)
 		logrus.Debugf("Using log filter: %q", custom)

--- a/internal/oci/oci_linux.go
+++ b/internal/oci/oci_linux.go
@@ -36,7 +36,7 @@ func sysProcAttrPlatform() *syscall.SysProcAttr {
 }
 
 // newPipe creates a unix socket pair for communication
-func newPipe() (parent, child *os.File, err error) {
+func newPipe() (parent, child *os.File, _ error) {
 	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
 		return nil, nil, err
@@ -44,8 +44,9 @@ func newPipe() (parent, child *os.File, err error) {
 	return os.NewFile(uintptr(fds[1]), "parent"), os.NewFile(uintptr(fds[0]), "child"), nil
 }
 
-func (r *runtimeOCI) containerStats(ctr *Container, cgroup string) (stats *ContainerStats, err error) {
-	stats = &ContainerStats{}
+func (r *runtimeOCI) containerStats(ctr *Container, cgroup string) (*ContainerStats, error) {
+	stats := &ContainerStats{}
+	var err error
 	stats.Container = ctr.ID()
 	stats.SystemNano = time.Now().UnixNano()
 

--- a/internal/oci/oci_unsupported.go
+++ b/internal/oci/oci_unsupported.go
@@ -17,6 +17,6 @@ func sysProcAttrPlatform() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{}
 }
 
-func newPipe() (parent *os.File, child *os.File, err error) {
+func newPipe() (*os.File, *os.File, error) {
 	return os.Pipe()
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -241,7 +241,8 @@ func (r *runtimeOCI) StartContainer(c *Container) error {
 	return nil
 }
 
-func prepareExec() (pidFile, parentPipe, childPipe *os.File, err error) {
+func prepareExec() (pidFile, parentPipe, childPipe *os.File, _ error) {
+	var err error
 	parentPipe, childPipe, err = os.Pipe()
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/config/sysctl.go
+++ b/pkg/config/sysctl.go
@@ -22,7 +22,8 @@ func (s *Sysctl) Value() string {
 }
 
 // Sysctls returns the parsed sysctl slice and an error if not parsable
-func (c *RuntimeConfig) Sysctls() (sysctls []Sysctl, err error) {
+func (c *RuntimeConfig) Sysctls() ([]Sysctl, error) {
+	sysctls := make([]Sysctl, 0, len(c.DefaultSysctls))
 	for _, sysctl := range c.DefaultSysctls {
 		// skip empty values for sake of backwards compatibility
 		if sysctl == "" {

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -13,8 +13,8 @@ import (
 )
 
 // Attach prepares a streaming endpoint to attach to a running container.
-func (s *Server) Attach(ctx context.Context, req *pb.AttachRequest) (resp *pb.AttachResponse, err error) {
-	resp, err = s.getAttach(req)
+func (s *Server) Attach(ctx context.Context, req *pb.AttachRequest) (*pb.AttachResponse, error) {
+	resp, err := s.getAttach(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to prepare attach endpoint")
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -129,7 +129,7 @@ func getMountInfo(mountInfos []*mount.Info, dir string) *mount.Info {
 	return nil
 }
 
-func getSourceMount(source string, mountInfos []*mount.Info) (path, optionalMountInfo string, errRet error) {
+func getSourceMount(source string, mountInfos []*mount.Info) (path, optionalMountInfo string, _ error) {
 	mountinfo := getMountInfo(mountInfos, source)
 	if mountinfo != nil {
 		return source, mountinfo.Optional, nil

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -13,8 +13,8 @@ import (
 )
 
 // Exec prepares a streaming endpoint to execute a command in the container.
-func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (resp *pb.ExecResponse, err error) {
-	resp, err = s.getExec(req)
+func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecResponse, error) {
+	resp, err := s.getExec(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to prepare exec endpoint: %v", err)
 	}

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ExecSync runs a command in a container synchronously.
-func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *pb.ExecSyncResponse, err error) {
+func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (*pb.ExecSyncResponse, error) {
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
@@ -35,11 +35,9 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *p
 	if err != nil {
 		return nil, err
 	}
-	resp = &pb.ExecSyncResponse{
+	return &pb.ExecSyncResponse{
 		Stdout:   execResp.Stdout,
 		Stderr:   execResp.Stderr,
 		ExitCode: execResp.ExitCode,
-	}
-
-	return resp, nil
+	}, nil
 }

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -61,7 +61,7 @@ func (s *Server) filterContainerList(ctx context.Context, filter *pb.ContainerFi
 }
 
 // ListContainers lists all containers by filters.
-func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersRequest) (resp *pb.ListContainersResponse, err error) {
+func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersRequest) (*pb.ListContainersResponse, error) {
 	var ctrs []*pb.Container
 	filter := req.GetFilter()
 	ctrList, err := s.ContainerServer.ListContainers()
@@ -113,8 +113,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 		}
 	}
 
-	resp = &pb.ListContainersResponse{
+	return &pb.ListContainersResponse{
 		Containers: ctrs,
-	}
-	return resp, nil
+	}, nil
 }

--- a/server/container_portforward.go
+++ b/server/container_portforward.go
@@ -14,8 +14,8 @@ import (
 )
 
 // PortForward prepares a streaming endpoint to forward ports from a PodSandbox.
-func (s *Server) PortForward(ctx context.Context, req *pb.PortForwardRequest) (resp *pb.PortForwardResponse, err error) {
-	resp, err = s.getPortForward(req)
+func (s *Server) PortForward(ctx context.Context, req *pb.PortForwardRequest) (*pb.PortForwardResponse, error) {
+	resp, err := s.getPortForward(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to prepare portforward endpoint")
 	}

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -10,7 +10,7 @@ import (
 
 // RemoveContainer removes the container. If the container is running, the container
 // should be force removed.
-func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (resp *pb.RemoveContainerResponse, err error) {
+func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerRequest) (*pb.RemoveContainerResponse, error) {
 	log.Infof(ctx, "Removing container: %s", req.GetContainerId())
 	// save container description to print
 	c, err := s.GetContainerFromShortID(req.ContainerId)
@@ -18,12 +18,10 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
-	_, err = s.ContainerServer.Remove(ctx, req.ContainerId, true)
-	if err != nil {
+	if _, err := s.ContainerServer.Remove(ctx, req.ContainerId, true); err != nil {
 		return nil, err
 	}
 
 	log.Infof(ctx, "Removed container %s: %s", c.ID(), c.Description())
-	resp = &pb.RemoveContainerResponse{}
-	return resp, nil
+	return &pb.RemoveContainerResponse{}, nil
 }

--- a/server/container_reopen_log.go
+++ b/server/container_reopen_log.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ReopenContainerLog reopens the containers log file
-func (s *Server) ReopenContainerLog(ctx context.Context, req *pb.ReopenContainerLogRequest) (resp *pb.ReopenContainerLogResponse, err error) {
+func (s *Server) ReopenContainerLog(ctx context.Context, req *pb.ReopenContainerLogRequest) (*pb.ReopenContainerLogResponse, error) {
 	containerID := req.ContainerId
 	c := s.GetContainer(containerID)
 
@@ -26,10 +26,8 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *pb.ReopenContainer
 		return nil, fmt.Errorf("container is not created or running")
 	}
 
-	err = s.ContainerServer.Runtime().ReopenContainerLog(c)
-	if err == nil {
-		resp = &pb.ReopenContainerLogResponse{}
+	if err := s.ContainerServer.Runtime().ReopenContainerLog(c); err != nil {
+		return nil, err
 	}
-
-	return resp, err
+	return &pb.ReopenContainerLogResponse{}, nil
 }

--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -48,7 +48,7 @@ func (s *Server) buildContainerStats(ctx context.Context, stats *oci.ContainerSt
 
 // ContainerStats returns stats of the container. If the container does not
 // exist, the call returns an error.
-func (s *Server) ContainerStats(ctx context.Context, req *pb.ContainerStatsRequest) (resp *pb.ContainerStatsResponse, err error) {
+func (s *Server) ContainerStats(ctx context.Context, req *pb.ContainerStatsRequest) (*pb.ContainerStatsResponse, error) {
 	container, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
 		return nil, err

--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ListContainerStats returns stats of all running containers.
-func (s *Server) ListContainerStats(ctx context.Context, req *pb.ListContainerStatsRequest) (resp *pb.ListContainerStatsResponse, err error) {
+func (s *Server) ListContainerStats(ctx context.Context, req *pb.ListContainerStatsRequest) (*pb.ListContainerStatsResponse, error) {
 	ctrList, err := s.ContainerServer.ListContainers()
 	if err != nil {
 		return nil, err

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -20,14 +20,14 @@ const (
 )
 
 // ContainerStatus returns status of the container.
-func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusRequest) (resp *pb.ContainerStatusResponse, err error) {
+func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusRequest) (*pb.ContainerStatusResponse, error) {
 	c, err := s.GetContainerFromShortID(req.ContainerId)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
 	containerID := c.ID()
-	resp = &pb.ContainerStatusResponse{
+	resp := &pb.ContainerStatusResponse{
 		Status: &pb.ContainerStatus{
 			Id:          containerID,
 			Metadata:    c.Metadata(),

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -9,7 +9,7 @@ import (
 )
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
-func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest) (resp *pb.StopContainerResponse, err error) {
+func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest) (*pb.StopContainerResponse, error) {
 	log.Infof(ctx, "Stopping container: %s", req.GetContainerId())
 	// save container description to print
 	c, err := s.GetContainerFromShortID(req.ContainerId)
@@ -23,6 +23,5 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 	}
 
 	log.Infof(ctx, "Stopped container %s: %s", c.ID(), c.Description())
-	resp = &pb.StopContainerResponse{}
-	return resp, nil
+	return &pb.StopContainerResponse{}, nil
 }

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -12,7 +12,7 @@ import (
 )
 
 // UpdateContainerResources updates ContainerConfig of the container.
-func (s *Server) UpdateContainerResources(ctx context.Context, req *pb.UpdateContainerResourcesRequest) (resp *pb.UpdateContainerResourcesResponse, err error) {
+func (s *Server) UpdateContainerResources(ctx context.Context, req *pb.UpdateContainerResourcesRequest) (*pb.UpdateContainerResourcesResponse, error) {
 	c, err := s.GetContainerFromShortID(req.GetContainerId())
 	if err != nil {
 		return nil, err

--- a/server/container_updateruntimeconfig.go
+++ b/server/container_updateruntimeconfig.go
@@ -6,6 +6,6 @@ import (
 )
 
 // UpdateRuntimeConfig updates the configuration of a running container.
-func (s *Server) UpdateRuntimeConfig(ctx context.Context, req *pb.UpdateRuntimeConfigRequest) (resp *pb.UpdateRuntimeConfigResponse, err error) {
+func (s *Server) UpdateRuntimeConfig(ctx context.Context, req *pb.UpdateRuntimeConfigRequest) (*pb.UpdateRuntimeConfigResponse, error) {
 	return &pb.UpdateRuntimeConfigResponse{}, nil
 }

--- a/server/image_fs_info.go
+++ b/server/image_fs_info.go
@@ -31,7 +31,7 @@ func getStorageFsInfo(store storage.Store) (*pb.FilesystemUsage, error) {
 }
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
-func (s *Server) ImageFsInfo(ctx context.Context, req *pb.ImageFsInfoRequest) (resp *pb.ImageFsInfoResponse, err error) {
+func (s *Server) ImageFsInfo(ctx context.Context, req *pb.ImageFsInfoRequest) (*pb.ImageFsInfoResponse, error) {
 	store := s.StorageImageServer().GetStore()
 	fsUsage, err := getStorageFsInfo(store)
 

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ListImages lists existing images.
-func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (resp *pb.ListImagesResponse, err error) {
+func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (*pb.ListImagesResponse, error) {
 	filter := ""
 	reqFilter := req.GetFilter()
 	if reqFilter != nil {
@@ -20,7 +20,7 @@ func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (res
 	if err != nil {
 		return nil, err
 	}
-	resp = &pb.ListImagesResponse{}
+	resp := &pb.ListImagesResponse{}
 	for i := range results {
 		image := ConvertImage(&results[i])
 		resp.Images = append(resp.Images, image)

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -21,8 +21,9 @@ import (
 var localRegistryPrefix = libpodImage.DefaultLocalRegistry + "/"
 
 // PullImage pulls a image with authentication config.
-func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp *pb.PullImageResponse, err error) {
+func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (*pb.PullImageResponse, error) {
 	// TODO: what else do we need here? (Signatures when the story isn't just pulling from docker://)
+	var err error
 	image := ""
 	img := req.GetImage()
 	if img != nil {
@@ -86,10 +87,9 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 	}
 
 	log.Infof(ctx, "Pulled image: %v", pullOp.imageRef)
-	resp = &pb.PullImageResponse{
+	return &pb.PullImageResponse{
 		ImageRef: pullOp.imageRef,
-	}
-	return resp, nil
+	}, nil
 }
 
 // pullImage performs the actual pull operation of PullImage. Used to separate
@@ -272,7 +272,7 @@ func tryIncrementImagePullFailureMetric(ctx context.Context, img string, err err
 	}
 }
 
-func decodeDockerAuth(s string) (user, password string, err error) {
+func decodeDockerAuth(s string) (user, password string, _ error) {
 	decoded, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
 		return "", "", err

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -10,7 +10,7 @@ import (
 )
 
 // RemoveImage removes the image.
-func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (resp *pb.RemoveImageResponse, err error) {
+func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (*pb.RemoveImageResponse, error) {
 	image := ""
 	img := req.GetImage()
 	if img != nil {
@@ -19,11 +19,8 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (r
 	if image == "" {
 		return nil, fmt.Errorf("no image specified")
 	}
-	var (
-		images  []string
-		deleted bool
-	)
-	images, err = s.StorageImageServer().ResolveNames(s.config.SystemContext, image)
+	var deleted bool
+	images, err := s.StorageImageServer().ResolveNames(s.config.SystemContext, image)
 	if err != nil {
 		if err == storage.ErrCannotParseImageID {
 			images = append(images, image)
@@ -43,6 +40,5 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (r
 	if !deleted && err != nil {
 		return nil, err
 	}
-	resp = &pb.RemoveImageResponse{}
-	return resp, nil
+	return &pb.RemoveImageResponse{}, nil
 }

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -16,7 +16,8 @@ import (
 )
 
 // ImageStatus returns the status of the image.
-func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (resp *pb.ImageStatusResponse, err error) {
+func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (*pb.ImageStatusResponse, error) {
+	var resp *pb.ImageStatusResponse
 	image := ""
 	img := req.GetImage()
 	if img != nil {

--- a/server/naming.go
+++ b/server/naming.go
@@ -25,13 +25,13 @@ func makeSandboxContainerName(sandboxConfig *pb.PodSandboxConfig) string {
 	}, nameDelimiter)
 }
 
-func (s *Server) ReserveSandboxContainerIDAndName(config *pb.PodSandboxConfig) (name string, err error) {
+func (s *Server) ReserveSandboxContainerIDAndName(config *pb.PodSandboxConfig) (string, error) {
 	if config == nil || config.Metadata == nil {
 		return "", fmt.Errorf("cannot generate sandbox container name without metadata")
 	}
 
 	id := stringid.GenerateNonCryptoID()
-	name, err = s.ReserveContainerName(id, makeSandboxContainerName(config))
+	name, err := s.ReserveContainerName(id, makeSandboxContainerName(config))
 	if err != nil {
 		return "", err
 	}

--- a/server/runtime_status.go
+++ b/server/runtime_status.go
@@ -11,7 +11,7 @@ import (
 const networkNotReadyReason = "NetworkPluginNotReady"
 
 // Status returns the status of the runtime
-func (s *Server) Status(ctx context.Context, req *pb.StatusRequest) (resp *pb.StatusResponse, err error) {
+func (s *Server) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {
 	runtimeCondition := &pb.RuntimeCondition{
 		Type:   pb.RuntimeReady,
 		Status: true,
@@ -27,14 +27,12 @@ func (s *Server) Status(ctx context.Context, req *pb.StatusRequest) (resp *pb.St
 		networkCondition.Message = fmt.Sprintf("Network plugin returns error: %v", err)
 	}
 
-	resp = &pb.StatusResponse{
+	return &pb.StatusResponse{
 		Status: &pb.RuntimeStatus{
 			Conditions: []*pb.RuntimeCondition{
 				runtimeCondition,
 				networkCondition,
 			},
 		},
-	}
-
-	return resp, nil
+	}, nil
 }

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -27,7 +27,7 @@ func filterSandbox(p *pb.PodSandbox, filter *pb.PodSandboxFilter) bool {
 }
 
 // ListPodSandbox returns a list of SandBoxes.
-func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxRequest) (resp *pb.ListPodSandboxResponse, err error) {
+func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxRequest) (*pb.ListPodSandboxResponse, error) {
 	var pods []*pb.PodSandbox
 	var podList []*sandbox.Sandbox
 	podList = append(podList, s.ContainerServer.ListSandboxes()...)
@@ -79,8 +79,7 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 		}
 	}
 
-	resp = &pb.ListPodSandboxResponse{
+	return &pb.ListPodSandboxResponse{
 		Items: pods,
-	}
-	return resp, nil
+	}, nil
 }

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -101,7 +101,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 }
 
 // getSandboxIP retrieves the IP address for the sandbox
-func (s *Server) getSandboxIPs(sb *sandbox.Sandbox) (podIPs []string, err error) {
+func (s *Server) getSandboxIPs(sb *sandbox.Sandbox) ([]string, error) {
 	if sb.HostNetwork() {
 		return nil, nil
 	}
@@ -120,6 +120,7 @@ func (s *Server) getSandboxIPs(sb *sandbox.Sandbox) (podIPs []string, err error)
 		return nil, fmt.Errorf("failed to get network JSON for pod sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 	}
 
+	podIPs := make([]string, 0, len(res.IPs))
 	for _, podIPConfig := range res.IPs {
 		podIPs = append(podIPs, strings.Split(podIPConfig.Address.String(), "/")[0])
 	}

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -15,7 +15,7 @@ import (
 
 // RemovePodSandbox deletes the sandbox. If there are any running containers in the
 // sandbox, they should be force deleted.
-func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxRequest) (resp *pb.RemovePodSandboxResponse, err error) {
+func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxRequest) (*pb.RemovePodSandboxResponse, error) {
 	log.Infof(ctx, "Removing pod sandbox: %s", req.GetPodSandboxId())
 	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
 	if err != nil {
@@ -26,10 +26,8 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 		// If the sandbox isn't found we just return an empty response to adhere
 		// the CRI interface which expects to not error out in not found
 		// cases.
-
-		resp = &pb.RemovePodSandboxResponse{}
 		log.Warnf(ctx, "could not get sandbox %s, it's probably been removed already: %v", req.PodSandboxId, err)
-		return resp, nil
+		return &pb.RemovePodSandboxResponse{}, nil
 	}
 
 	podInfraContainer := sb.InfraContainer()
@@ -117,6 +115,5 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	}
 
 	log.Infof(ctx, "Removed pod sandbox: %s", sb.ID())
-	resp = &pb.RemovePodSandboxResponse{}
-	return resp, nil
+	return &pb.RemovePodSandboxResponse{}, nil
 }

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -63,7 +63,7 @@ func (s *Server) runtimeHandler(req *pb.RunPodSandboxRequest) (string, error) {
 }
 
 // RunPodSandbox creates and runs a pod-level sandbox.
-func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (resp *pb.RunPodSandboxResponse, err error) {
+func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (*pb.RunPodSandboxResponse, error) {
 	// platform dependent call
 	return s.runPodSandbox(ctx, req)
 }

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -680,7 +680,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	return resp, nil
 }
 
-func setupShm(podSandboxRunDir, mountLabel string) (shmPath string, err error) {
+func setupShm(podSandboxRunDir, mountLabel string) (shmPath string, _ error) {
 	shmPath = filepath.Join(podSandboxRunDir, "shm")
 	if err := os.Mkdir(shmPath, 0700); err != nil {
 		return "", err

--- a/server/sandbox_run_unsupported.go
+++ b/server/sandbox_run_unsupported.go
@@ -9,6 +9,6 @@ import (
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (resp *pb.RunPodSandboxResponse, err error) {
+func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (*pb.RunPodSandboxResponse, error) {
 	return nil, fmt.Errorf("unsupported")
 }

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PodSandboxStatus returns the Status of the PodSandbox.
-func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusRequest) (resp *pb.PodSandboxStatusResponse, err error) {
+func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusRequest) (*pb.PodSandboxStatusResponse, error) {
 	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "could not find pod %q: %v", req.PodSandboxId, err)
@@ -35,7 +35,7 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 	}
 
 	sandboxID := sb.ID()
-	resp = &pb.PodSandboxStatusResponse{
+	resp := &pb.PodSandboxStatusResponse{
 		Status: &pb.PodSandboxStatus{
 			Id:          sandboxID,
 			CreatedAt:   sb.CreatedAt().UnixNano(),

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -8,7 +8,7 @@ import (
 
 // StopPodSandbox stops the sandbox. If there are any running containers in the
 // sandbox, they should be force terminated.
-func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxRequest) (resp *pb.StopPodSandboxResponse, err error) {
+func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxRequest) (*pb.StopPodSandboxResponse, error) {
 	// platform dependent call
 	return s.stopPodSandbox(ctx, req)
 }

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -15,9 +15,10 @@ import (
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxRequest) (resp *pb.StopPodSandboxResponse, err error) {
+func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxRequest) (*pb.StopPodSandboxResponse, error) {
 	log.Infof(ctx, "Stopping pod sandbox: %s", req.GetPodSandboxId())
 	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
+	resp := &pb.StopPodSandboxResponse{}
 	if err != nil {
 		if err == sandbox.ErrIDEmpty {
 			return nil, err
@@ -27,7 +28,6 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		// the CRI interface which expects to not error out in not found
 		// cases.
 
-		resp = &pb.StopPodSandboxResponse{}
 		log.Warnf(ctx, "could not get sandbox %s, it's probably been stopped already: %v", req.PodSandboxId, err)
 		log.Debugf(ctx, "StopPodSandboxResponse %s: %+v", req.PodSandboxId, resp)
 		return resp, nil
@@ -43,7 +43,6 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 
 	if sb.Stopped() {
 		log.Infof(ctx, "Stopped pod sandbox (already stopped): %s", sb.ID())
-		resp = &pb.StopPodSandboxResponse{}
 		return resp, nil
 	}
 
@@ -110,6 +109,5 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	log.Infof(ctx, "Stopped pod sandbox: %s", sb.ID())
 	sb.SetStopped(true)
 
-	resp = &pb.StopPodSandboxResponse{}
 	return resp, nil
 }

--- a/server/sandbox_stop_unsupported.go
+++ b/server/sandbox_stop_unsupported.go
@@ -9,6 +9,6 @@ import (
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxRequest) (resp *pb.StopPodSandboxResponse, err error) {
+func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxRequest) (*pb.StopPodSandboxResponse, error) {
 	return nil, fmt.Errorf("unsupported")
 }

--- a/server/secrets.go
+++ b/server/secrets.go
@@ -83,7 +83,7 @@ func readFile(root, name string) ([]SecretData, error) {
 }
 
 // getMountsMap separates the host:container paths
-func getMountsMap(path string) (host, container string, err error) {
+func getMountsMap(path string) (host, container string, _ error) {
 	arr := strings.SplitN(path, ":", 2)
 	if len(arr) == 2 {
 		return arr[0], arr[1], nil

--- a/server/version.go
+++ b/server/version.go
@@ -17,7 +17,7 @@ const (
 )
 
 // Version returns the runtime name, runtime version and runtime API version
-func (s *Server) Version(ctx context.Context, req *pb.VersionRequest) (resp *pb.VersionResponse, err error) {
+func (s *Server) Version(ctx context.Context, req *pb.VersionRequest) (*pb.VersionResponse, error) {
 	return &pb.VersionResponse{
 		Version:           kubeAPIVersion,
 		RuntimeName:       containerName,

--- a/utils/fifo/fifo.go
+++ b/utils/fifo/fifo.go
@@ -235,6 +235,6 @@ func (f *fifo) Close() (retErr error) {
 	}
 }
 
-func mkfifo(path string, mode uint32) (err error) {
+func mkfifo(path string, mode uint32) error {
 	return syscall.Mkfifo(path, mode)
 }

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -8,8 +8,8 @@ import (
 
 // GetDiskUsageStats accepts a path to a directory or file
 // and returns the number of bytes and inodes used by the path
-func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, err error) {
-	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, _ error) {
+	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		// Walk does not follow symbolic links
 		if err != nil {
 			return err
@@ -19,13 +19,11 @@ func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, err error) {
 		inodeCount++
 
 		return nil
-	})
-
-	if err != nil {
+	}); err != nil {
 		return 0, 0, err
 	}
 
-	return dirSize, inodeCount, err
+	return dirSize, inodeCount, nil
 }
 
 // IsDirectory tests whether the given path exists and is a directory. It

--- a/utils/io/container_io.go
+++ b/utils/io/container_io.go
@@ -72,7 +72,7 @@ func WithNewFIFOs(root string, tty, stdin bool) ContainerIOOpts {
 }
 
 // NewContainerIO creates container io.
-func NewContainerIO(id string, opts ...ContainerIOOpts) (_ *ContainerIO, err error) {
+func NewContainerIO(id string, opts ...ContainerIOOpts) (*ContainerIO, error) {
 	c := &ContainerIO{
 		id:          id,
 		stdoutGroup: cioutil.NewWriterGroup(),

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -92,7 +92,11 @@ func (DetachError) Error() string {
 }
 
 // CopyDetachable is similar to io.Copy but support a detach key sequence to break out.
-func CopyDetachable(dst io.Writer, src io.Reader, keys []byte) (written int64, err error) {
+func CopyDetachable(dst io.Writer, src io.Reader, keys []byte) (int64, error) {
+	var (
+		written int64
+		err     error
+	)
 	// Sanity check interfaces
 	if dst == nil || src == nil {
 		return 0, fmt.Errorf("src/dst reader/writer nil")
@@ -201,7 +205,7 @@ func openContainerFile(rootfs, path string) (io.ReadCloser, error) {
 
 // GetUserInfo returns UID, GID and additional groups for specified user
 // by looking them up in /etc/passwd and /etc/group
-func GetUserInfo(rootfs, userName string) (uid, gid uint32, additionalGids []uint32, err error) {
+func GetUserInfo(rootfs, userName string) (uid, gid uint32, additionalGids []uint32, _ error) {
 	// We don't care if we can't open the file because
 	// not all images will have these files
 	passwdFile, err := openContainerFile(rootfs, "/etc/passwd")

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -15,11 +15,11 @@ import (
 type errorReaderWriter struct {
 }
 
-func (m *errorReaderWriter) Write(p []byte) (n int, err error) {
+func (m *errorReaderWriter) Write(p []byte) (int, error) {
 	return 0, t.TestError
 }
 
-func (m *errorReaderWriter) Read(p []byte) (n int, err error) {
+func (m *errorReaderWriter) Read(p []byte) (int, error) {
 	return 0, t.TestError
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:
relates to https://github.com/cri-o/cri-o/pull/3596 and https://github.com/cri-o/cri-o/pull/3586

essentially, it is error prone and risky to name a return value `err`. Instead, let's name every occurrence of a named error `retErr`. Also, drop named return variables in favor of anonymous ones when they don't meet the following two conditions:
- the error is among the list of a list of variables whose purpose could use clarification that variable names can provide (parentPipe and childPipe is one such example)
- the error is checked in a defer

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fixed bug where pod names would sometimes leak on creation, causing the kubelet to fail to recreate
```
