### PR TITLE
oci: return IsAlive error instead of logging

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -391,14 +391,9 @@ func (c *Container) exitFilePath() string {
 
 // IsAlive is a function that checks if a container's init PID exists.
 // It is used to check a container state when we don't want a `$runtime state` call
-func (c *Container) IsAlive() bool {
+func (c *Container) IsAlive() error {
 	_, err := c.pid()
-	if err != nil {
-		logrus.Errorf("checking if PID of %s is running failed: %v", c.id, err)
-		return false
-	}
-
-	return true
+	return errors.Wrapf(err, "checking if PID of %s is running failed", c.id)
 }
 
 // Pid returns the container's init PID.

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -306,7 +306,7 @@ var _ = t.Describe("Container", func() {
 			err := sut.IsAlive()
 
 			// Then
-			Expect(err).To(Equal(false))
+			Expect(err).NotTo(BeNil())
 		})
 		It("should succeed if pid is running", func() {
 			// Given
@@ -318,7 +318,7 @@ var _ = t.Describe("Container", func() {
 			err := sut.IsAlive()
 
 			// Then
-			Expect(err).To(Equal(true))
+			Expect(err).To(BeNil())
 		})
 		It("should be false if pid is not running", func() {
 			// Given
@@ -331,7 +331,7 @@ var _ = t.Describe("Container", func() {
 			err := sut.IsAlive()
 
 			// Then
-			Expect(err).To(Equal(false))
+			Expect(err).NotTo(BeNil())
 		})
 	})
 	t.Describe("Pid", func() {

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -1,8 +1,7 @@
 package server
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -16,13 +15,13 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (*pb.Exe
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
-	if !c.IsAlive() {
-		return nil, fmt.Errorf("container is not created or running")
+	if err := c.IsAlive(); err != nil {
+		return nil, status.Errorf(codes.NotFound, "container is not created or running: %v", err)
 	}
 
 	cmd := req.Cmd
 	if cmd == nil {
-		return nil, fmt.Errorf("exec command cannot be empty")
+		return nil, errors.New("exec command cannot be empty")
 	}
 
 	execResp, err := s.Runtime().ExecSyncContainer(c, cmd, req.Timeout)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup

> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:
When a container has been stopped, but the rest of its pod is still stopping, the kubelet still runs exec probes
IsAlive() correctly identifies the container has been stopped, and logs an error, but in reality, this is expected.

Instead of logging the error, return it in IsAlive (and also ExecSync), and let the kubelet report it if it thinks it'll be problematic

This fixes superluous errors like this:
"Checking if PID of 4a81020e858fbdd1ee6a271190ab36aec1940489386e177f33c2e62afa309580 is running failed: PID running but not the original container. PID wrap may have occurred"

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
