### PR TITLE
Fix the functions' name in completions

### DIFF
--- a/completions/bash/crio
+++ b/completions/bash/crio
@@ -1,4 +1,4 @@
-_cli_bash_autocomplete() {
+_cli_crio_bash_autocomplete() {
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
@@ -94,4 +94,4 @@ h
     return 0
 }
 
-complete -F _cli_bash_autocomplete crio
+complete -F _cli_crio_bash_autocomplete crio

--- a/completions/bash/crio-status
+++ b/completions/bash/crio-status
@@ -1,4 +1,4 @@
-_cli_bash_autocomplete() {
+_cli_crio_status_bash_autocomplete() {
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
@@ -24,4 +24,4 @@ h
     return 0
 }
 
-complete -F _cli_bash_autocomplete crio-status
+complete -F _cli_crio_status_bash_autocomplete crio-status

--- a/completions/zsh/_crio
+++ b/completions/zsh/_crio
@@ -1,9 +1,9 @@
-_cli_zsh_autocomplete() {
+_cli_crio_zsh_autocomplete() {
 
   local -a cmds
   cmds=('complete:Generate bash, fish or zsh completions.' 'completion:Generate bash, fish or zsh completions.' 'man:Generate the man page documentation.' 'markdown:Generate the markdown documentation.' 'md:Generate the markdown documentation.' 'config:Outputs a commented version of the configuration file that could be used
 by CRI-O. This allows you to save you current configuration setup and then load
-it later with **--config**. Global options will modify the output.' 'version:display detailed version information' 'wipe:wipe CRI-O's container and image storage' 'help:Shows a list of commands or help for one command' 'h:Shows a list of commands or help for one command')
+it later with **--config**. Global options will modify the output.' 'version:display detailed version information' "wipe:wipe CRI-O's container and image storage" 'help:Shows a list of commands or help for one command' 'h:Shows a list of commands or help for one command')
   _describe 'commands' cmds
 
   local -a opts
@@ -13,4 +13,4 @@ it later with **--config**. Global options will modify the output.' 'version:dis
   return
 }
 
-compdef _cli_zsh_autocomplete crio
+compdef _cli_crio_zsh_autocomplete crio

--- a/completions/zsh/_crio-status
+++ b/completions/zsh/_crio-status
@@ -1,4 +1,4 @@
-_cli_zsh_autocomplete() {
+_cli_crio_status_zsh_autocomplete() {
 
   local -a cmds
   cmds=('complete:Generate bash, fish or zsh completions.' 'completion:Generate bash, fish or zsh completions.' 'man:Generate the man page documentation.' 'markdown:Generate the markdown documentation.' 'md:Generate the markdown documentation.' 'config:Show the configuration of CRI-O as TOML string.' 'c:Show the configuration of CRI-O as TOML string.' 'containers:Display detailed information about the provided container ID.' 'container:Display detailed information about the provided container ID.' 'cs:Display detailed information about the provided container ID.' 's:Display detailed information about the provided container ID.' 'info:Retrieve generic information about CRI-O, like the cgroup and storage driver.' 'i:Retrieve generic information about CRI-O, like the cgroup and storage driver.' 'help:Shows a list of commands or help for one command' 'h:Shows a list of commands or help for one command')
@@ -11,4 +11,4 @@ _cli_zsh_autocomplete() {
   return
 }
 
-compdef _cli_zsh_autocomplete crio-status
+compdef _cli_crio_status_zsh_autocomplete crio-status


### PR DESCRIPTION
Give the completion functions different names for crio and crio-status, fix the single quote in crio completion function.

Signed-off-by: Grammy Jiang <grammy.jiang@gmail.com>

Sorry, I am not familiar with fish completion functions, so I only fix bash and zsh.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change

bug

> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

The completion functions' names are identical between `crio` and `crio-status`, this will ruin each other when both of them are enabled.

The single quote are not escaped in `crio` completion function, which will cause syntax error:
* [cri-o/_crio at release-1.20 · cri-o/cri-o](https://github.com/cri-o/cri-o/blob/release-1.20/completions/zsh/_crio#L6)

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

The details are described in the following comments.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
