### PR TITLE
Update container status on ListContainers

### DIFF
--- a/server/container_list.go
+++ b/server/container_list.go
@@ -85,6 +85,15 @@ func (s *Server) ListContainers(ctx context.Context, req *types.ListContainersRe
 		img := &types.ImageSpec{
 			Image: ctr.Image(),
 		}
+
+		if cState.Status == oci.ContainerStateStopped && cState.ExitCode == nil {
+			err := s.Runtime().UpdateContainerStatus(ctx, ctr)
+			if err != nil {
+				log.Warnf(ctx, "Failed to update container status for %s: %v", ctr.ID(), err)
+			}
+			cState = ctr.State()
+		}
+
 		c := &types.Container{
 			ID:           cID,
 			PodSandboxID: podSandboxID,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
There are cases where the container status is outdated when returned by
the `ListContainers` RPC. We now update the status for each container
before returning the list, which should mitigate this corner case.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/4693
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
