### PR TITLE
test: add no-pull-on-run; fix no pull on create

### DIFF
--- a/crictl.yaml
+++ b/crictl.yaml
@@ -2,5 +2,3 @@ runtime-endpoint: "unix:///var/run/crio/crio.sock"
 image-endpoint: "unix:///var/run/crio/crio.sock"
 timeout: 0
 debug: false
-pull-image-on-create: true
-disable-pull-on-run: false

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -621,23 +621,6 @@ function wait_until_exit() {
 	[[ "$output" =~ 00000000002020db ]]
 }
 
-@test "run ctr with image with Config.Volumes" {
-	if test -n "$CONTAINER_UID_MAPPINGS"; then
-		skip "userNS enabled"
-	fi
-
-	start_crio
-
-	crictl pull gcr.io/k8s-testimages/redis:e2e
-	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-
-	jq '	  .image.image = "gcr.io/k8s-testimages/redis:e2e"
-		| .args = []' \
-		"$TESTDATA"/container_redis.json > "$newconfig"
-
-	crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
-}
-
 @test "ctr oom" {
 	start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -171,6 +171,20 @@ function setup_test() {
     cp "$INTEGRATION_ROOT"/cni_plugin_helper.bash "$CRIO_CNI_PLUGIN"
     sed -i "s;%TEST_DIR%;$TESTDIR;" "$CRIO_CNI_PLUGIN"/cni_plugin_helper.bash
 
+    # Configure crictl to not try pulling images on create/run,
+    # as $IMAGES are already preloaded, and eliminating network
+    # interaction results in less flakes when creating containers.
+    #
+    # A test case that requires an image not listed in $IMAGES
+    # should either do an explicit "crictl pull", or use --with-pull.
+    crictl config \
+        --set pull-image-on-create=false \
+        --set disable-pull-on-run=true \
+        2>/dev/null || true
+    #   ^^^^^^^^^^^^^^^^^^^ TODO: remove the line above once crictl is updated
+    # to >= 1.19. It is not a problem if this setting is not working, and since
+    # some CI jobs (kata) use older crictl, set this on a best-effort basis.
+
     PATH=$PATH:$TESTDIR
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind ci
/kind flake

#### What this PR does / why we need it:

This builds on #4311.

crictl 1.19 added these options in https://github.com/kubernetes-sigs/cri-tools/pull/627

First, set no-pull-on-run, which should eliminate flakes like this one:

> `ctr_id=$(crictl run "$TESTDIR"/container_pids_limit.json "$TESTDATA"/sandbox_config.json)' failed
> time="2020-11-18T05:02:01Z" level=fatal msg="running container: creating container failed: rpc error: code = Unknown desc = Error reading blob sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4: Get \"https://cdn02.quay.io/sharedimages/86f0a285-6f29-47c4-a3ae-7e2c70cad0ba/layer?Expires=1605676304&Signature=N976UlLi1Hb~jhKGQAy8JcmhlqFPdTzI3I3WiR7iEmb-x1YaIA6cWgWB3DffhwlaOrkzwHU8bAuWUEcwbD1N4tx3tAy7rhfQSyqWzbrs-OZJGON9aH7C5PkoqYPFDwGxQ1dzxtLSFR-hx1FmyN1lIuzFUKRmiQlPZPj14VGh51olcYgw2QVOPHE7~asGYa7EtQO~9q9A4Cgo7AAKzVsgDTjw19KReyIl5yh8am272W0AMrCoELwqC83F0FV3i6IZsomhnm30BHa4D5Xz1Jzr-dy4VWpM-Y8mowR4AVH9PLi6aALmYk1Ei54QjDEtkjSwc4sIVISb7g2uiKSDbLFHbQ__&Key-Pair-Id=APKAJ67PQLWGCSP66DGA\": net/http: TLS handshake timeout"

seen in many PRs, but most recently here: https://github.com/cri-o/cri-o/pull/4351#issuecomment-729775894

Second, while no-pull-on-create is the default, set it anyway
explicitly.

A test case that requires an image not listed in $IMAGES
should either do an explicit "crictl pull", or use --with-pull.

Finally, remove the pull-related options from `crictl.yaml` so they don't have precedence.
Hopefully this will fix occasional CI errors that are still seen even after #4311 is merged.

#### Which issue(s) this PR fixes:

See above.

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
