### PR TITLE
[1.17] test/config: fix "config dir should fail with invalid option"

### DIFF
--- a/test/config.bats
+++ b/test/config.bats
@@ -30,13 +30,13 @@ function teardown() {
 
 @test "config dir should fail with invalid option" {
     # given
-    printf "[crio.runtime]\nlog_level = info\n" > "$CRIO_CONFIG"
-    printf "[crio.runtime]\nlog_level = wrong\n" > "$CRIO_CONFIG_DIR"/00-default
+    printf '[crio.runtime]\nlog_level = "info"\n' > "$CRIO_CONFIG"
+    printf '[crio.runtime]\nlog_level = "wrong-level"\n' > "$CRIO_CONFIG_DIR"/00-default
 
     # when
-    "$CRIO_BINARY_PATH" -c "$CRIO_CONFIG" -d "$CRIO_CONFIG_DIR" &> >(tee "$CRIO_LOG") || true
-    RES=$(cat "$CRIO_LOG")
+    run "$CRIO_BINARY_PATH" -c "$CRIO_CONFIG" -d "$CRIO_CONFIG_DIR"
 
     # then
-    [[ "$RES" =~ "unable to decode configuration" ]]
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not a valid logrus"*"wrong-level"* ]]
 }


### PR DESCRIPTION
_this is a partial backport of https://github.com/cri-o/cri-o/pull/4213 to release-1.17 branch_


#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Sometimes this test fails like this:

> not ok 11 config dir should fail with invalid option
> (in test file ./config.bats, line 38)
>   `RES=$(cat "$CRIO_LOG")' failed
> cat: /tmp/tmp.nho2aP6lqh/crio.log: No such file or directory
> unable to decode configuration /tmp/tmp.nho2aP6lqh/crio.conf: Near line 2 (last key parsed 'crio.runtime.log_level'): expected value but found "info" instead

The reason it fails is logs are written by using tee,
which for some reason is run in a subshell, and it looks
like a race between the main shell and the subshell.

Anyway, using tee is not needed here. Simplify it by using run,
and add a check for non-zero exit code.

The second problem is, the test is not doing what it supposed to.
Judging by the test name ("config dir should fail"), it seems the test
should write a correct log_level value to the main config file, a wrong
value to a file under crio.conf.d, and check that crio fails.

The problem is, the value in main file is wrong as well it is not quoted.

Fix the test so the main config file has the correct log_level value.
Fix the output check to look for the specific bad key.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```