### PR TITLE
[release-1.18] runtime_vm: Fix non terminating pods

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -626,7 +626,7 @@ func (r *runtimeVM) updateContainerStatus(c *Container) error {
 		ID: c.ID(),
 	})
 	if err != nil {
-		if errors.Cause(err) != ttrpc.ErrClosed {
+		if errors.Is(err, ttrpc.ErrClosed) {
 			return errdefs.FromGRPC(err)
 		}
 		return errdefs.ErrNotFound

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -506,7 +506,10 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 
 	stopCh := make(chan error)
 	go func() {
-		if _, err := r.wait(ctx, c.ID(), ""); err != nil {
+		// errdefs.ErrNotFound actually comes from a closed connection, which is expected
+		// when stoping the container, with the agent and the VM going off. In such case.
+		// let's just ignore the error.
+		if _, err := r.wait(ctx, c.ID(), ""); err != nil && !errors.Is(err, errdefs.ErrNotFound) {
 			stopCh <- errdefs.FromGRPC(err)
 		}
 

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -626,7 +626,7 @@ func (r *runtimeVM) updateContainerStatus(c *Container) error {
 		ID: c.ID(),
 	})
 	if err != nil {
-		if errors.Is(err, ttrpc.ErrClosed) {
+		if !errors.Is(err, ttrpc.ErrClosed) {
 			return errdefs.FromGRPC(err)
 		}
 		return errdefs.ErrNotFound

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -804,7 +804,10 @@ func (r *runtimeVM) wait(ctx context.Context, ctrID, execID string) (int32, erro
 		ExecID: execID,
 	})
 	if err != nil {
-		return -1, errdefs.FromGRPC(err)
+		if !errors.Is(err, ttrpc.ErrClosed) {
+			return -1, errdefs.FromGRPC(err)
+		}
+		return -1, errdefs.ErrNotFound
 	}
 
 	return int32(resp.ExitStatus), nil

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -833,7 +833,7 @@ func (r *runtimeVM) remove(ctx context.Context, ctrID, execID string) error {
 	if _, err := r.task.Delete(ctx, &task.DeleteRequest{
 		ID:     ctrID,
 		ExecID: execID,
-	}); err != nil {
+	}); err != nil && !errors.Is(err, ttrpc.ErrClosed) {
 		return errdefs.FromGRPC(err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

It's been reported by Robert Krawitz that some pods were not terminating when using the VM runtime type.  I've tried to reproduce the issue locally and failed.  Robert, then, gave me access to one of his macines and his scripts and turns out the situation doesn't happen all the time and, when it happens, it happens usually with an infra pod hanging and with pods containing init pods, and it seems to happen because the VM is shutdown, which causes a ttrpc.ErrClosed report, but we don't handle it properly.   This PR tries to fix the issue mentioned.


#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
None
```