### PR TITLE
Do not return `<none>` placeholders for images any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ default UID mappings (format <container>:<host>:<size>):
 
 Please refer to the [CRI-O Metrics guide](tutorials/metrics.md).
 
+#### Container Runtime Interface special cases
+
+Some aspects of the Container Runtime are worth some additional explanation.
+These details are summarized in a [dedicated guide](cri.md).
+
 ## Adopters
 
 An incomplete list of adopters of CRI-O in production environments can be found [here](ADOPTERS.md).

--- a/cri.md
+++ b/cri.md
@@ -1,0 +1,148 @@
+# Container Runtime Interface special cases
+
+The target of this document is to outline corner cases and common pitfalls in
+conjunction with the Container Runtime Interface (CRI). This document outlines
+CRI-O's interpretation of certain aspects of the interface, which may not be 
+completely formalized.
+
+The main documentation of the CRI can be found [in the corresponding protobuf
+definition][0], whereas this document follows it on the `service`/`rpc` level.
+
+## `ListImages`
+
+`ListImages` lists existing images. Its response consists of an array of
+`Image` types. Besides other information, an `Image` contains `repo_tags` and
+`repo_digests`, which are defined as:
+
+```proto
+// Other names by which this image is known.
+repeated string repo_tags = 2;
+
+// Digests by which this image is known.
+repeated string repo_digests = 3;
+```
+
+Both tags and digests will be used by:
+
+- The kubelet, which displays them in the node status as a flat list, for example:
+
+  ```
+  > kubectl get node 127.0.0.1 -o json | jq .status.images
+  ```
+
+  ```json
+  [
+    {
+      "names": [
+        "k8s.gcr.io/pause@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108",
+        "k8s.gcr.io/pause@sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f",
+        "k8s.gcr.io/pause:3.2"
+      ],
+      "sizeBytes": 688049
+    }
+  ]
+  ```
+
+  Right now, the amount of images shown is limited by the kubelet flag
+  `--node-status-max-images` (). The scheduler uses this list to
+  score nodes based on the information if a container image already exists.
+
+- crictl, which is able to output the image list in a human readable way:
+  ```
+  > sudo crictl images --digests
+  IMAGE                 TAG       DIGEST           IMAGE ID         SIZE
+  k8s.gcr.io/pause      3.2       4a1c4b21597c1    80d28bedfe5de    688kB
+  ```
+
+CRI-O implements the [`ConvertImage`][1] function to follow the following self-defined
+rules:
+
+- always return at least one `repo_digests` value
+- return zero or more `repo_tags` values
+
+There are multiple use-cases where this behavior is relevant. Those will be
+covered separately by using real world examples.
+
+### Pulling an image from a remote registry
+
+This is the standard behavior and already shown in the `pause` image example
+above. `crictl` is able to display all information, like the image name, tag and
+digest. There are multiple digests available for this image, which gets a
+correct representation within the `kubelet`'s node status.
+
+### Pulling an updated version of an image with the same tag
+
+Let's assume we pulled the image `quay.io/saschagrunert/hello-world` and
+afterwards its `latest` tag got updated. Now we pull the image again, which
+results in untagging the local image in favor of the new remote one.
+
+CRI-O would now have no available `RepoTags` nor `RepoDigests` within the
+`storage.ImageResult`. In this case, CRI-O uses an assembled `repoDigests`
+value from the `PreviousName` and the image digest:
+
+```go
+repoDigests = []string{from.PreviousName + "@" + string(from.Digest)}
+```
+
+This allows tools like `crictl` to output the image name by adding a `<none>`
+placeholder for the tag:
+
+```
+> sudo crictl images --digests
+IMAGE                               TAG       DIGEST           IMAGE ID         SIZE
+quay.io/saschagrunert/hello-world   <none>    2403474085c1e    14c28051b743c    5.88MB
+quay.io/saschagrunert/hello-world   latest    ca810c5740f66    d1165f2212346    17.7kB
+```
+
+The `kubelet` is still able to list the image by its digest, which could be
+referenced by a Kubernetes container:
+
+```
+> kubectl get node 127.0.0.1 -o json | jq .status.images
+```
+
+```json
+{
+  "names": [
+    "quay.io/saschagrunert/hello-world@sha256:2403474085c1e68c0aa171eb1b2b824a841a4aa636a4f2500c8d2e2f6d3cb422"
+  ],
+  "sizeBytes": 5884835
+}
+```
+
+#### Building container images locally
+
+We assume that we consecutively build a container image locally like this:
+
+```
+> sudo podman build --no-cache -t test .
+```
+
+The previous image tag gets removed by Podman and applied to the current build.
+In that case CRI-O will use the `PreviousName` in the same way as described in
+the use-case above.
+
+#### Pulling images by digest
+
+If we pull a container image by its digest like this:
+
+```
+> sudo crictl pull docker.io/alpine@sha256:2a8831c57b2e2cb2cda0f3a7c260d3b6c51ad04daea0b3bfc5b55f489ebafd71
+```
+
+Then CRI-O will not be able to provide a `RepoTags` result, but a single entry
+in `RepoDigests`. The output for tools like `crictl` will be the same as
+described in the examples above. In the same way the node status receives the
+single digest entry:
+
+```json
+{
+  "names": [
+    "docker.io/library/alpine@sha256:2a8831c57b2e2cb2cda0f3a7c260d3b6c51ad04daea0b3bfc5b55f489ebafd71"
+  ],
+  "sizeBytes": 5850080
+}
+```
+
+[0]: https://github.com/kubernetes/cri-api/blob/ca4df7a/pkg/apis/runtime/v1/api.proto
+[1]: https://github.com/cri-o/cri-o/blob/master/server/image_list.go#L31

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -28,21 +28,25 @@ func (s *Server) ListImages(ctx context.Context, req *types.ListImagesRequest) (
 	return resp, nil
 }
 
