### PR TITLE
[1.20] config: pre-create pinns directories

### DIFF
--- a/internal/config/nsmgr/types.go
+++ b/internal/config/nsmgr/types.go
@@ -1,0 +1,20 @@
+package nsmgr
+
+// NSType is an abstraction about available namespace types
+type NSType string
+
+const (
+	NETNS         NSType = "net"
+	IPCNS         NSType = "ipc"
+	UTSNS         NSType = "uts"
+	USERNS        NSType = "user"
+	PIDNS         NSType = "pid"
+	NumNamespaces        = 4
+)
+
+// SupportedNamespacesForPinning returns a slice of
+// the names of namespaces that CRI-O supports
+// pinning.
+func SupportedNamespacesForPinning() []NSType {
+	return []NSType{NETNS, IPCNS, UTSNS, USERNS}
+}

--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/pkg/config"
 	"github.com/pkg/errors"
@@ -58,18 +59,6 @@ type NamespaceOption struct {
 	TargetID string `json:"target_id,omitempty"`
 }
 
-// NSType is an abstraction about available namespace types
-type NSType string
-
-const (
-	NETNS         NSType = "net"
-	IPCNS         NSType = "ipc"
-	UTSNS         NSType = "uts"
-	USERNS        NSType = "user"
-	PIDNS         NSType = "pid"
-	numNamespaces        = 4
-)
-
 // NamespaceIface provides a generic namespace interface
 type NamespaceIface interface {
 	// Close closes this network namespace
@@ -91,7 +80,7 @@ type NamespaceIface interface {
 	Path() string
 
 	// Type returns the namespace type (net, ipc or uts)
-	Type() NSType
+	Type() nsmgr.NSType
 }
 
 // ManagedNamespace is a structure that holds all the necessary information a caller would
@@ -101,11 +90,11 @@ type NamespaceIface interface {
 // by CRI-O, but instead is based off of the infra pid)
 type ManagedNamespace struct {
 	nsPath string
-	nsType NSType
+	nsType nsmgr.NSType
 }
 
 // Type returns the namespace type
-func (m *ManagedNamespace) Type() NSType {
+func (m *ManagedNamespace) Type() nsmgr.NSType {
 	return m.nsType
 }
 
@@ -116,15 +105,15 @@ func (m *ManagedNamespace) Path() string {
 
 // CreateManagedNamespaces calls pinnsPath on all the managed namespaces for the sandbox.
 // It returns a slice of ManagedNamespaces it created.
-func (s *Sandbox) CreateManagedNamespaces(managedNamespaces []NSType, idMappings *idtools.IDMappings, sysctls map[string]string, cfg *config.Config) ([]*ManagedNamespace, error) {
+func (s *Sandbox) CreateManagedNamespaces(managedNamespaces []nsmgr.NSType, idMappings *idtools.IDMappings, sysctls map[string]string, cfg *config.Config) ([]*ManagedNamespace, error) {
 	return s.CreateNamespacesWithFunc(managedNamespaces, idMappings, sysctls, cfg, pinNamespaces)
 }
 
-type namespacePinner func([]NSType, *config.Config, *idtools.IDMappings, map[string]string) ([]NamespaceIface, error)
+type namespacePinner func([]nsmgr.NSType, *config.Config, *idtools.IDMappings, map[string]string) ([]NamespaceIface, error)
 
 // CreateManagedNamespacesWithFunc is mainly added for testing purposes. There's no point in actually calling the pinns binary
 // in unit tests, so this function allows the actual pin func to be abstracted out. Every other caller should use CreateManagedNamespaces
-func (s *Sandbox) CreateNamespacesWithFunc(managedNamespaces []NSType, idMappings *idtools.IDMappings, sysctls map[string]string, cfg *config.Config, pinFunc namespacePinner) (mns []*ManagedNamespace, retErr error) {
+func (s *Sandbox) CreateNamespacesWithFunc(managedNamespaces []nsmgr.NSType, idMappings *idtools.IDMappings, sysctls map[string]string, cfg *config.Config, pinFunc namespacePinner) (mns []*ManagedNamespace, retErr error) {
 	typesAndPaths := make([]*ManagedNamespace, 0, 4)
 	if len(managedNamespaces) == 0 {
 		return typesAndPaths, nil
@@ -146,29 +135,29 @@ func (s *Sandbox) CreateNamespacesWithFunc(managedNamespaces []NSType, idMapping
 		}()
 
 		switch namespace.Type() {
-		case NETNS:
+		case nsmgr.NETNS:
 			s.netns = namespaceIface
 			typesAndPaths = append(typesAndPaths, &ManagedNamespace{
-				nsType: NETNS,
+				nsType: nsmgr.NETNS,
 				nsPath: namespace.Path(),
 			})
-		case IPCNS:
+		case nsmgr.IPCNS:
 			s.ipcns = namespaceIface
 			typesAndPaths = append(typesAndPaths, &ManagedNamespace{
-				nsType: IPCNS,
+				nsType: nsmgr.IPCNS,
 				nsPath: namespace.Path(),
 			})
-		case UTSNS:
+		case nsmgr.UTSNS:
 			s.utsns = namespaceIface
 			typesAndPaths = append(typesAndPaths, &ManagedNamespace{
-				nsType: UTSNS,
+				nsType: nsmgr.UTSNS,
 				nsPath: namespace.Path(),
 			})
-		case USERNS:
+		case nsmgr.USERNS:
 			if idMappings != nil {
 				s.userns = namespaceIface
 				typesAndPaths = append(typesAndPaths, &ManagedNamespace{
-					nsType: USERNS,
+					nsType: nsmgr.USERNS,
 					nsPath: namespace.Path(),
 				})
 			}
@@ -188,29 +177,29 @@ func (s *Sandbox) CreateNamespacesWithFunc(managedNamespaces []NSType, idMapping
 func (s *Sandbox) NamespacePaths() []*ManagedNamespace {
 	pid := infraPid(s.InfraContainer())
 
-	typesAndPaths := make([]*ManagedNamespace, 0, numNamespaces)
+	typesAndPaths := make([]*ManagedNamespace, 0, nsmgr.NumNamespaces)
 
-	if ipc := nsPathGivenInfraPid(s.ipcns, IPCNS, pid); ipc != "" {
+	if ipc := nsPathGivenInfraPid(s.ipcns, nsmgr.IPCNS, pid); ipc != "" {
 		typesAndPaths = append(typesAndPaths, &ManagedNamespace{
-			nsType: IPCNS,
+			nsType: nsmgr.IPCNS,
 			nsPath: ipc,
 		})
 	}
-	if net := nsPathGivenInfraPid(s.netns, NETNS, pid); net != "" {
+	if net := nsPathGivenInfraPid(s.netns, nsmgr.NETNS, pid); net != "" {
 		typesAndPaths = append(typesAndPaths, &ManagedNamespace{
-			nsType: NETNS,
+			nsType: nsmgr.NETNS,
 			nsPath: net,
 		})
 	}
-	if uts := nsPathGivenInfraPid(s.utsns, UTSNS, pid); uts != "" {
+	if uts := nsPathGivenInfraPid(s.utsns, nsmgr.UTSNS, pid); uts != "" {
 		typesAndPaths = append(typesAndPaths, &ManagedNamespace{
-			nsType: UTSNS,
+			nsType: nsmgr.UTSNS,
 			nsPath: uts,
 		})
 	}
-	if user := nsPathGivenInfraPid(s.userns, USERNS, pid); user != "" {
+	if user := nsPathGivenInfraPid(s.userns, nsmgr.USERNS, pid); user != "" {
 		typesAndPaths = append(typesAndPaths, &ManagedNamespace{
-			nsType: USERNS,
+			nsType: nsmgr.USERNS,
 			nsPath: user,
 		})
 	}
@@ -256,13 +245,13 @@ func (s *Sandbox) RemoveManagedNamespaces() error {
 // NetNsPath returns the path to the network namespace of the sandbox.
 // If the sandbox uses the host namespace, the empty string is returned
 func (s *Sandbox) NetNsPath() string {
-	return s.nsPath(s.netns, NETNS)
+	return s.nsPath(s.netns, nsmgr.NETNS)
 }
 
 // NetNsJoin attempts to join the sandbox to an existing network namespace
 // This will fail if the sandbox is already part of a network namespace
 func (s *Sandbox) NetNsJoin(nspath string) error {
-	ns, err := nsJoin(nspath, NETNS, s.netns)
+	ns, err := nsJoin(nspath, nsmgr.NETNS, s.netns)
 	if err != nil {
 		return err
 	}
@@ -275,13 +264,13 @@ func (s *Sandbox) NetNsJoin(nspath string) error {
 // IpcNsPath returns the path to the network namespace of the sandbox.
 // If the sandbox uses the host namespace, the empty string is returned
 func (s *Sandbox) IpcNsPath() string {
-	return s.nsPath(s.ipcns, IPCNS)
+	return s.nsPath(s.ipcns, nsmgr.IPCNS)
 }
 
 // IpcNsJoin attempts to join the sandbox to an existing IPC namespace
 // This will fail if the sandbox is already part of a IPC namespace
 func (s *Sandbox) IpcNsJoin(nspath string) error {
-	ns, err := nsJoin(nspath, IPCNS, s.ipcns)
+	ns, err := nsJoin(nspath, nsmgr.IPCNS, s.ipcns)
 	if err != nil {
 		return err
 	}
@@ -294,13 +283,13 @@ func (s *Sandbox) IpcNsJoin(nspath string) error {
 // UtsNsPath returns the path to the network namespace of the sandbox.
 // If the sandbox uses the host namespace, the empty string is returned
 func (s *Sandbox) UtsNsPath() string {
-	return s.nsPath(s.utsns, UTSNS)
+	return s.nsPath(s.utsns, nsmgr.UTSNS)
 }
 
 // UtsNsJoin attempts to join the sandbox to an existing UTS namespace
 // This will fail if the sandbox is already part of a UTS namespace
 func (s *Sandbox) UtsNsJoin(nspath string) error {
-	ns, err := nsJoin(nspath, UTSNS, s.utsns)
+	ns, err := nsJoin(nspath, nsmgr.UTSNS, s.utsns)
 	if err != nil {
 		return err
 	}
@@ -313,13 +302,13 @@ func (s *Sandbox) UtsNsJoin(nspath string) error {
 // UserNsPath returns the path to the user namespace of the sandbox.
 // If the sandbox uses the host namespace, the empty string is returned
 func (s *Sandbox) UserNsPath() string {
-	return s.nsPath(s.userns, USERNS)
+	return s.nsPath(s.userns, nsmgr.USERNS)
 }
 
 // UserNsJoin attempts to join the sandbox to an existing User namespace
 // This will fail if the sandbox is already part of a User namespace
 func (s *Sandbox) UserNsJoin(nspath string) error {
-	ns, err := nsJoin(nspath, USERNS, s.userns)
+	ns, err := nsJoin(nspath, nsmgr.USERNS, s.userns)
 	if err != nil {
 		return err
 	}
@@ -332,11 +321,11 @@ func (s *Sandbox) UserNsJoin(nspath string) error {
 // PidNsPath returns the path to the pid namespace of the sandbox.
 // If the sandbox uses the host namespace, the empty string is returned.
 func (s *Sandbox) PidNsPath() string {
-	return s.nsPath(nil, PIDNS)
+	return s.nsPath(nil, nsmgr.PIDNS)
 }
 
 // nsJoin checks if the current iface is nil, and if so gets the namespace at nsPath
-func nsJoin(nsPath string, nsType NSType, currentIface NamespaceIface) (NamespaceIface, error) {
+func nsJoin(nsPath string, nsType nsmgr.NSType, currentIface NamespaceIface) (NamespaceIface, error) {
 	if currentIface != nil {
 		return currentIface, fmt.Errorf("sandbox already has a %s namespace, cannot join another", nsType)
 	}
@@ -346,7 +335,7 @@ func nsJoin(nsPath string, nsType NSType, currentIface NamespaceIface) (Namespac
 
 // nsPath returns the path to a namespace of the sandbox.
 // If the sandbox uses the host namespace, nil is returned
-func (s *Sandbox) nsPath(ns NamespaceIface, nsType NSType) string {
+func (s *Sandbox) nsPath(ns NamespaceIface, nsType nsmgr.NSType) string {
 	return nsPathGivenInfraPid(ns, nsType, infraPid(s.InfraContainer()))
 }
 
@@ -373,7 +362,7 @@ func infraPid(infra *oci.Container) int {
 
 // nsPathGivenInfraPid allows callers to cache the infra pid, rather than
 // calling a container.State() in batch operations
-func nsPathGivenInfraPid(ns NamespaceIface, nsType NSType, infraPid int) string {
+func nsPathGivenInfraPid(ns NamespaceIface, nsType nsmgr.NSType, infraPid int) string {
 	// caller is responsible for checking if infraContainer
 	// is valid. If not, infraPid should be less than or equal to 0
 	if ns == nil || ns.Get() == nil {
@@ -388,7 +377,7 @@ func nsPathGivenInfraPid(ns NamespaceIface, nsType NSType, infraPid int) string 
 
 // infraNsPath returns the namespace path of type nsType for infra
 // with pid infraContainerPid
-func infraNsPath(nsType NSType, infraContainerPid int) string {
+func infraNsPath(nsType nsmgr.NSType, infraContainerPid int) string {
 	// verify nsPath exists on the host. This will prevent us from fatally erroring
 	// on network tear down if the path doesn't exist
 	// Technically, this is pretty racy, but so is every check using the infra container PID.

--- a/internal/lib/sandbox/namespaces_linux.go
+++ b/internal/lib/sandbox/namespaces_linux.go
@@ -13,6 +13,7 @@ import (
 
 	nspkg "github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	"github.com/cri-o/cri-o/pkg/config"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -26,7 +27,7 @@ type Namespace struct {
 	ns          NS
 	closed      bool
 	initialized bool
-	nsType      NSType
+	nsType      nsmgr.NSType
 	nsPath      string
 }
 
@@ -65,12 +66,12 @@ func getMappingsForPinns(mappings []idtools.IDMap) string {
 
 // Creates a new persistent namespace and returns an object
 // representing that namespace, without switching to it
-func pinNamespaces(nsTypes []NSType, cfg *config.Config, idMappings *idtools.IDMappings, sysctls map[string]string) ([]NamespaceIface, error) {
-	typeToArg := map[NSType]string{
-		IPCNS:  "-i",
-		UTSNS:  "-u",
-		USERNS: "-U",
-		NETNS:  "-n",
+func pinNamespaces(nsTypes []nsmgr.NSType, cfg *config.Config, idMappings *idtools.IDMappings, sysctls map[string]string) ([]NamespaceIface, error) {
+	typeToArg := map[nsmgr.NSType]string{
+		nsmgr.IPCNS:  "-i",
+		nsmgr.UTSNS:  "-u",
+		nsmgr.USERNS: "-U",
+		nsmgr.NETNS:  "-n",
 	}
 
 	pinnedNamespace := uuid.New().String()
@@ -85,7 +86,7 @@ func pinNamespaces(nsTypes []NSType, cfg *config.Config, idMappings *idtools.IDM
 
 	type namespaceInfo struct {
 		path   string
-		nsType NSType
+		nsType nsmgr.NSType
 	}
 
 	mountedNamespaces := make([]namespaceInfo, 0, len(nsTypes))
@@ -192,7 +193,7 @@ func (n *Namespace) Path() string {
 }
 
 // Type returns which namespace this structure represents
-func (n *Namespace) Type() NSType {
+func (n *Namespace) Type() nsmgr.NSType {
 	return n.nsType
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/BurntSushi/toml"
 	conmonconfig "github.com/containers/conmon/runner/config"
@@ -23,6 +24,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/conmonmgr"
 	"github.com/cri-o/cri-o/internal/config/device"
 	"github.com/cri-o/cri-o/internal/config/node"
+	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	"github.com/cri-o/cri-o/internal/config/seccomp"
 	"github.com/cri-o/cri-o/internal/config/ulimits"
 	"github.com/cri-o/cri-o/server/useragent"
@@ -852,6 +854,28 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 
 		if err := os.MkdirAll(c.NamespacesDir, 0o755); err != nil {
 			return errors.Wrap(err, "invalid namespaces_dir")
+		}
+
+		for _, ns := range nsmgr.SupportedNamespacesForPinning() {
+			nsDir := filepath.Join(c.NamespacesDir, string(ns))
+			if err := utils.IsDirectory(nsDir); err != nil {
+				// The file is not a directory, but exists.
+				// We should remove it.
+				if errors.Is(err, syscall.ENOTDIR) {
+					if err := os.Remove(nsDir); err != nil {
+						return errors.Wrapf(err, "remove file to create namespaces sub-dir")
+					}
+					logrus.Infof("Removed file %s to create directory in that path.", nsDir)
+				} else if !os.IsNotExist(err) {
+					// if it's neither an error because the file exists
+					// nor an error because it does not exist, it is
+					// some other disk error.
+					return errors.Wrapf(err, "checking whether namespaces sub-dir exists")
+				}
+				if err := os.MkdirAll(nsDir, 0o755); err != nil {
+					return errors.Wrap(err, "invalid namespaces sub-dir")
+				}
+			}
 		}
 
 		if c.SeccompUseDefaultWhenEmpty {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/internal/config/node"
+	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	"github.com/cri-o/cri-o/internal/lib"
 	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
@@ -1051,13 +1052,13 @@ func (s *Server) configureGeneratorForSysctls(ctx context.Context, g generate.Ge
 // it returns a slice of cleanup funcs, all of which are the respective NamespaceRemove() for the sandbox.
 // The caller should defer the cleanup funcs if there is an error, to make sure each namespace we are managing is properly cleaned up.
 func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, hostPID bool, idMappings *idtools.IDMappings, sysctls map[string]string, sb *libsandbox.Sandbox, g generate.Generator) (cleanupFuncs []func() error, retErr error) {
-	managedNamespaces := make([]libsandbox.NSType, 0, 3)
+	managedNamespaces := make([]nsmgr.NSType, 0, 3)
 	if hostNetwork {
 		if err := g.RemoveLinuxNamespace(string(spec.NetworkNamespace)); err != nil {
 			return nil, err
 		}
 	} else if s.config.ManageNSLifecycle {
-		managedNamespaces = append(managedNamespaces, libsandbox.NETNS)
+		managedNamespaces = append(managedNamespaces, nsmgr.NETNS)
 	}
 
 	if hostIPC {
@@ -1065,7 +1066,7 @@ func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, ho
 			return nil, err
 		}
 	} else if s.config.ManageNSLifecycle {
-		managedNamespaces = append(managedNamespaces, libsandbox.IPCNS)
+		managedNamespaces = append(managedNamespaces, nsmgr.IPCNS)
 	}
 
 	if idMappings == nil {
@@ -1073,7 +1074,7 @@ func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, ho
 			return nil, err
 		}
 	} else if s.config.ManageNSLifecycle {
-		managedNamespaces = append(managedNamespaces, libsandbox.USERNS)
+		managedNamespaces = append(managedNamespaces, nsmgr.USERNS)
 	}
 
 	// Since we need a process to hold open the PID namespace, CRI-O can't manage the NS lifecycle
@@ -1085,7 +1086,7 @@ func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, ho
 
 	// There's no option to set hostUTS
 	if s.config.ManageNSLifecycle {
-		managedNamespaces = append(managedNamespaces, libsandbox.UTSNS)
+		managedNamespaces = append(managedNamespaces, nsmgr.UTSNS)
 
 		// now that we've configured the namespaces we're sharing, tell sandbox to configure them
 		managedNamespaces, err := sb.CreateManagedNamespaces(managedNamespaces, idMappings, sysctls, &s.config)
@@ -1106,11 +1107,11 @@ func (s *Server) configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, ho
 // configureGeneratorGivenNamespacePaths takes a map of nsType -> nsPath. It configures the generator
 // to add or replace the defaults to these paths
 func configureGeneratorGivenNamespacePaths(managedNamespaces []*libsandbox.ManagedNamespace, g generate.Generator) error {
-	typeToSpec := map[libsandbox.NSType]spec.LinuxNamespaceType{
-		libsandbox.IPCNS:  spec.IPCNamespace,
-		libsandbox.NETNS:  spec.NetworkNamespace,
-		libsandbox.UTSNS:  spec.UTSNamespace,
-		libsandbox.USERNS: spec.UserNamespace,
+	typeToSpec := map[nsmgr.NSType]spec.LinuxNamespaceType{
+		nsmgr.IPCNS:  spec.IPCNamespace,
+		nsmgr.NETNS:  spec.NetworkNamespace,
+		nsmgr.UTSNS:  spec.UTSNamespace,
+		nsmgr.USERNS: spec.UserNamespace,
 	}
 
 	for _, ns := range managedNamespaces {

--- a/test/mocks/sandbox/sandbox.go
+++ b/test/mocks/sandbox/sandbox.go
@@ -5,6 +5,7 @@
 package sandboxmock
 
 import (
+	nsmgr "github.com/cri-o/cri-o/internal/config/nsmgr"
 	sandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
@@ -118,10 +119,10 @@ func (mr *MockNamespaceIfaceMockRecorder) Remove() *gomock.Call {
 }
 
 // Type mocks base method
-func (m *MockNamespaceIface) Type() sandbox.NSType {
+func (m *MockNamespaceIface) Type() nsmgr.NSType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
-	ret0, _ := ret[0].(sandbox.NSType)
+	ret0, _ := ret[0].(nsmgr.NSType)
 	return ret0
 }
 


### PR DESCRIPTION
as well as remove any file that exists in that spot
as well as create nsmgr package to mirror release-1.21 structure (only holding the NSType right now)

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:


as well as remove any file that exists in that spot
and introduce a skeleton of nsmgr package. We'd have to introduce a new package regardless (if we wanted to keep NSType and SupportedNamespacsForPinning() together) as we get a cyclical import importing sandbox from the config

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
pick of https://github.com/cri-o/cri-o/pull/4532
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
