### PR TITLE
Add arm64 static builds to v1.20 release.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
           make completions
           hack/tree_status.sh
 
-  build-static:
+  build-static-amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -139,23 +139,47 @@ jobs:
       - run: result/bin/crio version
       - uses: actions/upload-artifact@v2
         with:
-          name: build-static
+          name: build-static-amd64
           path: |
             result/bin/crio
             result/bin/crio-status
             result/bin/pinns
 
-  bundle:
+  build-static-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - uses: cachix/cachix-action@v8
+        with:
+          name: cri-o-static
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix-build nix/default-arm64.nix
+      - run: file result/bin/crio
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-static-arm64
+          path: |
+            result/bin/crio
+            result/bin/crio-status
+            result/bin/pinns
+
+  bundles:
     runs-on: ubuntu-latest
     needs:
       - build
-      - build-static
+      - build-static-amd64
+      - build-static-arm64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
-          name: build-static
-          path: bin/static
+          name: build-static-amd64
+          path: bin/static-amd64
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-static-arm64
+          path: bin/static-arm64
       - uses: actions/download-artifact@v2
         with:
           name: docs
@@ -164,7 +188,7 @@ jobs:
         with:
           name: config
       - run: chmod -R +x bin
-      - run: make bundle
+      - run: make bundles
       - uses: actions/upload-artifact@v2
         with:
           name: bundle
@@ -172,7 +196,7 @@ jobs:
 
   bundle-test:
     runs-on: ubuntu-latest
-    needs: bundle
+    needs: bundles
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -433,6 +433,10 @@ bundle:
 bundle-test:
 	sudo contrib/bundle/test
 
+bundles:
+	contrib/bundle/build amd64
+	contrib/bundle/build arm64
+
 install: .gopathok install.bin install.man install.completions install.systemd install.config
 
 install.bin-nobuild:
@@ -527,6 +531,7 @@ metrics-exporter: bin/metrics-exporter
 	git-validation \
 	binaries \
 	bundle \
+	bundles \
 	bundle-test \
 	build-static \
 	clean \

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,6 @@ BASE_LDFLAGS = ${SHRINKFLAGS} \
 
 GO_LDFLAGS = -ldflags '${BASE_LDFLAGS} ${EXTRA_LDFLAGS}'
 
-TESTIMAGE_VERSION := master-1.6.1
-TESTIMAGE_REGISTRY := quay.io/crio
-TESTIMAGE_SCRIPT := scripts/build-test-image -r $(TESTIMAGE_REGISTRY) -v $(TESTIMAGE_VERSION)
-TESTIMAGE_NAME ?= $(shell $(TESTIMAGE_SCRIPT) -d)
-
 all: binaries crio.conf docs
 
 default: help
@@ -120,7 +115,7 @@ help:
 	@echo " * 'install' - Install binaries to system locations"
 	@echo " * 'binaries' - Build crio and pinns"
 	@echo " * 'release-note' - Generate release note"
-	@echo " * 'integration' - Execute integration tests"
+	@echo " * 'localintegration' - Execute integration tests"
 	@echo " * 'clean' - Clean artifacts"
 	@echo " * 'lint' - Execute the source code linter"
 	@echo " * 'shfmt' - shell format check and apply diff"
@@ -224,39 +219,9 @@ bin/crio.cross.%: .gopathok .explicit_phony
 	GOARCH="$${TARGET##*.}" \
 	$(GO_BUILD) $(GO_LDFLAGS) -tags "containers_image_openpgp btrfs_noversion" -o "$@" $(PROJECT)/cmd/crio
 
-local-image:
-	$(TESTIMAGE_SCRIPT)
-
-test-images:
-	$(TESTIMAGE_SCRIPT) -g 1.15 -a amd64
-	$(TESTIMAGE_SCRIPT) -g 1.15 -a 386
-	$(TESTIMAGE_SCRIPT) -g 1.14 -a amd64
-
 nixpkgs:
-	@nix run -f channel:nixos-20.03 nix-prefetch-git -c nix-prefetch-git \
+	@nix run -f channel:nixos-20.09 nix-prefetch-git -c nix-prefetch-git \
 		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json
