### PR TITLE
test/network.bats: fixes

### DIFF
--- a/test/inspect.bats
+++ b/test/inspect.bats
@@ -48,8 +48,8 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 
-	ipv4=$(parse_pod_ipv4 "$ctr_id")
-	ipv6=$(parse_pod_ipv6 "$ctr_id")
+	ipv4=$(pod_ip -4 "$ctr_id")
+	ipv6=$(pod_ip -6 "$ctr_id")
 	[[ "$out" == *"\"ip_addresses\":[\"$ipv4\",\"$ipv6\"]"* ]]
 	[[ "$output" == *"\"ip\": \"$ipv4\""* ]]
 

--- a/test/network.bats
+++ b/test/network.bats
@@ -13,26 +13,20 @@ function teardown() {
 
 @test "ensure correct hostname" {
 	start_crio
-	run crictl runp "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	pod_id="$output"
-	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -eq 0  ]
-	ctr_id="$output"
-	run crictl start "$ctr_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
 
 	run crictl exec --sync "$ctr_id" sh -c "hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"crictl_host"* ]]
+
 	run crictl exec --sync "$ctr_id" sh -c "echo \$HOSTNAME"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"crictl_host"* ]]
+
 	run crictl exec --sync "$ctr_id" sh -c "cat /etc/hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -41,28 +35,23 @@ function teardown() {
 
 @test "ensure correct hostname for hostnetwork:true" {
 	start_crio
-	hostnetworkconfig=$(cat "$TESTDATA"/sandbox_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["security_context"]["namespace_options"]["network"] = 2; obj["annotations"] = {}; obj["hostname"] = ""; json.dump(obj, sys.stdout)')
-	echo "$hostnetworkconfig" > "$TESTDIR"/sandbox_hostnetwork_config.json
-	run crictl runp "$TESTDIR"/sandbox_hostnetwork_config.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	pod_id="$output"
-	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/sandbox_hostnetwork_config.json
-	echo "$output"
-	[ "$status" -eq 0  ]
-	ctr_id="$output"
-	run crictl start "$ctr_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
+	python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["security_context"]["namespace_options"]["network"] = 2; obj["annotations"] = {}; obj["hostname"] = ""; json.dump(obj, sys.stdout)' \
+	< "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_hostnetwork_config.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_hostnetwork_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/sandbox_hostnetwork_config.json)
+	crictl start "$ctr_id"
 
 	run crictl exec --sync "$ctr_id" sh -c "hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"$HOSTNAME"* ]]
+
 	run crictl exec --sync "$ctr_id" sh -c "echo \$HOSTNAME"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"$HOSTNAME"* ]]
+
 	run crictl exec --sync "$ctr_id" sh -c "cat /etc/hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -71,29 +60,22 @@ function teardown() {
 
 @test "Check for valid pod netns CIDR" {
 	start_crio
-	run crictl runp "$TESTDATA"/sandbox_config.json
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+
+	run crictl exec --sync "$ctr_id" ip addr show dev eth0 scope global
 	echo "$output"
 	[ "$status" -eq 0 ]
-	pod_id="$output"
-
-	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -eq 0  ]
-	ctr_id="$output"
-
-    run crictl exec --sync $ctr_id ip addr show dev eth0 scope global 2>&1
-    echo "$output"
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ $POD_IPV4_CIDR_START ]]
-    [[ "$output" =~ $POD_IPV6_CIDR_START ]]
+	[[ "$output" = *"$POD_IPV4_CIDR_START"* ]]
+	[[ "$output" = *"$POD_IPV6_CIDR_START"* ]]
 }
 
 @test "Ensure correct CNI plugin namespace/name/container-id arguments" {
 	start_crio "" "prepare_plugin_test_args_network_conf"
-	run crictl runp "$TESTDATA"/sandbox_config.json
-	[ "$status" -eq 0 ]
+	crictl runp "$TESTDATA"/sandbox_config.json
 
-	. $TESTDIR/plugin_test_args.out
+	# shellcheck disable=SC1091
+	. "$TESTDIR"/plugin_test_args.out
 
 	[ "$FOUND_CNI_CONTAINERID" != "redhat.test.crio" ]
 	[ "$FOUND_CNI_CONTAINERID" != "podsandbox1" ]
@@ -103,26 +85,14 @@ function teardown() {
 
 @test "Connect to pod hostport from the host" {
 	start_crio
-	run crictl runp "$TESTDATA"/sandbox_config_hostport.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	pod_id="$output"
-
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config_hostport.json)
 	host_ip=$(get_host_ip)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_config_hostport.json "$TESTDATA"/sandbox_config_hostport.json)
+	crictl start "$ctr_id"
 
-	run crictl create "$pod_id" "$TESTDATA"/container_config_hostport.json "$TESTDATA"/sandbox_config_hostport.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	ctr_id="$output"
-	run crictl start "$ctr_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run nc -w 5 $host_ip 4888 </dev/null
+	run nc -w 5 "$host_ip" 4888 </dev/null
 	echo "$output"
 	[ "$output" = "crictl_host" ]
-	[ "$status" -eq 0 ]
-	run crictl stop "$ctr_id"
-	echo "$output"
 	[ "$status" -eq 0 ]
 }
 
