### PR TITLE
config: Don't fail if the non default runtime doesn't pass validation

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -459,15 +459,28 @@ var _ = t.Describe("Config", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should fail if executable not in $PATH", func() {
+		It("should fail if default executable not in $PATH", func() {
 			// Given
 			sut.Runtimes[invalidPath] = &config.RuntimeHandler{RuntimePath: ""}
+			sut.DefaultRuntime = invalidPath
 
 			// When
 			err := sut.RuntimeConfig.ValidateRuntimes()
 
 			// Then
 			Expect(err).NotTo(BeNil())
+		})
+
+		It("should not fail if non-default executable not in $PATH", func() {
+			// Given
+			sut.Runtimes[invalidPath] = &config.RuntimeHandler{RuntimePath: ""}
+			sut.DefaultRuntime = "runc"
+
+			// When
+			err := sut.RuntimeConfig.ValidateRuntimes()
+
+			// Then
+			Expect(err).To(BeNil())
 		})
 
 		It("should fail with wrong but set runtime_path", func() {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

CRI-O is too strict by simply not starting up in case a **non** default runtime is misconfigured.

#### Which issue(s) this PR fixes:

Fixes: #4621

#### Special notes for your reviewer:

I need to get to writing tests to it, but I wasn't successful on a  quick try. :-/

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Instead of failing to start, CRI-O now only prints a warning and ignores the runtime, in case a **non** default runtime is misconfigured.
```
