### PR TITLE
Restore Sandbox createdAt timestamp on cri-o restart

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -194,7 +194,12 @@ func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 		return errors.Wrapf(err, "error unmarshalling %s annotation", annotations.NamespaceOptions)
 	}
 
-	sb, err := sandbox.New(id, m.Annotations[annotations.Namespace], name, m.Annotations[annotations.KubeName], filepath.Dir(m.Annotations[annotations.LogPath]), labels, kubeAnnotations, processLabel, mountLabel, &metadata, m.Annotations[annotations.ShmPath], m.Annotations[annotations.CgroupParent], privileged, m.Annotations[annotations.RuntimeHandler], m.Annotations[annotations.ResolvPath], m.Annotations[annotations.HostName], portMappings, hostNetwork)
+	created, err := time.Parse(time.RFC3339Nano, m.Annotations[annotations.Created])
+	if err != nil {
+		return errors.Wrap(err, "parsing created timestamp annotation")
+	}
+
+	sb, err := sandbox.New(id, m.Annotations[annotations.Namespace], name, m.Annotations[annotations.KubeName], filepath.Dir(m.Annotations[annotations.LogPath]), labels, kubeAnnotations, processLabel, mountLabel, &metadata, m.Annotations[annotations.ShmPath], m.Annotations[annotations.CgroupParent], privileged, m.Annotations[annotations.RuntimeHandler], m.Annotations[annotations.ResolvPath], m.Annotations[annotations.HostName], portMappings, hostNetwork, created)
 	if err != nil {
 		return err
 	}
@@ -262,11 +267,6 @@ func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 			c.ReleaseContainerName(cname)
 		}
 	}()
