### PR TITLE
ci: move docs-gen and completions to github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,15 +61,9 @@ workflows:
       - bundle-test:
           requires:
             - bundle
-      - completions-validation:
-          requires:
-            - build
       - dependencies:
           requires:
             - release-notes
-      - docs-generation:
-          requires:
-            - build
       - integration
       - integration:
           name: integration-critest
@@ -214,44 +208,6 @@ jobs:
       - run:
           name: test
           command: make bundle-test
-
-  completions-validation:
-    executor: container
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          keys:
-            - v1-completions-validation-{{ checksum "go.sum" }}
-      - run:
-          name: doc validation
-          command: |
-            make completions
-            hack/tree_status.sh
-      - save_cache:
-          key: v1-completions-validation-{{ checksum "go.sum" }}
-          paths:
-            - *gocache
-
-  docs-generation:
-    executor: container
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          keys:
-            - v1-docs-generation-{{ checksum "go.sum" }}
-      - run:
-          name: doc generation
-          command: |
-            make docs-generation
-            hack/tree_status.sh
-      - save_cache:
-          key: v1-docs-generation-{{ checksum "go.sum" }}
-          paths:
-            - *gocache
 
   dependencies:
     executor: container

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -46,6 +46,28 @@ jobs:
     - name: validate-docs
       run: make docs-validation
 
+  gendocs:
+    name: gendocs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt update && sudo apt install libselinux1-dev
+    - name: validate generated docs
+      run: |
+        make docs-generation
+        ./hack/tree_status.sh
+
+  completions:
+    name: completions
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: validate-completions
+      run: |
+        make completions
+        ./hack/tree_status.sh
+
   vendor:
     name: vendor
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Move docs generation and completions validation to github actions.

These tasks are relatively small/quick and it would be nice to see the status earlier.

NOTE at the time both jobs are supposed to fail (#4415, #FIXME)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
