### PR TITLE
[1.17] config: set internal RootConfig to default storage if not specified

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,7 +59,7 @@ type Iface interface {
 }
 
 // GetStore returns the container storage for a given configuration
-func (c *Config) GetStore() (cstorage.Store, error) {
+func (c *RootConfig) GetStore() (storage.Store, error) {
 	return cstorage.GetStore(cstorage.StoreOptions{
 		RunRoot:            c.RunRoot,
 		GraphRoot:          c.Root,
@@ -646,6 +646,18 @@ func (c *RootConfig) Validate(onExecution bool) error {
 		if err := os.MkdirAll(c.LogDir, 0700); err != nil {
 			return errors.Wrapf(err, "invalid log_dir")
 		}
+		store, err := c.GetStore()
+		if err != nil {
+			return errors.Wrapf(err, "failed to get store to set defaults")
+		}
+		// This step merges the /etc/container/storage.conf with the
+		// storage configuration in crio.conf
+		// If we don't do this step, we risk returning the incorrect info
+		// on Inspect (/info) requests
+		c.RunRoot = store.RunRoot()
+		c.Root = store.GraphRoot()
+		c.Storage = store.GraphDriverName()
+		c.StorageOptions = store.GraphOptions()
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/containers/storage"
 	"github.com/cri-o/cri-o/pkg/config"
 
 	. "github.com/onsi/ginkgo"
@@ -671,6 +672,46 @@ var _ = t.Describe("Config", func() {
 
 			// Then
 			Expect(err).NotTo(BeNil())
+		})
+
+		It("should get default storage options when options are empty", func() {
+			// Given
+			defaultStore, err := storage.GetStore(storage.StoreOptions{})
+			Expect(err).To(BeNil())
+
+			sut.RootConfig.RunRoot = ""
+			sut.RootConfig.Root = ""
+			sut.RootConfig.Storage = ""
+			sut.RootConfig.StorageOptions = make([]string, 0)
+			sut.HooksDir = []string{validDirPath}
+
+			// When
+			err = sut.Validate(nil, true)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.RootConfig.RunRoot).To(Equal(defaultStore.RunRoot()))
+			Expect(sut.RootConfig.Root).To(Equal(defaultStore.GraphRoot()))
+			Expect(sut.RootConfig.Storage).To(Equal(defaultStore.GraphDriverName()))
+			Expect(sut.RootConfig.StorageOptions).To(Equal(defaultStore.GraphOptions()))
+		})
+
+		It("should override default storage options", func() {
+			// Given
+			defaultStore, err := storage.GetStore(storage.StoreOptions{})
+			Expect(err).To(BeNil())
+
+			sut.RootConfig.RunRoot = "/tmp"
+			sut.RootConfig.Root = "/tmp"
+			sut.HooksDir = []string{validDirPath}
+
+			// When
+			err = sut.Validate(nil, true)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.RootConfig.RunRoot).NotTo(Equal(defaultStore.RunRoot()))
+			Expect(sut.RootConfig.Root).NotTo(Equal(defaultStore.GraphRoot()))
 		})
 	})
 


### PR DESCRIPTION
After we pull in the initial config, it is our source of truth for telling the world where our container storage is
in particular, if we, say, have an empty `storage` entry, we will return `StorageDriver: ""` on an Inspect request

the problem is, that is a lie. c/storage populates defaults for us, so we actually use overlay in that scenerio.

we don't encounter this normally, because if the toml field isn't specified (as it isn't by default), then we inherit the information from the default config
However, if a user (or an ignition config) overrides those fields to empty, we will listen to it as the source of truth, and never update to what is actually being used

Fix this by inheriting the values from c/storage on the validation step.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix bug where empty config fields having to do with storage cause `/info` requests to return incorrect information (which causes cadvisor to fail to read imageFs information)
```
