### PR TITLE
test: reconfigure how runtimes are passed in

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -15,7 +15,7 @@ Integration tests are written in *bash* using the
 
 ### Containerized tests
 
-The easiest way to run integration tests is with Docker:
+The easiest way to run integration tests is with Podman:
 ```
 $ make integration
 ```
@@ -70,11 +70,16 @@ Tests on the host will run with `runc` as the default runtime.
 However you can select other OCI compatible runtimes by setting
 the `RUNTIME` environment variable.
 
-For example one could use the [Clear Containers](https://github.com/clearcontainers/runtime)
-runtime instead of `runc`:
-
+For example, to use [crun](https://github.com/containers/crun) instead of `runc`:
 ```
-make localintegration RUNTIME=cc-runtime
+make CONTAINER_DEFAULT_RUNTIME=crun localintegration
+```
+
+If you'd like to run the tests with a runtime of a different type, you need to also specify `$RUNTIME_TYPE`
+
+For example, to use [kata](https://github.com/kata-containers/runtime) with shim v2:
+```
+make CONTAINER_DEFAULT_RUNTIME=containerd-shim-kata-v2 RUNTIME_TYPE=vm localintegration
 ```
 
 ## Writing integration tests

--- a/test/config.bats
+++ b/test/config.bats
@@ -41,6 +41,7 @@ function teardown() {
 
 @test "replace default runtime should succeed" {
 	# when
+	unset CONTAINER_RUNTIMES
 	RES=$("$CRIO_BINARY_PATH" -d "$TESTDATA"/50-crun-default.conf config 2>&1)
 
 	# then

--- a/test/devices.bats
+++ b/test/devices.bats
@@ -20,7 +20,7 @@ function create_device_runtime() {
 [crio.runtime]
 default_runtime = "device"
 [crio.runtime.runtimes.device]
-runtime_path = "$RUNTIME_BINARY"
+runtime_path = "$RUNTIME_BINARY_PATH"
 runtime_root = "$RUNTIME_ROOT"
 runtime_type = "$RUNTIME_TYPE"
 allowed_annotations = ["io.kubernetes.cri-o.Devices"]

--- a/test/drop_infra.bats
+++ b/test/drop_infra.bats
@@ -21,7 +21,7 @@ function teardown() {
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_no_infra.json
 	pod_id=$(crictl runp "$TESTDIR"/sandbox_no_infra.json)
 
-	output=$("$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list)
+	output=$(runtime list)
 	[[ ! "$output" = *"$pod_id"* ]]
 }
 
@@ -30,6 +30,6 @@ function teardown() {
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_no_infra.json
 	pod_id=$(crictl runp "$TESTDIR"/sandbox_no_infra.json)
 
-	output=$("$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list)
+	output=$(runtime list)
 	[[ "$output" = *"$pod_id"* ]]
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -263,11 +263,6 @@ function setup_crio() {
     CNI_DEFAULT_NETWORK=${CNI_DEFAULT_NETWORK:-crio}
     CNI_TYPE=${CNI_TYPE:-bridge}
 
-    # Workaround for https://github.com/containers/crun/pull/531.
-    # TODO: remove once crun > 0.15 is released and used here.
-    if $RUNTIME_BINARY --version | grep -q '^crun '; then
-        OVERRIDE_OPTIONS="$OVERRIDE_OPTIONS --selinux=false"
-    fi
     RUNTIME_ROOT="$TESTDIR/crio-runtime-root"
 
     # shellcheck disable=SC2086

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -198,6 +198,11 @@ function crictl() {
     "$CRICTL_BINARY" -r "unix://$CRIO_SOCKET" -i "unix://$CRIO_SOCKET" "$@"
 }
 
+# Run the runtime binary with the specified RUNTIME_ROOT
+function runtime() {
+    "$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" "$@"
+}
+
 # Communicate with Docker on the host machine.
 # Should rarely use this.
 function docker_host() {

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -62,7 +62,7 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	"$CONTAINER_RUNTIME" delete -f "$pod_id"
+	runtime delete -f "$pod_id"
 
 	start_crio
 
@@ -79,8 +79,8 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	"$CONTAINER_RUNTIME" delete -f "$pod_id"
-	"$CONTAINER_RUNTIME" delete -f "$ctr_id"
+	runtime delete -f "$pod_id"
+	runtime delete -f "$ctr_id"
 
 	start_crio
 
@@ -98,8 +98,8 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	"$CONTAINER_RUNTIME" delete -f "$pod_id"
-	"$CONTAINER_RUNTIME" delete -f "$ctr_id"
+	runtime delete -f "$pod_id"
+	runtime delete -f "$ctr_id"
 
 	start_crio
 
@@ -118,7 +118,7 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	"$CONTAINER_RUNTIME" delete -f "$pod_id"
+	runtime delete -f "$pod_id"
 
 	start_crio
 
@@ -141,8 +141,8 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runc state going away
-	"$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" delete -f "$pod_id"
-	"$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" delete -f "$ctr_id"
+	runtime delete -f "$pod_id"
+	runtime delete -f "$ctr_id"
 
 	start_crio
 	output=$(crictl pods --quiet)
@@ -171,8 +171,8 @@ function teardown() {
 	stop_crio
 
 	# simulate reboot with runtime state and config.json going away
-	"$CONTAINER_RUNTIME" delete -f "$pod_id"
-	"$CONTAINER_RUNTIME" delete -f "$ctr_id"
+	runtime delete -f "$pod_id"
+	runtime delete -f "$ctr_id"
 	find "$TESTDIR"/ -name config.json -exec rm \{\} \;
 	find "$TESTDIR"/ -name shm -exec umount -l \{\} \;
 

--- a/test/shm_size.bats
+++ b/test/shm_size.bats
@@ -15,7 +15,7 @@ function create_shmsize_runtime() {
 [crio.runtime]
 default_runtime = "shmsize"
 [crio.runtime.runtimes.shmsize]
-runtime_path = "$RUNTIME_BINARY"
+runtime_path = "$RUNTIME_BINARY_PATH"
 runtime_root = "$RUNTIME_ROOT"
 runtime_type = "$RUNTIME_TYPE"
 allowed_annotations = ["io.kubernetes.cri-o.ShmSize"]

--- a/test/timeout.bats
+++ b/test/timeout.bats
@@ -58,7 +58,7 @@ function wait_clean() {
 	pods=$(crictl pods -q)
 	[[ -z "$pods" ]]
 
-	created_ctr_id=$("$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q)
+	created_ctr_id=$(runtime list -q)
 	[ -n "$created_ctr_id" ]
 
 	output=$(crictl runp "$TESTDATA"/sandbox_config.json)
@@ -81,7 +81,7 @@ function wait_clean() {
 	[[ -z "$ctrs" ]]
 
 	# cri-o should have created a container
-	created_ctr_id=$("$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q | grep -v "$pod_id")
+	created_ctr_id=$(runtime list -q | grep -v "$pod_id")
 	[ -n "$created_ctr_id" ]
 
 	output=$(crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
@@ -98,7 +98,7 @@ function wait_clean() {
 
 	wait_create
 
-	created_ctr_id=$("$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q)
+	created_ctr_id=$(runtime list -q)
 	[ -n "$created_ctr_id" ]
 
 	# we should create a new pod and not reuse the old one
@@ -108,7 +108,7 @@ function wait_clean() {
 	wait_clean
 
 	# the old, timed out container should have been removed
-	! "$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q | grep "$created_ctr_id"
+	! runtime list -q | grep "$created_ctr_id"
 }
 
 @test "should clean up container after timeout if request changes" {
@@ -123,7 +123,7 @@ function wait_clean() {
 	wait_create
 
 	# cri-o should have created a container
-	created_ctr_id=$("$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q | grep -v "$pod_id")
+	created_ctr_id=$(runtime list -q | grep -v "$pod_id")
 	[ -n "$created_ctr_id" ]
 
 	# should create a new container and not reuse the old one
@@ -133,7 +133,7 @@ function wait_clean() {
 	wait_clean
 
 	# the old, timed out container should have been removed
-	! "$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q | grep "$created_ctr_id"
+	! runtime list -q | grep "$created_ctr_id"
 }
 
 @test "should clean up pod after timeout if not re-requested" {
@@ -151,7 +151,7 @@ function wait_clean() {
 	[[ -z "$pods" ]]
 
 	# pod should have been cleaned up
-	[[ -z $("$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q) ]]
+	[[ -z $(runtime list -q) ]]
 
 	# we should recreate the pod and not reuse the old one
 	crictl runp "$TESTDATA"/sandbox_config.json
@@ -173,7 +173,7 @@ function wait_clean() {
 	[[ -z "$ctrs" ]]
 
 	# container should have been cleaned up
-	! "$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q | grep -v "$pod_id"
+	! runtime list -q | grep -v "$pod_id"
 
 	# we should recreate the container and not reuse the old one
 	crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json
@@ -193,7 +193,7 @@ function wait_clean() {
 	wait_create
 
 	# container should not have been cleaned up
-	created_ctr_id=$("$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q)
+	created_ctr_id=$(runtime list -q)
 	[ -n "$created_ctr_id" ]
 
 	! crictl create "$created_ctr_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json
@@ -213,7 +213,7 @@ function wait_clean() {
 	wait_create
 
 	# cri-o should have created a container
-	created_ctr_id=$("$CONTAINER_RUNTIME" --root "$RUNTIME_ROOT" list -q | grep -v "$pod_id")
+	created_ctr_id=$(runtime list -q | grep -v "$pod_id")
 	[ -n "$created_ctr_id" ]
 
 	! crictl start "$created_ctr_id"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

 /kind cleanup


#### What this PR does / why we need it:
As well as update documentation describing how to specify an alternative runtime
And fix some inconsistencies in how the runtime is called in restore.bats

Signed-off-by: Peter Hunt <pehunt@redhat.com>
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
replaces https://github.com/cri-o/cri-o/pull/4099
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
