### PR TITLE
Add clean v1alpha2 CRI API interface

### DIFF
--- a/server/cri/v1alpha2/api.go
+++ b/server/cri/v1alpha2/api.go
@@ -1,0 +1,21 @@
+package v1alpha2
+
+import (
+	"google.golang.org/grpc"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+type Service interface {
+	pb.RuntimeServiceServer
+	pb.ImageServiceServer
+}
+
+type service struct{}
+
+// New creates a new v1alpha2 Service instance.
+func New(server *grpc.Server) Service {
+	s := &service{}
+	pb.RegisterRuntimeServiceServer(server, s)
+	pb.RegisterImageServiceServer(server, s)
+	return s
+}

--- a/server/cri/v1alpha2/rpc_attach.go
+++ b/server/cri/v1alpha2/rpc_attach.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) Attach(
+	ctx context.Context, req *pb.AttachRequest,
+) (*pb.AttachResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_container_stats.go
+++ b/server/cri/v1alpha2/rpc_container_stats.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ContainerStats(
+	ctx context.Context, req *pb.ContainerStatsRequest,
+) (*pb.ContainerStatsResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_container_status.go
+++ b/server/cri/v1alpha2/rpc_container_status.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ContainerStatus(
+	ctx context.Context, req *pb.ContainerStatusRequest,
+) (*pb.ContainerStatusResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_create_container.go
+++ b/server/cri/v1alpha2/rpc_create_container.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) CreateContainer(
+	ctx context.Context, req *pb.CreateContainerRequest,
+) (res *pb.CreateContainerResponse, retErr error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_exec.go
+++ b/server/cri/v1alpha2/rpc_exec.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) Exec(
+	ctx context.Context, req *pb.ExecRequest,
+) (*pb.ExecResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_exec_sync.go
+++ b/server/cri/v1alpha2/rpc_exec_sync.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ExecSync(
+	ctx context.Context, req *pb.ExecSyncRequest,
+) (*pb.ExecSyncResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_image_fs_info.go
+++ b/server/cri/v1alpha2/rpc_image_fs_info.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ImageFsInfo(
+	ctx context.Context, req *pb.ImageFsInfoRequest,
+) (*pb.ImageFsInfoResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_image_status.go
+++ b/server/cri/v1alpha2/rpc_image_status.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ImageStatus(
+	ctx context.Context, req *pb.ImageStatusRequest,
+) (*pb.ImageStatusResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_list_container_stats.go
+++ b/server/cri/v1alpha2/rpc_list_container_stats.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ListContainerStats(
+	ctx context.Context, req *pb.ListContainerStatsRequest,
+) (*pb.ListContainerStatsResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_list_containers.go
+++ b/server/cri/v1alpha2/rpc_list_containers.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ListContainers(
+	ctx context.Context, req *pb.ListContainersRequest,
+) (*pb.ListContainersResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_list_images.go
+++ b/server/cri/v1alpha2/rpc_list_images.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ListImages(
+	ctx context.Context, req *pb.ListImagesRequest,
+) (*pb.ListImagesResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_list_pod_sandbox.go
+++ b/server/cri/v1alpha2/rpc_list_pod_sandbox.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ListPodSandbox(
+	ctx context.Context, req *pb.ListPodSandboxRequest,
+) (*pb.ListPodSandboxResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_pod_sandbox_status.go
+++ b/server/cri/v1alpha2/rpc_pod_sandbox_status.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) PodSandboxStatus(
+	ctx context.Context, req *pb.PodSandboxStatusRequest,
+) (*pb.PodSandboxStatusResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_port_forward.go
+++ b/server/cri/v1alpha2/rpc_port_forward.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) PortForward(
+	ctx context.Context, req *pb.PortForwardRequest,
+) (*pb.PortForwardResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_pull_image.go
+++ b/server/cri/v1alpha2/rpc_pull_image.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) PullImage(
+	ctx context.Context, req *pb.PullImageRequest,
+) (*pb.PullImageResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_remove_container.go
+++ b/server/cri/v1alpha2/rpc_remove_container.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) RemoveContainer(
+	ctx context.Context, req *pb.RemoveContainerRequest,
+) (*pb.RemoveContainerResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_remove_image.go
+++ b/server/cri/v1alpha2/rpc_remove_image.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) RemoveImage(
+	ctx context.Context, req *pb.RemoveImageRequest,
+) (*pb.RemoveImageResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_remove_pod_sandbox.go
+++ b/server/cri/v1alpha2/rpc_remove_pod_sandbox.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) RemovePodSandbox(
+	ctx context.Context, req *pb.RemovePodSandboxRequest,
+) (*pb.RemovePodSandboxResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_reopen_container_log.go
+++ b/server/cri/v1alpha2/rpc_reopen_container_log.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) ReopenContainerLog(
+	ctx context.Context, req *pb.ReopenContainerLogRequest,
+) (*pb.ReopenContainerLogResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_run_pod_sandbox.go
+++ b/server/cri/v1alpha2/rpc_run_pod_sandbox.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) RunPodSandbox(
+	ctx context.Context, req *pb.RunPodSandboxRequest,
+) (*pb.RunPodSandboxResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_start_container.go
+++ b/server/cri/v1alpha2/rpc_start_container.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) StartContainer(
+	ctx context.Context, req *pb.StartContainerRequest,
+) (resp *pb.StartContainerResponse, retErr error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_status.go
+++ b/server/cri/v1alpha2/rpc_status.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) Status(
+	ctx context.Context, req *pb.StatusRequest,
+) (*pb.StatusResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_stop_container.go
+++ b/server/cri/v1alpha2/rpc_stop_container.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) StopContainer(
+	ctx context.Context, req *pb.StopContainerRequest,
+) (*pb.StopContainerResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_stop_pod_sandbox.go
+++ b/server/cri/v1alpha2/rpc_stop_pod_sandbox.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) StopPodSandbox(
+	ctx context.Context, req *pb.StopPodSandboxRequest,
+) (*pb.StopPodSandboxResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_update_container_resources.go
+++ b/server/cri/v1alpha2/rpc_update_container_resources.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) UpdateContainerResources(
+	ctx context.Context, req *pb.UpdateContainerResourcesRequest,
+) (*pb.UpdateContainerResourcesResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_update_runtime_config.go
+++ b/server/cri/v1alpha2/rpc_update_runtime_config.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) UpdateRuntimeConfig(
+	ctx context.Context, req *pb.UpdateRuntimeConfigRequest,
+) (*pb.UpdateRuntimeConfigResponse, error) {
+	return nil, nil
+}

--- a/server/cri/v1alpha2/rpc_version.go
+++ b/server/cri/v1alpha2/rpc_version.go
@@ -1,0 +1,13 @@
+package v1alpha2
+
+import (
+	"context"
+
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *service) Version(
+	ctx context.Context, req *pb.VersionRequest,
+) (*pb.VersionResponse, error) {
+	return nil, nil
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:
To be able to support v1alpha2 as well as the new v1 CRI API we would
have to decouple the server from the protobuf API. This patch is the
first step in adding a clean interface around the v1alpha2 API.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
