### PR TITLE
test/status.bats: improve

### DIFF
--- a/test/status.bats
+++ b/test/status.bats
@@ -60,17 +60,9 @@ function run_crio_status() {
 
 @test "succeed to retrieve the container info" {
     # given
-    run crictl runp "$TESTDATA"/sandbox_config.json
-    echo "$output"
-    [ "$status" -eq 0 ]
-    pod="$output"
-    run crictl create "$pod" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
-    echo "$output"
-    [ "$status" -eq 0 ]
-    ctr="$output"
-    run crictl start "$ctr"
-    echo "$output"
-    [ "$status" -eq 0 ]
+    pod=$(crictl runp "$TESTDATA"/sandbox_config.json)
+    ctr=$(crictl create "$pod" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+    crictl start "$ctr"
 
     # when
     run_crio_status --socket="${CRIO_SOCKET}" containers --id "$ctr"

--- a/test/status.bats
+++ b/test/status.bats
@@ -12,13 +12,13 @@ function teardown() {
 }
 
 function run_crio_status() {
-    run "${CRIO_STATUS_BINARY_PATH}" $@
+    run "${CRIO_STATUS_BINARY_PATH}" "$@"
+    echo "$output"
 }
 
 @test "status should fail if no subcommand is provided" {
     # when
     run_crio_status
-    echo "$output"
 
     # then
     [ "$status" -eq 1 ]
@@ -27,7 +27,6 @@ function run_crio_status() {
 @test "status should succeed to retrieve the config" {
     # when
     run_crio_status --socket="${CRIO_SOCKET}" config
-    echo "$output"
 
     # then
     [ "$status" -eq 0 ]
@@ -37,7 +36,6 @@ function run_crio_status() {
 @test "status should fail to retrieve the config with invalid socket" {
     # when
     run_crio_status --socket wrong.sock c
-    echo "$output"
 
     # then
     [ "$status" -eq 1 ]
@@ -46,7 +44,6 @@ function run_crio_status() {
 @test "status should succeed to retrieve the info" {
     # when
     run_crio_status --socket="${CRIO_SOCKET}" info
-    echo "$output"
 
     # then
     [ "$status" -eq 0 ]
@@ -56,7 +53,6 @@ function run_crio_status() {
 @test "status should fail to retrieve the info with invalid socket" {
     # when
     run_crio_status --socket wrong.sock i
-    echo "$output"
 
     # then
     [ "$status" -eq 1 ]
@@ -78,7 +74,6 @@ function run_crio_status() {
 
     # when
     run_crio_status --socket="${CRIO_SOCKET}" containers --id "$ctr"
-    echo "$output"
 
     # then
     [ "$status" -eq 0 ]
@@ -88,7 +83,6 @@ function run_crio_status() {
 @test "should fail to retrieve the container info without ID" {
     # when
     run_crio_status --socket="${CRIO_SOCKET}" containers
-    echo "$output"
 
     # then
     [ "$status" -eq 1 ]
@@ -97,7 +91,6 @@ function run_crio_status() {
 @test "should fail to retrieve the container with invalid socket" {
     # when
     run_crio_status --socket wrong.sock s
-    echo "$output"
 
     # then
     [ "$status" -eq 1 ]

--- a/test/status.bats
+++ b/test/status.bats
@@ -3,87 +3,87 @@
 load helpers
 
 function setup() {
-    setup_test
-    start_crio
+	setup_test
+	start_crio
 }
 
 function teardown() {
-    cleanup_test
+	cleanup_test
 }
 
 function run_crio_status() {
-    run "${CRIO_STATUS_BINARY_PATH}" "$@"
-    echo "$output"
+	run "${CRIO_STATUS_BINARY_PATH}" "$@"
+	echo "$output"
 }
 
 @test "status should fail if no subcommand is provided" {
-    # when
-    run_crio_status
+	# when
+	run_crio_status
 
-    # then
-    [ "$status" -eq 1 ]
+	# then
+	[ "$status" -eq 1 ]
 }
 
 @test "status should succeed to retrieve the config" {
-    # when
-    run_crio_status --socket="${CRIO_SOCKET}" config
+	# when
+	run_crio_status --socket="${CRIO_SOCKET}" config
 
-    # then
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"[crio]"* ]]
+	# then
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"[crio]"* ]]
 }
 
 @test "status should fail to retrieve the config with invalid socket" {
-    # when
-    run_crio_status --socket wrong.sock c
+	# when
+	run_crio_status --socket wrong.sock c
 
-    # then
-    [ "$status" -eq 1 ]
+	# then
+	[ "$status" -eq 1 ]
 }
 
 @test "status should succeed to retrieve the info" {
-    # when
-    run_crio_status --socket="${CRIO_SOCKET}" info
+	# when
+	run_crio_status --socket="${CRIO_SOCKET}" info
 
-    # then
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"storage driver"* ]]
+	# then
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"storage driver"* ]]
 }
 
 @test "status should fail to retrieve the info with invalid socket" {
-    # when
-    run_crio_status --socket wrong.sock i
+	# when
+	run_crio_status --socket wrong.sock i
 
-    # then
-    [ "$status" -eq 1 ]
+	# then
+	[ "$status" -eq 1 ]
 }
 
 @test "succeed to retrieve the container info" {
-    # given
-    pod=$(crictl runp "$TESTDATA"/sandbox_config.json)
-    ctr=$(crictl create "$pod" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
-    crictl start "$ctr"
+	# given
+	pod=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr=$(crictl create "$pod" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr"
 
-    # when
-    run_crio_status --socket="${CRIO_SOCKET}" containers --id "$ctr"
+	# when
+	run_crio_status --socket="${CRIO_SOCKET}" containers --id "$ctr"
 
-    # then
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"sandbox: $pod"* ]]
+	# then
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"sandbox: $pod"* ]]
 }
 
 @test "should fail to retrieve the container info without ID" {
-    # when
-    run_crio_status --socket="${CRIO_SOCKET}" containers
+	# when
+	run_crio_status --socket="${CRIO_SOCKET}" containers
 
-    # then
-    [ "$status" -eq 1 ]
+	# then
+	[ "$status" -eq 1 ]
 }
 
 @test "should fail to retrieve the container with invalid socket" {
-    # when
-    run_crio_status --socket wrong.sock s
+	# when
+	run_crio_status --socket wrong.sock s
 
-    # then
-    [ "$status" -eq 1 ]
+	# then
+	[ "$status" -eq 1 ]
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:

Improvements for `status.bats` tests:

* Remove excessive `run` usage
* Move `echo` to `run_crio_status`
* Fix shellcheck SC2086 warning
* Reformat using shfmt (which gained bats support recently, see https://github.com/mvdan/sh/issues/600)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Please review commit-by-commit. Last one is just whitespace changes.

#### Does this PR introduce a user-facing change?

```release-note
None
```
