### PR TITLE
Cleanup pod network on sandbox removal

### DIFF
--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -78,6 +78,11 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *types.RemovePodSandb
 		}
 	}
 
+	// Cleanup network resources for this pod
+	if err := s.networkStop(ctx, sb); err != nil {
+		return errors.Wrap(err, "stop pod network")
+	}
+
 	s.removeInfraContainer(podInfraContainer)
 	podInfraContainer.CleanupConmonCgroup()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
We may encounter situations where sandboxes gets killed. In this case,
we now try to cleanup the network on removal of the sandbox to ensure
that no resources (like networks) left stale on the machine.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/4727
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Cleanup pod networks on sandbox removal, which now removes networks even if the pod sandbox got killed.
```
