### PR TITLE
[1.19] Set systemd property KillMode to mixed for containers

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -453,6 +453,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 			if node.SystemdHasCollectMode() {
 				specgen.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
 			}
+			// Set systemd killmode to mixed so that only the main container process gets the SIGTERM
+			// This prevents issues with double signals to child processes inside the container
+			// when the main process propagates the signals down.
+			specgen.AddAnnotation("org.systemd.property.KillMode", "'mixed'")
 		}
 
 		if ctr.Privileged() {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -343,8 +343,17 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		g.AddAnnotation("org.opencontainers.image.stopSignal", podContainer.Config.Config.StopSignal)
 	}
 
-	if s.config.CgroupManager().IsSystemd() && node.SystemdHasCollectMode() {
-		g.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
+	if s.config.CgroupManager().IsSystemd() {
+		if node.SystemdHasCollectMode() {
+			g.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
+		}
+
+		// Set systemd killmode to mixed so that only the main container process gets the SIGTERM
+		// This prevents issues with double signals to child processes inside the container
+		// when the main process propagates the signals down.
+		if s.config.CgroupManager().IsSystemd() {
+			g.AddAnnotation("org.systemd.property.KillMode", "'mixed'")
+		}
 	}
 
 	created := time.Now()


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>


#### What type of PR is this?



/kind bug


#### What this PR does / why we need it:
This PR sets the systemd KillMode for container scopes to mixed
so on stop, only the main process gets the SIGTERM and is 
responsible for forwarding it if needed to child processes.

Without this, we end up with double SIGTERMS leading to unexpected
failures in graceful termination on node shutdown or reboot.


#### Which issue(s) this PR fixes:

https://bugzilla.redhat.com/show_bug.cgi?id=1882750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
Set systemd KillMode to mixed for container scopes modifying behavior on node shutdown
```
