### PR TITLE
ResourceStore: fix segfault and update tests

### DIFF
--- a/internal/resourcestore/resourcestore.go
+++ b/internal/resourcestore/resourcestore.go
@@ -34,6 +34,12 @@ type Resource struct {
 	name         string
 }
 
+// wasPut checks that a resource has been fully defined yet.
+// This is defined as a resource that only has watchers, but no associated resource.
+func (r *Resource) wasPut() bool {
+	return r != nil && r.resource != nil
+}
+
 // IdentifiableCreatable are the qualities needed by the caller of the resource.
 // Once a resource is retrieved, SetCreated() will be called, indicating to the server
 // that resource is ready to be listed and operated upon, and ID() will be used to identify the
@@ -101,6 +107,11 @@ func (rc *ResourceStore) Get(name string) string {
 	if !ok {
 		return ""
 	}
+	// It is possible there are existing watchers,
+	// but no resource created yet
+	if !r.wasPut() {
+		return ""
+	}
 	delete(rc.resources, name)
 	r.resource.SetCreated()
 	return r.resource.ID()
@@ -121,7 +132,7 @@ func (rc *ResourceStore) Put(name string, resource IdentifiableCreatable, cleanu
 		rc.resources[name] = r
 	}
 	// make sure the resource hasn't already been added to the store
-	if r.resource != nil || r.cleanupFuncs != nil {
+	if ok && r.wasPut() {
 		return errors.Errorf("failed to add entry %s to ResourceStore; entry already exists", name)
 	}
 

--- a/internal/resourcestore/resourcestore.go
+++ b/internal/resourcestore/resourcestore.go
@@ -147,7 +147,9 @@ func (rc *ResourceStore) Put(name string, resource IdentifiableCreatable, cleanu
 	return nil
 }
 
-// WatcherForResource looks up a Resource by name, and gives it a watcher if it's found.
+// WatcherForResource looks up a Resource by name, and gives it a watcher.
+// If no entry exists for that resource, a placeholder is created and a watcher is given to that
+// placeholder resource.
 // A watcher can be used for concurrent processes to wait for the resource to be created.
 // This is useful for situations where clients retry requests quickly after they "fail" because
 // they've taken too long. Adding a watcher allows the server to slow down the client, but still

--- a/internal/resourcestore/resourcestore_test.go
+++ b/internal/resourcestore/resourcestore_test.go
@@ -42,6 +42,9 @@ var _ = t.Describe("ResourceStore", func() {
 				id: testID,
 			}
 		})
+		AfterEach(func() {
+			sut.Close()
+		})
 		It("Put should be able to get resource after adding", func() {
 			// Given
 
@@ -104,6 +107,9 @@ var _ = t.Describe("ResourceStore", func() {
 			e = &entry{
 				id: testID,
 			}
+		})
+		AfterEach(func() {
+			sut.Close()
 		})
 		It("Put should call cleanup funcs after timeout", func() {
 			// Given

--- a/internal/resourcestore/resourcestore_test.go
+++ b/internal/resourcestore/resourcestore_test.go
@@ -34,81 +34,76 @@ var _ = t.Describe("ResourceStore", func() {
 		cleanupFuncs []func()
 		e            *entry
 	)
-	BeforeEach(func() {
-		sut = resourcestore.New()
-		cleanupFuncs = make([]func(), 0)
-		e = &entry{
-			id: testID,
-		}
-	})
-	It("Put should be able to get resource after adding", func() {
-		// Given
-
-		// When
-		Expect(sut.Put(testName, e, cleanupFuncs)).To(BeNil())
-
-		// Then
-		id := sut.Get(testName)
-		Expect(id).To(Equal(e.id))
-
-		id = sut.Get(testName)
-		Expect(id).To(BeEmpty())
-	})
-	It("Put should fail to readd resource", func() {
-		// Given
-
-		// When
-		Expect(sut.Put(testName, e, cleanupFuncs)).To(BeNil())
-
-		// Then
-		Expect(sut.Put(testName, e, cleanupFuncs)).NotTo(BeNil())
-	})
-	It("Get should call SetCreated", func() {
-		// When
-		Expect(sut.Put(testName, e, cleanupFuncs)).To(BeNil())
-
-		// Then
-		id := sut.Get(testName)
-		Expect(id).To(Equal(e.id))
-		Expect(e.created).To(BeTrue())
-	})
-})
-
-var _ = t.Describe("ResourceStore and timeout", func() {
-	// Setup the test
-	var (
-		sut          *resourcestore.ResourceStore
-		cleanupFuncs []func()
-		e            *entry
-	)
-	BeforeEach(func() {
-		cleanupFuncs = make([]func(), 0)
-		e = &entry{
-			id: testID,
-		}
-	})
-	It("Put should call cleanup funcs after timeout", func() {
-		// Given
-		timeout := 2 * time.Second
-		sut = resourcestore.NewWithTimeout(timeout)
-
-		timedOutChan := make(chan bool)
-		cleanupFuncs = append(cleanupFuncs, func() {
-			timedOutChan <- true
+	Context("no timeout", func() {
+		BeforeEach(func() {
+			sut = resourcestore.New()
+			cleanupFuncs = make([]func(), 0)
+			e = &entry{
+				id: testID,
+			}
 		})
-		go func() {
-			time.Sleep(timeout * 3)
-			timedOutChan <- false
-		}()
+		It("Put should be able to get resource after adding", func() {
+			// Given
 
-		// When
-		Expect(sut.Put(testName, e, cleanupFuncs)).To(BeNil())
+			// When
+			Expect(sut.Put(testName, e, cleanupFuncs)).To(BeNil())
 
-		// Then
-		didStoreCallTimeoutFunc := <-timedOutChan
-		Expect(didStoreCallTimeoutFunc).To(Equal(true))
+			// Then
+			id := sut.Get(testName)
+			Expect(id).To(Equal(e.id))
 
-		id := sut.Get(testName)
-		Expect(id).To(BeEmpty())
+			id = sut.Get(testName)
+			Expect(id).To(BeEmpty())
+		})
+		It("Put should fail to readd resource", func() {
+			// Given
+
+			// When
+			Expect(sut.Put(testName, e, cleanupFuncs)).To(BeNil())
+
+			// Then
+			Expect(sut.Put(testName, e, cleanupFuncs)).NotTo(BeNil())
+		})
+		It("Get should call SetCreated", func() {
+			// When
+			Expect(sut.Put(testName, e, cleanupFuncs)).To(BeNil())
+
+			// Then
+			id := sut.Get(testName)
+			Expect(id).To(Equal(e.id))
+			Expect(e.created).To(BeTrue())
+		})
+	})
+	Context("with timeout", func() {
+		BeforeEach(func() {
+			cleanupFuncs = make([]func(), 0)
+			e = &entry{
+				id: testID,
+			}
+		})
+		It("Put should call cleanup funcs after timeout", func() {
+			// Given
+			timeout := 2 * time.Second
+			sut = resourcestore.NewWithTimeout(timeout)
+
+			timedOutChan := make(chan bool)
+			cleanupFuncs = append(cleanupFuncs, func() {
+				timedOutChan <- true
+			})
+			go func() {
+				time.Sleep(timeout * 3)
+				timedOutChan <- false
+			}()
+
+			// When
+			Expect(sut.Put(testName, e, cleanupFuncs)).To(BeNil())
+
+			// Then
+			didStoreCallTimeoutFunc := <-timedOutChan
+			Expect(didStoreCallTimeoutFunc).To(Equal(true))
+
+			id := sut.Get(testName)
+			Expect(id).To(BeEmpty())
+		})
 	})
 })

--- a/internal/resourcestore/resourcestore_test.go
+++ b/internal/resourcestore/resourcestore_test.go
@@ -73,6 +73,30 @@ var _ = t.Describe("ResourceStore", func() {
 			Expect(id).To(Equal(e.id))
 			Expect(e.created).To(BeTrue())
 		})
+		It("Should not fail to Get after retrieving Watcher", func() {
+			// When
+			_ = sut.WatcherForResource(testName)
+
+			// Then
+			id := sut.Get(testName)
+			Expect(id).To(BeEmpty())
+		})
+		It("Should be able to get multiple Watchers", func() {
+			// Given
+			watcher1 := sut.WatcherForResource(testName)
+			watcher2 := sut.WatcherForResource(testName)
+
+			waitWatcherSet := func(watcher chan struct{}) bool {
+				<-watcher
+				return true
+			}
+
+			// When
+			Expect(sut.Put(testName, e, cleanupFuncs)).To(BeNil())
+			// Then
+			Expect(waitWatcherSet(watcher1)).To(BeTrue())
+			Expect(waitWatcherSet(watcher2)).To(BeTrue())
+		})
 	})
 	Context("with timeout", func() {
 		BeforeEach(func() {

--- a/server/server.go
+++ b/server/server.go
@@ -276,6 +276,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	// notice this won't trigger just on system halt but also on normal
 	// crio.service restart!!!
 	s.cleanupSandboxesOnShutdown(ctx)
+	s.resourceStore.Close()
 
 	return s.ContainerServer.Shutdown()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
There is a chance that a WatcherForResource() followed by a Get() would cause cri-o to segfault. Fix this
also extend the test suite to add a test for this and another situation, as well as move around the tests so they're all run
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fixed a bug that could cause CRI-O to segfault when a node is under heavy load
```
