### PR TITLE
[1.20] Run GitHub actions on release branches

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,7 @@ on:
       - v*
     branches:
       - master
+      - release-*
   pull_request:
 jobs:
   critest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
       - v*
     branches:
       - master
+      - release-*
   pull_request:
 jobs:
   build:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,6 +5,7 @@ on:
       - v*
     branches:
       - master
+      - release-*
   pull_request:
 jobs:
   lint:


### PR DESCRIPTION

#### What type of PR is this?

/kind ci


#### What this PR does / why we need it:
We have to run the actions on all release branches, too.

Cherry-picked: 128151e82620095352d6a0a4f075c3294564ae35
Signed-off-by: Sascha Grunert <sgrunert@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Refers to https://github.com/cri-o/cri-o/pull/4665
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
