### PR TITLE
Allow seccomp hook tracing for separate containers

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -231,6 +231,13 @@ func (r *Runtime) AllowShmSizeAnnotation(handler string) (bool, error) {
 	return r.allowAnnotation(handler, annotations.ShmSizeAnnotation)
 }
 
+// AllowOCISeccompBPFHookAnnotation searches through the AllowedAnnotations for
+// the OCI seccomp BPF hook annotation, checking whether this runtime allows
+// processing of "io.containers.trace-syscall".
+func (r *Runtime) AllowOCISeccompBPFHookAnnotation(handler string) (bool, error) {
+	return r.allowAnnotation(handler, annotations.OCISeccompBPFHookAnnotation)
+}
+
 func (r *Runtime) allowAnnotation(handler, annotation string) (bool, error) {
 	rh, err := r.getRuntimeHandler(handler)
 	if err != nil {

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -55,6 +55,7 @@ var _ = t.Describe("Oci", func() {
 					annotations.CPULoadBalancingAnnotation,
 					annotations.IRQLoadBalancingAnnotation,
 					annotations.CPUQuotaAnnotation,
+					annotations.OCISeccompBPFHookAnnotation,
 				},
 			},
 		}
@@ -140,6 +141,24 @@ var _ = t.Describe("Oci", func() {
 			// Then
 			Expect(err).To(BeNil())
 			Expect(allowed).To(Equal(true))
+		})
+		It("AllowOCISeccompBPFHookAnnotation should be true when set", func() {
+			// Given
+			// When
+			allowed, err := sut.AllowOCISeccompBPFHookAnnotation(performanceRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(allowed).To(Equal(true))
+		})
+		It("AllowOCISeccompBPFHookAnnotation should be false when runtime invalid", func() {
+			// Given
+			// When
+			allowed, err := sut.AllowOCISeccompBPFHookAnnotation(invalidRuntime)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(allowed).To(Equal(false))
 		})
 	})
 

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -24,4 +24,7 @@ const (
 
 	// IRQLoadBalancingAnnotation indicates that IRQ load balancing should be disabled for CPUs used by the container
 	IRQLoadBalancingAnnotation = "irq-load-balancing.crio.io"
+
+	// OCISeccompBPFHookAnnotation is the annotation used by the OCI seccomp BPF hook for tracing container syscalls
+	OCISeccompBPFHookAnnotation = "io.containers.trace-syscall"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	"github.com/cri-o/cri-o/internal/config/seccomp"
 	"github.com/cri-o/cri-o/internal/config/ulimits"
+	"github.com/cri-o/cri-o/pkg/annotations"
 	"github.com/cri-o/cri-o/server/useragent"
 	"github.com/cri-o/cri-o/utils"
 	"github.com/cri-o/ocicni/pkg/ocicni"
@@ -164,6 +165,7 @@ type RuntimeHandler struct {
 	// "io.kubernetes.cri-o.Devices" for configuring devices for the pod.
 	// "io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
 	// "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
+	// "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
 	AllowedAnnotations []string `toml:"allowed_annotations,omitempty"`
 }
 
@@ -594,6 +596,9 @@ func DefaultConfig() (*Config, error) {
 				defaultRuntime: {
 					RuntimeType: DefaultRuntimeType,
 					RuntimeRoot: DefaultRuntimeRoot,
+					AllowedAnnotations: []string{
+						annotations.OCISeccompBPFHookAnnotation,
+					},
 				},
 			},
 			ConmonEnv: []string{
@@ -1039,8 +1044,12 @@ func (r *RuntimeHandler) ValidateRuntimePath(name string) error {
 		return fmt.Errorf("invalid runtime_path for runtime '%s': %q",
 			name, err)
 	}
-	logrus.Debugf("found valid runtime %q for runtime_path %q",
-		name, r.RuntimePath)
+	logrus.Debugf(
+		"Found valid runtime %q for runtime_path %q", name, r.RuntimePath,
+	)
+	logrus.Debugf(
+		"Allowed annotations for runtime: %v", r.AllowedAnnotations,
+	)
 	return nil
 }
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -304,6 +304,7 @@ default_runtime = "{{ .DefaultRuntime }}"
 #   "io.kubernetes.cri-o.Devices" for configuring devices for the pod.
 #   "io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
 #   "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
+#   "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
 
 {{ range $runtime_name, $runtime_handler := .Runtimes  }}
 [crio.runtime.runtimes.{{ $runtime_name }}]

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -342,6 +342,15 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
+	allowOCISeccompBPFHookAnnotation, err := s.Runtime().AllowOCISeccompBPFHookAnnotation(runtimeHandler)
+	if err != nil {
+		return nil, errors.Wrap(err, "check for allowed OCI seccomp BPF hook annotation")
+	}
+	// Remove the OCI seccomp BPF hook annotation if it is not allowed
+	if !allowOCISeccompBPFHookAnnotation {
+		delete(kubeAnnotations, ann.OCISeccompBPFHookAnnotation)
+	}
+
 	idMappingsOptions, err := s.configureSandboxIDMappings(usernsMode, sbox.Config().Linux.SecurityContext, runtimeHandler)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
This change allows us to trace different containers into dedicated
files. For example the workload:

```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
spec:
  selector:
    matchLabels:
      app: test
  replicas: 1
  template:
    metadata:
      labels:
        app: test
      annotations:
        io.containers.trace-syscall/nginx: of:/tmp/nginx.json
        io.containers.trace-syscall/redis: of:/tmp/redis.json
    spec:
      containers:
        - name: nginx
          image: nginx:latest
        - name: redis
          image: redis:latest
```

Will now create two separate files containing only the syscalls from
each workload.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/containers/oci-seccomp-bpf-hook/issues/74
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added feature to allow the OCI seccomp BPF hook to trace containers into dedicated files by
using the annotation key `io.containers.trace-syscall/container-name`
```
