### PR TITLE
Print seccomp profile JSON only on trace log level

### DIFF
--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -34,7 +34,14 @@ func (c *Config) LoadProfile(profilePath string) error {
 	if profilePath == "" {
 		c.profile = seccomp.DefaultProfile()
 		logrus.Info("No seccomp profile specified, using the internal default")
-		logrus.Debugf("Current seccomp profile content: %+v", c.profile)
+
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			profileString, err := json.MarshalToString(c.profile)
+			if err != nil {
+				return errors.Wrap(err, "marshal default seccomp profile to string")
+			}
+			logrus.Tracef("Current seccomp profile content: %s", profileString)
+		}
 		return nil
 	}
 
@@ -50,7 +57,7 @@ func (c *Config) LoadProfile(profilePath string) error {
 
 	c.profile = tmpProfile
 	logrus.Infof("Successfully loaded seccomp profile %q", profilePath)
-	logrus.Debugf("Current seccomp profile content: %+v", c.profile)
+	logrus.Tracef("Current seccomp profile content: %s", profile)
 	return nil
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
To sync up the behavior with AppArmor, we now print the content of the
seccomp profile only on trace log level. Beside that, we print the JSON
instead of the struct to provide more information to the user.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed the output of the printed seccomp profile to JSON instead of the struct. The profile will be only printed on CRI-O startup and if the `--log-level`/`log_level` is set to `trace`.
```
