### PR TITLE
Reload the main config file when reloading configs

### DIFF
--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -49,7 +49,7 @@ func (c *Config) Reload() error {
 			return err
 		}
 	} else {
-		logrus.Infof("skipping not-existing config file %s", c.singleConfigPath)
+		logrus.Infof("skipping not-existing config file %q", c.singleConfigPath)
 	}
 
 	if _, err := os.Stat(c.dropInConfigDir); !os.IsNotExist(err) {
@@ -58,7 +58,7 @@ func (c *Config) Reload() error {
 			return err
 		}
 	} else {
-		logrus.Infof("skipping not-existing config path %s", c.dropInConfigDir)
+		logrus.Infof("skipping not-existing config path %q", c.dropInConfigDir)
 	}
 
 	// Reload all available options


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When reloading the configuration, don't overwrite the name of the main configuration file with the name of the last drop-in that we parse, which would prevent us from reloading its contents the next time.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

`pkg/config.Config.UpdateFromPath()` was calling `pkg/config.Config.UpdateFromFile()`, which always updated the `Config` object's `singleConfigPath` value, which it would later treat as the main configuration file in `pkg/config.Config.Reload()`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug which would cause configuration files to not be reloaded properly on SIGHUP when one or more "drop-in" configuration files were being used.
```