### PR TITLE
Support passing properties to RunUnderSystemScope

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -52,16 +52,17 @@ func StatusToExitCode(status int) int {
 }
 
 // RunUnderSystemdScope adds the specified pid to a systemd scope
-func RunUnderSystemdScope(pid int, slice, unitName string) error {
-	var properties []systemdDbus.Property
+func RunUnderSystemdScope(pid int, slice, unitName string, properties ...systemdDbus.Property) error {
 	conn, err := systemdDbus.New()
 	if err != nil {
 		return err
 	}
-	properties = append(properties,
+	defaultProperties := []systemdDbus.Property{
 		newProp("PIDs", []uint32{uint32(pid)}),
 		newProp("Delegate", true),
-		newProp("DefaultDependencies", false))
+		newProp("DefaultDependencies", false),
+	}
+	properties = append(defaultProperties, properties...)
 	if slice != "" {
 		properties = append(properties, systemdDbus.PropSlice(slice))
 	}


### PR DESCRIPTION
This allows callers to set properties such as CollectMode.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
This PR adds functionality to pass properties to systemd scope creation utility function

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No

```release-note
None
```
