### PR TITLE
Disable the release branch forward script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,13 +91,14 @@ workflows:
           name: integration-cgroupfs
           cgroup_manager: cgroupfs
       - lint
-      - release-branch-forward:
-          requires:
-            - results
-          filters:
-            branches:
-              only:
-                - master
+      # TODO: re-enable after when we branch for 1.20
+      # - release-branch-forward:
+      #     requires:
+      #       - results
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
       - release-notes:
           requires:
             - results


### PR DESCRIPTION
Looks like the master PRs are still being forwarded
to the release-1.19 branch even after we cut the rc.1
tag. Going to disable to script for now, will re-enable
when we create a branch for 1.20.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>


```release-note
None
```
