### PR TITLE
cgroup: implement fix for swap memcg on cgroup v2

### DIFF
--- a/internal/config/node/cgroups.go
+++ b/internal/config/node/cgroups.go
@@ -4,6 +4,7 @@ package node
 
 import (
 	"os"
+	"path/filepath"
 	"sync"
 
 	libpodcgroups "github.com/containers/libpod/v2/pkg/cgroups"
@@ -34,6 +35,17 @@ func CgroupIsV2() bool {
 func CgroupHasMemorySwap() bool {
 	cgroupHasMemorySwapOnce.Do(func() {
 		if CgroupIsV2() {
+			cg, err := libctrcgroups.ParseCgroupFile("/proc/self/cgroup")
+			if err != nil {
+				cgroupHasMemorySwapErr = err
+				cgroupHasMemorySwap = false
+				return
+			}
+			memSwap := filepath.Join("/sys/fs/cgroup", cg[""], "memory.swap.current")
+			if _, err := os.Stat(memSwap); err != nil {
+				cgroupHasMemorySwap = false
+				return
+			}
 			cgroupHasMemorySwap = true
 			return
 		}


### PR DESCRIPTION
CRI-O assumed that the swap memcg is always present on cgroup v2 but
that is not always true as a kernel can be compiled without
CONFIG_SWAP or CONFIG_MEMCG_SWAP.

Implement the swap memcg check by looking into the current cgroup if
the memory.swap.current is present.  Now the assumption is that the
"memory" controller is enabled in the current cgroup.

Closes: https://github.com/containers/crun/issues/570

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
