### PR TITLE
storage: use volatile containers

### DIFF
--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -258,6 +258,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 
 	coptions := storage.ContainerOptions{
 		LabelOpts: labelOptions,
+		Volatile:  true,
 	}
 	if idMappingsOptions != nil {
 		coptions.IDMappingOptions = *idMappingsOptions


### PR DESCRIPTION
overlay supports a new mount option "volatile" that reduces I/O by
ignoring fsync and syncfs requests.

Enable it for CRI-O containers as they are "volatile" by nature and
are not supposed to survive a reboot.

Even in the case containers created by CRI-O are persistent, we
already have code in place to throw away the storage if the shutdown
was not clean, so they will be cleaned up in any case.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:

Enable `volatile` for the overlay storage.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
Enable the  "volatile" option for the overlay drivers when it is supported by the underlying kernel.
```
