### PR TITLE
test/image_volume.bats: fixes

### DIFF
--- a/test/image_volume.bats
+++ b/test/image_volume.bats
@@ -11,7 +11,7 @@ function teardown() {
 }
 
 @test "image volume ignore" {
-	CONTAINER_IMAGE_VOLUMES=ignore start_crio
+	CONTAINER_IMAGE_VOLUMES="ignore" start_crio
 	run crictl runp "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -41,7 +41,7 @@ function teardown() {
 	if test -n "$CONTAINER_UID_MAPPINGS"; then
 		skip "userNS enabled"
 	fi
-	CONTAINER_IMAGE_VOLUMES=bind start_crio
+	CONTAINER_IMAGE_VOLUMES="bind" start_crio
 	run crictl runp "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -71,7 +71,7 @@ function teardown() {
 	if test -n "$UID_MAPPINGS"; then
 		skip "userNS enabled"
 	fi
-	IMAGE_VOLUMES=mkdir start_crio
+	CONTAINER_IMAGE_VOLUMES="mkdir" start_crio
 	run crictl runp "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -99,7 +99,4 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
 }


### PR DESCRIPTION
1. Use `CONTAINER_IMAGE_VOLUME` rather than `IMAGE_VOLUME`. The test
   case was working before because `mkdir` is the default.

2. Quote the value assigned to CONTAINER_IMAGE_VOLUME. This helps
   readability, and eliminates the following shellcheck warning:

```
In test/image_volume.bats line 74:
	IMAGE_VOLUMES=mkdir start_crio
	^----------------------------^ SC2209: Use var=$(command) to assign output (or quote to assign string).
```

3. Remove the cleanup/stop from the last test case. This is performed in
   teardown() anyway.

/kind cleanup

```release-note
NONE
```
