### PR TITLE
oci: don't wait too long on a long stop

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -462,6 +462,9 @@ func (c *Container) pid() (int, error) {
 	if err := c.verifyPid(); err != nil {
 		return 0, err
 	}
+	if err := unix.Kill(c.state.InitPid, 0); err == unix.ESRCH {
+		return 0, errors.Wrapf(err, "check whether %d is running", c.state.InitPid)
+	}
 	return c.state.InitPid, nil
 }
 

--- a/internal/oci/oci_unix.go
+++ b/internal/oci/oci_unix.go
@@ -17,7 +17,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
-func kill(pid int) error {
+func Kill(pid int) error {
 	err := unix.Kill(pid, unix.SIGKILL)
 	if err != nil && err != unix.ESRCH {
 		return fmt.Errorf("failed to kill process: %v", err)

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -647,6 +647,11 @@ func WaitContainerStop(ctx context.Context, c *Container, timeout time.Duration,
 			// interrupt the old one, and start a new one
 			newTargetTime := time.Now().Add(newTimeout)
 
+			// but only if it's earlier
+			if !newTargetTime.Before(targetTime) {
+				continue
+			}
+
 			targetTime = newTargetTime
 			timeout = newTimeout
 		}

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -643,12 +643,6 @@ func WaitContainerStop(ctx context.Context, c *Container, timeout time.Duration,
 			}
 			killed = true
 		case newTimeout := <-c.stopTimeoutChan:
-			// If we're already at the "killing" step,
-			// we should use the killingContainerTimeout,
-			// and not override.
-			if !ignoreKill {
-				continue
-			}
 			// If a new timeout comes in,
 			// interrupt the old one, and start a new one
 			newTargetTime := time.Now().Add(newTimeout)

--- a/internal/oci/runtime_oci_test.go
+++ b/internal/oci/runtime_oci_test.go
@@ -1,0 +1,185 @@
+package oci_test
+
+import (
+	"context"
+	"math/rand"
+	"os/exec"
+	"time"
+
+	"github.com/cri-o/cri-o/internal/oci"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+const (
+	shortTimeout  int64 = 1
+	mediumTimeout int64 = 3
+	longTimeout   int64 = 15
+)
+
+// The actual test suite
+var _ = t.Describe("Oci", func() {
+	Context("ContainerStop", func() {
+		var (
+			sut          *oci.Container
+			sleepProcess *exec.Cmd
+		)
+
+		BeforeEach(func() {
+			sleepProcess = exec.Command("sleep", "100000")
+			Expect(sleepProcess.Start()).To(BeNil())
+
+			Expect(sleepProcess.Process.Pid).NotTo(Equal(0))
+
+			sut = getTestContainer()
+			state := &oci.ContainerState{}
+			state.Pid = sleepProcess.Process.Pid
+			Expect(state.SetInitPid(sleepProcess.Process.Pid)).To(BeNil())
+			sut.SetState(state)
+		})
+		AfterEach(func() {
+			// nolint:errcheck
+			oci.Kill(sleepProcess.Process.Pid)
+			// make sure the entry in the process table is cleaned up
+			// nolint:errcheck
+			sleepProcess.Wait()
+		})
+		tests := []struct {
+			ignoreKill             bool
+			verifyCorrectlyStopped func(*oci.Container, *exec.Cmd, error)
+			name                   string
+		}{
+			{
+				ignoreKill:             true,
+				verifyCorrectlyStopped: verifyContainerNotStopped,
+				name:                   "ignoring kill",
+			},
+			{
+				ignoreKill:             false,
+				verifyCorrectlyStopped: verifyContainerStopped,
+				name:                   "not ignoring kill",
+			},
+		}
+		for _, test := range tests {
+			test := test
+			It("should stop container after timeout if "+test.name, func() {
+				// Given
+				sut.SetAsStopping(shortTimeout)
+
+				// When
+				err := oci.WaitContainerStop(context.Background(), sut, inSeconds(shortTimeout), test.ignoreKill)
+
+				// Then
+				test.verifyCorrectlyStopped(sut, sleepProcess, err)
+			})
+			It("should interrupt longer stop timeout if "+test.name, func() {
+				// Given
+				stoppedChan := make(chan error, 1)
+				sut.SetAsStopping(longTimeout)
+				go waitContainerStopAndFailAfterTimeout(context.Background(), stoppedChan, sut, longTimeout, longTimeout, test.ignoreKill)
+
+				// When
+				sut.SetAsStopping(shortTimeout)
+
+				// Then
+				test.verifyCorrectlyStopped(sut, sleepProcess, <-stoppedChan)
+			})
+			It("should handle being killed mid-timeout if "+test.name, func() {
+				// Given
+				stoppedChan := make(chan error, 1)
+				sut.SetAsStopping(longTimeout)
+				go waitContainerStopAndFailAfterTimeout(context.Background(), stoppedChan, sut, longTimeout, mediumTimeout, test.ignoreKill)
+
+				// When
+				// nolint:errcheck
+				oci.Kill(sleepProcess.Process.Pid)
+				waitForKillToComplete(sleepProcess)
+
+				// Then
+				// unconditionally expect the container was stopped
+				verifyContainerStopped(sut, sleepProcess, <-stoppedChan)
+			})
+			It("should handle context timeout if "+test.name, func() {
+				// Given
+				ctx, cancel := context.WithCancel(context.Background())
+				stoppedChan := make(chan error, 1)
+				sut.SetAsStopping(longTimeout)
+				go waitContainerStopAndFailAfterTimeout(ctx, stoppedChan, sut, longTimeout, mediumTimeout, test.ignoreKill)
+
+				// When
+				cancel()
+
+				// Then
+				// unconditionally expect the container was not stopped
+				verifyContainerNotStopped(sut, sleepProcess, <-stoppedChan)
+			})
+			It("should not update time if chronologically after if "+test.name, func() {
+				// Given
+				stoppedChan := make(chan error, 1)
+				sut.SetAsStopping(mediumTimeout)
+				go waitContainerStopAndFailAfterTimeout(context.Background(), stoppedChan, sut, mediumTimeout, mediumTimeout, test.ignoreKill)
+
+				// When
+				sut.SetAsStopping(longTimeout)
+
+				// Then
+				test.verifyCorrectlyStopped(sut, sleepProcess, <-stoppedChan)
+			})
+			It("should handle many updates if "+test.name, func() {
+				// Given
+				stoppedChan := make(chan error, 1)
+				sut.SetAsStopping(longTimeout)
+				go waitContainerStopAndFailAfterTimeout(context.Background(), stoppedChan, sut, longTimeout, longTimeout, test.ignoreKill)
+
+				// When
+				for i := 0; i < 5; i++ {
+					go sut.SetAsStopping(int64(rand.Intn(10)))
+				}
+
+				// Then
+				test.verifyCorrectlyStopped(sut, sleepProcess, <-stoppedChan)
+			})
+		}
+	})
+})
+
+func waitContainerStopAndFailAfterTimeout(ctx context.Context,
+	stoppedChan chan error,
+	sut *oci.Container,
+	waitContainerStopTimeout int64,
+	failAfterTimeout int64,
+	ignoreKill bool) {
+	select {
+	case stoppedChan <- oci.WaitContainerStop(ctx, sut, inSeconds(waitContainerStopTimeout), ignoreKill):
+	case <-time.After(inSeconds(failAfterTimeout)):
+		stoppedChan <- errors.Errorf("%d seconds passed, container kill should have been recognized", failAfterTimeout)
+	}
+	close(stoppedChan)
+}
+
+func verifyContainerStopped(sut *oci.Container, sleepProcess *exec.Cmd, waitError error) {
+	Expect(waitError).To(BeNil())
+	waitForKillToComplete(sleepProcess)
+	pid, err := sut.Pid()
+	Expect(pid).To(Equal(0))
+	Expect(err).NotTo(BeNil())
+}
+
+func waitForKillToComplete(sleepProcess *exec.Cmd) {
+	Expect(sleepProcess.Wait()).NotTo(BeNil())
+	// this fixes a race with the kernel cleaning up the /proc entry
+	// even adding a Kill() in the call to Pid() doesn't fix
+	time.Sleep(inSeconds(shortTimeout))
+}
+
+func verifyContainerNotStopped(sut *oci.Container, _ *exec.Cmd, waitError error) {
+	Expect(waitError).NotTo(BeNil())
+	pid, err := sut.Pid()
+	Expect(pid).NotTo(Equal(0))
+	Expect(err).To(BeNil())
+}
+
+func inSeconds(d int64) time.Duration {
+	return time.Duration(d) * time.Second
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
oci: don't wait too long on a long stop

if a long stop timeout comes in, and a shorter one comes in after
we never interrupt the old one. This can cause the new container stop to be DOSed

instead, interrupt the old stop, so the new one can proceed as expected

This PR is https://github.com/cri-o/cri-o/pull/4548 plus a couple of usability tweaks and unit tests


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
