### PR TITLE
add libbtrfs-dev to unit tests

### DIFF
--- a/scripts/github-actions-packages
+++ b/scripts/github-actions-packages
@@ -6,6 +6,7 @@ sudo apt install -y \
     conntrack \
     libaio-dev \
     libapparmor-dev \
+    libbtrfs-dev \
     libcap-dev \
     libdevmapper-dev \
     libfuse-dev \


### PR DESCRIPTION
Fix unit tests by adding libbtrfs-dev to be installed.

Signed-off-by: Ryan Phillips <rphillips@redhat.com>

#### What type of PR is this?
/kind ci

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```