### PR TITLE
Remove "should cleanup in parallel" test

### DIFF
--- a/internal/resourcestore/resourcecleaner_test.go
+++ b/internal/resourcestore/resourcecleaner_test.go
@@ -79,27 +79,4 @@ var _ = t.Describe("ResourceCleaner", func() {
 		Expect(err).NotTo(BeNil())
 		Expect(failureCnt).To(Equal(3))
 	})
-
-	It("should run in parallel", func() {
-		// Given
-		sut := resourcestore.NewResourceCleaner()
-		testChan := make(chan bool, 1)
-		succ := false
-		sut.Add(context.Background(), "test1", func() error {
-			testChan <- true
-			return nil
-		})
-		sut.Add(context.Background(), "test2", func() error {
-			<-testChan
-			succ = true
-			return nil
-		})
-
-		// When
-		err := sut.Cleanup()
-
-		// Then
-		Expect(err).To(BeNil())
-		Expect(succ).To(BeTrue())
-	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

The cleanup does not run in parallel any more which means that this test
blocks forever.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
