### PR TITLE
[1.11] Release 1.11.16

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.11.16"
+const Version = "1.11.17-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.11.16-dev"
+const Version = "1.11.16"


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Tag the 1.11.16 release.

#### Which issue(s) this PR fixes(a.k.a. changelog since [1.11.15](https://github.com/cri-o/cri-o/releases/tag/v1.11.15)

##### Changes

 - #4115 fix supplementary user groups (fixes [BZ 1782105](https://bugzilla.redhat.com/show_bug.cgi?id=1782105))
 - #4062 hostport: don't masquerade localhost-to-localhost traffic (fixes https://github.com/kubernetes/kubernetes/issues/66067)
 - #3995 do not touch original spec on exec(sync) (fixes #3988)
 - #3532 oci: handle timeouts correctly for probes
 - #3881 no lock on container status (fixes #3455)
 - #3784 conmon: protect from OOM killer
 - #3299 update containers/image (fixes CVE-2020-1702)
 - #3218 port forward: drain the stream on error (fixes [BZ 1798193](https://bugzilla.redhat.com/show_bug.cgi?id=1798193))
 - #2630 conmon: check it is a valid pid before killing it (fixes [BZ 1730919](
https://bugzilla.redhat.com/show_bug.cgi?id=1730919))

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
