### PR TITLE
[1.18] server: cleanup container in runtime after failed creation

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -604,6 +604,14 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	if err := s.createContainerPlatform(newContainer, sb.CgroupParent()); err != nil {
 		return nil, err
 	}
+	defer func() {
+		if retErr != nil {
+			log.Infof(ctx, "createCtr: removing container ID %s from runtime", ctr.ID())
+			if err2 := s.Runtime().DeleteContainer(newContainer); err2 != nil {
+				log.Warnf(ctx, "failed to delete container in runtime %s: %v", ctr.ID(), err)
+			}
+		}
+	}()
 
 	if err := s.ContainerStateToDisk(newContainer); err != nil {
 		log.Warnf(ctx, "unable to write containers %s state to disk: %v", newContainer.ID(), err)

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -248,13 +248,13 @@ function retry() {
     local i
 
     for ((i = 0; i < attempts; i++)); do
-        if run "$@"; then
+        if "$@"; then
             return 0
         fi
         sleep "$delay"
     done
 
-    echo "Command \"$*\" failed $attempts times. Output: $output"
+    echo "Command \"$*\" failed $attempts times"
     false
 }
 


### PR DESCRIPTION
This is a non-automated cherry-pick of #4201

/kind bug

it also includes https://github.com/cri-o/cri-o/commit/5bce7486aca3a07441bbee01c1fd2207c4949878 to hopefully fix integration_fedora flakes on this branch
```release-note
Fixed a bug where a container creation failure caused that container to leak in the runtime
```