### PR TITLE
Fix static binary mode retrieval for musl toolchains

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -176,7 +176,8 @@ func getLinkmode() string {
 		return ""
 	}
 	if _, err = utils.ExecCmd("ldd", abspath); err != nil {
-		if strings.Contains(err.Error(), "not a dynamic executable") {
+		if strings.Contains(err.Error(), "not a dynamic executable") ||
+			strings.Contains(strings.ToLower(err.Error()), "not a valid dynamic program") {
 			return "static"
 		}
 		logrus.Warnf("Encountered error detecting link mode of binary: %v", err)


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The returned error is `Not a valid dynamic program` which is now catched
by the binary check as well.
#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed `crio version` binary mode parsing on musl toolchains
```
