### PR TITLE
test: do test user namespace

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -936,6 +936,10 @@ function wait_until_exit() {
 }
 
 @test "privileged ctr -- check for rw mounts" {
+	# Can't run privileged container in userns
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
 	start_crio
 
 	sandbox_config="$TESTDIR"/sandbox_config.json

--- a/test/drop_infra.bats
+++ b/test/drop_infra.bats
@@ -3,6 +3,11 @@
 load helpers
 
 function setup() {
+	# TODO: drop this skip once userns works with CONTAINER_MANAGE_NS_LIFECYCLE=true
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
 	setup_test
 	CONTAINER_MANAGE_NS_LIFECYCLE=true CONTAINER_DROP_INFRA_CTR=true start_crio
 }

--- a/test/image_volume.bats
+++ b/test/image_volume.bats
@@ -41,7 +41,7 @@ function teardown() {
 }
 
 @test "image volume user mkdir" {
-	if test -n "$UID_MAPPINGS"; then
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
 		skip "userNS enabled"
 	fi
 	CONTAINER_IMAGE_VOLUMES="mkdir" start_crio

--- a/test/network.bats
+++ b/test/network.bats
@@ -27,6 +27,10 @@ function teardown() {
 }
 
 @test "ensure correct hostname for hostnetwork:true" {
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
 	start_crio
 	python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["security_context"]["namespace_options"]["network"] = 2; obj["annotations"] = {}; obj["hostname"] = ""; json.dump(obj, sys.stdout)' \
 		< "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_hostnetwork_config.json

--- a/test/network_ping.bats
+++ b/test/network_ping.bats
@@ -3,6 +3,9 @@
 load helpers
 
 function setup() {
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "FIXME: can't set ping_group_range inside the container"
+	fi
 	setup_test
 	CONTAINER_DEFAULT_SYSCTLS='net.ipv4.ping_group_range=0   2147483647' start_crio
 }

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -188,6 +188,11 @@ function teardown() {
 }
 
 @test "crio restore first not managing then managing" {
+	# TODO: drop this skip once userns works with CONTAINER_MANAGE_NS_LIFECYCLE=true
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
 	CONTAINER_MANAGE_NS_LIFECYCLE=false CONTAINER_DROP_INFRA_CTR=false start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	pod_list_info=$(crictl pods --quiet --id "$pod_id")
@@ -230,6 +235,11 @@ function teardown() {
 }
 
 @test "crio restore first managing then not managing" {
+	# TODO: drop this skip once userns works with CONTAINER_MANAGE_NS_LIFECYCLE=true
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
 	CONTAINER_MANAGE_NS_LIFECYCLE=true CONTAINER_DROP_INFRA_CTR=true start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	pod_list_info=$(crictl pods --quiet --id "$pod_id")
@@ -271,6 +281,11 @@ function teardown() {
 }
 
 @test "crio restore changing managing dir" {
+	# TODO: drop this skip once userns works with CONTAINER_MANAGE_NS_LIFECYCLE=true
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
 	CONTAINER_MANAGE_NS_LIFECYCLE=true CONTAINER_NAMESPACE_DIR="$TESTDIR/ns1" start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	pod_list_info=$(crictl pods --quiet --id "$pod_id")

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -7,8 +7,13 @@ cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 if [[ -n "$TEST_USERNS" ]]; then
     echo "Enabled user namespace testing"
-    export UID_MAPPINGS="0:100000:100000"
-    export GID_MAPPINGS="0:200000:100000"
+    # TODO: rm CONTAINER_MANAGE_NS_LIFECYCLE, CONTAINER_DROP_INFRA_CTR
+    # once userns works with them set to default (true).
+    export \
+        CONTAINER_UID_MAPPINGS="0:100000:100000" \
+        CONTAINER_GID_MAPPINGS="0:200000:100000" \
+        CONTAINER_MANAGE_NS_LIFECYCLE=false \
+        CONTAINER_DROP_INFRA_CTR=false
 
     # Needed for RHEL
     if [[ -w /proc/sys/user/max_user_namespaces ]]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

(I consider it a bug in CI that prevented userns testing)

#### What this PR does / why we need it:

##### 1. test: bring back userns testing

Commit 92caff26d ("Added EnvVar to cri-o cli flags", May 29 2019)
changed some testing code to use CONTAINER_{U,G}ID_MAPPING
instead of {U,G}ID_MAPPING environment variables, but a place
in test/test_runner.sh was omitted. This, I guess, resulted
in not testing userns (at least partially -- there are tests that enable
it explicitly rather through a TEST_USERNS env var).

Next, commit b80c31b9cf ("Allow CRI-O to manage IPC and UTS namespaces",
Dec 16 2019) changed the option ManageNetworkNSLifecycle to
ManageNSLifecycle, and changed its default to be true. Since this
commit, it is now needed to disable the option to allow userns testing
(otherwise we get "cannot use UIDMappings with ManageNSLifecycle"
error).

This commit fixes both issues, allegedly bringing back user namespace
testing.

##### 2. misc

Disable various tests that are not possible to run with userns enabled.

Some of them need to be re-enabled later once we fix userns+manage_ns_lifecycle
working together. Those are marked with TODO.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
