### PR TITLE
circleci: fix cri-tools install

### DIFF
--- a/scripts/circle-setup
+++ b/scripts/circle-setup
@@ -100,10 +100,9 @@ install_critools() {
 
     git clone $URL
     pushd cri-tools
-    make binaries
-    sudo make BINDIR=/usr/bin install
+    sudo -E PATH="$PATH" make BINDIR=/usr/bin install
     popd
-    rm -rf cri-tools
+    sudo rm -rf cri-tools
     sudo critest --version
     sudo crictl --version
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

scripts/circle-setup currently fails like this while trying to install
cri-tools:

> sudo make BINDIR=/usr/bin install
> make: go: Command not found

This is caused by https://github.com/kubernetes-sigs/cri-tools/pull/684.
Basically, it now tries to build binaries under sudo and it fails
because go binary is not in the $PATH.

To fix, use `sudo -E PATH=$PATH`.

While at it, drop `make binaries` as this is now redundant.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
