### PR TITLE
selinux: override only specified values

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -267,12 +267,27 @@ func (c *container) ReadOnly(serverIsReadOnly bool) bool {
 // it takes the sandbox's label, which it falls back upon
 func (c *container) SelinuxLabel(sboxLabel string) ([]string, error) {
 	selinuxConfig := c.config.GetLinux().GetSecurityContext().GetSelinuxOptions()
-	if selinuxConfig != nil {
-		return utils.GetLabelOptions(selinuxConfig), nil
-	}
+
+	labels := map[string]string{}
+
 	labelOptions, err := label.DupSecOpt(sboxLabel)
 	if err != nil {
 		return nil, err
 	}
-	return labelOptions, nil
+	for _, r := range labelOptions {
+		k := strings.Split(r, ":")[0]
+		labels[k] = r
+	}
+
+	if selinuxConfig != nil {
+		for _, r := range utils.GetLabelOptions(selinuxConfig) {
+			k := strings.Split(r, ":")[0]
+			labels[k] = r
+		}
+	}
+	ret := []string{}
+	for _, v := range labels {
+		ret = append(ret, v)
+	}
+	return ret, nil
 }


### PR DESCRIPTION
use the sandbox selinux label options from the pod when if they are
not overriden in the configuration.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1868122

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1868122

```release-note
NONE
```
