### PR TITLE
runtimeVM: Improve CreateContainer cleanup in case of failures

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -119,9 +119,10 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err erro
 
 	defer func() {
 		if err != nil {
-			r.Lock()
-			delete(r.ctrs, c.ID())
-			r.Unlock()
+			logrus.WithError(err).Warnf("Cleaning up container %s", c.ID())
+			if cleanupErr := r.deleteContainer(c, true); cleanupErr != nil {
+				logrus.WithError(cleanupErr).Infof("deleteContainer failed for container %s", c.ID())
+			}
 		}
 	}()
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

In case of failures on CreateContainer, let's do a full cleanup by
closing the IO opened, removing the container, shutting it down, and
finally removing it from the containers' map, which is performed by the
recently introduced deleteContainer() function.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```