### PR TITLE
Move go1.14 and 386 builds to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,6 @@ stdenv: &stdenv
   environment:
     GOCACHE: &gocache /tmp/go-build
     IMAGE: &image quay.io/crio/crio-build-amd64-go1.15:master-1.6.1
-    IMAGELEGACY: &imagelegacy quay.io/crio/crio-build-amd64-go1.14:master-1.6.1
-    IMAGE386: &image386 quay.io/crio/crio-build-386-go1.15:master-1.6.1
     JOBS: &jobs 4
     WORKDIR: &workdir /go/src/github.com/cri-o/cri-o
     WORKDIR_VM: &workdir_vm /home/circleci/go/src/github.com/cri-o/cri-o
@@ -15,24 +13,6 @@ executors:
   container:
     docker:
       - image: *image
-    <<: *stdenv
-    working_directory: *workdir
-
-  container-legacy:
-    docker:
-      - image: *imagelegacy
-    <<: *stdenv
-    working_directory: *workdir
-
-  container-386:
-    docker:
-      - image: *image386
-    <<: *stdenv
-    working_directory: *workdir
-
-  container-base:
-    docker:
-      - image: golang:1.15
     <<: *stdenv
     working_directory: *workdir
 
@@ -46,13 +26,6 @@ workflows:
   version: 2
   pipeline:
     jobs:
-      - build
-      - build:
-          name: build-go1.14
-          executor: container-legacy
-      - build:
-          name: build-386
-          executor: container-386
       - dependencies:
           requires:
             - release-notes
@@ -88,40 +61,6 @@ workflows:
       - unit-tests
 
 jobs:
-  build:
-    parameters:
-      executor:
-        type: string
-        default: container
-    executor: << parameters.executor >>
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-build-<< parameters.executor >>-{{ checksum "go.sum" }}
-      - run: go version
-      - run: go env
-      - run:
-          command: make binaries -j $JOBS
-      - run:
-          name: Show CRI-O version
-          command: ./bin/crio version
-      - run:
-          command: make crio.conf
-      - run:
-          command: make docs -j $JOBS
-      - save_cache:
-          key: v1-build-<< parameters.executor >>-{{ checksum "go.sum" }}
-          paths:
-            - *gocache
-            - build/bin/go-md2man
-      - persist_to_workspace:
-          root: .
-          paths:
-            - bin
-            - crio.conf
-            - docs
-
   dependencies:
     executor: container
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,56 @@ jobs:
           name: config
           path: crio.conf
 
+  build-go1_14:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-build-legacy-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-build-legacy-
+      - run: scripts/github-actions-packages
+      - run: make
+      - run: bin/crio version
+
+  build-386:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-build-386-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-build-386-
+      - name: Build 386 binary in container
+        run: |
+          mkdir -p ~/.cache/go-build ~/go/pkg/mod
+          sudo podman run \
+            -v ~/go/pkg/mod:/go/pkg/mod \
+            -v ~/.cache/go-build:/root/.cache/go-build \
+            -v $PWD:/build \
+            -w /build \
+            -it i386/golang:1.15-alpine \
+            sh -c \
+              "apk --no-cache add \
+                bash \
+                build-base \
+                gpgme-dev \
+                libseccomp-dev \
+                libselinux-dev \
+                linux-headers \
+                tzdata && \
+              make bin/crio && \
+              bin/crio version"
+
   validate-docs:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

This patch moves the CircleCI go1.14 and 386 architecture build into GitHub actions.

#### Which issue(s) this PR fixes:

Refers to #4489

#### Special notes for your reviewer:

/hold requires https://github.com/cri-o/cri-o/pull/4510 to be merged first
#### Does this PR introduce a user-facing change?

```release-note
None
```
