### PR TITLE
enable/disable some e2e tests; rm TODOs; rework regex

### DIFF
--- a/contrib/test/integration/e2e-features.yml
+++ b/contrib/test/integration/e2e-features.yml
@@ -4,6 +4,10 @@
   include: "e2e-base.yml"
 
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
+  vars:
+    skip_tests:
+      - "[Slow]"
+      - "[Flaky]"
   set_fact:
     e2e_shell_cmd: >
         KUBE_CONTAINER_RUNTIME="remote" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y
@@ -14,7 +18,7 @@
                         --ginkgo.noColor
                         --ginkgo.succinct
                         --ginkgo.focus=\[NodeFeature:.*\]|\[Feature:(Seccomp|ScopeSelectors|PodPriority|Ingress|ComprehensiveNamespaceDraining|Networking-IPv4|TokenRequestProjection)\]
-                        --ginkgo.skip=\[(Slow|Flaky)\]
+                        --ginkgo.skip={{ skip_tests | join('|') | replace(' ', '\\s') | regex_replace('([][)(])', '\\\\\1') }}
                         --report-dir={{ artifacts }}"
             &> {{ artifacts }}/e2e.log
   # Fix vim syntax hilighting: "

--- a/contrib/test/integration/e2e-features.yml
+++ b/contrib/test/integration/e2e-features.yml
@@ -8,6 +8,7 @@
     skip_tests:
       - "[Slow]"
       - "[Flaky]"
+      - "[Serial]"
   set_fact:
     e2e_shell_cmd: >
         KUBE_CONTAINER_RUNTIME="remote" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y

--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -9,7 +9,6 @@
     state: present
     value: 1048576
 
-# TODO remove the second to last test skipped once https://github.com/cri-o/cri-o/pull/1217 is merged
 # TODO remove the last six tests once the newtworking issue with AWS is figured out https://github.com/cri-o/cri-o/issues/1529
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
   set_fact:

--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -9,8 +9,20 @@
     state: present
     value: 1048576
 
-# TODO remove the last six tests once the newtworking issue with AWS is figured out https://github.com/cri-o/cri-o/issues/1529
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
+  vars:
+    skip_tests:
+      - "[Slow]"
+      - "[Serial]"
+      - "[Disruptive]"
+      - "[Flaky]"
+      - "[Feature:"
+      - "[sig-instrumentation] MetricsGrabber"
+      - "for NodePort service"
+      - "In-tree Volumes [Driver: local]"
+      - "PersistentVolumes-local"
+      - "CSI Volumes [Driver: csi-hostpath] [Testpattern: Dynamic PV (block volmode)] provisioning should provision storage with pvc data source"
+      - "CSI Volumes [Driver: csi-hostpath] [Testpattern: Dynamic PV (block volmode)] volumes should store data"
   set_fact:
     e2e_shell_cmd: >
         DBUS_SESSION_BUS_ADDRESS="unix:path=/var/run/dbus/system_bus_socket" KUBE_CONTAINER_RUNTIME="remote" GINKGO_TOLERATE_FLAKES="y" GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y KUBE_SSH_USER="{{ ssh_user }}" LOCAL_SSH_KEY="{{ ssh_location }}"
@@ -18,12 +30,11 @@
             --provider=local
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
-                        --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates|\[sig-storage\].In-tree.Volumes.\[Driver:.local\]|\[sig-storage\].CSI.Volumes.CSI.Topology.test.using.GCE.PD.driver|\[sig\-storage\]\sCSI\sVolumes\s\[Driver\:\scsi\-hostpath\]\s\[Testpattern\:\sDynamic\sPV\s\(block\svolmode\)\]\svolumes\sshould\sstore\sdata|\[sig\-storage\]\sCSI\sVolumes\s\[Driver\:\scsi\-hostpath\]\s\[Testpattern\:\sDynamic\sPV\s\(block\svolmode\)\]\sprovisioning\sshould\sprovision\sstorage\swith\spvc\sdata\ssource|\[sig-network\]\sServices\sshould\sbe\sable\sto\spreserve\sUDP\straffic\swhen\sserver\spod\scycles\sfor\sa\sNodePort\sservice|Events.should.be.sent.by.kubelets.and.the.scheduler.about.pods.scheduling.and.running|\[sig\-apps\].DisruptionController.should.block.an.eviction.until.the.PDB.is.updated.to.allow.it|\[sig\-instrumentation\].MetricsGrabber
+                        --ginkgo.skip={{ skip_tests | join('|') | replace(' ', '\\s') | regex_replace('([][)(])', '\\\\\1') }}
                         --ginkgo.noColor
                         --ginkgo.succinct
                         --report-dir={{ artifacts }}"
             &> {{ artifacts }}/e2e.log
-  # Fix vim syntax highlighting: "
 
 - block:
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

TL;DR:
 - filter out some flaky tests in e2e-features (less flakes in CI :tada:)
 - remove some (obsoleted?) elements from the skip regex in e2e
 - simplify adding tests to skip (improve maintainability :tada:)

1. contrib/test/int/e2e: rm obsoleted TODO
    
    Commit 7d2bde110abe94242 (Dec 8 2017) adds the TODO item, and excludes
    the "should.support.inline.execution.and.attach" test case.
    
    Now, commit 54d1971c71f68 (Jun 24 2019) removes this test from the
    exclude regexp, but forgots to remove the TODO.

2. contrib/test/int/e2e: rework skip regex
    
    In its current form, it is very hard to read, maintain, or make any
    sense out of.
    
    Play with ansible/jinja a bit to enable much simpler way to list
    the tests to skip.
    
    The downside is we have to play some tricks to create a regular
    expression:
    
     1. join the elements of skip_tests via `|`
     2. replace spaces with `\\s`
     3. prepend square brackets and parentheses with `\\`

    This commit also removes some apparently obsoleted elements from the regexp.

3.     contrib/test/int/e2e-features: rework "skip" regex
    
See the previous commit for details.

4. contrib/test/int/e2e-features: skip Serial tests
    
    This is mostly done to fix the flake caused by the test case
    
    > Kubernetes e2e suite: [sig-network] IngressClass [Feature:Ingress] should not set default value if no default IngressClass [Serial]
    
    which fails like this:
    
    > ingressclasses.networking.k8s.io "ingressclass1" already exists
    
    This test depends on a system state and thus can't be run in parallel.
    It was marked as [Serial] recently (see https://github.com/kubernetes/kubernetes/pull/93427) but I just found out
    we do not skip Serial tests in e2e-features.
    
    Fix this.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```