### PR TITLE
Preserve sandbox annotations for handling OCI hooks

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -133,6 +133,13 @@ func (c *container) SpecAddAnnotations(sb *sandbox.Sandbox, containerVolumes []o
 	if err != nil {
 		return err
 	}
+
+	// Preserve the sandbox annotations. OCI hooks may re-use the sandbox
+	// annotation values to apply them to the container later on.
+	for k, v := range sb.Annotations() {
+		c.spec.AddAnnotation(k, v)
+	}
+
 	c.spec.AddAnnotation(annotations.Image, image)
 	c.spec.AddAnnotation(annotations.ImageName, imageResult.Name)
 	c.spec.AddAnnotation(annotations.ImageRef, imageResult.ID)


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Some OCI hooks like the oci-seccomp-bpf-hook may re-use the sandbox
annotations which would get lost before applying this patch. This means
we now preserve all sandbox annotations for containers and overwrite
specific values during setup.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed bug that all custom sandbox annotations will be passed to OCI hooks and therefore are also available on the containers
```
