### PR TITLE
Add After=crio.service dependency to containers and conmon

### DIFF
--- a/internal/config/cgmgr/systemd.go
+++ b/internal/config/cgmgr/systemd.go
@@ -82,7 +82,7 @@ func (*SystemdManager) MoveConmonToCgroup(cid, cgroupParent, conmonCgroup string
 		Value: dbus.MakeVariant(int(unix.SIGPIPE)),
 	}
 	logrus.Debugf("Running conmon under slice %s and unitName %s", cgroupParent, conmonUnitName)
-	if err := utils.RunUnderSystemdScope(pid, cgroupParent, conmonUnitName, killSignalProp); err != nil {
+	if err := utils.RunUnderSystemdScope(pid, cgroupParent, conmonUnitName, killSignalProp, systemdDbus.PropAfter("crio.service")); err != nil {
 		return "", errors.Wrapf(err, "failed to add conmon to systemd sandbox cgroup")
 	}
 	// return empty string as path because cgroup cleanup is done by systemd

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -247,6 +247,7 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 			c.spec.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
 		}
 		c.spec.AddAnnotation("org.systemd.property.DefaultDependencies", "true")
+		c.spec.AddAnnotation("org.systemd.property.After", "['crio.service']")
 	}
 
 	if configStopSignal != "" {


### PR DESCRIPTION
This allows us to predictably shut down the node and help ensure
clean shutdown.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>



#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?



```release-note
Add systemd After=crio.service to containers and conmon
```
