### PR TITLE
Remove resolvPath when Relabel fails

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -163,6 +163,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			return nil, err
 		}
 		if err := label.Relabel(resolvPath, mountLabel, false); err != nil && errors.Cause(err) != unix.ENOTSUP {
+			if err1 := removeFile(resolvPath); err1 != nil {
+				return nil, fmt.Errorf("%v; failed to remove %s: %v", err, resolvPath, err1)
+			}
 			return nil, err
 		}
 		mnt := spec.Mount{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR removes resolvPath if Relabel fails in Server#runPodSandbox.

#### Which issue(s) this PR fixes:

Fixes #3976

```release-note
None
```
