### PR TITLE
WIP container stats: cache disk stats

### DIFF
--- a/internal/config/statsmgr/cached_statsmgr.go
+++ b/internal/config/statsmgr/cached_statsmgr.go
@@ -1,0 +1,151 @@
+package statsmgr
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cri-o/cri-o/server/cri/types"
+	"github.com/pkg/errors"
+)
+
+// SyncPeriod is the amount of time between
+// refreshing the disk stats.
+// It is based on the Kubelet's defaultHousekeepingInterval
+// (https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cadvisor/cadvisor_linux.go#L65).
+var SyncPeriod time.Duration = 10 * time.Second
+
+// cachedStatsManager is an implementation of StatsManager
+// that results in fewer disk reads.
+// Specifically, it caches the InodeCount and DirSize for
+// each container ID it is in charge of.
+// It refreshes this cache every `SyncPeriod`.
+type cachedStatsManager struct {
+	statsMap map[string]*managedDiskStats
+	done     chan struct{}
+	sync.RWMutex
+}
+
+// newCachedStatsManager creates a new CachedStatsManager,
+// and starts the updateLoop in a new goroutine
+func newCachedStatsManager() *cachedStatsManager {
+	sm := &cachedStatsManager{
+		statsMap: make(map[string]*managedDiskStats),
+		done:     make(chan struct{}, 1),
+	}
+	go sm.updateLoop()
+
+	return sm
+}
+
+// managedDiskStats is an internal structure that holds the cached stats,
+// along with a lock to keep its update atomic, and the path of the rootFs of the container.
+type managedDiskStats struct {
+	path       string
+	errorCount int
+	lastError  error
+	InodeCount uint64
+	DirSize    uint64
+	sync.RWMutex
+}
+
+// updateLoop runs every `SyncPeriod`, or until Shutdown() is called.
+// It updates all of the container stats that are currently tracked.
+func (sm *cachedStatsManager) updateLoop() {
+	for {
+		sm.RLock()
+		for _, stats := range sm.statsMap {
+			go stats.updateStats()
+		}
+		sm.RUnlock()
+
+		select {
+		case <-time.After(SyncPeriod):
+		case <-sm.done:
+			return
+		}
+	}
+}
+
+// UpdateWithDiskStats updates the ContainerStats object with the disk stats
+// for every container the cachedStatsManager currently watches.
+func (sm *cachedStatsManager) UpdateWithDiskStats(criStats []*types.ContainerStats) error {
+	return updateWithDiskStats(criStats, sm.statsForID)
+}
+
+// statsForID is an internal function that returns the cached DirSize and InodeCount.
+func (sm *cachedStatsManager) statsForID(id string) (dirSize, inodeCount uint64, _ error) {
+	sm.RLock()
+	defer sm.RUnlock()
+	managedStat, ok := sm.statsMap[id]
+	// the most likely situation this occurs is
+	// we've just added the container, and the stats object hasn't been populated yet
+	// it's an unlikely race, and the client will be okay not knowing the stats
+	// for this new container for one request
+	if !ok {
+		return 0, 0, nil
+	}
+	managedStat.RLock()
+	defer managedStat.RUnlock()
+
+	// errors should be reported
+	if managedStat.errorCount > 0 {
+		// If we don't attempt to update the stats,
+		// then these requests will error continuously until they're
+		// re-updated. However, we don't want to waste resources
+		// updating stats that will never succeed.
+		if managedStat.errorCount < 5 {
+			go managedStat.updateStats()
+		}
+		return 0, 0, errors.Errorf("finding disk stats has failed the following number of times: %d. Last error: %v", managedStat.errorCount, managedStat.lastError)
+	}
+
+	return managedStat.DirSize, managedStat.InodeCount, nil
+}
+
+// AddID adds a container to the set of containers that cachedStatsManager watches.
+// It will initialize the disk stats, and save the ID and path for cache updates.
+func (sm *cachedStatsManager) AddID(id, path string) {
+	mds := &managedDiskStats{
+		path: path,
+	}
+
+	sm.Lock()
+	sm.statsMap[id] = mds
+	sm.Unlock()
+
+	mds.updateStats()
+}
+
+// updateStats updates the DirSize and InodeCount for this container's managedDiskStats.
+func (mds *managedDiskStats) updateStats() {
+	mds.Lock()
+	defer mds.Unlock()
+	dirSize, inodeCount, err := GetDiskUsageStats(mds.path)
+	if err != nil {
+		fmt.Println("hello")
+		mds.errorCount++
+		mds.lastError = err
+		return
+	}
+
+	// reset the error count
+	mds.errorCount = 0
+	mds.lastError = nil
+
+	mds.DirSize = dirSize
+	mds.InodeCount = inodeCount
+}
+
+// RemoveID causes the cachedStatsManager to no longer
+// track the disk usage of this container ID.
+func (sm *cachedStatsManager) RemoveID(id string) {
+	sm.Lock()
+	defer sm.Unlock()
+	delete(sm.statsMap, id)
+}
+
+// Shutdown stops the updateLoop.
+func (sm *cachedStatsManager) Shutdown() {
+	sm.done <- struct{}{}
+}

