### PR TITLE
Add correct start time to initial log output

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -140,12 +140,11 @@ func main() {
 			return err
 		}
 
-		cf := &logrus.TextFormatter{
+		logrus.SetFormatter(&logrus.TextFormatter{
 			TimestampFormat: "2006-01-02 15:04:05.000000000Z07:00",
 			FullTimestamp:   true,
-		}
-
-		logrus.SetFormatter(cf)
+		})
+		version.LogVersion()
 
 		level, err := logrus.ParseLevel(config.LogLevel)
 		if err != nil {
@@ -350,9 +349,6 @@ func main() {
 
 		return nil
 	}
-
-	// Log our version early at startup
-	version.LogVersion()
 
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Before applying this patch the startup time would be zero
(`INFO[0000]`), which is now changed to use the correct formatting
timestmap we're defaulting to.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed version log timestamp when starting CRI-O
```
