### PR TITLE
Validate that apparmor_parser binary is available on the host

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -832,6 +832,10 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 		if !c.cgroupManager.IsSystemd() && c.ConmonCgroup != "pod" && c.ConmonCgroup != "" {
 			return errors.New("cgroupfs manager conmon cgroup should be 'pod' or empty")
 		}
+
+		if err := c.apparmorConfig.Validate(); err != nil {
+			return errors.Wrap(err, "validate AppArmor config")
+		}
 	}
 
 	return nil


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
If AppArmor is enabled, then we now pre-check on CRI-O startup if the
`apparmor_parser` binary is either in `/sbin` or in `$PATH`. This way we
can let the user know that there is still a missing runtime dependency.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added validation of the existence of the `apparmor_parser` binary (either in `/sbin` or in `$PATH`) on CRI-O start, if the feature is enabled by the build or the host.
```
