### PR TITLE
update pinns to support pinning host level namespaces

### DIFF
--- a/internal/config/nsmgr/nsmgr.go
+++ b/internal/config/nsmgr/nsmgr.go
@@ -34,16 +34,19 @@ func New(namespacesDir, pinnsPath string) *NamespaceManager {
 // NewPodNamespaces creates new namespaces for a pod.
 // It's responsible for running pinns and creating the Namespace objects.
 // The caller is responsible for cleaning up the namespaces by calling Namespace.Remove().
-func (mgr *NamespaceManager) NewPodNamespaces(managedNamespaces []NSType, idMappings *idtools.IDMappings, sysctls map[string]string) ([]Namespace, error) {
-	if len(managedNamespaces) == 0 {
+func (mgr *NamespaceManager) NewPodNamespaces(cfg *PodNamespacesConfig) ([]Namespace, error) {
+	if cfg == nil {
+		return nil, errors.New("PodNamespacesConfig cannot be nil")
+	}
+	if len(cfg.Namespaces) == 0 {
 		return []Namespace{}, nil
 	}
 
 	typeToArg := map[NSType]string{
-		IPCNS:  "-i",
-		UTSNS:  "-u",
-		USERNS: "-U",
-		NETNS:  "-n",
+		IPCNS:  "--ipc",
+		UTSNS:  "--uts",
+		USERNS: "--user",
+		NETNS:  "--net",
 	}
 
 	pinnedNamespace := uuid.New().String()
@@ -52,44 +55,33 @@ func (mgr *NamespaceManager) NewPodNamespaces(managedNamespaces []NSType, idMapp
 		"-f", pinnedNamespace,
 	}
 
-	if len(sysctls) != 0 {
-		pinnsArgs = append(pinnsArgs, "-s", getSysctlForPinns(sysctls))
+	if len(cfg.Sysctls) != 0 {
+		pinnsArgs = append(pinnsArgs, "-s", getSysctlForPinns(cfg.Sysctls))
 	}
-
-	type namespaceInfo struct {
-		path   string
-		nsType NSType
-	}
-
-	mountedNamespaces := make([]namespaceInfo, 0, len(managedNamespaces))
 
 	var rootPair idtools.IDPair
-	if idMappings != nil {
-		rootPair = idMappings.RootPair()
+	if cfg.IDMappings != nil {
+		rootPair = cfg.IDMappings.RootPair()
 	}
 
-	for _, nsType := range managedNamespaces {
-		arg, ok := typeToArg[nsType]
+	for _, ns := range cfg.Namespaces {
+		arg, ok := typeToArg[ns.Type]
 		if !ok {
-			return nil, errors.Errorf("Invalid namespace type: %s", nsType)
+			return nil, errors.Errorf("Invalid namespace type: %s", ns.Type)
 		}
 		pinnsArgs = append(pinnsArgs, arg)
-		pinPath := filepath.Join(mgr.namespacesDir, string(nsType)+"ns", pinnedNamespace)
-		mountedNamespaces = append(mountedNamespaces, namespaceInfo{
-			path:   pinPath,
-			nsType: nsType,
-		})
-		if idMappings != nil {
-			if err := chownDirToIDPair(pinPath, rootPair); err != nil {
+		ns.Path = filepath.Join(mgr.namespacesDir, string(ns.Type)+"ns", pinnedNamespace)
+		if cfg.IDMappings != nil {
+			if err := chownDirToIDPair(ns.Path, rootPair); err != nil {
 				return nil, err
 			}
 		}
 	}
 
-	if idMappings != nil {
+	if cfg.IDMappings != nil {
 		pinnsArgs = append(pinnsArgs,
-			"--uid-mapping="+getMappingsForPinns(idMappings.UIDs()),
-			"--gid-mapping="+getMappingsForPinns(idMappings.GIDs()))
+			"--uid-mapping="+getMappingsForPinns(cfg.IDMappings.UIDs()),
+			"--gid-mapping="+getMappingsForPinns(cfg.IDMappings.GIDs()))
 	}
 
 	logrus.Debugf("calling pinns with %v", pinnsArgs)
@@ -97,18 +89,18 @@ func (mgr *NamespaceManager) NewPodNamespaces(managedNamespaces []NSType, idMapp
 	if err != nil {
 		logrus.Warnf("pinns %v failed: %s (%v)", pinnsArgs, string(output), err)
 		// cleanup the mounts
-		for _, info := range mountedNamespaces {
-			if mErr := unix.Unmount(info.path, unix.MNT_DETACH); mErr != nil && mErr != unix.EINVAL {
-				logrus.Warnf("failed to unmount %s: %v", info.path, mErr)
+		for _, ns := range cfg.Namespaces {
+			if mErr := unix.Unmount(ns.Path, unix.MNT_DETACH); mErr != nil && mErr != unix.EINVAL {
+				logrus.Warnf("failed to unmount %s: %v", ns.Path, mErr)
 			}
 		}
 
-		return nil, fmt.Errorf("failed to pin namespaces %v: %s %v", managedNamespaces, output, err)
+		return nil, fmt.Errorf("failed to pin namespaces %v: %s %v", cfg.Namespaces, output, err)
 	}
 
-	returnedNamespaces := make([]Namespace, 0, len(managedNamespaces))
-	for _, info := range mountedNamespaces {
-		ns, err := GetNamespace(info.path, info.nsType)
+	returnedNamespaces := make([]Namespace, 0, len(cfg.Namespaces))
+	for _, ns := range cfg.Namespaces {
+		ns, err := GetNamespace(ns.Path, ns.Type)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/nsmgr/nsmgr.go
+++ b/internal/config/nsmgr/nsmgr.go
@@ -69,6 +69,9 @@ func (mgr *NamespaceManager) NewPodNamespaces(cfg *PodNamespacesConfig) ([]Names
 		if !ok {
 			return nil, errors.Errorf("Invalid namespace type: %s", ns.Type)
 		}
+		if ns.Host {
+			arg += "=host"
+		}
 		pinnsArgs = append(pinnsArgs, arg)
 		ns.Path = filepath.Join(mgr.namespacesDir, string(ns.Type)+"ns", pinnedNamespace)
 		if cfg.IDMappings != nil {

--- a/internal/config/nsmgr/types.go
+++ b/internal/config/nsmgr/types.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	nspkg "github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -22,6 +23,17 @@ const (
 	PIDNS                NSType = "pid"
 	ManagedNamespacesNum        = 4
 )
+
+type PodNamespacesConfig struct {
+	Namespaces []*PodNamespaceConfig
+	IDMappings *idtools.IDMappings
+	Sysctls    map[string]string
+}
+
+type PodNamespaceConfig struct {
+	Type NSType
+	Path string
+}
 
 // Namespace provides a generic namespace interface.
 type Namespace interface {

--- a/internal/config/nsmgr/types.go
+++ b/internal/config/nsmgr/types.go
@@ -32,6 +32,7 @@ type PodNamespacesConfig struct {
 
 type PodNamespaceConfig struct {
 	Type NSType
+	Host bool
 	Path string
 }
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1049,9 +1049,11 @@ func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, ho
 		Namespaces: []*nsmgr.PodNamespaceConfig{
 			{
 				Type: nsmgr.IPCNS,
+				Host: hostIPC,
 			},
 			{
 				Type: nsmgr.NETNS,
+				Host: hostNetwork,
 			},
 			{
 				Type: nsmgr.UTSNS, // there is no option for host UTSNS

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1037,41 +1037,35 @@ func (s *Server) configureGeneratorForSysctls(ctx context.Context, g generate.Ge
 // it returns a slice of cleanup funcs, all of which are the respective NamespaceRemove() for the sandbox.
 // The caller should defer the cleanup funcs if there is an error, to make sure each namespace we are managing is properly cleaned up.
 func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, hostPID bool, idMappings *idtools.IDMappings, sysctls map[string]string, sb *libsandbox.Sandbox, g generate.Generator) (cleanupFuncs []func() error, retErr error) {
-	// UTS is never host
-	managedNamespaces := []nsmgr.NSType{nsmgr.UTSNS}
-	if hostNetwork {
-		if err := g.RemoveLinuxNamespace(string(spec.NetworkNamespace)); err != nil {
-			return nil, err
-		}
-	} else {
-		managedNamespaces = append(managedNamespaces, nsmgr.NETNS)
-	}
-
-	if hostIPC {
-		if err := g.RemoveLinuxNamespace(string(spec.IPCNamespace)); err != nil {
-			return nil, err
-		}
-	} else {
-		managedNamespaces = append(managedNamespaces, nsmgr.IPCNS)
-	}
-
-	if idMappings == nil {
-		if err := g.RemoveLinuxNamespace(string(spec.UserNamespace)); err != nil {
-			return nil, err
-		}
-	} else {
-		managedNamespaces = append(managedNamespaces, nsmgr.USERNS)
-	}
-
 	// Since we need a process to hold open the PID namespace, CRI-O can't manage the NS lifecycle
 	if hostPID {
 		if err := g.RemoveLinuxNamespace(string(spec.PIDNamespace)); err != nil {
 			return nil, err
 		}
 	}
+	namespaceConfig := &nsmgr.PodNamespacesConfig{
+		Sysctls:    sysctls,
+		IDMappings: idMappings,
+		Namespaces: []*nsmgr.PodNamespaceConfig{
+			{
+				Type: nsmgr.IPCNS,
+			},
+			{
+				Type: nsmgr.NETNS,
+			},
+			{
+				Type: nsmgr.UTSNS, // there is no option for host UTSNS
+			},
+		},
+	}
+	if idMappings != nil {
+		namespaceConfig.Namespaces = append(namespaceConfig.Namespaces, &nsmgr.PodNamespaceConfig{
+			Type: nsmgr.USERNS,
+		})
+	}
 
 	// now that we've configured the namespaces we're sharing, create them
-	namespaces, err := s.config.NamespaceManager().NewPodNamespaces(managedNamespaces, idMappings, sysctls)
+	namespaces, err := s.config.NamespaceManager().NewPodNamespaces(namespaceConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
When we manage NS lifecycle, we currently do nothing for host level namespaces, instead using the /proc/ entry of the infra container for the location of that namespace.

The problem is, when we drop infra, there's no pid to use in the /proc/ entry, so we don't know where the namespace is.

This means, when we drop the infra container, we actually can't use port_forward on pods that use the host network... oops.

This PR, among many other things, updates pinns to support binding the location of the namespace, but not unsharing, thus binding the location of the host namespace.


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
replaces https://github.com/cri-o/cri-o/pull/4431
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where pods with `hostNetwork: true` couldn't have ports forwarded from them when drop_infra_ctr=true
```
