### PR TITLE
circle-ci: use go 1.15.3

### DIFF
--- a/scripts/circle-setup
+++ b/scripts/circle-setup
@@ -10,6 +10,7 @@ main() {
     prepare_system
 
     install_packages
+    install_golang
     install_bats
     install_conmon
     install_cri_tools
@@ -35,7 +36,7 @@ prepare_system() {
     sudo iptables -t nat -I POSTROUTING -s 127.0.0.1 ! -d 127.0.0.1 -j MASQUERADE
 }
 
-install_packages() {
+install_golang() {
     # remove old golang version
     sudo rm -rf /usr/local/go
     sudo rm -rf /usr/local/bin/go
@@ -43,14 +44,19 @@ install_packages() {
     # set GOPATH
     echo "export GOPATH=/home/circleci/go" >>~/.bashrc
 
-    sudo add-apt-repository -y ppa:longsleep/golang-backports
+    curl -fsSL "https://dl.google.com/go/go${VERSIONS["go"]}.linux-amd64.tar.gz" | sudo tar Cxz /usr/local
+
+    go version
+    go env
+}
+
+install_packages() {
     sudo apt-get update
     sudo apt-get install -y \
         apparmor \
         btrfs-tools \
         conntrack \
         e2fslibs-dev \
-        golang-go \
         jq \
         libaio-dev \
         libapparmor-dev \
@@ -66,9 +72,6 @@ install_packages() {
         libseccomp-dev \
         libsystemd-dev \
         libudev-dev
-
-    go version
-    go env
 }
 
 install_bats() {

--- a/scripts/versions
+++ b/scripts/versions
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Versions to be used
 declare -A VERSIONS=(
+    ["go"]=1.15.3
     ["cni-plugins"]=v0.8.7
     ["conmon"]=v2.0.20
     ["cri-tools"]=v1.19.0


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:

We were using golang from longsleep/golang-backports PPA.
Unfortunately, that repo is apparently no longer updated for Ubuntu
Xenial, with the latest golang being 1.13.

Since 1.13 is no longer supported, let's switch to binary distribution
from google.com, and update to 1.15.

#### Which issue(s) this PR fixes:

Fixes: https://github.com/cri-o/cri-o/issues/4298

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
