### PR TITLE
Switch to Kubernetes AppArmor unconfined const

### DIFF
--- a/internal/config/apparmor/apparmor.go
+++ b/internal/config/apparmor/apparmor.go
@@ -9,12 +9,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-const (
-	// DefaultProfile is the default profile name
-	DefaultProfile = "crio-default"
-
-	unconfined = "unconfined"
-)
+// DefaultProfile is the default profile name
+const DefaultProfile = "crio-default"
 
 // Config is the global AppArmor configuration type
 type Config struct {
@@ -38,9 +34,9 @@ func (c *Config) LoadProfile(profile string) error {
 		return nil
 	}
 
-	if profile == unconfined {
+	if profile == v1.AppArmorBetaProfileNameUnconfined {
 		logrus.Info("AppArmor profile is unconfined which basically disables it")
-		c.defaultProfile = unconfined
+		c.defaultProfile = v1.AppArmorBetaProfileNameUnconfined
 		return nil
 	}
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This makes the definition of an own `unconfined` value obsolete by
sticking to the predefined ones in Kubernetes.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
