### PR TITLE
test: rm disabling selinux from userns tests

### DIFF
--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -19,10 +19,6 @@ function teardown() {
 	export CONTAINER_UID_MAPPINGS="0:100000:100000"
 	export CONTAINER_GID_MAPPINGS="0:200000:100000"
 
-	# Workaround for https://github.com/opencontainers/runc/pull/1562
-	# Remove once the fix hits the CI
-	export OVERRIDE_OPTIONS="--selinux=false"
-
 	# Needed for RHEL
 	if test -e /proc/sys/user/max_user_namespaces; then
 		echo 15000 > /proc/sys/user/max_user_namespaces

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -250,6 +250,12 @@ function setup_crio() {
     CNI_DEFAULT_NETWORK=${CNI_DEFAULT_NETWORK:-crio}
     CNI_TYPE=${CNI_TYPE:-bridge}
 
+    # Workaround for https://github.com/containers/crun/pull/531.
+    # TODO: remove once crun > 0.15 is released and used here.
+    if $RUNTIME_BINARY --version | grep -q '^crun '; then
+        OVERRIDE_OPTIONS="$OVERRIDE_OPTIONS --selinux=false"
+    fi
+
     # shellcheck disable=SC2086
     "$CRIO_BINARY_PATH" \
         --hooks-dir="$HOOKSDIR" \

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -16,10 +16,6 @@ if [[ -n "$TEST_USERNS" ]]; then
     fi
 fi
 
-# Workaround for https://github.com/opencontainers/runc/pull/1562
-# Remove once the fix hits the CI
-export OVERRIDE_OPTIONS="--selinux=false"
-
 # Load the helpers.
 . helpers.bash
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This workaround was added a long time ago and the feature
should supposedly be fixed by now.

Removing it, though, revealed a bug in crun that is being fixed
in containers/crun#531. Until the fix is available in a released crun
version, add another workaround.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