--- a/internal/config/statsmgr/legacy_statsmgr.go
+++ b/internal/config/statsmgr/legacy_statsmgr.go
@@ -1,0 +1,73 @@
+package statsmgr
+
+import (
+	"sync"
+
+	"github.com/cri-o/cri-o/server/cri/types"
+)
+
+// legacyStatsManager is an implementation of the StatsManager interface
+// that covers the legacy functionality: check the disk stats with every
+// ContainerStats{,List} call.
+// The main purpose of this implementation is to prevent duplicated
+// DiskStats caches if the client is also keeping a cache (as the Kubelet does
+// by default with cadvisor as of the time of writing this).
+// Users should transition to using cachedStatsManager and change their
+// clients to not keep their own cache.
+type legacyStatsManager struct {
+	pathMap map[string]string
+	sync.RWMutex
+}
+
+// newLegacyStatsManager creates a new legacyStatsManager.
+func newLegacyStatsManager() *legacyStatsManager {
+	return &legacyStatsManager{
+		pathMap: make(map[string]string),
+	}
+}
+
+// AddID adds a container to the set of containers that legacyStatsManager
+// will update when asked to.
+func (sm *legacyStatsManager) AddID(id, path string) {
+	sm.Lock()
+	sm.pathMap[id] = path
+	sm.Unlock()
+}
+
+// RemoveID removes the container with ID `id` from the set of contaienrs
+// that will have their stats updated when requested.
+func (sm *legacyStatsManager) RemoveID(id string) {
+	sm.Lock()
+	defer sm.Unlock()
+	delete(sm.pathMap, id)
+}
+
+// UpdateWithDiskStats updates a ContainerStats object to have the DiskStats of the containers
+// legacyStatsManager is keeping track of.
+func (sm *legacyStatsManager) UpdateWithDiskStats(criStats []*types.ContainerStats) error {
+	return updateWithDiskStats(criStats, sm.statsForID)
+}
+
+// statsForID is an internal function that returns the computed DirSize and InodeCount.
+func (sm *legacyStatsManager) statsForID(id string) (dirSize, inodeCount uint64, _ error) {
+	sm.RLock()
+	defer sm.RUnlock()
+	path, ok := sm.pathMap[id]
+	// the most likely situation this occurs is
+	// we've just added the container, and the stats object hasn't been populated yet
+	// it's an unlikely race, and the client will be okay not knowing the stats
+	// for this new container for one request
+	if !ok {
+		return 0, 0, nil
+	}
+
+	dirSize, inodeCount, err := GetDiskUsageStats(path)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return dirSize, inodeCount, nil
+}
+
+// Shutdown is a noop for legacyStatsManager, as there is no routine keeping the cache.
+func (*legacyStatsManager) Shutdown() {}

