### PR TITLE
ci: bump crun to 0.16; test crun with selinux

### DIFF
--- a/scripts/versions
+++ b/scripts/versions
@@ -8,7 +8,7 @@ declare -A VERSIONS=(
     ["conmon"]=v2.0.20
     ["cri-tools"]=v1.19.0
     ["runc"]=v1.0.0-rc92
-    ["crun"]=0.15
+    ["crun"]=0.16
     ["bats"]=v1.2.1
 )
 export VERSIONS

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -250,12 +250,6 @@ function setup_crio() {
     CNI_DEFAULT_NETWORK=${CNI_DEFAULT_NETWORK:-crio}
     CNI_TYPE=${CNI_TYPE:-bridge}
 
-    # Workaround for https://github.com/containers/crun/pull/531.
-    # TODO: remove once crun > 0.15 is released and used here.
-    if $RUNTIME_BINARY --version | grep -q '^crun '; then
-        OVERRIDE_OPTIONS="$OVERRIDE_OPTIONS --selinux=false"
-    fi
-
     # shellcheck disable=SC2086
     "$CRIO_BINARY_PATH" \
         --hooks-dir="$HOOKSDIR" \


### PR DESCRIPTION
/kind ci

#### What this PR does / why we need it:

ci: bump crun to 0.16

Among the other things, it comes with the selinux fix
from https://github.com/containers/crun/pull/531, so
remove the workaround from the integration test suite.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
