### PR TITLE
fix: Don't set `image-endpoint` in crictl config

### DIFF
--- a/crictl.yaml
+++ b/crictl.yaml
@@ -1,4 +1,3 @@
 runtime-endpoint: "unix:///var/run/crio/crio.sock"
-image-endpoint: "unix:///var/run/crio/crio.sock"
 timeout: 0
 debug: false


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

This change removes the `image-endpoint:` line from the `crictl.yaml`
file in this repository which gets bundled into the cri-o RPMs. Doing so
ensures that as long as cri-o uses the same path for the runtime and
image RPC endpoints, a user can do the naive thing and execute
`crictl --runtime-endpoint /somewhere/else [command]`, assuming thatthe
path to the alternate runtime's RPC will be used as the image endpoint
for that command too.

#### Which issue(s) this PR fixes:

Fixes #4607

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
