### PR TITLE
server: leave swap mem limit unset if not supported

### DIFF
--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -35,10 +35,10 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *types.Update
 
 // toOCIResources converts CRI resource constraints to OCI.
 func toOCIResources(r *types.LinuxContainerResources) *rspec.LinuxResources {
-	var swap int64
+	var swap *int64
 	memory := r.MemoryLimitInBytes
 	if node.CgroupHasMemorySwap() {
-		swap = memory
+		swap = proto.Int64(memory)
 	}
 	return &rspec.LinuxResources{
 		CPU: &rspec.LinuxCPU{
@@ -50,7 +50,7 @@ func toOCIResources(r *types.LinuxContainerResources) *rspec.LinuxResources {
 		},
 		Memory: &rspec.LinuxMemory{
 			Limit: proto.Int64(memory),
-			Swap:  proto.Int64(swap),
+			Swap:  swap,
 		},
 		// TODO(runcom): OOMScoreAdj is missing
 	}


### PR DESCRIPTION
if the memory swap limit is not supported by cgroup, leave the value
unset instead of forcing it to 0.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

if swap memcg is not supported, leave the value unset instead of setting it to 0

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
