### PR TITLE
Fix make vendor GOSUMDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ ${SHELLCHECK}:
 	curl -sSfL $$URL | tar xfJ - -C ${BUILD_BIN_PATH} --strip 1 shellcheck-$$VERSION/shellcheck && \
 	sha256sum ${SHELLCHECK} | grep -q $$SHA256SUM
 
-vendor: export GOSUMDB := ""
+vendor: export GOSUMDB :=
 vendor:
 	$(GO) mod tidy
 	$(GO) mod vendor


### PR DESCRIPTION

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:
This fixes the intentionally unset `GOSUMDB` variable when running `make
vendor`.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
