### PR TITLE
server: don't call ContainerStateToDisk() to a nil container

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -503,6 +503,10 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 // ContainerStateToDisk writes the container's state information to a JSON file
 // on disk
 func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
+	if ctr == nil {
+		return nil
+	}
+
 	if err := c.Runtime().UpdateContainerStatus(ctr); err != nil {
 		logrus.Warnf("error updating the container status %q: %v", ctr.ID(), err)
 	}

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -67,7 +67,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		for _, ctr := range containers[i:max] {
 			cStatus := ctr.State()
 			if cStatus.Status != oci.ContainerStateStopped {
-				if ctr.ID() == podInfraContainer.ID() {
+				if podInfraContainer != nil && ctr.ID() == podInfraContainer.ID() {
 					continue
 				}
 				c := ctr

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -112,6 +112,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
 		log.Warnf(ctx, "failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
+
 	if err := s.ContainerStateToDisk(podInfraContainer); err != nil {
 		log.Warnf(ctx, "error writing pod infra container %q state to disk: %v", podInfraContainer.ID(), err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
I didn't face any specific issue about this, but there's the risk of
calling ContainerStateToDisk() when podContainerInfra is nil, and it
could be causing issues as down in the stack there's no guard to ensure
the container is not nil.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```