### PR TITLE
 Add support to drop ALL and add back few capabilities

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -360,8 +360,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 			}
 			// Clear default capabilities from spec
 			specgen.ClearProcessCapabilities()
-			capabilities.AddCapabilities = append(capabilities.AddCapabilities, s.config.DefaultCapabilities...)
-			err = setupCapabilities(specgen, capabilities)
+			err = setupCapabilities(specgen, capabilities, s.config.DefaultCapabilities)
 			if err != nil {
 				return nil, err
 			}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -446,11 +446,8 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 
 	// Add capabilities from crio.conf if default_capabilities is defined
 	capabilities := &types.Capability{}
-	if s.config.DefaultCapabilities != nil {
-		g.ClearProcessCapabilities()
-		capabilities.AddCapabilities = append(capabilities.AddCapabilities, s.config.DefaultCapabilities...)
-	}
-	if err := setupCapabilities(g, capabilities); err != nil {
+	g.ClearProcessCapabilities()
+	if err := setupCapabilities(g, capabilities, s.config.DefaultCapabilities); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The current implemention has an issue where we add the default
capabilties when the user does drop ALL and add few.


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
#4922 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix drop ALL and add back few caps behavior to not include the default configured capabilities
```
