### PR TITLE
`crio-shutdown.service`: Support Graceful Reboot for AIO Node

### DIFF
--- a/contrib/systemd/crio-shutdown.service
+++ b/contrib/systemd/crio-shutdown.service
@@ -2,13 +2,11 @@
 Description=Shutdown CRI-O containers before shutting down the system
 Wants=crio.service
 After=crio.service
-Documentation=man:crio(8)
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/rm -f /var/lib/crio/crio.shutdown
-ExecStop=/usr/bin/env bash -c "/usr/bin/mkdir /var/lib/crio; /usr/bin/touch /var/lib/crio/crio.shutdown"
 RemainAfterExit=yes
+ExecStop=/usr/local/bin/crictl rm -af
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/crio-wipe.service
+++ b/contrib/systemd/crio-wipe.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=CRI-O Auto Update Script
 Before=crio.service
-RequiresMountsFor=/var/lib/containers
+Wants=crio.service
 
 [Service]
+Type=oneshot
 EnvironmentFile=-/etc/sysconfig/crio
 ExecStart=/usr/local/bin/crio \
           $CRIO_CONFIG_OPTIONS \
@@ -12,8 +13,6 @@ ExecStart=/usr/local/bin/crio \
           $CRIO_NETWORK_OPTIONS \
           $CRIO_METRICS_OPTIONS \
           wipe
-
-Type=oneshot
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/crio.service
+++ b/contrib/systemd/crio.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Container Runtime Interface for OCI (CRI-O)
 Documentation=https://github.com/cri-o/cri-o
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target local-fs.target remote-fs.target time-sync.target
+After=network-online.target local-fs.target remote-fs.target time-sync.target
 
 [Service]
 Type=notify

--- a/contrib/test/ci/crio.service
+++ b/contrib/test/ci/crio.service
@@ -1,16 +1,16 @@
 [Unit]
-Description=Open Container Initiative Daemon
-Documentation=https://github.com/kubernetes-sigs/cri-o
-After=network-online.target
+Description=Container Runtime Interface for OCI (CRI-O)
+Documentation=https://github.com/cri-o/cri-o
+Wants=network-online.target local-fs.target remote-fs.target time-sync.target
+After=network-online.target local-fs.target remote-fs.target time-sync.target
 
 [Service]
 Type=notify
 EnvironmentFile=-/etc/sysconfig/crio
-EnvironmentFile=-/etc/sysconfig/crio-metrics
-EnvironmentFile=-/etc/sysconfig/crio-network
-EnvironmentFile=-/etc/sysconfig/crio-storage
 Environment=GOTRACEBACK=crash
 ExecStart=/usr/local/bin/crio \
+          $CRIO_CONFIG_OPTIONS \
+          $CRIO_RUNTIME_OPTIONS \
           $CRIO_STORAGE_OPTIONS \
           $CRIO_NETWORK_OPTIONS \
           $CRIO_METRICS_OPTIONS


### PR DESCRIPTION
Currently our sample systemd service file
`contrib/systemd/crio-shutdown.service` handle shutdown dependency as
below:

    [Service]
    Type=oneshot
    ExecStart=/usr/bin/rm -f /var/lib/crio/crio.shutdown
    ExecStop=/usr/bin/env bash -c "/usr/bin/mkdir /var/lib/crio; /usr/bin/touch /var/lib/crio/crio.shutdown"
    RemainAfterExit=yes

For some rare condition, e.g. bare matel AIO deployment with Rook/CephFS
as loopback PVC, `crio.service` may not stop early enough before Ceph
components get stopped during graceful system reboot, therefore
containers may not able to be stopped correctly since PVC target already
gone, with current `/var/lib/crio/crio.shutdown` implementation.

This PR introduce:

  - `crio.service`: Ensure crio start after `remote-fs.target` so
    postpone as late as possible during startup, therefore always stop
    as early as possible during graceful system reboot
  - `crio-shutdown.service`: Always stop all running containers with
    `crictl` just before `crio.service` get stopped (i.e. avoid loopback
    deadlock)

The logic is concept proof by
<https://github.com/alvistack/ansible-role-etcd/tree/develop>; also
works as expected with Ceph + Kubernetes deployment by
<https://github.com/alvistack/ansible-collection-kubernetes/tree/develop>.
No more deadlock happened during graceful system reboot, both AIO
single/multiple node with loopback mount.

Also see:

  - <https://github.com/ceph/ceph/pull/36776>
  - <https://github.com/etcd-io/etcd/pull/12259>
  - <https://github.com/cri-o/cri-o/pull/4128>
  - <https://github.com/kubernetes/release/pull/1504>

Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>

![image](https://user-images.githubusercontent.com/780562/91795958-a00e0180-ec51-11ea-95f8-2a9548e150a8.png)


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


> /kind cleanup
> /kind feature


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`crio-shutdown.service`: Support Graceful Reboot for AIO Node
```
