### PR TITLE
Add initial Kata Containers support to contrib/test/integration playbook

### DIFF
--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -48,6 +48,18 @@
       [crio.runtime.runtimes.crun]
   when: "build_crun | default(False) | bool"
 
+- name: use kata
+  copy:
+    dest: /etc/crio/crio.conf.d/50-kata.conf
+    content: |
+      [crio.runtime]
+      default_runtime = "kata"
+      [crio.runtime.runtimes.kata]
+      runtime_path = "/usr/bin/containerd-shim-kata-v2"
+      runtime_type = "vm"
+      runtime_root = "/run/vc"
+  when: "build_kata | default(False) | bool"
+
 - name: install configs
   copy:
     src: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/{{ item.src }}"

--- a/contrib/test/integration/build/kata.yml
+++ b/contrib/test/integration/build/kata.yml
@@ -1,0 +1,122 @@
+---
+- name: retrieve kvm module name
+  block:
+    - name: retrieve kvm module name (x86_64 arch)
+      set_fact:
+        kvm_mod_name: kvm_intel
+      when: ansible_architecture == "x86_64"
+
+    - name: retrieve kvm module name (s390x arch)
+      set_fact:
+        kvm_mod_name: kvm
+      when: ansible_architecture == "s390x"
+
+    - block:
+        - name: retrieve kvm module name (unknown arch)
+          debug:
+            msg: "{{ ansible_architecture }} arch, guessing kvm module as 'kvm'"
+
+        - set_fact:
+            kvm_mod_name: kvm
+
+      when: kvm_mod_name is undefined
+
+- name: check nested virtualization
+  block:
+    - name: ensure kvm module is loaded
+      block:
+        - name: ensure kvm module is loaded
+          command: modprobe {{ kvm_mod_name|quote }}
+          register: result
+
+        - fail:
+            msg: Cannot load {{ kvm_mod_name }} module
+          when: result.rc != 0
+
+    - name: ensure nested virtualization is enabled
+      block:
+        - name: check nested virtualization is enabled
+          command: cat /sys/module/{{ kvm_mod_name }}/parameters/nested
+          register: result
+
+        - name: reload kvm module
+          block:
+            - name: unload kvm module
+              command: modprobe -r {{ kvm_mod_name|quote }}
+
+            - name: load kvm module with parameters
+              command: modprobe {{ kvm_mod_name|quote }} nested=1
+
+            - name: check nested virtualization activation
+              command: cat /sys/module/{{ kvm_mod_name }}/parameters/nested
+              register: nested
+
+            - fail:
+                msg: Cannot enable nested virtualization
+              when: nested.stdout != "Y" and result.stdout != "1"
+          # You will find "Y" in Fedora and "1" in CentOS 8
+          when: result.stdout != "Y" and result.stdout != "1"
+
+# Fedora ships kata containers packages starting from version 31: for older
+# Fedora versions and CentOS we need an external repo.
+- name:  add Kata Containers repo for older versions of Fedora and CentOS
+  block:
+    - name: add Fedora < 31 and CentOS 7 repo from opensuse
+      block:
+      - name: install dnf-plugins-core
+        yum:
+          state: present
+          name: dnf-plugins-core
+
+      - name: add Kata Containers repo
+        yum_repository:
+          name: kata
+          description: Branch project for Kata Containers branch stable-1.11
+          baseurl: https://download.opensuse.org/repositories/home:/katacontainers:/releases:/{{ ansible_architecture }}:/stable-1.11/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}
+          gpgkey: https://download.opensuse.org/repositories/home:/katacontainers:/releases:/{{ ansible_architecture }}:/stable-1.11/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}/repodata/repomd.xml.key
+          gpgcheck: yes
+          state: present
+
+      when: >
+        (ansible_distribution == "Fedora" and ansible_distribution_major_version|int == 30) or
+        (ansible_distribution == "CentOS" and ansible_distribution_major_version|int == 7)
+
+    - name: add CentOS 8 repos
+      block:
+      - name: add Advanced Virtualization repo
+        yum_repository:
+          name: advanced-virt
+          description: Advanced Virtualization
+          baseurl: http://mirror.centos.org/$contentdir/$releasever/virt/$basearch/advanced-virtualization
+          gpgkey: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
+          gpgcheck: yes
+          skip_if_unavailable: yes
+
+      - name: add Kata Containers repo
+        yum_repository:
+          name: kata-containers
+          description: Kata Containers
+          baseurl: http://mirror.centos.org/$contentdir/$releasever/virt/$basearch/kata-containers
+          gpgkey: https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization
+          gpgcheck: yes
+          skip_if_unavailable: yes
+
+      # We need to pick up qemu from the Advanced Virtualization repo
+      - name: disable virt module
+        command: dnf module disable -y virt:rhel
+
+      - name: install qemu
+        yum:
+          state: present
+          name:
+            - qemu-kvm
+
+      when: ansible_distribution == "CentOS" and ansible_distribution_major_version|int == 8
+
+- name: install Kata Containers
+  yum:
+    state: present
+    name:
+      - kata-runtime
+      - kata-shim
+

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -51,6 +51,10 @@
       include: "build/crun.yml"
       when: "build_crun | bool"
 
