### PR TITLE
Improve image name tag and digest retrieval

### DIFF
--- a/server/image_list.go
+++ b/server/image_list.go
@@ -33,16 +33,20 @@ func ConvertImage(from *storage.ImageResult) *types.Image {
 		return nil
 	}
 
-	repoTags := []string{"<none>:<none>"}
+	repoTags := []string{}
 	if len(from.RepoTags) > 0 {
 		repoTags = from.RepoTags
 	} else if from.PreviousName != "" {
 		repoTags = []string{from.PreviousName + ":<none>"}
 	}
 
-	repoDigests := []string{"<none>@<none>"}
-	if len(from.RepoDigests) > 0 {
+	repoDigests := []string{}
+	if len(from.RepoDigests) > 0 { // nolint: gocritic
 		repoDigests = from.RepoDigests
+	} else if from.Name != "" {
+		repoDigests = []string{from.Name + "@" + from.Digest.String()}
+	} else if from.PreviousName != "" {
+		repoDigests = []string{from.PreviousName + "@" + from.Digest.String()}
 	}
 
 	to := &types.Image{

--- a/server/image_list_test.go
+++ b/server/image_list_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
 )
 
 // The actual test suite
@@ -92,10 +93,8 @@ var _ = t.Describe("ImageList", func() {
 
 			// Then
 			Expect(result).NotTo(BeNil())
-			Expect(result.RepoTags).To(HaveLen(1))
-			Expect(result.RepoTags).To(ContainElement("<none>:<none>"))
-			Expect(result.RepoDigests).To(HaveLen(1))
-			Expect(result.RepoDigests).To(ContainElement("<none>@<none>"))
+			Expect(result.RepoTags).To(HaveLen(0))
+			Expect(result.RepoDigests).To(HaveLen(0))
 		})
 
 		It("should succeed with repo tags and digests", func() {
@@ -132,6 +131,38 @@ var _ = t.Describe("ImageList", func() {
 			Expect(result).NotTo(BeNil())
 			Expect(result.RepoTags).To(HaveLen(1))
 			Expect(result.RepoTags).To(ContainElement("1:<none>"))
+		})
+
+		It("should succeed with name and digest", func() {
+			// Given
+			image := &storage.ImageResult{
+				Name:   "1",
+				Digest: digest.Digest("2"),
+			}
+
+			// When
+			result := server.ConvertImage(image)
+
+			// Then
+			Expect(result).NotTo(BeNil())
+			Expect(result.RepoDigests).To(HaveLen(1))
+			Expect(result.RepoDigests).To(ContainElement("1@2"))
+		})
+
+		It("should succeed with previous name and digest", func() {
+			// Given
+			image := &storage.ImageResult{
+				PreviousName: "1",
+				Digest:       digest.Digest("2"),
+			}
+
+			// When
+			result := server.ConvertImage(image)
+
+			// Then
+			Expect(result).NotTo(BeNil())
+			Expect(result.RepoDigests).To(HaveLen(1))
+			Expect(result.RepoDigests).To(ContainElement("1@2"))
 		})
 
 		It("should return nil if input image is nil", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The image result features a name and digest which can be re-used for the
image list result. This means we do not return `<none>:<none>` and
`<none>@<none>` any more in case we do not have any name available. This
aligns with the Kubernetes scheduler which takes the result of the image
list into account.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Refers to https://bugzilla.redhat.com/show_bug.cgi?id=1852637
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed the image list result to contain more useful information for the default kube scheduler
```
