### PR TITLE
runtimeVM: Store logs again, and store them in the correct format

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -108,7 +108,23 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (retErr e
 		return err
 	}
 
-	containerIO.AddOutput("logfile", f, f)
+	var stdoutCh, stderrCh <-chan struct{}
+	wc := cioutil.NewSerialWriteCloser(f)
+	stdout, stdoutCh := cio.NewCRILogger(c.LogPath(), wc, cio.Stdout, -1)
+	stderr, stderrCh := cio.NewCRILogger(c.LogPath(), wc, cio.Stderr, -1)
+
+	go func() {
+		if stdoutCh != nil {
+			<-stdoutCh
+		}
+		if stderrCh != nil {
+			<-stderrCh
+		}
+		logrus.Debugf("Finish redirecting log file %q, closing it", c.LogPath())
+		f.Close()
+	}()
+
+	containerIO.AddOutput(c.LogPath(), stdout, stderr)
 	containerIO.Pipe()
 
 	r.Lock()

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -148,12 +148,10 @@ func (r *runtimeVM) CreateContainer(c *Container, cgroupParent string) (retErr e
 
 	select {
 	case err = <-createdCh:
-		f.Close()
 		if err != nil {
 			return errors.Errorf("CreateContainer failed: %v", err)
 		}
 	case <-time.After(ContainerCreateTimeout):
-		f.Close()
 		if err := r.remove(r.ctx, c.ID(), ""); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

The first patch of this series reverts commit 924a8e9830f112821f03984d417f938f945ba442, as the commit in question introduced a regression on CRI-O, when using the VM runtime type, which caused the logs to never be stored in:
`/var/log/pods/$namespace_$pod_name_$pod_uid/$container_name/$restart_number.log`

The second commit fixes the log format as the current format of logs stored by CRI-O, when using the VM runtime type, looks like:
```
[root@k8s cri-o]# cat /var/log/pods/default_fio-test_855d9cec-2b0f-42d2-bbe5-cce769cb7b10/fio/0.log
{
  "fio version" : "fio-2.17-45-g06cb",
  "timestamp" : 1597428680,
  "timestamp_ms" : 1597428680853,
  "time" : "Fri Aug 14 18:11:20 2020",
  "jobs" : [
    {
      "jobname" : "random-writers-emptydir",
      "groupid" : 0,
      "error" : 0,
      "eta" : 0,
      "elapsed" : 61,
      "job options" : {
        "name" : "random-writers-emptydir",
        "filename" : "/test-volume/testfile",
        "ioengine" : "libaio",
        "iodepth" : "16",
        "rw" : "randwrite",
        "bs" : "512",
        "direct" : "0",
        "size" : "1G",
        "numjobs" : "1",
        "runtime" : "60s",
        "fallocate" : "none",
        "invalidate" : "1"
      },
...
```

Although this is exactly what we'd expect as the output of `kubectl logs $pod`, the format in question will lead to the following error:
`failed to get parse function: unsupported log format: "{\n"`

After taking a look at containerd code, specifically at https://github.com/containerd/cri/blob/4e6644c8cf7fb825f62e0007421b7d83dfeab5a1/pkg/server/container_start.go#L173, it's clear that we had to hook the already present (but never used) NewCRILogger() function to the standard output & error.

Once it's done, the format of the logs stored by CRI-O, when using the VM runtime type, looks like:
```
[root@k8s cri-o]# cat /var/log/pods/default_fio-test_6278a00a-1abe-41e8-b048-5c22be826876/fio/0.log
2020-08-14T20:20:02.17267229+02:00 stdout F {
2020-08-14T20:20:02.172720217+02:00 stdout F   "fio version" : "fio-2.17-45-g06cb",
2020-08-14T20:20:02.172726757+02:00 stdout F   "timestamp" : 1597429202,
2020-08-14T20:20:02.172749864+02:00 stdout F   "timestamp_ms" : 1597429202414,
2020-08-14T20:20:02.172752913+02:00 stdout F   "time" : "Fri Aug 14 18:20:02 2020",
2020-08-14T20:20:02.172755049+02:00 stdout F   "jobs" : [
2020-08-14T20:20:02.172757593+02:00 stdout F     {
2020-08-14T20:20:02.172759998+02:00 stdout F       "jobname" : "random-writers-emptydir",
2020-08-14T20:20:02.172762745+02:00 stdout F       "groupid" : 0,
2020-08-14T20:20:02.172764845+02:00 stdout F       "error" : 0,
2020-08-14T20:20:02.172766929+02:00 stdout F       "eta" : 0,
2020-08-14T20:20:02.172769756+02:00 stdout F       "elapsed" : 61,
2020-08-14T20:20:02.1727719+02:00 stdout F       "job options" : {
2020-08-14T20:20:02.172774095+02:00 stdout F         "name" : "random-writers-emptydir",
2020-08-14T20:20:02.172776168+02:00 stdout F         "filename" : "/test-volume/testfile",
2020-08-14T20:20:02.172778173+02:00 stdout F         "ioengine" : "libaio",
2020-08-14T20:20:02.172780201+02:00 stdout F         "iodepth" : "16",
2020-08-14T20:20:02.172782184+02:00 stdout F         "rw" : "randwrite",
2020-08-14T20:20:02.172784156+02:00 stdout F         "bs" : "512",
2020-08-14T20:20:02.17278615+02:00 stdout F         "direct" : "0",
2020-08-14T20:20:02.172788418+02:00 stdout F         "size" : "1G",
2020-08-14T20:20:02.172791139+02:00 stdout F         "numjobs" : "1",
2020-08-14T20:20:02.1727932+02:00 stdout F         "runtime" : "60s",
2020-08-14T20:20:02.172795277+02:00 stdout F         "fallocate" : "none",
2020-08-14T20:20:02.172797446+02:00 stdout F         "invalidate" : "1"
2020-08-14T20:20:02.1727995+02:00 stdout F       },
...
```

Now it matches exactly what we have for the OCI runtime type and kubelet is happy about that, as shown below:
```
[root@k8s cri-o]# kubectl logs fio-test
{
  "fio version" : "fio-2.17-45-g06cb",
  "timestamp" : 1597429202,
  "timestamp_ms" : 1597429202414,
  "time" : "Fri Aug 14 18:20:02 2020",
  "jobs" : [
    {
      "jobname" : "random-writers-emptydir",
      "groupid" : 0,
      "error" : 0,
      "eta" : 0,
      "elapsed" : 61,
      "job options" : {
        "name" : "random-writers-emptydir",
        "filename" : "/test-volume/testfile",
        "ioengine" : "libaio",
        "iodepth" : "16",
        "rw" : "randwrite",
        "bs" : "512",
        "direct" : "0",
        "size" : "1G",
        "numjobs" : "1",
        "runtime" : "60s",
        "fallocate" : "none",
        "invalidate" : "1"
      },
...
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/cri-o/cri-o/issues/4081
Fixes https://github.com/cri-o/cri-o/issues/4029
Fixes https://github.com/kata-containers/runtime/issues/2764

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
