### PR TITLE
Update Kubeadm with off line configurations

### DIFF
--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -50,7 +50,7 @@ blocked = false
 location = "user.private.repo/pause:3.2"
 ```
 
-Next the user should reload and restart CRI-O service to load the configurations.
+Next the user should reload and restart the CRI-O service to load the configurations.
 
 Last step the user also should add the cgroup driver on the configuration file or pass it as a parameter when starting kubeadm for the master node sample of parameters for configuration file:
 

--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -52,7 +52,7 @@ location = "user.private.repo/pause:3.2"
 
 Next the user should reload and restart the CRI-O service to load the configurations.
 
-Last step the user also should add the cgroup driver on the configuration file or pass it as a parameter when starting kubeadm for the master node sample of parameters for configuration file:
+Last step. The user also should add the cgroup driver to the configuration file or pass it as a parameter when starting kubeadm for the master node.  The following are samples of parameters for the configuration file:
 
 ```bash
 ---

--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -22,7 +22,7 @@ Note: This file assumes you've set your cgroup_driver as systemd
 Given you've set CIDR, and you've properly set the kubelet file, all you need to do is start crio (as defined [here](setup.md)), and run:
 `kubeadm init --pod-network-cidr=$CIDR`
 
-# Running kubeadm in a off line network
+# Running kubeadm in an off line network
 
 We will assume that the user has installed CRI-O and alls necessary packages. We will also assume that all necessary components are configured and everything is working as expected. The user should have a private repo where the docker images are pushed. Sample of images fot version 1.18.2:
 

--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -21,3 +21,42 @@ Note: This file assumes you've set your cgroup_driver as systemd
 
 Given you've set CIDR, and you've properly set the kubelet file, all you need to do is start crio (as defined [here](setup.md)), and run:
 `kubeadm init --pod-network-cidr=$CIDR`
+
+# Running kubeadm in a off line network
+
+We will assume that the user has installed CRI-O and alls necessary packages. We will also assume that all necessary components are configured and everything is working as expected. The user should have a private repo where the docker images are pushed. Sample of images fot version 1.18.2:
+
+```bash
+$ kubeadm config images list --image-repository user.private.repo --kubernetes-version=v1.18.2
+user.private.repo/kube-apiserver:v1.18.2
+user.private.repo/kube-controller-manager:v1.18.2
+user.private.repo/kube-scheduler:v1.18.2
+user.private.repo/kube-proxy:v1.18.2
+user.private.repo/pause:3.2
+user.private.repo/etcd:3.4.3-0
+user.private.repo/coredns:1.6.7
+```
+
+The user needs to configure the [registries.conf](https://www.mankier.com/5/containers-registries.conf) file.
+
+Sample of configurations:
+
+```bash
+$ cat /etc/containers/registries.conf
+[[registry]]
+prefix = "k8s.gcr.io/pause:3.2"
+insecure = false
+blocked = false
+location = "user.private.repo/pause:3.2"
+```
+
+Next the user should reload and restart CRI-O service to load the configurations.
+
+Last step the user also should add the cgroup driver on the configuration file or pass it as a parameter when starting kubeadm for the master node sample of parameters for configuration file:
+
+```bash
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: systemd
+```


### PR DESCRIPTION
The proposed documentation was added  in order to help other users to be able to launch Kubernetes with crio socket on offline network. There is a ticket that someone can find more information [Kubernetes v1.18.2 with crio version 1.18.2 failing to sync with kubelet on RH7
#3915](https://github.com/cri-o/cri-o/issues/3915)

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:

It is a tested solution on RH 7 offline kubernetes that is using CRI-O as socket.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #3915 `, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
