### PR TITLE
runtime_vm: Avoid premature container info cleanup on creation failure

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -113,12 +113,6 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err erro
 		cio: containerIO,
 	}
 
-	defer func() {
-		if err != nil {
-			delete(r.ctrs, c.ID())
-		}
-	}()
-
 	// We can now create the container, interacting with the server
 	request := &task.CreateTaskRequest{
 		ID:       c.ID(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

While the removing the container info of the failed container from the
containers' map seems harmless, it'll end up causing an error when
actually cleaning up / deleting the failed container.

The reason for this is that CreateContainer, on Kata side, will remove
the failed container, wich will result on DeleteContainer, on the CRI-O
side, being called and then failing to actually remove the container, as
its info has already been removed from the containers' map.

This issue has been reported as part of a PR opened by Evan Foster:
https://github.com/kata-containers/runtime/pull/2826#issuecomment-657754302

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```