### PR TITLE
Revert "runtime_vm: Cleanup process when the Container is Stopped"

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -273,12 +273,6 @@ func (r *runtimeVM) StartContainer(c *Container) error {
 			if err1 := r.updateContainerStatus(c); err1 != nil {
 				logrus.Warningf("error updating container status %v", err1)
 			}
-
-			if c.state.Status == ContainerStateStopped {
-				if err1 := r.deleteContainer(c, true); err1 != nil {
-					logrus.WithError(err1).Infof("deleteContainer failed for container %s", c.ID())
-				}
-			}
 		} else {
 			logrus.Warningf("wait for %s returned: %v", c.ID(), err)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This reverts commit 814c1bb01e84d6e42cd01b5957cad6e441228fa5.

We cannot simply delete the container when its status changes to
stopped. The intention of this fix is okay-ish, but implemented in the
wrong layer.

What containerd does is calling Shutdown(), when the *pod* is finished,
and that's what we should do as well.


#### Which issue(s) this PR fixes:
None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
None
```