### PR TITLE
[CLI] "crio config" only prints the fields that are different than the default

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -74,6 +74,6 @@ it later with **--config**. Global options will modify the output.`,
 		}
 
 		// Output the commented config.
-		return conf.WriteTemplate(os.Stdout)
+		return conf.WriteTemplate(c.Bool("default"), os.Stdout)
 	},
 }

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -66,6 +66,12 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 	if err := config.UpdateFromPath(ctx.String("config-dir")); err != nil {
 		return err
 	}
+	// If "config-dir" is specified, config.UpdateFromPath() will set config.singleConfigPath as
+	// the last config file in "config-dir".
+	// We need correct it to the path specified by "config"
+	if path != "" {
+		config.SetSingleConfigPath(path)
+	}
 
 	// Override options set with the CLI.
 	if ctx.IsSet("conmon") {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1156,3 +1156,8 @@ func (r *RuntimeHandler) ValidateRuntimeAllowedAnnotations() error {
 func (c *NetworkConfig) CNIPlugin() ocicni.CNIPlugin {
 	return c.cniPlugin
 }
+
+// SetSingleConfigPath set single config path for config
+func (c *Config) SetSingleConfigPath(singleConfigPath string) {
+	c.singleConfigPath = singleConfigPath
+}

--- a/pkg/config/template_test.go
+++ b/pkg/config/template_test.go
@@ -17,7 +17,7 @@ var _ = t.Describe("Config", func() {
 			var wr bytes.Buffer
 
 			// When
-			err := sut.WriteTemplate(&wr)
+			err := sut.WriteTemplate(true, &wr)
 
 			// Then
 			Expect(err).To(BeNil())

--- a/test/config.bats
+++ b/test/config.bats
@@ -42,7 +42,7 @@ function teardown() {
 @test "replace default runtime should succeed" {
 	# when
 	unset CONTAINER_RUNTIMES
-	RES=$("$CRIO_BINARY_PATH" -d "$TESTDATA"/50-crun-default.conf config 2>&1)
+	RES=$("$CRIO_BINARY_PATH" -c "$TESTDATA"/50-crun-default.conf -d "" config 2>&1)
 
 	# then
 	[[ "$RES" == *"default_runtime = \"crun\""* ]]
@@ -52,10 +52,10 @@ function teardown() {
 
 @test "retain default runtime should succeed" {
 	# when
-	RES=$("$CRIO_BINARY_PATH" -d "$TESTDATA"/50-crun.conf config 2>&1)
+	RES=$("$CRIO_BINARY_PATH" -c "$TESTDATA"/50-crun.conf -d "" config 2>&1)
 
 	# then
-	[[ "$RES" == *"default_runtime = \"runc\""* ]]
+	[[ "$RES" != *"default_runtime = \"crun\""* ]]
 	[[ "$RES" == *"crio.runtime.runtimes.runc"* ]]
 	[[ "$RES" == *"crio.runtime.runtimes.crun"* ]]
 }

--- a/test/config_migrate.bats
+++ b/test/config_migrate.bats
@@ -14,16 +14,13 @@ load helpers
 
 	# then
 	[[ "$output" == *'Changing \"apparmor_profile\" to \"crio-default\"'* ]]
-	[[ "$output" == *'apparmor_profile = "crio-default"'* ]]
 
 	[[ "$output" == *'Removing \"default_capabilities\" entry \"NET_RAW\"'* ]]
 	[[ "$output" == *'Removing \"default_capabilities\" entry \"SYS_CHROOT\"'* ]]
 
 	[[ "$output" == *'Changing \"log_level\" to \"info\"'* ]]
-	[[ "$output" == *'log_level = "info"'* ]]
 
 	[[ "$output" == *'Changing \"ctr_stop_timeout\" to 30'* ]]
-	[[ "$output" == *'ctr_stop_timeout = 30'* ]]
 }
 
 @test "config migrate should fail on invalid version" {

--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -27,7 +27,7 @@ function teardown() {
 
 # run crio_wipe calls crio_wipe and tests it succeeded
 function run_crio_wipe() {
-	"$CRIO_BINARY_PATH" --config "$CRIO_CONFIG" wipe
+	"$CRIO_BINARY_PATH" --config "$CRIO_CONFIG" -d "$CRIO_CONFIG_DIR" wipe
 }
 
 # test_crio_wiped_containers checks if a running crio instance
@@ -167,7 +167,7 @@ function start_crio_with_stopped_pod() {
 	rm "$CONTAINER_CLEAN_SHUTDOWN_FILE"
 	rm "$CONTAINER_VERSION_FILE"
 
-	run "$CRIO_BINARY_PATH" --config "$CRIO_CONFIG" wipe
+	run "$CRIO_BINARY_PATH" --config "$CRIO_CONFIG" -d "$CRIO_CONFIG_DIR" wipe
 	echo "$status"
 	echo "$output"
 	[ "$status" -ne 0 ]

--- a/test/docs-validation/main.go
+++ b/test/docs-validation/main.go
@@ -89,7 +89,7 @@ func validateTags(cfg *config.Config) (failed bool) {
 
 	// Parse the template into a buffer
 	var templateBytes bytes.Buffer
-	if err := cfg.WriteTemplate(&templateBytes); err != nil {
+	if err := cfg.WriteTemplate(true, &templateBytes); err != nil {
 		logrus.Fatalf("Unable to write template: %v", err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
> /kind feature

#### What this PR does / why we need it:
As described in #4506 , this PR lets ``crio config`` only prints the fields that are different than the default.

#### Which issue(s) this PR fixes:
Fixes #4506

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes.

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
"crio config" only prints the fields that are different than the default configuration.
```