+// ConvertImage takes an containers/storage ImageResult and converts it into a
+// CRI protobuf type. More information about the "why"s of this function can be
+// found in ../cri.md.
 func ConvertImage(from *storage.ImageResult) *types.Image {
 	if from == nil {
 		return nil
 	}
 
-	repoTags := []string{"<none>:<none>"}
+	repoTags := []string{}
+	repoDigests := []string{}
+
 	if len(from.RepoTags) > 0 {
 		repoTags = from.RepoTags
-	} else if from.PreviousName != "" {
-		repoTags = []string{from.PreviousName + ":<none>"}
 	}
 
-	repoDigests := []string{"<none>@<none>"}
 	if len(from.RepoDigests) > 0 {
 		repoDigests = from.RepoDigests
+	} else if from.PreviousName != "" && from.Digest != "" {
+		repoDigests = []string{from.PreviousName + "@" + string(from.Digest)}
 	}
 
 	to := &types.Image{

--- a/server/image_list_test.go
+++ b/server/image_list_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
 )
 
 // The actual test suite
@@ -92,10 +93,8 @@ var _ = t.Describe("ImageList", func() {
 
 			// Then
 			Expect(result).NotTo(BeNil())
-			Expect(result.RepoTags).To(HaveLen(1))
-			Expect(result.RepoTags).To(ContainElement("<none>:<none>"))
-			Expect(result.RepoDigests).To(HaveLen(1))
-			Expect(result.RepoDigests).To(ContainElement("<none>@<none>"))
+			Expect(result.RepoTags).To(HaveLen(0))
+			Expect(result.RepoDigests).To(HaveLen(0))
 		})
 
 		It("should succeed with repo tags and digests", func() {
@@ -123,15 +122,19 @@ var _ = t.Describe("ImageList", func() {
 
 		It("should succeed with previous tag but no current", func() {
 			// Given
-			image := &storage.ImageResult{PreviousName: "1"}
+			image := &storage.ImageResult{
+				PreviousName: "1",
+				Digest:       digest.Digest("2"),
+			}
 
 			// When
 			result := server.ConvertImage(image)
 
 			// Then
 			Expect(result).NotTo(BeNil())
-			Expect(result.RepoTags).To(HaveLen(1))
-			Expect(result.RepoTags).To(ContainElement("1:<none>"))
+			Expect(result.RepoTags).To(HaveLen(0))
+			Expect(result.RepoDigests).To(HaveLen(1))
+			Expect(result.RepoDigests).To(ContainElement("1@2"))
 		})
 
 		It("should return nil if input image is nil", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now plainly use the `RepoTags` and `RepoDigests` from the returned
image result, with one exception: If there is a previous image name
available, then we use it together with the `Digest` to let tools like
`crictl` be able to display them together with the `<none>` placeholder.

#### Which issue(s) this PR fixes:

Follow-up of https://github.com/cri-o/cri-o/pull/4662

#### Special notes for your reviewer:

@mtrmac please take a look

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
CRI-O does not return `<none>` placeholders for missing tags and digests any more when doing a `ListImages` RPC
```
