### PR TITLE
Fix bundle e2e test while fixing coredns

### DIFF
--- a/contrib/bundle/test-e2e
+++ b/contrib/bundle/test-e2e
@@ -7,6 +7,9 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
+# Bypass local DNS
+sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+
 # Prepare the system
 ufw disable
 ip6tables --list >/dev/null


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test


#### What this PR does / why we need it:
The bundle e2e tests were complaining about a coredns loop back to the
local machine. This was caused by the `/etc/resolv.conf`:

```
nameserver 127.0.0.53
options edns0 trust-ad
search kzav01uq0i3u1f1hch3ggm0mbb.bx.internal.cloudapp.net
```

This is now being fixed by using the local content from
`/run/systemd/resolve/resolv.conf`, which looks like:

```
nameserver 168.63.129.16
search gbcyptfplzzunl4htqv55y2vfc.jx.internal.cloudapp.net
```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
