### PR TITLE
[1.18] change variable name err to retErr for deferred comparisons

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -107,7 +107,7 @@ func (r *Runtime) ValidateRuntimeHandler(handler string) (*config.RuntimeHandler
 // WaitContainerStateStopped runs a loop polling UpdateStatus(), seeking for
 // the container status to be updated to 'stopped'. Either it gets the expected
 // status and returns nil, or it reaches the timeout and returns an error.
-func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) (err error) {
+func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) error {
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -76,7 +76,7 @@ type exitCodeInfo struct {
 }
 
 // CreateContainer creates a container.
-func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err error) {
+func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (retErr error) {
 	var stderrBuf bytes.Buffer
 	parentPipe, childPipe, err := newPipe()
 	childStartPipe, parentStartPipe, err := newPipe()
@@ -179,7 +179,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 
 	// We will delete all container resources if creation fails
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			if err := r.DeleteContainer(c); err != nil {
 				logrus.Warnf("unable to delete container %s: %v", c.ID(), err)
 			}
@@ -364,7 +364,7 @@ func (r *runtimeOCI) ExecContainer(c *Container, cmd []string, stdin io.Reader, 
 }
 
 // ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
-func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout int64) (resp *ExecSyncResponse, err error) {
+func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout int64) (*ExecSyncResponse, error) {
 	pidFile, parentPipe, childPipe, err := prepareExec()
 	if err != nil {
 		return nil, &ExecSyncError{

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -75,7 +75,7 @@ func newRuntimeVM(path string) RuntimeImpl {
 }
 
 // CreateContainer creates a container.
-func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err error) {
+func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (retErr error) {
 	logrus.Debug("runtimeVM.createContainer() start")
 	defer logrus.Debug("runtimeVM.createContainer() end")
 
@@ -96,7 +96,7 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err erro
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			containerIO.Close()
 		}
 	}()
@@ -114,7 +114,7 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err erro
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			delete(r.ctrs, c.ID())
 		}
 	}()
@@ -297,7 +297,7 @@ func (r *runtimeVM) ExecSyncContainer(c *Container, command []string, timeout in
 	}, nil
 }
 
