### PR TITLE
contrib/test/integration playbook with kata: use kata 2.x when available

### DIFF
--- a/contrib/test/integration/build/kata.yml
+++ b/contrib/test/integration/build/kata.yml
@@ -53,7 +53,7 @@
 
             - fail:
                 msg: Cannot enable nested virtualization
-              when: nested.stdout != "Y" and result.stdout != "1"
+              when: nested.stdout != "Y" and nested.stdout != "1"
           # You will find "Y" in Fedora and "1" in CentOS 8
           when: result.stdout != "Y" and result.stdout != "1"
 

--- a/contrib/test/integration/build/kata.yml
+++ b/contrib/test/integration/build/kata.yml
@@ -92,6 +92,13 @@
           gpgcheck: yes
           skip_if_unavailable: yes
 
+      # We need to enable the module_hotfixes option to provide an updated qemu-kvm-common package:
+      # qemu-kiwi needs a more recent version than the one shipped by default.
+      - name: add the module_hotfixes option to the Advanced Virtualization repo
+        lineinfile:
+          path: /etc/yum.repos.d/advanced-virt.repo
+          line: module_hotfixes = 1
+
       - name: add Kata Containers repo
         yum_repository:
           name: kata-containers
@@ -101,22 +108,45 @@
           gpgcheck: yes
           skip_if_unavailable: yes
 
-      # We need to pick up qemu from the Advanced Virtualization repo
-      - name: disable virt module
-        command: dnf module disable -y virt:rhel
-
-      - name: install qemu
-        yum:
-          state: present
-          name:
-            - qemu-kvm
-
-      when: ansible_distribution == "CentOS" and ansible_distribution_major_version|int == 8
+      when: ansible_distribution == "CentOS" and ansible_distribution_major_version|int >= 8
 
 - name: install Kata Containers
-  yum:
-    state: present
-    name:
-      - kata-runtime
-      - kata-shim
+  block:
+    - name: install Kata Containers (old Fedora/CentOS versions)
+      yum:
+        state: present
+        name:
+          - kata-runtime
+          - kata-shim
+      when: >
+        (ansible_distribution == "Fedora" and ansible_distribution_major_version|int <= 33) or
+        (ansible_distribution == "CentOS" and ansible_distribution_major_version|int == 7)
+
+    - name: install Kata Containers
+      yum:
+        state: present
+        name:
+          - kata-containers
+      when: >
+        (ansible_distribution == "Fedora" and ansible_distribution_major_version|int >= 34) or
+        (ansible_distribution == "CentOS" and ansible_distribution_major_version|int >= 8)
+
+# Kata package in CentOS 8 comes with a wrong configuration file.
+- name: fix CentOS 8 Kata Containers configuration file
+  block:
+  - name: fix qemu binary in Kata Containers configuration file
+    replace:
+      path: /usr/share/kata-containers/defaults/configuration.toml
+      regexp: 'qemu-kvm'
+      replace: 'qemu-kiwi'
+
+    # this may be needed for F34 too.
+  - name: allow as many core as available to Qemu VM
+    lineinfile:
+      dest: /usr/share/kata-containers/defaults/configuration.toml
+      line: 'default_vcpus = -1'
+      regexp: '^default_vcpus'
+      state: present
+
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version|int >= 8
 

--- a/contrib/test/integration/python3.yml
+++ b/contrib/test/integration/python3.yml
@@ -3,4 +3,6 @@
   set_fact:
     supports_python3: true
     cacheable: true
-  when: (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8) or (ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 30)
+  when: (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8) or
+        (ansible_distribution == 'CentOS' and ansible_distribution_major_version|int >= 8) or
+        (ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 30)

--- a/contrib/test/integration/system-packages.yml
+++ b/contrib/test/integration/system-packages.yml
@@ -73,7 +73,7 @@
     state: present
   with_items:
    - python-boto
-  when: (supports_python3 is not defined or not supports_python3) and ansible_distribution in ['RedHat', 'Centos']
+  when: (supports_python3 is not defined or not supports_python3) and ansible_distribution in ['RedHat', 'CentOS']
 
 - name: Update all packages
   package:
@@ -83,6 +83,6 @@
   poll: 10
   when: supports_python3 is not defined or not supports_python3
 
-- name: Update all packages RHEL 8 and Fedora >= 30
+- name: Update all packages RHEL 8, CentOS 8 and Fedora >= 30
   shell: sudo yum update -y
   when: supports_python3 is defined and supports_python3

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -44,7 +44,8 @@ kata_int_test_env:
     JOBS: "1"  # TODO: add support to parallelization in kata (causes failures in the integration tests)
 
 kata_skip_ctr_tests:
-  - 'test "ctr oom"'  # https://github.com/kata-containers/tests/issues/714
+  - 'test "ctr lifecycle"'
+  - 'test "ctr logging"'
   - 'test "ctr journald logging"'
   - 'test "ctr log max"'
   - 'test "ctr log max with minimum value"'
@@ -53,12 +54,13 @@ kata_skip_ctr_tests:
   - 'test "ctr execsync should not overwrite initial spec args"'
   - 'test "privileged ctr device add"'
   - 'test "ctr execsync std{out,err}"'
-  - 'test "ctr with default list of capabilities from crio.conf"'
-  - 'test "ctr with list of capabilities given by user in crio.conf"'
-  - 'test "ctr /etc/resolv.conf rw/ro mode"'
+  - 'test "ctr create with non-existent command"'
+  - 'test "ctr create with non-existent command \[tty\]"'
   - 'test "ctr update resources"'
-  - 'test "ctr execsync conflicting with conmon env"'
   - 'test "ctr resources"'
   - 'test "ctr with non-root user has no effective capabilities"'
+  - 'test "ctr with low memory configured should not be created"'
   - 'test "privileged ctr -- check for rw mounts"'
+  - 'test "annotations passed through"'
   - 'test "ctr with default_env set in configuration"'
+  - 'test "ctr with absent mount that should be rejected"'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind ci


#### What this PR does / why we need it:
Starting from CentOS 8 and Fedora 34 we have packages for the 2.x kata branch.
Use these newer packages for the integration tests: instruct the playbook to install the newer packages.
Change also the subset of the run tests to match the passing ones.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```
