### PR TITLE
test: reduce flakes

### DIFF
--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -409,8 +409,9 @@ func (s *Sandbox) UnmountShm() error {
 		return nil
 	}
 
-	// try to unmount, ignoring "not mounted" (EINVAL) error
-	if err := unix.Unmount(fp, unix.MNT_DETACH); err != nil && err != unix.EINVAL {
+	// try to unmount, ignoring "not mounted" (EINVAL) error and
+	// "already unmounted" (ENOENT) error
+	if err := unix.Unmount(fp, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
 		return errors.Wrapf(err, "unable to unmount %s", fp)
 	}
 

--- a/test/stats.bats
+++ b/test/stats.bats
@@ -33,15 +33,12 @@ function teardown() {
 
 @test "container stats" {
     # given
-    python -c 'import json,sys;obj=json.load(sys.stdin);obj["name"] = ["podsandbox1-sleep2"];obj["metadata"]["name"] = "podsandbox1-sleep2"; json.dump(obj, sys.stdout)' \
-        < "$TESTDATA"/container_sleep.json > "$TESTDIR"/container_sleep2.json
-
     pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 
     ctr1_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
     crictl start "$ctr1_id"
 
-    ctr2_id=$(crictl create "$pod_id" "$TESTDIR"/container_sleep2.json "$TESTDATA"/sandbox_config.json)
+    ctr2_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
     crictl start "$ctr2_id"
 
     # when


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind flake

#### What this PR does / why we need it:
deflake stats test by making the two containers different
deflake all tests by ignoring ENOENT on the shm unmount (as we're allowed to attempt to UnmountShm() multiple times)
Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
