### PR TITLE
node: fix panic if /sys/fs/cgroup failed to stat

### DIFF
--- a/internal/config/node/cgroups.go
+++ b/internal/config/node/cgroups.go
@@ -6,7 +6,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/opencontainers/runc/libcontainer/cgroups"
+	libpodcgroups "github.com/containers/libpod/pkg/cgroups"
+	libctrcgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/pkg/errors"
 )
 
@@ -19,9 +20,15 @@ var (
 	cgroupControllerErr  error
 	cgroupHasHugetlb     bool
 	cgroupHasPid         bool
+
+	cgroupIsV2Err error
 )
 
-var CgroupIsV2 = cgroups.IsCgroup2UnifiedMode
+func CgroupIsV2() bool {
+	var cgroupIsV2 bool
+	cgroupIsV2, cgroupIsV2Err = libpodcgroups.IsCgroup2UnifiedMode()
+	return cgroupIsV2
+}
 
 // CgroupHasMemorySwap returns whether the memory swap controller is present
 func CgroupHasMemorySwap() bool {
@@ -70,7 +77,7 @@ func checkRelevantControllers() {
 				enabled: &cgroupHasHugetlb,
 			},
 		}
-		ctrls, err := cgroups.GetAllSubsystems()
+		ctrls, err := libctrcgroups.GetAllSubsystems()
 		if err != nil {
 			cgroupControllerErr = err
 			return

--- a/internal/config/node/node.go
+++ b/internal/config/node/node.go
@@ -42,6 +42,13 @@ func ValidateConfig() error {
 			fatal:     false,
 		},
 		{
+			name:      "cgroup v2",
+			init:      CgroupIsV2,
+			err:       &cgroupIsV2Err,
+			activated: nil,
+			fatal:     false,
+		},
+		{
 			name:      "systemd CollectMode",
 			init:      SystemdHasCollectMode,
 			err:       &systemdHasCollectModeErr,
@@ -58,7 +65,9 @@ func ValidateConfig() error {
 			}
 			logrus.Error(err.Error())
 		}
-		logrus.Infof("node configuration value for %s is %v", i.name, *i.activated)
+		if i.activated != nil {
+			logrus.Infof("node configuration value for %s is %v", i.name, *i.activated)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
 /kind bug


#### What this PR does / why we need it:

our rhel 7 boxes that are used to package cri-o are failing with the following error:
```
panic: cannot statfs cgroup root
goroutine 1 [running]:
```
this is because the libcontainer cgroup packages opts to panic when the stat on /sys/fs/cgroup fails, rather than return an error

The point of the node package is to gracefully catch and handle these errors, so we switch to libpod version instead, and will now print
we failed to stat, rather than panic on it.

Note: these nodes are not suitable for running workloads, as runc will later panic, but packaging (in this case, building a config) should not panic because of it.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fixes panic when /sys/fs/cgroup can't be stat'ed
```
