### PR TITLE
inspect: use first container when reporting pid of a pod with no infra

### DIFF
--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -95,3 +95,8 @@ func (*CgroupfsManager) MoveConmonToCgroup(cid, cgroupParent, conmonCgroup strin
 	}
 	return cgroupPath, nil
 }
+
+// CreateSandboxCgroup calls the helper function createSandboxCgroup for this manager.
+func (m *CgroupfsManager) CreateSandboxCgroup(sbParent, containerID string) error {
+	return createSandboxCgroup(sbParent, containerID, m)
+}

--- a/internal/config/cgmgr/systemd.go
+++ b/internal/config/cgmgr/systemd.go
@@ -125,3 +125,8 @@ func convertCgroupFsNameToSystemd(cgroupfsName string) string {
 	// per systemd convention.
 	return path.Base(cgroupfsName)
 }
+
+// CreateSandboxCgroup calls the helper function createSandboxCgroup for this manager.
+func (m *SystemdManager) CreateSandboxCgroup(sbParent, containerID string) error {
+	return createSandboxCgroup(sbParent, containerID, m)
+}

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -295,7 +295,7 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (retErr er
 			}
 		}
 	} else {
-		scontainer = oci.NewSpoofedContainer(cID, cname, labels, created, sandboxPath)
+		scontainer = oci.NewSpoofedContainer(cID, cname, labels, id, created, sandboxPath)
 	}
 
 	if err := c.ContainerStateFromDisk(ctx, scontainer); err != nil {

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -142,7 +142,7 @@ func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations,
 	return c, nil
 }
 
-func NewSpoofedContainer(id, name string, labels map[string]string, created time.Time, dir string) *Container {
+func NewSpoofedContainer(id, name string, labels map[string]string, sandbox string, created time.Time, dir string) *Container {
 	state := &ContainerState{}
 	state.Created = created
 	state.Started = created
@@ -153,6 +153,7 @@ func NewSpoofedContainer(id, name string, labels map[string]string, created time
 		spoofed: true,
 		state:   state,
 		dir:     dir,
+		sandbox: sandbox,
 	}
 	c.annotations = map[string]string{
 		ann.SpoofedContainer: "true",

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -495,7 +495,7 @@ var _ = t.Describe("Container", func() {
 
 var _ = t.Describe("SpoofedContainer", func() {
 	It("should succeed to get the container fields", func() {
-		sut := oci.NewSpoofedContainer("id", "name", map[string]string{"key": "label"}, time.Now(), "dir")
+		sut := oci.NewSpoofedContainer("id", "name", map[string]string{"key": "label"}, "sbox", time.Now(), "dir")
 		// Given
 		// When
 		// Then
@@ -507,5 +507,6 @@ var _ = t.Describe("SpoofedContainer", func() {
 		Expect(sut.CreatedAt().UnixNano()).
 			To(BeNumerically("<", time.Now().UnixNano()))
 		Expect(sut.Dir()).To(Equal("dir"))
+		Expect(sut.Sandbox()).To(Equal("sbox"))
 	})
 })

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -874,7 +874,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		container.SetSpec(g.Config)
 	} else {
 		log.Debugf(ctx, "dropping infra container for pod %s", sbox.ID())
-		container = oci.NewSpoofedContainer(sbox.ID(), containerName, labels, created, podContainer.RunDir)
+		container = oci.NewSpoofedContainer(sbox.ID(), containerName, labels, sbox.ID(), created, podContainer.RunDir)
 		g.AddAnnotation(ann.SpoofedContainer, "true")
 	}
 	// needed for getSandboxIDMappings()

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -876,6 +876,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		log.Debugf(ctx, "dropping infra container for pod %s", sbox.ID())
 		container = oci.NewSpoofedContainer(sbox.ID(), containerName, labels, sbox.ID(), created, podContainer.RunDir)
 		g.AddAnnotation(ann.SpoofedContainer, "true")
+		if err := s.config.CgroupManager().CreateSandboxCgroup(cgroupParent, sbox.ID()); err != nil {
+			return nil, errors.Wrapf(err, "create dropped infra %s cgroup", sbox.ID())
+		}
 	}
 	// needed for getSandboxIDMappings()
 	container.SetIDMappings(sandboxIDMappings)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
.. that's a mouthful!

When we drop the infra container, there's no PID associated with the pod. This is fine, unless cAdvisor is trying to find the network stats for the pod, as it uses the PID to parse `/proc/$pid/net/dev`, and skips for a PID that is 0.

Luckily, containers in the pod share the pod's network namespace. We can find the first running container in the pod, return that PID, and cAdvisor will parse the correct dev file
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When dropping the infra container, the container inspect endpoint now returns a PID when requesting the infra container. 
```
