### PR TITLE
add `regitries` deprecation notice

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -291,6 +291,8 @@ CRI-O reads its configured registries defaults from the system wide containers-r
 **registries**=["docker.io"]
   List of registries to be used when pulling an unqualified image (e.g., "alpine:latest"). By default, registries is set to "docker.io" for compatibility reasons. Depending on your workload and usecase you may add more registries (e.g., "quay.io", "registry.fedoraproject.org", "registry.opensuse.org", etc.).
 
+  NOTE: The registries option has been deprecated and will be removed with CRI-O 1.21. Please refer to registries.conf(5) for configuring unqualified-search registries.
+
 **big_files_temporary_dir**=""
   Path to the temporary directory to use for storing big files, used to store image blobs and data streams related to containers image management.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -489,6 +489,11 @@ func (c *Config) UpdateFromFile(path string) error {
 		delete(c.Runtimes, defaultRuntime)
 	}
 
+	if len(t.Crio.Image.Registries) > 0 {
+		logrus.Warnf("The 'registries' option in crio.conf(5) (referenced in %q) has been deprecated and will be removed with CRI-O 1.21.", path)
+		logrus.Warn("Please refer to containers-registries.conf(5) for configuring unqualified-search registries.")
+	}
+
 	t.toConfig(c)
 	c.singleConfigPath = path
 	return nil


### PR DESCRIPTION
The `registries` option will be removed from CRI-O 1.21.  To better
communicate this upcoming change to users, add a deprecation warning
when loading a config and another to the man page.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

#### What type of PR is this?

> /kind deprecation

#### What this PR does / why we need it:

@haircommander forced me to.

```release-note
The `registries` option from crio.conf(5) has been deprecated in favour of using containers-registries.conf(5) for configuring unqualified-search registries.  The `registries` option will be removed from CRI-O 1.21.
```
