### PR TITLE
Update pause image to 3.5

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -32,14 +32,14 @@ it later with **--config**. Global options will modify the output.`,
     To run a config migration, just select the input config via the global
     '--config,-c' command line argument, for example:
     `+"```"+`
-    crio -c /etc/crio/crio.conf.d/00-default.conf config -m 1.17
+    crio -c /etc/crio/crio.conf.d/00-default.conf config -m 1.20
     `+"```"+`
     The migration will print converted configuration options to stderr and will
     output the resulting configuration to stdout.
     Please note that the migration will overwrite any fields that have changed
     defaults between versions. To save a custom configuration change, it should
     be in a drop-in configuration file instead.
-    Possible values: %q`, migrate.From1_17),
+    Possible values: %q`, migrate.From1_20),
 			Value: migrate.FromPrevious,
 		},
 	},

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -148,14 +148,14 @@ complete -c crio -n '__fish_seen_subcommand_from config' -f -l migrate-defaults 
     To run a config migration, just select the input config via the global
     \'--config,-c\' command line argument, for example:
     ```
-    crio -c /etc/crio/crio.conf.d/00-default.conf config -m 1.17
+    crio -c /etc/crio/crio.conf.d/00-default.conf config -m 1.20
     ```
     The migration will print converted configuration options to stderr and will
     output the resulting configuration to stdout.
     Please note that the migration will overwrite any fields that have changed
     defaults between versions. To save a custom configuration change, it should
     be in a drop-in configuration file instead.
-    Possible values: "1.17"'
+    Possible values: "1.20"'
 complete -c crio -n '__fish_seen_subcommand_from version' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'version' -d 'display detailed version information'
 complete -c crio -n '__fish_seen_subcommand_from version' -f -l json -s j -d 'print JSON instead of text'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -260,7 +260,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--pause-command**="": Path to the pause executable in the pause image (default: /pause)
 
-**--pause-image**="": Image which contains the pause executable (default: k8s.gcr.io/pause:3.2)
+**--pause-image**="": Image which contains the pause executable (default: k8s.gcr.io/pause:3.5)
 
 **--pause-image-auth-file**="": Path to a config file containing credentials for --pause-image (default: "")
 
@@ -347,14 +347,14 @@ it later with **--config**. Global options will modify the output.
     To run a config migration, just select the input config via the global
     '--config,-c' command line argument, for example:
     ```
-    crio -c /etc/crio/crio.conf.d/00-default.conf config -m 1.17
+    crio -c /etc/crio/crio.conf.d/00-default.conf config -m 1.20
     ```
     The migration will print converted configuration options to stderr and will
     output the resulting configuration to stdout.
     Please note that the migration will overwrite any fields that have changed
     defaults between versions. To save a custom configuration change, it should
     be in a drop-in configuration file instead.
-    Possible values: "1.17" (default: 1.17)
+    Possible values: "1.20" (default: 1.20)
 
 ## version
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -283,7 +283,7 @@ CRI-O reads its configured registries defaults from the system wide containers-r
 **global_auth_file**=""
   The path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.
 
-**pause_image**="k8s.gcr.io/pause:3.2"
+**pause_image**="k8s.gcr.io/pause:3.5"
   The image used to instantiate infra containers. This option supports live configuration reload.
 
 **pause_image_auth_file**=""

--- a/internal/config/migrate/from_1_20.go
+++ b/internal/config/migrate/from_1_20.go
@@ -1,0 +1,18 @@
+package migrate
+
+import (
+	"github.com/cri-o/cri-o/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+// migrateFrom1_20 migrates a config from the 1.20.x version
+func migrateFrom1_20(cfg *config.Config) error {
+	// Upgrade pause image
+	logrus.Infof("Checking for pause_image, which now should be k8s.gcr.io/pause:3.5 instead of k8s.gcr.io/pause:3.2")
+	if cfg.PauseImage == "k8s.gcr.io/pause:3.2" {
+		cfg.PauseImage = config.DefaultPauseImage
+		logrus.Infof(`Changing "pause_image" to %s`, cfg.PauseImage)
+	}
+
+	return nil
+}

--- a/internal/config/migrate/migrate.go
+++ b/internal/config/migrate/migrate.go
@@ -7,8 +7,9 @@ import (
 
 // All possible migration scenarios
 const (
-	FromPrevious = From1_17
+	FromPrevious = From1_20
 	From1_17     = "1.17"
+	From1_20     = "1.20"
 )
 
 // Config migrates the provided config from the provided scenario to the
@@ -17,6 +18,11 @@ func Config(cfg *config.Config, from string) error {
 	// 1.17 specific settings
 	if from == From1_17 {
 		return migrateFrom1_17(cfg)
+	}
+
+	// 1.20 specific settings
+	if from == From1_20 {
+		return migrateFrom1_20(cfg)
 	}
 
 	return errors.Errorf("unsupported migration version %q", from)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,7 @@ const (
 	RuntimeTypeVM         = "vm"
 	defaultCtrStopTimeout = 30 // seconds
 	defaultNamespacesDir  = "/var/run"
+	DefaultPauseImage     = "k8s.gcr.io/pause:3.5"
 )
 
 // Config represents the entire set of configuration values that can be set for
@@ -635,7 +636,7 @@ func DefaultConfig() (*Config, error) {
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport: "docker://",
-			PauseImage:       "k8s.gcr.io/pause:3.2",
+			PauseImage:       DefaultPauseImage,
 			PauseCommand:     "/pause",
 			ImageVolumes:     ImageVolumesMkdir,
 		},

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -84,7 +84,7 @@ POD_IPV6_CIDR_START="1100:2"
 POD_IPV6_DEF_ROUTE="1100:200::1/24"
 
 IMAGES=(
-    k8s.gcr.io/pause:3.2
+    k8s.gcr.io/pause:3.5
     quay.io/crio/busybox:latest
     quay.io/crio/fedora-ping:latest
     quay.io/crio/image-volume-test:latest


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
We upgraded the pause image to 3.5, which is now reflected in CRI-O as
well as our config migration.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update default pause image to version 3.5
```
