### PR TITLE
Use HTML comment for /kind in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,18 +31,20 @@ Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
 remove leading whitespace from that line:
 -->
 
-> /kind api-change
-> /kind bug
-> /kind ci
-> /kind cleanup
-> /kind dependency-change
-> /kind deprecation
-> /kind design
-> /kind documentation
-> /kind failing-test
-> /kind feature
-> /kind flake
-> /kind other
+<!--
+/kind api-change
+/kind bug
+/kind ci
+/kind cleanup
+/kind dependency-change
+/kind deprecation
+/kind design
+/kind documentation
+/kind failing-test
+/kind feature
+/kind flake
+/kind other
+-->
 
 #### What this PR does / why we need it:
 


### PR DESCRIPTION


#### What type of PR is this?

<!--
/kind api-change
/kind bug
-->

/kind documentation


#### What this PR does / why we need it:
Prow supports excluding HTML comments since quite some time. We now
switch to the same syntax like in k/k to make setting the `/kind` more
comfortable.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
