### PR TITLE
Updates yq commnands for yq v4

### DIFF
--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -46,8 +46,8 @@ if [ ! $(which kubeadm) ]; then
 fi                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                               
 kubeadm config print init-defaults --component-configs=KubeletConfiguration > "$KUBEADM_CONFIG"                                                                                                                                                      
-yq w -i "$KUBEADM_CONFIG" nodeRegistration.criSocket unix:///var/run/crio/crio.sock                                                                                                                                                                  
-yq w -i --doc 2 "$KUBEADM_CONFIG" cgroupDriver systemd
+yq -i eval 'select(.nodeRegistration.criSocket) |= .nodeRegistration.criSocket = "unix:///var/run/crio/crio.sock"' "$KUBEADM_CONFIG"
+yq -i eval 'select(di == 1) |= .cgroupDriver = "systemd"' "$KUBEADM_CONFIG"
 ```
 
 This will create a kubeadm configuration file that kubeadm will use to configure the Kubelet to be able to communicate with CRI-O.


### PR DESCRIPTION

The `yq` command in the script is no longer valid with `yq` v4 which is backwards incompatible with v3. This change updates the script to work with `yq` v4

#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:

Updates script to run with new v4 version of `yq`

#### Which issue(s) this PR fixes:

Fixes #4599

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
none

```
