### PR TITLE
Added Gitpod config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+# Install podman from Kubic project
+RUN (echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list) && \
+	curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/Release.key | sudo apt-key add - && \
+	sudo apt-get update && \
+	sudo apt-get -y upgrade && \
+	sudo apt-get -y install podman 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: make
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/cri-o/cri-o)](https://goreportcard.com/report/github.com/cri-o/cri-o)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fcri-o%2Fcri-o.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fcri-o%2Fcri-o?ref=badge_shield)
 [![Mentioned in Awesome CRI-O](https://awesome.re/mentioned-badge.svg)](awesome.md)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/cri-o/cri-o)
 
 ## Compatibility matrix: CRI-O ⬄ Kubernetes
 


### PR DESCRIPTION
Hi cri-o team! 👋

here is a PR that fully-automates the dev setup of cri-o with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/cri-o/cri-o)

<img width="1377" alt="Screen Shot 2021-05-04 at 18 01 53" src="https://user-images.githubusercontent.com/377752/117033767-fe204680-ad02-11eb-918c-e6ea0d42fc74.png">

### What it does

* Comes with all cri-o lifecycle dependencies pre-installed (Go, Docker...)
* Runs `make` ahead-of-time so you don't need to wait
* Gives anyone immediate access to the pre-compiled cri-o, and allows to easily edit & rebuild the code

I hope this can make life easier for contributors, and for maintainers who need to review many PRs (hint: you can already open this PR in Gitpod to easily review & test it without messing up your local checkout).

I'm looking forward to your feedback on this PR! 🚀

```release-note
none
```
