### PR TITLE
Make Ingress/Egress Burst upper limit slightly under 4GB

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -130,11 +130,11 @@ func (s *Server) newPodNetwork(sb *sandbox.Sandbox) (ocicni.PodNetwork, error) {
 		bwConfig = &ocicni.BandwidthConfig{}
 		if ingress > 0 {
 			bwConfig.IngressRate = uint64(ingress)
-			bwConfig.IngressBurst = math.MaxUint32 * 8 // 4GB burst limit
+			bwConfig.IngressBurst = math.MaxUint32*8 - 1 // 4GB burst limit
 		}
 		if egress > 0 {
 			bwConfig.EgressRate = uint64(egress)
-			bwConfig.EgressBurst = math.MaxUint32 * 8 // 4GB burst limit
+			bwConfig.EgressBurst = math.MaxUint32*8 - 1 // 4GB burst limit
 		}
 	}
 


### PR DESCRIPTION
Bandwidht CNI plugin reserved an upper limit on burst,in which banned include boundary.  
See: https://github.com/containernetworking/plugins/blob/v0.8.7/plugins/meta/bandwidth/main.go#L113. 

Signed-off-by: Zizon Qiu <zzdtsv@gmail.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

#### What this PR does / why we need it:
bandwidth CNI plugin use equality compare, which prevents the exactly 4GB setting. 

#### Which issue(s) this PR fixes:
make it slightly below 4GB.
A better approach maybe introduc new annotation for burst but would still need to under this value to let default behavior go.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Ingress/Egress burst limit is now set slightly below 4GB, which properly sets 4GB as the upper limit of burst
```
