### PR TITLE
update pause image to 3.5（3.4.1 for multi-arch support and 3.5 for non-root）

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -256,7 +256,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--pause-command**="": Path to the pause executable in the pause image (default: /pause)
 
-**--pause-image**="": Image which contains the pause executable (default: k8s.gcr.io/pause:3.2)
+**--pause-image**="": Image which contains the pause executable (default: k8s.gcr.io/pause:3.5)
 
 **--pause-image-auth-file**="": Path to a config file containing credentials for --pause-image (default: "")
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -275,7 +275,7 @@ CRI-O reads its configured registries defaults from the system wide containers-r
 **global_auth_file**=""
   The path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.
 
-**pause_image**="k8s.gcr.io/pause:3.2"
+**pause_image**="k8s.gcr.io/pause:3.5"
   The image used to instantiate infra containers. This option supports live configuration reload.
 
 **pause_image_auth_file**=""

--- a/internal/config/migrate/from_1_17.go
+++ b/internal/config/migrate/from_1_17.go
@@ -60,11 +60,10 @@ func migrateFrom1_17(cfg *config.Config) error {
 	}
 
 	// Upgrade pause image
-	// https://github.com/cri-o/cri-o/pull/3582
-	logrus.Infof("Checking for pause_image, which now should be k8s.gcr.io/pause:3.2 instead of k8s.gcr.io/pause:3.1")
-	newPauseImage := "k8s.gcr.io/pause:3.2"
-	if cfg.PauseImage == "k8s.gcr.io/pause:3.1" {
-		cfg.PauseImage = newPauseImage
+	// https://github.com/cri-o/cri-o/pull/4550
+	logrus.Infof("Checking for pause_image, which now should be %s instead of k8s.gcr.io/pause:3.1 or 3.2", config.DefaultPauseImage)
+	if cfg.PauseImage == "k8s.gcr.io/pause:3.1" || cfg.PauseImage == "k8s.gcr.io/pause:3.2" {
+		cfg.PauseImage = config.DefaultPauseImage
 		logrus.Infof(`Changing "pause_image" to %s`, cfg.PauseImage)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,6 +94,8 @@ const (
 	ImageVolumesIgnore ImageVolumesType = "ignore"
 	// ImageVolumesBind option is for using bind mounted volumes
 	ImageVolumesBind ImageVolumesType = "bind"
+	// DefaultPauseImage is default pause image
+	DefaultPauseImage string = "k8s.gcr.io/pause:3.5"
 )
 
 const (
@@ -622,7 +624,7 @@ func DefaultConfig() (*Config, error) {
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport: "docker://",
-			PauseImage:       "k8s.gcr.io/pause:3.2",
+			PauseImage:       DefaultPauseImage,
 			PauseCommand:     "/pause",
 			ImageVolumes:     ImageVolumesMkdir,
 		},

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -91,7 +91,7 @@ POD_IPV6_CIDR_START="1100:2"
 POD_IPV6_DEF_ROUTE="1100:200::1/24"
 
 IMAGES=(
-    k8s.gcr.io/pause:3.2
+    k8s.gcr.io/pause:3.5
     quay.io/crio/busybox:latest
     quay.io/crio/fedora-ping:latest
     quay.io/crio/image-volume-test:latest


### PR DESCRIPTION
#### What type of PR is this?
/kind dependency-change

#### What this PR does / why we need it:
bumps pause image to 3.5
Per https://github.com/kubernetes/kubernetes/pull/100292

#### Which issue(s) this PR fixes:
None

part of https://github.com/kubernetes/kubernetes/pull/98205 (changelogs there)

#### Special notes for your reviewer:
k8s.gcr.io/pause:3.4.1 is for both windows/linux. Details in kubernetes/kubernetes/#98205

- [x] https://github.com/containers/common/blob/master/pkg/config/default.go#L48 wait for vendor update?
- [x] after https://github.com/kubernetes/kubernetes/pull/98205 merged

#### Does this PR introduce a user-facing change?
```release-note
Default pause image is `k8s.gcr.io/pause:3.5`
```