### PR TITLE
Assorted test fixes (might help CI flakes)

### DIFF
--- a/test/critest.bats
+++ b/test/critest.bats
@@ -24,7 +24,5 @@ function teardown() {
                 --ginkgo.skip="${CRI_SKIP}" \
                 --ginkgo.flakeAttempts=3 >&3
 
-    [ "$status" -eq 0 ]
-
     stop_crio
 }

--- a/test/critest.bats
+++ b/test/critest.bats
@@ -3,7 +3,12 @@
 load helpers
 
 function setup() {
+    if [[ -z $RUN_CRITEST ]]; then
+        skip "critest because RUN_CRITEST is not set"
+    fi
+
     setup_test
+    start_crio
 }
 
 function teardown() {
@@ -11,18 +16,10 @@ function teardown() {
 }
 
 @test "run the critest suite" {
-    if [[ -z $RUN_CRITEST ]]; then
-        skip "critest because RUN_CRITEST is not set"
-    fi
-
-    start_crio
-
     critest --parallel 8 \
                 --runtime-endpoint "${CRIO_SOCKET}" \
                 --image-endpoint "${CRIO_SOCKET}" \
                 --ginkgo.focus="${CRI_FOCUS}" \
                 --ginkgo.skip="${CRI_SKIP}" \
                 --ginkgo.flakeAttempts=3 >&3
-
-    stop_crio
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -577,27 +577,15 @@ function get_host_ip() {
 
 function ping_pod() {
     ipv4=$(parse_pod_ipv4 "$1")
-    if output=$(ping -W 1 -c 5 "$ipv4"); then
-        echo "$output"
-    else
-        exit 1
-    fi
+    ping -W 1 -c 5 "$ipv4"
 
     ipv6=$(parse_pod_ipv6 "$1")
-    if output=$(ping6 -W 1 -c 5 "$ipv6"); then
-        echo "$output"
-    else
-        exit 1
-    fi
+    ping6 -W 1 -c 5 "$ipv6"
 }
 
 function ping_pod_from_pod() {
     ipv4=$(parse_pod_ipv4 "$1")
-    if output=$(run crictl exec --sync "$2" ping -W 1 -c 2 "$ipv4"); then
-        echo "$output"
-    else
-        exit 1
-    fi
+    crictl exec --sync "$2" ping -W 1 -c 2 "$ipv4"
 
     # since RHEL kernels don't mirror ipv4.ip_forward sysctl to ipv6, this fails
     # in such an environment without giving all containers NET_RAW capability
@@ -607,11 +595,7 @@ function ping_pod_from_pod() {
         return
     fi
     ipv6=$(parse_pod_ipv6 "$1")
-    if output=$(run crictl exec --sync "$2" ping6 -W 1 -c 2 "$ipv6"); then
-        echo "$output"
-    else
-        exit 1
-    fi
+    crictl exec --sync "$2" ping6 -W 1 -c 2 "$ipv6"
 }
 
 function cleanup_network_conf() {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -325,7 +325,7 @@ function setup_crio() {
 }
 
 function pull_test_containers() {
-    if ! run crictl inspecti quay.io/crio/redis:alpine; then
+    if ! crictl inspecti quay.io/crio/redis:alpine; then
         crictl pull quay.io/crio/redis:alpine
     fi
     REDIS_IMAGEID=$(crictl inspecti --output=table quay.io/crio/redis:alpine | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
@@ -333,25 +333,25 @@ function pull_test_containers() {
     REDIS_IMAGEREF=$(crictl inspecti --output=table quay.io/crio/redis:alpine | grep ^Digest: | head -n 1 | sed -e "s/Digest: //g")
     export REDIS_IMAGEREF
 
-    if ! run crictl inspecti quay.io/crio/oom; then
+    if ! crictl inspecti quay.io/crio/oom; then
         crictl pull quay.io/crio/oom
     fi
     OOM_IMAGEID=$(crictl inspecti quay.io/crio/oom | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
     export OOM_IMAGEID
 
-    if ! run crictl inspecti quay.io/crio/stderr-test; then
+    if ! crictl inspecti quay.io/crio/stderr-test; then
         crictl pull quay.io/crio/stderr-test:latest
     fi
     STDERR_IMAGEID=$(crictl inspecti quay.io/crio/stderr-test | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
     export STDERR_IMAGEID
 
-    if ! run crictl inspecti quay.io/crio/busybox; then
+    if ! crictl inspecti quay.io/crio/busybox; then
         crictl pull quay.io/crio/busybox:latest
     fi
     BUSYBOX_IMAGEID=$(crictl inspecti quay.io/crio/busybox | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
     export BUSYBOX_IMAGEID
 
-    if ! run crictl inspecti quay.io/crio/image-volume-test; then
+    if ! crictl inspecti quay.io/crio/image-volume-test; then
         crictl pull quay.io/crio/image-volume-test:latest
     fi
     VOLUME_IMAGEID=$(crictl inspecti quay.io/crio/image-volume-test | grep ^ID: | head -n 1 | sed -e "s/ID: //g")

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -246,13 +246,13 @@ function retry() {
     local i
 
     for ((i = 0; i < attempts; i++)); do
-        if run "$@"; then
+        if "$@"; then
             return 0
         fi
         sleep "$delay"
     done
 
-    echo "Command \"$*\" failed $attempts times. Output: $output"
+    echo "Command \"$*\" failed $attempts times"
     false
 }
 


### PR DESCRIPTION
/kind failing-test

#### What this PR does / why we need it:

A set of few fixes related to using bats' `run` function in the tests.
These are real fixes, not some refactoring or code style improvements.

##### 1. test/pull_test_containers: fix
    
Using `if ! run cmd` is useless as `run` always succeeds (and puts the
exit code of `cmd` to `$status`. Remove it.

##### 2. test/ping_pod_from_pod: fix
    
1. The bats `run` command always returns 0 exit code, so
       `ping_pod_from_pod` never tested anything, as it always succeeded.
    
2. Using `$output=$(run cmd)` is wrong, since `run` assigns the output
       itself, and do not print anything per se (so `$output` is always
       empty in this case).
    
3. Using `exit 1` from the function is excessive.
    
4. There is no need for the whole `if ... ` construct, as bats tests are
       run with `set -e` and if the ping fails the test will fail.
    
Fix the `ping_pod` in the same way.

##### 3. test/wait_until_reachable: fix
    
Commit 39aef1a09c1ad broke the command exit code check,
as `run` always returns 0.
    
Fix: do not use run.
    
This might help some CI flakes :crossed_fingers: 

##### 4. critest.bats wrong $status check

Variable `$output` is only set by the `run` function provided by bats.
Since we're not using `run` here, it does not make sense to check
$output, more to say, it is dangerous because it leads to test failure
(as most probably `$output` is unset and so check is failing).
    
This fixes the following issue:
    
     ...
     Ran 74 of 81 Specs in 57.964 seconds
     SUCCESS! -- 74 Passed | 0 Failed | 1 Flaked | 0 Pending | 7 Skipped
    
     Ginkgo ran 1 suite in 58.01304415s
     Test Suite Passed
     PASS
     not ok 1 run the critest suite
     # (in test file critest.bats, line 27)
     #   `[ "$status" -eq 0 ]' failed with status 2
     #

##### 5. test/critest.bats: move setup/cleanup out of test

This change results in

1. Not doing any unnecessary preparation steps in case we're going to
   skip the test.

2. Making sure cleanup is performed even if the test fails.

Note that stop_crio is in cleanup_test so there's no need to call it
again explicitly.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
