### PR TITLE
resource store: prevent segfault on cleanup step

### DIFF
--- a/internal/resourcestore/resourcestore.go
+++ b/internal/resourcestore/resourcestore.go
@@ -94,6 +94,15 @@ func (rc *ResourceStore) cleanupStaleResources() {
 		resourcesToReap := []*Resource{}
 		rc.Lock()
 		for name, r := range rc.resources {
+			// this resource shouldn't be marked as stale if it
+			// hasn't yet been added to the store.
+			// This can happen if a creation is in progress, and a watcher is added
+			// before the creation completes.
+			// If this resource isn't skipped from being marked as stale,
+			// we risk segfaulting in the Cleanup() step.
+			if !r.wasPut() {
+				continue
+			}
 			if r.stale {
 				resourcesToReap = append(resourcesToReap, r)
 				delete(rc.resources, name)
@@ -177,6 +186,7 @@ func (rc *ResourceStore) WatcherForResource(name string) chan struct{} {
 	if !ok {
 		rc.resources[name] = &Resource{
 			watchers: []chan struct{}{watcher},
+			name:     name,
 		}
 		return watcher
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
if a resource has a watcher, but has not yet been put to the store, we should not be marking it as stale.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
related to https://bugzilla.redhat.com/show_bug.cgi?id=1955596
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a segfault when CRI-O has takes more than 8 minutes to create a pod or container
```
