### PR TITLE
Bump cri-tools to v1.21.0

### DIFF
--- a/scripts/versions
+++ b/scripts/versions
@@ -5,7 +5,7 @@ set -euo pipefail
 declare -A VERSIONS=(
     ["cni-plugins"]=v0.9.1
     ["conmon"]=v2.0.26
-    ["cri-tools"]=v1.20.0
+    ["cri-tools"]=v1.21.0
     ["runc"]=v1.0.0-rc93
     ["crun"]=0.18
     ["bats"]=v1.3.0


### PR DESCRIPTION

#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:
This mainly affects the static binary bundle, for testing we already use
the latest cri-tools master.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated cri-tools to v1.21.0 within static binary bundle
```
