### PR TITLE
Rebase release-notes job before pushing gh-pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,7 +281,7 @@ jobs:
       - run: make codecov
 
   release-notes:
-    if: github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/release')
+    if: github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -329,8 +329,8 @@ jobs:
           path: build/dependencies
 
   release-branch-forward:
-    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -223,6 +223,15 @@ Download one of our static release bundles via our Google Cloud Bucket:
 		return errors.Wrap(err, "commit")
 	}
 
+	// Other jobs could run in parallel, rebase before pushing
+	if err := repo.FetchRemote(git.DefaultRemote); err != nil {
+		return errors.Wrap(err, "fetch remote")
+	}
+
+	if err := repo.Rebase(branch); err != nil {
+		return errors.Wrapf(err, "rebase to branch %s", branch)
+	}
+
 	if err := repo.Push(branch); err != nil {
 		return errors.Wrap(err, "push changes")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
This should avoid races where release branches and the master try to
update the release notes in parallel. It also enables release notes for
tags, which may have the same issue.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