+    - name: install Kata Containers
+      include: "build/kata.yml"
+      when: "build_kata | bool"
+
     - name: clone build and install networking plugins
       include: "build/plugins.yml"
 
@@ -92,6 +96,10 @@
     - name: clone build and install runc
       include: "build/runc.yml"
       when: "build_runc | bool"
+
+    - name: install Kata Containers
+      include: "build/kata.yml"
+      when: "build_kata | bool"
 
     - name: set fs.may_detach_mounts = 1
       sysctl:

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -12,6 +12,24 @@
     path: "{{ artifacts }}"
     state: directory
 
+- name: kata configuration
+  block:
+    - name: configure integration test suite for kata
+      set_fact:
+        int_test_env: '{{ int_test_env | combine(kata_int_test_env) }}'
+        int_test_timeout: '{{60 * 60}}' # seconds
+        userns_int_test_skip: True
+
+    - name: skip tests not working in kata
+      lineinfile:
+        dest: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/test/ctr.bats"
+        insertafter: "{{ item }}"
+        line: "skip \"{{ item  | regex_replace('\"', \"'\") }} not working in kata\""
+        state: present
+      with_items: "{{ kata_skip_ctr_tests }}"
+
+  when: "build_kata | bool"
+
 - block:
 
     - name: Disable selinux during integration tests

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -23,7 +23,7 @@
       args:
         chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
       environment: '{{ int_test_env }}'  # from vars.yml and main.yml
-      async: '{{ 60 * 30 }}'  # seconds
+      async: '{{ int_test_timeout | default(60 * 30) }}'  # seconds
       poll: 30
 
     - name: run integration tests with userNS enabled + alternate results file
@@ -31,7 +31,7 @@
       args:
         chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
       environment: '{{ int_test_env | combine(userns_int_test_env) }} '
-      async: '{{ 60 * 30 }}'  # seconds
+      async: '{{ int_test_timeout | default(60 * 30) }}'  # seconds
       poll: 30
 
   always:

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -33,6 +33,7 @@
       environment: '{{ int_test_env | combine(userns_int_test_env) }} '
       async: '{{ int_test_timeout | default(60 * 30) }}'  # seconds
       poll: 30
+      when: userns_int_test_skip is not defined or not userns_int_test_skip
 
   always:
 

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -8,6 +8,7 @@ manage_ns_lifecycle: True
 
 build_runc: True
 build_crun: False
+build_kata: False
 cgroupv2: False
 
 # For results.yml Paths use rsync 'source' conventions
@@ -31,3 +32,33 @@ ssh_location: "{{ lookup('env','HOME') }}/.ssh/id_rsa"
 # Additional environment variables for integration tests w/ userNS enabled
 userns_int_test_env:
     TEST_USERNS: "1"  # Consumed by test/test_runner.sh, by way of Makefile
+
+kata_int_test_env:
+    CONTAINER_RUNTIMES: "containerd-shim-kata-v2:/usr/bin/containerd-shim-kata-v2:/run/vc:vm"
+    CONTAINER_RUNTIME: "containerd-shim-kata-v2"
+    CONTAINER_DEFAULT_RUNTIME: "containerd-shim-kata-v2"
+    RUNTIME_NAME: "containerd-shim-kata-v2"
+    RUNTIME_ROOT: "/run/vc"
+    RUNTIME_TYPE: "vm"
+    TESTFLAGS: "ctr.bats"
+    JOBS: "1"  # TODO: add support to parallelization in kata (causes failures in the integration tests)
+
+kata_skip_ctr_tests:
+  - 'test "ctr oom"'  # https://github.com/kata-containers/tests/issues/714
+  - 'test "ctr journald logging"'
+  - 'test "ctr log max"'
+  - 'test "ctr log max with minimum value"'
+  - 'test "ctr partial line logging"'
+  - 'test "ctr execsync"'
+  - 'test "ctr execsync should not overwrite initial spec args"'
+  - 'test "privileged ctr device add"'
+  - 'test "ctr execsync std{out,err}"'
+  - 'test "ctr with default list of capabilities from crio.conf"'
+  - 'test "ctr with list of capabilities given by user in crio.conf"'
+  - 'test "ctr /etc/resolv.conf rw/ro mode"'
+  - 'test "ctr update resources"'
+  - 'test "ctr execsync conflicting with conmon env"'
+  - 'test "ctr resources"'
+  - 'test "ctr with non-root user has no effective capabilities"'
+  - 'test "privileged ctr -- check for rw mounts"'
+  - 'test "ctr with default_env set in configuration"'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind ci

#### What this PR does / why we need it:

This PR introduces support to Kata Containers  runtime in the contrib/test/integration playbook to allow to run integration tests via ansible. A new boolean environment variable has been added (build_kata). When set to true, Kata Container packages are installed and the environment configured to use Kata as the default runtime (shimv2 binary).
Only a small subset of the integration tests are run: many are not working with Kata Containers yet.
Targeted distributions are Fedora and CentOS.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
This PR aims to bring initial support to Kata Containers. The set of integration tests run is small, but tested to pass on CentOS 7 and Fedora 32/33. More integration tests may be later added and Kata Containers packages may be updated as newer stable versions are released.

#### Does this PR introduce a user-facing change?


```release-note
None
```
