### PR TITLE
Move unit tests to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,6 @@ workflows:
             - integration-cgroupfs
             - integration-critest
             - integration-userns
-            - unit-tests
-      - unit-tests
 
 jobs:
   build:
@@ -262,51 +260,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - store_test_results:
-          path: build/junit
       - store_artifacts:
           path: bin
           destination: bin
       - store_artifacts:
           path: build
           destination: build
-
-  unit-tests:
-    executor: container
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          keys:
-            - v1-unit-tests-{{ checksum "go.sum" }}
-      - run:
-          name: check mocks
-          command: |
-            make mockgen -j $JOBS
-      - run:
-          name: install pinns
-          command: make PREFIX=/ install
-      - run:
-          name: build ginkgo
-          command: make $(pwd)/build/bin/ginkgo
-      - run:
-          name: unit tests
-          command: make testunit
-      - run:
-          name: code coverage
-          command: make codecov
-      - store_test_results:
-          path: build/junit
-      - save_cache:
-          key: v1-unit-tests-{{ checksum "go.sum" }}
-          paths:
-            - *gocache
-            - build/bin/ginkgo
-            - build/bin/mockgen
-            - /bin/pinns
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build/coverage
-            - build/junit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,3 +143,40 @@ jobs:
         env:
           GCS_BUCKET_SA: ${{ secrets.GCS_BUCKET_SA }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-unit-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-unit-
+      - run: scripts/github-actions-packages
+      - run: |
+          make mockgen -j $(nproc)
+          hack/tree_status.sh
+      - run: make testunit
+      - uses: actions/upload-artifact@v2
+        with:
+          name: unit
+          path: |
+            build/coverage
+            build/junit
+
+  coverage:
+    needs: unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: unit
+          path: build
+      - run: make codecov


### PR DESCRIPTION


#### What type of PR is this?

/kind ci


#### What this PR does / why we need it:
We now use GitHub actions for the unit test execution instead of
CircleCi. We also separate the pipeline into the three steps of mock
verification, unit test execution and coverage upload.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to #4489 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
