### PR TITLE
runtime_vm: Ensure closeIOChan is not nil inside CloseStdin's function …

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -362,7 +362,9 @@ func (r *runtimeVM) execContainerCommon(c *Container, cmd []string, timeout int6
 		Tty:       tty,
 		StdinOnce: true,
 		CloseStdin: func() error {
-			<-closeIOChan
+			if closeIOChan != nil {
+				<-closeIOChan
+			}
 			return r.closeIO(ctx, c.ID(), execID)
 		},
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This patch fixes the situation of `kubectl cp` hanging forever.

Debugging this issue I've faced a quite interesting situatuon where after `closeIOChan` is closed, the `CloseStdin` functions "resumes" while `closeIOChan` is **nil**, making the function to sit there and wait forever.

Honestly, this bugs my mind quite a bit as I was under the impression that all the everyone waiting for the channel to be closed would be notified, would consume its content, and only after that it'd be nullified.  Well, Today I learnt.

The simplest and more future proof way to work this issue around is to ensure `closeIOChan` is not **nil** inside CloseStdin's function.

Thanks to @liubin, @haircommander, and @r4f4 for being available to discuss the issue.

#### Which issue(s) this PR fixes:

Fixes #4353

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```