### PR TITLE
Make NamespaceOption an internal type in sandbox

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -190,7 +190,7 @@ func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 
 	privileged := isTrue(m.Annotations[annotations.PrivilegedRuntime])
 	hostNetwork := isTrue(m.Annotations[annotations.HostNetwork])
-	nsOpts := pb.NamespaceOption{}
+	nsOpts := sandbox.NamespaceOption{}
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.NamespaceOptions]), &nsOpts); err != nil {
 		return errors.Wrapf(err, "error unmarshalling %s annotation", annotations.NamespaceOptions)
 	}

--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -11,6 +11,53 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// A NamespaceMode describes the intended namespace configuration for each
+// of the namespaces (Network, PID, IPC) in NamespaceOption. Runtimes should
+// map these modes as appropriate for the technology underlying the runtime.
+type NamespaceMode int32
+
+const (
+	// A pod namespace is common to all containers in a pod.
+	// For example, a container with a pid namespace of pod expects to view
+	// all of the processes in all of the containers in the pod.
+	NamespaceModePod NamespaceMode = 0
+
+	// A container namespace is restricted to a single container.
+	// For example, a container with a pid namespace of container expects to
+	// view only the processes in that container.
+	NamespaceModeContainer NamespaceMode = 1
+
+	// A node namespace is the namespace of the Kubernetes node.
+	// For example, a container with a pid namespace of node expects to view
+	// all of the processes on the host running the kubelet.
+	NamespaceModeNode NamespaceMode = 2
+
+	// NamespaceModeTarget targets the namespace of another container. When
+	// this is specified, a target_id must be specified in NamespaceOption and
+	// refer to a container previously created with NamespaceModeContainer.
+	// This containers namespace will be made to match that of container
+	// target_id.  For example, a container with a pid namespace of
+	// NamespaceModeTarget expects to view all of the processes that container
+	// target_id can view.
+	NamespaceModeTarget NamespaceMode = 3
+)
+
+type NamespaceOption struct {
+	// Network namespace for this container/sandbox.
+	Network NamespaceMode `json:"network,omitempty"`
+
+	// PID namespace for this container/sandbox.
+	Pid NamespaceMode `json:"pid,omitempty"`
+
+	// IPC namespace for this container/sandbox.
+	Ipc NamespaceMode `json:"ipc,omitempty"`
+
+	// Target Container ID for NamespaceModeTarget. This container must have
+	// been previously created in the same pod. It is not possible to specify
+	// different targets for each namespace.
+	TargetID string `json:"target_id,omitempty"`
+}
+
 // NSType is an abstraction about available namespace types
 type NSType string
 

