### PR TITLE
[do not merge] debug ns file removal

### DIFF
--- a/internal/lib/sandbox/namespaces_linux.go
+++ b/internal/lib/sandbox/namespaces_linux.go
@@ -230,5 +230,9 @@ func (n *Namespace) Remove() error {
 	if err := unix.Unmount(fp, unix.MNT_DETACH); err != nil && err != unix.EINVAL {
 		return errors.Wrapf(err, "unable to unmount %s", fp)
 	}
-	return os.RemoveAll(fp)
+	out, execErr := exec.Command("sh", "-c", "grep "+filepath.Base(fp)+" /proc/*/mountinfo").CombinedOutput()
+	if err := os.Remove(fp); err != nil {
+		return errors.Wrapf(err, "can't remove ns mount file; mountinfo shows: %s (err: %v)", out, execErr)
+	}
+	return nil
 }

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -e
+
+set -x
+uname -a
+tail /proc/sys/fs/may_detach_mounts
+grep may_detach_mounts /etc/sysctl.conf /etc/sysctl.d/*
+exit 0
 
 TEST_USERNS=${TEST_USERNS:-}
 


### PR DESCRIPTION
Just trying to debug a failure that happened here:

* https://github.com/cri-o/cri-o/pull/4208#issuecomment-694593726
* https://github.com/cri-o/cri-o/pull/4208#issuecomment-694633670

The issue:
 * https://github.com/cri-o/cri-o/issues/3996

Similar bug: 
 * https://github.com/containerd/containerd/issues/3667

### Hypothesis of the hour

The mount gets propagated to other namespaces, and it takes time for the unmount event to be propagated. Might have to do with an older/buggy RHEL7 kernel. Might need to be mitigated by retrying with a wee sleep.