### PR TITLE
Remove .gitattributes files from vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ result
 *~
 \#*\#
 .\#*
+
+# See https://github.com/cri-o/cri-o/issues/4820
+/vendor/**/.gitattributes

--- a/vendor/github.com/Microsoft/hcsshim/.gitattributes
+++ b/vendor/github.com/Microsoft/hcsshim/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto eol=lf

--- a/vendor/github.com/containerd/fifo/.gitattributes
+++ b/vendor/github.com/containerd/fifo/.gitattributes
@@ -1,1 +1,0 @@
-*.go text eol=lf

--- a/vendor/github.com/fsnotify/fsnotify/.gitattributes
+++ b/vendor/github.com/fsnotify/fsnotify/.gitattributes
@@ -1,1 +1,0 @@
-go.sum linguist-generated

--- a/vendor/github.com/fsouza/go-dockerclient/.gitattributes
+++ b/vendor/github.com/fsouza/go-dockerclient/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto eol=lf

--- a/vendor/github.com/go-task/slim-sprig/.gitattributes
+++ b/vendor/github.com/go-task/slim-sprig/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto

--- a/vendor/github.com/kevinburke/ssh_config/.gitattributes
+++ b/vendor/github.com/kevinburke/ssh_config/.gitattributes
@@ -1,1 +1,0 @@
-testdata/dos-lines eol=crlf

--- a/vendor/k8s.io/client-go/pkg/version/.gitattributes
+++ b/vendor/k8s.io/client-go/pkg/version/.gitattributes
@@ -1,1 +1,0 @@
-base.go export-subst

--- a/vendor/k8s.io/component-base/version/.gitattributes
+++ b/vendor/k8s.io/component-base/version/.gitattributes
@@ -1,1 +1,0 @@
-base.go export-subst


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
.gitattributes files containing `export-subst` will cause that the
source code tarball  contents will change when the short commit does. To
avoid that we now ignore .gitattributes files from the vendor directory.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/4820
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
