### PR TITLE
Ensure CloseIO is called after Start for exec

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -78,8 +78,8 @@ func newRuntimeVM(path string) RuntimeImpl {
 
 // CreateContainer creates a container.
 func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (retErr error) {
-	logrus.Debug("runtimeVM.createContainer() start")
-	defer logrus.Debug("runtimeVM.createContainer() end")
+	logrus.Debug("runtimeVM.CreateContainer() start")
+	defer logrus.Debug("runtimeVM.CreateContainer() end")
 
 	// Lock the container
 	c.opLock.Lock()
@@ -239,8 +239,8 @@ func (r *runtimeVM) startRuntimeDaemon(c *Container) error {
 
 // StartContainer starts a container.
 func (r *runtimeVM) StartContainer(c *Container) error {
-	logrus.Debug("runtimeVM.startContainer() start")
-	defer logrus.Debug("runtimeVM.startContainer() end")
+	logrus.Debug("runtimeVM.StartContainer() start")
+	defer logrus.Debug("runtimeVM.StartContainer() end")
 
 	// Lock the container
 	c.opLock.Lock()
@@ -275,8 +275,8 @@ func (r *runtimeVM) StartContainer(c *Container) error {
 
 // ExecContainer prepares a streaming endpoint to execute a command in the container.
 func (r *runtimeVM) ExecContainer(c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
-	logrus.Debug("runtimeVM.execContainer() start")
-	defer logrus.Debug("runtimeVM.execContainer() end")
+	logrus.Debug("runtimeVM.ExecContainer() start")
+	defer logrus.Debug("runtimeVM.ExecContainer() end")
 
 	exitCode, err := r.execContainerCommon(c, cmd, 0, stdin, stdout, stderr, tty, resize)
 	if err != nil {
@@ -294,8 +294,8 @@ func (r *runtimeVM) ExecContainer(c *Container, cmd []string, stdin io.Reader, s
 
 // ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
 func (r *runtimeVM) ExecSyncContainer(c *Container, command []string, timeout int64) (*ExecSyncResponse, error) {
-	logrus.Debug("runtimeVM.execSyncContainer() start")
-	defer logrus.Debug("runtimeVM.execSyncContainer() end")
+	logrus.Debug("runtimeVM.ExecSyncContainer() start")
+	defer logrus.Debug("runtimeVM.ExecSyncContainer() end")
 
 	var stdoutBuf, stderrBuf bytes.Buffer
 	stdout := cioutil.NewNopWriteCloser(&stdoutBuf)
@@ -317,8 +317,8 @@ func (r *runtimeVM) ExecSyncContainer(c *Container, command []string, timeout in
 }
 
 func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int64, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) (exitCode int32, retErr error) {
-	logrus.Debug("runtimeVM.execContainer() start")
-	defer logrus.Debug("runtimeVM.execContainer() end")
+	logrus.Debug("runtimeVM.execContainerCommon() start")
+	defer logrus.Debug("runtimeVM.execContainerCommon() end")
 
 	// Cancel the context before returning to ensure goroutines are stopped.
 	ctx, cancel := context.WithCancel(r.ctx)
@@ -457,8 +457,8 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 
 // UpdateContainer updates container resources
 func (r *runtimeVM) UpdateContainer(c *Container, res *rspec.LinuxResources) error {
-	logrus.Debug("runtimeVM.updateContainer() start")
-	defer logrus.Debug("runtimeVM.updateContainer() end")
+	logrus.Debug("runtimeVM.UpdateContainer() start")
+	defer logrus.Debug("runtimeVM.UpdateContainer() end")
 
 	// Lock the container
 	c.opLock.Lock()

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -337,6 +337,14 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 	}
 	defer execIO.Close()
 
+	// chan to notify that can call runtime's CloseIO API
+	closeIOChan := make(chan bool)
+	defer func() {
+		if closeIOChan != nil {
+			close(closeIOChan)
+		}
+	}()
+
 	execIO.Attach(cio.AttachOptions{
 		Stdin:     stdin,
 		Stdout:    stdout,
@@ -344,6 +352,7 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 		Tty:       tty,
 		StdinOnce: true,
 		CloseStdin: func() error {
+			<-closeIOChan
 			return r.closeIO(ctx, c.ID(), execID)
 		},
 	})
@@ -383,6 +392,10 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 	if err := r.start(ctx, c.ID(), execID); err != nil {
 		return -1, err
 	}
+
+	// close closeIOChan to notify execIO exec has started.
+	close(closeIOChan)
+	closeIOChan = nil
 
 	// Initialize terminal resizing if necessary
 	if resize != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For shim v2 `exec` API, the call sequences to runtime is uncertain.
It's may be `CloseIO` -> `Exec` -> `Start` or `Exec` -> `CloseIO` -> `Start`, or
`Exec` -> `Start` -> `CloseIO`. The last call sequence is the right one.

This PR will ensure the call sequence as `Exec` -> `Start` -> `CloseIO`.


#### Which issue(s) this PR fixes:

Fixes #4046 

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
