### PR TITLE
Bump OpenShift CI cri-tools version and fix build path

### DIFF
--- a/contrib/test/integration/build/cri-tools.yml
+++ b/contrib/test/integration/build/cri-tools.yml
@@ -13,7 +13,7 @@
 
 - name: link crictl and critest
   file:
-    src: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-tools/_output/{{ item }}"
+    src: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-tools/build/bin/{{ item }}"
     dest: "/usr/bin/{{ item }}"
     state: link
   with_items:

--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -32,6 +32,9 @@
     path: "{{ artifacts }}"
     state: directory
 
+- name: Print critest version
+  command: critest --version
+
 - name: run critest validation
   shell: "critest --report-dir={{ artifacts }} --runtime-endpoint unix:///var/run/crio/crio.sock --image-endpoint unix:///var/run/crio/crio.sock --ginkgo.flakeAttempts=3"
   args:

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -20,7 +20,7 @@
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:
-        cri_tools_git_version: v1.19.0
+        cri_tools_git_version: v1.21.0
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
@@ -125,7 +125,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: true
-        cri_tools_git_version: v1.19.0
+        cri_tools_git_version: v1.21.0
     - name: run cri-o integration tests
       include: test.yml
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

We changed the output build path in cri-tools a while ago which would cause always falling back to the wrong version.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
