### PR TITLE
Support CRI seccomp security profiles

### DIFF
--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -1,12 +1,19 @@
 package seccomp
 
 import (
+	"context"
 	"io/ioutil"
+	"path/filepath"
+	"strings"
 
 	"github.com/containers/common/pkg/seccomp"
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/server/cri/types"
 	json "github.com/json-iterator/go"
+	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	k8sV1 "k8s.io/api/core/v1"
 )
 
 // Config is the global seccomp configuration type
@@ -83,4 +90,149 @@ func (c *Config) IsDisabled() bool {
 // Profile returns the currently loaded seccomp profile
 func (c *Config) Profile() *seccomp.Seccomp {
 	return c.profile
+}
+
+// Setup can be used to setup the seccomp profile.
+func (c *Config) Setup(
+	ctx context.Context,
+	specGenerator *generate.Generator,
+	profileField *types.SecurityProfile,
+	profilePath string,
+) error {
+	if profileField == nil {
+		// Path based seccomp profiles will be used with a higher priority and are
+		// going to be removed in future Kubernetes versions.
+		if err := c.setupFromPath(ctx, specGenerator, profilePath); err != nil {
+			return errors.Wrap(err, "from profile path")
+		}
+	} else if err := c.setupFromField(ctx, specGenerator, profileField); err != nil {
+		// Field based seccomp profiles are newer than the path based ones and will
+		// be the standard in future Kubernetes versions.
+		return errors.Wrap(err, "from field")
+	}
+
+	return nil
+}
+
+func (c *Config) setupFromPath(
+	ctx context.Context, specGenerator *generate.Generator, profilePath string,
+) error {
+	log.Debugf(ctx, "Setup seccomp from profile path: %s", profilePath)
+
+	if profilePath == "" {
+		if !c.UseDefaultWhenEmpty() {
+			// running w/o seccomp, aka unconfined
+			specGenerator.Config.Linux.Seccomp = nil
+			return nil
+		}
+		// default to SeccompProfileRuntimeDefault if user sets UseDefaultWhenEmpty
+		profilePath = k8sV1.SeccompProfileRuntimeDefault
+	}
+
+	// kubelet defaults sandboxes to run as `runtime/default`, we consider the
+	// default profilePath as unconfined if Seccomp disabled
+	// https://github.com/kubernetes/kubernetes/blob/12d9183da03d86c65f9f17e3e28be3c7c18ed22a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go#L162-L163
+	if c.IsDisabled() {
+		if profilePath == k8sV1.SeccompProfileRuntimeDefault {
+			// running w/o seccomp, aka unconfined
+			specGenerator.Config.Linux.Seccomp = nil
+			return nil
+		}
+		if profilePath != k8sV1.SeccompProfileNameUnconfined {
+			return errors.New(
+				"seccomp is not enabled, cannot run with a profile",
+			)
+		}
+
+		log.Warnf(ctx, "Seccomp is not enabled in the kernel, running container without profile")
+	}
+
+	if profilePath == k8sV1.SeccompProfileNameUnconfined {
+		// running w/o seccomp, aka unconfined
+		specGenerator.Config.Linux.Seccomp = nil
+		return nil
+	}
+
+	// Load the default seccomp profile from the server if the profilePath is a
+	// default one
+	if profilePath == k8sV1.SeccompProfileRuntimeDefault || profilePath == k8sV1.DeprecatedSeccompProfileDockerDefault {
+		linuxSpecs, err := seccomp.LoadProfileFromConfig(
+			c.Profile(), specGenerator.Config,
+		)
+		if err != nil {
+			return errors.Wrap(err, "load default profile")
+		}
+
+		specGenerator.Config.Linux.Seccomp = linuxSpecs
+		return nil
+	}
+
+	// Load local seccomp profiles including their availability validation
+	if !strings.HasPrefix(profilePath, k8sV1.SeccompLocalhostProfileNamePrefix) {
+		return errors.Errorf("unknown seccomp profile path: %q", profilePath)
+	}
+
+	fname := strings.TrimPrefix(profilePath, k8sV1.SeccompLocalhostProfileNamePrefix)
+	file, err := ioutil.ReadFile(filepath.FromSlash(fname))
+	if err != nil {
+		return errors.Errorf("cannot load seccomp profile %q: %v", fname, err)
+	}
+
+	linuxSpecs, err := seccomp.LoadProfileFromBytes(file, specGenerator.Config)
+	if err != nil {
+		return err
+	}
+	specGenerator.Config.Linux.Seccomp = linuxSpecs
+	return nil
+}
+
+func (c *Config) setupFromField(
+	ctx context.Context,
+	specGenerator *generate.Generator,
+	profileField *types.SecurityProfile,
+) error {
+	log.Debugf(ctx, "Setup seccomp from profile field: %+v", profileField)
+
+	if c.IsDisabled() {
+		if profileField.ProfileType != types.SecurityProfileTypeUnconfined {
+			return errors.Errorf(
+				"seccomp is not enabled, cannot run with a profile",
+			)
+		}
+		log.Warnf(ctx, "seccomp is not enabled, running without profile")
+		specGenerator.Config.Linux.Seccomp = nil
+		return nil
+	}
+
+	if profileField.ProfileType == types.SecurityProfileTypeUnconfined {
+		// running w/o seccomp, aka unconfined
+		specGenerator.Config.Linux.Seccomp = nil
+		return nil
+	}
+
+	if profileField.ProfileType == types.SecurityProfileTypeRuntimeDefault {
+		linuxSpecs, err := seccomp.LoadProfileFromConfig(
+			c.Profile(), specGenerator.Config,
+		)
+		if err != nil {
+			return errors.Wrap(err, "load default profile")
+		}
+		specGenerator.Config.Linux.Seccomp = linuxSpecs
+		return nil
+	}
+
+	// Load local seccomp profiles including their availability validation
+	file, err := ioutil.ReadFile(filepath.FromSlash(profileField.LocalhostRef))
+	if err != nil {
+		return errors.Wrapf(
+			err, "unable to load local profile %q", profileField.LocalhostRef,
+		)
+	}
+
+	linuxSpecs, err := seccomp.LoadProfileFromBytes(file, specGenerator.Config)
+	if err != nil {
+		return errors.Wrap(err, "load local profile")
+	}
+	specGenerator.Config.Linux.Seccomp = linuxSpecs
+	return nil
 }

--- a/internal/config/seccomp/seccomp_test.go
+++ b/internal/config/seccomp/seccomp_test.go
@@ -1,12 +1,16 @@
 package seccomp_test
 
 import (
+	"context"
 	"io/ioutil"
 
 	containers_seccomp "github.com/containers/common/pkg/seccomp"
 	"github.com/cri-o/cri-o/internal/config/seccomp"
+	"github.com/cri-o/cri-o/server/cri/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/opencontainers/runtime-tools/generate"
+	k8sV1 "k8s.io/api/core/v1"
 )
 
 // The actual test suite
@@ -17,6 +21,30 @@ var _ = t.Describe("Config", func() {
 		sut = seccomp.New()
 		Expect(sut).NotTo(BeNil())
 	})
+
+	writeProfileFile := func() string {
+		file := t.MustTempFile("")
+		Expect(ioutil.WriteFile(file, []byte(`{
+				"names": ["clone"],
+				"action": "SCMP_ACT_ALLOW",
+				"args": [
+					{
+					"index": 1,
+					"value": 2080505856,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+					}
+				],
+				"comment": "s390 parameter ordering for clone is different",
+				"includes": {
+					"arches": ["s390", "s390x"]
+				},
+				"excludes": {
+					"caps": ["CAP_SYS_ADMIN"]
+				}
+			}`), 0o644)).To(BeNil())
+		return file
+	}
 
 	t.Describe("Profile", func() {
 		It("should be the default without any load", func() {
@@ -42,26 +70,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed with profile", func() {
 			// Given
-			file := t.MustTempFile("")
-			Expect(ioutil.WriteFile(file, []byte(`{
-				"names": ["clone"],
-				"action": "SCMP_ACT_ALLOW",
-				"args": [
-					{
-					"index": 1,
-					"value": 2080505856,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_MASKED_EQ"
-					}
-				],
-				"comment": "s390 parameter ordering for clone is different",
-				"includes": {
-					"arches": ["s390", "s390x"]
-				},
-				"excludes": {
-					"caps": ["CAP_SYS_ADMIN"]
-				}
-			}`), 0o644)).To(BeNil())
+			file := writeProfileFile()
 
 			// When
 			err := sut.LoadProfile(file)
@@ -80,5 +89,122 @@ var _ = t.Describe("Config", func() {
 				Expect(err).NotTo(BeNil())
 			})
 		}
+	})
+
+	t.Describe("Setup", func() {
+		It("should succeed with profile from file", func() {
+			// Given
+			generator, err := generate.New("linux")
+			Expect(err).To(BeNil())
+			file := writeProfileFile()
+
+			// When
+			err = sut.Setup(
+				context.Background(),
+				&generator,
+				nil,
+				k8sV1.SeccompLocalhostProfileNamePrefix+file,
+			)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed with profile from file and runtime default", func() {
+			// Given
+			generator, err := generate.New("linux")
+			Expect(err).To(BeNil())
+
+			// When
+			err = sut.Setup(
+				context.Background(),
+				&generator,
+				nil,
+				k8sV1.SeccompProfileRuntimeDefault,
+			)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should fail with profile from file if wrong filename", func() {
+			// Given
+			generator, err := generate.New("linux")
+			Expect(err).To(BeNil())
+
+			// When
+			err = sut.Setup(
+				context.Background(),
+				&generator,
+				nil,
+				"not-existing",
+			)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should succeed with custom profile from field", func() {
+			// Given
+			generator, err := generate.New("linux")
+			Expect(err).To(BeNil())
+			field := &types.SecurityProfile{
+				ProfileType: types.SecurityProfileTypeRuntimeDefault,
+			}
+
+			// When
+			err = sut.Setup(
+				context.Background(),
+				&generator,
+				field,
+				"",
+			)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed with custom profile from field", func() {
+			// Given
+			generator, err := generate.New("linux")
+			Expect(err).To(BeNil())
+			file := writeProfileFile()
+			field := &types.SecurityProfile{
+				ProfileType:  types.SecurityProfileTypeLocalhost,
+				LocalhostRef: file,
+			}
+
+			// When
+			err = sut.Setup(
+				context.Background(),
+				&generator,
+				field,
+				"",
+			)
+
+			// Then
+			Expect(err).To(BeNil())
+		})
+
+		It("should fail with custom profile from field if not existing", func() {
+			// Given
+			generator, err := generate.New("linux")
+			Expect(err).To(BeNil())
+			field := &types.SecurityProfile{
+				ProfileType:  types.SecurityProfileTypeLocalhost,
+				LocalhostRef: "not-existing",
+			}
+
+			// When
+			err = sut.Setup(
+				context.Background(),
+				&generator,
+				field,
+				"",
+			)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
 	})
 })

--- a/server/cri/types/types.go
+++ b/server/cri/types/types.go
@@ -324,6 +324,8 @@ type LinuxSandboxSecurityContext struct {
 	SelinuxOptions     *SELinuxOption
 	RunAsUser          *Int64Value
 	RunAsGroup         *Int64Value
+	Seccomp            *SecurityProfile
+	Apparmor           *SecurityProfile
 	SeccompProfilePath string
 	SupplementalGroups []int64
 	ReadonlyRootfs     bool
@@ -511,6 +513,8 @@ type LinuxContainerSecurityContext struct {
 	SelinuxOptions     *SELinuxOption
 	RunAsUser          *Int64Value
 	RunAsGroup         *Int64Value
+	Seccomp            *SecurityProfile
+	Apparmor           *SecurityProfile
 	RunAsUsername      string
 	ApparmorProfile    string
 	SeccompProfilePath string
@@ -620,3 +624,16 @@ type ContainerStatsFilter struct {
 	PodSandboxID  string
 	LabelSelector map[string]string
 }
+
+type SecurityProfile struct {
+	ProfileType  SecurityProfileType
+	LocalhostRef string
+}
+
+type SecurityProfileType int32
+
+const (
+	SecurityProfileTypeRuntimeDefault SecurityProfileType = 0
+	SecurityProfileTypeUnconfined     SecurityProfileType = 1
+	SecurityProfileTypeLocalhost      SecurityProfileType = 2
+)

--- a/server/cri/v1/rpc_create_container.go
+++ b/server/cri/v1/rpc_create_container.go
@@ -82,6 +82,18 @@ func (s *service) CreateContainer(
 						DropCapabilities: req.Config.Linux.SecurityContext.Capabilities.DropCapabilities,
 					}
 				}
+				if req.Config.Linux.SecurityContext.Seccomp != nil {
+					r.Config.Linux.SecurityContext.Seccomp = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.Config.Linux.SecurityContext.Seccomp.ProfileType),
+						LocalhostRef: req.Config.Linux.SecurityContext.Seccomp.LocalhostRef,
+					}
+				}
+				if req.Config.Linux.SecurityContext.Apparmor != nil {
+					r.Config.Linux.SecurityContext.Apparmor = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.Config.Linux.SecurityContext.Apparmor.ProfileType),
+						LocalhostRef: req.Config.Linux.SecurityContext.Apparmor.LocalhostRef,
+					}
+				}
 				if req.Config.Linux.SecurityContext.NamespaceOptions != nil {
 					r.Config.Linux.SecurityContext.NamespaceOptions = &types.NamespaceOption{
 						Network:  types.NamespaceMode(req.Config.Linux.SecurityContext.NamespaceOptions.Network),
@@ -188,6 +200,18 @@ func (s *service) CreateContainer(
 					Privileged:         req.SandboxConfig.Linux.SecurityContext.Privileged,
 					NamespaceOptions:   &types.NamespaceOption{},
 					SelinuxOptions:     &types.SELinuxOption{},
+				}
+				if req.SandboxConfig.Linux.SecurityContext.Seccomp != nil {
+					r.SandboxConfig.Linux.SecurityContext.Seccomp = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.SandboxConfig.Linux.SecurityContext.Seccomp.ProfileType),
+						LocalhostRef: req.SandboxConfig.Linux.SecurityContext.Seccomp.LocalhostRef,
+					}
+				}
+				if req.SandboxConfig.Linux.SecurityContext.Apparmor != nil {
+					r.SandboxConfig.Linux.SecurityContext.Apparmor = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.SandboxConfig.Linux.SecurityContext.Apparmor.ProfileType),
+						LocalhostRef: req.SandboxConfig.Linux.SecurityContext.Apparmor.LocalhostRef,
+					}
 				}
 				if req.SandboxConfig.Linux.SecurityContext.NamespaceOptions != nil {
 					r.SandboxConfig.Linux.SecurityContext.NamespaceOptions = &types.NamespaceOption{

--- a/server/cri/v1/rpc_pull_image.go
+++ b/server/cri/v1/rpc_pull_image.go
@@ -87,6 +87,18 @@ func (s *service) PullImage(
 					NamespaceOptions:   &types.NamespaceOption{},
 					SelinuxOptions:     &types.SELinuxOption{},
 				}
+				if req.SandboxConfig.Linux.SecurityContext.Seccomp != nil {
+					r.SandboxConfig.Linux.SecurityContext.Seccomp = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.SandboxConfig.Linux.SecurityContext.Seccomp.ProfileType),
+						LocalhostRef: req.SandboxConfig.Linux.SecurityContext.Seccomp.LocalhostRef,
+					}
+				}
+				if req.SandboxConfig.Linux.SecurityContext.Apparmor != nil {
+					r.SandboxConfig.Linux.SecurityContext.Apparmor = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.SandboxConfig.Linux.SecurityContext.Apparmor.ProfileType),
+						LocalhostRef: req.SandboxConfig.Linux.SecurityContext.Apparmor.LocalhostRef,
+					}
+				}
 				if req.SandboxConfig.Linux.SecurityContext.NamespaceOptions != nil {
 					r.SandboxConfig.Linux.SecurityContext.NamespaceOptions = &types.NamespaceOption{
 						Network:  types.NamespaceMode(req.SandboxConfig.Linux.SecurityContext.NamespaceOptions.Network),

--- a/server/cri/v1/rpc_run_pod_sandbox.go
+++ b/server/cri/v1/rpc_run_pod_sandbox.go
@@ -62,6 +62,18 @@ func (s *service) RunPodSandbox(
 					NamespaceOptions:   &types.NamespaceOption{},
 					SelinuxOptions:     &types.SELinuxOption{},
 				}
+				if req.Config.Linux.SecurityContext.Seccomp != nil {
+					r.Config.Linux.SecurityContext.Seccomp = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.Config.Linux.SecurityContext.Seccomp.ProfileType),
+						LocalhostRef: req.Config.Linux.SecurityContext.Seccomp.LocalhostRef,
+					}
+				}
+				if req.Config.Linux.SecurityContext.Apparmor != nil {
+					r.Config.Linux.SecurityContext.Apparmor = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.Config.Linux.SecurityContext.Apparmor.ProfileType),
+						LocalhostRef: req.Config.Linux.SecurityContext.Apparmor.LocalhostRef,
+					}
+				}
 				if req.Config.Linux.SecurityContext.NamespaceOptions != nil {
 					r.Config.Linux.SecurityContext.NamespaceOptions = &types.NamespaceOption{
 						Network:  types.NamespaceMode(req.Config.Linux.SecurityContext.NamespaceOptions.Network),

--- a/server/cri/v1alpha2/rpc_create_container.go
+++ b/server/cri/v1alpha2/rpc_create_container.go
@@ -82,6 +82,18 @@ func (s *service) CreateContainer(
 						DropCapabilities: req.Config.Linux.SecurityContext.Capabilities.DropCapabilities,
 					}
 				}
+				if req.Config.Linux.SecurityContext.Seccomp != nil {
+					r.Config.Linux.SecurityContext.Seccomp = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.Config.Linux.SecurityContext.Seccomp.ProfileType),
+						LocalhostRef: req.Config.Linux.SecurityContext.Seccomp.LocalhostRef,
+					}
+				}
+				if req.Config.Linux.SecurityContext.Apparmor != nil {
+					r.Config.Linux.SecurityContext.Apparmor = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.Config.Linux.SecurityContext.Apparmor.ProfileType),
+						LocalhostRef: req.Config.Linux.SecurityContext.Apparmor.LocalhostRef,
+					}
+				}
 				if req.Config.Linux.SecurityContext.NamespaceOptions != nil {
 					r.Config.Linux.SecurityContext.NamespaceOptions = &types.NamespaceOption{
 						Network:  types.NamespaceMode(req.Config.Linux.SecurityContext.NamespaceOptions.Network),
@@ -188,6 +200,18 @@ func (s *service) CreateContainer(
 					Privileged:         req.SandboxConfig.Linux.SecurityContext.Privileged,
 					NamespaceOptions:   &types.NamespaceOption{},
 					SelinuxOptions:     &types.SELinuxOption{},
+				}
+				if req.SandboxConfig.Linux.SecurityContext.Seccomp != nil {
+					r.SandboxConfig.Linux.SecurityContext.Seccomp = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.SandboxConfig.Linux.SecurityContext.Seccomp.ProfileType),
+						LocalhostRef: req.SandboxConfig.Linux.SecurityContext.Seccomp.LocalhostRef,
+					}
+				}
+				if req.SandboxConfig.Linux.SecurityContext.Apparmor != nil {
+					r.SandboxConfig.Linux.SecurityContext.Apparmor = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.SandboxConfig.Linux.SecurityContext.Apparmor.ProfileType),
+						LocalhostRef: req.SandboxConfig.Linux.SecurityContext.Apparmor.LocalhostRef,
+					}
 				}
 				if req.SandboxConfig.Linux.SecurityContext.NamespaceOptions != nil {
 					r.SandboxConfig.Linux.SecurityContext.NamespaceOptions = &types.NamespaceOption{

--- a/server/cri/v1alpha2/rpc_pull_image.go
+++ b/server/cri/v1alpha2/rpc_pull_image.go
@@ -87,6 +87,18 @@ func (s *service) PullImage(
 					NamespaceOptions:   &types.NamespaceOption{},
 					SelinuxOptions:     &types.SELinuxOption{},
 				}
+				if req.SandboxConfig.Linux.SecurityContext.Seccomp != nil {
+					r.SandboxConfig.Linux.SecurityContext.Seccomp = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.SandboxConfig.Linux.SecurityContext.Seccomp.ProfileType),
+						LocalhostRef: req.SandboxConfig.Linux.SecurityContext.Seccomp.LocalhostRef,
+					}
+				}
+				if req.SandboxConfig.Linux.SecurityContext.Apparmor != nil {
+					r.SandboxConfig.Linux.SecurityContext.Apparmor = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.SandboxConfig.Linux.SecurityContext.Apparmor.ProfileType),
+						LocalhostRef: req.SandboxConfig.Linux.SecurityContext.Apparmor.LocalhostRef,
+					}
+				}
 				if req.SandboxConfig.Linux.SecurityContext.NamespaceOptions != nil {
 					r.SandboxConfig.Linux.SecurityContext.NamespaceOptions = &types.NamespaceOption{
 						Network:  types.NamespaceMode(req.SandboxConfig.Linux.SecurityContext.NamespaceOptions.Network),

--- a/server/cri/v1alpha2/rpc_run_pod_sandbox.go
+++ b/server/cri/v1alpha2/rpc_run_pod_sandbox.go
@@ -62,6 +62,18 @@ func (s *service) RunPodSandbox(
 					NamespaceOptions:   &types.NamespaceOption{},
 					SelinuxOptions:     &types.SELinuxOption{},
 				}
+				if req.Config.Linux.SecurityContext.Seccomp != nil {
+					r.Config.Linux.SecurityContext.Seccomp = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.Config.Linux.SecurityContext.Seccomp.ProfileType),
+						LocalhostRef: req.Config.Linux.SecurityContext.Seccomp.LocalhostRef,
+					}
+				}
+				if req.Config.Linux.SecurityContext.Apparmor != nil {
+					r.Config.Linux.SecurityContext.Apparmor = &types.SecurityProfile{
+						ProfileType:  types.SecurityProfileType(req.Config.Linux.SecurityContext.Apparmor.ProfileType),
+						LocalhostRef: req.Config.Linux.SecurityContext.Apparmor.LocalhostRef,
+					}
+				}
 				if req.Config.Linux.SecurityContext.NamespaceOptions != nil {
 					r.Config.Linux.SecurityContext.NamespaceOptions = &types.NamespaceOption{
 						Network:  types.NamespaceMode(req.Config.Linux.SecurityContext.NamespaceOptions.Network),

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -830,12 +830,14 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		},
 	)
 
