### PR TITLE
[1.20] oci: don't wait too long on a long stop

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -72,6 +72,10 @@ type Container struct {
 	stdinOnce          bool
 	created            bool
 	spoofed            bool
+	stopping           bool
+	stopTimeoutChan    chan time.Duration
+	stoppedChan        chan struct{}
+	stopLock           sync.Mutex
 }
 
 // Metadata holds all necessary information for building the container name.
@@ -132,6 +136,8 @@ func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations,
 		dir:             dir,
 		state:           state,
 		stopSignal:      stopSignal,
+		stopTimeoutChan: make(chan time.Duration, 1),
+		stoppedChan:     make(chan struct{}, 1),
 	}
 	return c, nil
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -616,35 +616,89 @@ func waitContainerStop(ctx context.Context, c *Container, timeout time.Duration,
 			}
 		}
 	}()
-	select {
-	case <-done:
-		return nil
-	case <-ctx.Done():
-		close(chControl)
-		return ctx.Err()
-	case <-time.After(timeout):
-		close(chControl)
-		if ignoreKill {
-			return fmt.Errorf("timeout reached after %.0f seconds waiting for container process to exit",
-				timeout.Seconds())
-		}
-		pid, err := c.pid()
-		if err != nil {
-			return err
-		}
-		if err := kill(pid); err != nil {
-			return fmt.Errorf("failed to kill process: %v", err)
+	// Operate in terms of targetTime, so that we can pause in the middle of the operation
+	// to catch a new timeout (and possibly ignore that new timeout if it's not correct to
+	// take a new one).
+	targetTime := time.Now().Add(timeout)
+	for {
+		select {
+		case <-done:
+			return nil
+		case <-ctx.Done():
+			close(chControl)
+			return ctx.Err()
+		case <-time.After(time.Until(targetTime)):
+			close(chControl)
+			if ignoreKill {
+				return fmt.Errorf("timeout reached after %.0f seconds waiting for container process to exit",
+					timeout.Seconds())
+			}
+			pid, err := c.pid()
+			if err != nil {
+				return err
+			}
+			if err := kill(pid); err != nil {
+				return fmt.Errorf("failed to kill process: %v", err)
+			}
+		case newTimeout := <-c.stopTimeoutChan:
+			// If we're already at the "killing" step,
+			// we should use the killingContainerTimeout,
+			// and not override.
+			if !ignoreKill {
+				continue
+			}
+			// If a new timeout comes in,
+			// interrupt the old one, and start a new one
+			newTargetTime := time.Now().Add(newTimeout)
+
+			targetTime = newTargetTime
+
+			continue
 		}
 	}
-
 	c.state.Finished = time.Now()
+	// Successfully stopped! This is to prevent other routines from
+	// racing with this one and waiting forever.
+	// close only the dedicated channel. If we close stopTimeoutChan,
+	// any other waiting goroutine will panic, not gracefully exit.
+	close(c.stoppedChan)
 	return nil
 }
 
 // StopContainer stops a container. Timeout is given in seconds.
-func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout int64) error {
+func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout int64) (retErr error) {
+	// first, need to check if the container is already stopping
+	c.stopLock.Lock()
+	if c.stopping {
+		// If so, we shouldn't wait forever on the opLock.
+		// This can cause issues where the container stop gets DOSed by a very long
+		// timeout, followed a shorter one coming in.
+		// Instead, interrupt the other stop with this new one.
+		select {
+		case c.stopTimeoutChan <- time.Duration(timeout) * time.Second:
+		case <-c.stoppedChan: // This case is to avoid waiting forever once another routine has finished.
+			c.stopLock.Unlock()
+			return nil
+		}
+	}
+	// Regardless, set the container as actively stopping.
+	c.stopping = true
+	c.stopLock.Unlock()
+
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
+
+	defer func() {
+		if retErr != nil {
+			// Failed to stop, set stopping to false.
+			// Otherwise, we won't actually
+			// attempt to stop when a new request comes in,
+			// even though we're not actively stopping anymore.
+			c.stopLock.Lock()
+			c.stopping = false
+			c.stopLock.Unlock()
+		}
+	}()
 
 	if err := c.ShouldBeStopped(); err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
oci: don't wait too long on a long stop

if a long stop timeout comes in, and a shorter one comes in after
we never interrupt the old one. This can cause the new container stop to be DOSed

instead, interrupt the old stop, so the new one can proceed as expected

Signed-off-by: Peter Hunt <pehunt@redhat.com>


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
