### PR TITLE
test: disable crictl pull on create

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -171,9 +171,6 @@ function setup_test() {
     cp "$INTEGRATION_ROOT"/cni_plugin_helper.bash "$CRIO_CNI_PLUGIN"
     sed -i "s;%TEST_DIR%;$TESTDIR;" "$CRIO_CNI_PLUGIN"/cni_plugin_helper.bash
 
-    # configure crictl globally
-    crictl config --set pull-image-on-create=true || true
-
     PATH=$PATH:$TESTDIR
 }
 

--- a/test/image.bats
+++ b/test/image.bats
@@ -75,6 +75,7 @@ function teardown() {
 	start_crio
 
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	crictl pull "$IMAGE_LIST_DIGEST"
 
 	sed -e "s|%VALUE%|$IMAGE_LIST_DIGEST|g" -e 's|"/bin/ls"|"/bin/sleep", "1d"|g' "$TESTDATA"/container_config_by_imageid.json > "$TESTDIR"/ctr_by_imagelistref.json
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
  
We already preload a bunch of images before running tests, and it makes
sense to disable pull during crictl create, as it should save some time
and result in less flakiness in the tests (related to network glitches).
    
crictl 1.19 added this option, and "no pull on create" is the new
default. This reverts the hunk of commit 40b9d971fe (PR #4150)
which changes the default.

For more details, see https://github.com/kubernetes-sigs/cri-tools/pull/627

#### Which issue(s) this PR fixes:

This should eventually fix the flakes caused by network issues
while running tests.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
