### PR TITLE
Fix GitHub actions checkout permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,9 +232,13 @@ jobs:
       - run: make codecov
 
   release-notes:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -252,9 +256,13 @@ jobs:
           if-no-files-found: ignore
 
   dependencies:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -275,6 +283,9 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
Two fixes are part of this patch:

- Fixing the fetch depth to contain the full history of the repository.
  This allows to checkout branches like `gh-pages`.
- Adding the access token to the checkout to be able to make repository
  modifications within the CI.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to #4489 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
