### PR TITLE
Bring back pprof

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
Commit 6025578f11 (Oct 23 2019, "Update golangci lint and apply fixes")
inadvertently removed the pprof import, as a result, pprof can't be used
even when enabled during runtime (via --profile flag), giving 404 on
every URL.

Bring it back.

Fixes PR #2916 (https://github.com/cri-o/cri-o/pull/2916/commits/6025578f117b2905f91d75dded6d2aac346c2af2#diff-702431da3a2e35392cf253955d15f774)

/kind bug

```release-note
None
```