--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -55,7 +55,7 @@ type Sandbox struct {
 	annotations        map[string]string
 	infraContainer     *oci.Container
 	metadata           *pb.PodSandboxMetadata
-	nsOpts             *pb.NamespaceOption
+	nsOpts             *NamespaceOption
 	stopMutex          sync.RWMutex
 	created            bool
 	stopped            bool
@@ -121,12 +121,12 @@ func (s *Sandbox) AddIPs(ips []string) {
 }
 
 // SetNamespaceOptions sets whether the pod is running using host network
-func (s *Sandbox) SetNamespaceOptions(nsOpts *pb.NamespaceOption) {
+func (s *Sandbox) SetNamespaceOptions(nsOpts *NamespaceOption) {
 	s.nsOpts = nsOpts
 }
 
 // NamespaceOptions returns the namespace options for the sandbox
-func (s *Sandbox) NamespaceOptions() *pb.NamespaceOption {
+func (s *Sandbox) NamespaceOptions() *NamespaceOption {
 	return s.nsOpts
 }
 
@@ -435,5 +435,5 @@ func (s *Sandbox) UnmountShm() error {
 // If the server manages the namespace lifecycles, and the Pid option on the sandbox
 // is node or container level, the infra container is not needed
 func (s *Sandbox) NeedsInfra(serverDropsInfra bool) bool {
-	return !serverDropsInfra || s.nsOpts.GetPid() == pb.NamespaceMode_POD
+	return !serverDropsInfra || s.nsOpts.Pid == NamespaceModePod
 }

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -156,7 +156,7 @@ var _ = t.Describe("Sandbox", func() {
 	t.Describe("SetNamespaceOptions", func() {
 		It("should succeed", func() {
 			// Given
-			newNamespaceOption := &pb.NamespaceOption{
+			newNamespaceOption := &sandbox.NamespaceOption{
 				Network: 1,
 				Pid:     2,
 				Ipc:     3,
@@ -261,8 +261,8 @@ var _ = t.Describe("Sandbox", func() {
 		It("should not need when managing NS and NS mode NODE", func() {
 			// Given
 			manageNS := true
-			newNamespaceOption := &pb.NamespaceOption{
-				Pid: pb.NamespaceMode_NODE,
+			newNamespaceOption := &sandbox.NamespaceOption{
+				Pid: sandbox.NamespaceModeNode,
 			}
 
 			// When
@@ -275,8 +275,8 @@ var _ = t.Describe("Sandbox", func() {
 		It("should not need when managing NS and NS mode CONTAINER", func() {
 			// Given
 			manageNS := true
-			newNamespaceOption := &pb.NamespaceOption{
-				Pid: pb.NamespaceMode_CONTAINER,
+			newNamespaceOption := &sandbox.NamespaceOption{
+				Pid: sandbox.NamespaceModeContainer,
 			}
 
 			// When
@@ -289,8 +289,8 @@ var _ = t.Describe("Sandbox", func() {
 		It("should need when namespace mode POD", func() {
 			// Given
 			manageNS := false
-			newNamespaceOption := &pb.NamespaceOption{
-				Pid: pb.NamespaceMode_POD,
+			newNamespaceOption := &sandbox.NamespaceOption{
+				Pid: sandbox.NamespaceModePod,
 			}
 
 			// When
@@ -303,8 +303,8 @@ var _ = t.Describe("Sandbox", func() {
 		It("should need when not managing NS", func() {
 			// Given
 			manageNS := true
-			newNamespaceOption := &pb.NamespaceOption{
-				Pid: pb.NamespaceMode_CONTAINER,
+			newNamespaceOption := &sandbox.NamespaceOption{
+				Pid: sandbox.NamespaceModeContainer,
 			}
 
 			// When

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -819,7 +819,15 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		makeOCIConfigurationRootless(&g)
 	}
 
-	sb.SetNamespaceOptions(securityContext.GetNamespaceOptions())
+	namespaceOpts := securityContext.GetNamespaceOptions()
+	sb.SetNamespaceOptions(
+		&libsandbox.NamespaceOption{
+			Network:  libsandbox.NamespaceMode(namespaceOpts.GetNetwork()),
+			Pid:      libsandbox.NamespaceMode(namespaceOpts.GetPid()),
+			Ipc:      libsandbox.NamespaceMode(namespaceOpts.GetIpc()),
+			TargetID: namespaceOpts.GetTargetId(),
+		},
+	)
 
 	spp := securityContext.GetSeccompProfilePath()
 	g.AddAnnotation(annotations.SeccompProfilePath, spp)

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -23,14 +23,17 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 		rStatus = pb.PodSandboxState_SANDBOX_READY
 	}
 
-	linux := &pb.LinuxPodSandboxStatus{
-		Namespaces: &pb.Namespace{
-			Options: &pb.NamespaceOption{
-				Network: sb.NamespaceOptions().GetNetwork(),
-				Ipc:     sb.NamespaceOptions().GetIpc(),
-				Pid:     sb.NamespaceOptions().GetPid(),
+	var linux *pb.LinuxPodSandboxStatus
+	if sb.NamespaceOptions() != nil {
+		linux = &pb.LinuxPodSandboxStatus{
+			Namespaces: &pb.Namespace{
+				Options: &pb.NamespaceOption{
+					Network: pb.NamespaceMode(sb.NamespaceOptions().Network),
+					Ipc:     pb.NamespaceMode(sb.NamespaceOptions().Ipc),
+					Pid:     pb.NamespaceMode(sb.NamespaceOptions().Pid),
+				},
 			},
-		},
+		}
 	}
 
 	sandboxID := sb.ID()


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The fact that we re-use the protobuf devotions in the lower level
implementation details of CRI-O increases the burden to support multiple
Container Runtime Interface versions. This patch is one of a series of
patches to remove the protobuf type usage from the internal lib. This
allows us to create a middle layer later on to support two CRI versions
in parallel.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Required for https://github.com/cri-o/cri-o/pull/4372
#### Special notes for your reviewer:
We have to do that with every `pb.Type` we're using in CRI-O. This seems the only way to me to cleanly re-use the implementations without having a need for copy-pasting code around.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
