### PR TITLE
Do not log file path on ioutil.ReadFile

### DIFF
--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -60,7 +60,7 @@ func (c *Config) LoadProfile(profilePath string) error {
 
 	profile, err := ioutil.ReadFile(profilePath)
 	if err != nil {
-		return errors.Wrapf(err, "open seccomp profile %s failed", profilePath)
+		return errors.Wrap(err, "open seccomp profile")
 	}
 
 	tmpProfile := &seccomp.Seccomp{}

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -822,7 +822,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 		}
 		statusCodeStr, err := ioutil.ReadFile(exitFilePath)
 		if err != nil {
-			return fmt.Errorf("failed to read exit file: %v", err)
+			return errors.Wrap(err, "failed to read exit file: %v")
 		}
 		statusCode, err := strconv.Atoi(string(statusCodeStr))
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -117,7 +117,7 @@ func (cc *certConfigCache) GetConfigForClient(hello *tls.ClientHelloInfo) (*tls.
 	if len(cc.tlsCA) > 0 {
 		caBytes, err := ioutil.ReadFile(cc.tlsCA)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "read TLS CA file")
 		}
 		certPool := x509.NewCertPool()
 		certPool.AppendCertsFromPEM(caBytes)
@@ -283,7 +283,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 func configureMaxThreads() error {
 	mt, err := ioutil.ReadFile("/proc/sys/kernel/threads-max")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "read max threads file")
 	}
 	mtint, err := strconv.Atoi(strings.TrimSpace(string(mt)))
 	if err != nil {

--- a/server/utils.go
+++ b/server/utils.go
@@ -259,7 +259,7 @@ func getDecryptionKeys(keysPath string) (*encconfig.DecryptConfig, error) {
 
 		privateKey, err := ioutil.ReadFile(path)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "read private key file")
 		}
 
 		sEnc := b64.StdEncoding.EncodeToString(privateKey)

--- a/test/docs-validation/main.go
+++ b/test/docs-validation/main.go
@@ -204,7 +204,7 @@ func validateCli(cfg *config.Config) (failed bool) {
 func openFile(path string) []byte {
 	file, err := ioutil.ReadFile(path)
 	if err != nil {
-		logrus.Fatalf("Unable to open %q: %v", path, err)
+		logrus.Fatalf("Unable to open file: %v", err)
 	}
 	return file
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -276,7 +276,7 @@ func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir st
 		if os.IsNotExist(err) {
 			return "", nil
 		}
-		return "", errors.Wrapf(err, "unable to read passwd file %s", originPasswdFile)
+		return "", errors.Wrapf(err, "read passwd file")
 	}
 	if username == "" {
 		username = "default"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The error message will already indicate which file is affected by the
failure. This way we do not have to need to log the filename multiple
times to lower the logging noise.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
