### PR TITLE
ci: bump crun to 0.15/HEAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,14 +286,14 @@ ${GOLANGCI_LINT}:
 		VERSION=v1.30.0 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
-	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
+	curl -sSfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
 
 ${SHELLCHECK}:
 	mkdir -p ${BUILD_BIN_PATH} && \
 	VERSION=v0.7.0 \
 	URL=https://github.com/koalaman/shellcheck/releases/download/$$VERSION/shellcheck-$$VERSION.linux.x86_64.tar.xz \
 	SHA256SUM=c37d4f51e26ec8ab96b03d84af8c050548d7288a47f755ffb57706c6c458e027 && \
-	curl -sfL $$URL | tar xfJ - -C ${BUILD_BIN_PATH} --strip 1 shellcheck-$$VERSION/shellcheck && \
+	curl -sSfL $$URL | tar xfJ - -C ${BUILD_BIN_PATH} --strip 1 shellcheck-$$VERSION/shellcheck && \
 	sha256sum ${SHELLCHECK} | grep -q $$SHA256SUM
 
 vendor: export GOSUMDB := ""

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -106,7 +106,7 @@ chmod +x "$TMP_BIN/runc"
 
 # crun
 curl_to "$TMP_BIN/crun" \
-    https://github.com/containers/crun/releases/download/"${VERSIONS["crun"]}"/crun-"${VERSIONS["crun"]}"-static-x86_64
+    https://github.com/containers/crun/releases/download/"${VERSIONS["crun"]}"/crun-"${VERSIONS["crun"]}"-linux-amd64
 chmod +x "$TMP_BIN/crun"
 
 # CNI plugins

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -90,7 +90,7 @@ cp "$GIT_ROOT/contrib/bundle/Makefile" "$TMPDIR"
 cp "$GIT_ROOT/contrib/bundle/README.md" "$TMPDIR"
 
 curl_to() {
-    curl -sfL -o "$1" "$2"
+    curl -sSfL -o "$1" "$2"
 }
 TMP_BIN=$TMPDIR/bin
 

--- a/contrib/test/integration/build/crun.yml
+++ b/contrib/test/integration/build/crun.yml
@@ -5,7 +5,7 @@
     repo: "https://github.com/containers/crun.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/containers/crun"
     force: "{{ force_clone | default(False) | bool}}"
-    version: "0.15"
+    version: "HEAD"
 
 - name: Install crun dependencies
   raw: >

--- a/scripts/upload-artifacts
+++ b/scripts/upload-artifacts
@@ -20,7 +20,7 @@ if TAG=$(git describe --exact-match --tags 2>/dev/null); then
     if [[ -z $GITHUB_TOKEN ]]; then
         echo GITHUB_TOKEN not set, skipping artifact upload to GitHub
     else
-        UPLOAD_URL=$(curl -sfL https://api.github.com/repos/cri-o/cri-o/releases |
+        UPLOAD_URL=$(curl -sSfL https://api.github.com/repos/cri-o/cri-o/releases |
             jq -r ".[] | select(.tag_name == \"$TAG\") | .upload_url")
         if [[ -z $UPLOAD_URL ]]; then
             echo "Unable to find GitHub release for tag $TAG"

--- a/scripts/versions
+++ b/scripts/versions
@@ -8,7 +8,7 @@ declare -A VERSIONS=(
     ["conmon"]=v2.0.20
     ["cri-tools"]=v1.19.0
     ["runc"]=v1.0.0-rc92
-    ["crun"]=0.14.1
+    ["crun"]=0.15
     ["bats"]=v1.2.1
 )
 export VERSIONS


### PR DESCRIPTION
1. Since this is a master branch, it makes sense to test crun from
   HEAD (rather than a released version) if we're compiling it from
   source. A similar change was done for runc in commit 9e10f54d3ba834d (PR #3493).

2. For binary crun version, bump to latest 1.15.

/kind dependency-change

```release-note
None
```

@giuseppe PTAL