### PR TITLE
ci/gha: nits

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 jobs:
   critest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -30,7 +30,7 @@ jobs:
           RUN_CRITEST: '1'
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -51,7 +51,7 @@ jobs:
           JOBS: '2'
 
   test-cgroupfs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -75,7 +75,7 @@ jobs:
           CONTAINER_CONMON_CGROUP: pod
 
   test-userns:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -44,7 +44,7 @@ jobs:
           path: crio.conf
 
   build-go1_14:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -62,7 +62,7 @@ jobs:
       - run: bin/crio version
 
   build-386:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -95,7 +95,7 @@ jobs:
 
   validate-docs:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -111,7 +111,7 @@ jobs:
 
   validate-completions:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -126,7 +126,7 @@ jobs:
           hack/tree_status.sh
 
   build-static-amd64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v12
@@ -145,7 +145,7 @@ jobs:
             result/bin/pinns
 
   build-static-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v12
@@ -164,7 +164,7 @@ jobs:
             result/bin/pinns
 
   bundles:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
       - build-static-amd64
@@ -194,7 +194,7 @@ jobs:
           path: build/bundle/*.tar.gz
 
   bundle-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: bundles
     steps:
       - uses: actions/checkout@v2
@@ -205,7 +205,7 @@ jobs:
       - run: make bundle-test
 
   upload-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: bundle-test
     steps:
       - uses: actions/checkout@v2
@@ -219,7 +219,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -246,7 +246,7 @@ jobs:
 
   coverage:
     needs: unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -257,7 +257,7 @@ jobs:
 
   release-notes:
     if: github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/release')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -282,7 +282,7 @@ jobs:
   dependencies:
     if: github.ref == 'refs/heads/master'
     needs: release-notes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -304,7 +304,7 @@ jobs:
           path: build/dependencies
 
   release-branch-forward:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
@@ -20,26 +20,26 @@ jobs:
           only-new-issues: true
 
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: lumaxis/shellcheck-problem-matchers@v1
     - run: make shellcheck
 
   shfmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - run: make shfmt
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - run: make docs-validation
 
   vendor:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -53,7 +53,7 @@ jobs:
       - run: make check-vendor
 
   get-script:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: |


### PR DESCRIPTION
/kind ci

#### What this PR does / why we need it:

- ci/gha: use ubuntu-20.04 to fix a GHA warning
- ~~ci/gha: bump golangci-lint to 1.36~~

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Since we're switching from ubuntu 16.04 to 20.04, there's a slight chance some things might break.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
