### PR TITLE
Add links to OBS projects to install documentation

### DIFF
--- a/install.md
+++ b/install.md
@@ -36,9 +36,15 @@ It is assumed you are running a Linux machine.
 
 ## Install packaged versions of CRI-O
 
-CRI-O builds for native package managers using [openSUSE's OBS](build.opensuse.org)
+CRI-O builds for native package managers using [openSUSE's OBS](https://build.opensuse.org).
 
 ### Supported versions
+
+All available versions are available in the OBS [libcontainers:stable
+project](https://build.opensuse.org/project/show/devel:kubic:libcontainers:stable),
+which contains
+[subprojects](https://build.opensuse.org/project/subprojects/devel:kubic:libcontainers:stable)
+to the dedicated versions.
 
 CRI-O follows the [Kubernetes support cycle](https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions) of three minor releases.
 CRI-O also attempts to package for the following operating systems:


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:
This fixes a broken link and adds links to the certain projects in OBS
to have no need for a manual search.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
The compatibility matrix below my code changes needs to be updated to mention 1.19 and 1.20. I saw that builds for Centos 7 for example are existing, so I was not sure if we want to mention them as "to be supported". Any thoughts on that?
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
