### PR TITLE
[1.18] test/config: fix "config dir should fail with invalid option"

### DIFF
--- a/test/config.bats
+++ b/test/config.bats
@@ -30,13 +30,13 @@ function teardown() {
 
 @test "config dir should fail with invalid option" {
     # given
-    printf "[crio.runtime]\nlog_level = info\n" > "$CRIO_CONFIG"
-    printf "[crio.runtime]\nlog_level = wrong\n" > "$CRIO_CONFIG_DIR"/00-default
+    printf '[crio.runtime]\nlog_level = "info"\n' > "$CRIO_CONFIG"
+    printf '[crio.runtime]\nlog_level = "wrong-level"\n' > "$CRIO_CONFIG_DIR"/00-default
 
     # when
-    "$CRIO_BINARY_PATH" -c "$CRIO_CONFIG" -d "$CRIO_CONFIG_DIR" &> >(tee "$CRIO_LOG") || true
-    RES=$(cat "$CRIO_LOG")
+    run "$CRIO_BINARY_PATH" -c "$CRIO_CONFIG" -d "$CRIO_CONFIG_DIR"
 
     # then
-    [[ "$RES" =~ "unable to decode configuration" ]]
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not a valid logrus"*"wrong-level"* ]]
 }


### PR DESCRIPTION
Sometimes this test fails like this:

> not ok 11 config dir should fail with invalid option
> (in test file ./config.bats, line 38)
>   `RES=$(cat "$CRIO_LOG")' failed
> cat: /tmp/tmp.nho2aP6lqh/crio.log: No such file or directory
> unable to decode configuration /tmp/tmp.nho2aP6lqh/crio.conf: Near line 2 (last key parsed 'crio.runtime.log_level'): expected value but found "info" instead

The reason it fails is logs are written by using tee,
which for some reason is run in a subshell, and it looks
like a race between the main shell and the subshell.

Anyway, using tee is not needed here. Simplify it by using run,
and add a check for non-zero exit code.

The second proble is, the test is not doing what it supposed to.
Judging by the test name ("config dir should fail"), it seems the test
should write a correct log_level value to the main config file, a wrong
value to a file under crio.conf.d, and check that crio fails.

The problem is, the value in main file is wrong as well it is not quoted.

Fix the test so the main config file has the correct log_level value.
Fix the output check to look for the specific bad key.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
cherry-pick of https://github.com/cri-o/cri-o/pull/4220
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
