### PR TITLE
[release-1.18] Backport "Use the container_kvm_t label when using kata as the runtime" (and follow-ups)

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -961,20 +961,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		return nil, err
 	}
 
-	runtimeType, err := s.Runtime().ContainerRuntimeType(ociContainer)
-	if err != nil {
-		return nil, err
-	}
-	// If using kata runtime, the process label should be set to container_kvm_t
-	// Note: the requirement here is that the name used for the runtime class has "kata" in it
-	// or the runtime_type is set to "vm"
-	if runtimeType == libconfig.RuntimeTypeVM || strings.Contains(strings.ToLower(sb.RuntimeHandler()), "kata") {
-		processLabel, err = selinux.SELinuxKVMLabel(processLabel)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	specgen.SetLinuxMountLabel(mountLabel)
 	specgen.SetProcessSelinuxLabel(processLabel)
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -961,6 +961,20 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 		return nil, err
 	}
 
+	runtimeType, err := s.Runtime().ContainerRuntimeType(ociContainer)
+	if err != nil {
+		return nil, err
+	}
+	// If using kata runtime, the process label should be set to container_kvm_t
+	// Note: the requirement here is that the name used for the runtime class has "kata" in it
+	// or the runtime_type is set to "vm"
+	if runtimeType == libconfig.RuntimeTypeVM || strings.Contains(strings.ToLower(sb.RuntimeHandler()), "kata") {
+		processLabel, err = selinux.SELinuxKVMLabel(processLabel)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	specgen.SetLinuxMountLabel(mountLabel)
 	specgen.SetProcessSelinuxLabel(processLabel)
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -17,6 +17,7 @@ import (
 	current "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/cgroups"
+	selinux "github.com/containers/libpod/pkg/selinux"
 	"github.com/containers/storage"
 	"github.com/cri-o/cri-o/internal/lib"
 	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
@@ -491,6 +492,23 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if err != nil {
 		return nil, err
 	}
+
+	runtimeType, err := s.Runtime().ContainerRuntimeType(container)
+	if err != nil {
+		return nil, err
+	}
+	// If using kata runtime, the process label should be set to container_kvm_t
+	// Keep in mind that kata does *not* apply any process label to containers within the VM
+	// Note: the requirement here is that the name used for the runtime class has "kata" in it
+	// or the runtime_type is set to "vm"
+	if runtimeType == libconfig.RuntimeTypeVM || strings.Contains(strings.ToLower(runtimeHandler), "kata") {
+		processLabel, err = selinux.SELinuxKVMLabel(processLabel)
+		if err != nil {
+			return nil, err
+		}
+		g.SetProcessSelinuxLabel(processLabel)
+	}
+
 	container.SetMountPoint(mountPoint)
 
 	container.SetIDMappings(s.defaultIDMappings)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -487,7 +487,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation(annotations.HostnamePath, hostnamePath)
 	sb.AddHostnamePath(hostnamePath)
 
-	container, err := oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, s.config.PauseImage, "", "", nil, sbox.ID(), false, false, false, sb.RuntimeHandler(), podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+	container, err := oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, s.config.PauseImage, "", "", nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -22,7 +22,7 @@ import (
 	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
-	"github.com/cri-o/cri-o/pkg/config"
+	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/pkg/sandbox"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
@@ -746,7 +746,7 @@ func AddCgroupAnnotation(ctx context.Context, g generate.Generator, mountPath, c
 }
 
 // PauseCommand returns the pause command for the provided image configuration.
-func PauseCommand(cfg *config.Config, image *v1.Image) ([]string, error) {
+func PauseCommand(cfg *libconfig.Config, image *v1.Image) ([]string, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("provided configuration is nil")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:

In order to have take fully advantage of SELinux, would be good to have the commits enabling it on CRI-O side as part of release-1.18 as well (and not only 1.19).

While I know backporting features is not exactly the best practices, this only affects the VM runtime type and is a quite self-contained.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
