### PR TITLE
server: use IsAlive() more

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -694,6 +694,9 @@ func (c *ContainerServer) ListSandboxes() []*sandbox.Sandbox {
 // StopContainerAndWait is a wrapping function that stops a container and waits for the container state to be stopped
 func (c *ContainerServer) StopContainerAndWait(ctx context.Context, ctr *oci.Container, timeout int64) error {
 	if err := c.Runtime().StopContainer(ctx, ctr, timeout); err != nil {
+		if errors.Is(err, oci.ErrContainerStopped) {
+			return nil
+		}
 		return fmt.Errorf("failed to stop container %s: %v", ctr.Name(), err)
 	}
 	if err := c.Runtime().WaitContainerStateStopped(ctx, ctr); err != nil {

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/server/cri/types"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -29,13 +28,8 @@ func (s StreamService) Attach(containerID string, inputStream io.Reader, outputS
 		return status.Errorf(codes.NotFound, "could not find container %q: %v", containerID, err)
 	}
 
-	if err := s.runtimeServer.Runtime().UpdateContainerStatus(c); err != nil {
-		return err
-	}
-
-	cState := c.State()
-	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
-		return fmt.Errorf("container is not created or running")
+	if err := c.IsAlive(); err != nil {
+		return status.Errorf(codes.NotFound, "container is not created or running: %v", err)
 	}
 
 	return s.runtimeServer.Runtime().AttachContainer(c, inputStream, outputStream, errorStream, tty, resize)

--- a/server/container_reopen_log.go
+++ b/server/container_reopen_log.go
@@ -1,9 +1,6 @@
 package server
 
 import (
-	"fmt"
-
-	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/server/cri/types"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -16,13 +13,8 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *types.ReopenContai
 		return errors.Wrapf(err, "could not find container %s", req.ContainerID)
 	}
 
-	if err := s.ContainerServer.Runtime().UpdateContainerStatus(c); err != nil {
-		return err
-	}
-
-	cState := c.State()
-	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
-		return fmt.Errorf("container is not created or running")
+	if err := c.IsAlive(); err != nil {
+		return errors.Errorf("container is not created or running: %v", err)
 	}
 
 	if err := s.ContainerServer.Runtime().ReopenContainerLog(c); err != nil {

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -1,14 +1,11 @@
 package server
 
 import (
-	"fmt"
-
 	"github.com/cri-o/cri-o/internal/config/node"
-	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/server/cri/types"
 	"github.com/gogo/protobuf/proto"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
-
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -18,9 +15,9 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *types.Update
 	if err != nil {
 		return err
 	}
-	state := c.State()
-	if !(state.Status == oci.ContainerStateRunning || state.Status == oci.ContainerStateCreated) {
-		return fmt.Errorf("container %s is not running or created state: %s", c.ID(), state.Status)
+
+	if err := c.IsAlive(); err != nil {
+		return errors.Errorf("container is not created or running: %v", err)
 	}
 
 	if req.Linux != nil {

--- a/server/container_update_resources_test.go
+++ b/server/container_update_resources_test.go
@@ -30,7 +30,7 @@ var _ = t.Describe("UpdateContainerResources", func() {
 					Resources: &specs.LinuxResources{},
 				},
 			})
-			testContainer.SetState(&oci.ContainerState{
+			testContainer.SetStateAndSpoofPid(&oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateRunning},
 			})
 			addContainerAndSandbox()
@@ -53,7 +53,7 @@ var _ = t.Describe("UpdateContainerResources", func() {
 					Resources: &specs.LinuxResources{},
 				},
 			})
-			testContainer.SetState(&oci.ContainerState{
+			testContainer.SetStateAndSpoofPid(&oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateRunning},
 			})
 			addContainerAndSandbox()

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
-	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
 	"github.com/cri-o/cri-o/server/cri/types"
 	"github.com/pkg/errors"
@@ -67,8 +66,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *types.StopPodSandboxRe
 			max = len(containers)
 		}
 		for _, ctr := range containers[i:max] {
-			cStatus := ctr.State()
-			if cStatus.Status != oci.ContainerStateStopped {
+			if ctr.IsAlive() == nil {
 				if ctr.ID() == podInfraContainer.ID() {
 					continue
 				}
@@ -98,12 +96,10 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *types.StopPodSandboxRe
 		}
 	}
 
-	if podInfraContainer != nil {
-		podInfraStatus := podInfraContainer.State()
-		if podInfraStatus.Status != oci.ContainerStateStopped {
-			if err := s.StopContainerAndWait(ctx, podInfraContainer, int64(10)); err != nil {
-				return fmt.Errorf("failed to stop infra container for pod sandbox %s: %v", sb.ID(), err)
-			}
+	// only stop the infra container if it exists and is still alive
+	if podInfraContainer != nil && !podInfraContainer.Spoofed() && podInfraContainer.IsAlive() == nil {
+		if err := s.StopContainerAndWait(ctx, podInfraContainer, int64(10)); err != nil {
+			return fmt.Errorf("failed to stop infra container for pod sandbox %s: %v", sb.ID(), err)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind ci

/kind cleanup

> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
this replaces unneeded State() and UpdateContainerResources() calls,
which both saves on lock contention, as well as possibly saves on a call to `runc state`

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
replaces https://github.com/cri-o/cri-o/pull/3864
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
