### PR TITLE
rootless: enable resource limit when cgroup v2 controllers are delegated

### DIFF
--- a/server/rootless.go
+++ b/server/rootless.go
@@ -1,10 +1,14 @@
 package server
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"strings"
 
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/sirupsen/logrus"
 )
 
 func hasNetworkNamespace(config *rspec.Spec) bool {
@@ -17,7 +21,43 @@ func hasNetworkNamespace(config *rspec.Spec) bool {
 }
 
 func makeOCIConfigurationRootless(g *generate.Generator) {
-	g.Config.Linux.Resources = nil
+	// Resource limitations requires cgroup v2 delegation (https://rootlesscontaine.rs/getting-started/common/cgroup2/).
+	if r := g.Config.Linux.Resources; r != nil {
+		// cannot control device eBPF with rootless
+		r.Devices = nil
+		if r.Memory != nil || r.CPU != nil || r.Pids != nil || r.BlockIO != nil || r.Rdma != nil || r.HugepageLimits != nil {
+			v2Controllers := getAvailableV2Controllers()
+			if _, ok := v2Controllers["memory"]; !ok && r.Memory != nil {
+				logrus.Warn("rootless: cgroup v2 memory controller is not delegated. Discarding memory limit.")
+				r.Memory = nil
+			}
+			if _, ok := v2Controllers["cpu"]; !ok && r.CPU != nil {
+				logrus.Warn("rootless: cgroup v2 cpu controller is not delegated. Discarding cpu limit.")
+				r.CPU = nil
+			}
+			if _, ok := v2Controllers["cpuset"]; !ok && r.CPU != nil {
+				logrus.Warn("rootless: cgroup v2 cpuset controller is not delegated. Discarding cpuset limit.")
+				r.CPU.Cpus = ""
+				r.CPU.Mems = ""
+			}
+			if _, ok := v2Controllers["pids"]; !ok && r.Pids != nil {
+				logrus.Warn("rootless: cgroup v2 pids controller is not delegated. Discarding pids limit.")
+				r.Pids = nil
+			}
+			if _, ok := v2Controllers["io"]; !ok && r.BlockIO != nil {
+				logrus.Warn("rootless: cgroup v2 io controller is not delegated. Discarding block I/O limit.")
+				r.BlockIO = nil
+			}
+			if _, ok := v2Controllers["rdma"]; !ok && r.Rdma != nil {
+				logrus.Warn("rootless: cgroup v2 rdma controller is not delegated. Discarding RDMA limit.")
+				r.Rdma = nil
+			}
+			if _, ok := v2Controllers["hugetlb"]; !ok && r.HugepageLimits != nil {
+				logrus.Warn("rootless: cgroup v2 hugetlb controller is not delegated. Discarding RDMA limit.")
+				r.HugepageLimits = nil
+			}
+		}
+	}
 	g.Config.Process.OOMScoreAdj = nil
 	g.Config.Process.ApparmorProfile = ""
 
@@ -44,4 +84,28 @@ func makeOCIConfigurationRootless(g *generate.Generator) {
 	}
 
 	g.SetLinuxCgroupsPath("")
+}
+
+// getAvailableV2Controllers returns the entries in /sys/fs/cgroup/<SELF>/cgroup.controllers
+func getAvailableV2Controllers() map[string]struct{} {
+	procSelfCgroup, err := cgroups.ParseCgroupFile("/proc/self/cgroup")
+	if err != nil {
+		logrus.Error(err)
+		return nil
+	}
+	v2Group := procSelfCgroup[""]
+	if v2Group == "" {
+		return nil
+	}
+	controllersPath := filepath.Join("/sys/fs/cgroup", v2Group, "cgroup.controllers")
+	controllersBytes, err := ioutil.ReadFile(controllersPath)
+	if err != nil {
+		logrus.Error(err)
+		return nil
+	}
+	result := make(map[string]struct{})
+	for _, controller := range strings.Split(strings.TrimSpace(string(controllersBytes)), " ") {
+		result[controller] = struct{}{}
+	}
+	return result
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature


#### What this PR does / why we need it:

rootless: enable resource limit when cgroup v2 controllers are delegated.

Required by [Usernetes](https://github.com/rootless-containers/usernetes)


#### Special notes for your reviewer:

The patch is from https://github.com/rootless-containers/usernetes/blob/v20210201.0/src/patches/crio/0001-rootless-enable-resource-limit-when-cgroup-v2-contro.patch .


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
rootless: enable resource limit when cgroup v2 controllers are delegated.
```
- - -
# Test steps

## Prepare environment
Just as in Rootless Podman, cgroup v2 delegation needs to be configured: https://rootlesscontaine.rs/getting-started/common/cgroup2/

Also, the following sysctl is needed, depending on distro:
```bash
sudo sysctl kernel.dmesg_restrict=0
```

## Install Usernetes
[Usernetes v20210201.0](https://github.com/rootless-containers/usernetes) contains CRI-O binary (`./usernetes/bin/crio`) with this PR applied.

```bash
wget https://github.com/rootless-containers/usernetes/releases/download/v20210201.0/usernetes-x86_64.tbz
tar xjvf usernetes-x86_64.tbz
cd usernetes
./install.sh --cri=crio
```

## Run a test pod
```bash
export KUBECONFIG=$HOME/.config/usernetes/master/admin-localhost.kubeconfig

kubectl apply -f - << EOF
apiVersion: v1
kind: Pod
metadata:
  name: test-limits
spec:
  containers:
  - name: test-limits
    image: alpine
    command: ["top"]
    resources:
      limits:
        cpu: 420m
        memory: 42Mi
EOF
```

A new cgroup with the resource limits is created for the pod:

```console
$ cat /proc/$(pgrep top)/cgroup
0::/user.slice/user-1001.slice/user@1001.service/u7s-rootlesskit.service/615fc903ca7ea59a4b534816b2908c29cc30d669f1f7042467ec8ea15524f74c

$ cd /sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/u7s-rootlesskit.service/615fc903ca7ea59a4b534816b2908c29cc30d669f1f7042467ec8ea15524f74c

$ cat cpu.max 
42000 100000

$ cat memory.max 
44040192
```
