### PR TITLE
Fix links to installation documentation

### DIFF
--- a/tutorials/crictl.md
+++ b/tutorials/crictl.md
@@ -2,7 +2,7 @@
 
 This tutorial will walk you through the creation of [Redis](https://redis.io/) server running in a [Pod](http://kubernetes.io/docs/user-guide/pods/) using [crictl](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md)
 
-It assumes you've already downloaded and configured `CRI-O`. If not, see [here for CRI-O](setup.md).
+It assumes you've already downloaded and configured `CRI-O`. If not, see [here for CRI-O](/install.md).
 It also assumes you've set up CNI, and are using the default plugins as described [here](/contrib/cni/README.md). If you are using a different configuration, results may vary.
 
 ## Installation

--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -1,6 +1,6 @@
 # Running CRI-O with kubeadm
 
-This tutorial assumes you've already installed and setup CRI-O. If you have not, start [here](setup.md).
+This tutorial assumes you've already installed and setup CRI-O. If you have not, start [here](/install.md).
 It also assumes you've set up your system to use kubeadm. If you haven't done so, [here is a good tutorial](https://www.mirantis.com/blog/how-install-kubernetes-kubeadm/)
 
 ### Configuring CNI
@@ -19,7 +19,7 @@ Note: This file assumes you've set your cgroup_driver as systemd
 
 # Running kubeadm
 
-Given you've set CIDR, and you've properly set the kubelet file, all you need to do is start crio (as defined [here](setup.md)), and run:
+Given you've set CIDR, and you've properly set the kubelet file, all you need to do is start crio (as defined [here](/install.md)), and run:
 `kubeadm init --pod-network-cidr=$CIDR`
 
 # Running kubeadm in an off line network


### PR DESCRIPTION
Signed-off-by: Markus Thömmes <markusthoemmes@me.com>

#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

This PR fixes a few links to a document that is no longer there but crucial during initial setup of cri-o.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
