### PR TITLE
Make integration-cgroupfs tests depdent on results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ workflows:
           requires:
             - bundle-test
             - integration
+            - integration-cgroupfs
             - integration-critest
             - integration-static
             - integration-userns


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This should bring the CI in order again to not slip-through the recently
added integration suite.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
