### PR TITLE
Use and publish version marker for CRI-O

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -6,6 +6,7 @@ ARCH_ARM64=arm64
 ARCH=
 VERSION=
 GITHUB_TOKEN=${GITHUB_TOKEN:-}
+GCB_URL=https://storage.googleapis.com/k8s-conform-cri-o
 
 usage() {
     printf "Usage: %s [-a ARCH] [ -t TAG|SHA ] [ -h ]\n\n" "$(basename "$0")"
@@ -17,7 +18,6 @@ usage() {
 
 parse_args() {
     echo "Welcome to the CRI-O install script!"
-    echo "Export a GITHUB_TOKEN environment variable to avoid GitHub API rate limits"
 
     while getopts 'a:t:h' OPTION; do
         case "$OPTION" in
@@ -74,15 +74,23 @@ latest_version() {
     fi
 
     if [[ $VERSION == "" ]]; then
-        echo No version provided, finding latest successful GitHub actions run
+        echo Searching for latest version via marker file
+        COMMIT=$(curl -sSfL --retry 5 --retry-delay 3 "$GCB_URL/latest-master.txt")
+        if [[ "$COMMIT" != "" ]]; then
+            VERSION=$COMMIT
+            echo "Found latest version $VERSION"
+            return
+        fi
 
+        echo No version marker found, trying latest successful GitHub actions run
+        echo Export a GITHUB_TOKEN environment variable to avoid GitHub API rate limits
         PAGE=0
         while true; do
             PAGE=$((PAGE + 1))
             echo Searching GitHub actions page $PAGE
 
             URL="${GH_API_URL}&page=$PAGE"
-            JSON=$(curl -sSfL "${GH_HEADERS[@]}" "$URL")
+            JSON=$(curl -sSfL --retry 5 --retry-delay 3 "${GH_HEADERS[@]}" "$URL")
 
             if echo "$JSON" | jq -e '.workflow_runs | length == 0' >/dev/null; then
                 echo No more GitHub action runs available to search
@@ -116,14 +124,13 @@ prepare() {
 
 prepare "$@"
 
-GCB_URL=https://storage.googleapis.com/k8s-conform-cri-o/artifacts
-TARBALL_URL=$GCB_URL/cri-o.$ARCH.$VERSION.tar.gz
+TARBALL_URL=$GCB_URL/artifacts/cri-o.$ARCH.$VERSION.tar.gz
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf -- "$TMPDIR"' EXIT
 
 echo "Downloading $TARBALL_URL to $TMPDIR"
-curl -sSfL "$TARBALL_URL" | tar xfz - --strip-components=1 -C "$TMPDIR"
+curl -sSfL --retry 5 --retry-delay 3 "$TARBALL_URL" | tar xfz - --strip-components=1 -C "$TMPDIR"
 
 echo Installing CRI-O
 pushd "$TMPDIR"

--- a/scripts/upload-artifacts
+++ b/scripts/upload-artifacts
@@ -13,6 +13,11 @@ else
 
     BUCKET=gs://k8s-conform-cri-o
     gsutil cp -n build/bundle/*.tar.gz $BUCKET/artifacts
+
+    # update the latest version marker file
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    git rev-parse HEAD >"latest-$BRANCH.txt"
+    gsutil cp "latest-$BRANCH.txt" $BUCKET
 fi
 
 if TAG=$(git describe --exact-match --tags 2>/dev/null); then


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This allows us to not rely on the GitHub API any more when querying the
latest master version bundle for CRI-O. We still use the GitHub API
approach as fallback, which should make the `get` script more fail-safe.

The version marker gets updated for each branch (master and release branches) within a file like this:
https://console.cloud.google.com/storage/browser/_details/k8s-conform-cri-o/latest-master.txt


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
