### PR TITLE
Verify Cgroup Memory - cgroupfs

### DIFF
--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -14,7 +14,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type CgroupfsManager struct{}
+// CgroupfsManager defines functionality whrn **** TODO: Update this
+type CgroupfsManager struct {
+	memoryPath, memoryMaxFile string
+}
 
 const (
 	defaultCgroupfsParent = "/crio"
@@ -49,10 +52,15 @@ func (m *CgroupfsManager) ContainerCgroupAbsolutePath(sbParent, containerID stri
 
 // SandboxCgroupPath takes the sandbox parent, and sandbox ID. It
 // returns the cgroup parent, cgroup path, and error.
-func (*CgroupfsManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgPath string, _ error) {
+func (m *CgroupfsManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgPath string, _ error) {
 	if strings.HasSuffix(path.Base(sbParent), ".slice") {
 		return "", "", fmt.Errorf("cri-o configured with cgroupfs cgroup manager, but received systemd slice as parent: %s", sbParent)
 	}
+
+	if err := verifyCgroupHasEnoughMemory(sbParent, m.memoryPath, m.memoryMaxFile); err != nil {
+		return "", "", err
+	}
+
 	return sbParent, filepath.Join(sbParent, crioPrefix+"-"+sbID), nil
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:


> /kind api-change
> /kind bug
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
-->
> /kind cleanup


#### What this PR does / why we need it:
Refractoring to check if cgroupfs cgroup manager has enough memory

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


Fixes  #3840 
<!--
or
None


#### Special notes for your reviewer:
-->
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
