### PR TITLE
test/*bats: fix shellcheck SC2076

### DIFF
--- a/test/apparmor.bats
+++ b/test/apparmor.bats
@@ -57,7 +57,7 @@ load_a_specific_apparmor_profile_as_default_apparmor_and_run_a_container_with_it
     ctr_id="$output"
     run crictl exec --sync "$ctr_id" touch test.txt
     echo "$output"
-    [[ "$output" =~ "Permission denied" ]]
+    [[ "$output" == *"Permission denied"* ]]
 
     remove_apparmor_profile "$APPARMOR_TEST_PROFILE_PATH"
     cleanup_test
@@ -83,7 +83,7 @@ load_default_apparmor_profile_and_run_a_container_with_another_apparmor_profile(
     ctr_id="$output"
     run crictl exec --sync "$ctr_id" touch test.txt
     echo "$output"
-    [[ "$output" =~ "Permission denied" ]]
+    [[ "$output" == *"Permission denied"* ]]
 
     remove_apparmor_profile "$APPARMOR_TEST_PROFILE_PATH"
     cleanup_test
@@ -105,7 +105,7 @@ run_a_container_with_wrong_apparmor_profile_name() {
     run crictl create "$pod_id" "$TESTDIR"/apparmor_container4.json "$TESTDIR"/apparmor4.json
     echo "$output"
     [ "$status" -ne 0 ]
-    [[ "$output" =~ "Creating container failed" ]]
+    [[ "$output" == *"Creating container failed"* ]]
 
     cleanup_test
 }

--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -31,7 +31,7 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" cat /sys/fs/cgroup/pids/pids.max
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "1234" ]]
+	[[ "$output" == "1234" ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -50,7 +50,7 @@ function teardown() {
 	pod_id="$output"
 	scope_name="crio-conmon-$pod_id.scope"
 	run systemctl status $scope_name
-	[[ "$output" =~ "customcrioconmon.slice" ]]
+	[[ "$output" == *"customcrioconmon.slice"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test/command.bats
+++ b/test/command.bats
@@ -15,11 +15,11 @@ load helpers
 	run ${CRIO_BINARY_PATH} --default-ulimits doesntexist=2042
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "invalid ulimit type: doesntexist" ]]
+	[[ "$output" == *"invalid ulimit type: doesntexist"* ]]
 	run ${CRIO_BINARY_PATH} --default-ulimits nproc=2042:42
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "ulimit soft limit must be less than or equal to hard limit: 2042 > 42" ]]
+	[[ "$output" == *"ulimit soft limit must be less than or equal to hard limit: 2042 > 42"* ]]
 	# can't cover everything here, ulimits parsing is tested in
 	# github.com/docker/go-units package
 }
@@ -28,15 +28,15 @@ load helpers
 	run ${CRIO_BINARY_PATH} --additional-devices /dev/sda:/dev/foo:123
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "invalid device mode:" ]]
+	[[ "$output" == *"invalid device mode:"* ]]
 	run ${CRIO_BINARY_PATH} --additional-devices /dev/sda:/dee/foo:rm
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "invalid device mode:" ]]
+	[[ "$output" == *"invalid device mode:"* ]]
 	run ${CRIO_BINARY_PATH} --additional-devices /dee/sda:rmw
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "invalid device mode:" ]]
+	[[ "$output" == *"invalid device mode:"* ]]
 }
 
 @test "invalid metrics port" {
@@ -45,11 +45,11 @@ load helpers
 	run ${CRIO_BINARY_PATH} ${opt} --metrics-port foo --enable-metrics
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "invalid value \"foo\" for flag" ]]
+	[[ "$output" == *'invalid value "foo" for flag'* ]]
 	run ${CRIO_BINARY_PATH} ${opt} --metrics-port 18446744073709551616 --enable-metrics
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "value out of range" ]]
+	[[ "$output" == *"value out of range"* ]]
 }
 
 @test "invalid log max" {
@@ -58,7 +58,7 @@ load helpers
 	run ${CRIO_BINARY_PATH} ${opt} --log-size-max foo
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "invalid value \"foo\" for flag" ]]
+	[[ "$output" == *'invalid value "foo" for flag'* ]]
 }
 
 @test "log max boundary testing" {
@@ -68,15 +68,15 @@ load helpers
 	run ${CRIO_BINARY_PATH} ${opt} --log-size-max 0
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "log size max should be negative or >= 8192" ]]
+	[[ "$output" == *"log size max should be negative or >= 8192"* ]]
 	# log size max is less than 8192 and more than 0
 	run ${CRIO_BINARY_PATH} ${opt} --log-size-max 8191
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "log size max should be negative or >= 8192" ]]
+	[[ "$output" == *"log size max should be negative or >= 8192"* ]]
 	# log size max is out of the range of 64-bit signed integers
 	run ${CRIO_BINARY_PATH} ${opt} --log-size-max 18446744073709551616
 	echo $output
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "value out of range" ]]
+	[[ "$output" == *"value out of range"* ]]
 }

--- a/test/config.bats
+++ b/test/config.bats
@@ -25,7 +25,7 @@ function teardown() {
 
     # then
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "pids_limit = 5678" ]]
+    [[ "$output" == *"pids_limit = 5678"* ]]
 }
 
 @test "config dir should fail with invalid option" {
@@ -38,5 +38,5 @@ function teardown() {
     RES=$(cat "$CRIO_LOG")
 
     # then
-    [[ "$RES" =~ "unable to decode configuration" ]]
+    [[ "$RES" == *"unable to decode configuration"* ]]
 }

--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -58,7 +58,7 @@ function test_crio_wiped_images() {
 	run crictl images
 	echo "$output"
 	[ "$status" == 0 ]
-	[[ ! "$output" =~ "pause" ]]
+	[[ ! "$output" == *"pause"* ]]
 }
 
 function test_crio_did_not_wipe_images() {
@@ -66,7 +66,7 @@ function test_crio_did_not_wipe_images() {
 	run crictl images
 	echo "$output"
 	[ "$status" == 0 ]
-	[[ "$output" =~ "pause" ]]
+	[[ "$output" == *"pause"* ]]
 }
 
 function start_crio_with_stopped_pod() {
@@ -132,5 +132,5 @@ function start_crio_with_stopped_pod() {
 	run_crio_wipe
 
 	run_podman_with_args ps -a
-	[[ "$output" =~ "test" ]]
+	[[ "$output" == *"test"* ]]
 }

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -21,8 +21,8 @@ function wait_until_exit() {
         run crictl inspect -o table "$ctr_id"
         echo "$output"
         [ "$status" -eq 0 ]
-        if [[ "$output" =~ "State: CONTAINER_EXITED" ]]; then
-            [[ "$output" =~ "Exit Code: ${EXPECTED_EXIT_STATUS:-0}" ]]
+        if [[ "$output" == *"State: CONTAINER_EXITED"* ]]; then
+            [[ "$output" == *"Exit Code: ${EXPECTED_EXIT_STATUS:-0}"* ]]
             return 0
         fi
         sleep 1
@@ -57,7 +57,7 @@ function wait_until_exit() {
 	run crictl inspect --output yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "reason: Completed" ]]
+	[[ "$output" == *"reason: Completed"* ]]
 }
 
 @test "ctr termination reason Error" {
@@ -80,7 +80,7 @@ function wait_until_exit() {
 	run crictl inspect --output yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "reason: Error" ]]
+	[[ "$output" == *"reason: Error"* ]]
 }
 
 @test "ulimits" {
@@ -103,16 +103,16 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" sh -c "ulimit -n"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "42" ]]
+	[[ "$output" == "42" ]]
 	run crictl exec --sync "$ctr_id" sh -c "ulimit -p"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "1024" ]]
+	[[ "$output" == "1024" ]]
 
 	run crictl exec --sync "$ctr_id" sh -c "ulimit -Hp"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "2048" ]]
+	[[ "$output" == "2048" ]]
 
 	run crictl stopp "$pod_id"
 	echo "$output"
@@ -195,21 +195,21 @@ function wait_until_exit() {
 		# Dump the deviced cgroup configuration for debugging.
 		run crictl exec --timeout=$timeout --sync "$ctr_id" cat /sys/fs/cgroup/devices/devices.list
 		echo $output
-		[[ "$output" =~ "c 10:237 w" ]]
+		[[ "$output" == *"c 10:237 w"* ]]
 	fi
 
         # Opening the device in read mode should fail because the device
         # cgroup access only allows writes.
 	run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=$device of=/dev/null count=1
 	echo $output
-	[[ "$output" =~ "Operation not permitted" ]]
+	[[ "$output" == *"Operation not permitted"* ]]
 
     # The write should be allowed by the devices cgroup policy, so we
     # should see an EINVAL from the device when the device fails it.
     # TODO: fix that test, currently fails with "dd: can't open '/dev/loop-control': No such device non-zero exit code"
     # run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=/dev/zero of=$device count=1
     # echo $output
-    # [[ "$output" =~ "Invalid argument" ]]
+    # [[ "$output" == *"Invalid argument"* ]]
 
 	run crictl stopp "$pod_id"
 	echo "$output"
@@ -427,7 +427,7 @@ function wait_until_exit() {
 	run crictl logs "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "here is some output" ]]
+	[[ "$output" == *"here is some output"* ]]
 
 	run crictl rm "$ctr_id"
 	echo "$output"
@@ -764,16 +764,16 @@ function wait_until_exit() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" != "" ]]
-	[[ "$output" =~ "$ctr1_id" ]]
-	[[ "$output" =~ "$ctr2_id" ]]
+	[[ "$output" == *"$ctr1_id"* ]]
+	[[ "$output" == *"$ctr2_id"* ]]
 	[[ "$output" != "$ctr3_id" ]]
 	run crictl ps --label "group=test" --quiet --all
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" != "" ]]
-	[[ "$output" =~ "$ctr1_id"  ]]
-	[[ "$output" =~ "$ctr2_id"  ]]
-	[[ "$output" =~ "$ctr3_id"  ]]
+	[[ "$output" == *"$ctr1_id"* ]]
+	[[ "$output" == *"$ctr2_id"* ]]
+	[[ "$output" == *"$ctr3_id"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -797,15 +797,15 @@ function wait_until_exit() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	# TODO: expected value should not hard coded here
-	[[ "$output" =~ "name: container1" ]]
-	[[ "$output" =~ "attempt: 1" ]]
+	[[ "$output" == *"name: container1"* ]]
+	[[ "$output" == *"attempt: 1"* ]]
 
 	run crictl inspect -o table "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	# TODO: expected value should not hard coded here
-	[[ "$output" =~ "Name: container1" ]]
-	[[ "$output" =~ "Attempt: 1" ]]
+	[[ "$output" == *"Name: container1"* ]]
+	[[ "$output" == *"Attempt: 1"* ]]
 }
 
 @test "ctr execsync conflicting with conmon flags parsing" {
@@ -846,7 +846,7 @@ function wait_until_exit() {
 	[[ "$output" == "HELLO" ]]
 	run crictl exec --sync --timeout 1 "$ctr_id" sleep 3
 	echo "$output"
-	[[ "$output" =~ "command timed out" ]]
+	[[ "$output" == *"command timed out"* ]]
 	[ "$status" -ne 0 ]
 	run crictl stopp "$pod_id"
 	echo "$output"
@@ -903,7 +903,7 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" ls /dev/mynull
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "/dev/mynull" ]]
+	[[ "$output" == *"/dev/mynull"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -938,7 +938,7 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" ls /dev/mynull
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "/dev/mynull" ]]
+	[[ "$output" == *"/dev/mynull"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -981,7 +981,7 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" env
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "HOSTNAME" ]]
+	[[ "$output" == *"HOSTNAME"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -1045,7 +1045,7 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" echo hello0 stdout
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "hello0 stdout" ]]
+	[[ "$output" == *"hello0 stdout"* ]]
 
 	stderrconfig=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "quay.io/crio/stderr-test"; obj["command"] = ["/bin/sleep", "600"]; json.dump(obj, sys.stdout)')
 	echo "$stderrconfig" > "$TESTDIR"/container_config_stderr.json
@@ -1059,7 +1059,7 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" stderr
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "this goes to stderr" ]]
+	[[ "$output" == *"this goes to stderr"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -1202,12 +1202,12 @@ function wait_until_exit() {
 		run crictl inspect --output yaml "$ctr_id"
 		echo "$output"
 		[ "$status" -eq 0 ]
-		if [[ "$output" =~ "OOMKilled" ]]; then
+		if [[ "$output" == *"OOMKilled"* ]]; then
 			break
 		fi
 		sleep 10
 	done
-	[[ "$output" =~ "OOMKilled" ]]
+	[[ "$output" == *"OOMKilled"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -1252,7 +1252,7 @@ function wait_until_exit() {
 	echo "$newconfig" > "$TESTDIR"/container_nonexistent.json
 	run crictl create "$pod_id" "$TESTDIR"/container_nonexistent.json "$TESTDATA"/sandbox_config.json
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "executable file not found" ]]
+	[[ "$output" == *"executable file not found"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -1271,7 +1271,7 @@ function wait_until_exit() {
 	echo "$newconfig" > "$TESTDIR"/container_nonexistent.json
 	run crictl create "$pod_id" "$TESTDIR"/container_nonexistent.json "$TESTDATA"/sandbox_config.json
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "executable file not found" ]]
+	[[ "$output" == *"executable file not found"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -1305,7 +1305,7 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" sh -c "cat $CGROUP_MEM_FILE"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "209715200" ]]
+	[[ "$output" == *"209715200"* ]]
 
 
 	# we can only rely on these files being here if cgroup memory swap is enabled
@@ -1321,26 +1321,26 @@ function wait_until_exit() {
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.max"
 		echo "$output"
 		[ "$status" -eq 0 ]
-		[[ "$output" =~ "20000 10000" ]]
+		[[ "$output" == *"20000 10000"* ]]
 
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.weight"
 		echo "$output"
 		[ "$status" -eq 0 ]
 		# 512 shares are converted to cpu.weight 20
-		[[ "$output" =~ "20" ]]
+		[[ "$output" == *"20"* ]]
 	else
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.shares"
 		echo "$output"
 		[ "$status" -eq 0 ]
-		[[ "$output" =~ "512" ]]
+		[[ "$output" == *"512"* ]]
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.cfs_period_us"
 		echo "$output"
 		[ "$status" -eq 0 ]
-		[[ "$output" =~ "10000" ]]
+		[[ "$output" == *"10000"* ]]
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us"
 		echo "$output"
 		[ "$status" -eq 0 ]
-		[[ "$output" =~ "20000" ]]
+		[[ "$output" == *"20000"* ]]
 	fi
 
 	run crictl update --memory 524288000 --cpu-period 20000 --cpu-quota 10000 --cpu-share 256 "$ctr_id"
@@ -1350,7 +1350,7 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" sh -c "cat $CGROUP_MEM_FILE"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "524288000" ]]
+	[[ "$output" == *"524288000"* ]]
 
 	if test -r "$CGROUP_MEM_SWAP_FILE" ; then
 		run crictl exec --sync "$ctr_id" sh -c "cat $CGROUP_MEM_SWAP_FILE"
@@ -1363,26 +1363,26 @@ function wait_until_exit() {
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.max"
 		echo "$output"
 		[ "$status" -eq 0 ]
-		[[ "$output" =~ "10000 20000" ]]
+		[[ "$output" == *"10000 20000"* ]]
 
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.weight"
 		echo "$output"
 		[ "$status" -eq 0 ]
 		# 256 shares are converted to cpu.weight 10
-		[[ "$output" =~ "10" ]]
+		[[ "$output" == *"10"* ]]
 	else
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.shares"
 		echo "$output"
 		[ "$status" -eq 0 ]
-		[[ "$output" =~ "256" ]]
+		[[ "$output" == *"256"* ]]
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.cfs_period_us"
 		echo "$output"
 		[ "$status" -eq 0 ]
-		[[ "$output" =~ "20000" ]]
+		[[ "$output" == *"20000"* ]]
 		run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us"
 		echo "$output"
 		[ "$status" -eq 0 ]
-		[[ "$output" =~ "10000" ]]
+		[[ "$output" == *"10000"* ]]
 	fi
 }
 
@@ -1408,7 +1408,7 @@ function wait_until_exit() {
 	echo "$output"
 	[ "$status" -ne 0 ]
 	ctr_id="$output"
-	[[ "$output" =~ "not a directory" ]]
+	[[ "$output" == *"not a directory"* ]]
 }
 
 @test "ctr execsync conflicting with conmon env" {
@@ -1428,11 +1428,11 @@ function wait_until_exit() {
 	echo "$output"
 	echo "$status"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "acustompathinpath" ]]
+	[[ "$output" == *"acustompathinpath"* ]]
 	run crictl exec --sync "$ctr_id" env
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "acustompathinpath" ]]
+	[[ "$output" == *"acustompathinpath"* ]]
 }
 
 @test "ctr resources" {
@@ -1452,11 +1452,11 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpuset/cpuset.cpus || cat /sys/fs/cgroup/cpuset.cpus"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "0" ]]
+	[[ "$output" == *"0"* ]]
 	run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpuset/cpuset.mems || cat /sys/fs/cgroup/cpuset.mems"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "0" ]]
+	[[ "$output" == *"0"* ]]
 }
 
 @test "ctr with non-root user has no effective capabilities" {
@@ -1598,9 +1598,9 @@ function wait_until_exit() {
 	run crictl exec "$ctr_id" cat /proc/mounts
 	[ "$status" -eq 0 ]
 	if test $(stat -f -c%T /sys/fs/cgroup) = cgroup2fs; then
-		[[ "$output" =~ "/sys/fs/cgroup cgroup2" ]]
+		[[ "$output" == *"/sys/fs/cgroup cgroup2"* ]]
 	else
-		[[ "$output" =~ "/sys/fs/cgroup tmpfs" ]]
+		[[ "$output" == *"/sys/fs/cgroup tmpfs"* ]]
 	fi
 
 	run crictl stopp "$pod_id"
@@ -1642,7 +1642,7 @@ function wait_until_exit() {
 	run crictl exec --sync "$ctr_id" env
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "NSS_SDB_USE_CACHE=no" ]]
+	[[ "$output" == *"NSS_SDB_USE_CACHE=no"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -766,7 +766,7 @@ function wait_until_exit() {
 	[[ "$output" != "" ]]
 	[[ "$output" == *"$ctr1_id"* ]]
 	[[ "$output" == *"$ctr2_id"* ]]
-	[[ "$output" != "$ctr3_id" ]]
+	[[ "$output" != *"$ctr3_id"* ]]
 	run crictl ps --label "group=test" --quiet --all
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -74,7 +74,7 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" chmod 777 .
 	echo "$output"
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "Operation not permitted" ]]
+	[[ "$output" == *"Operation not permitted"* ]]
 }
 
 # 3. test running with ctr unconfined and profile empty
@@ -166,7 +166,7 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" chmod 777 .
 	echo "$output"
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "Operation not permitted" ]]
+	[[ "$output" == *"Operation not permitted"* ]]
 }
 
 # 6. test running with ctr docker/default
@@ -200,5 +200,5 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" chmod 777 .
 	echo "$output"
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "Operation not permitted" ]]
+	[[ "$output" == *"Operation not permitted"* ]]
 }

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -48,6 +48,6 @@ function teardown() {
 
 	out=`echo -e "GET /info HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:$CRIO_SOCKET`
 	echo "$out"
-	[[ "$out" =~ "100000" ]]
-	[[ "$out" =~ "200000" ]]
+	[[ "$out" == *"100000"* ]]
+	[[ "$out" == *"200000"* ]]
 }

--- a/test/default_mounts.bats
+++ b/test/default_mounts.bats
@@ -33,11 +33,11 @@ function teardown() {
     run crictl exec --sync "$ctr_id" ls /run/secrets
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "test.txt" ]]
+    [[ "$output" == *"test.txt"* ]]
     run crictl exec --sync "$ctr_id" ls /run/secrets/mysymlink
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "key.pem" ]]
+    [[ "$output" == *"key.pem"* ]]
 }
 
 @test "default mounts correctly sorted with other mounts" {
@@ -64,14 +64,14 @@ function teardown() {
     run crictl exec --sync "$ctr_id" cat /run/secrets/clash/clashing.txt
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "clashing..." ]]
+    [[ "$output" == *"clashing..."* ]]
     run crictl exec --sync "$ctr_id" ls -la /run/secrets
     echo "$output"
     [ "$status" -eq 0 ]
     run crictl exec --sync "$ctr_id" cat /run/secrets/test.txt
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Testing secrets mounts. I am mounted!" ]]
+    [[ "$output" == *"Testing secrets mounts. I am mounted!"* ]]
 }
 
 @test "test deprecated --default-mounts flag" {
@@ -87,5 +87,5 @@ function teardown() {
     run crictl exec --sync "$ctr_id" ls /container/path1
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "test.txt" ]]
+    [[ "$output" == *"test.txt"* ]]
 }

--- a/test/image.bats
+++ b/test/image.bats
@@ -55,8 +55,8 @@ function teardown() {
 	run crictl inspect -o yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "image: quay.io/crio/redis:alpine" ]]
-	[[ "$output" =~ "imageRef: $REDIS_IMAGEREF" ]]
+	[[ "$output" == *"image: quay.io/crio/redis:alpine"* ]]
+	[[ "$output" == *"imageRef: $REDIS_IMAGEREF"* ]]
 }
 
 @test "container status when created by image tagged reference" {
@@ -77,8 +77,8 @@ function teardown() {
 	run crictl inspect -o yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "image: quay.io/crio/redis:alpine" ]]
-	[[ "$output" =~ "imageRef: $REDIS_IMAGEREF" ]]
+	[[ "$output" == *"image: quay.io/crio/redis:alpine"* ]]
+	[[ "$output" == *"imageRef: $REDIS_IMAGEREF"* ]]
 }
 
 @test "container status when created by image canonical reference" {
@@ -103,8 +103,8 @@ function teardown() {
 	run crictl inspect -o yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "image: quay.io/crio/redis:alpine" ]]
-	[[ "$output" =~ "imageRef: $REDIS_IMAGEREF" ]]
+	[[ "$output" == *"image: quay.io/crio/redis:alpine"* ]]
+	[[ "$output" == *"imageRef: $REDIS_IMAGEREF"* ]]
 }
 
 @test "container status when created by image list canonical reference" {
@@ -129,8 +129,8 @@ function teardown() {
 	run crictl inspect -o yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "image: $IMAGE_LIST_DIGEST" ]]
-	[[ "$output" =~ "imageRef: $IMAGE_LIST_DIGEST" ]]
+	[[ "$output" == *"image: $IMAGE_LIST_DIGEST"* ]]
+	[[ "$output" == *"imageRef: $IMAGE_LIST_DIGEST"* ]]
 }
 
 @test "image pull and list" {
@@ -147,7 +147,7 @@ function teardown() {
 
 	run crictl images @"$imageid"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "$IMAGE" ]]
+	[[ "$output" == *"$IMAGE"* ]]
 
 	run crictl images --quiet "$imageid"
 	[ "$status" -eq 0 ]
@@ -232,7 +232,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ "$output" != "" ]
-	[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST}" ]]
+	[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST}"* ]]
 
 	case $(go env GOARCH) in
 	amd64)
@@ -240,7 +240,7 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_AMD64}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_AMD64}"* ]]
 		;;
 	esac
 
@@ -281,7 +281,7 @@ function teardown() {
 		echo "$output"
 		exit 1
 	fi
-	[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_FOR_TAG}" ]]
+	[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_FOR_TAG}"* ]]
 
 	case $(go env GOARCH) in
 	amd64)
@@ -289,28 +289,28 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}"* ]]
 		;;
 	arm64)
 		run crictl images -v ${IMAGE_LIST_DIGEST_ARM64}
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_ARM64}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_ARM64}"* ]]
 		;;
 	ppc64le)
 		run crictl images -v ${IMAGE_LIST_DIGEST_PPC64LE}
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_PPC64LE}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_PPC64LE}"* ]]
 		;;
 	s390x)
 		run crictl images -v ${IMAGE_LIST_DIGEST_S390X}
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_S390X}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_S390X}"* ]]
 		;;
 	esac
 
@@ -348,7 +348,7 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_AMD64}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_AMD64}"* ]]
 		;;
 	arm64)
 		run crictl pull ${IMAGE_LIST_DIGEST_ARM64}
@@ -356,7 +356,7 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_ARM64}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_ARM64}"* ]]
 		;;
 	ppc64le)
 		run crictl pull ${IMAGE_LIST_DIGEST_PPC64LE}
@@ -364,7 +364,7 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_PPC64LE}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_PPC64LE}"* ]]
 		;;
 	s390x)
 		run crictl pull ${IMAGE_LIST_DIGEST_S390X}
@@ -372,7 +372,7 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_S390X}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_S390X}"* ]]
 		;;
 	esac
 
@@ -380,7 +380,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ "$output" != "" ]
-	[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST}" ]]
+	[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST}"* ]]
 
 	run crictl images --quiet @"$imageid"
 	[ "$status" -eq 0 ]
@@ -406,7 +406,7 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_AMD64}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_AMD64}"* ]]
 		;;
 	arm64)
 		run crictl pull ${IMAGE_LIST_DIGEST_ARM64}
@@ -414,7 +414,7 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_ARM64}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_ARM64}"* ]]
 		;;
 	ppc64le)
 		run crictl pull ${IMAGE_LIST_DIGEST_PPC64LE}
@@ -422,7 +422,7 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_PPC64LE}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_PPC64LE}"* ]]
 		;;
 	s390x)
 		run crictl pull ${IMAGE_LIST_DIGEST_S390X}
@@ -430,7 +430,7 @@ function teardown() {
 		[ "$status" -eq 0 ]
 		echo "$output"
 		[ "$output" != "" ]
-		[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST_S390X}" ]]
+		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_S390X}"* ]]
 		;;
 	esac
 
@@ -448,7 +448,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ "$output" != "" ]
-	[[ "$output" =~ "RepoDigests: ${IMAGE_LIST_DIGEST}" ]]
+	[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST}"* ]]
 
 	run crictl images --quiet @"$imageid"
 	[ "$status" -eq 0 ]

--- a/test/image_volume.bats
+++ b/test/image_volume.bats
@@ -28,7 +28,7 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" ls /imagevolume
 	echo "$output"
 	[ "$status" -ne 0 ]
-	[[ "$output" =~ "ls: /imagevolume: No such file or directory" ]]
+	[[ "$output" == *"ls: /imagevolume: No such file or directory"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -92,7 +92,7 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" id
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "uid=1000 gid=0(root)" ]]
+	[[ "$output" == *"uid=1000 gid=0(root)"* ]]
 	run crictl stopp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test/inspect.bats
+++ b/test/inspect.bats
@@ -14,8 +14,8 @@ function teardown() {
 	start_crio
 	out=`echo -e "GET /info HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:$CRIO_SOCKET`
 	echo "$out"
-	[[ "$out" =~ "\"cgroup_driver\":\"$CONTAINER_CGROUP_MANAGER\"" ]]
-	[[ "$out" =~ "\"storage_root\":\"$TESTDIR/crio\"" ]]
+	[[ "$out" == *"\"cgroup_driver\":\"$CONTAINER_CGROUP_MANAGER\""* ]]
+	[[ "$out" == *"\"storage_root\":\"$TESTDIR/crio\""* ]]
 
 	stop_crio
 }
@@ -33,16 +33,16 @@ function teardown() {
 
 	out=`echo -e "GET /containers/$ctr_id HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:$CRIO_SOCKET`
 	echo "$out"
-	[[ "$out" =~ "\"sandbox\":\"$pod_id\"" ]]
-	[[ "$out" =~ "\"image\":\"quay.io/crio/redis:alpine\"" ]]
-	[[ "$out" =~ "\"image_ref\":\"$REDIS_IMAGEREF\"" ]]
+	[[ "$out" == *"\"sandbox\":\"$pod_id\""* ]]
+	[[ "$out" == *"\"image\":\"quay.io/crio/redis:alpine\""* ]]
+	[[ "$out" == *"\"image_ref\":\"$REDIS_IMAGEREF\""* ]]
 
 	run crictl inspect --output json "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "\"id\": \"$ctr_id\"" ]]
-	[[ "$output" =~ "\"image\": \"quay.io/crio/redis:alpine\"" ]]
-	[[ "$output" =~ "\"imageRef\": \"$REDIS_IMAGEREF\"" ]]
+	[[ "$output" == *"\"id\": \"$ctr_id\""* ]]
+	[[ "$output" == *"\"image\": \"quay.io/crio/redis:alpine\""* ]]
+	[[ "$output" == *"\"imageRef\": \"$REDIS_IMAGEREF\""* ]]
 
 	run crictl inspectp --output json "$pod_id"
 	echo "$output"
@@ -50,8 +50,8 @@ function teardown() {
 
 	ipv4=$(parse_pod_ipv4 "$ctr_id")
 	ipv6=$(parse_pod_ipv6 "$ctr_id")
-	[[ "$out" =~ "\"ip_addresses\":[\"$ipv4\",\"$ipv6\"]" ]]
-	[[ "$output" =~ "\"ip\": \"$ipv4\"" ]]
+	[[ "$out" == *"\"ip_addresses\":[\"$ipv4\",\"$ipv6\"]"* ]]
+	[[ "$output" == *"\"ip\": \"$ipv4\""* ]]
 
 
 # TODO: add some other check based on the json below:
@@ -63,7 +63,7 @@ function teardown() {
 	start_crio
 	out=`echo -e "GET /containers/notexists HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:$CRIO_SOCKET`
 	echo "$out"
-	[[ "$out" =~ "can't find the container with id notexists" ]]
+	[[ "$out" == *"can't find the container with id notexists"* ]]
 
 	stop_crio
 }

--- a/test/network.bats
+++ b/test/network.bats
@@ -28,15 +28,15 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" sh -c "hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "crictl_host" ]]
+	[[ "$output" == *"crictl_host"* ]]
 	run crictl exec --sync "$ctr_id" sh -c "echo \$HOSTNAME"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "crictl_host" ]]
+	[[ "$output" == *"crictl_host"* ]]
 	run crictl exec --sync "$ctr_id" sh -c "cat /etc/hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "crictl_host" ]]
+	[[ "$output" == *"crictl_host"* ]]
 }
 
 @test "ensure correct hostname for hostnetwork:true" {
@@ -58,15 +58,15 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" sh -c "hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "$HOSTNAME" ]]
+	[[ "$output" == *"$HOSTNAME"* ]]
 	run crictl exec --sync "$ctr_id" sh -c "echo \$HOSTNAME"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "$HOSTNAME" ]]
+	[[ "$output" == *"$HOSTNAME"* ]]
 	run crictl exec --sync "$ctr_id" sh -c "cat /etc/hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "$HOSTNAME" ]]
+	[[ "$output" == *"$HOSTNAME"* ]]
 }
 
 @test "Check for valid pod netns CIDR" {

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -104,7 +104,7 @@ function teardown() {
 	[[ "$output" != "" ]]
 	[[ "$output" == *"$pod1_id"* ]]
 	[[ "$output" == *"$pod2_id"* ]]
-	[[ "$output" != "$pod3_id" ]]
+	[[ "$output" != *"$pod3_id"* ]]
 	run crictl pods --label "group=test" --quiet
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -102,16 +102,16 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" != "" ]]
-	[[ "$output" =~ "$pod1_id" ]]
-	[[ "$output" =~ "$pod2_id" ]]
+	[[ "$output" == *"$pod1_id"* ]]
+	[[ "$output" == *"$pod2_id"* ]]
 	[[ "$output" != "$pod3_id" ]]
 	run crictl pods --label "group=test" --quiet
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" != "" ]]
-	[[ "$output" =~ "$pod1_id" ]]
-	[[ "$output" =~ "$pod2_id" ]]
-	[[ "$output" =~ "$pod3_id" ]]
+	[[ "$output" == *"$pod1_id"* ]]
+	[[ "$output" == *"$pod2_id"* ]]
+	[[ "$output" == *"$pod3_id"* ]]
 	run crictl pods --id "$pod1_id" --quiet
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -176,19 +176,19 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	# TODO: expected value should not hard coded here
-	[[ "$output" =~ "Name: podsandbox1" ]]
-	[[ "$output" =~ "UID: redhat-test-crio" ]]
-	[[ "$output" =~ "Namespace: redhat.test.crio" ]]
-	[[ "$output" =~ "Attempt: 1" ]]
+	[[ "$output" == *"Name: podsandbox1"* ]]
+	[[ "$output" == *"UID: redhat-test-crio"* ]]
+	[[ "$output" == *"Namespace: redhat.test.crio"* ]]
+	[[ "$output" == *"Attempt: 1"* ]]
 
 	run crictl inspectp --output=table "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	# TODO: expected value should not hard coded here
-	[[ "$output" =~ "Name: podsandbox1" ]]
-	[[ "$output" =~ "UID: redhat-test-crio" ]]
-	[[ "$output" =~ "Namespace: redhat.test.crio" ]]
-	[[ "$output" =~ "Attempt: 1" ]]
+	[[ "$output" == *"Name: podsandbox1"* ]]
+	[[ "$output" == *"UID: redhat-test-crio"* ]]
+	[[ "$output" == *"Namespace: redhat.test.crio"* ]]
+	[[ "$output" == *"Attempt: 1"* ]]
 }
 
 @test "pass pod sysctls to runtime" {
@@ -214,22 +214,22 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" sysctl kernel.shm_rmid_forced
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "kernel.shm_rmid_forced = 1" ]]
+	[[ "$output" == *"kernel.shm_rmid_forced = 1"* ]]
 
 	run crictl exec --sync "$ctr_id" sysctl kernel.msgmax
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "kernel.msgmax = 8192" ]]
+	[[ "$output" == *"kernel.msgmax = 8192"* ]]
 
 	run crictl exec --sync "$ctr_id" sysctl net.ipv4.ip_local_port_range
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "net.ipv4.ip_local_port_range = 1024	65000" ]]
+	[[ "$output" == *"net.ipv4.ip_local_port_range = 1024	65000"* ]]
 
 	run crictl exec --sync "$ctr_id" sysctl net.ipv4.ip_forward
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "net.ipv4.ip_forward = 1" ]]
+	[[ "$output" == *"net.ipv4.ip_forward = 1"* ]]
 }
 
 @test "pod stop idempotent" {
@@ -331,7 +331,7 @@ function teardown() {
 	run systemctl list-units --type=slice
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "Burstable-pod_integration_tests-123.slice" ]]
+	[[ "$output" == *"Burstable-pod_integration_tests-123.slice"* ]]
 }
 
 @test "kubernetes pod terminationGracePeriod passthru" {

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -169,7 +169,7 @@ function teardown() {
 	run crictl stop "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 1 ]
-	[[ "${output}" =~ "not found" ]]
+	[[ "${output}" == *"not found"* ]]
 }
 
 @test "crio restore with bad state and pod removed" {
@@ -209,7 +209,7 @@ function teardown() {
 	run crictl inspectp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "${output}" =~ "SANDBOX_READY" ]]
+	[[ "${output}" == *"SANDBOX_READY"* ]]
 
 	run crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -219,7 +219,7 @@ function teardown() {
 	run crictl inspect -o table "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "${output}" =~ "CONTAINER_CREATED" ]]
+	[[ "${output}" == *"CONTAINER_CREATED"* ]]
 
 	stop_crio
 
@@ -232,25 +232,25 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "${output}" != "" ]]
-	[[ "${output}" =~ "${pod_id}" ]]
+	[[ "${output}" == *"${pod_id}"* ]]
 
 	run crictl inspectp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "${output}" =~ "SANDBOX_NOTREADY" ]]
+	[[ "${output}" == *"SANDBOX_NOTREADY"* ]]
 
 	run crictl ps --quiet --all
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "${output}" != "" ]]
-	[[ "${output}" =~ "${ctr_id}" ]]
+	[[ "${output}" == *"${ctr_id}"* ]]
 
 	run crictl inspect -o table "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "${output}" =~ "CONTAINER_EXITED" ]]
+	[[ "${output}" == *"CONTAINER_EXITED"* ]]
 	# TODO: may be cri-tool should display Exit Code
-	#[[ "${output}" =~ "Exit Code: 255" ]]
+	#[[ "${output}" == *"Exit Code: 255"* ]]
 
 	run crictl stopp "$pod_id"
 	echo "$output"

--- a/test/status.bats
+++ b/test/status.bats
@@ -31,7 +31,7 @@ function run_crio_status() {
 
     # then
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "[crio]" ]]
+    [[ "$output" == *"[crio]"* ]]
 }
 
 @test "status should fail to retrieve the config with invalid socket" {
@@ -50,7 +50,7 @@ function run_crio_status() {
 
     # then
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "storage driver" ]]
+    [[ "$output" == *"storage driver"* ]]
 }
 
 @test "status should fail to retrieve the info with invalid socket" {
@@ -82,7 +82,7 @@ function run_crio_status() {
 
     # then
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "sandbox: $pod" ]]
+    [[ "$output" == *"sandbox: $pod"* ]]
 }
 
 @test "should fail to retrieve the container info without ID" {

--- a/test/version.bats
+++ b/test/version.bats
@@ -10,16 +10,16 @@ load helpers
 
     # then
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Version:" ]]
-    [[ "$output" =~ "GitCommit:" ]]
-    [[ "$output" =~ "GitTreeState:" ]]
-    if [[ "$output" =~ "Linkmode: dynamic" ]]; then
-        [[ "$output" =~ "BuildDate:" ]]
+    [[ "$output" == *"Version:"* ]]
+    [[ "$output" == *"GitCommit:"* ]]
+    [[ "$output" == *"GitTreeState:"* ]]
+    if [[ "$output" == *"Linkmode: dynamic"* ]]; then
+        [[ "$output" == *"BuildDate:"* ]]
     fi
-    [[ "$output" =~ "GoVersion:" ]]
-    [[ "$output" =~ "Compiler:" ]]
-    [[ "$output" =~ "Platform:" ]]
-    [[ "$output" =~ "Linkmode:" ]]
+    [[ "$output" == *"GoVersion:"* ]]
+    [[ "$output" == *"Compiler:"* ]]
+    [[ "$output" == *"Platform:"* ]]
+    [[ "$output" == *"Linkmode:"* ]]
 }
 
 @test "version should succeed with JSON" {


### PR DESCRIPTION
/kind cleanup

```release-note
NONE
```

### 1. test/*bats: fix shellcheck SC2076

This fixes shellcheck warning SC2076, for example

```
In default_mounts.bats line 90:
    [[ "$output" =~ "test.txt" ]]
                    ^--------^ SC2076: Don't quote right-hand side of =~, it'll match literally rather than as a regex.
```

So, operator `~=` does a comparison against a regular expression, and yet
in all the places we are actually using it to search for a substring, not a regex.

Use the substring syntax (i.e. `[[ "$output" == *"substring"* ]]`) instead
to be more clear about what we're doing.

This commit is courtesy of
```bash
for f in *.bats; do sed -i -e 's/ =\~ "\(.*\)" ]]/ == *"\1"* ]]/g' $f; done
```

and a few manual fixes on top of it.

------

### 2. test/*.bats: fix checks that id is not present

> [[ "$output" != *"$ctr3_id"* ]]
> [[ "$output" != "$pod3_id" ]]

These two checks meant to check that the ID is not present in the
output. They don't work as they perform string comparison, while
we need to search for a substring.
    
Fix by adding * around the substring.

Fixes: b0b6611bdf (#1156)
Fixes: 25dfde9044 (#1159)