-
-dbuild:
-	$(CONTAINER_RUNTIME) run --rm --name=${CRIO_INSTANCE} --privileged \
-		-v $(shell pwd):/go/src/${PROJECT} -w /go/src/${PROJECT} \
-		$(TESTIMAGE_NAME) make
-
-integration: ${GINKGO}
-	$(CONTAINER_RUNTIME) run \
-		-e CI=true \
-		-e CRIO_BINARY \
-		-e JOBS \
-		-e RUN_CRITEST \
-		-e STORAGE_OPTIONS="-s=vfs" \
-		-e TESTFLAGS \
-		-e TEST_USERNS \
-		-it --privileged --rm \
-		-v $(shell pwd):/go/src/${PROJECT} \
-		-v ${GINKGO}:/usr/bin/ginkgo \
-		-w /go/src/${PROJECT} \
-		--sysctl net.ipv6.conf.all.disable_ipv6=0 \
-		$(TESTIMAGE_NAME) \
-		make localintegration
 
 define go-build
 	$(shell cd `pwd` && $(GO_BUILD) -o $(BUILD_BIN_PATH)/$(shell basename $(1)) $(1))
@@ -338,7 +303,6 @@ mockgen: \
 	mock-criostorage \
 	mock-lib-config \
 	mock-oci \
-	mock-sandbox \
 	mock-image-types \
 	mock-ocicni-types
 
@@ -371,12 +335,6 @@ mock-oci: ${MOCKGEN}
 		-package ocimock \
 		-destination ${MOCK_PATH}/oci/oci.go \
 		github.com/cri-o/cri-o/internal/oci RuntimeImpl
-
-mock-sandbox: ${MOCKGEN}
-	${MOCKGEN} \
-		-package sandboxmock \
-		-destination ${MOCK_PATH}/sandbox/sandbox.go \
-		github.com/cri-o/cri-o/internal/lib/sandbox NamespaceIface
 
 mock-image-types: ${MOCKGEN}
 	${BUILD_BIN_PATH}/mockgen \

--- a/contrib/bundle/Makefile
+++ b/contrib/bundle/Makefile
@@ -12,6 +12,8 @@ ZSHINSTALLDIR ?= $(PREFIX)/share/zsh/site-functions
 SYSTEMDDIR ?= $(PREFIX)/lib/systemd/system
 OPT_CNI_BIN_DIR ?= /opt/cni/bin
 
+ARCH ?= amd64
+
 all: install
 
 .PHONY: install
@@ -64,7 +66,9 @@ install-pinns:
 
 .PHONY: install-runc
 install-runc:
+ifeq ($(ARCH),amd64)
 	install $(SELINUX) -D -m 755 -t $(BINDIR) bin/runc
+endif
 
 .PHONY: install-crun
 install-crun:
@@ -115,7 +119,9 @@ uninstall-pinns:
 
 .PHONY: uninstall-runc
 uninstall-runc:
+ifeq ($(ARCH),amd64)
 	rm $(BINDIR)/runc
+endif
 
 .PHONY: uninstall-crun
 uninstall-crun:

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ARCH_AMD64=amd64
+ARCH_ARM64=arm64
+
+ARCH=${1:-$ARCH_AMD64}
+
 # Global vars to be used
 # shellcheck source=vars
-source "$(dirname "${BASH_SOURCE[0]}")"/vars
+source "$(dirname "${BASH_SOURCE[0]}")"/vars "$ARCH"
 
 cd "$(dirname "$0")"
 
