### PR TITLE
config: drop commented config lines

### DIFF
--- a/contrib/bundle/test-e2e
+++ b/contrib/bundle/test-e2e
@@ -36,6 +36,9 @@ EOT
 runc --version
 conmon --version
 
+crio config
+crio config --default
+
 # Start CRI-O
 systemctl daemon-reload
 systemctl start crio

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -411,11 +411,6 @@ func initCrioTemplateConfig(c *Config) ([]*templateConfigValue, error) {
 			isDefaultValue: simpleEqual(dc.ImageVolumes, c.ImageVolumes),
 		},
 		{
-			templateString: templateStringCrioImageRegistries,
-			group:          crioImageConfig,
-			isDefaultValue: stringSliceEqual(dc.Registries, c.Registries),
-		},
-		{
 			templateString: templateStringCrioImageBigFilesTemporaryDir,
 			group:          crioImageConfig,
 			isDefaultValue: simpleEqual(dc.BigFilesTemporaryDir, c.BigFilesTemporaryDir),
@@ -1058,16 +1053,6 @@ insecure_registries = [
 const templateStringCrioImageImageVolumes = `# Controls how image volumes are handled. The valid values are mkdir, bind and
 # ignore; the latter will ignore volumes entirely.
 image_volumes = "{{ .ImageVolumes }}"
-
-`
-
-const templateStringCrioImageRegistries = `# List of registries to be used when pulling an unqualified image (e.g.,
-# "alpine:latest"). By default, registries is set to "docker.io" for
-# compatibility reasons. Depending on your workload and usecase you may add more
-# registries (e.g., "quay.io", "registry.fedoraproject.org",
-# "registry.opensuse.org", etc.).
-registries = [
-{{ range $opt := .Registries }}{{ printf "\t%q,\n" $opt }}{{ end }}]
 
 `
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1050,7 +1050,8 @@ signature_policy = "{{ .SignaturePolicyPath }}"
 const templateStringCrioImageInsecureRegistries = `# List of registries to skip TLS verification for pulling images. Please
 # consider configuring the registries via /etc/containers/registries.conf before
 # changing them here.
-insecure_registries = "{{ .InsecureRegistries }}"
+insecure_registries = [
+{{ range $opt := .InsecureRegistries }}{{ printf "\t%q,\n" $opt }}{{ end }}]
 
 `
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -538,25 +538,25 @@ const templateStringCrio = `[crio]
 
 const templateStringCrioRoot = `# Path to the "root directory". CRI-O stores all of its data, including
 # containers images, in this directory.
-#root = "{{ .Root }}"
+root = "{{ .Root }}"
 
 `
 
 const templateStringCrioRunroot = `# Path to the "run directory". CRI-O stores all of its state in this directory.
-#runroot = "{{ .RunRoot }}"
+runroot = "{{ .RunRoot }}"
 
 `
 
 const templateStringCrioStorageDriver = `# Storage driver used to manage the storage of images and containers. Please
 # refer to containers-storage.conf(5) to see all available storage drivers.
-#storage_driver = "{{ .Storage }}"
+storage_driver = "{{ .Storage }}"
 
 `
 
 const templateStringCrioStorageOption = `# List to pass options to the storage driver. Please refer to
 # containers-storage.conf(5) to see all available storage options.
-#storage_option = [
-{{ range $opt := .StorageOptions }}{{ printf "#\t%q,\n" $opt }}{{ end }}#]
+storage_option = [
+{{ range $opt := .StorageOptions }}{{ printf "\t%q,\n" $opt }}{{ end }}]
 
 `
 
@@ -658,8 +658,8 @@ const templateStringCrioRuntimeDefaultUlimits = `# A list of ulimits to be set i
 # "<ulimit name>=<soft limit>:<hard limit>", for example:
 # "nofile=1024:2048"
 # If nothing is set here, settings will be inherited from the CRI-O daemon
-#default_ulimits = [
-{{ range $ulimit := .DefaultUlimits }}{{ printf "#\t%q,\n" $ulimit }}{{ end }}#]
+default_ulimits = [
+{{ range $ulimit := .DefaultUlimits }}{{ printf "\t%q,\n" $ulimit }}{{ end }}]
 
 `
 
@@ -762,7 +762,7 @@ default_sysctls = [
 
 const templateStringCrioRuntimeAdditionalDevices = `# List of additional devices. specified as
 # "<device-on-host>:<device-on-container>:<permissions>", for example: "--device=/dev/sdc:/dev/xvdc:rwm".
-#If it is empty or commented out, only the devices
+# If it is empty or commented out, only the devices
 # defined in the container json file by the user/kube will be added.
 additional_devices = [
 {{ range $device := .AdditionalDevices}}{{ printf "\t%q,\n" $device}}{{ end }}]
@@ -789,7 +789,7 @@ const templateStringCrioRuntimeDefaultMountsFile = `# Path to the file specifyin
 #      you can change the default_mounts_file. Note, if this is done, CRI-O will
 #      only add mounts it finds in this file.
 #
-#default_mounts_file = "{{ .DefaultMountsFile }}"
+default_mounts_file = "{{ .DefaultMountsFile }}"
 
 `
 
@@ -1050,7 +1050,7 @@ signature_policy = "{{ .SignaturePolicyPath }}"
 const templateStringCrioImageInsecureRegistries = `# List of registries to skip TLS verification for pulling images. Please
 # consider configuring the registries via /etc/containers/registries.conf before
 # changing them here.
-#insecure_registries = "{{ .InsecureRegistries }}"
+insecure_registries = "{{ .InsecureRegistries }}"
 
 `
 
@@ -1065,8 +1065,8 @@ const templateStringCrioImageRegistries = `# List of registries to be used when 
 # compatibility reasons. Depending on your workload and usecase you may add more
 # registries (e.g., "quay.io", "registry.fedoraproject.org",
 # "registry.opensuse.org", etc.).
-#registries = [
-# {{ range $opt := .Registries }}{{ printf "\t%q,\n#" $opt }}{{ end }}]
+registries = [
+{{ range $opt := .Registries }}{{ printf "\t%q,\n" $opt }}{{ end }}]
 
 `
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -289,8 +289,6 @@ function setup_crio() {
         -d "" \
         $OVERRIDE_OPTIONS \
         config >"$CRIO_CUSTOM_CONFIG"
-    sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?default_ulimits = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i "$CRIO_CONFIG"
-    sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?default_ulimits = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i "$CRIO_CUSTOM_CONFIG"
     # make sure we don't run with nodev, or else mounting a readonly rootfs will fail: https://github.com/cri-o/cri-o/issues/1929#issuecomment-474240498
     sed -r -e 's/nodev(,)?//g' -i "$CRIO_CONFIG"
     sed -r -e 's/nodev(,)?//g' -i "$CRIO_CUSTOM_CONFIG"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -289,6 +289,8 @@ function setup_crio() {
         -d "" \
         $OVERRIDE_OPTIONS \
         config >"$CRIO_CUSTOM_CONFIG"
+    sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?default_ulimits = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i "$CRIO_CONFIG"
+    sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?default_ulimits = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i "$CRIO_CUSTOM_CONFIG"
     # make sure we don't run with nodev, or else mounting a readonly rootfs will fail: https://github.com/cri-o/cri-o/issues/1929#issuecomment-474240498
     sed -r -e 's/nodev(,)?//g' -i "$CRIO_CONFIG"
     sed -r -e 's/nodev(,)?//g' -i "$CRIO_CUSTOM_CONFIG"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind ci
> /kind cleanup
> /kind dependency-change
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
now that we only print fields that are different from the default,
we can uncomment the config template fields that we previously didn't want to mess with.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Some fields in the crio configuration related to storage and images were commented out by default (when running `crio config`). They have been uncommented, and will be applied (if they're different from the default value).
```
