### PR TITLE
change variable name err to retErr for deferred comparisons

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -103,7 +103,7 @@ func (r *Runtime) ValidateRuntimeHandler(handler string) (*config.RuntimeHandler
 // WaitContainerStateStopped runs a loop polling UpdateStatus(), seeking for
 // the container status to be updated to 'stopped'. Either it gets the expected
 // status and returns nil, or it reaches the timeout and returns an error.
-func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) (err error) {
+func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) error {
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -77,7 +77,7 @@ type exitCodeInfo struct {
 }
 
 // CreateContainer creates a container.
-func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err error) {
+func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (retErr error) {
 	var stderrBuf bytes.Buffer
 	parentPipe, childPipe, err := newPipe()
 	childStartPipe, parentStartPipe, err := newPipe()
@@ -182,7 +182,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 
 	// We will delete all container resources if creation fails
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			if err := r.DeleteContainer(c); err != nil {
 				logrus.Warnf("unable to delete container %s: %v", c.ID(), err)
 			}
@@ -368,7 +368,7 @@ func (r *runtimeOCI) ExecContainer(c *Container, cmd []string, stdin io.Reader, 
 }
 
 // ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
-func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout int64) (resp *ExecSyncResponse, err error) {
+func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout int64) (*ExecSyncResponse, error) {
 	pidFile, parentPipe, childPipe, err := prepareExec()
 	if err != nil {
 		return nil, &ExecSyncError{

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -77,7 +77,7 @@ func newRuntimeVM(path string) RuntimeImpl {
 }
 
 // CreateContainer creates a container.
-func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err error) {
+func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (retErr error) {
 	logrus.Debug("runtimeVM.createContainer() start")
 	defer logrus.Debug("runtimeVM.createContainer() end")
 
@@ -98,7 +98,7 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err erro
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			containerIO.Close()
 		}
 	}()
@@ -118,7 +118,7 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (err erro
 	r.Unlock()
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			logrus.WithError(err).Warnf("Cleaning up container %s", c.ID())
 			if cleanupErr := r.deleteContainer(c, true); cleanupErr != nil {
 				logrus.WithError(cleanupErr).Infof("deleteContainer failed for container %s", c.ID())
@@ -309,7 +309,7 @@ func (r *runtimeVM) ExecSyncContainer(c *Container, command []string, timeout in
 	}, nil
 }
 
-func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int64, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) (exitCode int32, err error) {
+func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int64, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) (exitCode int32, retErr error) {
 	logrus.Debug("runtimeVM.execContainer() start")
 	defer logrus.Debug("runtimeVM.execContainer() end")
 
@@ -365,7 +365,7 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			if err := r.remove(ctx, c.ID(), execID); err != nil {
 				logrus.Debugf("unable to remove container %s: %v", c.ID(), err)
 			}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -129,7 +129,7 @@ func getMountInfo(mountInfos []*mount.Info, dir string) *mount.Info {
 	return nil
 }
 
-func getSourceMount(source string, mountInfos []*mount.Info) (path, optionalMountInfo string, err error) {
+func getSourceMount(source string, mountInfos []*mount.Info) (path, optionalMountInfo string, errRet error) {
 	mountinfo := getMountInfo(mountInfos, source)
 	if mountinfo != nil {
 		return source, mountinfo.Optional, nil
@@ -492,7 +492,7 @@ func addSecretsBindMounts(ctx context.Context, mountLabel, ctrRunDir string, def
 }
 
 // CreateContainer creates a new container in specified PodSandbox
-func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (res *pb.CreateContainerResponse, err error) {
+func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (res *pb.CreateContainerResponse, retErr error) {
 	log.Infof(ctx, "Creating container: %s", translateLabelsToDescription(req.GetConfig().GetLabels()))
 
 	s.updateLock.RLock()
@@ -533,7 +533,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "createCtr: releasing container name %s", ctr.Name())
 			s.ReleaseContainerName(ctr.Name())
 		}
@@ -544,7 +544,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		return nil, err
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "createCtr: deleting container %s from storage", ctr.ID())
 			err2 := s.StorageRuntimeServer().DeleteContainer(ctr.ID())
 			if err2 != nil {
@@ -555,7 +555,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 
 	s.addContainer(newContainer)
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "createCtr: removing container %s", newContainer.ID())
 			s.removeContainer(newContainer)
 		}
@@ -565,7 +565,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		return nil, err
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "createCtr: deleting container ID %s from idIndex", ctr.ID())
 			if err2 := s.CtrIDIndex().Delete(ctr.ID()); err2 != nil {
 				log.Warnf(ctx, "couldn't delete ctr id %s from idIndex", ctr.ID())
@@ -589,11 +589,9 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	}
 
 	log.Infof(ctx, "Created container %s: %s", newContainer.ID(), newContainer.Description())
-	resp := &pb.CreateContainerResponse{
+	return &pb.CreateContainerResponse{
 		ContainerId: ctr.ID(),
-	}
-
-	return resp, nil
+	}, nil
 }
 
 func isInCRIMounts(dst string, mounts []*pb.Mount) bool {

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -203,7 +203,7 @@ func makeAccessible(path string, uid, gid int) error {
 }
 
 // nolint:gocyclo
-func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Container, sb *sandbox.Sandbox) (cntr *oci.Container, errRet error) {
+func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Container, sb *sandbox.Sandbox) (cntr *oci.Container, retErr error) {
 	// TODO: simplify this function (cyclomatic complexity here is high)
 	// TODO: factor generating/updating the spec into something other projects can vendor
 
@@ -351,7 +351,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 	}
 
 	defer func() {
-		if errRet != nil {
+		if retErr != nil {
 			log.Infof(ctx, "createCtrLinux: deleting container %s from storage", containerInfo.ID)
 			err2 := s.StorageRuntimeServer().DeleteContainer(containerInfo.ID)
 			if err2 != nil {
@@ -741,7 +741,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 		return nil, fmt.Errorf("failed to mount container %s(%s): %v", containerName, containerID, err)
 	}
 	defer func() {
-		if errRet != nil {
+		if retErr != nil {
 			log.Infof(ctx, "createCtrLinux: stopping storage container %s", containerID)
 			if err := s.StorageRuntimeServer().StopContainer(containerID); err != nil {
 				log.Warnf(ctx, "couldn't stop storage container: %v: %v", containerID, err)

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -18,7 +18,7 @@ import (
 
 // networkStart sets up the sandbox's network and returns the pod IP on success
 // or an error
-func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs []string, result cnitypes.Result, err error) {
+func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs []string, result cnitypes.Result, retErr error) {
 	overallStart := time.Now()
 	// give a network Start call 2 minutes, half of a RunPodSandbox request timeout limit
 	startCtx, startCancel := context.WithTimeout(ctx, 2*time.Minute)
@@ -30,13 +30,13 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 
 	podNetwork, err := s.newPodNetwork(sb)
 	if err != nil {
-		return
+		return nil, nil, err
 	}
 
 	// Ensure network resources are cleaned up if the plugin succeeded
 	// but an error happened between plugin success and the end of networkStart()
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			log.Infof(ctx, "networkStart: stopping network for sandbox %s", sb.ID())
 			if err2 := s.networkStop(startCtx, sb); err2 != nil {
 				log.Errorf(ctx, "error stopping network on cleanup: %v", err2)
@@ -47,8 +47,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 	podSetUpStart := time.Now()
 	_, err = s.config.CNIPlugin().SetUpPodWithContext(startCtx, podNetwork)
 	if err != nil {
-		err = fmt.Errorf("failed to create pod network sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
-		return
+		return nil, nil, fmt.Errorf("failed to create pod network sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 	}
 	// metric about the CNI network setup operation
 	metrics.CRIOOperationsLatency.WithLabelValues("network_setup_pod").
@@ -56,8 +55,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 
 	podNetworkStatus, err := s.config.CNIPlugin().GetPodNetworkStatusWithContext(startCtx, podNetwork)
 	if err != nil {
-		err = fmt.Errorf("failed to get network status for pod sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
-		return
+		return nil, nil, fmt.Errorf("failed to get network status for pod sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 	}
 
 	// only one cnitypes.Result is returned since newPodNetwork sets Networks list empty
@@ -66,8 +64,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 
 	network, err := cnicurrent.GetResult(result)
 	if err != nil {
-		err = fmt.Errorf("failed to get network JSON for pod sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
-		return
+		return nil, nil, fmt.Errorf("failed to get network JSON for pod sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 	}
 
 	for idx, podIPConfig := range network.IPs {
@@ -78,8 +75,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 		if idx == 0 && len(sb.PortMappings()) > 0 {
 			ip := net.ParseIP(podIP)
 			if ip == nil {
-				err = fmt.Errorf("failed to get valid ip address for sandbox %s(%s)", sb.Name(), sb.ID())
-				return
+				return nil, nil, fmt.Errorf("failed to get valid ip address for sandbox %s(%s)", sb.Name(), sb.ID())
 			}
 
 			err = s.hostportManager.Add(sb.ID(), &hostport.PodPortMapping{
@@ -89,8 +85,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 				HostNetwork:  false,
 			}, "lo")
 			if err != nil {
-				err = fmt.Errorf("failed to add hostport mapping for sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
-				return
+				return nil, nil, fmt.Errorf("failed to add hostport mapping for sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 			}
 		}
 

--- a/utils/io/helpers.go
+++ b/utils/io/helpers.go
@@ -96,7 +96,7 @@ type stdioPipes struct {
 }
 
 // newStdioPipes creates actual fifos for stdio.
-func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
+func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, retErr error) {
 	var (
 		f           io.ReadWriteCloser
 		set         []io.Closer
@@ -104,7 +104,7 @@ func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
 		p           = &stdioPipes{}
 	)
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			for _, f := range set {
 				f.Close()
 			}
@@ -113,20 +113,23 @@ func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
 	}()
 
 	if fifos.Stdin != "" {
-		if f, err = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+		f, err := fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+		if err != nil {
 			return nil, nil, err
 		}
 		p.stdin = f
 		set = append(set, f)
 	}
 
-	if f, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+	f, err := fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+	if err != nil {
 		return nil, nil, err
 	}
 	p.stdout = f
 	set = append(set, f)
 
-	if f, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+	f, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+	if err != nil {
 		return nil, nil, err
 	}
 	p.stderr = f


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug


#### What this PR does / why we need it:
if we're branching on whether we errored in execution at the end of a function,
we should use the retErr name, as it should not get shadowed

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
this includes the non-controversial half of https://github.com/cri-o/cri-o/pull/3934 (all of https://github.com/cri-o/cri-o/pull/3950)
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fixed bug where pod names would sometimes leak on creation, causing the kubelet to fail to recreate
```
