### PR TITLE
Remove unnecessary err assignment

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -170,7 +170,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		if err != nil {
 			err1 := removeFile(resolvPath)
 			if err1 != nil {
-				err = err1
 				return nil, fmt.Errorf("%v; failed to remove %s: %v", err, resolvPath, err1)
 			}
 			return nil, err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In Server#runPodSandbox, when both parseDNSOptions and removeFile calls return error, we shouldn't assign err1 to err because that would erase the reason behind parseDNSOptions failure.

#### Which issue(s) this PR fixes:

<!--
Fixes #
-->

```release-note
None
```
