### PR TITLE
Use own metadata types

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -24,7 +24,6 @@ import (
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // ContainerManagerCRIO specifies an annotation value which indicates that the
@@ -168,7 +167,7 @@ func (c *ContainerServer) LoadSandbox(id string) (retErr error) {
 			c.ReleasePodName(name)
 		}
 	}()
-	var metadata pb.PodSandboxMetadata
+	var metadata sandbox.Metadata
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.Metadata]), &metadata); err != nil {
 		return errors.Wrapf(err, "error unmarshalling %s annotation", annotations.Metadata)
 	}
@@ -410,7 +409,7 @@ func (c *ContainerServer) LoadContainer(id string) (retErr error) {
 		}
 	}()
 
-	var metadata pb.ContainerMetadata
+	var metadata oci.Metadata
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.Metadata]), &metadata); err != nil {
 		return err
 	}

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // The actual test suite
@@ -588,7 +587,7 @@ var _ = t.Describe("ContainerServer", func() {
 			container, err := oci.NewContainer(containerID, "", "", "",
 				make(map[string]string), make(map[string]string),
 				make(map[string]string), "", "", "",
-				&pb.ContainerMetadata{}, sandboxID, false,
+				&oci.Metadata{}, sandboxID, false,
 				false, false, "", "/invalid", time.Now(), "")
 			Expect(err).To(BeNil())
 

--- a/internal/lib/rename.go
+++ b/internal/lib/rename.go
@@ -3,10 +3,9 @@ package lib
 import (
 	"path/filepath"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
-
 	"github.com/containers/libpod/v2/pkg/annotations"
 	"github.com/containers/storage/pkg/ioutils"
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	json "github.com/json-iterator/go"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -85,7 +84,7 @@ func updateMetadata(specAnnotations map[string]string, name string) string {
 	containerType := specAnnotations[annotations.ContainerType]
 	switch containerType {
 	case "container":
-		metadata := runtime.ContainerMetadata{}
+		metadata := oci.Metadata{}
 		err := json.Unmarshal([]byte(oldMetadata), &metadata)
 		if err != nil {
 			return oldMetadata
@@ -98,7 +97,7 @@ func updateMetadata(specAnnotations map[string]string, name string) string {
 		return string(m)
 
 	case "sandbox":
-		metadata := runtime.PodSandboxMetadata{}
+		metadata := sandbox.Metadata{}
 		err := json.Unmarshal([]byte(oldMetadata), &metadata)
 		if err != nil {
 			return oldMetadata

--- a/internal/lib/sandbox/history_test.go
+++ b/internal/lib/sandbox/history_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // The actual test suite
@@ -19,7 +18,7 @@ var _ = t.Describe("History", func() {
 		beforeEach()
 		otherTestSandbox, err := sandbox.New("sandboxID", "", "", "", "",
 			make(map[string]string), make(map[string]string), "", "",
-			&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
+			&sandbox.Metadata{}, "", "", false, "", "", "",
 			[]*hostport.PortMapping{}, false, time.Now(), "")
 		Expect(err).To(BeNil())
 		Expect(testSandbox).NotTo(BeNil())

--- a/internal/lib/sandbox/namespaces_test.go
+++ b/internal/lib/sandbox/namespaces_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 var (
@@ -508,7 +507,7 @@ func setupInfraContainerWithPid(pid int) {
 	testContainer, err := oci.NewContainer("testid", "testname", "",
 		"/container/logs", map[string]string{},
 		map[string]string{}, map[string]string{}, "image",
-		"imageName", "imageRef", &pb.ContainerMetadata{},
+		"imageName", "imageRef", &oci.Metadata{},
 		"testsandboxid", false, false, false, "",
 		"/root/for/container", time.Now(), "SIGKILL")
 	Expect(err).To(BeNil())

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cri-o/cri-o/internal/oci"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // The actual test suite
@@ -28,7 +27,7 @@ var _ = t.Describe("Sandbox", func() {
 			annotations := map[string]string{"a": "annotA", "b": "annotB"}
 			processLabel := "processLabel"
 			mountLabel := "mountLabel"
-			metadata := pb.PodSandboxMetadata{Name: name}
+			metadata := sandbox.Metadata{Name: name}
 			shmPath := "shmPath"
 			cgroupParent := "cgroupParent"
 			privileged := true
@@ -184,7 +183,7 @@ var _ = t.Describe("Sandbox", func() {
 			testContainer, err = oci.NewContainer("testid", "testname", "",
 				"/container/logs", map[string]string{},
 				map[string]string{}, map[string]string{}, "image",
-				"imageName", "imageRef", &pb.ContainerMetadata{},
+				"imageName", "imageRef", &oci.Metadata{},
 				"testsandboxid", false, false, false, "",
 				"/root/for/container", time.Now(), "SIGKILL")
 			Expect(err).To(BeNil())

--- a/internal/lib/sandbox/suite_test.go
+++ b/internal/lib/sandbox/suite_test.go
@@ -15,7 +15,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // TestSandbox runs the created specs
@@ -52,7 +51,7 @@ func beforeEach() {
 	var err error
 	testSandbox, err = sandbox.New("sandboxID", "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
-		&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
+		&sandbox.Metadata{}, "", "", false, "", "", "",
 		[]*hostport.PortMapping{}, false, time.Now(), "")
 	Expect(err).To(BeNil())
 	Expect(testSandbox).NotTo(BeNil())

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // TestLib runs the created specs
@@ -141,14 +140,14 @@ func beforeEach() {
 	// Setup test vars
 	mySandbox, err = sandbox.New(sandboxID, "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
-		&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
+		&sandbox.Metadata{}, "", "", false, "", "", "",
 		[]*hostport.PortMapping{}, false, time.Now(), "")
 	Expect(err).To(BeNil())
 
 	myContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
 		make(map[string]string), "", "", "",
-		&pb.ContainerMetadata{}, sandboxID, false,
+		&oci.Metadata{}, sandboxID, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
 }

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/fields"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 )
 
@@ -64,7 +63,7 @@ type Container struct {
 	annotations        fields.Set
 	crioAnnotations    fields.Set
 	state              *ContainerState
-	metadata           *pb.ContainerMetadata
+	metadata           *Metadata
 	opLock             sync.RWMutex
 	spec               *specs.Spec
 	idMappings         *idtools.IDMappings
@@ -73,6 +72,17 @@ type Container struct {
 	stdinOnce          bool
 	created            bool
 	spoofed            bool
+}
+
+// Metadata holds all necessary information for building the container name.
+// The container runtime is encouraged to expose the metadata in its user
+// interface for better user experience.
+type Metadata struct {
+	// Name of the container.
+	Name string `json:"name,omitempty"`
+
+	// Attempt number of creating the container.
+	Attempt uint32 `json:"attempt,omitempty"`
 }
 
 // ContainerVolume is a bind mount for the container.
@@ -99,7 +109,7 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, image, imageName, imageRef string, metadata *pb.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
+func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, image, imageName, imageRef string, metadata *Metadata, sandbox string, terminal, stdin, stdinOnce bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
 	c := &Container{
@@ -337,7 +347,7 @@ func (c *Container) Dir() string {
 }
 
 // Metadata returns the metadata of the container.
-func (c *Container) Metadata() *pb.ContainerMetadata {
+func (c *Container) Metadata() *Metadata {
 	return c.metadata
 }
 

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 const (
@@ -49,7 +48,7 @@ var _ = t.Describe("Container", func() {
 		Expect(sut.Sandbox()).To(Equal("sandbox"))
 		Expect(sut.Dir()).To(Equal("dir"))
 		Expect(sut.StatePath()).To(Equal("dir/state.json"))
-		Expect(sut.Metadata()).To(Equal(&pb.ContainerMetadata{}))
+		Expect(sut.Metadata()).To(Equal(&oci.Metadata{}))
 		Expect(sut.StateNoLock().Version).To(BeEmpty())
 		Expect(sut.GetStopSignal()).To(Equal("15"))
 		Expect(sut.CreatedAt().UnixNano()).
@@ -148,7 +147,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", "", "", &pb.ContainerMetadata{}, "",
+			"", "", "", &oci.Metadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGNO")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
@@ -164,7 +163,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", "", "", &pb.ContainerMetadata{}, "",
+			"", "", "", &oci.Metadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGTRAP")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())

--- a/internal/oci/suite_test.go
+++ b/internal/oci/suite_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // TestOci runs the created specs
@@ -39,7 +38,7 @@ func getTestContainer() *oci.Container {
 		map[string]string{"key": "label"},
 		map[string]string{"key": "crioAnnotation"},
 		map[string]string{"key": "annotation"},
-		"image", "imageName", "imageRef", &pb.ContainerMetadata{}, "sandbox",
+		"image", "imageName", "imageRef", &oci.Metadata{}, "sandbox",
 		false, false, false, "", "dir", time.Now(), "")
 	Expect(err).To(BeNil())
 	Expect(container).NotTo(BeNil())

--- a/internal/runtimehandlerhooks/high_performance_hooks_test.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 const (
@@ -25,7 +24,7 @@ var _ = Describe("high_performance_hooks", func() {
 	container, err := oci.NewContainer("containerID", "", "", "",
 		make(map[string]string), make(map[string]string),
 		make(map[string]string), "pauseImage", "", "",
-		&pb.ContainerMetadata{}, "sandboxID", false, false,
+		&oci.Metadata{}, "sandboxID", false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -85,7 +85,7 @@ var _ = t.Describe("Container", func() {
 
 			sb, err := sandbox.New("sandboxID", "", "", "", "test",
 				make(map[string]string), make(map[string]string), "", "",
-				&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
+				&sandbox.Metadata{}, "", "", false, "", "", "",
 				[]*hostport.PortMapping{}, false, currentTime, "")
 			Expect(err).To(BeNil())
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -660,7 +660,11 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 
 	crioAnnotations := specgen.Config.Annotations
 
-	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().GetAnnotations(), image, imageName, imageRef, metadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	ociMetadata := &oci.Metadata{
+		Name:    metadata.Name,
+		Attempt: metadata.Attempt,
+	}
+	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().GetAnnotations(), image, imageName, imageRef, ociMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -90,10 +90,13 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 			PodSandboxId: podSandboxID,
 			CreatedAt:    created,
 			Labels:       ctr.Labels(),
-			Metadata:     ctr.Metadata(),
-			Annotations:  ctr.Annotations(),
-			Image:        img,
-			ImageRef:     ctr.ImageRef(),
+			Metadata: &pb.ContainerMetadata{
+				Name:    ctr.Metadata().Name,
+				Attempt: ctr.Metadata().Attempt,
+			},
+			Annotations: ctr.Annotations(),
+			Image:       img,
+			ImageRef:    ctr.ImageRef(),
 		}
 
 		switch cState.Status {

--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -29,8 +29,11 @@ func (s *Server) buildContainerStats(ctx context.Context, stats *oci.ContainerSt
 	}
 	return &pb.ContainerStats{
 		Attributes: &pb.ContainerAttributes{
-			Id:          container.ID(),
-			Metadata:    container.Metadata(),
+			Id: container.ID(),
+			Metadata: &pb.ContainerMetadata{
+				Name:    container.Metadata().Name,
+				Attempt: container.Metadata().Attempt,
+			},
 			Labels:      container.Labels(),
 			Annotations: container.Annotations(),
 		},

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -28,8 +28,11 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	containerID := c.ID()
 	resp := &pb.ContainerStatusResponse{
 		Status: &pb.ContainerStatus{
-			Id:          containerID,
-			Metadata:    c.Metadata(),
+			Id: containerID,
+			Metadata: &pb.ContainerMetadata{
+				Name:    c.Metadata().Name,
+				Attempt: c.Metadata().Attempt,
+			},
 			Labels:      c.Labels(),
 			Annotations: c.Annotations(),
 			ImageRef:    c.ImageRef(),

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
-
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/pkg/config"
@@ -49,7 +47,7 @@ func TestGetContainerInfo(t *testing.T) {
 		"io.kubernetes.test1": "value1",
 	}
 	getContainerFunc := func(id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", "imageName", "imageRef", &oci.Metadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -166,7 +164,7 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &oci.Metadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -197,7 +195,7 @@ func TestGetContainerInfoSandboxNotFound(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &oci.Metadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -70,7 +70,12 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 			State:       rStatus,
 			Labels:      sb.Labels(),
 			Annotations: sb.Annotations(),
-			Metadata:    sb.Metadata(),
+			Metadata: &pb.PodSandboxMetadata{
+				Name:      sb.Metadata().Name,
+				Uid:       sb.Metadata().UID,
+				Namespace: sb.Metadata().Namespace,
+				Attempt:   sb.Metadata().Attempt,
+			},
 		}
 
 		// Filter by other criteria such as state and labels.

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -648,7 +648,13 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}
 
-	sb, err := libsandbox.New(sbox.ID(), namespace, sbox.Name(), kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, runtimeHandler, resolvPath, hostname, portMappings, hostNetwork, created, usernsMode)
+	sbMetadata := &libsandbox.Metadata{
+		Name:      metadata.GetName(),
+		UID:       metadata.GetUid(),
+		Namespace: metadata.GetNamespace(),
+		Attempt:   metadata.GetAttempt(),
+	}
+	sb, err := libsandbox.New(sbox.ID(), namespace, sbox.Name(), kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, sbMetadata, shmPath, cgroupParent, privileged, runtimeHandler, resolvPath, hostname, portMappings, hostNetwork, created, usernsMode)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -45,8 +45,13 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 			State:       rStatus,
 			Labels:      sb.Labels(),
 			Annotations: sb.Annotations(),
-			Metadata:    sb.Metadata(),
-			Linux:       linux,
+			Metadata: &pb.PodSandboxMetadata{
+				Name:      sb.Metadata().Name,
+				Uid:       sb.Metadata().UID,
+				Namespace: sb.Metadata().Namespace,
+				Attempt:   sb.Metadata().Attempt,
+			},
+			Linux: linux,
 		},
 	}
 

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/cri/streaming"
 )
 
@@ -154,14 +153,14 @@ var beforeEach = func() {
 	// Initialize test container and sandbox
 	testSandbox, err = sandbox.New(sandboxID, "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
-		&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
+		&sandbox.Metadata{}, "", "", false, "", "", "",
 		[]*hostport.PortMapping{}, false, time.Now(), "")
 	Expect(err).To(BeNil())
 
 	testContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
 		make(map[string]string), "pauseImage", "", "",
-		&pb.ContainerMetadata{}, sandboxID, false, false,
+		&oci.Metadata{}, sandboxID, false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
To be able to switch to a different protocol we have to use our own
`Metadata` type definitions for sandboxes and containers.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Follow-up of https://github.com/cri-o/cri-o/pull/4386
Required for #4372
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
