### PR TITLE
Update golangci-lint to v1.40.1 and fix lints

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           # must be specified without patch version
-          version: v1.35
+          version: v1.40.1
 
           # Only show new issues for a pull request.
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,8 +22,10 @@ linters:
     - depguard
     - dogsled
     - dupl
+    - durationcheck
     - errcheck
     - exportloopref
+    - forcetypeassert
     - gochecknoinits
     - goconst
     - gocritic
@@ -32,20 +34,17 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    - golint
     - goprintffuncname
     - gosimple
     - govet
+    - importas
     - ineffassign
-    - interfacer
     - makezero
-    - maligned
     - misspell
     - nakedret
     - nolintlint
     - prealloc
     - rowserrcheck
-    - scopelint
     - sqlclosecheck
     - staticcheck
     - structcheck
@@ -57,6 +56,7 @@ linters:
     - unused
     - varcheck
     - whitespace
+    # - cyclop
     # - errorlint
     # - exhaustive
     # - exhaustivestruct
@@ -69,16 +69,23 @@ linters:
     # - godox
     # - goerr113
     # - gomnd
+    # - gomoddirectives
     # - gomodguard
     # - gosec
+    # - ifshort
     # - lll
     # - nestif
+    # - nilerr
     # - nlreturn
     # - noctx
     # - paralleltest
     # - predeclared
+    # - promlinter
+    # - revive
+    # - tagliatelle
     # - testpackage
     # - thelper
+    # - wastedassign
     # - wrapcheck
     # - wsl
 linters-settings:

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ ${GO_MOD_OUTDATED}:
 	$(call go-build,./vendor/github.com/psampaz/go-mod-outdated)
 
 ${GOLANGCI_LINT}:
-	export VERSION=v1.35.2 \
+	export VERSION=v1.40.1 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
 	curl -sSfL $$URL/$$VERSION/install.sh | sh -s $$VERSION

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -84,6 +84,9 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 
 	var stderrBuf bytes.Buffer
 	parentPipe, childPipe, err := newPipe()
+	if err != nil {
+		return fmt.Errorf("error creating socket pair: %v", err)
+	}
 	childStartPipe, parentStartPipe, err := newPipe()
 	if err != nil {
 		return fmt.Errorf("error creating socket pair: %v", err)

--- a/test/copyimg/copyimg.go
+++ b/test/copyimg/copyimg.go
@@ -186,7 +186,7 @@ func main() {
 					log.Errorf(ctx, "error finding image: %v", err1)
 					os.Exit(1)
 				}
-				names := append(destImage.Names, imageName, addName)
+				names := append([]string{imageName, addName}, destImage.Names...)
 				err = store.SetNames(destImage.ID, names)
 				if err != nil {
 					log.Errorf(ctx, "error adding name to %s: %v", imageName, err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/godbus/dbus/v5"
@@ -53,7 +54,8 @@ func StatusToExitCode(status int) int {
 
 // RunUnderSystemdScope adds the specified pid to a systemd scope
 func RunUnderSystemdScope(pid int, slice, unitName string, properties ...systemdDbus.Property) error {
-	conn, err := systemdDbus.New()
+	ctx := context.Background()
+	conn, err := systemdDbus.NewWithContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -67,7 +69,7 @@ func RunUnderSystemdScope(pid int, slice, unitName string, properties ...systemd
 		properties = append(properties, systemdDbus.PropSlice(slice))
 	}
 	ch := make(chan string)
-	_, err = conn.StartTransientUnit(unitName, "replace", properties, ch)
+	_, err = conn.StartTransientUnitContext(ctx, unitName, "replace", properties, ch)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind ci
/kind failing-test
/kind dependency-update

#### What this PR does / why we need it:
This updates golangci-lint to the latest release and fixes new lints. It
also enables linters which do not report any issue.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
