### PR TITLE
Use /usr/bin/env bash in crio-shutdown.service

### DIFF
--- a/contrib/systemd/crio-shutdown.service
+++ b/contrib/systemd/crio-shutdown.service
@@ -7,7 +7,7 @@ Documentation=man:crio(8)
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/rm -f /var/lib/crio/crio.shutdown
-ExecStop=/usr/bin/bash -c "/usr/bin/mkdir /var/lib/crio; /usr/bin/touch /var/lib/crio/crio.shutdown"
+ExecStop=/usr/bin/env bash -c "/usr/bin/mkdir /var/lib/crio; /usr/bin/touch /var/lib/crio/crio.shutdown"
 RemainAfterExit=yes
 
 [Install]

--- a/contrib/systemd/crio-wipe.service
+++ b/contrib/systemd/crio-wipe.service
@@ -11,7 +11,7 @@ ExecStart=/usr/local/bin/crio \
           $CRIO_STORAGE_OPTIONS \
           $CRIO_NETWORK_OPTIONS \
           $CRIO_METRICS_OPTIONS \
-		  wipe
+          wipe
 
 Type=oneshot
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Some distributions have bash in other paths so we should call out to
`/usr/bin/env` to verify that the unit file works there as well.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fix path to bash via `/usr/bin/env` in crio-shutdown.service
```
