### PR TITLE
Move static build to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,14 +53,6 @@ workflows:
       - build:
           name: build-386
           executor: container-386
-      - build-static
-      - bundle:
-          requires:
-            - build
-            - build-static
-      - bundle-test:
-          requires:
-            - bundle
       - dependencies:
           requires:
             - release-notes
@@ -73,11 +65,6 @@ workflows:
       - integration:
           name: integration-userns
           test_userns: '1'
-      - integration:
-          name: integration-static
-          crio_binary: static/crio
-          requires:
-            - build-static
       - integration:
           name: integration-cgroupfs
           cgroup_manager: cgroupfs
@@ -96,13 +83,9 @@ workflows:
             - integration
             - integration-cgroupfs
             - integration-critest
-            - integration-static
             - integration-userns
             - unit-tests
       - unit-tests
-      - upload-artifacts:
-          requires:
-            - bundle-test
 
 jobs:
   build:
@@ -139,76 +122,6 @@ jobs:
             - crio.conf
             - docs
 
-  build-static:
-    executor: machine
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          keys:
-            - nix-v1-{{ checksum "nix/nixpkgs.json" }}
-      - run:
-          name: build
-          command: |
-            set -ex
-            sudo mkdir -p .cache
-            sudo mv .cache /nix
-            if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
-            sudo docker run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
-      - run:
-          name: Show CRI-O version for static binaries
-          command: |
-            ./result/bin/crio version
-      - store_artifacts:
-          path: result/bin/crio
-      - store_artifacts:
-          path: result/bin/crio-status
-      - store_artifacts:
-          path: result/bin/pinns
-      - run:
-          name: persist_to_workspace
-          command: |
-            mkdir -p bin/static
-            cp -rfT result/bin bin/static
-      - persist_to_workspace:
-          root: .
-          paths:
-            - bin/static
-      - run:
-          name: save_cache
-          command: |
-            sudo mv /nix .cache
-            sudo chown -Rf $(whoami) .cache
-      - save_cache:
-          key: nix-v1-{{ checksum "nix/nixpkgs.json" }}
-          paths:
-            - .cache
-
-  bundle:
-    executor: container
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: bundle
-          command: make bundle
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build/bundle/*.tar.gz
-
-  bundle-test:
-    executor: machine
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: test
-          command: make bundle-test
-
   dependencies:
     executor: container
     steps:
@@ -239,9 +152,6 @@ jobs:
   integration:
     executor: machine
     parameters:
-      crio_binary:
-        type: string
-        default: crio
       run_critest:
         type: string
         default: ''
@@ -288,7 +198,6 @@ jobs:
           no_output_timeout: 30m
           environment:
             JOBS: "<< parameters.jobs >>"
-            CRIO_BINARY: "<< parameters.crio_binary >>"
             RUN_CRITEST: "<< parameters.run_critest >>"
             TEST_ARGS: "<< parameters.test_args >>"
             TEST_USERNS: "<< parameters.test_userns >>"
@@ -361,9 +270,6 @@ jobs:
       - store_artifacts:
           path: build
           destination: build
-      - store_artifacts:
-          path: bundle
-          destination: bundle
 
   unit-tests:
     executor: container
@@ -404,13 +310,3 @@ jobs:
           paths:
             - build/coverage
             - build/junit
-
-  upload-artifacts:
-    executor: container
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Upload artifacts
-          command: make upload-artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,18 @@ jobs:
           path: |
             bin/crio
             bin/crio-status
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: |
+            docs/crio-status.8
+            docs/crio.8
+            docs/crio.conf.5
+            docs/crio.conf.d.5
+      - uses: actions/upload-artifact@v2
+        with:
+          name: config
+          path: crio.conf
 
   validate-docs:
     needs: build
@@ -43,6 +55,7 @@ jobs:
       - run: |
           chmod -R +x bin
           sudo rm /etc/containers/storage.conf
+      - run: |
           make docs-generation
           hack/tree_status.sh
 
@@ -55,7 +68,76 @@ jobs:
         with:
           name: build
           path: bin
+      - run: chmod -R +x bin
       - run: |
-          chmod -R +x bin
           make completions-generation
           hack/tree_status.sh
+
+  build-static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - uses: cachix/cachix-action@v8
+        with:
+          name: cri-o-static
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix-build nix
+      - run: result/bin/crio version
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-static
+          path: |
+            result/bin/crio
+            result/bin/crio-status
+            result/bin/pinns
+
+  bundle:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - build-static
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-static
+          path: bin/static
+      - uses: actions/download-artifact@v2
+        with:
+          name: docs
+          path: docs
+      - uses: actions/download-artifact@v2
+        with:
+          name: config
+      - run: chmod -R +x bin
+      - run: make bundle
+      - uses: actions/upload-artifact@v2
+        with:
+          name: bundle
+          path: build/bundle/*.tar.gz
+
+  bundle-test:
+    runs-on: ubuntu-latest
+    needs: bundle
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: bundle
+          path: build/bundle
+      - run: make bundle-test
+
+  upload-artifacts:
+    runs-on: ubuntu-latest
+    needs: bundle-test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: bundle
+          path: build/bundle
+      - run: make upload-artifacts
+        env:
+          GCS_BUCKET_SA: ${{ secrets.GCS_BUCKET_SA }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/contrib/bundle/Makefile
+++ b/contrib/bundle/Makefile
@@ -51,6 +51,7 @@ install-crio:
 	install $(SELINUX) -D -m 644 -t $(ETCDIR)/crio etc/crio.conf
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man5 man/crio.conf.5
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man5 man/crio.conf.d.5
+	install $(SELINUX) -D -m 644 -t $(MANDIR)/man8 man/crio-status.8
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man8 man/crio.8
 	install $(SELINUX) -D -m 644 -t $(BASHINSTALLDIR) completions/bash/crio
 	install $(SELINUX) -D -m 644 -t $(FISHINSTALLDIR) completions/fish/crio.fish
@@ -102,6 +103,7 @@ uninstall-crio:
 	rm $(ETCDIR)/crio/crio.conf
 	rm $(MANDIR)/man5/crio.conf.5
 	rm $(MANDIR)/man5/crio.conf.d.5
+	rm $(MANDIR)/man8/crio-status.8
 	rm $(MANDIR)/man8/crio.8
 	rm $(BASHINSTALLDIR)/crio
 	rm $(FISHINSTALLDIR)/crio.fish

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -17,6 +17,7 @@ FILES_BIN=(
     "$GIT_ROOT/bin/static/pinns"
 )
 FILES_MAN=(
+    "$GIT_ROOT/docs/crio-status.8"
     "$GIT_ROOT/docs/crio.8"
     "$GIT_ROOT/docs/crio.conf.5"
     "$GIT_ROOT/docs/crio.conf.d.5"


### PR DESCRIPTION

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This moves the whole static build pipeline from CircleCI to GitHub
actions, except the integration tests. The integration tests will follow
at some later point, if other integration tests are available and the
overall test strategy is clear.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to #4489 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added `crio-status.8` man page to static release bundle
```
