### PR TITLE
seccomp: Avoid strict profile checks when seccomp is disabled

### DIFF
--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -194,11 +194,6 @@ func (c *Config) setupFromField(
 	log.Debugf(ctx, "Setup seccomp from profile field: %+v", profileField)
 
 	if c.IsDisabled() {
-		if profileField.ProfileType != types.SecurityProfileTypeUnconfined {
-			return errors.Errorf(
-				"seccomp is not enabled, cannot run with a profile",
-			)
-		}
 		log.Warnf(ctx, "seccomp is not enabled, running without profile")
 		specGenerator.Config.Linux.Seccomp = nil
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

When seccomp is disabled (either via buildtag, or globabally in the
system), there's no point to error out if a profile that's being set up
is not the "Unconfinded" one.

By enforcing the check, we cause regressions on Kata Containers, which
are not able to start their pods up, as shown below
```
Events:
  Type     Reason                  Age                From               Message
  ----     ------                  ----               ----               -------
  Normal   Scheduled               44s                default-scheduler  Successfully assigned default/fedora to localhost
  Warning  FailedCreatePodSandBox  14s (x3 over 43s)  kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = setup seccomp: from field: seccomp is not enabled, cannot run with a profile
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #4627

#### Special notes for your reviewer:
I'm afraid this will break the tests and I wonder whether we could add a method to force seccomp to be disabled / enabled in the system, during the unit tests.  As it seems we can explicitly set  `c.enabled` in the unit tests, the tests may (or may not) fail on depending on the machine they're running (I can see some unit tests failures on my machine, using current git).

#### Does this PR introduce a user-facing change?

```release-note
None
```
