### PR TITLE
do not create & store context in runtime vm

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -262,7 +262,7 @@ func main() {
 		notifySystem()
 
 		go func() {
-			crioServer.StartExitMonitor()
+			crioServer.StartExitMonitor(ctx)
 		}()
 		hookSync := make(chan error, 2)
 		if crioServer.ContainerServer.Hooks == nil {

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -165,7 +165,7 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(testManifest)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -181,7 +181,7 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(manifest)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -197,7 +197,7 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(manifest)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -208,7 +208,7 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(testManifest)
 
 			// When
-			err := sut.LoadSandbox("")
+			err := sut.LoadSandbox(context.Background(), "")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -223,7 +223,7 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(manifest)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -238,7 +238,7 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(manifest)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -257,7 +257,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -274,7 +274,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -293,7 +293,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -312,7 +312,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -331,7 +331,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -350,7 +350,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -369,7 +369,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -388,7 +388,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -403,7 +403,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox("id")
+			err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -418,7 +418,7 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(testManifest)
 
 			// When
-			err := sut.LoadContainer("id")
+			err := sut.LoadContainer(context.Background(), "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -433,7 +433,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadContainer("id")
+			err := sut.LoadContainer(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -451,7 +451,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadContainer("id")
+			err := sut.LoadContainer(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -471,7 +471,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadContainer("id")
+			err := sut.LoadContainer(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -486,7 +486,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadContainer("id")
+			err := sut.LoadContainer(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -505,7 +505,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadContainer("id")
+			err := sut.LoadContainer(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -524,7 +524,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadContainer("id")
+			err := sut.LoadContainer(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -543,7 +543,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadContainer("id")
+			err := sut.LoadContainer(context.Background(), "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -563,7 +563,7 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadContainer("id")
+			err := sut.LoadContainer(context.Background(), "id")
 
 			// Then
 			Expect(err).To(Equal(lib.ErrIsNonCrioContainer))
@@ -574,7 +574,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should fail when file not found", func() {
 			// Given
 			// When
-			err := sut.ContainerStateFromDisk(myContainer)
+			err := sut.ContainerStateFromDisk(context.Background(), myContainer)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -592,7 +592,7 @@ var _ = t.Describe("ContainerServer", func() {
 			Expect(err).To(BeNil())
 
 			// When
-			err = sut.ContainerStateToDisk(container)
+			err = sut.ContainerStateToDisk(context.Background(), container)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/internal/lib/kill_test.go
+++ b/internal/lib/kill_test.go
@@ -1,6 +1,7 @@
 package lib_test
 
 import (
+	"context"
 	"syscall"
 
 	. "github.com/onsi/ginkgo"
@@ -16,7 +17,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should fail when not found", func() {
 			// Given
 			// When
-			res, err := sut.ContainerKill("", syscall.SIGINT)
+			res, err := sut.ContainerKill(context.Background(), "", syscall.SIGINT)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/internal/lib/pause.go
+++ b/internal/lib/pause.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cri-o/cri-o/internal/oci"
@@ -9,7 +10,7 @@ import (
 )
 
 // ContainerPause pauses a running container.
-func (c *ContainerServer) ContainerPause(container string) (string, error) {
+func (c *ContainerServer) ContainerPause(ctx context.Context, container string) (string, error) {
 	ctr, err := c.LookupContainer(container)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to find container %s", container)
@@ -17,10 +18,10 @@ func (c *ContainerServer) ContainerPause(container string) (string, error) {
 
 	cStatus := ctr.State()
 	if cStatus.Status != oci.ContainerStatePaused {
-		if err := c.runtime.PauseContainer(ctr); err != nil {
+		if err := c.runtime.PauseContainer(ctx, ctr); err != nil {
 			return "", errors.Wrapf(err, "failed to pause container %s", ctr.ID())
 		}
-		if err := c.ContainerStateToDisk(ctr); err != nil {
+		if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
 			logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
 		}
 	} else {
@@ -31,7 +32,7 @@ func (c *ContainerServer) ContainerPause(container string) (string, error) {
 }
 
 // ContainerUnpause unpauses a running container with a grace period (i.e., timeout).
-func (c *ContainerServer) ContainerUnpause(container string) (string, error) {
+func (c *ContainerServer) ContainerUnpause(ctx context.Context, container string) (string, error) {
 	ctr, err := c.LookupContainer(container)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to find container %s", container)
@@ -39,10 +40,10 @@ func (c *ContainerServer) ContainerUnpause(container string) (string, error) {
 
 	cStatus := ctr.State()
 	if cStatus.Status == oci.ContainerStatePaused {
-		if err := c.runtime.UnpauseContainer(ctr); err != nil {
+		if err := c.runtime.UnpauseContainer(ctx, ctr); err != nil {
 			return "", errors.Wrapf(err, "failed to unpause container %s", ctr.ID())
 		}
-		if err := c.ContainerStateToDisk(ctr); err != nil {
+		if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
 			logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
 		}
 	} else {

--- a/internal/lib/pause_test.go
+++ b/internal/lib/pause_test.go
@@ -1,6 +1,8 @@
 package lib_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -15,7 +17,7 @@ var _ = t.Describe("ContainerServer", func() {
 			// Given
 
 			// When
-			res, err := sut.ContainerPause("")
+			res, err := sut.ContainerPause(context.Background(), "")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -27,7 +29,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should fail on invalid container", func() {
 			// Given
 			// When
-			res, err := sut.ContainerUnpause("")
+			res, err := sut.ContainerUnpause(context.Background(), "")
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/internal/lib/remove.go
+++ b/internal/lib/remove.go
@@ -32,7 +32,7 @@ func (c *ContainerServer) Remove(ctx context.Context, container string, force bo
 		}
 	}
 
-	if err := c.runtime.DeleteContainer(ctr); err != nil {
+	if err := c.runtime.DeleteContainer(ctx, ctr); err != nil {
 		return "", errors.Wrapf(err, "failed to delete container %s", ctrID)
 	}
 	if err := os.Remove(filepath.Join(c.Config().RuntimeConfig.ContainerExitsDir, ctrID)); err != nil && !os.IsNotExist(err) {

--- a/internal/lib/stop.go
+++ b/internal/lib/stop.go
@@ -35,7 +35,7 @@ func (c *ContainerServer) ContainerStop(ctx context.Context, container string, t
 		}
 	}
 
-	if err := c.ContainerStateToDisk(ctr); err != nil {
+	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
 		logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
 

--- a/internal/lib/wait_test.go
+++ b/internal/lib/wait_test.go
@@ -1,6 +1,8 @@
 package lib_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -14,7 +16,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should fail on invalid container ID", func() {
 			// Given
 			// When
-			res, err := sut.ContainerWait("")
+			res, err := sut.ContainerWait(context.Background(), "")
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -76,7 +76,7 @@ type exitCodeInfo struct {
 }
 
 // CreateContainer creates a container.
-func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (retErr error) {
+func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupParent string) (retErr error) {
 	if c.Spoofed() {
 		return nil
 	}
@@ -186,7 +186,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (retErr 
 	// We will delete all container resources if creation fails
 	defer func() {
 		if retErr != nil {
-			if err := r.DeleteContainer(c); err != nil {
+			if err := r.DeleteContainer(ctx, c); err != nil {
 				logrus.Warnf("unable to delete container %s: %v", c.ID(), err)
 			}
 		}
@@ -238,7 +238,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (retErr 
 }
 
 // StartContainer starts a container.
-func (r *runtimeOCI) StartContainer(c *Container) error {
+func (r *runtimeOCI) StartContainer(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -319,7 +319,7 @@ func parseLog(l []byte) (stdout, stderr []byte) {
 }
 
 // ExecContainer prepares a streaming endpoint to execute a command in the container.
-func (r *runtimeOCI) ExecContainer(c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	if c.Spoofed() {
 		return nil
 	}
@@ -389,7 +389,7 @@ func (r *runtimeOCI) ExecContainer(c *Container, cmd []string, stdin io.Reader, 
 }
 
 // ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
-func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout int64) (*ExecSyncResponse, error) {
+func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, command []string, timeout int64) (*ExecSyncResponse, error) {
 	if c.Spoofed() {
 		return nil, nil
 	}
@@ -562,7 +562,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 }
 
 // UpdateContainer updates container resources
-func (r *runtimeOCI) UpdateContainer(c *Container, res *rspec.LinuxResources) error {
+func (r *runtimeOCI) UpdateContainer(ctx context.Context, c *Container, res *rspec.LinuxResources) error {
 	if c.Spoofed() {
 		return nil
 	}
@@ -728,7 +728,7 @@ func checkProcessGone(c *Container) {
 }
 
 // DeleteContainer deletes a container.
-func (r *runtimeOCI) DeleteContainer(c *Container) error {
+func (r *runtimeOCI) DeleteContainer(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -763,7 +763,7 @@ func updateContainerStatusFromExitFile(c *Container) error {
 }
 
 // UpdateContainerStatus refreshes the status of the container.
-func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
+func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -876,7 +876,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 }
 
 // PauseContainer pauses a container.
-func (r *runtimeOCI) PauseContainer(c *Container) error {
+func (r *runtimeOCI) PauseContainer(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -889,7 +889,7 @@ func (r *runtimeOCI) PauseContainer(c *Container) error {
 }
 
 // UnpauseContainer unpauses a container.
-func (r *runtimeOCI) UnpauseContainer(c *Container) error {
+func (r *runtimeOCI) UnpauseContainer(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -906,14 +906,14 @@ func (r *runtimeOCI) WaitContainerStateStopped(ctx context.Context, c *Container
 }
 
 // ContainerStats provides statistics of a container.
-func (r *runtimeOCI) ContainerStats(c *Container, cgroup string) (*ContainerStats, error) {
+func (r *runtimeOCI) ContainerStats(ctx context.Context, c *Container, cgroup string) (*ContainerStats, error) {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 	return r.containerStats(c, cgroup)
 }
 
 // SignalContainer sends a signal to a container process.
-func (r *runtimeOCI) SignalContainer(c *Container, sig syscall.Signal) error {
+func (r *runtimeOCI) SignalContainer(ctx context.Context, c *Container, sig syscall.Signal) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -932,7 +932,7 @@ func (r *runtimeOCI) SignalContainer(c *Container, sig syscall.Signal) error {
 }
 
 // AttachContainer attaches IO to a running container.
-func (r *runtimeOCI) AttachContainer(c *Container, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	if c.Spoofed() {
 		return nil
 	}
@@ -1095,7 +1095,7 @@ func (r *runtimeOCI) PortForwardContainer(ctx context.Context, c *Container, net
 }
 
 // ReopenContainerLog reopens the log file of a container.
-func (r *runtimeOCI) ReopenContainerLog(c *Container) error {
+func (r *runtimeOCI) ReopenContainerLog(ctx context.Context, c *Container) error {
 	if c.Spoofed() {
 		return nil
 	}

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -23,13 +23,13 @@ func (s *Server) Attach(ctx context.Context, req *types.AttachRequest) (*types.A
 }
 
 // Attach endpoint for streaming.Runtime
-func (s StreamService) Attach(ctx context.Context, containerID string, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (s StreamService) Attach(containerID string, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	c, err := s.runtimeServer.GetContainerFromShortID(containerID)
 	if err != nil {
 		return status.Errorf(codes.NotFound, "could not find container %q: %v", containerID, err)
 	}
 
-	if err := s.runtimeServer.Runtime().UpdateContainerStatus(ctx, c); err != nil {
+	if err := s.runtimeServer.Runtime().UpdateContainerStatus(s.ctx, c); err != nil {
 		return err
 	}
 
@@ -38,5 +38,5 @@ func (s StreamService) Attach(ctx context.Context, containerID string, inputStre
 		return fmt.Errorf("container is not created or running")
 	}
 
-	return s.runtimeServer.Runtime().AttachContainer(ctx, c, inputStream, outputStream, errorStream, tty, resize)
+	return s.runtimeServer.Runtime().AttachContainer(s.ctx, c, inputStream, outputStream, errorStream, tty, resize)
 }

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -23,13 +23,13 @@ func (s *Server) Attach(ctx context.Context, req *types.AttachRequest) (*types.A
 }
 
 // Attach endpoint for streaming.Runtime
-func (s StreamService) Attach(containerID string, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (s StreamService) Attach(ctx context.Context, containerID string, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	c, err := s.runtimeServer.GetContainerFromShortID(containerID)
 	if err != nil {
 		return status.Errorf(codes.NotFound, "could not find container %q: %v", containerID, err)
 	}
 
-	if err := s.runtimeServer.Runtime().UpdateContainerStatus(c); err != nil {
+	if err := s.runtimeServer.Runtime().UpdateContainerStatus(ctx, c); err != nil {
 		return err
 	}
 
@@ -38,5 +38,5 @@ func (s StreamService) Attach(containerID string, inputStream io.Reader, outputS
 		return fmt.Errorf("container is not created or running")
 	}
 
-	return s.runtimeServer.Runtime().AttachContainer(c, inputStream, outputStream, errorStream, tty, resize)
+	return s.runtimeServer.Runtime().AttachContainer(ctx, c, inputStream, outputStream, errorStream, tty, resize)
 }

--- a/server/container_attach_test.go
+++ b/server/container_attach_test.go
@@ -50,7 +50,7 @@ var _ = t.Describe("ContainerAttach", func() {
 		It("shoud fail if container was not found", func() {
 			// Given
 			// When
-			err := testStreamService.Attach(testContainer.ID(),
+			err := testStreamService.Attach(context.Background(), testContainer.ID(),
 				nil, nil, nil, false, make(chan remotecommand.TerminalSize))
 
 			// Then

--- a/server/container_attach_test.go
+++ b/server/container_attach_test.go
@@ -50,7 +50,7 @@ var _ = t.Describe("ContainerAttach", func() {
 		It("shoud fail if container was not found", func() {
 			// Given
 			// When
-			err := testStreamService.Attach(context.Background(), testContainer.ID(),
+			err := testStreamService.Attach(testContainer.ID(),
 				nil, nil, nil, false, make(chan remotecommand.TerminalSize))
 
 			// Then

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -530,19 +530,19 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 		return nil, err
 	}
 
-	if err := s.createContainerPlatform(newContainer, sb.CgroupParent(), mappings); err != nil {
+	if err := s.createContainerPlatform(ctx, newContainer, sb.CgroupParent(), mappings); err != nil {
 		return nil, err
 	}
 	cleanupFuncs = append(cleanupFuncs, func() {
 		if retErr != nil {
 			log.Infof(ctx, "createCtr: removing container ID %s from runtime", ctr.ID())
-			if err := s.Runtime().DeleteContainer(newContainer); err != nil {
+			if err := s.Runtime().DeleteContainer(ctx, newContainer); err != nil {
 				log.Warnf(ctx, "failed to delete container in runtime %s: %v", ctr.ID(), err)
 			}
 		}
 	})
 
-	if err := s.ContainerStateToDisk(newContainer); err != nil {
+	if err := s.ContainerStateToDisk(ctx, newContainer); err != nil {
 		log.Warnf(ctx, "unable to write containers %s state to disk: %v", newContainer.ID(), err)
 	}
 

--- a/server/container_create_generic.go
+++ b/server/container_create_generic.go
@@ -3,11 +3,13 @@
 package server
 
 import (
+	"context"
+
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/internal/oci"
 )
 
 // createContainerPlatform performs platform dependent intermediate steps before calling the container's oci.Runtime().CreateContainer()
-func (s *Server) createContainerPlatform(container *oci.Container, cgroupParent string, idMappings *idtools.IDMappings) error {
-	return s.Runtime().CreateContainer(container, cgroupParent)
+func (s *Server) createContainerPlatform(ctx context.Context, container *oci.Container, cgroupParent string, idMappings *idtools.IDMappings) error {
+	return s.Runtime().CreateContainer(ctx, container, cgroupParent)
 }

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -36,7 +36,7 @@ import (
 )
 
 // createContainerPlatform performs platform dependent intermediate steps before calling the container's oci.Runtime().CreateContainer()
-func (s *Server) createContainerPlatform(container *oci.Container, cgroupParent string, idMappings *idtools.IDMappings) error {
+func (s *Server) createContainerPlatform(ctx context.Context, container *oci.Container, cgroupParent string, idMappings *idtools.IDMappings) error {
 	if idMappings != nil && !container.Spoofed() {
 		rootPair := idMappings.RootPair()
 		for _, path := range []string{container.BundlePath(), container.MountPoint()} {
@@ -48,7 +48,7 @@ func (s *Server) createContainerPlatform(container *oci.Container, cgroupParent 
 			return err
 		}
 	}
-	return s.Runtime().CreateContainer(container, cgroupParent)
+	return s.Runtime().CreateContainer(ctx, container, cgroupParent)
 }
 
 // makeAccessible changes the path permission and each parent directory to have --x--x--x

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -23,13 +23,13 @@ func (s *Server) Exec(ctx context.Context, req *types.ExecRequest) (*types.ExecR
 }
 
 // Exec endpoint for streaming.Runtime
-func (s StreamService) Exec(ctx context.Context, containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (s StreamService) Exec(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	c, err := s.runtimeServer.GetContainerFromShortID(containerID)
 	if err != nil {
 		return status.Errorf(codes.NotFound, "could not find container %q: %v", containerID, err)
 	}
 
-	if err := s.runtimeServer.Runtime().UpdateContainerStatus(ctx, c); err != nil {
+	if err := s.runtimeServer.Runtime().UpdateContainerStatus(s.ctx, c); err != nil {
 		return err
 	}
 
@@ -38,5 +38,5 @@ func (s StreamService) Exec(ctx context.Context, containerID string, cmd []strin
 		return fmt.Errorf("container is not created or running")
 	}
 
-	return s.runtimeServer.Runtime().ExecContainer(ctx, c, cmd, stdin, stdout, stderr, tty, resize)
+	return s.runtimeServer.Runtime().ExecContainer(s.ctx, c, cmd, stdin, stdout, stderr, tty, resize)
 }

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -23,13 +23,13 @@ func (s *Server) Exec(ctx context.Context, req *types.ExecRequest) (*types.ExecR
 }
 
 // Exec endpoint for streaming.Runtime
-func (s StreamService) Exec(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (s StreamService) Exec(ctx context.Context, containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	c, err := s.runtimeServer.GetContainerFromShortID(containerID)
 	if err != nil {
 		return status.Errorf(codes.NotFound, "could not find container %q: %v", containerID, err)
 	}
 
-	if err := s.runtimeServer.Runtime().UpdateContainerStatus(c); err != nil {
+	if err := s.runtimeServer.Runtime().UpdateContainerStatus(ctx, c); err != nil {
 		return err
 	}
 
@@ -38,5 +38,5 @@ func (s StreamService) Exec(containerID string, cmd []string, stdin io.Reader, s
 		return fmt.Errorf("container is not created or running")
 	}
 
-	return s.runtimeServer.Runtime().ExecContainer(c, cmd, stdin, stdout, stderr, tty, resize)
+	return s.runtimeServer.Runtime().ExecContainer(ctx, c, cmd, stdin, stdout, stderr, tty, resize)
 }

--- a/server/container_exec_test.go
+++ b/server/container_exec_test.go
@@ -50,7 +50,7 @@ var _ = t.Describe("ContainerStart", func() {
 		It("shoud fail when container not found", func() {
 			// Given
 			// When
-			err := testStreamService.Exec(testContainer.ID(), []string{},
+			err := testStreamService.Exec(context.Background(), testContainer.ID(), []string{},
 				nil, nil, nil, false, make(chan remotecommand.TerminalSize))
 
 			// Then

--- a/server/container_exec_test.go
+++ b/server/container_exec_test.go
@@ -50,7 +50,7 @@ var _ = t.Describe("ContainerStart", func() {
 		It("shoud fail when container not found", func() {
 			// Given
 			// When
-			err := testStreamService.Exec(context.Background(), testContainer.ID(), []string{},
+			err := testStreamService.Exec(testContainer.ID(), []string{},
 				nil, nil, nil, false, make(chan remotecommand.TerminalSize))
 
 			// Then

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -24,7 +24,7 @@ func (s *Server) ExecSync(ctx context.Context, req *types.ExecSyncRequest) (*typ
 		return nil, errors.New("exec command cannot be empty")
 	}
 
-	execResp, err := s.Runtime().ExecSyncContainer(c, cmd, req.Timeout)
+	execResp, err := s.Runtime().ExecSyncContainer(ctx, c, cmd, req.Timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_reopen_log.go
+++ b/server/container_reopen_log.go
@@ -16,7 +16,7 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *types.ReopenContai
 		return errors.Wrapf(err, "could not find container %s", req.ContainerID)
 	}
 
-	if err := s.ContainerServer.Runtime().UpdateContainerStatus(c); err != nil {
+	if err := s.ContainerServer.Runtime().UpdateContainerStatus(ctx, c); err != nil {
 		return err
 	}
 
@@ -25,7 +25,7 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *types.ReopenContai
 		return fmt.Errorf("container is not created or running")
 	}
 
-	if err := s.ContainerServer.Runtime().ReopenContainerLog(c); err != nil {
+	if err := s.ContainerServer.Runtime().ReopenContainerLog(ctx, c); err != nil {
 		return err
 	}
 	return nil

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -43,7 +43,7 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 				}
 			}
 		}
-		if err := s.ContainerStateToDisk(c); err != nil {
+		if err := s.ContainerStateToDisk(ctx, c); err != nil {
 			log.Warnf(ctx, "unable to write containers %s state to disk: %v", c.ID(), err)
 		}
 	}()
@@ -54,7 +54,7 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 		}
 	}
 
-	if err := s.Runtime().StartContainer(c); err != nil {
+	if err := s.Runtime().StartContainer(ctx, c); err != nil {
 		return fmt.Errorf("failed to start container %s: %v", c.ID(), err)
 	}
 

--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -62,7 +62,7 @@ func (s *Server) ContainerStats(ctx context.Context, req *types.ContainerStatsRe
 	}
 	cgroup := sb.CgroupParent()
 
-	stats, err := s.Runtime().ContainerStats(container, cgroup)
+	stats, err := s.Runtime().ContainerStats(ctx, container, cgroup)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -35,7 +35,7 @@ func (s *Server) ListContainerStats(ctx context.Context, req *types.ListContaine
 			continue
 		}
 		cgroup := sb.CgroupParent()
-		stats, err := s.Runtime().ContainerStats(container, cgroup)
+		stats, err := s.Runtime().ContainerStats(ctx, container, cgroup)
 		if err != nil {
 			log.Warnf(ctx, "unable to get stats for container %s: %v", container.ID(), err)
 			continue

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -58,7 +58,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 	// If we defaulted to exit code not set earlier then we attempt to
 	// get the exit code from the exit file again.
 	if cState.Status == oci.ContainerStateStopped && cState.ExitCode == nil {
-		err := s.Runtime().UpdateContainerStatus(c)
+		err := s.Runtime().UpdateContainerStatus(ctx, c)
 		if err != nil {
 			log.Warnf(ctx, "Failed to UpdateStatus of container %s: %v", c.ID(), err)
 		}

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -25,7 +25,7 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *types.Update
 
 	if req.Linux != nil {
 		resources := toOCIResources(req.Linux)
-		if err := s.Runtime().UpdateContainer(c, resources); err != nil {
+		if err := s.Runtime().UpdateContainer(ctx, c, resources); err != nil {
 			return err
 		}
 

--- a/server/sandbox_list_test.go
+++ b/server/sandbox_list_test.go
@@ -75,7 +75,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 			// Given
 			mockDirs(testManifest)
 			createDummyState()
-			Expect(sut.LoadSandbox(sandboxID)).To(BeNil())
+			Expect(sut.LoadSandbox(context.Background(), sandboxID)).To(BeNil())
 
 			// When
 			response, err := sut.ListPodSandbox(context.Background(),
@@ -93,7 +93,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 			// Given
 			mockDirs(testManifest)
 			createDummyState()
-			Expect(sut.LoadSandbox(sandboxID)).To(BeNil())
+			Expect(sut.LoadSandbox(context.Background(), sandboxID)).To(BeNil())
 
 			// When
 			response, err := sut.ListPodSandbox(context.Background(),
@@ -114,7 +114,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 			// Given
 			mockDirs(testManifest)
 			createDummyState()
-			Expect(sut.LoadSandbox(sandboxID)).To(BeNil())
+			Expect(sut.LoadSandbox(context.Background(), sandboxID)).To(BeNil())
 
 			// When
 			response, err := sut.ListPodSandbox(context.Background(),

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -53,7 +53,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *types.RemovePodSandb
 			}
 		}
 
-		if err := s.Runtime().DeleteContainer(c); err != nil {
+		if err := s.Runtime().DeleteContainer(ctx, c); err != nil {
 			return fmt.Errorf("failed to delete container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 		}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -909,11 +909,11 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		}
 	}
 
-	if err := s.createContainerPlatform(container, sb.CgroupParent(), sandboxIDMappings); err != nil {
+	if err := s.createContainerPlatform(ctx, container, sb.CgroupParent(), sandboxIDMappings); err != nil {
 		return nil, err
 	}
 
-	if err := s.Runtime().StartContainer(container); err != nil {
+	if err := s.Runtime().StartContainer(ctx, container); err != nil {
 		return nil, err
 	}
 
@@ -927,16 +927,16 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 			log.Warnf(ctx, "failed to get container 'stopped' status %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
 		}
 		log.Infof(ctx, "runSandbox: deleting container %s", container.ID())
-		if err2 := s.Runtime().DeleteContainer(container); err2 != nil {
+		if err2 := s.Runtime().DeleteContainer(ctx, container); err2 != nil {
 			log.Warnf(ctx, "failed to delete container %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
 		}
 		log.Infof(ctx, "runSandbox: writing container %s state to disk", container.ID())
-		if err2 := s.ContainerStateToDisk(container); err2 != nil {
+		if err2 := s.ContainerStateToDisk(ctx, container); err2 != nil {
 			log.Warnf(ctx, "failed to write container state %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
 		}
 	})
 
-	if err := s.ContainerStateToDisk(container); err != nil {
+	if err := s.ContainerStateToDisk(ctx, container); err != nil {
 		log.Warnf(ctx, "unable to write containers %s state to disk: %v", container.ID(), err)
 	}
 

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -81,7 +81,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *types.StopPodSandboxRe
 						// assume container already umounted
 						log.Warnf(ctx, "failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 					}
-					if err := s.ContainerStateToDisk(c); err != nil {
+					if err := s.ContainerStateToDisk(ctx, c); err != nil {
 						return errors.Wrapf(err, "write container %q state do disk", c.Name())
 					}
 					return nil
@@ -114,7 +114,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *types.StopPodSandboxRe
 	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
 		log.Warnf(ctx, "failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
-	if err := s.ContainerStateToDisk(podInfraContainer); err != nil {
+	if err := s.ContainerStateToDisk(ctx, podInfraContainer); err != nil {
 		log.Warnf(ctx, "error writing pod infra container %q state to disk: %v", podInfraContainer.ID(), err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -187,7 +187,7 @@ func (s *Server) restore(ctx context.Context) {
 	// Go through all the pods and check if it can be restored. If an error occurs, delete the pod and any containers
 	// associated with it. Release the pod and container names as well.
 	for sbID, metadata := range pods {
-		if err = s.LoadSandbox(sbID); err == nil {
+		if err = s.LoadSandbox(ctx, sbID); err == nil {
 			continue
 		}
 		logrus.Warnf("could not restore sandbox %s container %s: %v", metadata.PodID, sbID, err)
@@ -222,7 +222,7 @@ func (s *Server) restore(ctx context.Context) {
 	// Go through all the containers and check if it can be restored. If an error occurs, delete the conainer and
 	// release the name associated with you.
 	for containerID := range podContainers {
-		if err := s.LoadContainer(containerID); err != nil {
+		if err := s.LoadContainer(ctx, containerID); err != nil {
 			// containers of other runtimes should not be deleted
 			if err == lib.ErrIsNonCrioContainer {
 				logrus.Infof("ignoring non CRI-O container %s", containerID)
@@ -460,7 +460,7 @@ func New(
 		}
 	}
 	s.stream.runtimeServer = s
-	s.stream.streamServer, err = streaming.NewServer(streamServerConfig, s.stream)
+	s.stream.streamServer, err = streaming.NewServer(ctx, streamServerConfig, s.stream)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create streaming server")
 	}
@@ -606,7 +606,7 @@ func (s *Server) MonitorsCloseChan() chan struct{} {
 
 // StartExitMonitor start a routine that monitors container exits
 // and updates the container status
-func (s *Server) StartExitMonitor() {
+func (s *Server) StartExitMonitor(ctx context.Context) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		logrus.Fatalf("Failed to create new watch: %v", err)
@@ -625,10 +625,10 @@ func (s *Server) StartExitMonitor() {
 					c := s.GetContainer(containerID)
 					if c != nil {
 						logrus.Debugf("container exited and found: %v", containerID)
-						err := s.Runtime().UpdateContainerStatus(c)
+						err := s.Runtime().UpdateContainerStatus(ctx, c)
 						if err != nil {
 							logrus.Warnf("Failed to update container status %s: %v", containerID, err)
-						} else if err := s.ContainerStateToDisk(c); err != nil {
+						} else if err := s.ContainerStateToDisk(ctx, c); err != nil {
 							logrus.Warnf("unable to write containers %s state to disk: %v", c.ID(), err)
 						}
 					} else {
@@ -640,10 +640,10 @@ func (s *Server) StartExitMonitor() {
 								continue
 							}
 							logrus.Debugf("sandbox exited and found: %v", containerID)
-							err := s.Runtime().UpdateContainerStatus(c)
+							err := s.Runtime().UpdateContainerStatus(ctx, c)
 							if err != nil {
 								logrus.Warnf("Failed to update sandbox infra container status %s: %v", c.ID(), err)
-							} else if err := s.ContainerStateToDisk(c); err != nil {
+							} else if err := s.ContainerStateToDisk(ctx, c); err != nil {
 								logrus.Warnf("unable to write containers %s state to disk: %v", c.ID(), err)
 							}
 						}

--- a/server/server.go
+++ b/server/server.go
@@ -47,6 +47,7 @@ var errSandboxNotCreated = errors.New("sandbox not created")
 
 // StreamService implements streaming.Runtime.
 type StreamService struct {
+	ctx                 context.Context
 	runtimeServer       *Server // needed by Exec() endpoint
 	streamServer        streaming.Server
 	streamServerCloseCh chan struct{}
@@ -459,6 +460,7 @@ func New(
 			Certificates:       []tls.Certificate{cert},
 		}
 	}
+	s.stream.ctx = ctx
 	s.stream.runtimeServer = s
 	s.stream.streamServer, err = streaming.NewServer(ctx, streamServerConfig, s.stream)
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -248,7 +248,7 @@ var _ = t.Describe("Server", func() {
 
 		It("should succeed", func() {
 			// Given
-			go sut.StartExitMonitor()
+			go sut.StartExitMonitor(context.Background())
 			closeChan := sut.MonitorsCloseChan()
 			Expect(closeChan).NotTo(BeNil())
 

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -39,103 +39,103 @@ func (m *MockRuntimeImpl) EXPECT() *MockRuntimeImplMockRecorder {
 }
 
 // AttachContainer mocks base method
-func (m *MockRuntimeImpl) AttachContainer(arg0 *oci.Container, arg1 io.Reader, arg2, arg3 io.WriteCloser, arg4 bool, arg5 <-chan remotecommand.TerminalSize) error {
+func (m *MockRuntimeImpl) AttachContainer(arg0 context.Context, arg1 *oci.Container, arg2 io.Reader, arg3, arg4 io.WriteCloser, arg5 bool, arg6 <-chan remotecommand.TerminalSize) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AttachContainer", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "AttachContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AttachContainer indicates an expected call of AttachContainer
-func (mr *MockRuntimeImplMockRecorder) AttachContainer(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) AttachContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).AttachContainer), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).AttachContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // ContainerStats mocks base method
-func (m *MockRuntimeImpl) ContainerStats(arg0 *oci.Container, arg1 string) (*oci.ContainerStats, error) {
+func (m *MockRuntimeImpl) ContainerStats(arg0 context.Context, arg1 *oci.Container, arg2 string) (*oci.ContainerStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainerStats", arg0, arg1)
+	ret := m.ctrl.Call(m, "ContainerStats", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*oci.ContainerStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContainerStats indicates an expected call of ContainerStats
-func (mr *MockRuntimeImplMockRecorder) ContainerStats(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) ContainerStats(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStats", reflect.TypeOf((*MockRuntimeImpl)(nil).ContainerStats), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStats", reflect.TypeOf((*MockRuntimeImpl)(nil).ContainerStats), arg0, arg1, arg2)
 }
 
 // CreateContainer mocks base method
-func (m *MockRuntimeImpl) CreateContainer(arg0 *oci.Container, arg1 string) error {
+func (m *MockRuntimeImpl) CreateContainer(arg0 context.Context, arg1 *oci.Container, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateContainer indicates an expected call of CreateContainer
-func (mr *MockRuntimeImplMockRecorder) CreateContainer(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) CreateContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).CreateContainer), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).CreateContainer), arg0, arg1, arg2)
 }
 
 // DeleteContainer mocks base method
-func (m *MockRuntimeImpl) DeleteContainer(arg0 *oci.Container) error {
+func (m *MockRuntimeImpl) DeleteContainer(arg0 context.Context, arg1 *oci.Container) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteContainer", arg0)
+	ret := m.ctrl.Call(m, "DeleteContainer", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteContainer indicates an expected call of DeleteContainer
-func (mr *MockRuntimeImplMockRecorder) DeleteContainer(arg0 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) DeleteContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).DeleteContainer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).DeleteContainer), arg0, arg1)
 }
 
 // ExecContainer mocks base method
-func (m *MockRuntimeImpl) ExecContainer(arg0 *oci.Container, arg1 []string, arg2 io.Reader, arg3, arg4 io.WriteCloser, arg5 bool, arg6 <-chan remotecommand.TerminalSize) error {
+func (m *MockRuntimeImpl) ExecContainer(arg0 context.Context, arg1 *oci.Container, arg2 []string, arg3 io.Reader, arg4, arg5 io.WriteCloser, arg6 bool, arg7 <-chan remotecommand.TerminalSize) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "ExecContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ExecContainer indicates an expected call of ExecContainer
-func (mr *MockRuntimeImplMockRecorder) ExecContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) ExecContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ExecContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ExecContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // ExecSyncContainer mocks base method
-func (m *MockRuntimeImpl) ExecSyncContainer(arg0 *oci.Container, arg1 []string, arg2 int64) (*oci.ExecSyncResponse, error) {
+func (m *MockRuntimeImpl) ExecSyncContainer(arg0 context.Context, arg1 *oci.Container, arg2 []string, arg3 int64) (*oci.ExecSyncResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecSyncContainer", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ExecSyncContainer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*oci.ExecSyncResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExecSyncContainer indicates an expected call of ExecSyncContainer
-func (mr *MockRuntimeImplMockRecorder) ExecSyncContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) ExecSyncContainer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecSyncContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ExecSyncContainer), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecSyncContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ExecSyncContainer), arg0, arg1, arg2, arg3)
 }
 
 // PauseContainer mocks base method
-func (m *MockRuntimeImpl) PauseContainer(arg0 *oci.Container) error {
+func (m *MockRuntimeImpl) PauseContainer(arg0 context.Context, arg1 *oci.Container) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PauseContainer", arg0)
+	ret := m.ctrl.Call(m, "PauseContainer", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PauseContainer indicates an expected call of PauseContainer
-func (mr *MockRuntimeImplMockRecorder) PauseContainer(arg0 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) PauseContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).PauseContainer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).PauseContainer), arg0, arg1)
 }
 
 // PortForwardContainer mocks base method
@@ -153,45 +153,45 @@ func (mr *MockRuntimeImplMockRecorder) PortForwardContainer(arg0, arg1, arg2, ar
 }
 
 // ReopenContainerLog mocks base method
-func (m *MockRuntimeImpl) ReopenContainerLog(arg0 *oci.Container) error {
+func (m *MockRuntimeImpl) ReopenContainerLog(arg0 context.Context, arg1 *oci.Container) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReopenContainerLog", arg0)
+	ret := m.ctrl.Call(m, "ReopenContainerLog", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReopenContainerLog indicates an expected call of ReopenContainerLog
-func (mr *MockRuntimeImplMockRecorder) ReopenContainerLog(arg0 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) ReopenContainerLog(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReopenContainerLog", reflect.TypeOf((*MockRuntimeImpl)(nil).ReopenContainerLog), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReopenContainerLog", reflect.TypeOf((*MockRuntimeImpl)(nil).ReopenContainerLog), arg0, arg1)
 }
 
 // SignalContainer mocks base method
-func (m *MockRuntimeImpl) SignalContainer(arg0 *oci.Container, arg1 syscall.Signal) error {
+func (m *MockRuntimeImpl) SignalContainer(arg0 context.Context, arg1 *oci.Container, arg2 syscall.Signal) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignalContainer", arg0, arg1)
+	ret := m.ctrl.Call(m, "SignalContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SignalContainer indicates an expected call of SignalContainer
-func (mr *MockRuntimeImplMockRecorder) SignalContainer(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) SignalContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignalContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).SignalContainer), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignalContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).SignalContainer), arg0, arg1, arg2)
 }
 
 // StartContainer mocks base method
-func (m *MockRuntimeImpl) StartContainer(arg0 *oci.Container) error {
+func (m *MockRuntimeImpl) StartContainer(arg0 context.Context, arg1 *oci.Container) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartContainer", arg0)
+	ret := m.ctrl.Call(m, "StartContainer", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StartContainer indicates an expected call of StartContainer
-func (mr *MockRuntimeImplMockRecorder) StartContainer(arg0 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) StartContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).StartContainer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).StartContainer), arg0, arg1)
 }
 
 // StopContainer mocks base method
@@ -209,45 +209,45 @@ func (mr *MockRuntimeImplMockRecorder) StopContainer(arg0, arg1, arg2 interface{
 }
 
 // UnpauseContainer mocks base method
-func (m *MockRuntimeImpl) UnpauseContainer(arg0 *oci.Container) error {
+func (m *MockRuntimeImpl) UnpauseContainer(arg0 context.Context, arg1 *oci.Container) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnpauseContainer", arg0)
+	ret := m.ctrl.Call(m, "UnpauseContainer", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnpauseContainer indicates an expected call of UnpauseContainer
-func (mr *MockRuntimeImplMockRecorder) UnpauseContainer(arg0 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) UnpauseContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpauseContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).UnpauseContainer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpauseContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).UnpauseContainer), arg0, arg1)
 }
 
 // UpdateContainer mocks base method
-func (m *MockRuntimeImpl) UpdateContainer(arg0 *oci.Container, arg1 *specs.LinuxResources) error {
+func (m *MockRuntimeImpl) UpdateContainer(arg0 context.Context, arg1 *oci.Container, arg2 *specs.LinuxResources) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateContainer", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateContainer indicates an expected call of UpdateContainer
-func (mr *MockRuntimeImplMockRecorder) UpdateContainer(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) UpdateContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).UpdateContainer), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).UpdateContainer), arg0, arg1, arg2)
 }
 
 // UpdateContainerStatus mocks base method
-func (m *MockRuntimeImpl) UpdateContainerStatus(arg0 *oci.Container) error {
+func (m *MockRuntimeImpl) UpdateContainerStatus(arg0 context.Context, arg1 *oci.Container) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateContainerStatus", arg0)
+	ret := m.ctrl.Call(m, "UpdateContainerStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateContainerStatus indicates an expected call of UpdateContainerStatus
-func (mr *MockRuntimeImplMockRecorder) UpdateContainerStatus(arg0 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) UpdateContainerStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerStatus", reflect.TypeOf((*MockRuntimeImpl)(nil).UpdateContainerStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerStatus", reflect.TypeOf((*MockRuntimeImpl)(nil).UpdateContainerStatus), arg0, arg1)
 }
 
 // WaitContainerStateStopped mocks base method


### PR DESCRIPTION
Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind bug


#### What this PR does / why we need it:

This PR reuses existing context object and avoids creating a new context object in runtime VM module and storing in its runtimeVM structure.

#### Which issue(s) this PR fixes:

The runtime VM creates its own context object and store in its structure which shouldn't be done as for crio process should contain only one context object which should be passed across API boundaries.  

Fixes #4634

#### Special notes for your reviewer:

`streaming#criAdapter{} `needed to store the existing `ctx` object, is that ok ?

#### Does this PR introduce a user-facing change?
```release-note
None
```