### PR TITLE
server: add warning when bind mounting to the root

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -814,9 +814,11 @@ func addOCIBindMounts(ctx context.Context, mountLabel string, containerConfig *t
 		if dest == "" {
 			return nil, nil, fmt.Errorf("mount.ContainerPath is empty")
 		}
-
 		if m.HostPath == "" {
 			return nil, nil, fmt.Errorf("mount.HostPath is empty")
+		}
+		if m.HostPath == "/" && dest == "/" {
+			log.Warnf(ctx, "configuration specifies mounting host root to the container root.  This is dangerous (especially with privileged containers) and should be avoided.")
 		}
 		src := filepath.Join(bindMountPrefix, m.HostPath)
 


### PR DESCRIPTION
if the bind mount points to the container root, raise a warning.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1950408

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

warn the user when a bind mount targets the container root

#### Which issue(s) this PR fixes:

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1950408

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
raise a warning when creating a bind mount on the container root
```
