### PR TITLE
add Devices to allowed annotations structure

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -249,7 +249,9 @@ The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  Th
 
 **allowed_annotations**=[]
   A list of experimental annotations this runtime handler is allowed to process.
-  The only currently recognized value is "io.kubernetes.cri-o.userns-mode" for configuring a usernamespace for the pod.
+  The currently recognized values are:
+  "io.kubernetes.cri-o.userns-mode" for configuring a user namespace for the pod.
+  "io.kubernetes.cri-o.Devices" for configuring devices for the pod.
 
 ## CRIO.IMAGE TABLE
 The `crio.image` table contains settings pertaining to the management of OCI images.

--- a/internal/config/device/device.go
+++ b/internal/config/device/device.go
@@ -9,6 +9,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+// DeviceAnnotationDelim is the character
+// used to separate devices in the annotation
+// `io.kubernetes.cri-o.Devices`
+const DeviceAnnotationDelim = ","
+
 // Config is the internal device configuration
 // it holds onto the contents of the additional_devices
 // field, allowing admins to configure devices that are given
@@ -42,6 +47,13 @@ func (d *Config) LoadDevices(devsFromConfig []string) error {
 	}
 	d.devices = devs
 	return nil
+}
+
+// DevicesFromAnnotation takes an annotation string of the form
+// io.kubernetes.cri-o.Device=$PATH:$PATH:$MODE,$PATH...
+// and returns a Device object that can be passed to a create config
+func DevicesFromAnnotation(annotation string) ([]Device, error) {
+	return devicesFromStrings(strings.Split(annotation, DeviceAnnotationDelim))
 }
 
 // devicesFromStrings takes a slice of strings in the form $PATH{:$PATH}{:$MODE}

--- a/internal/config/device/device_test.go
+++ b/internal/config/device/device_test.go
@@ -45,4 +45,46 @@ var _ = t.Describe("DeviceConfig", func() {
 			Expect(d.Devices()).To(BeEmpty())
 		})
 	})
