### PR TITLE
contrib/test/integration: parallel build process in CentOS

### DIFF
--- a/contrib/test/integration/build/parallel.yml
+++ b/contrib/test/integration/build/parallel.yml
@@ -6,18 +6,18 @@
   package:
     name: parallel
     state: present
-  when: (supports_python3 is not defined or not supports_python3) and ansible_distribution in ['Fedora', 'CentOS']
+  when: (supports_python3 is not defined or not supports_python3) and ansible_distribution in ['Fedora']
 
 - name: install parallel package for Fedora > 30
   shell: sudo yum install -y parallel
-  when: supports_python3 is defined and supports_python3 and ansible_distribution in ['Fedora', 'CentOS']
+  when: supports_python3 is defined and supports_python3 and ansible_distribution in ['Fedora']
 
 - name: download parallel sources
   unarchive:
     src: https://ftp.gnu.org/gnu/parallel/parallel-20190322.tar.bz2
     dest: "{{ ansible_env.HOME }}"
     remote_src: yes
-  when: ansible_distribution in ['RedHat']
+  when: ansible_distribution in ['RedHat', 'CentOS']
 
 - name: install parallel from sources
   shell: |
@@ -27,4 +27,4 @@
     ln -s /usr/bin/parallel /usr/bin/sem
   args:
     chdir: "{{ ansible_env.HOME }}/parallel-20190322"
-  when: ansible_distribution in ['RedHat']
+  when: ansible_distribution in ['RedHat', 'CentOS']

--- a/contrib/test/integration/build/parallel.yml
+++ b/contrib/test/integration/build/parallel.yml
@@ -24,7 +24,7 @@
     ./configure
     make
     cp ./src/{env_parallel*,niceload,parallel,parcat,parset,sql} /usr/bin
-    ln -s /usr/bin/parallel /usr/bin/sem
+    ln -sf /usr/bin/parallel /usr/bin/sem
   args:
     chdir: "{{ ansible_env.HOME }}/parallel-20190322"
   when: ansible_distribution in ['RedHat', 'CentOS']


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind ci

#### What this PR does / why we need it:
When running the contrib/test/integration main playbook on CentOS, the parallel installation fails as there is no packaged version of parallel in CentOS 7 nor in CentOS 8.
I guess we should build it as we do for RHEL.
Moreover, the build process ends adding a symbolic link to the just compiled parallel binary: if we don't force the link creation (-f) the operation will fail if the playbook runs twice.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Wondering if I'm missing an extra repo that we usually add here and that provides the parallel package for CentOS

#### Does this PR introduce a user-facing change?


```release-note
None
```
