### PR TITLE
test/network.bats: simplify, fix shellcheck

### DIFF
--- a/test/network.bats
+++ b/test/network.bats
@@ -13,26 +13,20 @@ function teardown() {
 
 @test "ensure correct hostname" {
 	start_crio
-	run crictl runp "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	pod_id="$output"
-	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -eq 0  ]
-	ctr_id="$output"
-	run crictl start "$ctr_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
 
 	run crictl exec --sync "$ctr_id" sh -c "hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"crictl_host"* ]]
+
 	run crictl exec --sync "$ctr_id" sh -c "echo \$HOSTNAME"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"crictl_host"* ]]
+
 	run crictl exec --sync "$ctr_id" sh -c "cat /etc/hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -41,28 +35,23 @@ function teardown() {
 
 @test "ensure correct hostname for hostnetwork:true" {
 	start_crio
-	hostnetworkconfig=$(cat "$TESTDATA"/sandbox_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["security_context"]["namespace_options"]["network"] = 2; obj["annotations"] = {}; obj["hostname"] = ""; json.dump(obj, sys.stdout)')
-	echo "$hostnetworkconfig" > "$TESTDIR"/sandbox_hostnetwork_config.json
-	run crictl runp "$TESTDIR"/sandbox_hostnetwork_config.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	pod_id="$output"
-	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/sandbox_hostnetwork_config.json
-	echo "$output"
-	[ "$status" -eq 0  ]
-	ctr_id="$output"
-	run crictl start "$ctr_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
+	python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["security_context"]["namespace_options"]["network"] = 2; obj["annotations"] = {}; obj["hostname"] = ""; json.dump(obj, sys.stdout)' \
+	< "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_hostnetwork_config.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_hostnetwork_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/sandbox_hostnetwork_config.json)
+	crictl start "$ctr_id"
 
 	run crictl exec --sync "$ctr_id" sh -c "hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"$HOSTNAME"* ]]
+
 	run crictl exec --sync "$ctr_id" sh -c "echo \$HOSTNAME"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"$HOSTNAME"* ]]
+
 	run crictl exec --sync "$ctr_id" sh -c "cat /etc/hostname"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -71,29 +60,22 @@ function teardown() {
 
 @test "Check for valid pod netns CIDR" {
 	start_crio
-	run crictl runp "$TESTDATA"/sandbox_config.json
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+
+	run crictl exec --sync "$ctr_id" ip addr show dev eth0 scope global
 	echo "$output"
 	[ "$status" -eq 0 ]
-	pod_id="$output"
-
-	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -eq 0  ]
-	ctr_id="$output"
-
-    run crictl exec --sync $ctr_id ip addr show dev eth0 scope global 2>&1
-    echo "$output"
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ $POD_IPV4_CIDR_START ]]
-    [[ "$output" =~ $POD_IPV6_CIDR_START ]]
+	[[ "$output" = *"$POD_IPV4_CIDR_START"* ]]
+	[[ "$output" = *"$POD_IPV6_CIDR_START"* ]]
 }
 
 @test "Ensure correct CNI plugin namespace/name/container-id arguments" {
 	start_crio "" "prepare_plugin_test_args_network_conf"
-	run crictl runp "$TESTDATA"/sandbox_config.json
-	[ "$status" -eq 0 ]
+	crictl runp "$TESTDATA"/sandbox_config.json
 
-	. $TESTDIR/plugin_test_args.out
+	# shellcheck disable=SC1091
+	. "$TESTDIR"/plugin_test_args.out
 
 	[ "$FOUND_CNI_CONTAINERID" != "redhat.test.crio" ]
 	[ "$FOUND_CNI_CONTAINERID" != "podsandbox1" ]
@@ -103,44 +85,29 @@ function teardown() {
 
 @test "Connect to pod hostport from the host" {
 	start_crio
-	run crictl runp "$TESTDATA"/sandbox_config_hostport.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	pod_id="$output"
-
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config_hostport.json)
 	host_ip=$(get_host_ip)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_config_hostport.json "$TESTDATA"/sandbox_config_hostport.json)
+	crictl start "$ctr_id"
 
-	run crictl create "$pod_id" "$TESTDATA"/container_config_hostport.json "$TESTDATA"/sandbox_config_hostport.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	ctr_id="$output"
-	run crictl start "$ctr_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run nc -w 5 $host_ip 4888 </dev/null
+	run nc -w 5 "$host_ip" 4888 </dev/null
 	echo "$output"
 	[ "$output" = "crictl_host" ]
-	[ "$status" -eq 0 ]
-	run crictl stop "$ctr_id"
-	echo "$output"
 	[ "$status" -eq 0 ]
 }
 
 @test "Clean up network if pod sandbox fails" {
 	# TODO FIXME find a way for sandbox setup to fail if manage ns is true
-	cp $(which conmon) "$TESTDIR"/conmon
+	CONMON_BINARY="$TESTDIR"/conmon
+	cp "$(which conmon)" "$CONMON_BINARY"
 	CONTAINER_MANAGE_NS_LIFECYCLE=false \
 		CONTAINER_DROP_INFRA_CTR=false \
-		CONMON_BINARY="$TESTDIR"/conmon \
 		start_crio "" "prepare_plugin_test_args_network_conf"
 
 	# make conmon non-executable to cause the sandbox setup to fail after
 	# networking has been configured
-	chmod 0644 $TESTDIR/conmon
-	run crictl runp "$TESTDATA"/sandbox_config.json
-	chmod 0755 $TESTDIR/conmon
-	echo "$output"
-	[ "$status" -ne 0 ]
+	chmod 0644 "$CONMON_BINARY"
+	crictl runp "$TESTDATA"/sandbox_config.json && fail "expected runp to fail"
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed after network setup
@@ -152,9 +119,7 @@ function teardown() {
 @test "Clean up network if pod sandbox fails after plugin success" {
 	start_crio "" "prepare_plugin_test_args_network_conf_malformed_result"
 
-	run crictl runp "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -ne 0 ]
+	crictl runp "$TESTDATA"/sandbox_config.json && fail "expected runp to fail"
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed during network setup after the CNI plugin itself succeeded


### PR DESCRIPTION
_This used to be a part of #4127, which I am splitting into smaller PRs_

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
1. Simplify the code.

For example,
```bash
	run crictl start ...
	echo "$output"
	[ "$status" -eq 0 ]
```
is equivalent to
```bash
	crictl start ...
```
as it much easier to read (yes, bats runs tests with set -e
so there is an error check in place).

One more example,
```bash
	run crictl runp ...
	echo "$output"
	[ "$status" -eq 0 ]
	pod_id="$output"
```
is roughly equivalent to
```bash
	pod_id=$(crictl runp ...)
```
(except it does not print stdout, only stderr).

Another example,
```bash
	cfg=$(python .... < $input)
	echo "$cfg" > $output
```
is equivalent to
```bash
	python ... < $input > $output
```
and avoids the use of a temporary variable (saves some memory).

Finally,
```bash
	run crictl start ...
	echo "$output"
	[ "$status" -ne 0 ]
```
is equivalent to
```bash
	crictl start ... && false
```
2. Optimize use of `CONMON_BINARY` variable, and remove unneeded cleanup.

3. Fix indentation, add some vertical whitespace for better readability.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
