### PR TITLE
Fix container cgroup under cgroupfs

### DIFF
--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -38,7 +38,7 @@ func (*CgroupfsManager) ContainerCgroupPath(sbParent, containerID string) string
 	if sbParent != "" {
 		parent = sbParent
 	}
-	return filepath.Join(parent, crioPrefix+"-"+containerID)
+	return filepath.Join("/", parent, crioPrefix+"-"+containerID)
 }
 
 // ContainerCgroupAbsolutePath just calls ContainerCgroupPath,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In case cgroupfs cgroup manager is used, the container got created under
the conmon cgroup (rather than under the root), and then the stats
doesn't work because the cgroup path is invalid.

For example, if the conmon cgroup is created as
/sys/fs/cgroup/pod_123-456/crio-conmon-<ID>, then the container cgroup
is created as
/sys/fs/cgroup/pod_123-456/crio-conmon-<ID>/pod_123-456/crio-<ID>,
rather than sys/fs/cgroup/pod_123-456/crio-conmon-<ID>.

The `cricrl stats` then fails as it can't find the container cgroup.

This happens because the cgroupsPath set in spec for such containers
is not absolute, so the cgroup is created under the current cgroup,
which is that of conmon.

The fix is easy.

#### Which issue(s) this PR fixes:

Fixes #4075 

#### Special notes for your reviewer:

Found while working on https://github.com/cri-o/cri-o/pull/4064. That PR has a test case (in test/stats.bats) which will check this issue, so there's no test case in here.

#### Does this PR introduce a user-facing change?

```release-note
Fix the container cgroup in case cgroupfs cgroup manager is used (#4075)
```
