### PR TITLE
Fix pinns compilation for TEMP_FAILURE_RETRY

### DIFF
--- a/pinns/utils.h
+++ b/pinns/utils.h
@@ -10,6 +10,17 @@
 #include <syslog.h>
 #include <unistd.h>
 
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(expression)                                         \
+  (__extension__({                                                             \
+    long int __result;                                                         \
+    do                                                                         \
+      __result = (long int)(expression);                                       \
+    while (__result == -1L && errno == EINTR);                                 \
+    __result;                                                                  \
+  }))
+#endif
+
 #define _pexit(s)                                                              \
   do {                                                                         \
     fprintf(stderr, "[pinns:e]: %s: %s\n", s, strerror(errno));                \


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In case the macro is not available we now define it on our own in the utils.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/4136
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed pinns compilation if the `TEMP_FAILURE_RETRY` macro is not available
```
