### PR TITLE
unconditionally unmount

### DIFF
--- a/internal/lib/sandbox/namespaces_linux.go
+++ b/internal/lib/sandbox/namespaces_linux.go
@@ -10,9 +10,8 @@ import (
 	"sync"
 
 	nspkg "github.com/containernetworking/plugins/pkg/ns"
-	"github.com/containers/storage/pkg/mount"
 	"github.com/cri-o/cri-o/pkg/config"
-	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/cri-o/cri-o/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -176,27 +175,13 @@ func (n *Namespace) Remove() error {
 
 	n.closed = true
 
-	// we got namespaces in the form of
-	// /var/run/$NSTYPEns/$NSTYPE-d08effa-06eb-a963-f51a-e2b0eceffc5d
-	// but /var/run on most system is symlinked to /run so we first resolve
-	// the symlink and then try and see if it's mounted
-	fp, err := securejoin.SecureJoin("/", n.Path())
-	if err != nil {
-		return errors.Wrapf(err, "unable to join '/' with %s path", n.Path())
-	}
-	mounted, err := mount.Mounted(fp)
-	if err != nil {
-		return errors.Wrap(err, "unable to check if path is mounted")
-	}
-	if mounted {
-		if err := unix.Unmount(fp, unix.MNT_DETACH); err != nil {
-			return err
-		}
+	if err := utils.Unmount(n.Path()); err != nil {
+		return errors.Wrapf(err, "failed to umount namespace path")
 	}
 
 	if n.Path() != "" {
 		if err := os.RemoveAll(n.Path()); err != nil {
-			return err
+			return errors.Wrapf(err, "failed to remove namespace path")
 		}
 	}
 

--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -7,12 +7,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containers/storage/pkg/mount"
 	"github.com/cri-o/cri-o/internal/oci"
-	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/cri-o/cri-o/utils"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/fields"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
@@ -402,20 +400,5 @@ func (s *Sandbox) UnmountShm() error {
 	if s.ShmPath() == DevShmPath {
 		return nil
 	}
-
-	// we got namespaces in the form of
-	// /var/run/containers/storage/overlay-containers/CID/userdata/shm
-	// but /var/run on most system is symlinked to /run so we first resolve
-	// the symlink and then try and see if it's mounted
-	fp, err := securejoin.SecureJoin("/", s.ShmPath())
-	if err != nil {
-		return err
-	}
-	if mounted, err := mount.Mounted(fp); err == nil && mounted {
-		if err := unix.Unmount(fp, unix.MNT_DETACH); err != nil {
-			return errors.Wrapf(err, "unable to unmount %s", fp)
-		}
-	}
-
-	return nil
+	return utils.Unmount(s.ShmPath())
 }

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -93,11 +93,6 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	if err := s.StorageRuntimeServer().RemovePodSandbox(sb.ID()); err != nil && err != pkgstorage.ErrInvalidSandboxID {
 		return nil, fmt.Errorf("failed to remove pod sandbox %s: %v", sb.ID(), err)
 	}
-	if s.config.ManageNSLifecycle {
-		if err := sb.RemoveManagedNamespaces(); err != nil {
-			return nil, errors.Wrap(err, "unable to remove managed namespaces")
-		}
-	}
 
 	if podInfraContainer != nil {
 		s.ReleaseContainerName(podInfraContainer.Name())
@@ -112,6 +107,11 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	}
 	if err := s.PodIDIndex().Delete(sb.ID()); err != nil {
 		return nil, fmt.Errorf("failed to delete pod sandbox %s from index: %v", sb.ID(), err)
+	}
+	if s.config.ManageNSLifecycle {
+		if err := sb.RemoveManagedNamespaces(); err != nil {
+			return nil, errors.Wrap(err, "unable to remove managed namespaces")
+		}
 	}
 
 	log.Infof(ctx, "Removed pod sandbox: %s", sb.ID())

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -341,18 +341,12 @@ func GetLabelOptions(selinuxOptions *pb.SELinuxOption) []string {
 	return labels
 }
 
-// Unmount is a helper function that unmounts
-// a path, accounting for symlinks
+// Unmount is a helper function that unmounts a path
+// and ignores situations in which it is not mounted
 func Unmount(path string) error {
-	// we may get files that are symlinked
-	// so we first resolve the symlink
-	fp, err := securejoin.SecureJoin("/", path)
-	if err != nil {
-		return err
-	}
 	// then umount unconditionally, ignoring EINVAL (mount point is not mounted)
-	if err := unix.Unmount(fp, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
-		return errors.Wrapf(err, "unable to unmount %s", fp)
+	if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
+		return errors.Wrapf(err, "unable to unmount %s", path)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change


/kind bug

> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:
    I have seen leaks in both managed ns creation (which may be resulting in the integration_rhel failures) as well as ShmPath
    I believe this is because the Mounted function does not always acurately say whether a point is mounted.
    Instead, we can unconditionally unmount, and ignore EINVAL
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix bug where managed namespaces and pod shm paths occasionally leak
```