--- a/internal/config/statsmgr/statsmgr.go
+++ b/internal/config/statsmgr/statsmgr.go
@@ -1,0 +1,82 @@
+package statsmgr
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/cri-o/cri-o/server/cri/types"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// CachedStatsManagerType is the string used to configure CRI-O to use
+// the CachedStatsManager
+const CachedStatsManagerType = "cached"
+
+// StatsManager is the interface for checking for disk stats of containers
+type StatsManager interface {
+	AddID(string, string)
+	RemoveID(string)
+	UpdateWithDiskStats([]*types.ContainerStats) error
+	Shutdown()
+}
+
+// New creates a new StatsManager based on the server configuration
+func New(statsManager string) StatsManager {
+	if statsManager == CachedStatsManagerType {
+		return newCachedStatsManager()
+	}
+	return newLegacyStatsManager()
+}
+
+// updateWithDiskStats is an internal helper function that covers shared behavior between the different implementations
+// of StatsManager.UpdateWithDiskStats.
+// It takes a functor `statsForIDFunc` that should return the usedBytes and inodesUsed for that particular container ID.
+func updateWithDiskStats(criStats []*types.ContainerStats, statsForIDFunc func(string) (uint64, uint64, error)) error {
+	failedUpdates := make([]string, 0)
+	for _, criStat := range criStats {
+		// shouldn't happen but good to check
+		if criStat == nil {
+			return errors.Errorf("ContainerStats object is invalid with a nil entry")
+		}
+		if criStat.Attributes == nil {
+			return errors.Errorf("ContainerStats object is invalid with a nil entry")
+		}
+		if criStat.WritableLayer == nil {
+			criStat.WritableLayer = &types.FilesystemUsage{}
+		}
+
+		usedBytes, inodesUsed, err := statsForIDFunc(criStat.Attributes.ID)
+		if err != nil {
+			logrus.Errorf("Failed to update disk stats for container %s: %v", criStat.Attributes.ID, err)
+			failedUpdates = append(failedUpdates, criStat.Attributes.ID)
+			continue
+		}
+		criStat.WritableLayer.UsedBytes = &types.UInt64Value{Value: usedBytes}
+		criStat.WritableLayer.InodesUsed = &types.UInt64Value{Value: inodesUsed}
+	}
+	if len(failedUpdates) > 0 {
+		return errors.Errorf("Failed to update disk stats for containers: %v", failedUpdates)
+	}
+	return nil
+}
+
+// GetDiskUsageStats accepts a path to a directory or file
+// and returns the number of bytes and inodes used by the path
+func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, _ error) {
+	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		// Walk does not follow symbolic links
+		if err != nil {
+			return err
+		}
+
+		dirSize += uint64(info.Size())
+		inodeCount++
+
+		return nil
+	}); err != nil {
+		return 0, 0, err
+	}
+
+	return dirSize, inodeCount, nil
+}

--- a/internal/config/statsmgr/statsmgr_test.go
+++ b/internal/config/statsmgr/statsmgr_test.go
@@ -1,0 +1,33 @@
+package statsmgr_test
+
+import (
+	"github.com/cri-o/cri-o/internal/config/statsmgr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = t.Describe("StatsManager", func() {
+	t.Describe("GetDiskUsageStats", func() {
+		It("should succeed at the current working directory", func() {
+			// Given
+			// When
+			bytes, inodes, err := statsmgr.GetDiskUsageStats(".")
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(bytes).To(SatisfyAll(BeNumerically(">", 0)))
+			Expect(inodes).To(SatisfyAll(BeNumerically(">", 0)))
+		})
+
+		It("should fail on invalid path", func() {
+			// Given
+			// When
+			bytes, inodes, err := statsmgr.GetDiskUsageStats("/not-existing")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(bytes).To(BeEquivalentTo(0))
+			Expect(inodes).To(BeEquivalentTo(0))
+		})
+	})
+})

--- a/internal/config/statsmgr/statsmgr_test.go
+++ b/internal/config/statsmgr/statsmgr_test.go
@@ -1,7 +1,11 @@
 package statsmgr_test
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/cri-o/cri-o/internal/config/statsmgr"
+	"github.com/cri-o/cri-o/server/cri/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -30,4 +34,70 @@ var _ = t.Describe("StatsManager", func() {
 			Expect(inodes).To(BeEquivalentTo(0))
 		})
 	})
