### PR TITLE
Code clean up in containers_create_linux.go

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -213,6 +213,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 	if err := ctr.SetPrivileged(); err != nil {
 		return nil, err
 	}
+	securityContext := containerConfig.GetLinux().GetSecurityContext()
 
 	// creates a spec Generator with the default spec.
 	specgen, err := generate.New("linux")
@@ -317,9 +318,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 	if !ctr.Privileged() {
 		processLabel = containerInfo.ProcessLabel
 	}
-	hostIPC := containerConfig.GetLinux().GetSecurityContext().GetNamespaceOptions().GetIpc() == pb.NamespaceMode_NODE
-	hostPID := containerConfig.GetLinux().GetSecurityContext().GetNamespaceOptions().GetPid() == pb.NamespaceMode_NODE
-	hostNet := containerConfig.GetLinux().GetSecurityContext().GetNamespaceOptions().GetNetwork() == pb.NamespaceMode_NODE
+	hostIPC := securityContext.GetNamespaceOptions().GetIpc() == pb.NamespaceMode_NODE
+	hostPID := securityContext.GetNamespaceOptions().GetPid() == pb.NamespaceMode_NODE
+	hostNet := securityContext.GetNamespaceOptions().GetNetwork() == pb.NamespaceMode_NODE
 
 	// Don't use SELinux separation with Host Pid or IPC Namespace or privileged.
 	if hostPID || hostIPC {
@@ -389,7 +390,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 	// set this container's apparmor profile if it is set by sandbox
 	if s.Config().AppArmor().IsEnabled() && !ctr.Privileged() {
 		profile, err := s.Config().AppArmor().Apply(
-			containerConfig.GetLinux().GetSecurityContext().GetApparmorProfile(),
+			securityContext.GetApparmorProfile(),
 		)
 		if err != nil {
 			return nil, errors.Wrapf(err, "applying apparmor profile to container %s", containerID)
@@ -458,7 +459,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 		if ctr.Privileged() {
 			specgen.SetupPrivileged(true)
 		} else {
-			capabilities := linux.GetSecurityContext().GetCapabilities()
+			capabilities := securityContext.GetCapabilities()
 			// Ensure we don't get a nil pointer error if the config
 			// doesn't set any capabilities
 			if capabilities == nil {
@@ -472,11 +473,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 				return nil, err
 			}
 		}
-		specgen.SetProcessNoNewPrivileges(linux.GetSecurityContext().GetNoNewPrivs())
+		specgen.SetProcessNoNewPrivileges(securityContext.GetNoNewPrivs())
 
 		if !ctr.Privileged() {
-			// TODO(runcom): have just one of this var at the top of the function
-			securityContext := containerConfig.GetLinux().GetSecurityContext()
 			for _, mp := range []string{
 				"/proc/acpi",
 				"/proc/kcore",
@@ -522,12 +521,12 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 		return nil, errors.Wrap(err, "failed to configure namespaces in container create")
 	}
 
-	if containerConfig.GetLinux().GetSecurityContext().GetNamespaceOptions().GetPid() == pb.NamespaceMode_NODE {
+	if securityContext.GetNamespaceOptions().GetPid() == pb.NamespaceMode_NODE {
 		// kubernetes PodSpec specify to use Host PID namespace
 		if err := specgen.RemoveLinuxNamespace(string(rspec.PIDNamespace)); err != nil {
 			return nil, err
 		}
-	} else if containerConfig.GetLinux().GetSecurityContext().GetNamespaceOptions().GetPid() == pb.NamespaceMode_POD {
+	} else if securityContext.GetNamespaceOptions().GetPid() == pb.NamespaceMode_POD {
 		pidNsPath := sb.PidNsPath()
 		if pidNsPath == "" {
 			return nil, errors.New("PID namespace requested, but sandbox infra container invalid")
@@ -706,7 +705,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 	}
 	specgen.AddAnnotation(annotations.Annotations, string(kubeAnnotationsJSON))
 
-	spp := containerConfig.GetLinux().GetSecurityContext().GetSeccompProfilePath()
+	spp := securityContext.GetSeccompProfilePath()
 	if !ctr.Privileged() {
 		if err := s.setupSeccomp(ctx, &specgen, spp); err != nil {
 			return nil, err
@@ -746,7 +745,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 
 	// Setup user and groups
 	if linux != nil {
-		if err := setupContainerUser(ctx, &specgen, mountPoint, mountLabel, containerInfo.RunDir, linux.GetSecurityContext(), containerImageConfig); err != nil {
+		if err := setupContainerUser(ctx, &specgen, mountPoint, mountLabel, containerInfo.RunDir, securityContext, containerImageConfig); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION


Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup


#### What this PR does / why we need it:
Noticed there was a TODO to assign GetSecurityContext()
a variable and use that through out the create function.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```
