### PR TITLE
Remove implicit GitHub action `name` fields

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,13 +7,11 @@ on:
       - master
   pull_request:
 jobs:
-  golangci:
-    name: lint
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v2
         with:
           # must be specified without patch version
           version: v1.32
@@ -22,44 +20,34 @@ jobs:
           only-new-issues: true
 
   shellcheck:
-    name: shellcheck
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: lumaxis/shellcheck-problem-matchers@v1
-    - name: shellcheck
-      run: make shellcheck
+    - run: make shellcheck
 
   shfmt:
-    name: shfmt
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: shfmt
-      run: make shfmt
+    - run: make shfmt
 
   docs:
-    name: docs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: validate-docs
-      run: make docs-validation
+    - run: make docs-validation
 
   vendor:
-    name: vendor
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: install go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: '1.15'
-      - name: cache go modules
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: go-${{ hashFiles('**/go.sum') }}
           restore-keys: go-
-      - name: vendor
-        run: make check-vendor
+      - run: make check-vendor


### PR DESCRIPTION
#### What type of PR is this?

/kind ci


#### What this PR does / why we need it:
Some name fields are duplicate because GitHub actions already names the
job based on its identifier. Beside that, it's easier to not name single
line bash jobs because then we can see the actual invocation better in
the UI.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
