### PR TITLE
Add GitHub API pages support to `get` script

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -66,7 +66,7 @@ verify_requirements() {
 }
 
 latest_version() {
-    GH_API_URL="https://api.github.com/repos/cri-o/cri-o/actions/runs"
+    GH_API_URL="https://api.github.com/repos/cri-o/cri-o/actions/runs?per_page=100"
 
     GH_HEADERS=(-H "Accept: application/vnd.github.v3+json")
     if [[ $GITHUB_TOKEN != "" ]]; then
@@ -75,10 +75,36 @@ latest_version() {
 
     if [[ $VERSION == "" ]]; then
         echo No version provided, finding latest successful GitHub actions run
-        VERSION=$(curl -sSfL "${GH_HEADERS[@]}" "$GH_API_URL" |
-            jq -r '.workflow_runs | map(select(.name == "test" and .head_branch == "master" and .conclusion == "success")) | first | .head_sha')
 
-        echo "Using latest successful GitHub action master: $VERSION"
+        PAGE=0
+        while true; do
+            PAGE=$((PAGE + 1))
+            echo Searching GitHub actions page $PAGE
+
+            URL="${GH_API_URL}&page=$PAGE"
+            JSON=$(curl -sSfL "${GH_HEADERS[@]}" "$URL")
+
+            if echo "$JSON" | jq -e '.workflow_runs | length == 0' >/dev/null; then
+                echo No more GitHub action runs available to search
+                exit 1
+            fi
+
+            FOUND=$(echo "$JSON" |
+                jq -r '.workflow_runs | map(select(.name == "test" and .head_branch == "master" and .conclusion == "success")) | first | .head_sha')
+
+            if [[ $FOUND == null ]]; then
+                continue
+            fi
+
+            VERSION=$FOUND
+            echo "Using latest successful GitHub action master: $VERSION"
+            break
+        done
+
+        if [[ $VERSION == "" ]]; then
+            echo "Unable to find successful GitHub action"
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
It may be possible that we do not find a result on the first page. This
means we do now add paging support to the search for a successful GitHub
actions run.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
