### PR TITLE
Add fidencio to OWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,5 @@
 # KEEP THIS FILE SORTED. Order is important. Last match takes precedence.
 
 *                                       @mrunalp @runcom
+internal/oci/runtime_vm.go              @fidencio
 pkg/storage/**                          @nalind @runcom @rhatdan

--- a/OWNERS
+++ b/OWNERS
@@ -10,3 +10,4 @@ approvers:
   - saschagrunert
   - vrothberg
   - haircommander
+  - fidencio


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

#### What this PR does / why we need it:
I've been working in the VM runtime type, and would like to officially
become responsible for this area.

Contributions made so far:
* runtime_vm: Apply the correct label before the sandbox is created
  - https://github.com/cri-o/cri-o/pull/3889
* Add runtume_type as an option of "--runtimes"
  - https://github.com/cri-o/cri-o/pull/3903
* runtime_vm: Ignore ttrpc.ErrClosed when shutting the container down
  - https://github.com/cri-o/cri-o/pull/3924
* runtimeVM: Improve CreateContainer cleanup in case of failures
  - https://github.com/cri-o/cri-o/pull/3956
* runtime_vm: Avoid possible deadlock on UpdateContainerStatus()
  - https://github.com/cri-o/cri-o/pull/3987
* runtimeVM: Cleanup a "Completed" container
  - https://github.com/cri-o/cri-o/pull/3998
* runtimeVM: Store logs again, and store them in the correct format
  - https://github.com/cri-o/cri-o/pull/4082
* And a bunch of backports ...

My main goal is to have the VM runtime type in a good shape so we can
have it properly tested & used on the kata side.

Together with the addition to the OWNERS file, I'm also adding myself to
the CODEOWNERS file, in order to automatically be added as a reviewer to
pull requests related to the VM runtime type.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
