### PR TITLE
tests: support default runtime different from runc

### DIFF
--- a/test/command.bats
+++ b/test/command.bats
@@ -3,20 +3,20 @@
 load helpers
 
 @test "crio commands" {
-	run ${CRIO_BINARY_PATH} -c /dev/null config > /dev/null
+	run crio -c /dev/null config > /dev/null
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run ${CRIO_BINARY_PATH} badoption > /dev/null
+	run crio badoption > /dev/null
 	echo "$output"
 	[ "$status" -ne 0 ]
 }
 
 @test "invalid ulimits" {
-	run ${CRIO_BINARY_PATH} --default-ulimits doesntexist=2042
+	run crio --default-ulimits doesntexist=2042
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"invalid ulimit type: doesntexist"* ]]
-	run ${CRIO_BINARY_PATH} --default-ulimits nproc=2042:42
+	run crio --default-ulimits nproc=2042:42
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"ulimit soft limit must be less than or equal to hard limit: 2042 > 42"* ]]
@@ -25,15 +25,15 @@ load helpers
 }
 
 @test "invalid devices" {
-	run ${CRIO_BINARY_PATH} --additional-devices /dev/sda:/dev/foo:123
+	run crio --additional-devices /dev/sda:/dev/foo:123
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"invalid device mode:"* ]]
-	run ${CRIO_BINARY_PATH} --additional-devices /dev/sda:/dee/foo:rm
+	run crio --additional-devices /dev/sda:/dee/foo:rm
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"invalid device mode:"* ]]
-	run ${CRIO_BINARY_PATH} --additional-devices /dee/sda:rmw
+	run crio --additional-devices /dee/sda:rmw
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"invalid device mode:"* ]]
@@ -42,11 +42,11 @@ load helpers
 @test "invalid metrics port" {
 	mkdir -p "$TESTDIR/cni/net.d"
 	opt="--cni-config-dir $TESTDIR/cni/net.d"
-	run ${CRIO_BINARY_PATH} ${opt} --metrics-port foo --enable-metrics
+	run crio ${opt} --metrics-port foo --enable-metrics
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *'invalid value "foo" for flag'* ]]
-	run ${CRIO_BINARY_PATH} ${opt} --metrics-port 18446744073709551616 --enable-metrics
+	run crio ${opt} --metrics-port 18446744073709551616 --enable-metrics
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"value out of range"* ]]
@@ -55,7 +55,7 @@ load helpers
 @test "invalid log max" {
 	mkdir -p "$TESTDIR/cni/net.d"
 	opt="--cni-config-dir $TESTDIR/cni/net.d"
-	run ${CRIO_BINARY_PATH} ${opt} --log-size-max foo
+	run crio ${opt} --log-size-max foo
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *'invalid value "foo" for flag'* ]]
@@ -65,17 +65,17 @@ load helpers
 	mkdir -p "$TESTDIR/cni/net.d"
 	opt="--cni-config-dir $TESTDIR/cni/net.d"
 	# log size max is special zero value
-	run ${CRIO_BINARY_PATH} ${opt} --log-size-max 0
+	run crio ${opt} --log-size-max 0
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"log size max should be negative or >= 8192"* ]]
 	# log size max is less than 8192 and more than 0
-	run ${CRIO_BINARY_PATH} ${opt} --log-size-max 8191
+	run crio ${opt} --log-size-max 8191
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"log size max should be negative or >= 8192"* ]]
 	# log size max is out of the range of 64-bit signed integers
-	run ${CRIO_BINARY_PATH} ${opt} --log-size-max 18446744073709551616
+	run crio ${opt} --log-size-max 18446744073709551616
 	echo $output
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"value out of range"* ]]

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -223,7 +223,7 @@ function setup_test() {
 # Run crio using the binary specified by $CRIO_BINARY_PATH.
 # This must ONLY be run on engines created with `start_crio`.
 function crio() {
-    "$CRIO_BINARY_PATH" --listen "$CRIO_SOCKET" "$@"
+    "$CRIO_BINARY_PATH" --listen "$CRIO_SOCKET" --runtimes "$RUNTIME_NAME:$RUNTIME_BINARY:$RUNTIME_ROOT:$RUNTIME_TYPE" "$@"
 }
 
 # Run crictl using the binary specified by $CRICTL_BINARY.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When running the tests specifing a different runtime, like, e.g.:
 $> CONTAINER_DEFAULT_RUNTIME=crun \
    RUNTIME_NAME=crun \
    CONTAINER_RUNTIME=crun \
    RUNTIME_ROOT=/run/containers \
    make localintegration
some tests (command.bats and config_migrate.bats) call the crio binary
without passing the RUNTIME_NAME, CONTAINER_RUNTIME and the RUNTIME_ROOT
environment variables, while CONTAINER_DEFAULT_RUNTIME is taken up
directly by the crio binary. This will cause the test to fail as the
default runtime is not found in the config.

(in test file test/command.bats, line 71)
 `[[ "$output" == *"log size max should be negative or >= 8192"* ]]' failed
time="2020-08-18 14:27:11.944731362+02:00" level=info msg="Node configuration value for hugetlb cgroup is true" time="2020-08-18 14:27:11.944804578+02:00" level=info msg="Node configuration value for pid cgroup is true" time="2020-08-18 14:27:11.944824466+02:00" level=info msg="Node configuration value for memoryswap cgroup is true" time="2020-08-18 14:27:11.950071414+02:00" level=info msg="Node configuration value for systemd CollectMode is true" time="2020-08-18 14:27:11.950143720+02:00" level=fatal msg="Validating runtime config: default_runtime set to \"crun\", but no runtime entry was found for it"


#### Which issue(s) this PR fixes:
 None

#### Special notes for your reviewer:
This looked to me as the best approach to deal with tests that need to call the CRI-O binary directly if we want to support running integration tests with different runtimes than runc.

#### Does this PR introduce a user-facing change?

None
