### PR TITLE
Speedup static build by utilizing CI cache on `/nix` folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,29 +156,42 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - restore_cache:
+          keys:
+            - nix-v1-{{ checksum "nix/nixpkgs.json" }}
       - run:
           name: build
           command: |
             set -ex
             sudo mkdir -p /nix
-            sudo docker run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix
+            sudo mkdir -p .cache
+            sudo mount --bind .cache /nix
+            if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
             sudo docker run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
-            mkdir -p bin
-            cp -r result/bin bin/static
+            sudo chown -Rf $(whoami) .cache
+      - save_cache:
+          key: nix-v1-{{ checksum "nix/nixpkgs.json" }}
+          paths:
+            - .cache
       - run:
           name: Show CRI-O version for static binaries
           command: |
-            ./bin/static/crio version
-      - persist_to_workspace:
-          root: .
-          paths:
-            - bin/static
+            ./result/bin/crio version
       - store_artifacts:
           path: result/bin/crio
       - store_artifacts:
           path: result/bin/crio-status
       - store_artifacts:
           path: result/bin/pinns
+      - run:
+          name: persist_to_workspace
+          command: |
+            mkdir -p bin/static
+            cp -rfT result/bin bin/static
+      - persist_to_workspace:
+          root: .
+          paths:
+            - bin/static
 
   build-test-binaries:
     executor: container

--- a/Dockerfile-nix
+++ b/Dockerfile-nix
@@ -1,8 +1,0 @@
-# vim: set syntax=dockerfile:
-FROM nixos/nix
-RUN apk add git
-COPY . /cri-o
-WORKDIR cri-o/nix
-RUN nix-build
-WORKDIR /
-RUN rm -rf cri-o

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "02591d02a910b3b92092153c5f3419a8d696aa1d",
-  "date": "2020-07-09T03:52:28+02:00",
-  "sha256": "1pp9v4rqmgx1b298gxix8b79m8pvxy1rcf8l25rxxxxnkr5ls1ng",
+  "rev": "b49e7987632e4c7ab3a093fdfc433e1826c4b9d7",
+  "date": "2020-07-26T09:18:52+02:00",
+  "sha256": "1mj6fy0p24izmasl653s5z4f2ka9v3b6mys45kjrqmkv889yk2r6",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind cleanup
> /kind feature

#### What this PR does / why we need it:

Speedup static build by utilizing CI cache on `/nix` folder

Also see:
- https://github.com/containers/crun/pull/428
- https://github.com/containers/conmon/pull/189
- https://github.com/containers/skopeo/pull/973
- https://github.com/containers/buildah/pull/2428
- https://github.com/containers/podman/pull/7076
- https://github.com/cri-o/cri-o/pull/4012

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #4005
Fixes #4009

#### Special notes for your reviewer:

Some more founding:
- Due to `nixos/nix` limitation which without `bash` bundled, not every CI with Docker engine direct support would happy with :-(
- Caching `/nix` directly may also make some CI not happy due to permission issue; therefore I cache it with `.cache` and export/import it in case already warm up, else copy from `nixos/nix` directly.
- Cache for Circle CI (for [CRI-O](https://github.com/cri-o/cri-o)) and GitHub Actions (for [crun](https://github.com/containers/crun)) are running well across multiple build with same cache key; BTW Cirrus CI (for [conmon](https://github.com/containers/conmon), [Skopeo](https://github.com/containers/skopeo) and [Buildah](https://github.com/containers/buildah)) only preserve it across multiple tasks inside a single build (please correct me) so caching didn't seems really functioning (although cache is generated and upload correctly, but always say "cache miss" during initial cache fetching phase) :-(
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

None

```release-note
None
```
