### PR TITLE
Use internal logging when context available

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -63,9 +63,9 @@ func catchShutdown(ctx context.Context, cancel context.CancelFunc, gserver *grpc
 			case unix.SIGPIPE:
 				continue
 			case signals.Interrupt:
-				logrus.Debugf("Caught SIGINT")
+				log.Debugf(ctx, "Caught SIGINT")
 			case signals.Term:
-				logrus.Debugf("Caught SIGTERM")
+				log.Debugf(ctx, "Caught SIGTERM")
 			default:
 				continue
 			}
@@ -73,12 +73,12 @@ func catchShutdown(ctx context.Context, cancel context.CancelFunc, gserver *grpc
 			gserver.GracefulStop()
 			hserver.Shutdown(ctx) // nolint: errcheck
 			if err := sserver.StopStreamServer(); err != nil {
-				logrus.Warnf("error shutting down streaming server: %v", err)
+				log.Warnf(ctx, "error shutting down streaming server: %v", err)
 			}
 			sserver.StopMonitors()
 			cancel()
 			if err := sserver.Shutdown(ctx); err != nil {
-				logrus.Warnf("error shutting down main service %v", err)
+				log.Warnf(ctx, "error shutting down main service %v", err)
 			}
 			return
 		}
@@ -186,9 +186,9 @@ func main() {
 			profilePort := c.Int("profile-port")
 			profileEndpoint := fmt.Sprintf("localhost:%v", profilePort)
 			go func() {
-				logrus.Debugf("starting profiling server on %v", profileEndpoint)
+				log.Debugf(ctx, "starting profiling server on %v", profileEndpoint)
 				if err := http.ListenAndServe(profileEndpoint, nil); err != nil {
-					logrus.Fatalf("unable to run profiling server: %v", err)
+					log.Fatalf(ctx, "unable to run profiling server: %v", err)
 				}
 			}()
 		}
@@ -212,7 +212,7 @@ func main() {
 
 		lis, err := server.Listen("unix", config.Listen)
 		if err != nil {
-			logrus.Fatalf("failed to listen: %v", err)
+			log.Fatalf(ctx, "failed to listen: %v", err)
 		}
 
 		grpcServer := grpc.NewServer(
@@ -255,13 +255,13 @@ func main() {
 			// CleanShutdownFile.
 			f, err := os.Create(config.CleanShutdownSupportedFileName())
 			if err != nil {
-				logrus.Errorf("Writing clean shutdown supported file: %v", err)
+				log.Errorf(ctx, "Writing clean shutdown supported file: %v", err)
 			}
 			f.Close()
 
 			// and sync the changes to disk
 			if err := utils.SyncParent(config.CleanShutdownFile); err != nil {
-				logrus.Errorf("failed to sync parent directory of clean shutdown file: %v", err)
+				log.Errorf(ctx, "failed to sync parent directory of clean shutdown file: %v", err)
 			}
 		}
 
@@ -301,12 +301,12 @@ func main() {
 
 		go func() {
 			if err := grpcServer.Serve(grpcL); err != nil {
-				logrus.Errorf("unable to run GRPC server: %v", err)
+				log.Errorf(ctx, "unable to run GRPC server: %v", err)
 			}
 		}()
 		go func() {
 			if err := httpServer.Serve(httpL); err != nil {
-				logrus.Debugf("closed http server")
+				log.Debugf(ctx, "closed http server")
 			}
 		}()
 
@@ -317,7 +317,7 @@ func main() {
 				if graceful && strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
 					err = nil
 				} else {
-					logrus.Errorf("Failed to serve grpc request: %v", err)
+					log.Errorf(ctx, "Failed to serve grpc request: %v", err)
 				}
 			}
 		}()
@@ -331,22 +331,22 @@ func main() {
 		}
 
 		if err := crioServer.Shutdown(ctx); err != nil {
-			logrus.Warnf("error shutting down service: %v", err)
+			log.Warnf(ctx, "error shutting down service: %v", err)
 		}
 		cancel()
 
 		<-streamServerCloseCh
-		logrus.Debug("closed stream server")
+		log.Debugf(ctx, "closed stream server")
 		<-serverMonitorsCh
-		logrus.Debug("closed monitors")
+		log.Debugf(ctx, "closed monitors")
 		err = <-hookSync
 		if err == nil || err == context.Canceled {
-			logrus.Debug("closed hook monitor")
+			log.Debugf(ctx, "closed hook monitor")
 		} else {
-			logrus.Errorf("hook monitor failed: %v", err)
+			log.Errorf(ctx, "hook monitor failed: %v", err)
 		}
 		<-serverCloseCh
-		logrus.Debug("closed main server")
+		log.Debugf(ctx, "closed main server")
 
 		return nil
 	}

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/storage/pkg/truncindex"
 	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
 	crioann "github.com/cri-o/cri-o/pkg/annotations"
