### PR TITLE
ci: move check vendor to github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,6 @@ workflows:
       - upload-artifacts:
           requires:
             - bundle-test
-      - vendor
 
 jobs:
   build:
@@ -458,20 +457,3 @@ jobs:
       - run:
           name: Upload artifacts
           command: make upload-artifacts
-
-  vendor:
-    executor: container-base
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-vendor-{{ checksum "go.sum" }}
-      - run:
-          name: check vendoring
-          command: |
-            make vendor
-            hack/tree_status.sh
-      - save_cache:
-          key: v1-vendor-{{ checksum "go.sum" }}
-          paths:
-            - /go/pkg

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -45,3 +45,21 @@ jobs:
     - uses: actions/checkout@v2
     - name: validate-docs
       run: make docs-validation
+
+  vendor:
+    name: vendor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - name: cache go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-
+      - name: vendor
+        run: make check-vendor

--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,9 @@ vendor:
 	$(GO) mod vendor
 	$(GO) mod verify
 
+check-vendor: vendor
+	./hack/tree_status.sh
+
 testunit: ${GINKGO}
 	rm -rf ${COVERAGE_PATH} && mkdir -p ${COVERAGE_PATH}
 	rm -rf ${JUNIT_PATH} && mkdir -p ${JUNIT_PATH}
@@ -546,6 +549,7 @@ metrics-exporter: bin/metrics-exporter
 	test-images \
 	uninstall \
 	vendor \
+	check-vendor \
 	bin/pinns \
 	dependencies \
 	upload-artifacts \

--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,9 @@ BATS_FILES := $(wildcard test/*.bats)
 ifeq ($(shell bash -c '[[ `command -v git` && `git rev-parse --git-dir 2>/dev/null` ]] && echo true'), true)
 	COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 	GIT_TREE_STATE := $(if $(shell git status --porcelain --untracked-files=no),dirty,clean)
-	GIT_MERGE_BASE := $(shell git merge-base origin/master $(shell git rev-parse --abbrev-ref HEAD))
 else
 	COMMIT_NO := unknown
 	GIT_TREE_STATE := unknown
-	GIT_MERGE_BASE := HEAD^
 endif
 
 # pass crio CLI options to generate custom configuration options at build time


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Following the footsteps of #4373, let's move verify vendor job from circleci to github actions.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
