### PR TITLE
Error if GitHub release could not be found

### DIFF
--- a/scripts/upload-artifacts
+++ b/scripts/upload-artifacts
@@ -22,6 +22,10 @@ if TAG=$(git describe --exact-match --tags 2>/dev/null); then
     else
         UPLOAD_URL=$(curl -sfL https://api.github.com/repos/cri-o/cri-o/releases |
             jq -r ".[] | select(.tag_name == \"$TAG\") | .upload_url")
+        if [[ -z $UPLOAD_URL ]]; then
+            echo "Unable to find GitHub release for tag $TAG"
+            exit 1
+        fi
         UPLOAD_URL=${UPLOAD_URL%"{?name,label}"}
         FILE=build/bundle/crio-$TAG.tar.gz
         curl -f \


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
If we want to auto-upload the artifacts to GitHub, then we now error if
there could be no release found.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