+	for _, name := range []string{"legacy", "cached"} {
+		name := name
+		t.Describe(name+"StatsManager", func() {
+			var (
+				sut   statsmgr.StatsManager
+				path  string
+				stats *types.ContainerStats
+				ctrID = "ctrID"
+			)
+			BeforeEach(func() {
+				sut = statsmgr.New(name)
+				path = t.MustTempDir(name + "-stats-mgr")
+				stats = &types.ContainerStats{
+					Attributes: &types.ContainerAttributes{
+						ID: ctrID,
+					},
+				}
+			})
+			AfterEach(func() {
+				sut.Shutdown()
+			})
+			It("should fail if stats improperly passed in", func() {
+				// Then
+				Expect(sut.UpdateWithDiskStats([]*types.ContainerStats{nil})).To(Not(BeNil()))
+				stats.Attributes = nil
+				Expect(sut.UpdateWithDiskStats([]*types.ContainerStats{nil})).To(Not(BeNil()))
+			})
+			It("should be able to get stats for added ID", func() {
+				// Given
+				sut.AddID(ctrID, path)
+				// When
+				Expect(sut.UpdateWithDiskStats([]*types.ContainerStats{stats})).To(BeNil())
+				// Then
+				Expect(stats.WritableLayer).To(Not(BeNil()))
+				Expect(stats.WritableLayer.UsedBytes.Value).To(Not(BeZero()))
+				Expect(stats.WritableLayer.InodesUsed.Value).To(Not(BeZero()))
+			})
+			It("should be able to remove non-existent ID", func() {
+				sut.RemoveID(ctrID)
+			})
+			It("should fail to get stats for non-existent dir", func() {
+				// Given
+				sut.AddID(ctrID, "/notthere")
+				// Then
+				Expect(sut.UpdateWithDiskStats([]*types.ContainerStats{stats})).NotTo(BeNil())
+			})
+			It("should succeed eventually to get stats for newly created dir", func() {
+				// When
+				path = filepath.Join(path, "new-path")
+				sut.AddID(ctrID, path)
+				Expect(sut.UpdateWithDiskStats([]*types.ContainerStats{stats})).NotTo(BeNil())
+				// Given
+				os.MkdirAll(path, 0o755)
+				// Then
+				Expect(sut.UpdateWithDiskStats([]*types.ContainerStats{stats})).To(BeNil())
+				// Given
+			})
+			It("should not fail to get stats for non-existent ID", func() {
+				// Then
+				Expect(sut.UpdateWithDiskStats([]*types.ContainerStats{stats})).To(BeNil())
+				Expect(stats.WritableLayer).NotTo(BeNil())
+				Expect(stats.WritableLayer.UsedBytes.Value).To(BeZero())
+				Expect(stats.WritableLayer.InodesUsed.Value).To(BeZero())
+			})
+		})
+	}
 })

--- a/internal/config/statsmgr/suite_test.go
+++ b/internal/config/statsmgr/suite_test.go
@@ -1,0 +1,26 @@
+package statsmgr_test
+
+import (
+	"testing"
+
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestStatsManager runs the created specs
+func TestStatsManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "StatsManager")
+}
+
+var t *TestFramework
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -158,6 +158,9 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 	if ctx.IsSet("apparmor-profile") {
 		config.ApparmorProfile = ctx.String("apparmor-profile")
 	}
+	if ctx.IsSet("stats-manager-type") {
+		config.StatsManagerType = ctx.String("stats-manager-type")
+	}
 	if ctx.IsSet("cgroup-manager") {
 		config.CgroupManagerName = ctx.String("cgroup-manager")
 	}

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -473,6 +473,10 @@ func (c *ContainerServer) LoadContainer(id string) (retErr error) {
 	if err := c.ContainerStateToDisk(ctr); err != nil {
 		return fmt.Errorf("failed to write container state to disk %q: %v", ctr.ID(), err)
 	}
+
+	// Begin tracking the container's disk stats
+	c.config.StatsManager().AddID(ctr.ID(), c.config.MountpointWritableLayer(ctr.MountPoint()))
+
 	ctr.SetCreated()
 
 	c.AddContainer(ctr)
@@ -609,6 +613,7 @@ func (c *ContainerServer) RemoveContainer(ctr *oci.Container) {
 		return
 	}
 	sb.RemoveContainer(ctr)
+	c.config.StatsManager().RemoveID(ctr.ID())
 	c.state.containers.Delete(ctr.ID())
 }
 

