### PR TITLE
[1.18] set inactive-or-failed CollectMode if appropriate

### DIFF
--- a/internal/config/node/node.go
+++ b/internal/config/node/node.go
@@ -1,0 +1,45 @@
+// +build linux
+
+package node
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// ValidateConfig initializes and validates all of the singleton variables
+// that store the node's configuration.
+// Currently, we check hugetlb, cgroup v1 or v2, pid and memory swap support for cgroups.
+// We check the error at server configuration validation, and if we error, shutdown
+// cri-o early, instead of when we're already trying to run containers.
+func ValidateConfig() error {
+	toInit := []struct {
+		name      string
+		init      func() bool
+		err       *error
+		activated *bool
+		fatal     bool
+	}{
+		{
+			name:      "systemd CollectMode",
+			init:      SystemdHasCollectMode,
+			err:       &systemdHasCollectModeErr,
+			activated: &systemdHasCollectMode,
+			fatal:     false,
+		},
+	}
+	for _, i := range toInit {
+		i.init()
+		if *i.err != nil {
+			err := errors.Errorf("node configuration validation for %s failed: %v", i.name, *i.err)
+			if i.fatal {
+				return err
+			}
+			logrus.Error(err.Error())
+		}
+		if i.activated != nil {
+			logrus.Infof("node configuration value for %s is %v", i.name, *i.activated)
+		}
+	}
+	return nil
+}

--- a/internal/config/node/systemd.go
+++ b/internal/config/node/systemd.go
@@ -1,0 +1,44 @@
+// +build linux
+
+package node
+
+import (
+	"os/exec"
+	"regexp"
+	"strconv"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	systemdHasCollectModeOnce sync.Once
+	systemdHasCollectMode     bool
+	systemdHasCollectModeErr  error
+)
+
+func SystemdHasCollectMode() bool {
+	systemdHasCollectModeOnce.Do(func() {
+		stdout, err := exec.Command("systemctl", "--version").Output()
+		if err != nil {
+			systemdHasCollectModeErr = err
+			return
+		}
+		matches := regexp.MustCompile(`^systemd (?P<Version>\d+)`).FindStringSubmatch(string(stdout))
+
+		if len(matches) != 2 {
+			systemdHasCollectModeErr = errors.Errorf("systemd version command returned incompatible formatted information: %v", string(stdout))
+			return
+		}
+
+		systemdVersion, err := strconv.Atoi(matches[1])
+		if err != nil {
+			systemdHasCollectModeErr = err
+			return
+		}
+		if systemdVersion >= 236 {
+			systemdHasCollectMode = true
+		}
+	})
+	return systemdHasCollectMode
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/apparmor"
 	"github.com/cri-o/cri-o/internal/config/capabilities"
 	"github.com/cri-o/cri-o/internal/config/conmonmgr"
+	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/config/seccomp"
 	"github.com/cri-o/cri-o/server/useragent"
 	"github.com/cri-o/cri-o/utils"
@@ -590,6 +591,12 @@ func (c *Config) Validate(onExecution bool) error {
 	case ImageVolumesBind:
 	default:
 		return fmt.Errorf("unrecognized image volume type specified")
+	}
+
+	if onExecution {
+		if err := node.ValidateConfig(); err != nil {
+			return err
+		}
 	}
 
 	if err := c.RootConfig.Validate(onExecution); err != nil {

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -20,6 +20,7 @@ import (
 	selinux "github.com/containers/libpod/pkg/selinux"
 	createconfig "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/storage/pkg/mount"
+	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
@@ -574,6 +575,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 			if useSystemd {
 				specgen.AddAnnotation("org.systemd.property.TimeoutStopUSec",
 					"uint64 "+t+"000000") // sec to usec
+				if node.SystemdHasCollectMode() {
+					specgen.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
+				}
 			}
 		}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/libpod/pkg/cgroups"
 	selinux "github.com/containers/libpod/pkg/selinux"
 	"github.com/containers/storage"
+	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/lib"
 	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
@@ -343,6 +344,10 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if podContainer.Config.Config.StopSignal != "" {
 		// this key is defined in image-spec conversion document at https://github.com/opencontainers/image-spec/pull/492/files#diff-8aafbe2c3690162540381b8cdb157112R57
 		g.AddAnnotation("org.opencontainers.image.stopSignal", podContainer.Config.Config.StopSignal)
+	}
+
+	if s.config.CgroupManager == oci.SystemdCgroupsManager && node.SystemdHasCollectMode() {
+		g.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
 	}
 
 	created := time.Now()


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
This commit introduces a bare bones internal/config/node package to support this feature.
Not cleaning failed scopes can cause mounts to fail, this piece of functionality is definitely a bug.
The rest of the internal/config/node package is not fixing a bug, so it's excluded.

currently, systemd leaks some scopes if they're failed.
This can be changed with the CollectMode annotation (which runc will set).
However, only systemd version >= 236 has support for this, so we need a new entry in internal/config/node to check whether systemd is the correct version

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
grabs https://github.com/cri-o/cri-o/pull/3859 and https://github.com/cri-o/cri-o/pull/3942 as well as a minimal implementation of the node package
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
CRI-O now sets `inactive-or-failed` on scopes if using the systemd cgroup manager and if systemd version is >= 236
```
