### PR TITLE
server: rework internal wipe to play better with reboots

### DIFF
--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -147,9 +147,10 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(testManifest)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).NotTo(BeNil())
 			Expect(err).To(BeNil())
 		})
 
@@ -163,9 +164,10 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(manifest)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).NotTo(BeNil())
 			Expect(err).To(BeNil())
 		})
 
@@ -179,9 +181,10 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(manifest)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).NotTo(BeNil())
 			Expect(err).To(BeNil())
 		})
 
@@ -190,9 +193,10 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(testManifest)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "")
+			sb, err := sut.LoadSandbox(context.Background(), "")
 
 			// Then
+			Expect(sb).NotTo(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -205,9 +209,10 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(manifest)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).NotTo(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -220,9 +225,10 @@ var _ = t.Describe("ContainerServer", func() {
 			mockDirs(manifest)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).NotTo(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -239,9 +245,10 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).NotTo(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -256,9 +263,10 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).NotTo(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -275,9 +283,10 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).To(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -294,9 +303,10 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).To(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -313,9 +323,10 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).To(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -332,9 +343,10 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).To(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -351,9 +363,10 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).To(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -370,9 +383,10 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).NotTo(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -385,9 +399,10 @@ var _ = t.Describe("ContainerServer", func() {
 			)
 
 			// When
-			err := sut.LoadSandbox(context.Background(), "id")
+			sb, err := sut.LoadSandbox(context.Background(), "id")
 
 			// Then
+			Expect(sb).To(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -18,6 +18,7 @@ import (
 
 	imageTypes "github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/idtools"
+	storageTypes "github.com/containers/storage/types"
 	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
@@ -202,7 +203,7 @@ func (s *Server) restore(ctx context.Context) []string {
 		}
 		log.Warnf(ctx, "could not restore sandbox %s container %s: %v", metadata.PodID, sbID, err)
 		for _, n := range names[sbID] {
-			if err := s.Store().DeleteContainer(n); err != nil {
+			if err := s.Store().DeleteContainer(n); err != nil && err != storageTypes.ErrNotAContainer {
 				log.Warnf(ctx, "unable to delete container %s: %v", n, err)
 			}
 			// Release the infra container name and the pod name for future use
@@ -217,7 +218,7 @@ func (s *Server) restore(ctx context.Context) []string {
 		for k, v := range podContainers {
 			if v.PodID == sbID {
 				for _, n := range names[k] {
-					if err := s.Store().DeleteContainer(n); err != nil {
+					if err := s.Store().DeleteContainer(n); err != nil && err != storageTypes.ErrNotAContainer {
 						log.Warnf(ctx, "unable to delete container %s: %v", n, err)
 					}
 					// Release the container name for future use
@@ -242,7 +243,7 @@ func (s *Server) restore(ctx context.Context) []string {
 		}
 		log.Warnf(ctx, "Could not restore container %s: %v", containerID, err)
 		for _, n := range names[containerID] {
-			if err := s.Store().DeleteContainer(n); err != nil {
+			if err := s.Store().DeleteContainer(n); err != nil && err != storageTypes.ErrNotAContainer {
 				log.Warnf(ctx, "Unable to delete container %s: %v", n, err)
 			}
 			// Release the container name

--- a/server/server.go
+++ b/server/server.go
@@ -168,7 +168,7 @@ func (s *Server) restore(ctx context.Context) {
 	pods := map[string]*storage.RuntimeContainerMetadata{}
 	podContainers := map[string]*storage.RuntimeContainerMetadata{}
 	names := map[string][]string{}
-	deletedPods := map[string]bool{}
+	deletedPods := map[string]*sandbox.Sandbox{}
 	for i := range containers {
 		metadata, err2 := s.StorageRuntimeServer().GetContainerMetadata(containers[i].ID)
 		if err2 != nil {
@@ -190,7 +190,8 @@ func (s *Server) restore(ctx context.Context) {
 	// Go through all the pods and check if it can be restored. If an error occurs, delete the pod and any containers
 	// associated with it. Release the pod and container names as well.
 	for sbID, metadata := range pods {
-		if err = s.LoadSandbox(ctx, sbID); err == nil {
+		sb, err := s.LoadSandbox(ctx, sbID)
+		if err == nil {
 			continue
 		}
 		log.Warnf(ctx, "could not restore sandbox %s container %s: %v", metadata.PodID, sbID, err)
@@ -218,8 +219,11 @@ func (s *Server) restore(ctx context.Context) {
 				}
 			}
 		}
-		// Add the pod id to the list of deletedPods so we don't try to restore IPs for it later on
-		deletedPods[sbID] = true
+		// Add the pod id to the list of deletedPods, to be able to call CNI DEL on the sandbox network.
+		// Unfortunately, if we weren't able to restore a sandbox, then there's little that can be done
+		if sb != nil {
+			deletedPods[sbID] = sb
+		}
 	}
 
 	// Go through all the containers and check if it can be restored. If an error occurs, delete the conainer and
@@ -243,14 +247,14 @@ func (s *Server) restore(ctx context.Context) {
 	}
 
 	// Restore sandbox IPs
-	for _, sb := range s.ListSandboxes() {
+	for _, sb := range deletedPods {
 		// Clean up networking if pod couldn't be restored and was deleted
-		if ok := deletedPods[sb.ID()]; ok {
-			if err := s.networkStop(ctx, sb); err != nil {
-				log.Warnf(ctx, "error stopping network on restore cleanup %v:", err)
-			}
-			continue
+		log.Infof(ctx, "Deleting pod %s", sb.ID())
+		if err := s.networkStop(ctx, sb); err != nil {
+			log.Warnf(ctx, "Error stopping network on restore cleanup %v:", err)
 		}
+	}
+	for _, sb := range s.ListSandboxes() {
 		ips, err := s.getSandboxIPs(sb)
 		if err != nil {
 			log.Warnf(ctx, "could not restore sandbox IP for %v: %v", sb.ID(), err)

--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -11,6 +11,8 @@ function setup() {
 	export CONTAINER_VERSION_FILE="$TESTDIR"/version.tmp
 	export CONTAINER_VERSION_FILE_PERSIST="$TESTDIR"/version-persist.tmp
 	export CONTAINER_CLEAN_SHUTDOWN_FILE="$TESTDIR"/clean-shutdown.tmp
+	CONTAINER_NAMESPACES_DIR=$(mktemp -d)
+	export CONTAINER_NAMESPACES_DIR
 }
 
 function run_podman_with_args() {
@@ -23,6 +25,7 @@ function teardown() {
 	cleanup_test
 	run_podman_with_args stop -a
 	run_podman_with_args rm -fa
+	cleanup_namespaces_dir
 }
 
 # run crio_wipe calls crio_wipe and tests it succeeded
@@ -55,6 +58,12 @@ function test_crio_did_not_wipe_images() {
 	# check that the pause image was not removed
 	output=$(crictl images)
 	[[ "$output" == *"$IMAGE_USED"* ]]
+}
+
+# simulate a reboot by unmounting and removing the namespaces
+function cleanup_namespaces_dir() {
+	find "$CONTAINER_NAMESPACES_DIR" -type f -exec umount {} \;
+	rm -fr "$CONTAINER_NAMESPACES_DIR"
 }
 
 function start_crio_with_stopped_pod() {
@@ -205,11 +214,14 @@ function start_crio_with_stopped_pod() {
 }
 
 @test "internal_wipe remove containers and images when remove both" {
+	# simulate a reboot by having a removable namespaces dir
 	start_crio_with_stopped_pod
 	stop_crio_no_clean
 
 	rm "$CONTAINER_VERSION_FILE"
 	rm "$CONTAINER_VERSION_FILE_PERSIST"
+	# simulate a reboot by having a removable namespaces dir
+	cleanup_namespaces_dir
 
 	CONTAINER_INTERNAL_WIPE=true start_crio_no_setup
 	test_crio_wiped_containers
@@ -221,6 +233,8 @@ function start_crio_with_stopped_pod() {
 	stop_crio_no_clean
 
 	rm "$CONTAINER_VERSION_FILE"
+	# simulate a reboot by having a removable namespaces dir
+	cleanup_namespaces_dir
 
 	CONTAINER_INTERNAL_WIPE=true start_crio_no_setup
 	test_crio_wiped_containers
@@ -232,6 +246,8 @@ function start_crio_with_stopped_pod() {
 	stop_crio_no_clean
 
 	rm "$CONTAINER_VERSION_FILE_PERSIST"
+	# simulate a reboot by having a removable namespaces dir
+	cleanup_namespaces_dir
 
 	CONTAINER_INTERNAL_WIPE=true start_crio_no_setup
 	test_crio_wiped_containers
@@ -276,6 +292,8 @@ function start_crio_with_stopped_pod() {
 
 	runtime kill "$ctr_id" || true
 	runtime kill "$pod_id" || true
+	# simulate a reboot by having a removable namespaces dir
+	cleanup_namespaces_dir
 
 	# pretend like the CNI plugin is waiting for a container to start
 	mv "$CRIO_CNI_PLUGIN"/"$CNI_TYPE" "$CRIO_CNI_PLUGIN"/"$CNI_TYPE"-hidden


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
Embarrassingly, the main use-case of internal wipe was one that I had not tested appropriately. It turns out, we never actually have any containers wipeIfAppropriate after we call restore.
This is because the managed ns no longer exists (it is in /run, a tmpfs). Even if its not in a tmpfs, it is not correctly mounted on reboot.

this is okay, though. It reduces complexity a bit. Now, instead of using the version_file to determine whether we rebooted, we just have to make sure we call CNI DEL as much as possible if we fail to restore a sandbox.

To do this, we must rework LoadSandbox to return the sandbox in question (as soon as possible, basically after unmarshalling all the data from the config.json), then call networkStop on that sandbox (inside a resource cleaner so we retry if the node is booting up).

As a result of this, we can simplify wipeIfAppropriate. It now must be passed a list of images, but will not need to do any thinking about containers. Another consequence is we can eventually deprecate version_file.

This PR also ignores some error cases that were not useful to log.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in `internal_wipe` that would mean CNI resources would be leaked across reboots.
```
