### PR TITLE
Make filter container list be able to filter short pod IDs

### DIFF
--- a/server/container_list.go
+++ b/server/container_list.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"strings"
+
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
@@ -35,28 +37,28 @@ func (s *Server) filterContainerList(ctx context.Context, filter *pb.ContainerFi
 		if err != nil {
 			// If we don't find a container ID with a filter, it should not
 			// be considered an error.  Log a warning and return an empty struct
-			log.Warnf(ctx, "unable to find container ID %s", filter.Id)
-			return []*oci.Container{}
+			log.Warnf(ctx, "Unable to find container ID %s", filter.Id)
+			return nil
 		}
 		c := s.ContainerServer.GetContainer(id)
 		if c != nil {
 			switch {
 			case filter.PodSandboxId == "":
 				return []*oci.Container{c}
-			case c.Sandbox() == filter.PodSandboxId:
+			case strings.HasPrefix(c.Sandbox(), filter.PodSandboxId):
 				return []*oci.Container{c}
 			default:
-				return []*oci.Container{}
+				return nil
 			}
 		}
 	} else if filter.PodSandboxId != "" {
-		pod := s.ContainerServer.GetSandbox(filter.PodSandboxId)
-		if pod == nil {
-			return []*oci.Container{}
+		sb, err := s.getPodSandboxFromRequest(filter.PodSandboxId)
+		if err != nil {
+			return nil
 		}
-		return pod.Containers().List()
+		return sb.Containers().List()
 	}
-	log.Debugf(ctx, "no filters were applied, returning full container list")
+	log.Debugf(ctx, "No filters were applied, returning full container list")
 	return origCtrList
 }
 


### PR DESCRIPTION
#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
The `PodSandboxID` can now be truncated because we're just checking for its prefix.
#### Which issue(s) this PR fixes:
Refers to https://github.com/kubernetes-sigs/cri-tools/pull/643

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added behavior to allow filtering by a partial Pod Sandbox ID
```