-	spp := securityContext.SeccompProfilePath
-	g.AddAnnotation(annotations.SeccompProfilePath, spp)
-	sb.SetSeccompProfilePath(spp)
+	seccompProfilePath := securityContext.SeccompProfilePath
+	g.AddAnnotation(annotations.SeccompProfilePath, seccompProfilePath)
+	sb.SetSeccompProfilePath(seccompProfilePath)
 	if !privileged {
-		if err := s.setupSeccomp(ctx, g, spp); err != nil {
-			return nil, err
+		if err := s.Config().Seccomp().Setup(
+			ctx, g, securityContext.Seccomp, seccompProfilePath,
+		); err != nil {
+			return nil, errors.Wrap(err, "setup seccomp")
 		}
 	}
 

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -61,7 +61,7 @@ function teardown() {
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	run crictl create "$pod_id" "$TESTDIR"/seccomp.json "$TESTDATA"/sandbox_config.json
 	[[ "$status" -ne 0 ]]
-	[[ "$output" =~ "unknown seccomp profile option:" ]]
+	[[ "$output" =~ "unknown seccomp profile " ]]
 	[[ "$output" =~ "wontwork" ]]
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now add support for seccomp security profiles within the CRI. We still support the deprecated code paths until the field is not available any more.

AppArmor support will follow later on.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support Container Runtime Interface (CRI) security profiles for seccomp, which has been introduced with Kubernetes v1.20.0 and the graduation of the CRI.
```
