### PR TITLE
Upload bundle in separate CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,6 @@ workflows:
             - results
       - results:
           requires:
-            - bundle-test
             - integration
             - integration-cgroupfs
             - integration-critest
@@ -112,6 +111,9 @@ workflows:
       - shellcheck
       - shfmt
       - unit-tests
+      - upload-artifacts:
+          requires:
+            - bundle-test
       - vendor
 
 jobs:
@@ -449,9 +451,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: Upload artifacts
-          command: make upload-artifacts
       - store_test_results:
           path: build/junit
       - store_artifacts:
@@ -535,6 +534,16 @@ jobs:
           paths:
             - build/coverage
             - build/junit
+
+  upload-artifacts:
+    executor: container
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Upload artifacts
+          command: make upload-artifacts
 
   vendor:
     executor: container-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,6 +370,7 @@ jobs:
       - run:
           name: integration test
           command: sudo -E test/test_runner.sh $TEST_ARGS 2>&1 | tee -a /tmp/testout
+          no_output_timeout: 30m
           environment:
             JOBS: "<< parameters.jobs >>"
             CRIO_BINARY: "<< parameters.crio_binary >>"


### PR DESCRIPTION

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
We have issues with integration test timeouts, which is now increased
from 10 to 30 minutes. Beside that, we upload the binary bundle without
their influence in a separate step. This should increase the
availability of uploaded artifacts and make commands like this working
better:

```
> curl -f https://storage.googleapis.com/k8s-conform-cri-o/artifacts/\
    crio-$(git ls-remote https://github.com/cri-o/cri-o master | cut -c1-9).tar.gz -o crio.tar.gz
```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
cc @harche 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
