### PR TITLE
[1.19] managed ns: ignore `PID not initialized` on sandbox creation

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -28,6 +28,7 @@ var (
 	defaultStopSignal   = strconv.Itoa(defaultStopSignalInt)
 	ErrContainerStopped = errors.New("container is already stopped")
 	ErrNotFound         = errors.New("container process not found")
+	ErrNotInitialized   = errors.New("container PID not initialized")
 )
 
 // Container represents a runtime container.
@@ -413,10 +414,10 @@ func (c *Container) Pid() (int, error) {
 // and it is the same process that was originally started by the runtime.
 func (c *Container) pid() (int, error) {
 	if c.state == nil {
-		return 0, errors.New("state not initialized")
+		return 0, ErrNotInitialized
 	}
 	if c.state.InitPid <= 0 {
-		return 0, errors.New("PID not initialized")
+		return 0, ErrNotInitialized
 	}
 
 	// container has stopped (as pid is initialized but the runc state has overwritten it)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug

> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:
everytime we create a sandbox with a pinned namespace, we spit out an error that says:
`Pid for infra container $id not found: PID not initialized`

in the pinned namespace case, we create the namespaces, create the networking stack (giving the created net namespace to the plugin), THEN create the pod.
Thus, we don't expect the infra container to be initialized.

Fix this by ignoring ErrNotInitialized when we're fetching the infraPid when finding the namespaces.

We can safely do this because the managed namespace case is covered (we don't use the pid, but use the managed namespace struct we've created)
And in the non-managed namespace case, we will (correctly) fail later because we return an invalid PID, which matches our invalid infra container.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
