### PR TITLE
Return runtime API version based on protocol

### DIFF
--- a/server/cri/v1/rpc_version.go
+++ b/server/cri/v1/rpc_version.go
@@ -9,7 +9,7 @@ import (
 func (s *service) Version(
 	ctx context.Context, req *pb.VersionRequest,
 ) (*pb.VersionResponse, error) {
-	resp, err := s.server.Version(ctx)
+	resp, err := s.server.Version(ctx, "v1")
 	if err != nil {
 		return nil, err
 	}

--- a/server/cri/v1alpha2/rpc_version.go
+++ b/server/cri/v1alpha2/rpc_version.go
@@ -9,7 +9,7 @@ import (
 func (s *service) Version(
 	ctx context.Context, req *pb.VersionRequest,
 ) (*pb.VersionResponse, error) {
-	resp, err := s.server.Version(ctx)
+	resp, err := s.server.Version(ctx, "v1alpha2")
 	if err != nil {
 		return nil, err
 	}

--- a/server/version.go
+++ b/server/version.go
@@ -13,16 +13,15 @@ const (
 	kubeAPIVersion = "0.1.0"
 	// containerName is the name prepended in kubectl describe->Container ID:
 	// cri-o://<CONTAINER_ID>
-	containerName     = "cri-o"
-	runtimeAPIVersion = "v1alpha1"
+	containerName = "cri-o"
 )
 
 // Version returns the runtime name, runtime version and runtime API version
-func (s *Server) Version(context.Context) (*types.VersionResponse, error) {
+func (s *Server) Version(_ context.Context, apiVersion string) (*types.VersionResponse, error) {
 	return &types.VersionResponse{
 		Version:           kubeAPIVersion,
 		RuntimeName:       containerName,
 		RuntimeVersion:    version.Get().Version,
-		RuntimeAPIVersion: runtimeAPIVersion,
+		RuntimeAPIVersion: apiVersion,
 	}, nil
 }

--- a/server/version_test.go
+++ b/server/version_test.go
@@ -19,8 +19,10 @@ var _ = t.Describe("Version", func() {
 	t.Describe("Version", func() {
 		It("should succeed", func() {
 			// Given
+			const testVersion = "v1"
+
 			// When
-			response, err := sut.Version(context.Background())
+			response, err := sut.Version(context.Background(), testVersion)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -28,7 +30,7 @@ var _ = t.Describe("Version", func() {
 			Expect(response.Version).NotTo(BeEmpty())
 			Expect(response.RuntimeName).NotTo(BeEmpty())
 			Expect(response.RuntimeName).NotTo(BeEmpty())
-			Expect(response.RuntimeAPIVersion).NotTo(BeEmpty())
+			Expect(response.RuntimeAPIVersion).To(Equal(testVersion))
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
To be able to distinguish the chosen CRI API version, we now return the
runtime API version based on the RPC code path.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
The CRI protocol mentioned that the version has to be semver compatible:
https://github.com/kubernetes/cri-api/blob/3094f92ca2a23915931d9345285a6721be06cf62/pkg/apis/runtime/v1alpha2/api.proto#L143-L145

Before this patch we had returned `v1alpha1`, which is neither the current CRI API version nor semver compatible. Any thought on that?

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed `VersionResponse.RuntimeApiVersion` to return either the `v1alpha2` or `v1` CRI API version
```
