### PR TITLE
Use CircleCI cache for static builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,12 @@ executors:
     <<: *stdenv
     working_directory: *workdir
 
+  container-nix:
+    docker:
+      - image: nixos/nix:latest
+    <<: *stdenv
+    working_directory: *workdir
+
   machine:
     machine:
       image: ubuntu-1604:201903-01
@@ -151,20 +157,24 @@ jobs:
             - docs
 
   build-static:
-    executor: machine
+    executor: container-nix
     steps:
       - checkout
       - attach_workspace:
           at: .
+      - restore_cache:
+          keys:
+            - v1-build-static-{{ checksum "nix/nixpkgs.json" }}
       - run:
           name: build
           command: |
-            set -ex
-            sudo mkdir -p /nix
-            sudo docker run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix
-            sudo docker run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
+            nix-build nix
             mkdir -p bin
             cp -r result/bin bin/static
+      - save_cache:
+          key: v1-build-static-{{ checksum "nix/nixpkgs.json" }}
+          paths:
+            - /nix
       - run:
           name: Show CRI-O version for static binaries
           command: |

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,6 +7,14 @@ let
         libassuan = (static pkg.libassuan);
         libgpgerror = (static pkg.libgpgerror);
         libseccomp = (static pkg.libseccomp);
+        go_1_14 = pkg.go_1_14.overrideAttrs (old: {
+          prePatch = ''
+            sed -i 's/TestChown/testChown/' src/os/os_unix_test.go
+            sed -i 's/TestFileChown/testFileChown/' src/os/os_unix_test.go
+            sed -i 's/TestLchown/testLchown/' src/os/os_unix_test.go
+            sed -i 's/TestTicker/testTicker/' src/time/tick_test.go
+          '' + old.prePatch;
+        });
       };
     };
   });


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Using the CircleCI cache should speed-up building the static binary.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
