### PR TITLE
Provide a better value for features specific annotations

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -202,6 +202,24 @@ func (r *Runtime) AllowDevicesAnnotation(handler string) (bool, error) {
 	return r.allowAnnotation(handler, annotations.DevicesAnnotation)
 }
 
+// AllowCPULoadBalancingAnnotation searches through the AllowedAnnotations for
+// the CPU load balancing annotation, checking whether this runtime allows processing of  "cpu-load-balancing.crio.io"
+func (r *Runtime) AllowCPULoadBalancingAnnotation(handler string) (bool, error) {
+	return r.allowAnnotation(handler, annotations.CPULoadBalancingAnnotation)
+}
+
+// AllowCPUQuotaAnnotation searches through the AllowedAnnotations for
+// the CPU quota annotation, checking whether this runtime allows processing of "cpu-quota.crio.io"
+func (r *Runtime) AllowCPUQuotaAnnotation(handler string) (bool, error) {
+	return r.allowAnnotation(handler, annotations.CPUQuotaAnnotation)
+}
+
+// AllowIRQLoadBalancingAnnotation searches through the AllowedAnnotations for
+// the IRQ load balancing annotation, checking whether this runtime allows processing of "irq-load-balancing.crio.io"
+func (r *Runtime) AllowIRQLoadBalancingAnnotation(handler string) (bool, error) {
+	return r.allowAnnotation(handler, annotations.IRQLoadBalancingAnnotation)
+}
+
 func (r *Runtime) allowAnnotation(handler, annotation string) (bool, error) {
 	rh, err := r.getRuntimeHandler(handler)
 	if err != nil {

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -30,9 +30,10 @@ var _ = t.Describe("Oci", func() {
 
 		// Test constants
 		const (
-			invalidRuntime = "invalid"
-			defaultRuntime = "runc"
-			usernsRuntime  = "userns"
+			invalidRuntime     = "invalid"
+			defaultRuntime     = "runc"
+			usernsRuntime      = "userns"
+			performanceRuntime = "high-performance"
 		)
 		runtimes := config.Runtimes{
 			defaultRuntime: {
@@ -45,6 +46,16 @@ var _ = t.Describe("Oci", func() {
 				RuntimeType:        "",
 				RuntimeRoot:        "/run/runc",
 				AllowedAnnotations: []string{annotations.UsernsModeAnnotation},
+			},
+			performanceRuntime: {
+				RuntimePath: "/bin/sh",
+				RuntimeType: "",
+				RuntimeRoot: "/run/runc",
+				AllowedAnnotations: []string{
+					annotations.CPULoadBalancingAnnotation,
+					annotations.IRQLoadBalancingAnnotation,
+					annotations.CPUQuotaAnnotation,
+				},
 			},
 		}
 
@@ -102,6 +113,33 @@ var _ = t.Describe("Oci", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 			Expect(allowed).To(Equal(false))
+		})
+		It("AllowCPULoadBalancingAnnotation should be true when set", func() {
+			// Given
+			// When
+			allowed, err := sut.AllowCPULoadBalancingAnnotation(performanceRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(allowed).To(Equal(true))
+		})
+		It("AllowCPUQuotaAnnotation should be true when set", func() {
+			// Given
+			// When
+			allowed, err := sut.AllowCPUQuotaAnnotation(performanceRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(allowed).To(Equal(true))
+		})
+		It("AllowIRQLoadBalancingAnnotation should be true when set", func() {
+			// Given
+			// When
+			allowed, err := sut.AllowIRQLoadBalancingAnnotation(performanceRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(allowed).To(Equal(true))
 		})
 	})
 

--- a/internal/runtimehandlerhooks/high_performance_hooks.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks.go
@@ -32,6 +32,7 @@ const (
 	annotationCPUQuota         = "cpu-quota.crio.io"
 	annotationIRQLoadBalancing = "irq-load-balancing.crio.io"
 	annotationTrue             = "true"
+	annotationDisable          = "disable"
 	schedDomainDir             = "/proc/sys/kernel/sched_domain"
 	irqSmpAffinityProcFile     = "/proc/irq/default_smp_affinity"
 	cgroupMountPoint           = "/sys/fs/cgroup"
@@ -119,15 +120,18 @@ func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s 
 }
 
 func shouldCPULoadBalancingBeDisabled(annotations fields.Set) bool {
-	return annotations[annotationCPULoadBalancing] == annotationTrue
+	return annotations[annotationCPULoadBalancing] == annotationTrue ||
+		annotations[annotationCPULoadBalancing] == annotationDisable
 }
 
 func shouldCPUQuotaBeDisabled(annotations fields.Set) bool {
-	return annotations[annotationCPUQuota] == annotationTrue
+	return annotations[annotationCPUQuota] == annotationTrue ||
+		annotations[annotationCPUQuota] == annotationDisable
 }
 
 func shouldIRQLoadBalancingBeDisabled(annotations fields.Set) bool {
-	return annotations[annotationIRQLoadBalancing] == annotationTrue
+	return annotations[annotationIRQLoadBalancing] == annotationTrue ||
+		annotations[annotationIRQLoadBalancing] == annotationDisable
 }
 
 func isCgroupParentBurstable(s *sandbox.Sandbox) bool {

--- a/internal/runtimehandlerhooks/runtime_handler_hooks.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks.go
@@ -5,19 +5,49 @@ import (
 	"strings"
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 )
 
 type RuntimeHandlerHooks interface {
-	PreStart(ctx context.Context, c *oci.Container, s *sandbox.Sandbox, r *oci.Runtime) error
-	PreStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox, r *oci.Runtime) error
+	PreStart(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error
+	PreStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error
 }
 
 // GetRuntimeHandlerHooks returns RuntimeHandlerHooks implementation by the runtime handler name
-func GetRuntimeHandlerHooks(handler string) RuntimeHandlerHooks {
-	if strings.Contains(handler, HighPerformance) {
-		return &HighPerformanceHooks{}
+func GetRuntimeHandlerHooks(ctx context.Context, handler string, r *oci.Runtime) (RuntimeHandlerHooks, error) {
+	allowAnnotations, err := allowHighPerformanceAnnotations(handler, r)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	if allowAnnotations {
+		return &HighPerformanceHooks{}, nil
+	}
+
+	if !allowAnnotations && strings.Contains(handler, HighPerformance) {
+		log.Warnf(ctx, "The usage of the handler %q without adding high-performance feature annotations under allowed_annotations will be deprecated under 1.21", HighPerformance)
+		return &HighPerformanceHooks{}, nil
+	}
+
+	return nil, nil
+}
+
+func allowHighPerformanceAnnotations(handler string, r *oci.Runtime) (bool, error) {
+	allowCPULoadBalancing, err := r.AllowCPUQuotaAnnotation(handler)
+	if err != nil {
+		return false, err
+	}
+
+	allowIRQLoadBalancing, err := r.AllowIRQLoadBalancingAnnotation(handler)
+	if err != nil {
+		return false, err
+	}
+
+	allowCPUQuota, err := r.AllowCPUQuotaAnnotation(handler)
+	if err != nil {
+		return false, err
+	}
+
+	return allowCPULoadBalancing || allowIRQLoadBalancing || allowCPUQuota, nil
 }

--- a/internal/runtimehandlerhooks/runtime_handler_hooks.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks.go
@@ -9,8 +9,8 @@ import (
 )
 
 type RuntimeHandlerHooks interface {
-	PreStart(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error
-	PreStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error
+	PreStart(ctx context.Context, c *oci.Container, s *sandbox.Sandbox, r *oci.Runtime) error
+	PreStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox, r *oci.Runtime) error
 }
 
 // GetRuntimeHandlerHooks returns RuntimeHandlerHooks implementation by the runtime handler name

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -12,4 +12,13 @@ const (
 
 	// DevicesAnnotation is a set of devices to give to the container
 	DevicesAnnotation = "io.kubernetes.cri-o.Devices"
+
+	// CPULoadBalancingAnnotation indicates that load balancing should be disabled for CPUs used by the container
+	CPULoadBalancingAnnotation = "cpu-load-balancing.crio.io"
+
+	// CPUQuotaAnnotation indicates that CPU quota should be disabled for CPUs used by the container
+	CPUQuotaAnnotation = "cpu-quota.crio.io"
+
+	// IRQLoadBalancingAnnotation indicates that IRQ load balancing should be disabled for CPUs used by the container
+	IRQLoadBalancingAnnotation = "irq-load-balancing.crio.io"
 )

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -36,7 +36,7 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 		if retErr != nil {
 			c.SetStartFailed(retErr)
 			if hooks != nil {
-				if err := hooks.PreStop(ctx, c, sandbox); err != nil {
+				if err := hooks.PreStop(ctx, c, sandbox, s.Runtime()); err != nil {
 					log.Warnf(ctx, "failed to run pre-stop hook for container %q: %v", c.ID(), err)
 				}
 			}
@@ -47,7 +47,7 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 	}()
 
 	if hooks != nil {
-		if err := hooks.PreStart(ctx, c, sandbox); err != nil {
+		if err := hooks.PreStart(ctx, c, sandbox, s.Runtime()); err != nil {
 			return nil, fmt.Errorf("failed to run pre-start hook for container %q: %v", c.ID(), err)
 		}
 	}

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -22,10 +22,13 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 	}
 
 	sandbox := s.getSandbox(c.Sandbox())
-	hooks := runtimehandlerhooks.GetRuntimeHandlerHooks(sandbox.RuntimeHandler())
+	hooks, err := runtimehandlerhooks.GetRuntimeHandlerHooks(ctx, sandbox.RuntimeHandler(), s.Runtime())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get runtime handler %q hooks", sandbox.RuntimeHandler())
+	}
 
 	if hooks != nil {
-		if err := hooks.PreStop(ctx, c, sandbox, s.Runtime()); err != nil {
+		if err := hooks.PreStop(ctx, c, sandbox); err != nil {
 			return nil, fmt.Errorf("failed to run pre-stop hook for container %q: %v", c.ID(), err)
 		}
 	}

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -25,7 +25,7 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 	hooks := runtimehandlerhooks.GetRuntimeHandlerHooks(sandbox.RuntimeHandler())
 
 	if hooks != nil {
-		if err := hooks.PreStop(ctx, c, sandbox); err != nil {
+		if err := hooks.PreStop(ctx, c, sandbox, s.Runtime()); err != nil {
 			return nil, fmt.Errorf("failed to run pre-stop hook for container %q: %v", c.ID(), err)
 		}
 	}

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -86,7 +86,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 				})
 			}
 			if hooks != nil {
-				if err := hooks.PreStop(ctx, ctr, sb); err != nil {
+				if err := hooks.PreStop(ctx, ctr, sb, s.Runtime()); err != nil {
 					log.Warnf(ctx, "failed to run PreStop hook for container %s in pod sandbox %s: %v", ctr.Name(), sb.ID(), err)
 				}
 			}

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -46,7 +46,10 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	}
 
 	// Get high-performance runtime hook to trigger preStop step for each container
-	hooks := runtimehandlerhooks.GetRuntimeHandlerHooks(sb.RuntimeHandler())
+	hooks, err := runtimehandlerhooks.GetRuntimeHandlerHooks(ctx, sb.RuntimeHandler(), s.Runtime())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get runtime handler %q hooks", sb.RuntimeHandler())
+	}
 
 	if sb.Stopped() {
 		log.Infof(ctx, "Stopped pod sandbox (already stopped): %s", sb.ID())
@@ -86,7 +89,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 				})
 			}
 			if hooks != nil {
-				if err := hooks.PreStop(ctx, ctr, sb, s.Runtime()); err != nil {
+				if err := hooks.PreStop(ctx, ctr, sb); err != nil {
 					log.Warnf(ctx, "failed to run PreStop hook for container %s in pod sandbox %s: %v", ctr.Name(), sb.ID(), err)
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change

/kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

The current value of CPU load balancing, IRQ balancing, and CPU quota annotations is misleading.
To provide a better UX, we should rename it to reflect the real functionality that done when these annotations are specified under the pod.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Provide an option to run performance hooks via specifying allowed_annotations under the runtime handler configuration
[DEPRECATION] The run of performance hooks for the high-performance runtime handler without specifying allowed_annotations will be deprecated under release 1.21
[DEPRECATION] Usage of performance annotation with the true value, will be deprecated under release 1.21, instead, the disable value should be used
```

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>