### PR TITLE
Add integration test for started/finished container time

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -98,13 +98,32 @@ function wait_until_exit() {
 	[ -n "$output" ]
 	echo "$output" | jq -e ".info.privileged == false"
 
+	YEAR=$(date +"%Y")
+	CREATED=$(echo "$output" | jq -re '.status.createdAt')
+	echo "$output" | jq -e '.status.createdAt | startswith("'"$YEAR"'")'
+
+	echo "$output" | jq -e '.status.startedAt | startswith("'"$YEAR"'") | not'
+	echo "$output" | jq -e '.status.finishedAt | startswith("'"$YEAR"'") | not'
+
 	crictl start "$ctr_id"
-	crictl inspect "$ctr_id"
+	output=$(crictl inspect "$ctr_id")
+	[[ "$CREATED" == $(echo "$output" | jq -re '.status.createdAt') ]]
+
+	STARTED=$(echo "$output" | jq -re '.status.startedAt')
+	echo "$output" | jq -e '.status.startedAt | startswith("'"$YEAR"'")'
+
+	echo "$output" | jq -e '.status.finishedAt | startswith("'"$YEAR"'") | not'
+
 	output=$(crictl ps --quiet --state running)
 	[[ "$output" == "$ctr_id" ]]
 
 	crictl stop "$ctr_id"
-	crictl inspect "$ctr_id"
+	output=$(crictl inspect "$ctr_id")
+
+	[[ "$CREATED" == $(echo "$output" | jq -re '.status.createdAt') ]]
+	[[ "$STARTED" == $(echo "$output" | jq -re '.status.startedAt') ]]
+	echo "$output" | jq -e '.status.finishedAt | startswith("'"$YEAR"'")'
+
 	output=$(crictl ps --quiet --state exited)
 	[[ "$output" == "$ctr_id" ]]
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This adds an integration test to verify the container start/finished time.
#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?


```release-note
None
```
