### PR TITLE
deprecate manage_ns_lifecycle option

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -92,7 +92,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l log-format -r -d 'Set the 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-journald -d 'Log to systemd journal (journald) in addition to kubernetes log file (default: false)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-level -s l -r -d 'Log messages above specified level: trace, debug, info, warn, error, fatal or panic'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l log-size-max -r -d 'Maximum log size in bytes for a container. If it is positive, it must be >= 8192 to match/exceed conmon read buffer'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l manage-ns-lifecycle -d 'Determines whether we pin and remove IPC, network and UTS namespaces and manage their lifecycle (default: true)'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l manage-ns-lifecycle -d 'Determines whether we pin and remove IPC, network and UTS namespaces and manage their lifecycle. This option is being deprecated, and will be unconditionally true in the future. (default: true)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l metrics-port -r -d 'Port for the metrics endpoint'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l metrics-socket -r -d 'Socket for the metrics endpoint'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l namespaces-dir -r -d 'The directory where the state of the managed namespaces gets tracked. Only used when manage-ns-lifecycle is true'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -239,7 +239,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--log-size-max**="": Maximum log size in bytes for a container. If it is positive, it must be >= 8192 to match/exceed conmon read buffer (default: -1)
 
-**--manage-ns-lifecycle**: Determines whether we pin and remove IPC, network and UTS namespaces and manage their lifecycle (default: true)
+**--manage-ns-lifecycle**: Determines whether we pin and remove IPC, network and UTS namespaces and manage their lifecycle. This option is being deprecated, and will be unconditionally true in the future. (default: true)
 
 **--metrics-port**="": Port for the metrics endpoint (default: 9090)
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -220,7 +220,7 @@ the container runtime configuration.
   The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container.
 
 **manage_ns_lifecycle**=true
-  Determines whether we pin and remove namespaces and manage their lifecycle.
+  Determines whether we pin and remove namespaces and manage their lifecycle. This option is being deprecated, and will be unconditionally true in the future.
 
 **drop_infra_ctr**=false
   Determines whether we drop the infra container when a pod does not have a private PID namespace, and does not use a kernel separating runtime (like kata).

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -725,7 +725,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:    "manage-ns-lifecycle",
-			Usage:   fmt.Sprintf("Determines whether we pin and remove IPC, network and UTS namespaces and manage their lifecycle (default: %v)", defConf.ManageNSLifecycle),
+			Usage:   fmt.Sprintf("Determines whether we pin and remove IPC, network and UTS namespaces and manage their lifecycle. This option is being deprecated, and will be unconditionally true in the future. (default: %v)", defConf.ManageNSLifecycle),
 			EnvVars: []string{"CONTAINER_MANAGE_NS_LIFECYCLE"},
 		},
 		&cli.BoolFlag{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -282,6 +282,7 @@ type RuntimeConfig struct {
 
 	// ManageNSLifecycle determines whether we pin and remove namespaces
 	// and manage their lifecycle
+	// This option is being deprecated
 	ManageNSLifecycle bool `toml:"manage_ns_lifecycle"`
 
 	// DropInfraCtr determines whether the infra container is dropped when appropriate.
@@ -771,6 +772,10 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 
 	if !(c.ConmonCgroup == "pod" || strings.HasSuffix(c.ConmonCgroup, ".slice")) {
 		return errors.New("conmon cgroup should be 'pod' or a systemd slice")
+	}
+
+	if !c.ManageNSLifecycle {
+		logrus.Infof("The manage-ns-lifecycle option is being deprecated, and will be unconditionally true in the future")
 	}
 
 	if c.UIDMappings != "" && c.ManageNSLifecycle {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -254,7 +254,8 @@ gid_mappings = "{{ .GIDMappings }}"
 ctr_stop_timeout = {{ .CtrStopTimeout }}
 
 # manage_ns_lifecycle determines whether we pin and remove namespaces
-# and manage their lifecycle
+# and manage their lifecycle.
+# This option is being deprecated, and will be unconditionally true in the future.
 manage_ns_lifecycle = {{ .ManageNSLifecycle }}
 
 # drop_infra_ctr determines whether CRI-O drops the infra container


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind documentation


#### What this PR does / why we need it:
the option was introduced in 1.17, and set as default in 1.19. Mark it as deprecated, and set to be removed by 1.21

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `manage_ns_lifecycle` option is now deprecated, and will be set to true unconditionally in the future. 
```
