### PR TITLE
Fix GitHub actions workflow syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,7 +232,7 @@ jobs:
       - run: make codecov
 
   release-notes:
-    if: github.ref == 'refs/heads/master' || contains(github.ref, "refs/heads/release")
+    if: github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The current CI is broken because GitHub reports that the workflow is invalid:
https://github.com/cri-o/cri-o/actions/runs/600281951
```
The workflow is not valid.
.github/workflows/test.yml (Line: 235, Col: 9): Unexpected symbol: '"refs/heads/release"'.
Located at position 59 within expression: github.ref == 'refs/heads/master' || contains(github.ref, "refs/heads/release")
```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Follow-up of https://github.com/cri-o/cri-o/pull/4601
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
