### PR TITLE
hostport manager clean up host ports

### DIFF
--- a/internal/hostport/hostport_manager.go
+++ b/internal/hostport/hostport_manager.go
@@ -238,8 +238,9 @@ func (hm *hostportManager) Remove(id string, podPortMapping *PodPortMapping) (er
 	}
 
 	// exit if there is nothing to remove
+	// don´t forget to clean up opened pod host ports
 	if len(existingChainsToRemove) == 0 {
-		return nil
+		return hm.closeHostports(hostportMappings)
 	}
 
 	natChains := bytes.NewBuffer(nil)


### PR DESCRIPTION
The host port manager, when Remove the hostport from the system, exists fast if there are no
iptables rules to delete.
However, it was missing to call the method that remove the hostports bound, so there is a possibility that we leak sockets.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

Thanks to @johnbelamaric 
https://github.com/kubernetes/kubernetes/pull/98755#discussion_r570413563

> /kind bug
> /kind cleanup
```release-note
NONE
```
