### PR TITLE
Make config tests work rootless

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,7 +23,7 @@ var _ = t.Describe("Config", func() {
 		}
 		sut.PinnsPath = validFilePath
 		sut.NamespacesDir = os.TempDir()
-		sut.Conmon = validConmonPath
+		sut.Conmon = validConmonPath()
 		tmpDir := t.MustTempDir("cni-test")
 		sut.NetworkConfig.PluginDirs = []string{tmpDir}
 		sut.NetworkDir = os.TempDir()
@@ -33,9 +33,14 @@ var _ = t.Describe("Config", func() {
 		return sut
 	}
 
+	isRootless := func() bool {
+		return os.Geteuid() != 0
+	}
+
 	t.Describe("ValidateConfig", func() {
 		It("should succeed with default config", func() {
 			// Given
+
 			// When
 			err := sut.Validate(false)
 
@@ -44,6 +49,10 @@ var _ = t.Describe("Config", func() {
 		})
 
 		It("should succeed with runtime checks", func() {
+			if isRootless() {
+				Skip("this test does not work rootless")
+			}
+
 			// Given
 			sut = runtimeValidConfig()
 
@@ -91,7 +100,7 @@ var _ = t.Describe("Config", func() {
 		It("should fail with invalid network config", func() {
 			// Given
 			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validDirPath}
-			sut.Conmon = validConmonPath
+			sut.Conmon = validConmonPath()
 			sut.NetworkConfig.NetworkDir = invalidPath
 
 			// When
@@ -213,7 +222,7 @@ var _ = t.Describe("Config", func() {
 			}
 			sut.PinnsPath = validFilePath
 			sut.NamespacesDir = os.TempDir()
-			sut.Conmon = validConmonPath
+			sut.Conmon = validConmonPath()
 			sut.HooksDir = []string{validDirPath, validDirPath, validDirPath}
 
 			// When
@@ -227,7 +236,7 @@ var _ = t.Describe("Config", func() {
 		It("should sort out invalid hooks directories", func() {
 			// Given
 			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validFilePath}
-			sut.Conmon = validConmonPath
+			sut.Conmon = validConmonPath()
 			sut.PinnsPath = validFilePath
 			sut.NamespacesDir = os.TempDir()
 			sut.HooksDir = []string{invalidPath, validDirPath, validDirPath}
@@ -243,7 +252,7 @@ var _ = t.Describe("Config", func() {
 		It("should create non-existent hooks directory", func() {
 			// Given
 			sut.Runtimes["runc"] = &config.RuntimeHandler{RuntimePath: validFilePath}
-			sut.Conmon = validConmonPath
+			sut.Conmon = validConmonPath()
 			sut.PinnsPath = validFilePath
 			sut.NamespacesDir = os.TempDir()
 			sut.HooksDir = []string{filepath.Join(validDirPath, "new")}
@@ -493,11 +502,11 @@ var _ = t.Describe("Config", func() {
 			sut.RuntimeConfig.Conmon = ""
 
 			// When
-			err := sut.RuntimeConfig.ValidateConmonPath(validConmonPath)
+			err := sut.RuntimeConfig.ValidateConmonPath(validConmonPath())
 
 			// Then
 			Expect(err).To(BeNil())
-			Expect(sut.RuntimeConfig.Conmon).To(Equal(validConmonPath))
+			Expect(sut.RuntimeConfig.Conmon).To(Equal(validConmonPath()))
 		})
 
 		It("should fail with invalid file in $PATH", func() {
@@ -513,7 +522,7 @@ var _ = t.Describe("Config", func() {
 
 		It("should succeed with valid file outside $PATH", func() {
 			// Given
-			sut.RuntimeConfig.Conmon = validConmonPath
+			sut.RuntimeConfig.Conmon = validConmonPath()
 
 			// When
 			err := sut.RuntimeConfig.ValidateConmonPath("")
@@ -650,6 +659,10 @@ var _ = t.Describe("Config", func() {
 		})
 
 		It("should succeed during runtime", func() {
+			if isRootless() {
+				Skip("this test does not work rootless")
+			}
+
 			// Given
 			sut = runtimeValidConfig()
 
@@ -683,6 +696,10 @@ var _ = t.Describe("Config", func() {
 		})
 
 		It("should get default storage options when options are empty", func() {
+			if isRootless() {
+				Skip("this test does not work rootless")
+			}
+
 			// Given
 			defaultStore, err := storage.GetStore(storage.StoreOptions{})
 			Expect(err).To(BeNil())
@@ -704,6 +721,10 @@ var _ = t.Describe("Config", func() {
 		})
 
 		It("should override default storage options", func() {
+			if isRootless() {
+				Skip("this test does not work rootless")
+			}
+
 			// Given
 			defaultStore, err := storage.GetStore(storage.StoreOptions{})
 			Expect(err).To(BeNil())

--- a/pkg/config/suite_test.go
+++ b/pkg/config/suite_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/cri-o/cri-o/pkg/config"
@@ -22,10 +23,15 @@ var (
 )
 
 const (
-	validFilePath   = "/bin/sh"
-	invalidPath     = "/proc/invalid"
-	validConmonPath = "/bin/conmon"
+	validFilePath = "/bin/sh"
+	invalidPath   = "/proc/invalid"
 )
+
+func validConmonPath() string {
+	conmonPath, err := exec.LookPath("conmon")
+	Expect(err).To(BeNil())
+	return conmonPath
+}
 
 var _ = BeforeSuite(func() {
 	t = NewTestFramework(NilFunc, NilFunc)


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The storage retrieval does not work without providing an UID map in
rootless mode. To avoid adding such non-used options we now exclude
those tests if they run in rootless mode.

Beside that, the conmon path might be different than the hard coded
within the test. This means we now lookup the path during test
execution to make the tests more robust.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