+	t.Describe("DevicesFromAnnotation", func() {
+		It("should fail with poorly formatted device", func() {
+			// Given
+			// When
+			d, err := device.DevicesFromAnnotation("invalid:invalid")
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(d).To(BeEmpty())
+		})
+		It("should fail if invalid device", func() {
+			// Given
+			// When
+			d, err := device.DevicesFromAnnotation("/dev/invalid")
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(d).To(BeEmpty())
+		})
+		It("should succeed with valid device", func() {
+			// Given
+			// When
+			d, err := device.DevicesFromAnnotation("/dev/null:/dev/null:w")
+			// Then
+			Expect(err).To(BeNil())
+			Expect(d).NotTo(BeEmpty())
+		})
+		It("should fail if one invalid device", func() {
+			// Given
+			// When
+			d, err := device.DevicesFromAnnotation("/dev/true,/dev/invalid")
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(d).To(BeEmpty())
+		})
+		It("should succeed if no devices", func() {
+			// Given
+			// When
+			d, err := device.DevicesFromAnnotation("")
+			// Then
+			Expect(err).To(BeNil())
+			Expect(d).To(BeEmpty())
+		})
+	})
 })

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -193,12 +193,22 @@ func (r *Runtime) PrivilegedWithoutHostDevices(handler string) (bool, error) {
 // AllowUsernsAnnotation searches through the AllowedAnnotations for
 // the userns annotation, checking whether this runtime allows processing of "io.kubernetes.cri-o.userns-mode"
 func (r *Runtime) AllowUsernsAnnotation(handler string) (bool, error) {
+	return r.allowAnnotation(handler, annotations.UsernsModeAnnotation)
+}
+
+// AllowDevicesAnnotation searches through the AllowedAnnotations for
+// the devices annotation, checking whether this runtime allows processing of "io.kubernetes.cri-o.Devices"
+func (r *Runtime) AllowDevicesAnnotation(handler string) (bool, error) {
+	return r.allowAnnotation(handler, annotations.DevicesAnnotation)
+}
+
+func (r *Runtime) allowAnnotation(handler, annotation string) (bool, error) {
 	rh, err := r.getRuntimeHandler(handler)
 	if err != nil {
 		return false, err
 	}
 	for _, ann := range rh.AllowedAnnotations {
-		if ann == annotations.UsernsModeAnnotation {
+		if ann == annotation {
 			return true, nil
 		}
 	}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -9,4 +9,7 @@ const (
 
 	// ShmSizeAnnotation is the K8S annotation used to set custom shm size
 	ShmSizeAnnotation = "io.kubernetes.cri-o.ShmSize"
+
+	// DevicesAnnotation is a set of devices to give to the container
+	DevicesAnnotation = "io.kubernetes.cri-o.Devices"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -150,7 +150,9 @@ type RuntimeHandler struct {
 	// to a container running as privileged.
 	PrivilegedWithoutHostDevices bool `toml:"privileged_without_host_devices,omitempty"`
 	// AllowedAnnotations is a slice of experimental annotations that this runtime handler is allowed to process.
-	// The only currently recognized value is "io.kubernetes.cri-o.userns-mode" for configuring a usernamespace for the pod
+	// The currently recognized values are:
+	// "io.kubernetes.cri-o.userns-mode" for configuring a user namespace for the pod.
+	// "io.kubernetes.cri-o.Devices" for configuring devices for the pod.
 	AllowedAnnotations []string `toml:"allowed_annotations,omitempty"`
 }
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -301,8 +301,9 @@ default_runtime = "{{ .DefaultRuntime }}"
 #   host devices from being passed to privileged containers.
 # - allowed_annotations (optional, array of strings): an option for specifying
 #   a list of experimental annotations that this runtime handler is allowed to process.
-#   The only currently recognized value is "io.kubernetes.cri-o.userns-mode" for configuring
-#   a usernamespace for the pod.
+#   The currently recognized values are:
+#   "io.kubernetes.cri-o.userns-mode" for configuring a user namespace for the pod.
+#   "io.kubernetes.cri-o.Devices" for configuring devices for the pod.
 
 {{ range $runtime_name, $runtime_handler := .Runtimes  }}
 [crio.runtime.runtimes.{{ $runtime_name }}]

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -88,7 +88,7 @@ type Container interface {
 	SpecAddAnnotations(sandbox *sandbox.Sandbox, containerVolume []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool) error
 
 	// SpecAddDevices adds devices from the server config, and container CRI config
-	SpecAddDevices([]device.Device, bool) error
+	SpecAddDevices([]device.Device, []device.Device, bool) error
 }
 
 // container is the hidden default type behind the Container interface

--- a/pkg/container/device.go
+++ b/pkg/container/device.go
@@ -13,13 +13,21 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *container) SpecAddDevices(configuredDevices []devicecfg.Device, privilegedWithoutHostDevices bool) error {
+func (c *container) SpecAddDevices(configuredDevices, annotationDevices []devicecfg.Device, privilegedWithoutHostDevices bool) error {
 	// First, clear the existing devices from the spec
 	c.Spec().Config.Linux.Devices = []rspec.LinuxDevice{}
 
 	// After that, add additional_devices from config
 	for i := range configuredDevices {
 		d := &configuredDevices[i]
+
+		c.Spec().AddDevice(d.Device)
+		c.Spec().AddLinuxResourcesDevice(d.Resource.Allow, d.Resource.Type, d.Resource.Major, d.Resource.Minor, d.Resource.Access)
+	}
+
+	// Next, verify and add the devices from annotations
+	for i := range annotationDevices {
+		d := &annotationDevices[i]
 
 		c.Spec().AddDevice(d.Device)
 		c.Spec().AddLinuxResourcesDevice(d.Resource.Allow, d.Resource.Type, d.Resource.Major, d.Resource.Minor, d.Resource.Access)

--- a/pkg/container/device_test.go
+++ b/pkg/container/device_test.go
@@ -71,7 +71,7 @@ var _ = t.Describe("Container", func() {
 				Expect(len(hostDevices)).NotTo(Equal(0))
 
 				// When
-				err := sut.SpecAddDevices(nil, test.privilegedWithoutHostDevices)
+				err := sut.SpecAddDevices(nil, nil, test.privilegedWithoutHostDevices)
 				// Then
 				Expect(err).To(BeNil())
 

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -80,65 +80,6 @@ function wait_until_exit() {
 	[ "$output" == "2048" ]
 }
 
-@test "additional devices support" {
-	if test -n "$CONTAINER_UID_MAPPINGS"; then
-		skip "userNS enabled"
-	fi
-	OVERRIDE_OPTIONS="--additional-devices /dev/null:/dev/qifoo:rwm" start_crio
-	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
-	crictl start "$ctr_id"
-
-	output=$(crictl exec --sync "$ctr_id" sh -c "ls /dev/qifoo")
-	[ "$output" == "/dev/qifoo" ]
-}
-
-@test "additional devices permissions" {
-	# We need a ubiquitously configured device that isn't in the
-	# OCI spec default set.
-	declare -r device="/dev/loop-control"
-	declare -r timeout=30
-
-	if test -n "$CONTAINER_UID_MAPPINGS"; then
-		skip "userNS enabled"
-	fi
-
-	if ! test -r $device; then
-		skip "$device not readable"
-	fi
-
-	if ! test -w $device; then
-		skip "$device not writeable"
-	fi
-
-	OVERRIDE_OPTIONS="--additional-devices ${device}:${device}:w" start_crio
-	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
-	crictl start "$ctr_id"
-
-	# Ensure the device is there.
-	crictl exec --timeout=$timeout --sync "$ctr_id" ls $device
-
-	if ! is_cgroup_v2; then
-		# Dump the deviced cgroup configuration for debugging.
-		output=$(crictl exec --timeout=$timeout --sync "$ctr_id" cat /sys/fs/cgroup/devices/devices.list)
-		[[ "$output" == *"c 10:237 w"* ]]
-	fi
-
-	# Opening the device in read mode should fail because the device
-	# cgroup access only allows writes.
-	run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=$device of=/dev/null count=1
-	[[ "$output" == *"Operation not permitted"* ]]
-
-	# The write should be allowed by the devices cgroup policy, so we
-	# should see an EINVAL from the device when the device fails it.
-	# TODO: fix that test, currently fails with "dd: can't open '/dev/loop-control': No such device non-zero exit code"
-	# run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=/dev/zero of=$device count=1
-	# echo $output
-	# [[ "$output" == *"Invalid argument"* ]]
-}
-
 @test "ctr remove" {
 	start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -11,10 +11,6 @@ function teardown() {
 	cleanup_test
 }
 
-function is_cgroup_v2() {
-	test "$(stat -f -c%T /sys/fs/cgroup)" = "cgroup2fs"
-}
-
 function wait_until_exit() {
 	ctr_id=$1
 	# Wait for container to exit

--- a/test/devices.bats
+++ b/test/devices.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_test
+	newconfig="$TESTDIR/config.json"
+}
+
+function teardown() {
+	cleanup_test
+}
+
+function create_device_runtime() {
+	cat << EOF > "$CRIO_CONFIG_DIR/01-device.conf"
+[crio.runtime]
+default_runtime = "device"
+[crio.runtime.runtimes.device]
+runtime_path = "$RUNTIME_BINARY"
+runtime_root = "$RUNTIME_ROOT"
+runtime_type = "$RUNTIME_TYPE"
+allowed_annotations = ["io.kubernetes.cri-o.Devices"]
+EOF
+}
+
+@test "additional devices support" {
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+	OVERRIDE_OPTIONS="--additional-devices /dev/null:/dev/qifoo:rwm" start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	output=$(crictl exec --sync "$ctr_id" sh -c "ls /dev/qifoo")
+	[ "$output" == "/dev/qifoo" ]
+}
+
+@test "additional devices permissions" {
+	# We need a ubiquitously configured device that isn't in the
+	# OCI spec default set.
+	declare -r device="/dev/loop-control"
+	declare -r timeout=30
+
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
+	if ! test -r $device; then
+		skip "$device not readable"
+	fi
+
+	if ! test -w $device; then
+		skip "$device not writeable"
+	fi
+
+	OVERRIDE_OPTIONS="--additional-devices ${device}:${device}:w" start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	# Ensure the device is there.
+	crictl exec --timeout=$timeout --sync "$ctr_id" ls $device
+
+	if ! is_cgroup_v2; then
+		# Dump the deviced cgroup configuration for debugging.
+		output=$(crictl exec --timeout=$timeout --sync "$ctr_id" cat /sys/fs/cgroup/devices/devices.list)
+		[[ "$output" == *"c 10:237 w"* ]]
+	fi
+
+	# Opening the device in read mode should fail because the device
+	# cgroup access only allows writes.
+	run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=$device of=/dev/null count=1
+	[[ "$output" == *"Operation not permitted"* ]]
+
+	# The write should be allowed by the devices cgroup policy, so we
+	# should see an EINVAL from the device when the device fails it.
+	# TODO: fix that test, currently fails with "dd: can't open '/dev/loop-control': No such device non-zero exit code"
+	# run crictl exec --timeout=$timeout --sync "$ctr_id" dd if=/dev/zero of=$device count=1
+	# echo $output
+	# [[ "$output" == *"Invalid argument"* ]]
+}
+
+@test "annotation devices support" {
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+	create_device_runtime
+	start_crio
+
+	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm"' \
+		"$TESTDATA"/sandbox_config.json > "$newconfig"
+
+	pod_id=$(crictl runp "$newconfig")
+
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	output=$(crictl exec --sync "$ctr_id" sh -c "ls /dev/qifoo")
+	[ "$output" == "/dev/qifoo" ]
+}
+
+@test "annotation should not be processed if not allowed" {
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
+	start_crio
+
+	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm"' \
+		"$TESTDATA"/sandbox_config.json > "$newconfig"
+
+	pod_id=$(crictl runp "$newconfig")
+
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	run crictl exec --sync "$ctr_id" sh -c "ls /dev/qifoo"
+	[ "$status" -ne 0 ]
+}
+
+@test "annotation should override configured additional_devices" {
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+	create_device_runtime
+
+	OVERRIDE_OPTIONS="--additional-devices /dev/urandom:/dev/qifoo:rwm" start_crio
+
+	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm"' \
+		"$TESTDATA"/sandbox_config.json > "$newconfig"
+
+	pod_id=$(crictl runp "$newconfig")
+
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	# if this was /dev/urandom, it would print output
+	output=$(crictl exec --sync "$ctr_id" sh -c "head -n1 /dev/qifoo")
+	[[ -z "$output" ]]
+}
+
+@test "annotation should configure multiple devices" {
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+	create_device_runtime
+	start_crio
+
+	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm,/dev/urandom:/dev/peterfoo:rwm"' \
+		"$TESTDATA"/sandbox_config.json > "$newconfig"
+
+	pod_id=$(crictl runp "$newconfig")
+
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	output=$(crictl exec --sync "$ctr_id" sh -c "head -n1 /dev/qifoo")
+	[[ -z "$output" ]]
+
+	output=$(crictl exec --sync "$ctr_id" sh -c "head -n1 /dev/peterfoo")
+	[[ ! -z "$output" ]]
+}
+
+@test "annotation should fail if one device is invalid" {
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+	create_device_runtime
+	start_crio
+
+	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm,/dove/null"' \
+		"$TESTDATA"/sandbox_config.json > "$newconfig"
+
+	pod_id=$(crictl runp "$newconfig")
+
+	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+	[ "$status" -ne 0 ]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -542,3 +542,8 @@ function fail() {
     echo "FAIL [${BATS_TEST_NAME} ${BASH_SOURCE[0]##*/}:${BASH_LINENO[0]}] $*" >&2
     exit 1
 }
+
+# tests whether the node is configured to use cgroupv2
+function is_cgroup_v2() {
+    test "$(stat -f -c%T /sys/fs/cgroup)" = "cgroup2fs"
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

> /kind flake

#### What this PR does / why we need it:
    
Before there was no way for a user to specify a device to be added to their containers.
The standard mechanism in k8s were clunky and didn't really work.
    
Instead, in the same way we allow userns to be specified with an annotation, add one such annotation for Devices.
Admins can restrict different runtime classes from this behavior with runtime classes.
    
also refactor devices tests to be all together in a separate file


Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add `io.kubernetes.cri-o.Devices` annotation to the list interpretable allowed annotations. Now, users can pass in devices they want added to their containers, but only if the runtime class is allowed to use the annotation.
```
