### PR TITLE
ci: use cri-tools from git head

### DIFF
--- a/contrib/test/integration/build/cri-tools.yml
+++ b/contrib/test/integration/build/cri-tools.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/kubernetes-sigs/cri-tools.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-tools"
-    version: "{{ cri_tools_git_version }}"
+    version: HEAD
     force: "{{ force_clone | default(False) | bool}}"
 
 - name: build cri-tools

--- a/scripts/circle-setup
+++ b/scripts/circle-setup
@@ -13,7 +13,7 @@ main() {
     install_golang
     install_bats
     install_conmon
-    install_cri_tools
+    install_critools
     install_runc
     install_ginkgo
     install_cni_plugins
@@ -95,20 +95,17 @@ install_conmon() {
     sudo rm -rf conmon
 }
 
-install_cri_tools() {
-    ARCHIVE=${VERSIONS["cri-tools"]}-linux-amd64.tar.gz
-    URL=https://github.com/kubernetes-sigs/cri-tools/releases/download
+install_critools() {
+    URL=https://github.com/kubernetes-sigs/cri-tools
 
-    BINARIES=(crictl critest)
-    for BINARY in "${BINARIES[@]}"; do
-        TARBALL=$BINARY-$ARCHIVE
-        echo "Downloading $TARBALL"
-        wget -O "$TARBALL" $URL/"${VERSIONS["cri-tools"]}"/"$TARBALL"
-        sudo tar xf "$TARBALL" --no-same-owner -C /usr/bin
-        sudo chown root:root /usr/bin/"$BINARY"
-        sudo "$BINARY" --version
-        rm "$TARBALL"
-    done
+    git clone $URL
+    pushd cri-tools
+    make binaries
+    sudo make BINDIR=/usr/bin install
+    popd
+    rm -rf cri-tools
+    sudo critest --version
+    sudo crictl --version
 }
 
 install_cni_plugins() {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

(this is not about failing-test; it's just I could not find any category which is closer to ci than this one)

#### What this PR does / why we need it:

Use cri-tools from git head for CI.

This is done so changes in cri-tools will be caught instantly
(as opposed to after a release).

Should help in finding bugs like the one fixed by https://github.com/kubernetes-sigs/cri-tools/pull/683

Note this should only be done for master cri-o branch.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
