### PR TITLE
set kubelet node IP

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -62,6 +62,10 @@
       export DNS_SERVER_IP={{ ansible_default_ipv4.address }}
       export API_HOST={{ ansible_default_ipv4.address }}
       export API_HOST_IP={{ ansible_default_ipv4.address }}
+      # Use the hostIP as node InternalIP
+      export HOSTNAME_OVERRIDE={{ ansible_default_ipv4.address }}
+      # Listen in all available interfaces
+      export KUBELET_HOST="0.0.0.0"
       export KUBE_ENABLE_CLUSTER_DNS=true
       export ENABLE_HOSTPATH_PROVISIONER=true
       export KUBELET_FLAGS="--enable-debugging-handlers=true --enable-server=true --anonymous-auth=true"


### PR DESCRIPTION
> /kind failing-test

#### What this PR does / why we need it:

The test ` validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]` creates two pods with the same hostPort but different NodeIPs.
It assumes that the Node has an IP that is not 127.0.0.1, so it tries to use HostIP=NodeIP and HostIP=127.0.0.1.
However, CRI-O CI has the kubelet nodeIP set to 127.0.0.1, hence the test tries to schedule 2 pods with the same hostport and hostIP in the same node, and it fails as expected.

We can configure the kubelet with the nodeip of the host where it is running, so it is more realistic, since Kubernetes nodes can't not use loopbacks as InternalIP, well, the can, but nobody will be able to communicate with them :)

#### Which issue(s) this PR fixes:

```release-note
NONE
```
