### PR TITLE
Switch to `cri-o` bucket

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,7 +240,7 @@ jobs:
           path: build/bundle
       - run: make upload-artifacts
         env:
-          GCS_BUCKET_SA: ${{ secrets.GCS_BUCKET_SA }}
+          GCS_CRIO_SA: ${{ secrets.GCS_CRIO_SA }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
   unit:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ We also provide a way in building [static binaries of `CRI-O`](install.md#static
 Those binaries are available for every successfully built commit on our [Google Cloud Storage Bucket][bucket].
 This means that the latest commit can be installed via our convinience script:
 
-[bucket]: https://console.cloud.google.com/storage/browser/k8s-conform-cri-o/artifacts
+[bucket]: https://console.cloud.google.com/storage/browser/cri-o/artifacts
 
 ```shell
 > curl https://raw.githubusercontent.com/cri-o/cri-o/master/scripts/get | bash
@@ -142,7 +142,7 @@ The above script resolves to the download URL of the static binary bundle
 tarball matching the format:
 
 ```
-https://storage.googleapis.com/k8s-conform-cri-o/artifacts/cri-o.$ARCH.$REV.tar.gz
+https://storage.googleapis.com/cri-o/artifacts/cri-o.$ARCH.$REV.tar.gz
 ```
 
 where `$ARCH` can be `amd64` or `arm64` and `$REV` can be any git SHA or tag.

--- a/scripts/get
+++ b/scripts/get
@@ -6,7 +6,7 @@ ARCH_ARM64=arm64
 ARCH=
 VERSION=
 GITHUB_TOKEN=${GITHUB_TOKEN:-}
-GCB_URL=https://storage.googleapis.com/k8s-conform-cri-o
+GCB_URL=https://storage.googleapis.com/cri-o
 
 usage() {
     printf "Usage: %s [-a ARCH] [ -t TAG|SHA ] [ -h ]\n\n" "$(basename "$0")"

--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -112,8 +112,8 @@ The release notes have been generated for the commit range
 
 Download one of our static release bundles via our Google Cloud Bucket:
 
-- [cri-o.amd64.%s.tar.gz](https://storage.googleapis.com/k8s-conform-cri-o/artifacts/cri-o.amd64.%s.tar.gz)
-- [cri-o.arm64.%s.tar.gz](https://storage.googleapis.com/k8s-conform-cri-o/artifacts/cri-o.arm64.%s.tar.gz)
+- [cri-o.amd64.%s.tar.gz](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz)
+- [cri-o.arm64.%s.tar.gz](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz)
 
 ## Changelog since %s
 

--- a/scripts/upload-artifacts
+++ b/scripts/upload-artifacts
@@ -2,22 +2,30 @@
 set -euo pipefail
 
 GITHUB_TOKEN=${GITHUB_TOKEN:-}
-GCS_BUCKET_SA=${GCS_BUCKET_SA:-}
+GCS_CRIO_SA=${GCS_CRIO_SA:-}
 
-if [[ -z $GCS_BUCKET_SA ]]; then
-    echo "Skipping artifact upload to Google Cloud Bucket (no \$GCS_BUCKET_SA set)"
+if [[ -z $GCS_CRIO_SA ]]; then
+    echo "Skipping artifact upload to Google Cloud Bucket (no \$GCS_CRIO_SA set)"
 else
     echo "Uploading artifacts to Google Cloud Bucket"
-    echo "$GCS_BUCKET_SA" >/tmp/key.json
+    echo "$GCS_CRIO_SA" >/tmp/key.json
     gcloud auth activate-service-account --key-file=/tmp/key.json
 
-    BUCKET=gs://k8s-conform-cri-o
+    BUCKET=gs://cri-o
     gsutil cp -n build/bundle/*.tar.gz $BUCKET/artifacts
 
-    # update the latest version marker file
-    BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    git rev-parse HEAD >"latest-$BRANCH.txt"
-    gsutil cp "latest-$BRANCH.txt" $BUCKET
+    # update the latest version marker file for the branch
+    MARKER=$(git rev-parse --abbrev-ref HEAD)
+    VERSION=$(git rev-parse HEAD)
+
+    # if in detached head state, we assume we're on a tag
+    if [[ $MARKER == HEAD ]]; then
+        # use the major.minor as marker
+        VERSION=$(git describe --tags --exact-match)
+        MARKER=$(echo "$VERSION" | cut -c 2-5)
+    fi
+    echo "$VERSION" >"latest-$MARKER.txt"
+    gsutil cp "latest-$MARKER.txt" $BUCKET
 fi
 
 if TAG=$(git describe --exact-match --tags 2>/dev/null); then


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We now switch to our own GCS bucket, update the keys and necessary paths
for those. The latest master artifacts have been already uploaded as
well as the v1.21.0 tag.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Switched build artifacts to be published via the [cri-o](https://console.cloud.google.com/storage/browser/cri-o) bucket.
```
