### PR TITLE
WIP: CreateContainer: normalize error on EOF

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -212,7 +212,11 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (retErr 
 	select {
 	case ss := <-ch:
 		if ss.err != nil {
-			return fmt.Errorf("error reading container (probably exited) json message: %v", ss.err)
+			if ss.err == io.EOF {
+				return fmt.Errorf("container create failed")
+			} else {
+				return fmt.Errorf("error reading container (probably exited) json message: %v", ss.err)
+			}
 		}
 		logrus.Debugf("Received container pid: %d", ss.si.Pid)
 		pid = ss.si.Pid


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If the container pid cannot be enumerated, then lets normalize the Error instead of `error: code = Unknown desc = error reading container (probably exited) json message: EOF`

#### Which issue(s) this PR fixes:

Part of https://bugzilla.redhat.com/show_bug.cgi?id=1915085

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```