-
-	created, err := time.Parse(time.RFC3339Nano, m.Annotations[annotations.Created])
-	if err != nil {
-		return err
-	}
 
 	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, m.Annotations[annotations.Image], "", "", nil, id, false, false, false, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {

--- a/internal/lib/sandbox/history_test.go
+++ b/internal/lib/sandbox/history_test.go
@@ -1,6 +1,8 @@
 package sandbox_test
 
 import (
+	"time"
+
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -18,7 +20,7 @@ var _ = t.Describe("History", func() {
 		otherTestSandbox, err := sandbox.New("sandboxID", "", "", "", "",
 			make(map[string]string), make(map[string]string), "", "",
 			&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
-			[]*hostport.PortMapping{}, false)
+			[]*hostport.PortMapping{}, false, time.Now())
 		Expect(err).To(BeNil())
 		Expect(testSandbox).NotTo(BeNil())
 		sut = &sandbox.History{testSandbox, otherTestSandbox}

--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -75,7 +75,7 @@ var ErrIDEmpty = errors.New("PodSandboxId should not be empty")
 // New creates and populates a new pod sandbox
 // New sandboxes have no containers, no infra container, and no network namespaces associated with them
 // An infra container must be attached before the sandbox is added to the state
-func New(id, namespace, name, kubeName, logDir string, labels, annotations map[string]string, processLabel, mountLabel string, metadata *pb.PodSandboxMetadata, shmPath, cgroupParent string, privileged bool, runtimeHandler, resolvPath, hostname string, portMappings []*hostport.PortMapping, hostNetwork bool) (*Sandbox, error) {
+func New(id, namespace, name, kubeName, logDir string, labels, annotations map[string]string, processLabel, mountLabel string, metadata *pb.PodSandboxMetadata, shmPath, cgroupParent string, privileged bool, runtimeHandler, resolvPath, hostname string, portMappings []*hostport.PortMapping, hostNetwork bool, createdAt time.Time) (*Sandbox, error) {
 	sb := new(Sandbox)
 	sb.id = id
 	sb.namespace = namespace
@@ -95,7 +95,7 @@ func New(id, namespace, name, kubeName, logDir string, labels, annotations map[s
 	sb.resolvPath = resolvPath
 	sb.hostname = hostname
 	sb.portMappings = portMappings
-	sb.createdAt = time.Now()
+	sb.createdAt = createdAt
 	sb.hostNetwork = hostNetwork
 
 	return sb, nil

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -37,12 +37,13 @@ var _ = t.Describe("Sandbox", func() {
 			hostname := "hostname"
 			portMappings := []*hostport.PortMapping{{}, {}}
 			hostNetwork := false
+			createdAt := time.Now()
 
 			// When
 			sandbox, err := sandbox.New(id, namespace, name, kubeName, logDir,
 				labels, annotations, processLabel, mountLabel, &metadata,
 				shmPath, cgroupParent, privileged, runtimeHandler,
-				resolvPath, hostname, portMappings, hostNetwork)
+				resolvPath, hostname, portMappings, hostNetwork, createdAt)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -67,6 +68,7 @@ var _ = t.Describe("Sandbox", func() {
 			Expect(sandbox.HostNetwork()).To(Equal(hostNetwork))
 			Expect(sandbox.StopMutex()).NotTo(BeNil())
 			Expect(sandbox.Containers()).NotTo(BeNil())
+			Expect(sandbox.CreatedAt()).To(Equal(createdAt))
 		})
 	})
 

--- a/internal/lib/sandbox/suite_test.go
+++ b/internal/lib/sandbox/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	. "github.com/cri-o/cri-o/test/framework"
@@ -52,7 +53,7 @@ func beforeEach() {
 	testSandbox, err = sandbox.New("sandboxID", "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
 		&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
-		[]*hostport.PortMapping{}, false)
+		[]*hostport.PortMapping{}, false, time.Now())
 	Expect(err).To(BeNil())
 	Expect(testSandbox).NotTo(BeNil())
 }

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -142,7 +142,7 @@ func beforeEach() {
 	mySandbox, err = sandbox.New(sandboxID, "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
 		&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
-		[]*hostport.PortMapping{}, false)
+		[]*hostport.PortMapping{}, false, time.Now())
 	Expect(err).To(BeNil())
 
 	myContainer, err = oci.NewContainer(containerID, "", "", "",

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -378,7 +378,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}
 
-	sb, err := libsandbox.New(sbox.ID(), namespace, sbox.Name(), kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, runtimeHandler, resolvPath, hostname, portMappings, hostNetwork)
+	sb, err := libsandbox.New(sbox.ID(), namespace, sbox.Name(), kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, runtimeHandler, resolvPath, hostname, portMappings, hostNetwork, created)
 	if err != nil {
 		return nil, err
 	}

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -155,7 +155,7 @@ var beforeEach = func() {
 	testSandbox, err = sandbox.New(sandboxID, "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
 		&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
-		[]*hostport.PortMapping{}, false)
+		[]*hostport.PortMapping{}, false, time.Now())
 	Expect(err).To(BeNil())
 
 	testContainer, err = oci.NewContainer(containerID, "", "", "",

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -22,11 +22,12 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	pod_list_info="$output"
 
-	run crictl inspectp -o table "$pod_id"
+	run crictl inspectp -o json "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	pod_status_info=`echo "$output" | grep Status`
-	pod_ip=`echo "$output" | grep IP`
+	pod_status_info=`echo "$output" | jq ".status.state"`
+	pod_ip=`echo "$output" | jq ".status.ip"`
+	pod_created_at=`echo "$output" | jq ".status.createdAt"`
 
 	run crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -57,13 +58,15 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "${output}" == "${pod_list_info}" ]]
 
-	run crictl inspectp -o table "$pod_id"
+	run crictl inspectp -o json "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	status_output=`echo "$output" | grep Status`
-	ip_output=`echo "$output" | grep IP`
+	status_output=`echo "$output" | jq ".status.state"`
+	ip_output=`echo "$output" | jq ".status.ip"`
+	created_at_output=`echo "$output" | jq ".status.createdAt"`
 	[[ "${status_output}" == "${pod_status_info}" ]]
 	[[ "${ip_output}" == "${pod_ip}" ]]
+	[[ "${created_at_output}" == "${pod_created_at}" ]]
 
 	run crictl ps --quiet --all
 	echo "$output"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

When restarting cri-o, try to restore the createdAt timestamp of Sandboxes from the annotations. Previously the timestamp was reset to time.Now() when restoring Sandboxes. As Sandbox are not guaranteed to be restored in creation order in server.restore() this could lead to ordering issues in calls like e.g. ListPodSandbox which would not return the Pods in the orginial creations order.

To reproduce this issue in crio, create a couple of Sandboxes (with `crictl`) using the same name but different "Attempt" numbers. Then restart crio and run `crio pods`. Two things should be visible:

* the `CREATED` time in the `crio pods` is reset with every crio restart. While the createdAt annoation seen with `crio inspectp` is staying the same
* The order in which the pods are listed might change during restarts and is not stable

The first issue might just be cosmetic. The second however is causing issues with kubelet, which seems to rely on the pods being returned in a certain order. See e.g. https://github.com/kubernetes/kubernetes/issues/93064 for some more details.
(I am also looking into a possible fix on the kubelet side, but still believe that we need this fix for cri-o  as well to preserve the timestamps after restart.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
Fixed crio restart behavior to make sure that Pod creation timestamps are restored and the order in the list of pods stays stable across restarts
```
