### PR TITLE
[1.18] Fix bogus CI test failures on RHEL7

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -94,6 +94,14 @@
       include: "build/runc.yml"
       when: "build_runc | bool"
 
+    - name: set fs.may_detach_mounts = 1
+      sysctl:
+        name: fs.may_detach_mounts
+        state: absent
+        value: 1
+        sysctl_set: yes
+        ignoreerrors: yes
+
   post_tasks:
     - name: Swap is disused and disabled as required for kubernetes
       include: "disable_swap.yml"

--- a/test/sanity_checks.bats
+++ b/test/sanity_checks.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+# Sanity checks for test environment. If any of the below tests fail,
+# the test environment is not to be trusted (i.e. bogus failures are
+# quite possible), and the test environment need to be fixed.
+
+
+# RHEL7 kernels should have this sysctl enabled, otherwise
+# we can see EBUSY on mount point removal, container removal
+# etc. It is set in production via runc rpm %postin script,
+# and in CI via contrib/test/integration/main.yml.
+# For more details, see
+#  - https://bugzilla.redhat.com/show_bug.cgi?id=1823374#c17
+#  - https://github.com/cri-o/cri-o/issues/3996
+@test "if fs.may_detach_mounts is set" {
+	file="/proc/sys/fs/may_detach_mounts"
+	test -f "$file" || return 0
+
+	grep "1" /proc/sys/fs/may_detach_mounts
+}


### PR DESCRIPTION
_This is a partial backport of #4217 to release-1.17 branch_

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The following failure happens in CI on RHEL7 from time to time:

> removing the pod sandbox "0d5bf5eeb0048bb70ab8ee9bca0a497e216a6c6cfa42507a8d735f61c825784d": rpc error: code = Unknown desc = unable to remove managed namespaces: Removing namespaces encountered the following errors [unlinkat /var/run/netns/0376543d-4917-417f-b406-7e8ab07cb847: device or resource busy]

(with different test cases and different namespaces).

RHEL7 kernel has upstream commit [1] backported, but the feature is
controlled by a sysctl and is off by default. For the feature to work,
one needs to set fs.may_detach_mounts = 1.

On production RHEL7 systems, this is done by runc rpm (see [2]), but
we're not using those rpms for CI, so we have to set the sysctl
manually.

Add an integration test case to check the sysctl is set.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8ed936b5671bfb33d89bc60bdcc7cf0470ba52fe
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1823374#c17

#### Which issue(s) this PR fixes:

Fixes: #3996
Some more notes at #4210

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```