### PR TITLE
Fix RuntimeDefault seccomp behavior if disabled

### DIFF
--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -194,9 +194,12 @@ func (c *Config) setupFromField(
 	log.Debugf(ctx, "Setup seccomp from profile field: %+v", profileField)
 
 	if c.IsDisabled() {
-		if profileField.ProfileType != types.SecurityProfileTypeUnconfined {
+		if profileField.ProfileType != types.SecurityProfileTypeUnconfined &&
+			// Kubernetes sandboxes run per default with `SecurityProfileTypeRuntimeDefault`:
+			// https://github.com/kubernetes/kubernetes/blob/629d5ab/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go#L155-L162
+			profileField.ProfileType != types.SecurityProfileTypeRuntimeDefault {
 			return errors.Errorf(
-				"seccomp is not enabled, cannot run with a profile",
+				"seccomp is not enabled, cannot run with custom profile",
 			)
 		}
 		log.Warnf(ctx, "seccomp is not enabled, running without profile")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The internal seccomp profile (`RuntimeDefault`) should be ignored in the
same way as it was before using the new field. This aligns the
implementation with CRI-O releases before v1.21.0.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/4786
#### Special notes for your reviewer:
The bug comes up because `SecurityProfileTypeRuntimeDefault == 0` (the default value if the field is not set)
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where it was not possible to run containers using the default or no seccomp profile on 
seccomp disabled builds/machines
```
