### PR TITLE
Parameterize strip binary in pinns/Makefile for cross-compilation

### DIFF
--- a/pinns/Makefile
+++ b/pinns/Makefile
@@ -1,6 +1,7 @@
 src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
+STRIP ?= strip
 override LIBS +=
 CFLAGS ?= -std=c99 -Os -Wall -Werror -Wextra
 override CFLAGS += -static
@@ -9,7 +10,7 @@ all: ../bin/pinns
 
 ../bin/pinns: $(obj) | ../bin
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
-	strip -s $@
+	$(STRIP) -s $@
 
 ../bin:
 	mkdir -p $@


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Allows cross compile tool-chains to select the correct `strip` binary to use.
Without this change it will attempt to use the host tool-chain instead of the target tool-chain, which will fail if the underlying architecture is not the same.

#### Does this PR introduce a user-facing change?
```release-note
None
```