### PR TITLE
test/network.bats: fix "Clean up network" tests

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -534,8 +534,6 @@ function prepare_network_conf() {
     }
 }
 EOF
-
-    echo 0
 }
 
 function write_plugin_test_args_network_conf() {
@@ -561,8 +559,6 @@ EOF
     if [[ -n "$1" ]]; then
         echo "DEBUG_ARGS=$1" >"$TESTDIR"/cni_plugin_helper_input.env
     fi
-
-    echo 0
 }
 
 function prepare_plugin_test_args_network_conf() {
@@ -617,7 +613,6 @@ function ping_pod_from_pod() {
 
 function cleanup_network_conf() {
     rm -rf "$CRIO_CNI_CONFIG"
-    echo 0
 }
 
 function temp_sandbox_conf() {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -161,7 +161,6 @@ fi
 
 function setup_test() {
     TESTDIR=$(mktemp -d)
-    RANDOM_CNI_NETWORK=${TESTDIR: -10}
 
     # Setup default hooks dir
     HOOKSDIR=$TESTDIR/hooks
@@ -295,12 +294,8 @@ function setup_crio() {
 
     # Prepare the CNI configuration files, we're running with non host
     # networking by default
-    CNI_DEFAULT_NETWORK=crio
-    netfunc="prepare_network_conf"
-    if [[ -n "$2" ]]; then
-        netfunc="$2"
-        CNI_DEFAULT_NETWORK="crio-$RANDOM_CNI_NETWORK"
-    fi
+    CNI_DEFAULT_NETWORK=${CNI_DEFAULT_NETWORK:-crio}
+    CNI_TYPE=${CNI_TYPE:-bridge}
 
     # shellcheck disable=SC2086
     "$CRIO_BINARY_PATH" \
@@ -328,7 +323,7 @@ function setup_crio() {
     sed -r -e 's/nodev(,)?//g' -i "$CRIO_CONFIG"
     sed -i -e 's;\(container_exits_dir =\) \(.*\);\1 "'"$CONTAINER_EXITS_DIR"'";g' "$CRIO_CONFIG"
     sed -i -e 's;\(container_attach_socket_dir =\) \(.*\);\1 "'"$CONTAINER_ATTACH_SOCKET_DIR"'";g' "$CRIO_CONFIG"
-    ${netfunc}
+    prepare_network_conf
 }
 
 function pull_test_containers() {
@@ -516,8 +511,8 @@ function prepare_network_conf() {
     cat >"$CRIO_CNI_CONFIG/10-crio.conf" <<-EOF
 {
     "cniVersion": "0.3.1",
-    "name": "crio",
-    "type": "bridge",
+    "name": "$CNI_DEFAULT_NETWORK",
+    "type": "$CNI_TYPE",
     "bridge": "cni0",
     "isGateway": true,
     "ipMasq": true,
@@ -534,39 +529,6 @@ function prepare_network_conf() {
     }
 }
 EOF
-}
-
-function write_plugin_test_args_network_conf() {
-    mkdir -p "$CRIO_CNI_CONFIG"
-    cat >"$CRIO_CNI_CONFIG/10-plugin-test-args.conf" <<-EOF
-{
-    "cniVersion": "0.3.1",
-    "name": "crio-$RANDOM_CNI_NETWORK",
-    "type": "cni_plugin_helper.bash",
-    "bridge": "cni0",
-    "isGateway": true,
-    "ipMasq": true,
-    "ipam": {
-        "type": "host-local",
-        "subnet": "$POD_IPV4_CIDR",
-        "routes": [
-            { "dst": "$POD_IPV4_DEF_ROUTE"  }
-        ]
-    }
-}
-EOF
-
-    if [[ -n "$1" ]]; then
-        echo "DEBUG_ARGS=$1" >"$TESTDIR"/cni_plugin_helper_input.env
-    fi
-}
-
-function prepare_plugin_test_args_network_conf() {
-    write_plugin_test_args_network_conf
-}
-
-function prepare_plugin_test_args_network_conf_malformed_result() {
-    write_plugin_test_args_network_conf "malformed-result"
 }
 
 function parse_pod_ip() {
@@ -643,4 +605,10 @@ function wait_for_log() {
 
 function replace_config() {
     sed -i -e 's;\('"$1"' = "\).*\("\);\1'"$2"'\2;' "$CRIO_CONFIG"
+}
+
+# Fails the current test, providing the error given.
+function fail() {
+    echo "FAIL [${BATS_TEST_NAME} ${BASH_SOURCE[0]##*/}:${BASH_LINENO[0]}] $*" >&2
+    exit 1
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Commit 58657488e31 replaced the last component of
/var/lib/cni/networks path in network.bats to be $RANDOM_CNI_NETWORK,
while in fact it should be $CNI_DEFAULT_NETWORK
(see https://github.com/cri-o/cri-o/commit/58657488e31518ebebe3ea27ae3f540f8a9fb5b2#diff-807eaca3d52b5557160919f85ff738bc)
    
The bug was never found because bats do not `set -o pipefail`
and so the non-zero exit code from `ls` was ignored.
    
Let's fix the bug. While at it,
 - merge some 90% duplicated code;
 - introduce and use `fail` helper function.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
