### PR TITLE
Use go 1.16 for release notes and forward jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,6 +285,9 @@ jobs:
     if: github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -310,6 +313,9 @@ jobs:
     needs: release-notes
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -333,6 +339,9 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test


#### What this PR does / why we need it:
The latest update of k/release requires using go 1.16. This is now being
fixed with this patch.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
