### PR TITLE
Watch and reload TLS certificates for metrics

### DIFF
--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -30,15 +30,6 @@ var _ = AfterSuite(func() {
 
 // The actual test suite
 var _ = t.Describe("Metrics", func() {
-	t.Describe("Register", func() {
-		It("should succeed", func() {
-			// Given
-			// When
-			// Then
-			metrics.Register()
-		})
-	})
-
 	t.Describe("SinceInMicroseconds", func() {
 		It("should succeed", func() {
 			// Given

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -225,23 +225,6 @@ var _ = t.Describe("Server", func() {
 		})
 	})
 
-	t.Describe("CreateMetricsEndpoint", func() {
-		// Prepare the sut
-		BeforeEach(setupSUT)
-
-		It("should succeed", func() {
-			// Given
-
-			// When
-			mux, err := sut.CreateMetricsEndpoint()
-
-			// Then
-			Expect(err).To(BeNil())
-			Expect(mux).NotTo(BeNil())
-			sut.StopMonitors()
-		})
-	})
-
 	t.Describe("StartExitMonitor", func() {
 		// Prepare the sut
 		BeforeEach(setupSUT)

--- a/test/metrics.bats
+++ b/test/metrics.bats
@@ -53,6 +53,12 @@ function teardown() {
 
 	# get metrics
 	curl -sfk "https://localhost:$PORT/metrics" | grep crio_operations
+
+	# remove the watched cert
+	rm "$TESTDIR/cert.pem"
+
+	# serving metrics should still work
+	curl -sfk "https://localhost:$PORT/metrics" | grep crio_operations
 }
 
 @test "metrics container oom" {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
We now add new file watchers for the metrics TLS cert and key as well as
reloading them on any event. If the reload fails, then we keep the old
certificates as fallback.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Automatically reload metrics TLS certificate and key if any of those specified files change.
```
