### PR TITLE
crio wipe: only completely wipe storage after a reboot

### DIFF
--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -117,25 +117,12 @@ function start_crio_with_stopped_pod() {
 	run_podman_with_args ps -a | grep test
 }
 
-@test "don't clear everything when not asked to check shutdown" {
-	start_crio_with_stopped_pod
-	stop_crio_no_clean
-
-	rm "$CONTAINER_CLEAN_SHUTDOWN_FILE"
-
-	CONTAINER_CLEAN_SHUTDOWN_FILE="" run_crio_wipe
-
-	start_crio_no_setup
-
-	test_crio_did_not_wipe_containers
-	test_crio_did_not_wipe_images
-}
-
 @test "do clear everything when shutdown file not found" {
 	start_crio_with_stopped_pod
 	stop_crio_no_clean
 
 	rm "$CONTAINER_CLEAN_SHUTDOWN_FILE"
+	rm "$CONTAINER_VERSION_FILE"
 
 	run_crio_wipe
 
@@ -158,6 +145,7 @@ function start_crio_with_stopped_pod() {
 	run_podman_with_args stop -a
 
 	rm "$CONTAINER_CLEAN_SHUTDOWN_FILE"
+	rm "$CONTAINER_VERSION_FILE"
 
 	run_crio_wipe
 
@@ -177,9 +165,22 @@ function start_crio_with_stopped_pod() {
 	run_podman_with_args run --name test -d quay.io/crio/busybox:latest top
 
 	rm "$CONTAINER_CLEAN_SHUTDOWN_FILE"
+	rm "$CONTAINER_VERSION_FILE"
 
 	run "$CRIO_BINARY_PATH" --config "$CRIO_CONFIG" wipe
 	echo "$status"
 	echo "$output"
 	[ "$status" -ne 0 ]
+}
+
+@test "don't clear containers on a forced restart of crio" {
+	start_crio_with_stopped_pod
+	stop_crio_no_clean "-9" || true
+
+	run_crio_wipe
+
+	start_crio_no_setup
+
+	test_crio_did_not_wipe_containers
+	test_crio_did_not_wipe_images
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -362,8 +362,9 @@ function cleanup_pods() {
 }
 
 function stop_crio_no_clean() {
+    local signal="$1"
     if [ -n "${CRIO_PID+x}" ]; then
-        kill "$CRIO_PID" >/dev/null 2>&1
+        kill "$signal" "$CRIO_PID" >/dev/null 2>&1 || true
         wait "$CRIO_PID"
         unset CRIO_PID
     fi
@@ -371,7 +372,7 @@ function stop_crio_no_clean() {
 
 # Stop crio.
 function stop_crio() {
-    stop_crio_no_clean
+    stop_crio_no_clean ""
     cleanup_network_conf
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
We created the CleanShutdownFile to work around issues where nodes didn't have time
to sync changes to disk before rebooting. This caused an unclean reboot.

However, for this to be relevant, the node had to actually reboot. If it didn't,
we could fail to remove the storage because the containers are still running.

In this case, we shouldn't wipe anything.

Signed-off-by: Peter Hunt <pehunt@redhat.com>
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a bug where crio wipe incorrectly wiped container storage even though the node wasn't rebooted
```