@@ -12,9 +17,9 @@ cd "$(dirname "$0")"
 source "$GIT_ROOT/scripts/versions"
 
 FILES_BIN=(
-    "$GIT_ROOT/bin/static/crio-status"
-    "$GIT_ROOT/bin/static/crio"
-    "$GIT_ROOT/bin/static/pinns"
+    "$GIT_ROOT/bin/static-$ARCH/crio-status"
+    "$GIT_ROOT/bin/static-$ARCH/crio"
+    "$GIT_ROOT/bin/static-$ARCH/pinns"
 )
 FILES_MAN=(
     "$GIT_ROOT/docs/crio.8"
@@ -87,6 +92,7 @@ fi
 
 # Local assets
 cp "$GIT_ROOT/contrib/bundle/Makefile" "$TMPDIR"
+sed -i "s/ARCH ?= amd64/ARCH ?= $ARCH/" "$TMPDIR/Makefile"
 cp "$GIT_ROOT/contrib/bundle/README.md" "$TMPDIR"
 
 curl_to() {
@@ -96,42 +102,72 @@ TMP_BIN=$TMPDIR/bin
 
 # conmon
 curl_to "$TMP_BIN/conmon" \
-    https://github.com/containers/conmon/releases/download/"${VERSIONS["conmon"]}"/conmon
+    "https://github.com/containers/conmon/releases/download/${VERSIONS["conmon"]}/conmon.$ARCH"
 chmod +x "$TMP_BIN/conmon"
 
 # runc
-curl_to "$TMP_BIN/runc" \
-    https://github.com/opencontainers/runc/releases/download/"${VERSIONS["runc"]}"/runc.amd64
-chmod +x "$TMP_BIN/runc"
+if [[ $ARCH == "$ARCH_AMD64" ]]; then
+    # runc
+    curl_to "$TMP_BIN/runc" \
+        "https://github.com/opencontainers/runc/releases/download/${VERSIONS["runc"]}/runc.amd64"
+    chmod +x "$TMP_BIN/runc"
+fi
 
 # crun
 curl_to "$TMP_BIN/crun" \
-    https://github.com/containers/crun/releases/download/"${VERSIONS["crun"]}"/crun-"${VERSIONS["crun"]}"-linux-amd64
+    "https://github.com/containers/crun/releases/download/${VERSIONS["crun"]}/crun-${VERSIONS["crun"]}-linux-$ARCH"
 chmod +x "$TMP_BIN/crun"
 
 # CNI plugins
 mkdir -p "$TMPDIR/cni-plugins"
-set -x
 curl_to - \
-    https://github.com/containernetworking/plugins/releases/download/"${VERSIONS["cni-plugins"]}"/cni-plugins-linux-amd64-"${VERSIONS["cni-plugins"]}".tgz |
+    "https://github.com/containernetworking/plugins/releases/download/${VERSIONS["cni-plugins"]}/cni-plugins-linux-$ARCH-${VERSIONS["cni-plugins"]}.tgz" |
     tar xfz - -C "$TMPDIR/cni-plugins"
 
 # crictl
 curl_to - \
-    https://github.com/kubernetes-sigs/cri-tools/releases/download/"${VERSIONS["cri-tools"]}"/crictl-"${VERSIONS["cri-tools"]}"-linux-amd64.tar.gz |
+    "https://github.com/kubernetes-sigs/cri-tools/releases/download/${VERSIONS["cri-tools"]}/crictl-${VERSIONS["cri-tools"]}-linux-$ARCH.tar.gz" |
     tar xfz - -C "$TMP_BIN"
+
+# Check the architectures of the binaries
+ELF_ARCH=x86-64
+if [[ $ARCH == "$ARCH_ARM64" ]]; then
+    ELF_ARCH=aarch64
+fi
+for FILE in "$TMP_BIN"/*; do
+    if ! file "$FILE" | grep -q "$ELF_ARCH"; then
+        echo "$FILE is not of required arch $ELF_ARCH"
+        exit 1
+    fi
+done
 
 # Create the archive
 pushd "$ARCHIVE_PATH"
 rm -f "$ARCHIVE"
-tar cfz "$ARCHIVE" tmp --transform s/tmp/"$BUNDLE"/
+TAR_DIR=cri-o
+tar cfz "$ARCHIVE" tmp --transform s/tmp/$TAR_DIR/
 rm -rf "$TMPDIR"
 echo "Created $ARCHIVE_PATH/$ARCHIVE"
 
 # Test the archive
 echo "Testing archive"
 tar xf "$ARCHIVE"
-pushd "$BUNDLE"
-make DESTDIR=test
+pushd "$TAR_DIR"
+export DESTDIR=test OPT_CNI_BIN_DIR=test/opt/cni/bin
+make
+EXP_CNT=61
+if [[ $ARCH == "$ARCH_AMD64" ]]; then
+    EXP_CNT=62
+fi
+ACT_CNT=$(find test | wc -l)
+if [[ "$EXP_CNT" != "$ACT_CNT" ]]; then
+    echo "make install file count does not match, expected: $EXP_CNT, actual: $ACT_CNT"
+    exit 1
+fi
+make uninstall
+if [[ $(find test -type f | wc -l) != 0 ]]; then
+    echo "make uninstall left over some files"
+    exit 1
+fi
 popd
-rm -rf "$BUNDLE"
+rm -rf "$TAR_DIR"

--- a/contrib/bundle/test
+++ b/contrib/bundle/test
@@ -7,6 +7,9 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
+# Assume we're running on this arch
+ARCH=amd64
+
 # Global vars to be used
 # shellcheck source=vars
 source "$(dirname "${BASH_SOURCE[0]}")"/vars
@@ -15,7 +18,7 @@ pushd "$ARCHIVE_PATH"
 
 # Untar the bundle
 tar xfvz "$ARCHIVE"
-pushd "$BUNDLE"
+pushd cri-o
 
 # Install and prepare config
 make install

--- a/contrib/bundle/vars
+++ b/contrib/bundle/vars
@@ -6,8 +6,7 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 ARCHIVE_PATH="$GIT_ROOT/build/bundle"
 mkdir -p "$ARCHIVE_PATH"
 
-BUNDLE=crio-$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
-ARCHIVE="$BUNDLE.tar.gz"
+ARCH=${1:-amd64}
+ARCHIVE="cri-o.$ARCH.$(git describe --tags --exact-match 2>/dev/null || git rev-parse HEAD).tar.gz"
 
-export BUNDLE
 export ARCHIVE

--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -33,7 +33,7 @@
     state: directory
 
 - name: run critest validation
-  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.flakeAttempts=3"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint unix:///var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.flakeAttempts=3"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
   async: 5400
@@ -46,7 +46,7 @@
   # https://bugzilla.redhat.com/show_bug.cgi?id=1414236
   # https://access.redhat.com/solutions/2897781
 - name: run critest validation
-  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.skip='should not allow privilege escalation when true' --ginkgo.flakeAttempts=3"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint unix:///var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.skip='should not allow privilege escalation when true' --ginkgo.flakeAttempts=3"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
   async: 5400

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,10 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "6e089d30148953df7abb3a1167169afc7848499c",
-  "date": "2020-11-05T09:56:30+01:00",
-  "sha256": "0ydqjkz7payl16psx445jwh6dc6lgbvj2w11xin1dqvbpcp03jcy",
-  "fetchSubmodules": false
+  "rev": "30c2fb65feaf1068b1c413a0b75470afd351c291",
+  "date": "2021-01-28T21:27:34-05:00",
+  "path": "/nix/store/zk71rlw37vg9hqc5j0vqi9x8qzb2ir0m-nixpkgs",
+  "sha256": "0b1y1lgzbagpgh9cvi9szkm162laifz0q2ss4pibns3j3gqpf5gl",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
 }

--- a/scripts/get
+++ b/scripts/get
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCH_AMD64=amd64
+ARCH_ARM64=arm64
+ARCH=
+VERSION=
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+
+usage() {
+    printf "Usage: %s [-a ARCH] [ -t TAG|SHA ] [ -h ]\n\n" "$(basename "$0")"
+    echo "Possible arguments:"
+    printf "  -a\tArchitecture to retrieve (defaults to the local system)\n"
+    printf "  -t\tVersion tag or full length SHA to be used (defaults to the latest available master)\n"
+    printf "  -h\tShow this help message\n"
+}
+
+parse_args() {
+    echo "Welcome to the CRI-O install script!"
+    echo "Export a GITHUB_TOKEN environment variable to avoid GitHub API rate limits"
+
+    while getopts 'a:t:h' OPTION; do
+        case "$OPTION" in
+        a)
+            ARCH="$OPTARG"
+            echo "Using architecture: $ARCH"
+            ;;
+        t)
+            VERSION="$OPTARG"
+            echo "Using version: $VERSION"
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        ?)
+            usage
+            exit 1
+            ;;
+        esac
+    done
+
+    if [[ $ARCH == "" ]]; then
+        LOCAL_ARCH=$(uname -m)
+        if [[ "$LOCAL_ARCH" == x86_64 ]]; then
+            ARCH=$ARCH_AMD64
+        elif [[ "$LOCAL_ARCH" == aarch64 ]]; then
+            ARCH=$ARCH_ARM64
+        else
+            echo "Unsupported local architecture: $LOCAL_ARCH"
+            exit 1
+        fi
+        echo "No architecture provided, using: $ARCH"
+    fi
+}
+
+verify_requirements() {
+    CMDS=(curl jq tar make)
+    echo "Checking if all commands are available: ${CMDS[*]}"
+    for CMD in "${CMDS[@]}"; do
+        if ! command -v "$CMD" >/dev/null; then
+            echo "Command $CMD not available but required"
+            exit 1
+        fi
+    done
+}
+
+latest_version() {
+    GH_API_URL="https://api.github.com/repos/cri-o/cri-o/actions/runs"
+    GH_QUERY="$GH_API_URL?event=push&status=success&branch=master"
+
+    GH_HEADERS=(-H "Accept: application/vnd.github.v3+json")
+    if [[ $GITHUB_TOKEN != "" ]]; then
+        GH_HEADERS+=(-H "Authorization: token $GITHUB_TOKEN")
+    fi
+
+    if [[ $VERSION == "" ]]; then
+        echo No version provided, finding latest successful GitHub actions run
+        VERSION=$(curl -sSfL "${GH_HEADERS[@]}" "$GH_QUERY" |
+            jq -r '.workflow_runs | map(select(.name == "test")) | first | .head_sha')
+
+        echo "Using latest successful GitHub action master: $VERSION"
+    fi
+}
+
+download_and_install() {
+    GCB_URL=https://storage.googleapis.com/k8s-conform-cri-o/artifacts
+    TARBALL_URL=$GCB_URL/cri-o.$ARCH.$VERSION.tar.gz
+
+    TMPDIR="$(mktemp -d)"
+    trap 'rm -rf -- "$TMPDIR"' EXIT
+
+    echo "Downloading $TARBALL_URL to $TMPDIR"
+    curl -sSfL "$TARBALL_URL" | tar xfz - --strip-components=1 -C "$TMPDIR"
+
+    echo Installing CRI-O
+    make -C "$TMPDIR"
+
+}
+
+main() {
+    parse_args "$@"
+    verify_requirements
+    latest_version
+    download_and_install
+}
+
+main "$@"

--- a/scripts/upload-artifacts
+++ b/scripts/upload-artifacts
@@ -27,12 +27,13 @@ if TAG=$(git describe --exact-match --tags 2>/dev/null); then
             exit 1
         fi
         UPLOAD_URL=${UPLOAD_URL%"{?name,label}"}
-        FILE=build/bundle/crio-$TAG.tar.gz
-        curl -f \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Content-Type: $(file -b --mime-type "$FILE")" \
-            --data-binary @"$FILE" \
-            "$UPLOAD_URL?name=$(basename "$FILE")"
+        for FILE in build/bundle/*.tar.gz; do
+            curl -f \
+                -H "Authorization: token $GITHUB_TOKEN" \
+                -H "Content-Type: $(file -b --mime-type "$FILE")" \
+                --data-binary @"$FILE" \
+                "$UPLOAD_URL?name=$(basename "$FILE")"
+        done
     fi
 else
     echo "Skipping artifact upload to GitHub (not on a tag)"

--- a/scripts/versions
+++ b/scripts/versions
@@ -5,10 +5,10 @@ set -euo pipefail
 declare -A VERSIONS=(
     ["go"]=1.15.5
     ["cni-plugins"]=v0.8.7
-    ["conmon"]=v2.0.20
+    ["conmon"]=v2.0.26
     ["cri-tools"]=v1.19.0
     ["runc"]=v1.0.0-rc92
-    ["crun"]=0.15
+    ["crun"]=0.18
     ["bats"]=v1.2.1
 )
 export VERSIONS

--- a/test/critest.bats
+++ b/test/critest.bats
@@ -17,7 +17,7 @@ function teardown() {
 
 @test "run the critest suite" {
 	critest --parallel 8 \
-		--runtime-endpoint "${CRIO_SOCKET}" \
+		--runtime-endpoint "unix://${CRIO_SOCKET}" \
 		--image-endpoint "${CRIO_SOCKET}" \
 		--ginkgo.focus="${CRI_FOCUS}" \
 		--ginkgo.skip="${CRI_SKIP}" \


### PR DESCRIPTION
> /kind ci

#### What this PR does / why we need it:

Adds arm64 static builds to v1.20 releases.

#### Which issue(s) this PR fixes:

Fixes #4717

#### Special notes for your reviewer:

A similar commit has been merged for v1.21 releases,
https://github.com/cri-o/cri-o/commit/4ff8662ffbb9c570fbd668b18671a46af42dac26#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88

#### Does this PR introduce a user-facing change?

```release-note
None
```
