### PR TITLE
persist shim sock path and use it for restore

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -27,4 +27,7 @@ const (
 
 	// OCISeccompBPFHookAnnotation is the annotation used by the OCI seccomp BPF hook for tracing container syscalls
 	OCISeccompBPFHookAnnotation = "io.containers.trace-syscall"
+
+	// ShimSocketPathAnnotation is a container state annotation created by vm runtime
+	ShimSocketPathAnnotation = "shim-sock-path.crio.io"
 )


### PR DESCRIPTION
This PR attempts to restore the containers properly with kata runtime after CRI-O reboot. currently for CRI-O service restart, the `containerd-shim-kata-v2` and `qemu-system-x86_64` processes are doubled for every container.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The shim sock path to be added in container state annotation and persist with its `state.json` and then use the sock path in the `updateContainerStatus `so that grpc client connection can be reestablished with running kata v2 shim server to query the container status. Otherwise restore fails for already running container and then CRI-O creates another sandbox and associated container.

#### Which issue(s) this PR fixes:
Fixes #2112
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
