### PR TITLE
Use `ctr_stop_timeout` for process shutdown

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -659,8 +659,8 @@ func (c *ContainerServer) ListSandboxes() []*sandbox.Sandbox {
 }
 
 // StopContainerAndWait is a wrapping function that stops a container and waits for the container state to be stopped
-func (c *ContainerServer) StopContainerAndWait(ctx context.Context, ctr *oci.Container, timeout int64) error {
-	if err := c.Runtime().StopContainer(ctx, ctr, timeout); err != nil {
+func (c *ContainerServer) StopContainerAndWait(ctx context.Context, ctr *oci.Container) error {
+	if err := c.Runtime().StopContainer(ctx, ctr, c.config.CtrStopTimeout); err != nil {
 		return fmt.Errorf("failed to stop container %s: %v", ctr.Name(), err)
 	}
 	if err := c.Runtime().WaitContainerStateStopped(ctx, ctr); err != nil {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -243,8 +243,14 @@ uid_mappings = "{{ .UIDMappings }}"
 gid_mappings = "{{ .GIDMappings }}"
 
 # The minimal amount of time in seconds to wait before issuing a timeout
-# regarding the proper termination of the container. The lowest possible
-# value is 30s, whereas lower values are not considered by CRI-O.
+# regarding the proper termination of the container.
+# This timeout will be applied two times:
+# - If the container gets signalled with its termination signal, then it waits
+#   the specified time until forcing the process to shutdown via SIGKILL
+# - If the container state gets written to disk
+#
+# The lowest possible value is 30s, whereas lower values are not considered
+# by CRI-O.
 ctr_stop_timeout = {{ .CtrStopTimeout }}
 
 # manage_ns_lifecycle determines whether we pin and remove namespaces

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -13,9 +13,9 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	return s.stopPodSandbox(ctx, req)
 }
 
-// stopAllPodSandboxes removes all pod sandboxes
+// stopAllPodSandboxes stops all pod sandboxes
 func (s *Server) stopAllPodSandboxes(ctx context.Context) {
-	log.Debugf(ctx, "stopAllPodSandboxes")
+	log.Debugf(ctx, "Stopping all pod sandboxes")
 	for _, sb := range s.ContainerServer.ListSandboxes() {
 		pod := &pb.StopPodSandboxRequest{
 			PodSandboxId: sb.ID(),

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -68,7 +68,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 				}
 				c := ctr
 				waitGroup.Go(func() error {
-					if err := s.StopContainerAndWait(ctx, c, int64(10)); err != nil {
+					if err := s.StopContainerAndWait(ctx, c); err != nil {
 						return fmt.Errorf("failed to stop container for pod sandbox %s: %v", sb.ID(), err)
 					}
 					if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
@@ -90,7 +90,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	if podInfraContainer != nil {
 		podInfraStatus := podInfraContainer.State()
 		if podInfraStatus.Status != oci.ContainerStateStopped {
-			if err := s.StopContainerAndWait(ctx, podInfraContainer, int64(10)); err != nil {
+			if err := s.StopContainerAndWait(ctx, podInfraContainer); err != nil {
 				return nil, fmt.Errorf("failed to stop infra container for pod sandbox %s: %v", sb.ID(), err)
 			}
 		}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This streamlines the documentation and behavior to replace the
hard-coded 10 second timeout for pod shutdown and re-uses
`ctr_stop_timeout` for that.

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- The configuration value of `ctr_stop_timeout` will now be used as termination timeout for pods, too.
```
