### PR TITLE
[1.11 backport] RunAsGroup fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,10 @@ install.tools: .install.gitvalidation .install.gometalinter .install.md2man .ins
 
 .install.release:
 	if [ ! -x "$(GOPATH)/bin/release-tool" ]; then \
-		go get -u github.com/containerd/release-tool; \
+		go get -d github.com/containerd/release-tool \
+		&& cd $(GOPATH)/src/github.com/containerd/release-tool \
+		&& git checkout 1808a54cbad02b6c565f0175e98a43e7497a9318 \
+		&& go install github.com/containerd/release-tool; \
 	fi
 
 .install.gitvalidation: .gopathok

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -531,12 +531,13 @@ func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.Linux
 	logrus.Debugf("CONTAINER USER: %+v", containerUser)
 
 	// Add uid, gid and groups from user
-	uid, _, addGroups, err := getUserInfo(rootfs, containerUser)
+	uid, gid, addGroups, err := getUserInfo(rootfs, containerUser)
 	if err != nil {
 		return err
 	}
 
 	specgen.SetProcessUID(uid)
+	specgen.SetProcessGID(gid)
 	if sc.GetRunAsGroup() != nil {
 		specgen.SetProcessGID(uint32(sc.GetRunAsGroup().GetValue()))
 	}


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

This is a backport of PR #2091 (which itself is a backport of PRs #1898 and #2090) to 1.11 branch, fixing supplementary container user groups.

#### Which issue(s) this PR fixes:

Should fix https://bugzilla.redhat.com/show_bug.cgi?id=1782105

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix supplementary container user groups
```
