### PR TITLE
Allow userns with manage ns lifecycle

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -770,12 +770,6 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 		logrus.Infof("The manage-ns-lifecycle option is being deprecated, and will be unconditionally true in the future")
 	}
 
-	if c.UIDMappings != "" && c.ManageNSLifecycle {
-		return errors.New("cannot use UIDMappings with ManageNSLifecycle")
-	}
-	if c.GIDMappings != "" && c.ManageNSLifecycle {
-		return errors.New("cannot use GIDMappings with ManageNSLifecycle")
-	}
 	if c.DropInfraCtr && !c.ManageNSLifecycle {
 		return errors.New("cannot drop infra without ManageNSLifecycle")
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -357,30 +357,6 @@ var _ = t.Describe("Config", func() {
 			Expect(err).NotTo(BeNil())
 		})
 
-		It("should fail wrong UID mappings", func() {
-			// Given
-			sut.UIDMappings = "value"
-			sut.ManageNSLifecycle = true
-
-			// When
-			err := sut.Validate(false)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
-		It("should fail wrong GID mappings", func() {
-			// Given
-			sut.GIDMappings = "value"
-			sut.ManageNSLifecycle = true
-
-			// When
-			err := sut.Validate(false)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
 		It("should fail wrong max log size", func() {
 			// Given
 			sut.LogSizeMax = 1

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -35,7 +35,7 @@ import (
 
 // createContainerPlatform performs platform dependent intermediate steps before calling the container's oci.Runtime().CreateContainer()
 func (s *Server) createContainerPlatform(container *oci.Container, cgroupParent string, idMappings *idtools.IDMappings) error {
-	if idMappings != nil {
+	if idMappings != nil && !container.Spoofed() {
 		rootPair := idMappings.RootPair()
 		for _, path := range []string{container.BundlePath(), container.MountPoint()} {
 			if err := makeAccessible(path, rootPair.UID, rootPair.GID, false); err != nil {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -830,14 +830,14 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 		container.SetMountPoint(mountPoint)
 
-		container.SetIDMappings(sandboxIDMappings)
-
 		container.SetSpec(g.Config)
 	} else {
 		log.Debugf(ctx, "dropping infra container for pod %s", sbox.ID())
 		container = oci.NewSpoofedContainer(sbox.ID(), containerName, labels, created, podContainer.RunDir)
 		g.AddAnnotation(ann.SpoofedContainer, "true")
 	}
+	// needed for getSandboxIDMappings()
+	container.SetIDMappings(sandboxIDMappings)
 
 	if err := sb.SetInfraContainer(container); err != nil {
 		return nil, err

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -188,11 +188,6 @@ function teardown() {
 }
 
 @test "crio restore first not managing then managing" {
-	# TODO: drop this skip once userns works with CONTAINER_MANAGE_NS_LIFECYCLE=true
-	if test -n "$CONTAINER_UID_MAPPINGS"; then
-		skip "userNS enabled"
-	fi
-
 	CONTAINER_MANAGE_NS_LIFECYCLE=false CONTAINER_DROP_INFRA_CTR=false start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	pod_list_info=$(crictl pods --quiet --id "$pod_id")
@@ -235,11 +230,6 @@ function teardown() {
 }
 
 @test "crio restore first managing then not managing" {
-	# TODO: drop this skip once userns works with CONTAINER_MANAGE_NS_LIFECYCLE=true
-	if test -n "$CONTAINER_UID_MAPPINGS"; then
-		skip "userNS enabled"
-	fi
-
 	CONTAINER_MANAGE_NS_LIFECYCLE=true CONTAINER_DROP_INFRA_CTR=true start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	pod_list_info=$(crictl pods --quiet --id "$pod_id")
@@ -281,11 +271,6 @@ function teardown() {
 }
 
 @test "crio restore changing managing dir" {
-	# TODO: drop this skip once userns works with CONTAINER_MANAGE_NS_LIFECYCLE=true
-	if test -n "$CONTAINER_UID_MAPPINGS"; then
-		skip "userNS enabled"
-	fi
-
 	CONTAINER_MANAGE_NS_LIFECYCLE=true CONTAINER_NAMESPACE_DIR="$TESTDIR/ns1" start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	pod_list_info=$(crictl pods --quiet --id "$pod_id")

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -7,13 +7,9 @@ cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 if [[ -n "$TEST_USERNS" ]]; then
     echo "Enabled user namespace testing"
-    # TODO: rm CONTAINER_MANAGE_NS_LIFECYCLE, CONTAINER_DROP_INFRA_CTR
-    # once userns works with them set to default (true).
     export \
         CONTAINER_UID_MAPPINGS="0:100000:100000" \
-        CONTAINER_GID_MAPPINGS="0:200000:100000" \
-        CONTAINER_MANAGE_NS_LIFECYCLE=false \
-        CONTAINER_DROP_INFRA_CTR=false
+        CONTAINER_GID_MAPPINGS="0:200000:100000"
 
     # Needed for RHEL
     if [[ -w /proc/sys/user/max_user_namespaces ]]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allow using rootless/userns together with ManageNSLifecycle, which is especially useful in view of

> level=info msg="The manage-ns-lifecycle option is being deprecated, and will be unconditionally true in the future"

#### Which issue(s) this PR fixes:

Fixes: #4327
Closes: #4331

#### Special notes for your reviewer:

Please review commit by commit.

#### Does this PR introduce a user-facing change?

```release-note
Allow using userns together with ManageNSLifecycle
```
