### PR TITLE
runtimeVM: Cleanup a "Completed" container

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -258,6 +258,12 @@ func (r *runtimeVM) StartContainer(c *Container) error {
 			if err1 := r.updateContainerStatus(c); err1 != nil {
 				logrus.Warningf("error updating container status %v", err1)
 			}
+
+			if c.state.Status == ContainerStateStopped {
+				if err1 := r.deleteContainer(c, true); err1 != nil {
+					logrus.WithError(err1).Infof("deleteContainer failed for container %s", c.ID())
+				}
+			}
 		} else {
 			logrus.Warningf("wait for %s returned: %v", c.ID(), err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

When the container finishes its execution a containerd-shim-kata-v2
process is left behind (only when using CRI-O).

The reason for that seems to be CRI-O not doing a cleanup of the process
whenever the container state has changed its state from running to
stopped.

The most reasonable way found to perform such cleanup seems to be taking
advantage of the goroutine used to update the container status and
performing the cleanup there, whenever it's needed.

#### Which issue(s) this PR fixes:

Related: https://github.com/kata-containers/runtime/issues/2719

#### Special notes for your reviewer:

This is yet another part of the series trying to not leave container-shim-kata-v2 processes around, but this time focusing on cleaning up when the container finishes its execution without errors.

This series also includes the patch provided in https://github.com/cri-o/cri-o/pull/3987

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
