### PR TITLE
Fix `get` script commit SHA retrieval

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -67,7 +67,6 @@ verify_requirements() {
 
 latest_version() {
     GH_API_URL="https://api.github.com/repos/cri-o/cri-o/actions/runs"
-    GH_QUERY="$GH_API_URL?event=push&status=success&branch=master"
 
     GH_HEADERS=(-H "Accept: application/vnd.github.v3+json")
     if [[ $GITHUB_TOKEN != "" ]]; then
@@ -76,8 +75,8 @@ latest_version() {
 
     if [[ $VERSION == "" ]]; then
         echo No version provided, finding latest successful GitHub actions run
-        VERSION=$(curl -sSfL "${GH_HEADERS[@]}" "$GH_QUERY" |
-            jq -r '.workflow_runs | map(select(.name == "test")) | first | .head_sha')
+        VERSION=$(curl -sSfL "${GH_HEADERS[@]}" "$GH_API_URL" |
+            jq -r '.workflow_runs | map(select(.name == "test" and .head_branch == "master" and .conclusion == "success")) | first | .head_sha')
 
         echo "Using latest successful GitHub action master: $VERSION"
     fi


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The parameter query does not seem to be correct so we now rely on plain
extraction via `jq`. This seems more robust and future proof.


#### Which issue(s) this PR fixes:
Fixes https://github.com/cri-o/cri-o/issues/4608
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
