### PR TITLE
runtime: parse oom file for VM type runtimes

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -650,6 +650,12 @@ func (r *runtimeVM) updateContainerStatus(c *Container) error {
 	exitCode := int32(response.ExitStatus)
 	c.state.ExitCode = &exitCode
 
+	if exitCode != 0 {
+		oomFilePath := filepath.Join(c.bundlePath, "oom")
+		if _, err = os.Stat(oomFilePath); err == nil {
+			c.state.OOMKilled = true
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Implement as runtimeOCI has done.

Signed-off-by: bin liu <bin@hyper.sh>

#### What type of PR is this?

> /kind feature

#### What this PR does / why we need it:

With this user can get the same experience as containerd, and in k8s it will show the detailed reason `OOMKilled` in `STATUS` field for `kubectl get pods` command.

#### Which issue(s) this PR fixes:

Fixes #4203 

#### Special notes for your reviewer:

This depends on that runtime like Kata containers to write `oom` file into the container's bundle directory, this is on the road for Kata containers( PR not merged yet: https://github.com/kata-containers/kata-containers/pull/698/commits/d7c77b69dc221195f66eb82799fd89f56ad24842 )

#### Does this PR introduce a user-facing change?

```release-note
None
```
