### PR TITLE
[1.18] conmonmgr: switch to semver

### DIFF
--- a/internal/config/conmonmgr/conmonmgr_test.go
+++ b/internal/config/conmonmgr/conmonmgr_test.go
@@ -85,32 +85,18 @@ var _ = t.Describe("ConmonManager", func() {
 	})
 	t.Describe("parseConmonVersion", func() {
 		var mgr *ConmonManager
-		const invalidNumber = "invalid"
-		const validNumber = "0"
 		BeforeEach(func() {
 			mgr = new(ConmonManager)
 		})
-		It("should fail when major not number", func() {
+		It("should fail when not number", func() {
 			// When
-			err := mgr.parseConmonVersion(invalidNumber, validNumber, validNumber)
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-		It("should fail when minor not number", func() {
-			// When
-			err := mgr.parseConmonVersion(validNumber, invalidNumber, validNumber)
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-		It("should fail when patch not number", func() {
-			// When
-			err := mgr.parseConmonVersion(validNumber, validNumber, invalidNumber)
+			err := mgr.parseConmonVersion("invalid.0.0")
 			// Then
 			Expect(err).NotTo(BeNil())
 		})
 		It("should succeed when all are numbers", func() {
 			// When
-			err := mgr.parseConmonVersion(validNumber, validNumber, validNumber)
+			err := mgr.parseConmonVersion("0.0.0")
 			// Then
 			Expect(err).To(BeNil())
 		})
@@ -122,8 +108,8 @@ var _ = t.Describe("ConmonManager", func() {
 		})
 		It("should be false when major version less", func() {
 			// Given
-			mgr.majorVersion = majorVersionSupportsSync - 1
-
+			err := mgr.parseConmonVersion("1.0.19")
+			Expect(err).To(BeNil())
 			// When
 			mgr.initializeSupportsSync()
 
@@ -132,7 +118,8 @@ var _ = t.Describe("ConmonManager", func() {
 		})
 		It("should be true when major version greater", func() {
 			// Given
-			mgr.majorVersion = majorVersionSupportsSync + 1
+			err := mgr.parseConmonVersion("3.0.19")
+			Expect(err).To(BeNil())
 
 			// When
 			mgr.initializeSupportsSync()
@@ -140,21 +127,10 @@ var _ = t.Describe("ConmonManager", func() {
 			// Then
 			Expect(mgr.SupportsSync()).To(Equal(true))
 		})
-		It("should be false when minor version less", func() {
-			// Given
-			mgr.majorVersion = majorVersionSupportsSync
-			mgr.minorVersion = minorVersionSupportsSync - 1
-
-			// When
-			mgr.initializeSupportsSync()
-
-			// Then
-			Expect(mgr.SupportsSync()).To(Equal(false))
-		})
 		It("should be true when minor version greater", func() {
 			// Given
-			mgr.majorVersion = majorVersionSupportsSync
-			mgr.minorVersion = minorVersionSupportsSync + 1
+			err := mgr.parseConmonVersion("2.1.18")
+			Expect(err).To(BeNil())
 
 			// When
 			mgr.initializeSupportsSync()
@@ -164,9 +140,8 @@ var _ = t.Describe("ConmonManager", func() {
 		})
 		It("should be false when patch version less", func() {
 			// Given
-			mgr.majorVersion = majorVersionSupportsSync
-			mgr.minorVersion = minorVersionSupportsSync
-			mgr.patchVersion = patchVersionSupportsSync - 1
+			err := mgr.parseConmonVersion("2.0.18")
+			Expect(err).To(BeNil())
 
 			// When
 			mgr.initializeSupportsSync()
@@ -176,9 +151,8 @@ var _ = t.Describe("ConmonManager", func() {
 		})
 		It("should be true when patch version greater", func() {
 			// Given
-			mgr.majorVersion = majorVersionSupportsSync
-			mgr.minorVersion = minorVersionSupportsSync
-			mgr.patchVersion = patchVersionSupportsSync + 1
+			err := mgr.parseConmonVersion("2.0.20")
+			Expect(err).To(BeNil())
 
 			// When
 			mgr.initializeSupportsSync()
@@ -188,9 +162,8 @@ var _ = t.Describe("ConmonManager", func() {
 		})
 		It("should be true when version equal", func() {
 			// Given
-			mgr.majorVersion = majorVersionSupportsSync
-			mgr.minorVersion = minorVersionSupportsSync
-			mgr.patchVersion = patchVersionSupportsSync
+			err := mgr.parseConmonVersion("2.0.19")
+			Expect(err).To(BeNil())
 
 			// When
 			mgr.initializeSupportsSync()


### PR DESCRIPTION
Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


 /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
