### PR TITLE
explicitly inherit "nofile" limit from crio daemon

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -99,7 +99,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
   The _name_ of the OCI runtime to be used as the default.
 
 **default_ulimits**=[]
-  A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example:"nofile=1024:2048". If nothing is set here, settings will be inherited from the CRI-O daemon.
+  A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example:"nofile=1024:2048". If nothing is set here, limits that aren't explicitly set by runtime-tools will be inherited from the process launching the container.
 
 **no_pivot**=false
   If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -652,7 +652,7 @@ const templateStringCrioRuntime = `# The crio.runtime table contains settings pe
 const templateStringCrioRuntimeDefaultUlimits = `# A list of ulimits to be set in containers by default, specified as
 # "<ulimit name>=<soft limit>:<hard limit>", for example:
 # "nofile=1024:2048"
-# If nothing is set here, settings will be inherited from the CRI-O daemon
+# If nothing is set here, limits that aren't explicitly set by runtime-tools will be inherited from the process launching the container.
 default_ulimits = [
 {{ range $ulimit := .DefaultUlimits }}{{ printf "\t%q,\n" $ulimit }}{{ end }}]
 

--- a/pkg/sandbox/infra.go
+++ b/pkg/sandbox/infra.go
@@ -26,7 +26,6 @@ func (s *sandbox) InitInfraContainer(serverConfig *libconfig.Config, podContaine
 
 	g := s.infra.Spec()
 	g.HostSpecific = true
-	g.ClearProcessRlimits()
 
 	// setup defaults for the pod sandbox
 	g.SetRootReadonly(true)

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -143,7 +143,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 	// creates a spec Generator with the default spec.
 	specgen := ctr.Spec()
 	specgen.HostSpecific = true
-	specgen.ClearProcessRlimits()
 
 	for _, u := range s.config.Ulimits() {
 		specgen.AddProcessRlimits(u.Name, u.Hard, u.Soft)


### PR DESCRIPTION
large "nofile" value may cause application running issues, lets
explicitly inherit it, as it's not natively inherited in all runtimes
as documented.

Signed-off-by: Snir Sheriber <ssheribe@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:
Fixes #4807 
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4807 

[also related](https://github.com/kata-containers/runtime/issues/2597)

#### Special notes for your reviewer:
`None`
#### Does this PR introduce a user-facing change?
`None`
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`None`
```