--- a/internal/lib/stop.go
+++ b/internal/lib/stop.go
@@ -38,6 +38,7 @@ func (c *ContainerServer) ContainerStop(ctx context.Context, container string, t
 	if err := c.ContainerStateToDisk(ctr); err != nil {
 		logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
+	c.config.StatsManager().RemoveID(ctr.ID())
 
 	return ctrID, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -746,7 +746,8 @@ func (c *RootConfig) Validate(onExecution bool) error {
 			return errors.Wrapf(err, "failed to get store to set defaults")
 		}
 
-		c.statsManager = statsmgr.New(c.StatsManagerType)
+		// c.statsManager = statsmgr.New(c.StatsManagerType)
+		c.statsManager = statsmgr.New("cached")
 		// This step merges the /etc/container/storage.conf with the
 		// storage configuration in crio.conf
 		// If we don't do this step, we risk returning the incorrect info

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -717,6 +717,7 @@ func (c *RootConfig) Validate(onExecution bool) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to get store to set defaults")
 		}
+
 		// This step merges the /etc/container/storage.conf with the
 		// storage configuration in crio.conf
 		// If we don't do this step, we risk returning the incorrect info

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -52,6 +52,10 @@ const templateString = `# The CRI-O configuration file specifies all of the avai
 # the kubelet. The log directory specified must be an absolute directory.
 log_dir = "{{ .LogDir }}"
 
+# The type of stats manager the server should use.
+# Currently the supported options are "" (legacy) or "cached".
+stats_manager_type = "{{ .StatsManagerType }}"
+
 # Location for CRI-O to lay down the temporary version file.
 # It is used to check if crio wipe should wipe containers, which should
 # always happen on a node reboot

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -549,6 +549,9 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 		log.Warnf(ctx, "unable to write containers %s state to disk: %v", newContainer.ID(), err)
 	}
 
+	// Begin tracking the container's disk stats
+	s.config.StatsManager().AddID(newContainer.ID(), s.config.MountpointWritableLayer(newContainer.MountPoint()))
+
 	if isContextError(ctx.Err()) {
 		if err := s.resourceStore.Put(ctr.Name(), newContainer, cleanupFuncs); err != nil {
 			log.Errorf(ctx, "createCtr: failed to save progress of container %s: %v", newContainer.ID(), err)

--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -11,6 +11,30 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ContainerStats returns stats of the container. If the container does not
+// exist, the call returns an error.
+func (s *Server) ContainerStats(ctx context.Context, req *types.ContainerStatsRequest) (*types.ContainerStatsResponse, error) {
+	container, err := s.GetContainerFromShortID(req.ContainerID)
+	if err != nil {
+		return nil, err
+	}
+	sb := s.GetSandbox(container.Sandbox())
+	if sb == nil {
+		return nil, errors.Errorf("unable to get stats for container %s: sandbox %s not found", container.ID(), container.Sandbox())
+	}
+	cgroup := sb.CgroupParent()
+
+	stats, err := s.Runtime().ContainerStats(container, cgroup)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.ContainerStatsResponse{Stats: s.buildContainerStats(ctx, stats, container)}, nil
+}
+
+// buildContainerStats takes stats directly from the container, and attempts to inject the filesystem
+// usage of the container.
+// This is not taken care of by the container because we access information on the server level (storage driver).
 func (s *Server) buildContainerStats(ctx context.Context, stats *oci.ContainerStats, container *oci.Container) *types.ContainerStats {
 	// TODO: Fix this for other storage drivers. This will only work with overlay.
 	var writableLayer *types.FilesystemUsage
@@ -47,25 +71,4 @@ func (s *Server) buildContainerStats(ctx context.Context, stats *oci.ContainerSt
 		},
 		WritableLayer: writableLayer,
 	}
-}
-
-// ContainerStats returns stats of the container. If the container does not
-// exist, the call returns an error.
-func (s *Server) ContainerStats(ctx context.Context, req *types.ContainerStatsRequest) (*types.ContainerStatsResponse, error) {
-	container, err := s.GetContainerFromShortID(req.ContainerID)
-	if err != nil {
-		return nil, err
-	}
-	sb := s.GetSandbox(container.Sandbox())
-	if sb == nil {
-		return nil, errors.Errorf("unable to get stats for container %s: sandbox %s not found", container.ID(), container.Sandbox())
-	}
-	cgroup := sb.CgroupParent()
-
-	stats, err := s.Runtime().ContainerStats(container, cgroup)
-	if err != nil {
-		return nil, err
-	}
-
-	return &types.ContainerStatsResponse{Stats: s.buildContainerStats(ctx, stats, container)}, nil
 }

--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"path/filepath"
 
+	"github.com/cri-o/cri-o/internal/config/statsmgr"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/server/cri/types"
-	crioStorage "github.com/cri-o/cri-o/utils"
 	"github.com/pkg/errors"
 )
 
@@ -40,7 +40,7 @@ func (s *Server) buildContainerStats(ctx context.Context, stats *oci.ContainerSt
 	var writableLayer *types.FilesystemUsage
 	if s.ContainerServer.Config().RootConfig.Storage == "overlay" {
 		diffDir := filepath.Join(filepath.Dir(container.MountPoint()), "diff")
-		bytesUsed, inodeUsed, err := crioStorage.GetDiskUsageStats(diffDir)
+		bytesUsed, inodeUsed, err := statsmgr.GetDiskUsageStats(diffDir)
 		if err != nil {
 			log.Warnf(ctx, "unable to get disk usage for container %s， %s", container.ID(), err)
 		}

--- a/server/image_fs_info.go
+++ b/server/image_fs_info.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/containers/storage"
+	"github.com/cri-o/cri-o/internal/config/statsmgr"
 	"github.com/cri-o/cri-o/server/cri/types"
-	crioStorage "github.com/cri-o/cri-o/utils"
 )
 
 func getStorageFsInfo(store storage.Store) (*types.FilesystemUsage, error) {
@@ -15,7 +15,7 @@ func getStorageFsInfo(store storage.Store) (*types.FilesystemUsage, error) {
 	storageDriver := store.GraphDriverName()
 	imagesPath := path.Join(rootPath, storageDriver+"-images")
 
-	bytesUsed, inodesUsed, err := crioStorage.GetDiskUsageStats(imagesPath)
+	bytesUsed, inodesUsed, err := statsmgr.GetDiskUsageStats(imagesPath)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -2,29 +2,8 @@ package utils
 
 import (
 	"os"
-	"path/filepath"
 	"syscall"
 )
-
-// GetDiskUsageStats accepts a path to a directory or file
-// and returns the number of bytes and inodes used by the path
-func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, _ error) {
-	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		// Walk does not follow symbolic links
-		if err != nil {
-			return err
-		}
-
-		dirSize += uint64(info.Size())
-		inodeCount++
-
-		return nil
-	}); err != nil {
-		return 0, 0, err
-	}
-
-	return dirSize, inodeCount, nil
-}
 
 // IsDirectory tests whether the given path exists and is a directory. It
 // follows symlinks.

--- a/utils/filesystem_test.go
+++ b/utils/filesystem_test.go
@@ -10,30 +10,6 @@ import (
 
 // The actual test suite
 var _ = t.Describe("Filesystem", func() {
-	t.Describe("GetDiskUsageStats", func() {
-		It("should succeed at the current working directory", func() {
-			// Given
-			// When
-			bytes, inodes, err := utils.GetDiskUsageStats(".")
-
-			// Then
-			Expect(err).To(BeNil())
-			Expect(bytes).To(SatisfyAll(BeNumerically(">", 0)))
-			Expect(inodes).To(SatisfyAll(BeNumerically(">", 0)))
-		})
-
-		It("should fail on invalid path", func() {
-			// Given
-			// When
-			bytes, inodes, err := utils.GetDiskUsageStats("/not-existing")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(bytes).To(BeEquivalentTo(0))
-			Expect(inodes).To(BeEquivalentTo(0))
-		})
-	})
-
 	t.Describe("IsDirectory", func() {
 		It("should succeed on a directory", func() {
 			Expect(utils.IsDirectory(".")).To(BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
cadvisor currently performs better than CRI stats because it utilizes a cache for the disk stats. this allows it to make fewer sycalls and fork fewer processes.

TODO: 
- [ ] check if we need to remove in more spots (stop??)
- [ ] add more tests
- [ ] make sure the performance comparison is within an acceptable margin

This PR adds a new package: statsmgr, that allows us to optionally cache disk stats.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add option `stats_manager_type` that allows users to have container disk stats cached every 10 seconds if set to `cached`.
```
