### PR TITLE
Unset GOSUMDB when vendoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ ${SHELLCHECK}:
 	sha256sum ${SHELLCHECK} | grep -q $$SHA256SUM
 
 vendor:
-	export GO111MODULE=on \
+	export GO111MODULE=on GOSUMDB= \
 		$(GO) mod tidy && \
 		$(GO) mod vendor && \
 		$(GO) mod verify


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If the GOSUMDB cache is not up to date remotely a vendoring errors with:

```
go: github.com/containers/common@v0.14.7/go.mod: verifying module: invalid GOSUMDB: malformed verifier id
```

To aviod such failures in the future we now unset the GOSUMDB variable
which forces golang to use the plain upstream address.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
