### PR TITLE
[1.18] server: mount cgroup with rslave

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -690,7 +690,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 			Destination: "/sys",
 			Type:        "sysfs",
 			Source:      "sysfs",
-			Options:     []string{"nosuid", "noexec", "nodev", "rw"},
+			Options:     []string{"nosuid", "noexec", "nodev", "rw", "rslave"},
 		}
 		specgen.AddMount(sysMnt)
 
@@ -698,7 +698,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID, contai
 			Destination: "/sys/fs/cgroup",
 			Type:        "cgroup",
 			Source:      "cgroup",
-			Options:     []string{"nosuid", "noexec", "nodev", "rw", "relatime"},
+			Options:     []string{"nosuid", "noexec", "nodev", "rw", "relatime", "rslave"},
 		}
 		specgen.AddMount(cgroupMnt)
 	}


### PR DESCRIPTION
This is a cherry-pick of #4575

```release-note
Fix running privileged systemd containers with bidirectional mounts
```
