### PR TITLE
test/ctr.bats: fix test check

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1005,10 +1005,7 @@ function wait_until_exit() {
 	[ "$status" -eq 0 ]
 	run crictl exec --sync "$ctr_id" doesnotexist
 	echo "$output"
-	[ "$status" -ne 0 ] || [ "$output" =~ "Exit code: 1" ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
+	[ "$status" -ne 0 ]
 }
 
 @test "ctr execsync exit code" {


### PR DESCRIPTION
First, the code

        [ "$status" -ne 0 ] || [ "$output" =~ "Exit code: 1" ]

is not working since one can't use `=~` operator inside `[..]`
(it is only working inside `[[..]]`).

Here's an example:
```console
        $ [ "aaa bbb" =~ "aaa" ]; echo $?
        bash: [: =~: binary operator expected
        2
```

Since the test never failed, I guess $status was always non-zero,
so the second part was never evaluated, thus it is not needed.

This was found by shellcheck:

```
In ctr.bats line 1008:
        [ "$status" -ne 0 ] || [ "$output" =~ "Exit code: 1" ]
                                           ^-- SC2074: Can't use =~ in [ ]. Use [[..]] instead.
```

Second, the cleanup/stop stuff added by the commit is not needed,
since `teardown()` is executed after each test, and it contains
a call to `cleanup_test()` which calls the same 3 functions that
were added.

This reverts commit 2649ebb1a5d39208f8d2d68303e42a81048f4bdf
(from PR https://github.com/cri-o/cri-o/pull/2943/)

/kind bug

```release-note
NONE
```

@giuseppe PTAL