### PR TITLE
[1.20] Set systemd property KillMode to mixed for containers

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -205,6 +205,10 @@ func (c *container) SpecAddAnnotations(sb *sandbox.Sandbox, containerVolumes []o
 		if systemdHasCollectMode {
 			c.spec.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
 		}
+		// Set systemd killmode to mixed so that only the main container process gets the SIGTERM
+		// This prevents issues with double signals to child processes inside the container
+		// when the main process propagates the signals down.
+		c.spec.AddAnnotation("org.systemd.property.KillMode", "'mixed'")
 	}
 
 	if configStopSignal != "" {


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>


#### What type of PR is this?



/kind bug


#### What this PR does / why we need it:
This PR sets the systemd KillMode for container scopes to mixed
so on stop, only the main process gets the SIGTERM and is 
responsible for forwarding it if needed to child processes.

Without this, we end up with double SIGTERMS leading to unexpected
failures in graceful termination on node shutdown or reboot.


#### Which issue(s) this PR fixes:

https://bugzilla.redhat.com/show_bug.cgi?id=1882750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
Set systemd KillMode to mixed for container scopes modifying behavior on node shutdown
```
