### PR TITLE
config: fix systemd version parsing

### DIFF
--- a/internal/config/node/systemd.go
+++ b/internal/config/node/systemd.go
@@ -24,7 +24,7 @@ func SystemdHasCollectMode() bool {
 			systemdHasCollectModeErr = err
 			return
 		}
-		matches := regexp.MustCompile(`^systemd (?P<Version>\d+) .*`).FindStringSubmatch(string(stdout))
+		matches := regexp.MustCompile(`^systemd (?P<Version>\d+)`).FindStringSubmatch(string(stdout))
 
 		if len(matches) != 2 {
 			systemdHasCollectModeErr = errors.Errorf("systemd version command returned incompatible formatted information: %v", string(stdout))


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The "systemctl --version" parsing code assumed output like, eg:

    systemd 243 (v243.8-1.fc31)

but it may just be, eg

    systemd 239

#### Which issue(s) this PR fixes:
None; seen in logs while debugging something else:

`Jul 10 00:49:38 master-0 crio[2250]: time="2020-07-10 00:49:38.185271104Z" level=error msg="Node configuration validation for systemd CollectMode failed: systemd version command returned incompatible formatted information: systemd 239\n+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=legacy\n"`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
