### PR TITLE
Add arm64 static build to GitHub actions and bundle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
           make completions-generation
           hack/tree_status.sh
 
-  build-static:
+  build-static-amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -138,23 +138,47 @@ jobs:
       - run: result/bin/crio version
       - uses: actions/upload-artifact@v2
         with:
-          name: build-static
+          name: build-static-amd64
           path: |
             result/bin/crio
             result/bin/crio-status
             result/bin/pinns
 
-  bundle:
+  build-static-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - uses: cachix/cachix-action@v8
+        with:
+          name: cri-o-static
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix-build nix/default-arm64.nix
+      - run: file result/bin/crio
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-static-arm64
+          path: |
+            result/bin/crio
+            result/bin/crio-status
+            result/bin/pinns
+
+  bundles:
     runs-on: ubuntu-latest
     needs:
       - build
-      - build-static
+      - build-static-amd64
+      - build-static-arm64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
-          name: build-static
-          path: bin/static
+          name: build-static-amd64
+          path: bin/static-amd64
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-static-arm64
+          path: bin/static-arm64
       - uses: actions/download-artifact@v2
         with:
           name: docs
@@ -163,7 +187,7 @@ jobs:
         with:
           name: config
       - run: chmod -R +x bin
-      - run: make bundle
+      - run: make bundles
       - uses: actions/upload-artifact@v2
         with:
           name: bundle
@@ -171,7 +195,7 @@ jobs:
 
   bundle-test:
     runs-on: ubuntu-latest
-    needs: bundle
+    needs: bundles
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,10 @@ bundle:
 bundle-test:
 	sudo contrib/bundle/test
 
+bundles:
+	contrib/bundle/build amd64
+	contrib/bundle/build arm64
+
 install: .gopathok install.bin install.man install.completions install.systemd install.config
 
 install.bin-nobuild:
@@ -486,6 +490,7 @@ metrics-exporter: bin/metrics-exporter
 	git-validation \
 	binaries \
 	bundle \
+	bundles \
 	bundle-test \
 	build-static \
 	clean \

--- a/README.md
+++ b/README.md
@@ -98,18 +98,43 @@ up a PR and add it to the list.
 ## Getting started
 
 ### Installing CRI-O
