### PR TITLE
Fix pinns error diagnostics, cleanup, and return

### DIFF
--- a/internal/lib/sandbox/namespaces_linux.go
+++ b/internal/lib/sandbox/namespaces_linux.go
@@ -143,7 +143,7 @@ func pinNamespaces(nsTypes []NSType, cfg *config.Config, idMappings *idtools.IDM
 		return nil, fmt.Errorf("failed to pin namespaces %v: %s %v", nsTypes, output, err)
 	}
 
-	returnedNamespaces := make([]NamespaceIface, 0)
+	returnedNamespaces := make([]NamespaceIface, 0, len(nsTypes))
 	for _, info := range mountedNamespaces {
 		ret, err := nspkg.GetNS(info.path)
 		if err != nil {

--- a/internal/lib/sandbox/namespaces_linux.go
+++ b/internal/lib/sandbox/namespaces_linux.go
@@ -95,7 +95,7 @@ func pinNamespaces(nsTypes []NSType, cfg *config.Config, idMappings *idtools.IDM
 			return nil, errors.Errorf("Invalid namespace type: %s", nsType)
 		}
 		pinnsArgs = append(pinnsArgs, arg)
-		pinPath := filepath.Join(cfg.NamespacesDir, fmt.Sprintf("%sns", string(nsType)), pinnedNamespace)
+		pinPath := filepath.Join(cfg.NamespacesDir, string(nsType)+"ns", pinnedNamespace)
 		mountedNamespaces = append(mountedNamespaces, namespaceInfo{
 			path:   pinPath,
 			nsType: nsType,


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

1. In case pinns fails, we want to return a clear error message saying
       it has failed, not that we failed to unmount some mounts. So, do not
       return the "failed to unmount" error as it's minor in nature, and log
       the failures instead.
    
2. In case pinns fails, we want to see its stderr, not just stdout.
       Before this patch, only stdout is collected (and now shown as it's empty).
    
3. We can't be sure that the mounts we are trying to unmount were
       actually mounted, so ignore EINVAL from unmount(2). EINVAL means
       that either argument is not the mount point (i.e. not mounted),
       or that the flags are wrong. We only provide MNT_DETACH which
       is not a wrong flag, ergo EINVAL means "not mounted" and it should
       be ignored.
    
4. Only log pinns output in case of error, and do it as a warning since
       it is pretty serious.

While at it, make some minor improvements around the code we're touching.

#### Which issue(s) this PR fixes:

Fixes: https://github.com/cri-o/cri-o/issues/4147

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
