### PR TITLE
[1.18] stats: return information on container level, not pod

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -31,6 +31,10 @@ const (
 	// SystemdCgroupsManager represents systemd native cgroup manager
 	SystemdCgroupsManager = "systemd"
 
+	// CrioScopePrefix is the crio specific scope prefix
+	// used for container cgroups
+	CrioScopePrefix = "crio"
+
 	// killContainerTimeout is the timeout that we wait for the container to
 	// be SIGKILLed.
 	killContainerTimeout = 2 * time.Minute

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -33,7 +33,6 @@ const (
 	seccompDockerDefault   = "docker/default"
 	seccompLocalhostPrefix = "localhost/"
 
-	scopePrefix           = "crio"
 	defaultCgroupfsParent = "/crio"
 	defaultSystemdParent  = "system.slice"
 )

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -562,9 +562,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 			parent = sb.CgroupParent()
 		}
 		if useSystemd {
-			cgPath = parent + ":" + scopePrefix + ":" + containerID
+			cgPath = parent + ":" + oci.CrioScopePrefix + ":" + containerID
 		} else {
-			cgPath = filepath.Join(parent, scopePrefix+"-"+containerID)
+			cgPath = filepath.Join(parent, oci.CrioScopePrefix+"-"+containerID)
 		}
 		specgen.SetLinuxCgroupsPath(cgPath)
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -736,7 +736,7 @@ func AddCgroupAnnotation(ctx context.Context, g generate.Generator, mountPath, c
 			if strings.HasSuffix(path.Base(cgroupParent), ".slice") {
 				return "", fmt.Errorf("cri-o configured with cgroupfs cgroup manager, but received systemd slice as parent: %s", cgroupParent)
 			}
-			cgPath := filepath.Join(cgroupParent, scopePrefix+"-"+id)
+			cgPath := filepath.Join(cgroupParent, oci.CrioScopePrefix+"-"+id)
 			g.SetLinuxCgroupsPath(cgPath)
 		}
 	}

--- a/test/stats.bats
+++ b/test/stats.bats
@@ -24,18 +24,63 @@ function teardown() {
 
     # then
     JSON="$output"
-    echo $JSON | jq -e '.stats[0].attributes.id != ""'
+    run echo $JSON | jq -e '.stats[0].attributes.id != ""'
     [ "$status" -eq 0 ]
 
-    echo $JSON | jq -e '.stats[0].cpu.timestamp > 0'
+    run echo $JSON | jq -e '.stats[0].cpu.timestamp > 0'
     [ "$status" -eq 0 ]
 
-    echo $JSON | jq -e '.stats[0].cpu.usageCoreNanoSeconds.value > 0'
+    run echo $JSON | jq -e '.stats[0].cpu.usageCoreNanoSeconds.value > 0'
     [ "$status" -eq 0 ]
 
-    echo $JSON | jq -e '.stats[0].memory.timestamp > 0'
+    run echo $JSON | jq -e '.stats[0].memory.timestamp > 0'
     [ "$status" -eq 0 ]
 
-    echo $JSON | jq -e '.stats[0].memory.workingSetBytes.value > 0'
+    run echo $JSON | jq -e '.stats[0].memory.workingSetBytes.value > 0'
+    [ "$status" -eq 0 ]
+}
+
+@test "container stats" {
+    # given
+    container2config=$(cat "$TESTDATA"/container_redis.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["name"] = ["podsandbox1-redis2"];obj["metadata"]["name"] = "podsandbox1-redis2"; json.dump(obj, sys.stdout)')
+    echo "$container2config" > "$TESTDIR"/container_redis2.json
+    run crictl runp "$TESTDATA"/sandbox_config.json
+    echo "$output"
+    [ "$status" -eq 0 ]
+    pod_id="$output"
+    run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+    echo "$output"
+    [ "$status" -eq 0 ]
+    ctr1_id="$output"
+    run crictl create "$pod_id" "$TESTDIR"/container_redis2.json "$TESTDATA"/sandbox_config.json
+    echo "$output"
+    [ "$status" -eq 0 ]
+    ctr2_id="$output"
+    run crictl start "$ctr1_id"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run crictl start "$ctr2_id"
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    # when
+    run crictl stats -o json "$ctr1_id"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    ctr1_stats_JSON="$output"
+
+    run crictl stats -o json "$crt2_id"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    ctr2_stats_JSON="$output"
+
+    run echo $ctr1_stats_JSON | jq -e '.stats[0].memory.workingSetBytes.value'
+    [ "$status" -eq 0 ]
+    ctr1_memory_bytes="$output"
+    run echo $ctr2_stats_JSON | jq -e '.stats[0].memory.workingSetBytes.value'
+    [ "$status" -eq 0 ]
+    ctr2_memory_bytes="$output"
+
+    run echo $ctr1_memory_bytes != $ctr2_memory_bytes
     [ "$status" -eq 0 ]
 }

--- a/test/stats.bats
+++ b/test/stats.bats
@@ -16,6 +16,7 @@ function teardown() {
     # given
     run crictl run "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
     [ "$status" -eq 0 ]
+    id="$output"
 
     # when
     run crictl stats -o json
@@ -23,21 +24,11 @@ function teardown() {
     [ "$status" -eq 0 ]
 
     # then
-    JSON="$output"
-    run echo $JSON | jq -e '.stats[0].attributes.id != ""'
-    [ "$status" -eq 0 ]
-
-    run echo $JSON | jq -e '.stats[0].cpu.timestamp > 0'
-    [ "$status" -eq 0 ]
-
-    run echo $JSON | jq -e '.stats[0].cpu.usageCoreNanoSeconds.value > 0'
-    [ "$status" -eq 0 ]
-
-    run echo $JSON | jq -e '.stats[0].memory.timestamp > 0'
-    [ "$status" -eq 0 ]
-
-    run echo $JSON | jq -e '.stats[0].memory.workingSetBytes.value > 0'
-    [ "$status" -eq 0 ]
+    jq -e '.stats[0].attributes.id = "'$id'"' <<< "$output"
+    jq -e '.stats[0].cpu.timestamp > 0' <<< "$output"
+    jq -e '.stats[0].cpu.usageCoreNanoSeconds.value > 0' <<< "$output"
+    jq -e '.stats[0].memory.timestamp > 0' <<< "$output"
+    jq -e '.stats[0].memory.workingSetBytes.value > 0' <<< "$output"
 }
 
 @test "container stats" {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug


#### What this PR does / why we need it:
this involves some reworking of where we save the scopePrefix (now renamed CrioScopePrefix and marked public in oci)

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
cherry pick of https://github.com/cri-o/cri-o/pull/3933
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fixed a bug where crictl only showed pod level stats, not container level stats.
```
