### PR TITLE
Copy spec to not touch original spec on exec(sync)

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1081,7 +1081,9 @@ func prepareProcessExec(c *Container, cmd []string, tty bool) (*os.File, error) 
 		return nil, err
 	}
 
-	pspec := c.Spec().Process
+	// It's important to make a spec copy here to not overwrite the initial
+	// process spec
+	pspec := *c.Spec().Process
 	pspec.Args = cmd
 	// We need to default this to false else it will inherit terminal as true
 	// from the container.

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -856,6 +856,26 @@ function wait_until_exit() {
 	[ "$status" -eq 0 ]
 }
 
+@test "ctr execsync should not overwrite initial spec args" {
+    start_crio
+
+    run crictl run "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+    [ "$status" -eq 0 ]
+    CTR="$output"
+
+    run crictl inspect $CTR | jq -e '.info.runtimeSpec.process.args[2] == "redis-server"'
+    [ "$status" -eq 0 ]
+
+    run crictl exec --sync $CTR echo Hello
+    [ "$status" -eq 0 ]
+
+    run crictl inspect $CTR | jq -e '.info.runtimeSpec.process.args[2] == "redis-server"'
+    [ "$status" -eq 0 ]
+
+    run crictl rm -f $CTR
+    [ "$status" -eq 0 ]
+}
+
 @test "ctr device add" {
 	# In an user namespace we can only bind mount devices from the host, not mknod
 	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
We have to make a spec copy before overwriting the args to not overwrite them for each exec(sync).
#### Which issue(s) this PR fixes:
Fixes #3988

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed a bug where exec sync requests (manually or automatically triggered via readiness/liveness probes) overwrite
  the runtime `info.runtimeSpec.process.args` of the container status (for example via `crictl inspect`).
```
