### PR TITLE
runtimeVM: Fix shimv2 binary name construction

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -476,4 +478,42 @@ type ExecSyncError struct {
 
 func (e *ExecSyncError) Error() string {
 	return fmt.Sprintf("command error: %+v, stdout: %s, stderr: %s, exit code %d", e.Err, e.Stdout.Bytes(), e.Stderr.Bytes(), e.ExitCode)
+}
+
+// BuildContainerdBinaryName() is responsible for ensuring the binary passed will
+// be properly converted to the containerd binary naming pattern.
+//
+// This method should never ever be called from anywhere else but the runtimeVM,
+// and the only reason its exported here is in order to get some test coverage.
+func BuildContainerdBinaryName(path string) string {
+	// containerd expects the runtime name to be in the following pattern:
+	//        ($dir.)?$prefix.$name.$version
+	//        -------- ------ ----- ---------
+	//              |     |     |      |
+	//              v     |     |      |
+	//      "/usr/local/bin"    |      |
+	//        (optional)  |     |      |
+	//                    v     |      |
+	//             "containerd.shim."  |
+	//                          |      |
+	//                          v      |
+	//                     "kata-qemu" |
+	//                                 v
+	//                                "v2"
+	const expectedPrefix = "containerd-shim-"
+	const expectedVersion = "-v2"
+
+	const binaryPrefix = "containerd.shim"
+	const binaryVersion = "v2"
+
+	runtimeDir := filepath.Dir(path)
+	// This is only safe to do because the runtime_path, for the VM runtime_type, is validated in the config,
+	// allowing us to take the liberty to simply go ahead and check, without having to ensure we're receiving
+	// the binary in the expected form.
+	//
+	// For clarity, it could be ensured twice, but we count on the developer to never ever call this function
+	// in a different context from the one used in the runtime_vm.go file.
+	runtimeName := strings.SplitAfter(strings.Split(filepath.Base(path), expectedVersion)[0], expectedPrefix)[1]
+
+	return filepath.Join(runtimeDir, fmt.Sprintf("%s.%s.%s", binaryPrefix, runtimeName, binaryVersion))
 }

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -40,7 +40,8 @@ var _ = t.Describe("Oci", func() {
 				RuntimePath: "/bin/sh",
 				RuntimeType: "",
 				RuntimeRoot: "/run/runc",
-			}, invalidRuntime: {},
+			},
+			invalidRuntime: {},
 			usernsRuntime: {
 				RuntimePath:        "/bin/sh",
 				RuntimeType:        "",

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -96,6 +96,26 @@ var _ = t.Describe("Oci", func() {
 			Expect(err).To(BeNil())
 			Expect(handler).To(Equal(runtimes[defaultRuntime]))
 		})
+
+		It("should return an OCI runtime type if none is set", func() {
+			// Given
+			// When
+			runtimeType, err := sut.RuntimeType(defaultRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(runtimeType).To(Equal(""))
+		})
+		It("should return a VM runtime type when it is set", func() {
+			// Given
+			// When
+			runtimeType, err := sut.RuntimeType(vmRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(runtimeType).To(Equal(config.RuntimeTypeVM))
+		})
+
 		It("AllowUsernsAnnotation should be true when set", func() {
 			// Given
 			// When

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -230,4 +230,26 @@ var _ = t.Describe("Oci", func() {
 			Expect(result).To(ContainSubstring("error"))
 		})
 	})
+
+	t.Describe("BuildContainerdBinaryName", func() {
+		It("Simple binary name (containerd-shim-kata-v2)", func() {
+			binaryName := oci.BuildContainerdBinaryName("containerd-shim-kata-v2")
+			Expect(binaryName).To(Equal("containerd.shim.kata.v2"))
+		})
+
+		It("Full binary path with a simple binary name (/usr/bin/containerd-shim-kata-v2)", func() {
+			binaryName := oci.BuildContainerdBinaryName("/usr/bin/containerd-shim-kata-v2")
+			Expect(binaryName).To(Equal("/usr/bin/containerd.shim.kata.v2"))
+		})
+
+		It("Composed binary name (containerd-shim-kata-qemu-with-dax-support-v2)", func() {
+			binaryName := oci.BuildContainerdBinaryName("containerd-shim-kata-qemu-with-dax-support-v2")
+			Expect(binaryName).To(Equal("containerd.shim.kata-qemu-with-dax-support.v2"))
+		})
+
+		It("Full binary path with a composed binary name (/usr/bin/containerd-shim-kata-v2)", func() {
+			binaryName := oci.BuildContainerdBinaryName("/usr/bin/containerd-shim-kata-qemu-with-dax-support-v2")
+			Expect(binaryName).To(Equal("/usr/bin/containerd.shim.kata-qemu-with-dax-support.v2"))
+		})
+	})
 })

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -34,6 +34,7 @@ var _ = t.Describe("Oci", func() {
 			defaultRuntime     = "runc"
 			usernsRuntime      = "userns"
 			performanceRuntime = "high-performance"
+			vmRuntime          = "kata"
 		)
 		runtimes := config.Runtimes{
 			defaultRuntime: {
@@ -58,6 +59,12 @@ var _ = t.Describe("Oci", func() {
 					annotations.CPUQuotaAnnotation,
 					annotations.OCISeccompBPFHookAnnotation,
 				},
+			},
+			vmRuntime: {
+				RuntimePath:                  "/usr/bin/containerd-shim-kata-v2",
+				RuntimeType:                  "vm",
+				RuntimeRoot:                  "/run/vc",
+				PrivilegedWithoutHostDevices: true,
 			},
 		}
 
@@ -160,6 +167,34 @@ var _ = t.Describe("Oci", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 			Expect(allowed).To(Equal(false))
+		})
+
+		It("PrivilegedWithoutHostDevices should be true when set", func() {
+			// Given
+			// When
+			privileged, err := sut.PrivilegedWithoutHostDevices(vmRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(privileged).To(Equal(true))
+		})
+		It("PrivilegedWithoutHostDevices should be false when runtime invalid", func() {
+			// Given
+			// When
+			privileged, err := sut.PrivilegedWithoutHostDevices(invalidRuntime)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(privileged).To(Equal(false))
+		})
+		It("PrivilegedWithoutHostDevices should be false when runtime is the default", func() {
+			// Given
+			// When
+			privileged, err := sut.PrivilegedWithoutHostDevices(defaultRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(privileged).To(Equal(false))
 		})
 	})
 

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -189,7 +189,7 @@ func (r *runtimeVM) startRuntimeDaemon(ctx context.Context, c *Container) error 
 	args = append(args, "start")
 
 	// Modify the runtime path so that it complies with v2 shim API
-	newRuntimePath := strings.ReplaceAll(r.path, "-", ".")
+	newRuntimePath := BuildContainerdBinaryName(r.path)
 
 	ctx = namespaces.WithNamespace(ctx, namespaces.Default)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -39,14 +40,15 @@ import (
 
 // Defaults if none are specified
 const (
-	defaultRuntime        = "runc"
-	DefaultRuntimeType    = "oci"
-	DefaultRuntimeRoot    = "/run/runc"
-	defaultGRPCMaxMsgSize = 16 * 1024 * 1024
-	OCIBufSize            = 8192
-	RuntimeTypeVM         = "vm"
-	defaultCtrStopTimeout = 30 // seconds
-	defaultNamespacesDir  = "/var/run"
+	defaultRuntime             = "runc"
+	DefaultRuntimeType         = "oci"
+	DefaultRuntimeRoot         = "/run/runc"
+	defaultGRPCMaxMsgSize      = 16 * 1024 * 1024
+	OCIBufSize                 = 8192
+	RuntimeTypeVM              = "vm"
+	defaultCtrStopTimeout      = 30 // seconds
+	defaultNamespacesDir       = "/var/run"
+	RuntimeTypeVMBinaryPattern = "containerd-shim-([a-zA-Z0-9\\-\\+])+-v2"
 )
 
 // Config represents the entire set of configuration values that can be set for
@@ -1036,6 +1038,21 @@ func (r *RuntimeHandler) Validate(name string) error {
 	return r.ValidateRuntimeType(name)
 }
 
+func (r *RuntimeHandler) ValidateRuntimeVMBinaryPattern() bool {
+	if r.RuntimeType != RuntimeTypeVM {
+		return true
+	}
+
+	binaryName := filepath.Base(r.RuntimePath)
+
+	matched, err := regexp.MatchString(RuntimeTypeVMBinaryPattern, binaryName)
+	if err != nil {
+		return false
+	}
+
+	return matched
+}
+
 // ValidateRuntimePath checks if the `RuntimePath` is either set or available
 // within the $PATH environment. The method fails on any `RuntimePath` lookup
 // error.
@@ -1051,6 +1068,13 @@ func (r *RuntimeHandler) ValidateRuntimePath(name string) error {
 		return fmt.Errorf("invalid runtime_path for runtime '%s': %q",
 			name, err)
 	}
+
+	ok := r.ValidateRuntimeVMBinaryPattern()
+	if !ok {
+		return fmt.Errorf("invalid runtime_path for runtime '%s': containerd binary naming pattern is not followed",
+			name)
+	}
+
 	logrus.Debugf(
 		"Found valid runtime %q for runtime_path %q", name, r.RuntimePath,
 	)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -944,4 +944,32 @@ var _ = t.Describe("Config", func() {
 			Expect(err).To(BeNil())
 		})
 	})
+
+	t.Describe("ValidateRuntimeVMBinaryPattern", func() {
+		It("should succeed when using RuntimeTypeVM and runtime_path follows the containerd pattern", func() {
+			// Given
+			sut.Runtimes["kata"] = &config.RuntimeHandler{
+				RuntimePath: "containerd-shim-kata-qemu-v2", RuntimeType: config.RuntimeTypeVM,
+			}
+
+			// When
+			ok := sut.Runtimes["kata"].ValidateRuntimeVMBinaryPattern()
+
+			// Then
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should fail when using RuntimeTypeVM and runtime_path does not follow the containerd pattern", func() {
+			// Given
+			sut.Runtimes["kata"] = &config.RuntimeHandler{
+				RuntimePath: "kata-runtime", RuntimeType: config.RuntimeTypeVM,
+			}
+
+			// When
+			ok := sut.Runtimes["kata"].ValidateRuntimeVMBinaryPattern()
+
+			// Then
+			Expect(ok).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:

shim v2 expected the runtime name to be in the following format:
```
    ($dir.)?$prefix.$name.$version
    -------- ------ ----- ---------
        |     |     |      |
        v     |     |      |
"/usr/local/bin"    |      |
  (optional)  |     |      |
              v     |      |
       "containerd.shim."  |
                    |      |
                    v      |
               "kata-qemu" |
                           v
                          "v2"
```

The current code simply replaces all the "-" by ".", which ends up
working well as long as the $name doesn't have a "-" in it, which is, by
luck, what's done by the Kata Operator.  However, whenever a name has
"-" in it, which we can see happening on upstream kata-deploy - which
uses $name as kata-qemu, for instance - it'll simply make containerd
library confused, not being able to invoke the binary.

With everything said above in mind, let's introduce a specialized
function to build the shim v2 path.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes: #4589

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
