### PR TITLE
contrib/test/int/build: bump a few deps

### DIFF
--- a/contrib/test/integration/build/bats.yml
+++ b/contrib/test/integration/build/bats.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/bats-core/bats-core.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/bats-core/bats-core"
-    version: v1.2.0
+    version: v1.2.1
 
 - name: install bats
   command: "./install.sh /usr/local"

--- a/contrib/test/integration/build/conmon.yml
+++ b/contrib/test/integration/build/conmon.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/containers/conmon.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/containers/conmon"
-    version: v2.0.15
+    version: v2.0.20
 
 - name: build conmon
   make:

--- a/contrib/test/integration/build/plugins.yml
+++ b/contrib/test/integration/build/plugins.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/containernetworking/plugins.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/containernetworking/plugins"
-    version: v0.8.4
+    version: v0.8.7
 
 - name: build plugins
   command: "./build_linux.sh"


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

contrib/test/int/build: bump a few deps

Notably: 

    conmon:      v2.0.15 -> v2.0.20
    bats:        v1.2.0  -> v1.2.1
    cni-plugins: v0.8.4  -> v0.8.7

Those were already bumped for circleci multiple times
(see commits 65fe2c5, d9ea392, 40b9d971fe, e48d23aab)
but not here.
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
