### PR TITLE
Bug 1881694: Add pull source as info level log

### DIFF
--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -103,7 +103,8 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 // readability and maintainability.
 func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string, error) {
 	var err error
-	sourceCtx := *s.config.SystemContext // A shallow copy we can modify
+	sourceCtx := *s.config.SystemContext   // A shallow copy we can modify
+	sourceCtx.DockerLogMirrorChoice = true // Add info level log of the pull source
 	if pullArgs.credentials.Username != "" {
 		sourceCtx.DockerAuthConfig = &pullArgs.credentials
 	}


### PR DESCRIPTION

This BZ needs change the log level of the image pull location from the debug to info.
Crio could use SystemContext.DockerLogPullSource to log the image source if it's from a mirror.

This PR should work with PR https://github.com/containers/image/pull/1099
Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->



 /kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1881694
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Crio adds info level log of the physical image source.
```
