### PR TITLE
[release-1.18] Revert "runtime_vm: Cleanup process when the Container is Stopped"

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -276,12 +276,6 @@ func (r *runtimeVM) StartContainer(c *Container) error {
 			if err1 := r.updateContainerStatus(c); err1 != nil {
 				logrus.Warningf("error updating container status %v", err1)
 			}
-
-			if c.state.Status == ContainerStateStopped {
-				if err1 := r.deleteContainer(c, true); err1 != nil {
-					logrus.WithError(err1).Infof("deleteContainer failed for container %s", c.ID())
-				}
-			}
 		}
 	}()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This reverts commit adb657c38057c6916ec2166e49076b49ea947a94.

We cannot simply delete the container when its status changes to
stopped. The intention of this fix is okay-ish, but implemented in the
wrong layer.

What containerd does is calling Shutdown(), when the *pod* is finished,
and that's what we should do as well.


#### Which issue(s) this PR fixes:
None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
None
```