### PR TITLE
test/ctr.bats: fix a "ctr execsync" flake

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -424,7 +424,7 @@ function wait_until_exit() {
 	output=$(crictl exec --sync "$ctr_id" echo HELLO)
 	[ "$output" = "HELLO" ]
 
-	run crictl exec --sync --timeout 1 "$ctr_id" sleep 3
+	run crictl exec --sync --timeout 10 "$ctr_id" sleep 20
 	echo "$output"
 	[[ "$output" == *"command timed out"* ]]
 	[ "$status" -ne 0 ]


### PR DESCRIPTION
#### What type of PR is this?

/kind ci
/kind flake

#### What this PR does / why we need it:

This test case is sometimes fails like this:

> not ok 40 ctr execsync
>  (in test file ./ctr.bats, line 429)
>    `[[ "$output" == *"command timed out"* ]]' failed
> .....
>  time="2020-12-02T23:28:58Z" level=fatal msg="connect: connect endpoint 'unix:///tmp/tmp.ncaFI2tZzn/crio.sock', make sure you are running as root and the endpoint has been started: context deadline exceeded"

This happens because our CI might be slow and this 1 second timeout
also applies to connect.

Increase the timeout and the sleep accordingly to fix the flake.

(seen in https://github.com/cri-o/cri-o/pull/4377#issuecomment-740206506)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
