### PR TITLE
Fix git-validation by always using HEAD^

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,9 @@ SHELLCHECK := ${BUILD_BIN_PATH}/shellcheck
 ifeq ($(shell bash -c '[[ `command -v git` && `git rev-parse --git-dir 2>/dev/null` ]] && echo true'), true)
 	COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 	GIT_TREE_STATE := $(if $(shell git status --porcelain --untracked-files=no),dirty,clean)
-	GIT_MERGE_BASE := $(shell git merge-base origin/master $(shell git rev-parse --abbrev-ref HEAD))
 else
 	COMMIT_NO := unknown
 	GIT_TREE_STATE := unknown
-	GIT_MERGE_BASE := HEAD^
 endif
 
 # pass crio CLI options to generate custom configuration options at build time
@@ -506,7 +504,7 @@ uninstall:
 git-validation: .gopathok ${GIT_VALIDATION}
 	GIT_CHECK_EXCLUDE="vendor" \
 		${GIT_VALIDATION} -v -run DCO,short-subject,dangling-whitespace \
-			-range ${GIT_MERGE_BASE}..HEAD
+			-range HEAD^..HEAD
 
 docs-validation:
 	$(GO_RUN) -tags "$(BUILDTAGS)" ./test/docs-validation


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The merge base is wrong for release branches. To decrease the complexity
we now just use the HEAD^ commit and assume that a PR consists of one
commit.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
git-validation is currently broken for release-1.19. So we might also
/cherrypick release-1.19
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
