### PR TITLE
nix: fix static build

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -44,7 +44,7 @@ let
       export CFLAGS='-static'
       export LDFLAGS='-s -w -static-libgcc -static'
       export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
-      export BUILDTAGS='static netgo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper seccomp apparmor selinux'
+      export BUILDTAGS='static netgo osusergo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper seccomp apparmor selinux'
     '';
     buildPhase = ''
       patchShebangs .


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When building a static version of cri-o, the following (valid) warnings
are shown:
```
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> go build  -ldflags '-s -w -X github.com/cri-o/cri-o/internal/pkg/criocli.DefaultsPath="" -X github.com/cri-o/cri-o/internal/version.buildDate='1980-01-01T00:00:00Z' -X github.com/cri-o/cri-o/internal/version.gitCommit=30353e32fa65a9e1d39249f2e5b0951278e8b493 -X github.com/cri-o/cri-o/internal/version.gitTreeState=dirty -s -w -linkmode external -extldflags "-static -lm"' -tags "static netgo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper seccomp apparmor selinux" -o bin/crio github.com/cri-o/cri-o/cmd/crio
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> # github.com/cri-o/cri-o/cmd/crio
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-533854781/000005.o: in function `mygetgrouplist':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-533854781/000004.o: in function `mygetgrgid_r':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-533854781/000004.o: in function `mygetgrnam_r':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /nix/store/an5cr212mg7f80pfza6cij1jnd19hn3l-libgpg-error-1.38/lib/libgpg-error.a(libgpg_error_la-sysutils.o): in function `_gpgrt_getpwdir':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> (.text+0x2aa): warning: Using 'getpwnam' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: (.text+0x2c8): warning: Using 'getpwuid' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-533854781/000004.o: in function `mygetpwnam_r':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-533854781/000004.o: in function `mygetpwuid_r':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> go build  -ldflags '-s -w -X github.com/cri-o/cri-o/internal/pkg/criocli.DefaultsPath="" -X github.com/cri-o/cri-o/internal/version.buildDate='1980-01-01T00:00:00Z' -X github.com/cri-o/cri-o/internal/version.gitCommit=30353e32fa65a9e1d39249f2e5b0951278e8b493 -X github.com/cri-o/cri-o/internal/version.gitTreeState=dirty -s -w -linkmode external -extldflags "-static -lm"' -tags "static netgo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper seccomp apparmor selinux" -o bin/crio-status github.com/cri-o/cri-o/cmd/crio-status
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> # github.com/cri-o/cri-o/cmd/crio-status
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-147846901/000005.o: in function `mygetgrouplist':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-147846901/000004.o: in function `mygetgrgid_r':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-147846901/000004.o: in function `mygetgrnam_r':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /nix/store/an5cr212mg7f80pfza6cij1jnd19hn3l-libgpg-error-1.38/lib/libgpg-error.a(libgpg_error_la-sysutils.o): in function `_gpgrt_getpwdir':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> (.text+0x2aa): warning: Using 'getpwnam' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: (.text+0x2c8): warning: Using 'getpwuid' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-147846901/000004.o: in function `mygetpwnam_r':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /tmp/nix-build-cri-o.drv-0/go-link-147846901/000004.o: in function `mygetpwuid_r':
[1/0/1 built, 0.0 MiB DL] building cri-ouildPhase)cri-o> /nix/store/p9q953ayhadbqr4q84l2j4fkpvn3s774-go-1.15.2/share/go/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

Again, these warnings are legit, and the fix is to not use the above
glibc functions from golang os/user package, but rather a pure golang
implementation of the functionality. This is achieved by adding osusergo
tag, available since go 1.11 (see https://github.com/golang/go/issues/23265).

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