@@ -138,19 +108,16 @@ function check_networking() {
 
 @test "Clean up network if pod sandbox fails" {
 	# TODO FIXME find a way for sandbox setup to fail if manage ns is true
-	cp $(which conmon) "$TESTDIR"/conmon
+	CONMON_BINARY="$TESTDIR"/conmon
+	cp "$(which conmon)" "$CONMON_BINARY"
 	CONTAINER_MANAGE_NS_LIFECYCLE=false \
 		CONTAINER_DROP_INFRA_CTR=false \
-		CONMON_BINARY="$TESTDIR"/conmon \
 		start_crio "" "prepare_plugin_test_args_network_conf"
 
 	# make conmon non-executable to cause the sandbox setup to fail after
 	# networking has been configured
-	chmod 0644 $TESTDIR/conmon
-	run crictl runp "$TESTDATA"/sandbox_config.json
-	chmod 0755 $TESTDIR/conmon
-	echo "$output"
-	[ "$status" -ne 0 ]
+	chmod 0644 "$CONMON_BINARY"
+	crictl runp "$TESTDATA"/sandbox_config.json && fail "expected runp to fail"
 
 	check_networking
 }
@@ -158,9 +125,7 @@ function check_networking() {
 @test "Clean up network if pod sandbox fails after plugin success" {
 	start_crio "" "prepare_plugin_test_args_network_conf_malformed_result"
 
-	run crictl runp "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -ne 0 ]
+	crictl runp "$TESTDATA"/sandbox_config.json && fail "expected runp to fail"
 
 	check_networking
 }

--- a/test/network_ping.bats
+++ b/test/network_ping.bats
@@ -12,40 +12,27 @@ function teardown() {
 }
 
 @test "Ping pod from the host" {
-    run crictl runp "$TESTDATA"/sandbox_config.json
-    echo "$output"
-    [ "$status" -eq 0 ]
-    pod_id="$output"
+    pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+    diag "pod $pod_id created"
+    ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_config_ping.json "$TESTDATA"/sandbox_config.json)
+    diag "ctr $ctr_id created"
 
-    run crictl create "$pod_id" "$TESTDATA"/container_config_ping.json "$TESTDATA"/sandbox_config.json
-    echo "$output"
-    [ "$status" -eq 0  ]
-    ctr_id="$output"
-
-    ping_pod $ctr_id
+    ping_pod "$ctr_id"
 }
 
 @test "Ping pod from another pod" {
-    run crictl runp "$TESTDATA"/sandbox_config.json
-    echo "$output"
-    [ "$status" -eq 0 ]
-    pod1_id="$output"
-    run crictl create "$pod1_id" "$TESTDATA"/container_config_ping.json "$TESTDATA"/sandbox_config.json
-    echo "$output"
-    [ "$status" -eq 0  ]
-    ctr1_id="$output"
+    pod1_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+    diag "pod1 $pod1_id created"
+    ctr1_id=$(crictl create "$pod1_id" "$TESTDATA"/container_config_ping.json "$TESTDATA"/sandbox_config.json)
+    diag "ctr1 $ctr1_id created"
 
     temp_sandbox_conf cni_test
 
-    run crictl runp "$TESTDIR"/sandbox_config_cni_test.json
-    echo "$output"
-    [ "$status" -eq 0 ]
-    pod2_id="$output"
-    run crictl create "$pod2_id" "$TESTDATA"/container_config_ping.json "$TESTDIR"/sandbox_config_cni_test.json
-    echo "$output"
-    [ "$status" -eq 0  ]
-    ctr2_id="$output"
+    pod2_id=$(crictl runp "$TESTDIR"/sandbox_config_cni_test.json)
+    diag "pod2 $pod2_id created"
+    ctr2_id=$(crictl create "$pod2_id" "$TESTDATA"/container_config_ping.json "$TESTDIR"/sandbox_config_cni_test.json)
+    diag "ctr2 $ctr2_id created"
 
-    ping_pod_from_pod $ctr1_id $ctr2_id
-    ping_pod_from_pod $ctr2_id $ctr1_id
+    ping_pod_from_pod "$ctr1_id" "$ctr2_id"
+    ping_pod_from_pod "$ctr2_id" "$ctr1_id"
 }


### PR DESCRIPTION
/kind bug
```release-note
NONE
```

### 1. test/network.bats: fix "clean up network" cases
    
Commit 58657488e31 replaced the last component of
/var/lib/cni/networks path to be $RANDOM_CNI_NETWORK,
while in fact it should be $CNI_DEFAULT_NETWORK.
    
The bug was never found because bats do not set -o pipefail
and so the non-zero exit code from ls was ignored.
    
While at it,
 - move the common checking code into a separate function;
 - fix network cleanup in teardown as well;
 - helpers.bash:
   - add `fail` helper;
   - remove useless `echo 0` from functions;
   - eliminate write_plugin_test_args_network_conf;
   - simplify prepare_plugin_test_args_network_conf_malformed_result;
   - get rid of RANDOM_CNI_NETWORK to avoid confusion.

### 2. test/network.bats: simplify, fix shellcheck

1. Simplify the code.

For example,

        run crictl start ...
        echo "$output"
        [ "$status" -eq 0 ]

is equivalent to

        crictl start ...

as it much easier to read (yes, bats runs tests with set -e
so there is an error check in place).

One more example,
        run crictl runp ...
        echo "$output"
        [ "$status" -eq 0 ]
        pod_id="$output"

is roughly equivalent to

        pod_id=$(crictl runp ...)

(except it does not print stdout, only stderr).

Another example,

        cfg=$(python .... < $input)
        echo "$cfg" > $output

is equivalent to

        python ... < $input > $output

and avoids the use of a temporary variable (saves some memory).

Finally,

        run crictl start ...
        echo "$output"
        [ "$status" -ne 0 ]

is equivalent to

        crictl start ... && false

2. Optimize use of `CONMON_BINARY` variable, and remove unneeded cleanup.

3. Fix indentation, add some vertical white-space for better readability.