### PR TITLE
add crio --profile test

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -360,7 +360,7 @@ function wait_until_exit() {
 		skip "journald not enabled"
 	fi
 
-	start_crio_journald
+	CONTAINER_LOG_JOURNALD=true start_crio
 	run crictl runp "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -1511,7 +1511,7 @@ function wait_until_exit() {
 @test "ctr expose metrics with default port" {
 	# start crio with default port 9090
 	port="9090"
-	start_crio_metrics
+	CONTAINER_ENABLE_METRICS=true start_crio
 	# ensure metrics port is listening
 	listened=$(check_metrics_port $port)
 	if [[ "$listened" -ne 0 ]]; then
@@ -1544,7 +1544,7 @@ function wait_until_exit() {
 @test "ctr expose metrics with custom port" {
 	# start crio with custom port
 	port="4321"
-	CONTAINER_METRICS_PORT=$port start_crio_metrics
+	CONTAINER_ENABLE_METRICS=true CONTAINER_METRICS_PORT=$port start_crio
 	# ensure metrics port is listening
 	listened=$(check_metrics_port $port)
 	if [[ "$listened" -ne 0 ]]; then

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -377,15 +377,6 @@ function start_crio() {
     pull_test_containers
 }
 
-# Start crio with journald logging
-function start_crio_journald() {
-    setup_crio "$@"
-    "$CRIO_BINARY_PATH" --log-journald -c "$CRIO_CONFIG" -d "$CRIO_CONFIG_DIR" &
-    CRIO_PID=$!
-    wait_until_reachable
-    pull_test_containers
-}
-
 function check_journald() {
     if ! pkg-config --exists libsystemd-journal; then
         if ! pkg-config --exists libsystemd; then
@@ -399,15 +390,6 @@ function check_journald() {
         return
     fi
     echo "0"
-}
-
-# Start crio with metrics enable
-function start_crio_metrics() {
-    setup_crio "$@"
-    "$CRIO_BINARY_PATH" --enable-metrics -c "$CRIO_CONFIG" -d "$CRIO_CONFIG_DIR" &
-    CRIO_PID=$!
-    wait_until_reachable
-    pull_test_containers
 }
 
 # Check whether metrics port is listening

--- a/test/profile.bats
+++ b/test/profile.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "pprof" {
+	CONTAINER_PROFILE=true start_crio
+	curl --silent --fail --show-error http://localhost:6060/debug/pprof/goroutine > /dev/null
+}


### PR DESCRIPTION
/kind bug

(NB: why don't we have kind: ci?)

#### What this PR does / why we need it:

Adds a CI integration test to make sure crio --profile works

#### Which issue(s) this PR fixes:

This is a followup to #4011, addressing the https://github.com/cri-o/cri-o/pull/4016#issuecomment-663587938

```release-note
NONE
```
