### PR TITLE
config: create hooks dir if not present

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -239,6 +239,22 @@ var _ = t.Describe("Config", func() {
 			Expect(sut.HooksDir).To(HaveLen(2))
 		})
 
+		It("should create non-existent hooks directory", func() {
+			// Given
+			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validFilePath}
+			sut.Conmon = validFilePath
+			sut.PinnsPath = validFilePath
+			sut.NamespacesDir = os.TempDir()
+			sut.HooksDir = []string{filepath.Join(validDirPath, "new")}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, true)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.HooksDir).To(HaveLen(1))
+		})
+
 		It("should fail on invalid conmon path", func() {
 			// Given
 			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validFilePath}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind design


#### What this PR does / why we need it:
We've changed the handling of hooks_dir quite a bit, hopefully this is the last of such changes.

There are cases where directories are not present on the host, but admins would desire some entity put hooks into said directory. The primary use case I can think of is a temporary directory in /run that allows hooks to be wiped on reboot. Not really a use case worth packaging for everyone, but instead something cri-o should handle  
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
hooks_dir entries are now created if they don't exist
```
