### PR TITLE
Update the container resources under the spec

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -668,3 +668,52 @@ func (c *ContainerServer) StopContainerAndWait(ctx context.Context, ctr *oci.Con
 	}
 	return nil
 }
+
+func (c *ContainerServer) UpdateContainerLinuxResources(ctr *oci.Container, resources *rspec.LinuxResources) {
+	updatedSpec := ctr.Spec()
+	if updatedSpec.Linux == nil {
+		updatedSpec.Linux = &rspec.Linux{}
+	}
+
+	if updatedSpec.Linux.Resources == nil {
+		updatedSpec.Linux.Resources = &rspec.LinuxResources{}
+	}
+
+	if updatedSpec.Linux.Resources.CPU == nil {
+		updatedSpec.Linux.Resources.CPU = &rspec.LinuxCPU{}
+	}
+
+	if *resources.CPU.Shares != 0 {
+		updatedSpec.Linux.Resources.CPU.Shares = resources.CPU.Shares
+	}
+
+	if *resources.CPU.Quota != 0 {
+		updatedSpec.Linux.Resources.CPU.Quota = resources.CPU.Quota
+	}
+
+	if *resources.CPU.Period != 0 {
+		updatedSpec.Linux.Resources.CPU.Period = resources.CPU.Period
+	}
+
+	if resources.CPU.Cpus != "" {
+		updatedSpec.Linux.Resources.CPU.Cpus = resources.CPU.Cpus
+	}
+
+	if resources.CPU.Mems != "" {
+		updatedSpec.Linux.Resources.CPU.Mems = resources.CPU.Mems
+	}
+
+	if updatedSpec.Linux.Resources.Memory == nil {
+		updatedSpec.Linux.Resources.Memory = &rspec.LinuxMemory{}
+	}
+
+	if *resources.Memory.Limit != 0 {
+		updatedSpec.Linux.Resources.Memory.Limit = resources.Memory.Limit
+	}
+
+	updatedSpec.Linux.Resources.Memory.Swap = resources.Memory.Swap
+
+	ctr.SetSpec(&updatedSpec)
+
+	c.state.containers.Add(ctr.ID(), ctr)
+}

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -7,7 +7,9 @@ import (
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/gogo/protobuf/proto"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
+
 	"golang.org/x/net/context"
+
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -26,6 +28,10 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *pb.UpdateCon
 	if err := s.Runtime().UpdateContainer(c, resources); err != nil {
 		return nil, err
 	}
+
+	// update memory store with updated resources
+	s.UpdateContainerLinuxResources(c, resources)
+
 	return &pb.UpdateContainerResourcesResponse{}, nil
 }
 

--- a/server/container_update_resources_test.go
+++ b/server/container_update_resources_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -24,19 +25,64 @@ var _ = t.Describe("UpdateContainerResources", func() {
 	t.Describe("UpdateContainerResources", func() {
 		It("should succeed", func() {
 			// Given
-			addContainerAndSandbox()
+			testContainer.SetSpec(&specs.Spec{
+				Linux: &specs.Linux{
+					Resources: &specs.LinuxResources{},
+				},
+			})
 			testContainer.SetState(&oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateRunning},
 			})
+			addContainerAndSandbox()
 
 			// When
 			response, err := sut.UpdateContainerResources(context.Background(),
 				&pb.UpdateContainerResourcesRequest{
-					ContainerId: testContainer.ID()})
+					ContainerId: testContainer.ID(),
+				},
+			)
 
 			// Then
 			Expect(err).To(BeNil())
 			Expect(response).NotTo(BeNil())
+		})
+
+		It("should update the container spec", func() {
+			// Given
+			testContainer.SetSpec(&specs.Spec{
+				Linux: &specs.Linux{
+					Resources: &specs.LinuxResources{},
+				},
+			})
+			testContainer.SetState(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateRunning},
+			})
+			addContainerAndSandbox()
+
+			// When
+			response, err := sut.UpdateContainerResources(context.Background(),
+				&pb.UpdateContainerResourcesRequest{
+					ContainerId: testContainer.ID(),
+					Linux: &pb.LinuxContainerResources{
+						CpuPeriod:  100000,
+						CpuQuota:   20000,
+						CpuShares:  1024,
+						CpusetCpus: "0-3,12-15",
+						CpusetMems: "0,1",
+					},
+				},
+			)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(response).NotTo(BeNil())
+
+			c := sut.GetContainer(testContainer.ID())
+			Expect(int(*c.Spec().Linux.Resources.CPU.Period)).To(Equal(100000))
+			Expect(int(*c.Spec().Linux.Resources.CPU.Quota)).To(Equal(20000))
+			Expect(int(*c.Spec().Linux.Resources.CPU.Shares)).To(Equal(1024))
+			Expect(c.Spec().Linux.Resources.CPU.Cpus).To(Equal("0-3,12-15"))
+			Expect(c.Spec().Linux.Resources.CPU.Mems).To(Equal("0,1"))
 		})
 
 		It("should fail when container is not in created/running state", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change

/kind bug

> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:

Call to the `UpdateContainerResources` did not update the resources under the container spec,
so we had a situation when resources had updated values under the cgroup, but it did not reflect
under the container spec.

Now `UpdateContainerResources` will update the container spec under the memory store once the updated command succeeded.

#### Which issue(s) this PR fixes:

Fixes #3963

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reflects resource updates under the container spec.
```

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>