### PR TITLE
Refactor hostport manager into own package

### DIFF
--- a/internal/hostport/hostport.go
+++ b/internal/hostport/hostport.go
@@ -1,0 +1,75 @@
+package hostport
+
+import (
+	"net"
+
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
+	iptablesproxy "k8s.io/kubernetes/pkg/proxy/iptables"
+	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	utilexec "k8s.io/utils/exec"
+)
+
+// Manager is the main structure of this package.
+type Manager struct {
+	v4 hostport.HostPortManager
+}
+
+// New creates a new hostport.Manager instance.
+func New() *Manager {
+	iptInterface := utiliptables.New(utilexec.New(), utiliptables.ProtocolIPv4)
+	if _, err := iptInterface.EnsureChain(
+		utiliptables.TableNAT, iptablesproxy.KubeMarkMasqChain,
+	); err != nil {
+		logrus.Warnf("Unable to ensure iptables chain: %v", err)
+	}
+	v4 := hostport.NewHostportManager(iptInterface)
+
+	return &Manager{v4}
+}
+
+// Add can be used to add a new hostport mapping to the provided sandbox.
+func (m *Manager) Add(sb *sandbox.Sandbox, ip net.IP) (err error) {
+	if sb == nil {
+		return errors.New("sandbox is nil")
+	}
+
+	mapping := &hostport.PodPortMapping{
+		Name:         sb.Name(),
+		PortMappings: sb.PortMappings(),
+		IP:           ip,
+		HostNetwork:  false,
+	}
+
+	// use the corresponding IP family hostportManager for the IP
+	if err := m.v4.Add(sb.ID(), mapping, "lo"); err != nil {
+		return errors.Wrapf(
+			err, "add hostport mapping for sandbox %s (%s)", sb.Name(), sb.ID(),
+		)
+	}
+
+	return nil
+}
+
+// Remove can be used to delete a hostport mapping from the provided sandbox.
+func (m *Manager) Remove(sb *sandbox.Sandbox) (err error) {
+	if sb == nil {
+		return errors.New("sandbox is nil")
+	}
+
+	mapping := &hostport.PodPortMapping{
+		Name:         sb.Name(),
+		PortMappings: sb.PortMappings(),
+		HostNetwork:  false,
+	}
+	if err := m.v4.Remove(sb.ID(), mapping); err != nil {
+		return errors.Wrapf(
+			err,
+			"remove hostport mapping for sandbox %s (%s)", sb.Name(), sb.ID(),
+		)
+	}
+
+	return nil
+}

--- a/internal/hostport/hostport_test.go
+++ b/internal/hostport/hostport_test.go
@@ -1,0 +1,112 @@
+package hostport_test
+
+import (
+	"net"
+	"time"
+
+	"github.com/cri-o/cri-o/internal/hostport"
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	k8sHostport "k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
+)
+
+// The actual test suite
+var _ = t.Describe("Hostport", func() {
+	var sut *hostport.Manager
+
+	BeforeEach(func() {
+		sut = hostport.New()
+		Expect(sut).NotTo(BeNil())
+	})
+
+	newSandbox := func(mappings []*k8sHostport.PortMapping) *sandbox.Sandbox {
+		sb, err := sandbox.New("sandboxID", "", "", "", "",
+			make(map[string]string), make(map[string]string), "", "",
+			&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
+			mappings, false, time.Now(), "")
+
+		Expect(err).To(BeNil())
+		Expect(sb).NotTo(BeNil())
+
+		return sb
+	}
+
+	t.Describe("Add", func() {
+		It("should succeed", func() {
+			// Given
+			sb := newSandbox(nil)
+
+			// When
+			err := sut.Add(sb, net.IPv4zero)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should fail when sandbox is nil", func() {
+			// Given
+			// When
+			err := sut.Add(nil, net.IPv4zero)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should fail for if mapping IP is missing", func() {
+			// Given
+			sb := newSandbox([]*k8sHostport.PortMapping{{
+				Name:          "test",
+				HostPort:      8080,
+				ContainerPort: 8080,
+				Protocol:      v1.ProtocolTCP,
+			}})
+
+			// When
+			err := sut.Add(sb, net.IPv4zero)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	t.Describe("Remove", func() {
+		It("should succeed", func() {
+			// Given
+			sb := newSandbox(nil)
+
+			// When
+			err := sut.Remove(sb)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should fail when sandbox is nil", func() {
+			// Given
+			// When
+			err := sut.Remove(nil)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should fail for if mapping IP is missing", func() {
+			// Given
+			sb := newSandbox([]*k8sHostport.PortMapping{{
+				Name:          "test",
+				HostPort:      8080,
+				ContainerPort: 8080,
+				Protocol:      v1.ProtocolTCP,
+			}})
+
+			// When
+			err := sut.Remove(sb)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+	})
+})

--- a/internal/hostport/suite_test.go
+++ b/internal/hostport/suite_test.go
@@ -1,0 +1,26 @@
+package hostport_test
+
+import (
+	"testing"
+
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestHostport runs the created specs
+func TestHostport(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "Hostport")
+}
+
+var t *TestFramework
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})

--- a/server/server.go
+++ b/server/server.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
@@ -30,10 +31,6 @@ import (
 	"github.com/sirupsen/logrus"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/cri/streaming"
-	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
-	iptablesproxy "k8s.io/kubernetes/pkg/proxy/iptables"
-	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	utilexec "k8s.io/utils/exec"
 )
 
 const (
@@ -54,7 +51,7 @@ type StreamService struct {
 type Server struct {
 	config          libconfig.Config
 	stream          StreamService
-	hostportManager hostport.HostPortManager
+	hostportManager *hostport.Manager
 
 	*lib.ContainerServer
 	monitorsChan      chan struct{}
@@ -335,12 +332,6 @@ func New(
 		return nil, err
 	}
 
-	iptInterface := utiliptables.New(utilexec.New(), utiliptables.ProtocolIPv4)
-	if _, err := iptInterface.EnsureChain(utiliptables.TableNAT, iptablesproxy.KubeMarkMasqChain); err != nil {
-		logrus.Warnf("unable to ensure iptables chain: %v", err)
-	}
-	hostportManager := hostport.NewHostportManager(iptInterface)
-
 	idMappings, err := getIDMappings(config)
 	if err != nil {
 		return nil, err
@@ -354,7 +345,7 @@ func New(
 
 	s := &Server{
 		ContainerServer:          containerServer,
-		hostportManager:          hostportManager,
+		hostportManager:          hostport.New(),
 		config:                   *config,
 		monitorsChan:             make(chan struct{}),
 		defaultIDMappings:        idMappings,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Both hostport managers are now part of a new package which can be
tested.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Follow-up of https://github.com/cri-o/cri-o/pull/4116
#### Special notes for your reviewer:
/cc @aojea 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```