### PR TITLE
[1.17] backports related to the VM runtime type

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -251,6 +251,7 @@ func (r *runtimeVM) StartContainer(c *Container) error {
 	if err := r.start(r.ctx, c.ID(), ""); err != nil {
 		return err
 	}
+	c.state.Started = time.Now()
 
 	// Spawn a goroutine waiting for the container to terminate. Once it
 	// happens, the container status is retrieved to be updated.

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -261,6 +261,12 @@ func (r *runtimeVM) StartContainer(c *Container) error {
 			if err1 := r.updateContainerStatus(c); err1 != nil {
 				logrus.Warningf("error updating container status %v", err1)
 			}
+
+			if c.state.Status == ContainerStateStopped {
+				if err1 := r.deleteContainer(c, true); err1 != nil {
+					logrus.WithError(err1).Infof("deleteContainer failed for container %s", c.ID())
+				}
+			}
 		}
 	}()
 

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -120,7 +120,10 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (retErr e
 	defer func() {
 		if retErr != nil {
 			r.Lock()
-			delete(r.ctrs, c.ID())
+			logrus.WithError(err).Warnf("Cleaning up container %s", c.ID())
+			if cleanupErr := r.deleteContainer(c, true); cleanupErr != nil {
+				logrus.WithError(cleanupErr).Infof("deleteContainer failed for container %s", c.ID())
+			}
 			r.Unlock()
 		}
 	}()

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -530,22 +530,30 @@ func (r *runtimeVM) DeleteContainer(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
+	return r.deleteContainer(c, false)
+}
+
+// deleteContainer performs all the operations needed to delete a container.
+// force must only be used on clean-up cases.
+// It does **not** Lock the container, thus it's the caller responsibility to do so, when needed.
+func (r *runtimeVM) deleteContainer(c *Container, force bool) error {
 	r.Lock()
 	cInfo, ok := r.ctrs[c.ID()]
 	r.Unlock()
-	if !ok {
+	if !ok && !force {
 		return errors.New("Could not retrieve container information")
 	}
 
-	if err := cInfo.cio.Close(); err != nil {
+	if err := cInfo.cio.Close(); err != nil && !force {
 		return err
 	}
 
-	if err := r.remove(r.ctx, c.ID(), ""); err != nil {
+	if err := r.remove(r.ctx, c.ID(), ""); err != nil && !force {
 		return err
 	}
 
-	if _, err := r.task.Shutdown(r.ctx, &task.ShutdownRequest{ID: c.ID()}); err != nil && err != ttrpc.ErrClosed {
+	_, err := r.task.Shutdown(r.ctx, &task.ShutdownRequest{ID: c.ID()})
+	if err != nil && err != ttrpc.ErrClosed && !force {
 		return err
 	}
 

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -537,7 +537,7 @@ func (r *runtimeVM) DeleteContainer(c *Container) error {
 		return err
 	}
 
-	if _, err := r.task.Shutdown(r.ctx, &task.ShutdownRequest{ID: c.ID()}); err != nil {
+	if _, err := r.task.Shutdown(r.ctx, &task.ShutdownRequest{ID: c.ID()}); err != nil && err != ttrpc.ErrClosed {
 		return err
 	}
 

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -771,7 +771,7 @@ func (r *runtimeVM) remove(ctx context.Context, ctrID, execID string) error {
 	return nil
 }
 
-func (r runtimeVM) resizePty(ctx context.Context, ctrID, execID string, size remotecommand.TerminalSize) error {
+func (r *runtimeVM) resizePty(ctx context.Context, ctrID, execID string, size remotecommand.TerminalSize) error {
 	_, err := r.task.ResizePty(ctx, &task.ResizePtyRequest{
 		ID:     ctrID,
 		ExecID: execID,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

This PR contains all the VM runtime type fixes provided in the last month or so.

Those fixes are related to processes (qemu, virtiofs, and containerd-shim-kata-v2) being left behind in several situations, such as:
- pod deletion;
- pod failure;
- pod completion;

Together with those, a bunch of possible deadlocks were fixed, some locks have been added, and a fix for a health check failures.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
None
-->

#### Special notes for your reviewer:

Although this PR brings a bunch of fixes for 1.17 branch, I would **not** do a 1.17 release after it's merged.
I'd wait a little bit for one or two more fixes which are in the queue to be reviewed / worked on. 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
