### PR TITLE
CI: remove unused job, move some jobs to github-actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,6 @@ workflows:
             - integration-static
             - integration-userns
             - unit-tests
-      - shellcheck
       - shfmt
       - unit-tests
       - upload-artifacts:
@@ -426,22 +425,6 @@ jobs:
       - store_artifacts:
           path: bundle
           destination: bundle
-
-  shellcheck:
-    executor: container
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-shellcheck-{{ checksum "go.sum" }}
-      - run:
-          name: Check shell files
-          command: make shellcheck
-      - save_cache:
-          key: v1-shellcheck-{{ checksum "go.sum" }}
-          paths:
-            - *gocache
-            - build/bin/shellcheck
 
   shfmt:
     executor: container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ workflows:
       - docs-generation:
           requires:
             - build
-      - docs-validation
       - integration
       - integration:
           name: integration-critest
@@ -252,21 +251,6 @@ jobs:
             hack/tree_status.sh
       - save_cache:
           key: v1-docs-generation-{{ checksum "go.sum" }}
-          paths:
-            - *gocache
-
-  docs-validation:
-    executor: container
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-docs-validation-{{ checksum "go.sum" }}
-      - run:
-          name: doc validation
-          command: make docs-validation
-      - save_cache:
-          key: v1-docs-validation-{{ checksum "go.sum" }}
           paths:
             - *gocache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,6 @@ workflows:
             - integration-static
             - integration-userns
             - unit-tests
-      - shfmt
       - unit-tests
       - upload-artifacts:
           requires:
@@ -425,22 +424,6 @@ jobs:
       - store_artifacts:
           path: bundle
           destination: bundle
-
-  shfmt:
-    executor: container
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-shfmt-{{ checksum "go.sum" }}
-      - run:
-          name: Format shell files
-          command: make shfmt
-      - save_cache:
-          key: v1-shfmt-{{ checksum "go.sum" }}
-          paths:
-            - *gocache
-            - build/bin/shfmt
 
   unit-tests:
     executor: container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ workflows:
           name: build-386
           executor: container-386
       - build-static
-      - build-test-binaries
       - bundle:
           requires:
             - build
@@ -196,26 +195,6 @@ jobs:
           key: nix-v1-{{ checksum "nix/nixpkgs.json" }}
           paths:
             - .cache
-
-  build-test-binaries:
-    executor: container
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-build-test-binaries-{{ checksum "go.sum" }}
-      - run:
-          name: build
-          command: make test-binaries -j $JOBS
-      - save_cache:
-          key: v1-build-test-binaries-{{ checksum "go.sum" }}
-          paths:
-            - *gocache
-      - persist_to_workspace:
-          root: .
-          paths:
-            - test/checkseccomp/checkseccomp
-            - test/copyimg/copyimg
 
   bundle:
     executor: container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ workflows:
       - integration:
           name: integration-cgroupfs
           cgroup_manager: cgroupfs
-      - lint
       - release-branch-forward:
           requires:
             - results
@@ -360,21 +359,6 @@ jobs:
             CONTAINER_CONMON_CGROUP: "<< parameters.conmon_cgroup >>"
       - save_cache:
           key: v1-integration-{{ checksum "go.sum" }}
-          paths:
-            - *gocache
-
-  lint:
-    executor: container
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v4-lint-{{ checksum "go.sum" }}
-      - run:
-          name: lint
-          command: make lint
-      - save_cache:
-          key: v4-lint-{{ checksum "go.sum" }}
           paths:
             - *gocache
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,3 +37,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: shfmt
       run: make shfmt
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: validate-docs
+      run: make docs-validation

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,3 +29,11 @@ jobs:
     - uses: lumaxis/shellcheck-problem-matchers@v1
     - name: shellcheck
       run: make shellcheck
+
+  shfmt:
+    name: shfmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: shfmt
+      run: make shfmt

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,3 +20,12 @@ jobs:
 
           # Only show new issues for a pull request.
           only-new-issues: true
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: lumaxis/shellcheck-problem-matchers@v1
+    - name: shellcheck
+      run: make shellcheck

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,22 @@
+name: verify
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # must be specified without patch version
+          version: v1.32
+
+          # Only show new issues for a pull request.
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,12 +3,14 @@ run:
   build-tags:
     - apparmor
     - containers_image_ostree_stub
-    - seccomp
+    # containers/image would use mtrmac/gpgme otherwise, which requires gpgme C headers
+    - containers_image_openpgp
     - selinux
     - test
-    # containers/storage currently has btrfs included, but the images don't, so
-    # the linter fails.
+    # needs btrfs headers installed
     - exclude_graphdriver_btrfs
+    # needs devmapper headers installed
+    - exclude_graphdriver_devicemapper
   concurrency: 6
   deadline: 5m
 linters:

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ ifeq ("$(wildcard $(GOPKGDIR))","")
 endif
 	touch "$(GOPATH)/.gopathok"
 
+# See also: .github/workflows/lint.yml
 lint: .gopathok ${GOLANGCI_LINT}
 	${GOLANGCI_LINT} version
 	${GOLANGCI_LINT} linters

--- a/Makefile
+++ b/Makefile
@@ -282,8 +282,7 @@ ${GO_MOD_OUTDATED}:
 	$(call go-build,./vendor/github.com/psampaz/go-mod-outdated)
 
 ${GOLANGCI_LINT}:
-	export \
-		VERSION=v1.30.0 \
+	VERSION=v1.32.2 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
 	curl -sSfL $$URL/$$VERSION/install.sh | sh -s $$VERSION


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

This moves a few short and straightforward CI jobs
out of circleci pipeline and into github actions.

The motivation is circleci's parallelism limit, which appears
to be recently introduced. Because of that, jobs like integration
testing are often not started right away, since the jobs like
shfmt and shellcheck are run first.

The other benefit is now commits are annotated with warnings
from e.g. shellcheck. This is not done for all linters though.

Now, I can't demo the end result here in this repo, but
you can take a look at how it looks like here: https://github.com/kolyshkin/cri-o/pull/1
In particular, take a look at annotations in commits.

Below is detailed description, copy-pasted from commits.

1. circleci: rm build-test-binaries job
    
    It looks like it is obsoleted by 964245f943e4fe.
    
    Now when the circleci paralellism is limited, this might help up to
    speed up CI completion.

2. ci: move golangci-lint from circleci to GH actions
    
    It should be faster, and the side benefit of using github
    actions is linter warnings will be shown in the diff
    as annotations (similar to review comments).
    
    To make it work without installing additional packages,
    fix the build tags in .golangci.yml. In particular,
    disable seccomp and device mapper, as they need some C
    headers to be compiled.
    
    Note that this is merely to be able to compile packages
    used by crio, and since we are only linting crio itself,
    and not the packages it imports, changing the tags not
    used by crio doesn't matter much (if at all).
    
    Note we still have `lint` target in Makefile, to be used
    by developers (but not for CI).

3. ci: move shellcheck from circleci to github actions
    
    Note that
    
    1. No golang caching is required (as it was done in circleci)
       since we do not build any go code, and it does not look like
       it make sense to cache a single binary we donwload from github.
    
    2. Use a problem matcher, so the PRs will be annotated with
       shellcheck warnings.

4. ci: move shfmt from circleci to github actions
    
    shfmt output is unified diff, so it's hard to apply a problem matcher.
    Besides, I think the unified diff format is the best (well, ideally
    we'd use something like github "suggestion" thing, but I was not able
    to find a way of doing it).

5. ci: move docs-validation to github actions


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
