### PR TITLE
UPSTREAM: 80591: hostport: Don't masquerade localhost-to-localhost traffic

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport/hostport.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport/hostport.go
@@ -134,10 +134,12 @@ func ensureKubeHostportChains(iptables utiliptables.Interface, natInterfaceName 
 			return fmt.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", tc.table, tc.chain, kubeHostportsChain, err)
 		}
 	}
-	// Need to SNAT traffic from localhost
-	args = []string{"-m", "comment", "--comment", "SNAT for localhost access to hostports", "-o", natInterfaceName, "-s", "127.0.0.0/8", "-j", "MASQUERADE"}
-	if _, err := iptables.EnsureRule(utiliptables.Append, utiliptables.TableNAT, utiliptables.ChainPostrouting, args...); err != nil {
-		return fmt.Errorf("Failed to ensure that %s chain %s jumps to MASQUERADE: %v", utiliptables.TableNAT, utiliptables.ChainPostrouting, err)
+	if natInterfaceName != "" && natInterfaceName != "lo" {
+		// Need to SNAT traffic from localhost
+		args = []string{"-m", "comment", "--comment", "SNAT for localhost access to hostports", "-o", natInterfaceName, "-s", "127.0.0.0/8", "-j", "MASQUERADE"}
+		if _, err := iptables.EnsureRule(utiliptables.Append, utiliptables.TableNAT, utiliptables.ChainPostrouting, args...); err != nil {
+			return fmt.Errorf("Failed to ensure that %s chain %s jumps to MASQUERADE: %v", utiliptables.TableNAT, utiliptables.ChainPostrouting, err)
+		}
 	}
 	return nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport/hostport_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport/hostport_manager.go
@@ -40,7 +40,7 @@ type HostPortManager interface {
 	// Add implements port mappings.
 	// id should be a unique identifier for a pod, e.g. podSandboxID.
 	// podPortMapping is the associated port mapping information for the pod.
-	// natInterfaceName is the interface that localhost used to talk to the given pod.
+	// natInterfaceName is the interface that localhost uses to talk to the given pod, if known.
 	Add(id string, podPortMapping *PodPortMapping, natInterfaceName string) error
 	// Remove cleans up matching port mappings
 	// Remove must be able to clean up port mappings without pod IP


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Cherry-picks vendored Kubernetes PR 80591.

```release-note
Fixes a bug where traffic from localhost is always masqueraded.
```