@@ -232,7 +233,7 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (retErr er
 	defer func() {
 		if retErr != nil {
 			if err := c.RemoveSandbox(sb.ID()); err != nil {
-				logrus.Warnf("could not remove sandbox ID %s: %v", sb.ID(), err)
+				log.Warnf(ctx, "could not remove sandbox ID %s: %v", sb.ID(), err)
 			}
 		}
 	}()
@@ -338,7 +339,7 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (retErr er
 	defer func() {
 		if retErr != nil {
 			if err1 := c.ctrIDIndex.Delete(scontainer.ID()); err1 != nil {
-				logrus.Warnf("could not delete container ID %s: %v", scontainer.ID(), err1)
+				log.Warnf(ctx, "could not delete container ID %s: %v", scontainer.ID(), err1)
 			}
 		}
 	}()
@@ -492,7 +493,7 @@ func (c *ContainerServer) ContainerStateFromDisk(ctx context.Context, ctr *oci.C
 // on disk
 func (c *ContainerServer) ContainerStateToDisk(ctx context.Context, ctr *oci.Container) error {
 	if err := c.Runtime().UpdateContainerStatus(ctx, ctr); err != nil {
-		logrus.Warnf("error updating the container status %q: %v", ctr.ID(), err)
+		log.Warnf(ctx, "error updating the container status %q: %v", ctr.ID(), err)
 	}
 
 	jsonSource, err := ioutils.NewAtomicFileWriter(ctr.StatePath(), 0o644)

--- a/internal/lib/stop.go
+++ b/internal/lib/stop.go
@@ -3,9 +3,10 @@ package lib
 import (
 	"context"
 
+	"github.com/cri-o/cri-o/internal/log"
+
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // ContainerStop stops a running container with a grace period (i.e., timeout).
@@ -36,7 +37,7 @@ func (c *ContainerServer) ContainerStop(ctx context.Context, container string, t
 	}
 
 	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
-		logrus.Warnf("unable to write containers %s state to disk: %v", ctr.ID(), err)
+		log.Warnf(ctx, "unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
 
 	return ctrID, nil

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -28,6 +28,10 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 	entry(ctx).Errorf(format, args...)
 }
 
+func Fatalf(ctx context.Context, format string, args ...interface{}) {
+	entry(ctx).Fatalf(format, args...)
+}
+
 func entry(ctx context.Context) *logrus.Entry {
 	logger := logrus.StandardLogger()
 	if ctx == nil {

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -137,4 +137,17 @@ var _ = t.Describe("Log", func() {
 			Expect(buf.String()).To(BeEmpty())
 		})
 	})
+
+	t.Describe("Fatalf", func() {
+		BeforeEach(func() { beforeEach(logrus.FatalLevel) })
+
+		It("should not error log", func() {
+			// Given
+			// When
+			log.Errorf(ctx, msg)
+
+			// Then
+			Expect(buf.String()).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

As stated in the issue, `internal/log` package stores more information than logrus and functions including context parameter should use `internal/log` package instead logrus.

#### Which issue(s) this PR fixes:
Fixes #4660 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