+
 To install `CRI-O`, you can follow our [installation guide](install.md).
 Alternatively, if you'd rather build `CRI-O` from source, checkout our [setup
 guide](install.md#build-and-install-cri-o-from-source).
 We also provide a way in building [static binaries of `CRI-O`](install.md#static-builds) via nix.
 Those binaries are available for every successfully built commit on our [Google Cloud Storage Bucket][bucket].
-This means that the latest commit can be downloaded via:
+This means that the latest commit can be installed via our convinience script:
 
 [bucket]: https://console.cloud.google.com/storage/browser/k8s-conform-cri-o/artifacts
 
 ```shell
-> curl -f https://storage.googleapis.com/k8s-conform-cri-o/artifacts/crio-$(git ls-remote https://github.com/cri-o/cri-o master | cut -c1-9).tar.gz -o crio.tar.gz
+> curl https://raw.githubusercontent.com/cri-o/cri-o/master/scripts/get | bash
 ```
+
+Beside `amd64` we also support the `arm64` bit architecture. This can be
+selected via the script, too:
+
+```shell
+> curl https://raw.githubusercontent.com/cri-o/cri-o/master/scripts/get | bash -s -- -a arm64
+```
+
+It is also possible to select a specific git SHA or tag by:
+
+```shell
+> curl https://raw.githubusercontent.com/cri-o/cri-o/master/scripts/get | bash -s -- -t v1.21.0
+```
+
+The above script resolves to the download URL of the static binary bundle
+tarball matching the format:
+
+```
+https://storage.googleapis.com/k8s-conform-cri-o/artifacts/cri-o.$ARCH.$REV.tar.gz
+```
+
+where `$ARCH` can be `amd64` or `arm64` and `$REV` can be any git SHA or tag.
+Please be aware that using the latest `master` SHA might cause a race, because
+the CI has not finished publishing the artifacts yet or failed.
 
 ### Running kubernetes with CRI-O
 

--- a/contrib/bundle/10-crun.conf
+++ b/contrib/bundle/10-crun.conf
@@ -1,0 +1,4 @@
+[crio.runtime]
+default_runtime = "crun"
+
+[crio.runtime.runtimes.crun]

--- a/contrib/bundle/Makefile
+++ b/contrib/bundle/Makefile
@@ -12,6 +12,8 @@ ZSHINSTALLDIR ?= $(PREFIX)/share/zsh/site-functions
 SYSTEMDDIR ?= $(PREFIX)/lib/systemd/system
 OPT_CNI_BIN_DIR ?= /opt/cni/bin
 
+ARCH ?= amd64
+
 all: install
 
 .PHONY: install
@@ -49,6 +51,7 @@ install-crio:
 	install $(SELINUX) -D -m 644 -t $(ETCDIR) etc/crictl.yaml
 	install $(SELINUX) -D -m 644 -t $(OCIDIR) etc/crio-umount.conf
 	install $(SELINUX) -D -m 644 -t $(ETCDIR)/crio etc/crio.conf
+	install $(SELINUX) -D -m 644 -t $(ETCDIR)/crio/crio.conf.d etc/10-crun.conf
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man5 man/crio.conf.5
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man5 man/crio.conf.d.5
 	install $(SELINUX) -D -m 644 -t $(MANDIR)/man8 man/crio-status.8
@@ -65,7 +68,9 @@ install-pinns:
 
 .PHONY: install-runc
 install-runc:
+ifeq ($(ARCH),amd64)
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/runc
+endif
 
 .PHONY: install-crun
 install-crun:
@@ -101,6 +106,7 @@ uninstall-crio:
 	rm $(ETCDIR)/crictl.yaml
 	rm $(OCIDIR)/crio-umount.conf
 	rm $(ETCDIR)/crio/crio.conf
+	rm $(ETCDIR)/crio/crio.conf.d/10-crun.conf
 	rm $(MANDIR)/man5/crio.conf.5
 	rm $(MANDIR)/man5/crio.conf.d.5
 	rm $(MANDIR)/man8/crio-status.8
@@ -117,7 +123,9 @@ uninstall-pinns:
 
 .PHONY: uninstall-runc
 uninstall-runc:
+ifeq ($(ARCH),amd64)
 	rm $(BINDIR)/runc
+endif
 
 .PHONY: uninstall-crun
 uninstall-crun:

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ARCH_AMD64=amd64
+ARCH_ARM64=arm64
+
+ARCH=${1:-$ARCH_AMD64}
+
 # Global vars to be used
 # shellcheck source=vars
-source "$(dirname "${BASH_SOURCE[0]}")"/vars
+source "$(dirname "${BASH_SOURCE[0]}")"/vars "$ARCH"
 
 cd "$(dirname "$0")"
 
@@ -12,9 +17,9 @@ cd "$(dirname "$0")"
 source "$GIT_ROOT/scripts/versions"
 
 FILES_BIN=(
-    "$GIT_ROOT/bin/static/crio-status"
-    "$GIT_ROOT/bin/static/crio"
-    "$GIT_ROOT/bin/static/pinns"
+    "$GIT_ROOT/bin/static-$ARCH/crio-status"
+    "$GIT_ROOT/bin/static-$ARCH/crio"
+    "$GIT_ROOT/bin/static-$ARCH/pinns"
 )
 FILES_MAN=(
     "$GIT_ROOT/docs/crio-status.8"
@@ -26,6 +31,7 @@ FILES_ETC=(
     "$GIT_ROOT/crictl.yaml"
     "$GIT_ROOT/crio-umount.conf"
     "$GIT_ROOT/crio.conf"
+    "$GIT_ROOT/contrib/bundle/10-crun.conf"
 )
 FILES_CONTRIB=(
     "$GIT_ROOT/contrib/cni/10-crio-bridge.conf"
@@ -88,6 +94,8 @@ fi
 
 # Local assets
 cp "$GIT_ROOT/contrib/bundle/Makefile" "$TMPDIR"
+sed -i "s/ARCH ?= amd64/ARCH ?= $ARCH/" "$TMPDIR/Makefile"
+
 cp "$GIT_ROOT/contrib/bundle/README.md" "$TMPDIR"
 
 curl_to() {
@@ -97,42 +105,71 @@ TMP_BIN=$TMPDIR/bin
 
 # conmon
 curl_to "$TMP_BIN/conmon" \
-    https://github.com/containers/conmon/releases/download/"${VERSIONS["conmon"]}"/conmon
+    "https://github.com/containers/conmon/releases/download/${VERSIONS["conmon"]}/conmon.$ARCH"
 chmod +x "$TMP_BIN/conmon"
 
-# runc
-curl_to "$TMP_BIN/runc" \
-    https://github.com/opencontainers/runc/releases/download/"${VERSIONS["runc"]}"/runc.amd64
-chmod +x "$TMP_BIN/runc"
+if [[ $ARCH == "$ARCH_AMD64" ]]; then
+    # runc
+    curl_to "$TMP_BIN/runc" \
+        "https://github.com/opencontainers/runc/releases/download/${VERSIONS["runc"]}/runc.amd64"
+    chmod +x "$TMP_BIN/runc"
+fi
 
 # crun
 curl_to "$TMP_BIN/crun" \
-    https://github.com/containers/crun/releases/download/"${VERSIONS["crun"]}"/crun-"${VERSIONS["crun"]}"-linux-amd64
+    "https://github.com/containers/crun/releases/download/${VERSIONS["crun"]}/crun-${VERSIONS["crun"]}-linux-$ARCH"
 chmod +x "$TMP_BIN/crun"
 
 # CNI plugins
 mkdir -p "$TMPDIR/cni-plugins"
-set -x
 curl_to - \
-    https://github.com/containernetworking/plugins/releases/download/"${VERSIONS["cni-plugins"]}"/cni-plugins-linux-amd64-"${VERSIONS["cni-plugins"]}".tgz |
+    "https://github.com/containernetworking/plugins/releases/download/${VERSIONS["cni-plugins"]}/cni-plugins-linux-$ARCH-${VERSIONS["cni-plugins"]}.tgz" |
     tar xfz - -C "$TMPDIR/cni-plugins"
 
 # crictl
 curl_to - \
-    https://github.com/kubernetes-sigs/cri-tools/releases/download/"${VERSIONS["cri-tools"]}"/crictl-"${VERSIONS["cri-tools"]}"-linux-amd64.tar.gz |
+    "https://github.com/kubernetes-sigs/cri-tools/releases/download/${VERSIONS["cri-tools"]}/crictl-${VERSIONS["cri-tools"]}-linux-$ARCH.tar.gz" |
     tar xfz - -C "$TMP_BIN"
+
+# Check the architectures of the binaries
+ELF_ARCH=x86-64
+if [[ $ARCH == "$ARCH_ARM64" ]]; then
+    ELF_ARCH=aarch64
+fi
+for FILE in "$TMP_BIN"/*; do
+    if ! file "$FILE" | grep -q "$ELF_ARCH"; then
+        echo "$FILE is not of required arch $ELF_ARCH"
+        exit 1
+    fi
+done
 
 # Create the archive
 pushd "$ARCHIVE_PATH"
 rm -f "$ARCHIVE"
-tar cfz "$ARCHIVE" tmp --transform s/tmp/"$BUNDLE"/
+TAR_DIR=cri-o
+tar cfz "$ARCHIVE" tmp --transform s/tmp/$TAR_DIR/
 rm -rf "$TMPDIR"
 echo "Created $ARCHIVE_PATH/$ARCHIVE"
 
 # Test the archive
 echo "Testing archive"
 tar xf "$ARCHIVE"
-pushd "$BUNDLE"
-make DESTDIR=test
+pushd $TAR_DIR
+export DESTDIR=test OPT_CNI_BIN_DIR=test/opt/cni/bin
+make
+EXP_CNT=64
+if [[ $ARCH == "$ARCH_AMD64" ]]; then
+    EXP_CNT=65
+fi
+ACT_CNT=$(find test | wc -l)
+if [[ "$EXP_CNT" != "$ACT_CNT" ]]; then
+    echo "make install file count does not match, expected: $EXP_CNT, actual: $ACT_CNT"
+    exit 1
+fi
+make uninstall
+if [[ $(find test -type f | wc -l) != 0 ]]; then
+    echo "make uninstall left over some files"
+    exit 1
+fi
 popd
-rm -rf "$BUNDLE"
+rm -rf $TAR_DIR

--- a/contrib/bundle/test
+++ b/contrib/bundle/test
@@ -7,6 +7,9 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
+# Assume we're running on this arch
+ARCH=amd64
+
 # Global vars to be used
 # shellcheck source=vars
 source "$(dirname "${BASH_SOURCE[0]}")"/vars
@@ -15,7 +18,7 @@ pushd "$ARCHIVE_PATH"
 
 # Untar the bundle
 tar xfvz "$ARCHIVE"
-pushd "$BUNDLE"
+pushd cri-o
 
 # Install and prepare config
 make install

--- a/contrib/bundle/vars
+++ b/contrib/bundle/vars
@@ -6,8 +6,7 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 ARCHIVE_PATH="$GIT_ROOT/build/bundle"
 mkdir -p "$ARCHIVE_PATH"
 
-BUNDLE=crio-$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
-ARCHIVE="$BUNDLE.tar.gz"
+ARCH=${1:-amd64}
+ARCHIVE="cri-o.$ARCH.$(git describe --tags --exact-match 2>/dev/null || git rev-parse HEAD).tar.gz"
 
-export BUNDLE
 export ARCHIVE

--- a/install.md
+++ b/install.md
@@ -338,7 +338,7 @@ make BUILDTAGS='seccomp apparmor'
 It is possible to build a statically linked binary of CRI-O by using the
 officially provided [nix](https://nixos.org/nix) package and the derivation of
 it [within this repository](../nix). The builds are completely reproducible and
-will create a `x86_64`/`amd64` stripped ELF binary for
+will create a `x86_64`/`amd64` or `aarch64`/`arm64` stripped ELF binary for
 [glibc](https://www.gnu.org/software/libc). These binaries are integration
 tested as well and support the following features:
 
@@ -350,36 +350,11 @@ tested as well and support the following features:
 - selinux
 
 To build the binaries locally either [install the nix package
-manager](https://nixos.org/nix/download.html) or setup a new container image
-from the root directory of this repository by executing:
-
-```
-make test-image-nix
-```
-
-Please note that you can specify the container runtime and image name by
-specifying:
-
-```
-make test-image-nix \
-    CONTAINER_RUNTIME=podman \
-    TESTIMAGE_NIX=crionix
-```
+manager](https://nixos.org/nix/download.html) or use the `make build-static`
+target which relies on the nixos/nix container image.
 
 The overall build process can take a tremendous amount of CPU time depending on
-the hardware. After the image has been successfully built, it should be possible
-to build the binaries:
-
-```
-make build-static
-```
-
-There exist an already pre-built container image used for the internal CI. This
-means that invoking `make build-static` should work even without building the
-image before.
-
-Note that the container runtime and nix image can be specified here, too. The
-resulting binaries should now be available within:
+the hardware. The resulting binaries should now be available within:
 
 - `bin/static/crio`
 
@@ -391,7 +366,12 @@ directory of this repository:
 nix build -f nix
 ```
 
-The resulting binary should be now available in `result-bin/bin`.
+The resulting binaries should be now available in `result/bin`. To build the arm
+variant of the binaries, just run:
+
+```
+nix build -f nix/default-arm64.nix
+```
 
 #### Creating a release archive
 
@@ -402,7 +382,7 @@ used to build a new release archive within the current repository:
 ```
 make release-bundle
 …
-Created ./bundle/crio-v1.15.0.tar.gz
+Created ./bundle/cri-o.amd64.v1.20.0.tar.gz
 ```
 
 ### Download conmon

--- a/nix/default-arm64.nix
+++ b/nix/default-arm64.nix
@@ -1,0 +1,89 @@
+let
+  pkgs = (import ./nixpkgs.nix {
+    crossSystem = {
+      config = "aarch64-unknown-linux-gnu";
+    };
+    config = {
+      packageOverrides = pkg: {
+        gpgme = (static pkg.gpgme);
+        libassuan = (static pkg.libassuan);
+        libgpgerror = (static pkg.libgpgerror);
+        libseccomp = (static pkg.libseccomp);
+        glib = (static pkg.glib).overrideAttrs (x: {
+          outputs = [ "bin" "out" "dev" ];
+          mesonFlags = [
+            "-Ddefault_library=static"
+            "-Ddevbindir=${placeholder ''dev''}/bin"
+            "-Dgtk_doc=false"
+            "-Dnls=disabled"
+          ];
+          postInstall = ''
+            moveToOutput "share/glib-2.0" "$dev"
+            substituteInPlace "$dev/bin/gdbus-codegen" --replace "$out" "$dev"
+            sed -i "$dev/bin/glib-gettextize" -e "s|^gettext_dir=.*|gettext_dir=$dev/share/glib-2.0/gettext|"
+            sed '1i#line 1 "${x.pname}-${x.version}/include/glib-2.0/gobject/gobjectnotifyqueue.c"' \
+              -i "$dev"/include/glib-2.0/gobject/gobjectnotifyqueue.c
+          '';
+        });
+      };
+    };
+  });
+
+  static = pkg: pkg.overrideAttrs (x: {
+    doCheck = false;
+    configureFlags = (x.configureFlags or [ ]) ++ [
+      "--without-shared"
+      "--disable-shared"
+    ];
+    dontDisableStatic = true;
+    enableSharedExecutables = false;
+    enableStatic = true;
+  });
+
+  self = with pkgs; buildGoModule {
+    name = "cri-o";
+    src = ./..;
+    vendorSha256 = null;
+    doCheck = false;
+    enableParallelBuilding = true;
+    outputs = [ "out" ];
+    nativeBuildInputs = with buildPackages; [
+      bash
+      gitMinimal
+      go-md2man
+      installShellFiles
+      makeWrapper
+      pkg-config
+      which
+    ];
+    buildInputs = [
+      glibc
+      glibc.static
+      gpgme
+      libassuan
+      libgpgerror
+      libseccomp
+      libapparmor
+      libselinux
+    ];
+    prePatch = ''
+      export CFLAGS='-static -pthread'
+      export LDFLAGS='-s -w -static-libgcc -static'
+      export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
+      export BUILDTAGS='static netgo osusergo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper seccomp apparmor selinux'
+      export CGO_ENABLED=1
+    '';
+    buildPhase = ''
+      patchShebangs .
+      make bin/crio
+      make bin/crio-status
+      make bin/pinns
+    '';
+    installPhase = ''
+      install -Dm755 bin/crio $out/bin/crio
+      install -Dm755 bin/crio-status $out/bin/crio-status
+      install -Dm755 bin/pinns $out/bin/pinns
+    '';
+  };
+in
+self

--- a/scripts/get
+++ b/scripts/get
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCH_AMD64=amd64
+ARCH_ARM64=arm64
+ARCH=
+VERSION=
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+
+usage() {
+    printf "Usage: %s [-a ARCH] [ -t TAG|SHA ] [ -h ]\n\n" "$(basename "$0")"
+    echo "Possible arguments:"
+    printf "  -a\tArchitecture to retrieve (defaults to the local system)\n"
+    printf "  -t\tVersion tag or full length SHA to be used (defaults to the latest available master)\n"
+    printf "  -h\tShow this help message\n"
+}
+
+parse_args() {
+    echo "Welcome to the CRI-O install script!"
+    echo "Export a GITHUB_TOKEN environment variable to avoid GitHub API rate limits"
+
+    while getopts 'a:t:h' OPTION; do
+        case "$OPTION" in
+        a)
+            ARCH="$OPTARG"
+            echo "Using architecture: $ARCH"
+            ;;
+        t)
+            VERSION="$OPTARG"
+            echo "Using version: $VERSION"
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        ?)
+            usage
+            exit 1
+            ;;
+        esac
+    done
+
+    if [[ $ARCH == "" ]]; then
+        LOCAL_ARCH=$(uname -m)
+        if [[ "$LOCAL_ARCH" == x86_64 ]]; then
+            ARCH=$ARCH_AMD64
+        elif [[ "$LOCAL_ARCH" == aarch64 ]]; then
+            ARCH=$ARCH_ARM64
+        else
+            echo "Unsupported local architecture: $LOCAL_ARCH"
+            exit 1
+        fi
+        echo "No architecture provided, using: $ARCH"
+    fi
+}
+
+verify_requirements() {
+    CMDS=(curl jq tar make)
+    echo "Checking if all commands are available: ${CMDS[*]}"
+    for CMD in "${CMDS[@]}"; do
+        if ! command -v "$CMD" >/dev/null; then
+            echo "Command $CMD not available but required"
+            exit 1
+        fi
+    done
+}
+
+latest_version() {
+    GH_API_URL="https://api.github.com/repos/cri-o/cri-o/actions/runs"
+    GH_QUERY="$GH_API_URL?event=push&status=success&branch=master"
+
+    GH_HEADERS=(-H "Accept: application/vnd.github.v3+json")
+    if [[ $GITHUB_TOKEN != "" ]]; then
+        GH_HEADERS+=(-H "Authorization: token $GITHUB_TOKEN")
+    fi
+
+    if [[ $VERSION == "" ]]; then
+        echo No version provided, finding latest successful GitHub actions run
+        VERSION=$(curl -sSfL "${GH_HEADERS[@]}" "$GH_QUERY" |
+            jq -r '.workflow_runs | map(select(.name == "test")) | first | .head_sha')
+
+        echo "Using latest successful GitHub action master: $VERSION"
+    fi
+}
+
+download_and_install() {
+    GCB_URL=https://storage.googleapis.com/k8s-conform-cri-o/artifacts
+    TARBALL_URL=$GCB_URL/cri-o.$ARCH.$VERSION.tar.gz
+
+    TMPDIR="$(mktemp -d)"
+    trap 'rm -rf -- "$TMPDIR"' EXIT
+
+    echo "Downloading $TARBALL_URL to $TMPDIR"
+    curl -sSfL "$TARBALL_URL" | tar xfz - --strip-components=1 -C "$TMPDIR"
+
+    echo Installing CRI-O
+    make -C "$TMPDIR"
+
+}
+
+main() {
+    parse_args "$@"
+    verify_requirements
+    latest_version
+    download_and_install
+}
+
+main "$@"

--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -91,7 +91,7 @@ func run() error {
 	defer func() { err = os.RemoveAll(templateFile.Name()) }()
 
 	// Check if we're on a tag and adapt variables if necessary
-	bundleVersion := head[:9]
+	bundleVersion := head
 	shortHead := head[:7]
 	endRev := head
 	if output, err := command.New(
@@ -110,10 +110,10 @@ The release notes have been generated for the commit range
 
 ## Downloads
 
-Download the static release bundle via our Google Cloud Bucket:
-[crio-%s.tar.gz][0]
+Download one of our static release bundles via our Google Cloud Bucket:
 
-[0]: https://storage.googleapis.com/k8s-conform-cri-o/artifacts/crio-%s.tar.gz
+- [cri-o.amd64.%s.tar.gz](https://storage.googleapis.com/k8s-conform-cri-o/artifacts/cri-o.amd64.%s.tar.gz)
+- [cri-o.arm64.%s.tar.gz](https://storage.googleapis.com/k8s-conform-cri-o/artifacts/cri-o.arm64.%s.tar.gz)
 
 ## Changelog since %s
 
@@ -135,6 +135,7 @@ Download the static release bundle via our Google Cloud Bucket:
 		startTag, shortHead,
 		startTag, endRev,
 		time.Now().Format(time.RFC1123),
+		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,
 		startTag,
 	)); err != nil {

--- a/scripts/upload-artifacts
+++ b/scripts/upload-artifacts
@@ -27,12 +27,13 @@ if TAG=$(git describe --exact-match --tags 2>/dev/null); then
             exit 1
         fi
         UPLOAD_URL=${UPLOAD_URL%"{?name,label}"}
-        FILE=build/bundle/crio-$TAG.tar.gz
-        curl -f \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Content-Type: $(file -b --mime-type "$FILE")" \
-            --data-binary @"$FILE" \
-            "$UPLOAD_URL?name=$(basename "$FILE")"
+        for FILE in build/bundle/*.tar.gz; do
+            curl -f \
+                -H "Authorization: token $GITHUB_TOKEN" \
+                -H "Content-Type: $(file -b --mime-type "$FILE")" \
+                --data-binary @"$FILE" \
+                "$UPLOAD_URL?name=$(basename "$FILE")"
+        done
     fi
 else
     echo "Skipping artifact upload to GitHub (not on a tag)"

--- a/scripts/versions
+++ b/scripts/versions
@@ -4,10 +4,10 @@ set -euo pipefail
 # Versions to be used
 declare -A VERSIONS=(
     ["cni-plugins"]=v0.8.7
-    ["conmon"]=v2.0.20
+    ["conmon"]=v2.0.26
     ["cri-tools"]=v1.19.0
     ["runc"]=v1.0.0-rc92
-    ["crun"]=0.15
+    ["crun"]=0.18
     ["bats"]=v1.2.1
 )
 export VERSIONS


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This adds a new derivation to build statically linked binaries for
arm64.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/4551
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added arm64 variant to static binary bundle. The bundle is now available via the URL
`https://storage.googleapis.com/k8s-conform-cri-o/artifacts/cri-o.$ARCH.$VERSION.tar.gz`,
where `$ARCH` can be `amd64` or `arm64` and `$VERSION` a tag or full length git SHA.
Beside that, we provide a new installation script
`curl https://raw.githubusercontent.com/cri-o/cri-o/master/scripts/get | bash`.
For this script, it is also possible to pass the architecture and version as arguments:
`get [amd64|arm64] [VERSION|SHA]`.
The static binary bundle now uses crun as default container runtime for CRI-O.
```
