### PR TITLE
Add klog to logrus shim

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -32,7 +31,6 @@ import (
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
-	"k8s.io/klog/v2"
 )
 
 func writeCrioGoroutineStacks() {
@@ -100,9 +98,7 @@ scope of the CRI.
 6. Resource isolation as required by the CRI.`
 
 func main() {
-	// Configure klog to not write any output
-	klog.LogToStderr(true)
-	klog.SetOutput(ioutil.Discard)
+	log.InitKlogShim()
 
 	if reexec.Init() {
 		fmt.Fprintf(os.Stderr, "unable to initialize container storage\n")

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/emicklei/go-restful v2.15.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-logr/logr v0.4.0
 	github.com/go-zoo/bone v1.3.0
 	github.com/godbus/dbus/v5 v5.0.4
 	github.com/gogo/protobuf v1.3.2

--- a/internal/log/klog.go
+++ b/internal/log/klog.go
@@ -1,0 +1,79 @@
+package log
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+	"k8s.io/klog/v2"
+)
+
+// InitKlogShim creates a shim between logrus and klog by forwarding klog
+// messages to the logrus logger. To reduce the overall verbosity we log every
+// Info klog message in logrus Debug verbosity.
+func InitKlogShim() {
+	klog.LogToStderr(false)
+	klog.SetLogger(&logger{})
+}
+
+type logger struct{}
+
+func (l *logger) Info(msg string, keysAndValues ...interface{}) {
+	res := &strings.Builder{}
+	res.WriteString(msg)
+	writeKeysAndValues(res, keysAndValues...)
+	logrus.Debug(res.String())
+}
+
+func (l *logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	res := &strings.Builder{}
+	res.WriteString(msg)
+	if err != nil {
+		res.WriteString(": ")
+		res.WriteString(err.Error())
+	}
+	writeKeysAndValues(res, keysAndValues...)
+	logrus.Error(res.String())
+}
+
+func writeKeysAndValues(b *strings.Builder, keysAndValues ...interface{}) {
+	const missingValue = "[MISSING]"
+	for i := 0; i < len(keysAndValues); i += 2 {
+		var v interface{}
+		k := keysAndValues[i]
+		if i+1 < len(keysAndValues) {
+			v = keysAndValues[i+1]
+		} else {
+			v = missingValue
+		}
+		if i == 0 {
+			b.WriteString(" (")
+		}
+		if i > 0 {
+			b.WriteRune(' ')
+		}
+
+		switch v.(type) {
+		case string, error:
+			b.WriteString(fmt.Sprintf("%s=%q", k, v))
+		case []byte:
+			b.WriteString(fmt.Sprintf("%s=%+q", k, v))
+		default:
+			if _, ok := v.(fmt.Stringer); ok {
+				b.WriteString(fmt.Sprintf("%s=%q", k, v))
+			} else {
+				b.WriteString(fmt.Sprintf("%s=%+v", k, v))
+			}
+		}
+
+		if i == len(keysAndValues) {
+			b.WriteRune(')')
+		}
+	}
+}
+
+func (l *logger) Enabled() bool                         { return true }
+func (l *logger) V(level int) logr.Logger               { return l }
+func (l *logger) WithValues(...interface{}) logr.Logger { return l }
+func (l *logger) WithName(string) logr.Logger           { return l }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -541,6 +541,7 @@ github.com/go-git/go-git/v5/utils/merkletrie/index
 github.com/go-git/go-git/v5/utils/merkletrie/internal/frame
 github.com/go-git/go-git/v5/utils/merkletrie/noder
 # github.com/go-logr/logr v0.4.0
+## explicit
 github.com/go-logr/logr
 # github.com/go-ole/go-ole v1.2.4
 github.com/go-ole/go-ole


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a klog to logrus logging shim. This allows us to convert messages into the logrus format by preserving the log layout.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Before:
```
INFO[2021-06-07 13:33:27.507085664+02:00] Starting CRI-O, version: 1.21.0, git: 1559a9af5e08f7c0a184ca5a3e0656848cfb6482(dirty)
E0607 13:33:30.689353 1786399 httpstream.go:143] (conn=&{0xc000560160 [0xc000323a40] {0 0} 0x1b90c80 0x13b4320}, request=0) timed out waiting for streams
E0607 13:33:30.690007 1786399 httpstream.go:143] (conn=&{0xc000560160 [0xc000323a40 0xc0006a2280] {0 0} 0x1b90c80 0x13b4320}, request=0) timed out waiting for streams
```

After:
```
INFO[2021-06-07 13:34:26.749451747+02:00] Starting CRI-O, version: 1.21.0, git: 793452dc36a72251984f65a79eb28959b54e49e2(dirty)
ERRO[2021-06-07 13:34:29.546098148+02:00] (conn=&{0xc00086a840 [0xc0004d6f00] {0 0} 0x1b91ca0 0x13b5340}, request=0) timed out waiting for streams
ERRO[2021-06-07 13:34:29.546657404+02:00] (conn=&{0xc00086a840 [0xc0004d6f00 0xc000298280] {0 0} 0x1b91ca0 0x13b5340}, request=0) timed out waiting for streams
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed the logging behavior of klog messages to be included in the CRI-O logs.
The klog info verbositry is converted to CRI-O debug to lower the log verbosity.
```
