### PR TITLE
handle runc not present on the system

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -452,9 +452,15 @@ func (c *Config) UpdateFromFile(path string) error {
 	t := new(tomlConfig)
 	t.fromConfig(c)
 
-	_, err = toml.Decode(string(data), t)
+	metadata, err := toml.Decode(string(data), t)
 	if err != nil {
 		return fmt.Errorf("unable to decode configuration %v: %v", path, err)
+	}
+
+	runtimesKey := []string{"crio", "runtime", "default_runtime"}
+	if metadata.IsDefined(runtimesKey...) &&
+		t.Crio.Runtime.RuntimeConfig.DefaultRuntime != defaultRuntime {
+		delete(c.Runtimes, defaultRuntime)
 	}
 
 	t.toConfig(c)

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -110,7 +110,8 @@ grpc_max_recv_msg_size = {{ .GRPCMaxRecvMsgSize }}
 {{ range $ulimit := .DefaultUlimits }}{{ printf "#\t%q,\n" $ulimit }}{{ end }}#]
 
 # default_runtime is the _name_ of the OCI runtime to be used as the default.
-# The name is matched against the runtimes map below.
+# The name is matched against the runtimes map below. If this value is changed,
+# the corresponding existing entry from the runtimes map below will be ignored.
 default_runtime = "{{ .DefaultRuntime }}"
 
 # If true, the runtime will not use pivot_root, but instead use MS_MOVE.


### PR DESCRIPTION


Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

https://github.com/cri-o/cri-o/commit/91d3d2791ce348098ba0a6a731f5809a060a1a67 introduced a regression that would cause CRIO to fail at startup if the `runc` binary is not present on the system. 

This PR attempts to preserve the changes brought in by https://github.com/cri-o/cri-o/commit/91d3d2791ce348098ba0a6a731f5809a060a1a67 as well as fix the https://github.com/cri-o/cri-o/issues/4069
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #4069 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If the default_runtime is changed from the default configuration, the corresponding existing default entry in the runtime map in the configuration will be ignored. 
```
