### PR TITLE
fix default dependencies on container scopes to fix graceful shutdowns

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -237,6 +237,7 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 		if systemdHasCollectMode {
 			c.spec.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
 		}
+		c.spec.AddAnnotation("org.systemd.property.DefaultDependencies", "true")
 	}
 
 	if configStopSignal != "" {


### PR DESCRIPTION
#### What type of PR is this?
I'm debugging an issue with the Kube API server not shutting down fully on a reboot. I'm not seeing the scope being terminated since DefaultDependencies is disabled. This PR enables the DefaultDependency as documented in the systemd [documentation](https://github.com/systemd/systemd/blob/fee6441601c979165ebcbb35472036439f8dad5f/man/systemd.scope.xml#L70-L85).

/kind bug

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
cri-o managed scopes now depend on the shutdown.target and network.target to allow graceful shutdowns.
```
