### PR TITLE
Add volume mount option for SELinux labeling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ bin/crio-status: $(GO_FILES) .gopathok
 	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/crio-status
 
 build-static:
-	$(CONTAINER_RUNTIME) run --rm -it -v $(shell pwd):/cri-o $(TESTIMAGE_NIX) sh -c \
+	$(CONTAINER_RUNTIME) run --rm -it -v $(shell pwd):/cri-o:Z $(TESTIMAGE_NIX) sh -c \
 		"nix build -f cri-o/nix && \
 		mkdir -p cri-o/bin && \
 		cp -r result/bin cri-o/bin/static"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change

/kind bug
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:
When trying to build a statically linked `crio` binary I was getting:

```shell
→ make build-static
podman run --rm -it -v /home/ifont/go/src/github.com/cri-o/cri-o:/cri-o quay.io/crio/nix:1.4.0 sh -c \
        "nix build -f cri-o/nix && \
        mkdir -p cri-o/bin && \
        cp -r result/bin cri-o/bin/static"
error: opening file '/cri-o/nix/default.nix': Permission denied
make: *** [Makefile:178: build-static] Error 1

```

This happens because SELinux requires the correct labeling on content that is volume mounted within the container. This option tells Podman to relabel the file objects on the volume with a private unshared label.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```
