### PR TITLE
[1.19] server: mount cgroup with rslave

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -565,7 +565,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 			Destination: "/sys",
 			Type:        "sysfs",
 			Source:      "sysfs",
-			Options:     []string{"nosuid", "noexec", "nodev", "rw"},
+			Options:     []string{"nosuid", "noexec", "nodev", "rw", "rslave"},
 		}
 		specgen.AddMount(sysMnt)
 
@@ -573,7 +573,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 			Destination: "/sys/fs/cgroup",
 			Type:        "cgroup",
 			Source:      "cgroup",
-			Options:     []string{"nosuid", "noexec", "nodev", "rw", "relatime"},
+			Options:     []string{"nosuid", "noexec", "nodev", "rw", "relatime", "rslave"},
 		}
 		specgen.AddMount(cgroupMnt)
 	}


### PR DESCRIPTION
This is a cherry-pick of #4575

```release-note
Fix running privileged systemd containers with bidirectional mounts
```

