### PR TITLE
Revert "dual stack portmap support"

### DIFF
--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cri-o/cri-o/server/metrics"
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
-	utilnet "k8s.io/utils/net"
 )
 
 // networkStart sets up the sandbox's network and returns the pod IP on success
@@ -79,19 +78,12 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 				return nil, nil, fmt.Errorf("failed to get valid ip address for sandbox %s(%s)", sb.Name(), sb.ID())
 			}
 
-			mapping := &hostport.PodPortMapping{
+			err = s.hostportManager.Add(sb.ID(), &hostport.PodPortMapping{
 				Name:         sb.Name(),
 				PortMappings: sb.PortMappings(),
 				IP:           ip,
 				HostNetwork:  false,
-			}
-
-			// use the corresponding IP family hostportManager for the IP
-			if utilnet.IsIPv6(ip) {
-				err = s.hostportManagerv6.Add(sb.ID(), mapping, "")
-			} else {
-				err = s.hostportManager.Add(sb.ID(), mapping, "")
-			}
+			}, "lo")
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to add hostport mapping for sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 			}
@@ -146,25 +138,13 @@ func (s *Server) networkStop(ctx context.Context, sb *sandbox.Sandbox) error {
 	stopCtx, stopCancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer stopCancel()
 
-	// If there are no IPs registered we can't teardown pod IP dependencies
-	ips := sb.IPs()
-	if len(ips) > 0 {
-		// we only allocated portmappings for the first ip
-		mapping := &hostport.PodPortMapping{
-			Name:         sb.Name(),
-			PortMappings: sb.PortMappings(),
-			HostNetwork:  false,
-		}
-		var err error
-		if utilnet.IsIPv6String(ips[0]) {
-			err = s.hostportManagerv6.Remove(sb.ID(), mapping)
-		} else {
-			err = s.hostportManager.Remove(sb.ID(), mapping)
-		}
-		if err != nil {
-			log.Warnf(ctx, "failed to remove hostport for pod sandbox %s(%s): %v",
-				sb.Name(), sb.ID(), err)
-		}
+	if err := s.hostportManager.Remove(sb.ID(), &hostport.PodPortMapping{
+		Name:         sb.Name(),
+		PortMappings: sb.PortMappings(),
+		HostNetwork:  false,
+	}); err != nil {
+		log.Warnf(ctx, "failed to remove hostport for pod sandbox %s(%s): %v",
+			sb.Name(), sb.ID(), err)
 	}
 
 	podNetwork, err := s.newPodNetwork(sb)

--- a/server/server.go
+++ b/server/server.go
@@ -52,10 +52,9 @@ type StreamService struct {
 
 // Server implements the RuntimeService and ImageService
 type Server struct {
-	config            libconfig.Config
-	stream            StreamService
-	hostportManager   hostport.HostPortManager
-	hostportManagerv6 hostport.HostPortManager
+	config          libconfig.Config
+	stream          StreamService
+	hostportManager hostport.HostPortManager
 
 	*lib.ContainerServer
 	monitorsChan      chan struct{}
@@ -342,12 +341,6 @@ func New(
 	}
 	hostportManager := hostport.NewHostportManager(iptInterface)
 
-	ip6tInterface := utiliptables.New(utilexec.New(), utiliptables.ProtocolIPv6)
-	if _, err := ip6tInterface.EnsureChain(utiliptables.TableNAT, iptablesproxy.KubeMarkMasqChain); err != nil {
-		logrus.Warnf("unable to ensure ip6tables chain: %v", err)
-	}
-	hostportManagerv6 := hostport.NewHostportManager(ip6tInterface)
-
 	idMappings, err := getIDMappings(config)
 	if err != nil {
 		return nil, err
@@ -362,7 +355,6 @@ func New(
 	s := &Server{
 		ContainerServer:          containerServer,
 		hostportManager:          hostportManager,
-		hostportManagerv6:        hostportManagerv6,
 		config:                   *config,
 		monitorsChan:             make(chan struct{}),
 		defaultIDMappings:        idMappings,


### PR DESCRIPTION
This reverts commit f97ad7fd3fb3f0901e70a45e7caa57724715ce6c.

This PR uncovered a serial of issues in the portmap behavior that is present upstream too-

When a pod with a PortMapping is created, the portmapper opens a socket in ALL addresses to avoid that another applications can "steal" the port.

https://github.com/cri-o/cri-o/blob/master/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport/hostport.go#L68-L84

However, as the test indicates, you should be able to user several host-ports in the same host on different addresses, this means that ALWAYS will fail to bind the first time.

It was working because, the second pod fails the first time

> Aug 28 15:03:59 crio-worker crio[18574]: time="2020-08-28 15:03:59.167098356Z" level=info msg="TEST adding hostport ips: 10.244.2.44 portmaps: &{ k8s_pod2_sched-pred-5589_0aa5a842-ed92-47b9-8523-3782181c83fd_0 [0xc000a825c0] false 10.244.2.44}" file="server/sandbox_network.go:89" id=3e9adfba-a430-4a1b-a513-eaee34cb2e4e name=/runtime.v1alpha2.RuntimeService/RunPodSandbox

if the pod fails to setup the network, it retries removing the failed pod

> Aug 28 15:03:59 crio-worker crio[18574]: time="2020-08-28 15:03:59.169900605Z" level=info msg="NetworkStart: stopping network for sandbox 7d2d754771fbaa3c7a337540cfb95f8cb31b4e22d1305c453ea8284df7404ee0" file="server/sandbox_network.go:41" id=3e9adfba-a430-4a1b-a513-eaee34cb2e4e name=/runtime.v1alpha2.RuntimeService/RunPodSandbox


and removing the portmap (of the second pod) and the process binding the port

> Aug 28 15:03:59 crio-worker crio[18574]: time="2020-08-28 15:03:59.169947955Z" level=info msg="TEST removing hostport ips: [] portmaps: [0xc000a825c0]" file="server/sandbox_network.go:152" id=3e9adfba-a430-4a1b-a513-eaee34cb2e4e name=/runtime.v1alpha2.RuntimeService/RunPodSandbox


The remove host-port does not have IP address, that's what I've changed in my PR, causing that we never release the socket binding to the hostport.

On the second try, it goes through, because it can bind the socket

Aug 28 15:04:11 crio-worker crio[18574]: time="2020-08-28 15:04:11.003530660Z" level=info msg="TEST adding hostport ips: 10.244.2.45 portmaps: &{ k8s_pod2_sched-pred-5589_0aa5a842-ed92-47b9-8523-3782181c83fd_0 [0xc000d91e00] false 10.244.2.45}" file="server/sandbox_network.go:89" id=ab50eefb-e8c7-4a21-8913-a2abf4c02a6b name=/runtime.v1alpha2.RuntimeService/RunPodSandbox

```release-note
NONE
```