### PR TITLE
Validate cgroupfs conmon cgroup on start

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -825,6 +825,10 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 			return errors.Wrap(err, "unable to update cgroup manager")
 		}
 		c.cgroupManager = cgroupManager
+
+		if !c.cgroupManager.IsSystemd() && c.ConmonCgroup != "pod" && c.ConmonCgroup != "" {
+			return errors.New("cgroupfs manager conmon cgroup should be 'pod' or empty")
+		}
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -422,6 +422,17 @@ var _ = t.Describe("Config", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 		})
+
+		It("should fail on invalid conmon cgroup", func() {
+			// Given
+			sut.ConmonCgroup = "invalid"
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
 	})
 
 	t.Describe("ValidateRuntimes", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Usually we would trigger this error on runtime but we can also report it
on CRI-O startup. This allows user to act early on misconfigurations.
#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added configuration validation to ensure a `conmon_cgroup == "pod"` if `cgroup_manager == "cgroupfs"`
```
