### PR TITLE
[1.18] Revert "container_server: disable fdatasync() for atomic writes"

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	_ "github.com/containers/libpod/pkg/hooks/0.1.0"
-	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/cri-o/cri-o/internal/criocli"
 	"github.com/cri-o/cri-o/internal/log"
@@ -109,9 +108,6 @@ func main() {
 	}
 
 	klog.SetOutput(ioutil.Discard)
-
-	// This must be done before reexec.Init()
-	ioutils.SetDefaultOptions(ioutils.AtomicFileWriterOptions{NoSync: true})
 
 	if reexec.Init() {
 		fmt.Fprintf(os.Stderr, "unable to initialize container storage\n")


### PR DESCRIPTION
This reverts commit ffffdf8f36267cd07dbe46e356b49cbdac4ccd65.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
Fix a bug where a sudden reboot causes incomplete image writes. This could cause image storage to be corrupted, resulting in an error `layer not known`.
```