### PR TITLE
Do not upload artifacts on dependabot branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,6 +230,7 @@ jobs:
       - run: make bundle-test-e2e
 
   upload-artifacts:
+    if: github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs: bundle-test
     steps:


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Those branches do not have to upload any artifacts, so we focus from now
on only on release branches, the master and tags.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
