### PR TITLE
Bump golangci-lint to v1.35.2

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # must be specified without patch version
-          version: v1.32
+          version: v1.35
 
           # Only show new issues for a pull request.
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
     - govet
     - ineffassign
     - interfacer
+    - makezero
     - maligned
     - misspell
     - nakedret
@@ -49,13 +50,17 @@ linters:
     - staticcheck
     - structcheck
     - stylecheck
+    - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
     - varcheck
     - whitespace
+    # - errorlint
     # - exhaustive
+    # - exhaustivestruct
+    # - forbidigo
     # - funlen
     # - gci
     # - gochecknoglobals
@@ -70,7 +75,11 @@ linters:
     # - nestif
     # - nlreturn
     # - noctx
+    # - paralleltest
+    # - predeclared
     # - testpackage
+    # - thelper
+    # - wrapcheck
     # - wsl
 linters-settings:
   errcheck:

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ ${GO_MOD_OUTDATED}:
 	$(call go-build,./vendor/github.com/psampaz/go-mod-outdated)
 
 ${GOLANGCI_LINT}:
-	export VERSION=v1.32.2 \
+	export VERSION=v1.35.2 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
 	curl -sSfL $$URL/$$VERSION/install.sh | sh -s $$VERSION

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -12,8 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type errorReaderWriter struct {
-}
+type errorReaderWriter struct{}
 
 func (m *errorReaderWriter) Write(p []byte) (int, error) {
 	return 0, t.TestError


### PR DESCRIPTION

#### What type of PR is this?

/kind dependency-change


#### What this PR does / why we need it:
This also fixes a new gofumpt issue as well as enabling linters which do
not report any further errors.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
