### PR TITLE
Log container stop timeout

### DIFF
--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -13,7 +13,7 @@ import (
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
 func (s *Server) StopContainer(ctx context.Context, req *types.StopContainerRequest) error {
-	log.Infof(ctx, "Stopping container: %s", req.ContainerID)
+	log.Infof(ctx, "Stopping container: %s (timeout: %ds)", req.ContainerID, req.Timeout)
 	// save container description to print
 	c, err := s.GetContainerFromShortID(req.ContainerID)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>


#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
Logs the container stop timeout so it is always visible at the info level.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
Log the container stop timeout at default log level
```