-func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int64, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) (exitCode int32, err error) {
+func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int64, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) (exitCode int32, retErr error) {
 	logrus.Debug("runtimeVM.execContainer() start")
 	defer logrus.Debug("runtimeVM.execContainer() end")
 
@@ -353,7 +353,7 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			if err := r.remove(ctx, c.ID(), execID); err != nil {
 				logrus.Debugf("unable to remove container %s: %v", c.ID(), err)
 			}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -263,7 +263,7 @@ func makeAccessible(path string, uid, gid int) error {
 }
 
 // nolint:gocyclo
-func (s *Server) createSandboxContainer(ctx context.Context, containerID, containerName string, sb *sandbox.Sandbox, sandboxConfig *pb.PodSandboxConfig, containerConfig *pb.ContainerConfig) (cntr *oci.Container, errRet error) {
+func (s *Server) createSandboxContainer(ctx context.Context, containerID, containerName string, sb *sandbox.Sandbox, sandboxConfig *pb.PodSandboxConfig, containerConfig *pb.ContainerConfig) (cntr *oci.Container, retErr error) {
 	if sb == nil {
 		return nil, errors.New("createSandboxContainer needs a sandbox")
 	}
@@ -416,7 +416,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 	}
 
 	defer func() {
-		if errRet != nil {
+		if retErr != nil {
 			log.Infof(ctx, "createCtrLinux: deleting container %s from storage", containerInfo.ID)
 			err2 := s.StorageRuntimeServer().DeleteContainer(containerInfo.ID)
 			if err2 != nil {
@@ -844,7 +844,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		return nil, fmt.Errorf("failed to mount container %s(%s): %v", containerName, containerID, err)
 	}
 	defer func() {
-		if errRet != nil {
+		if retErr != nil {
 			log.Infof(ctx, "createCtrLinux: stopping storage container %s", containerID)
 			if err := s.StorageRuntimeServer().StopContainer(containerID); err != nil {
 				log.Warnf(ctx, "couldn't stop storage container: %v: %v", containerID, err)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -40,7 +40,7 @@ import (
 const cgroupMemorySubsystemMountPathV1 = "/sys/fs/cgroup/memory"
 const cgroupMemorySubsystemMountPathV2 = "/sys/fs/cgroup"
 
-func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (resp *pb.RunPodSandboxResponse, err error) {
+func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (resp *pb.RunPodSandboxResponse, retErr error) {
 	s.updateLock.RLock()
 	defer s.updateLock.RUnlock()
 
@@ -58,16 +58,16 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	namespace := sbox.Config().GetMetadata().GetNamespace()
 	attempt := sbox.Config().GetMetadata().GetAttempt()
 
-	if err = sbox.SetNameAndID(); err != nil {
+	if err := sbox.SetNameAndID(); err != nil {
 		return nil, errors.Wrap(err, "setting pod sandbox name and id")
 	}
 
-	if _, err = s.ReservePodName(sbox.ID(), sbox.Name()); err != nil {
+	if _, err := s.ReservePodName(sbox.ID(), sbox.Name()); err != nil {
 		return nil, errors.Wrap(err, "reserving pod sandbox name")
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "runSandbox: releasing pod sandbox name: %s", sbox.Name())
 			s.ReleasePodName(sbox.Name())
 		}
@@ -78,7 +78,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "runSandbox: releasing container name: %s", containerName)
 			s.ReleaseContainerName(containerName)
 		}
@@ -113,7 +113,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, fmt.Errorf("error creating pod sandbox with name %q: %v", sbox.Name(), err)
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "runSandbox: removing pod sandbox from storage: %s", sbox.ID())
 			if err2 := s.StorageRuntimeServer().RemovePodSandbox(sbox.ID()); err2 != nil {
 				log.Warnf(ctx, "couldn't cleanup pod sandbox %q: %v", sbox.ID(), err2)
@@ -261,7 +261,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 		pathsToChown = append(pathsToChown, shmPath)
 		defer func() {
-			if err != nil {
+			if retErr != nil {
 				log.Infof(ctx, "runSandbox: unmounting shmPath for sandbox %s", sbox.ID())
 				if err2 := unix.Unmount(shmPath, unix.MNT_DETACH); err2 != nil {
 					log.Warnf(ctx, "failed to unmount shm for pod: %v", err2)
@@ -289,7 +289,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "runSandbox: deleting container ID from idIndex for sandbox %s", sbox.ID())
 			if err2 := s.CtrIDIndex().Delete(sbox.ID()); err2 != nil {
 				log.Warnf(ctx, "couldn't delete ctr id %s from idIndex", sbox.ID())
@@ -391,7 +391,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "runSandbox: removing pod sandbox %s", sbox.ID())
 			if err := s.removeSandbox(sbox.ID()); err != nil {
 				log.Warnf(ctx, "could not remove pod sandbox: %v", err)
@@ -404,7 +404,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "runSandbox: deleting pod ID %s from idIndex", sbox.ID())
 			if err := s.PodIDIndex().Delete(sbox.ID()); err != nil {
 				log.Warnf(ctx, "couldn't delete pod id %s from idIndex", sbox.ID())
@@ -438,7 +438,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	// We want to cleanup after ourselves if we are managing any namespaces and fail in this function.
 	for idx := range cleanupFuncs {
 		defer func(currentFunc int) {
-			if err != nil {
+			if retErr != nil {
 				log.Infof(ctx, "runSandbox: cleaning up namespaces after failing to run sandbox %s", sbox.ID())
 				if err2 := cleanupFuncs[currentFunc](); err2 != nil {
 					log.Debugf(ctx, err2.Error())
@@ -460,7 +460,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %v", containerName, sb.Name(), sbox.ID(), err)
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "runSandbox: stopping storage container for sandbox %s", sbox.ID())
 			if err2 := s.StorageRuntimeServer().StopContainer(sbox.ID()); err2 != nil {
 				log.Warnf(ctx, "couldn't stop storage container: %v: %v", sbox.ID(), err2)
@@ -560,7 +560,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			g.AddAnnotation(annotations.CNIResult, string(cniResultJSON))
 		}
 		defer func() {
-			if err != nil {
+			if retErr != nil {
 				log.Infof(ctx, "runSandbox: in manageNSLifecycle, stopping network for sandbox %s", sb.ID())
 				if err2 := s.networkStop(ctx, sb); err2 != nil {
 					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
@@ -594,7 +594,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	s.addInfraContainer(container)
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "runSandbox: removing infra container %s", container.ID())
 			s.removeInfraContainer(container)
 		}
@@ -618,7 +618,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			// Clean-up steps from RemovePodSanbox
 			log.Infof(ctx, "runSandbox: stopping container %s", container.ID())
 			if err2 := s.Runtime().StopContainer(ctx, container, int64(10)); err2 != nil {
@@ -648,7 +648,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			return nil, err
 		}
 		defer func() {
-			if err != nil {
+			if retErr != nil {
 				log.Infof(ctx, "runSandbox: in not manageNSLifecycle, stopping network for sandbox %s", sb.ID())
 				if err2 := s.networkStop(ctx, sb); err2 != nil {
 					log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
@@ -789,21 +789,19 @@ func (s *Server) configureGeneratorForSysctls(ctx context.Context, g generate.Ge
 // as well as whether CRI-O should be managing the namespace lifecycle.
 // it returns a slice of cleanup funcs, all of which are the respective NamespaceRemove() for the sandbox.
 // The caller should defer the cleanup funcs if there is an error, to make sure each namespace we are managing is properly cleaned up.
-func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, hostPID bool, sb *libsandbox.Sandbox, g generate.Generator) (cleanupFuncs []func() error, err error) {
+func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, hostPID bool, sb *libsandbox.Sandbox, g generate.Generator) (cleanupFuncs []func() error, retErr error) {
 	managedNamespaces := make([]libsandbox.NSType, 0, 3)
 	if hostNetwork {
-		err = g.RemoveLinuxNamespace(string(spec.NetworkNamespace))
-		if err != nil {
-			return
+		if err := g.RemoveLinuxNamespace(string(spec.NetworkNamespace)); err != nil {
+			return nil, err
 		}
 	} else if s.config.ManageNSLifecycle {
 		managedNamespaces = append(managedNamespaces, libsandbox.NETNS)
 	}
 
 	if hostIPC {
-		err = g.RemoveLinuxNamespace(string(spec.IPCNamespace))
-		if err != nil {
-			return
+		if err := g.RemoveLinuxNamespace(string(spec.IPCNamespace)); err != nil {
+			return nil, err
 		}
 	} else if s.config.ManageNSLifecycle {
 		managedNamespaces = append(managedNamespaces, libsandbox.IPCNS)
@@ -811,9 +809,8 @@ func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, ho
 
 	// Since we need a process to hold open the PID namespace, CRI-O can't manage the NS lifecycle
 	if hostPID {
-		err = g.RemoveLinuxNamespace(string(spec.PIDNamespace))
-		if err != nil {
-			return
+		if err := g.RemoveLinuxNamespace(string(spec.PIDNamespace)); err != nil {
+			return nil, err
 		}
 	}
 
@@ -834,7 +831,7 @@ func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, ho
 		}
 	}
 
-	return cleanupFuncs, err
+	return cleanupFuncs, nil
 }
 
 // configureGeneratorGivenNamespacePaths takes a map of nsType -> nsPath. It configures the generator

--- a/utils/io/helpers.go
+++ b/utils/io/helpers.go
@@ -96,7 +96,7 @@ type stdioPipes struct {
 }
 
 // newStdioPipes creates actual fifos for stdio.
-func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
+func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, retErr error) {
 	var (
 		f           io.ReadWriteCloser
 		set         []io.Closer
@@ -104,7 +104,7 @@ func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
 		p           = &stdioPipes{}
 	)
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			for _, f := range set {
 				f.Close()
 			}
@@ -113,20 +113,23 @@ func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
 	}()
 
 	if fifos.Stdin != "" {
-		if f, err = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+		f, err := fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+		if err != nil {
 			return nil, nil, err
 		}
 		p.stdin = f
 		set = append(set, f)
 	}
 
-	if f, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+	f, err := fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+	if err != nil {
 		return nil, nil, err
 	}
 	p.stdout = f
 	set = append(set, f)
 
-	if f, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+	f, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+	if err != nil {
 		return nil, nil, err
 	}
 	p.stderr = f


### PR DESCRIPTION
if we're branching on whether we errored in execution at the end of a function, we should use the retErr name, as it should not get shadowed

partial port of https://github.com/cri-o/cri-o/pull/3934/commits

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fixed bug where pod names would sometimes leak on creation, causing the kubelet to fail to recreate
```
