### PR TITLE
Add a performance hook banning network soft IRQs

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks.go
@@ -211,7 +211,7 @@ func setIRQLoadBalancing(c *oci.Container, enable bool, irqSmpAffinityFile strin
 		return err
 	}
 	currentIRQSMPSetting := strings.TrimSpace(string(content))
-	newIRQSMPSetting, newIRQBalanceSetting, err := UpdateIRQSmpAffinityMask(lspec.Resources.CPU.Cpus, currentIRQSMPSetting, enable)
+	newIRQSMPSetting, newIRQBalanceSetting, err := computeCPUmask(lspec.Resources.CPU.Cpus, currentIRQSMPSetting, enable)
 	if err != nil {
 		return err
 	}

--- a/internal/runtimehandlerhooks/utils.go
+++ b/internal/runtimehandlerhooks/utils.go
@@ -96,6 +96,18 @@ func computeCPUmask(cpus, mask string, set bool) (cpuMask, invertedCPUMask strin
 	if err != nil {
 		return cpus, "", err
 	}
+
+	// handle empty input mask, prepare an empty array
+	if len(maskArray) == 0 {
+		slice := inputCPUs.ToSlice()
+		maxCPUs := slice[len(slice)-1] + 1
+		maskLen := maxCPUs / 8
+		if maxCPUs%8 != 0 {
+			maskLen++
+		}
+		maskArray = make([]byte, maskLen)
+	}
+
 	invertedMaskArray := invertByteArray(maskArray)
 
 	for _, cpu := range inputCPUs.ToSlice() {

--- a/internal/runtimehandlerhooks/utils_test.go
+++ b/internal/runtimehandlerhooks/utils_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var _ = Describe("Utils", func() {
-	Describe("UpdateIRQSmpAffinityMask", func() {
+	Describe("computeCPUmask", func() {
 		type Input struct {
 			cpus string
 			mask string
@@ -24,7 +24,7 @@ var _ = Describe("Utils", func() {
 
 		DescribeTable("testing cpu mask",
 			func(c TestData) {
-				mask, invMask, err := UpdateIRQSmpAffinityMask(c.input.cpus, c.input.mask, c.input.set)
+				mask, invMask, err := computeCPUmask(c.input.cpus, c.input.mask, c.input.set)
 				Expect(err).To(BeNil())
 				Expect(mask).To(Equal(c.expected.mask))
 				Expect(invMask).To(Equal(c.expected.invMask))

--- a/internal/runtimehandlerhooks/utils_test.go
+++ b/internal/runtimehandlerhooks/utils_test.go
@@ -29,6 +29,18 @@ var _ = Describe("Utils", func() {
 				Expect(mask).To(Equal(c.expected.mask))
 				Expect(invMask).To(Equal(c.expected.invMask))
 			},
+			Entry("empty mask, set is true", TestData{
+				input:    Input{cpus: "0-7", mask: "", set: true},
+				expected: Expected{mask: "00000000,000000ff", invMask: "00000000,00000000"},
+			}),
+			Entry("empty mask, set is false", TestData{
+				input:    Input{cpus: "0-7", mask: "", set: false},
+				expected: Expected{mask: "00000000,00000000", invMask: "00000000,000000ff"},
+			}),
+			Entry("empty mask, nonsequencial cpus, set is true", TestData{
+				input:    Input{cpus: "7,31-33", mask: "", set: true},
+				expected: Expected{mask: "00000003,80000080", invMask: "000000fc,7fffff7f"},
+			}),
 			Entry("clear a single bit that was one", TestData{
 				input:    Input{cpus: "0", mask: "0000,00003003", set: false},
 				expected: Expected{mask: "00000000,00003002", invMask: "0000ffff,ffffcffd"},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add another performance hook to the high-performance runtime banning network soft IRQs.
    
Some guaranteed pods may have stricter performance constrains requiring network soft IRQs to not run on pod's CPUs.
Annotate those pods with "rps-load-balancing.crio.io: true".

Enable RPS on all the existing network devices (at the time the pod is created) masking out the pod's CPUs during container creation, restoring the previous configuration upon pod termination.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>
