### PR TITLE
Move metrics into singleton helpers

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -764,15 +764,10 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 		c.state.OOMKilled = true
 
 		// Collect total metric
-		metrics.CRIOContainersOOMTotal.Inc()
+		metrics.Instance().MetricContainersOOMTotalInc()
 
 		// Collect metric by container name
-		counter, err := metrics.CRIOContainersOOM.GetMetricWithLabelValues(c.Name())
-		if err != nil {
-			log.Warnf(ctx, "Unable to write OOM metric by container: %v", err)
-		} else {
-			counter.Inc()
-		}
+		metrics.Instance().MetricContainersOOMInc(c.Name())
 	}
 
 	return nil

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -664,15 +664,10 @@ func (r *runtimeVM) updateContainerStatus(ctx context.Context, c *Container) err
 			c.state.OOMKilled = true
 
 			// Collect total metric
-			metrics.CRIOContainersOOMTotal.Inc()
+			metrics.Instance().MetricContainersOOMTotalInc()
 
 			// Collect metric by container name
-			counter, err := metrics.CRIOContainersOOM.GetMetricWithLabelValues(c.Name())
-			if err != nil {
-				log.Warnf(ctx, "Unable to write OOM metric by container: %v", err)
-			} else {
-				counter.Inc()
-			}
+			metrics.Instance().MetricContainersOOMInc(c.Name())
 		}
 	}
 	return nil

--- a/server/metrics/interceptors.go
+++ b/server/metrics/interceptors.go
@@ -24,15 +24,13 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 		resp, err := handler(ctx, req)
 
 		// record the operation
-		CRIOOperations.WithLabelValues(operation).Inc()
-		CRIOOperationsLatency.WithLabelValues(operation).
-			Set(SinceInMicroseconds(operationStart))
-		CRIOOperationsLatencyTotal.WithLabelValues(operation).
-			Observe(SinceInMicroseconds(operationStart))
+		Instance().MetricOperationsInc(operation)
+		Instance().MetricOperationsLatencySet(operation, operationStart)
+		Instance().MetricOperationsLatencyTotalObserve(operation, operationStart)
 
 		// record error metric if occurred
 		if err != nil {
-			CRIOOperationsErrors.WithLabelValues(operation).Inc()
+			Instance().MetricOperationsErrorsInc(operation)
 		}
 
 		return resp, err

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -56,130 +56,6 @@ const (
 	subsystem = "container_runtime"
 )
 
-var (
-	// CRIOOperations collects operation counts by operation type.
-	CRIOOperations = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOOperationsKey,
-			Help:      "Cumulative number of CRI-O operations by operation type.",
-		},
-		[]string{"operation_type"},
-	)
-
-	// CRIOOperationsLatencyTotal collects operation latency numbers by operation
-	// type.
-	CRIOOperationsLatencyTotal = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Subsystem: subsystem,
-			Name:      CRIOOperationsLatencyTotalKey,
-			Help:      "Latency in microseconds of CRI-O operations. Broken down by operation type.",
-		},
-		[]string{"operation_type"},
-	)
-
-	// CRIOOperationsLatency collects operation latency numbers for each CRI call by operation
-	// type.
-	CRIOOperationsLatency = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: subsystem,
-			Name:      CRIOOperationsLatencyKey,
-			Help:      "Latency in microseconds of individual CRI calls for CRI-O operations. Broken down by operation type.",
-		},
-		[]string{"operation_type"},
-	)
-
-	// CRIOOperationsErrors collects operation errors by operation
-	// type.
-	CRIOOperationsErrors = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOOperationsErrorsKey,
-			Help:      "Cumulative number of CRI-O operation errors by operation type.",
-		},
-		[]string{"operation_type"},
-	)
-
-	// CRIOImagePullsByDigest collects image pull metrics for every image digest
-	CRIOImagePullsByDigest = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOImagePullsByDigestKey,
-			Help:      "Bytes transferred by CRI-O image pulls by digest",
-		},
-		[]string{"name", "digest", "mediatype", "size"},
-	)
-
-	// CRIOImagePullsByName collects image pull metrics for every image name
-	CRIOImagePullsByName = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOImagePullsByNameKey,
-			Help:      "Bytes transferred by CRI-O image pulls by name",
-		},
-		[]string{"name", "size"},
-	)
-
-	// CRIOImagePullsByNameSkipped collects image pull metrics for every image name (skipped)
-	CRIOImagePullsByNameSkipped = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOImagePullsByNameSkippedKey,
-			Help:      "Bytes skipped by CRI-O image pulls by name",
-		},
-		[]string{"name"},
-	)
-
-	// CRIOImagePullsFailures collects image pull failures
-	CRIOImagePullsFailures = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOImagePullsFailuresKey,
-			Help:      "Cumulative number of CRI-O image pull failures by error.",
-		},
-		[]string{"name", "error"},
-	)
-
-	// CRIOImagePullsSuccesses collects image pull successes
-	CRIOImagePullsSuccesses = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOImagePullsSuccessesKey,
-			Help:      "Cumulative number of CRI-O image pull successes.",
-		},
-		[]string{"name"},
-	)
-
-	// CRIOImageLayerReuse collects image pull metrics for every resused image layer
-	CRIOImageLayerReuse = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOImageLayerReuseKey,
-			Help:      "Reused (not pulled) local image layer count by name",
-		},
-		[]string{"name"},
-	)
-
-	// CRIOContainersOOMTotal collects container out of memory (oom) metrics for every container and sandboxes.
-	CRIOContainersOOMTotal = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOContainersOOMTotalKey,
-			Help:      "Amount of containers killed because they ran out of memory (OOM)",
-		},
-	)
-
-	// CRIOContainersOOM collects container out of memory (oom) metrics per container and sandbox name.
-	CRIOContainersOOM = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      CRIOContainersOOMKey,
-			Help:      "Amount of containers killed because they ran out of memory (OOM) by their name",
-		},
-		[]string{"name"},
-	)
-)
-
 // SinceInMicroseconds gets the time since the specified start in microseconds.
 func SinceInMicroseconds(start time.Time) float64 {
 	return float64(time.Since(start).Microseconds())
@@ -187,12 +63,132 @@ func SinceInMicroseconds(start time.Time) float64 {
 
 // Metrics is the main structure for starting the metrics endpoints.
 type Metrics struct {
-	config *libconfig.MetricsConfig
+	config                        *libconfig.MetricsConfig
+	metricOperations              *prometheus.CounterVec
+	metricOperationsLatency       *prometheus.GaugeVec
+	metricOperationsLatencyTotal  *prometheus.SummaryVec
+	metricOperationsErrors        *prometheus.CounterVec
+	metricImagePullsByDigest      *prometheus.CounterVec
+	metricImagePullsByName        *prometheus.CounterVec
+	metricImagePullsByNameSkipped *prometheus.CounterVec
+	metricImagePullsFailures      *prometheus.CounterVec
+	metricImagePullsSuccesses     *prometheus.CounterVec
+	metricImageLayerReuse         *prometheus.CounterVec
+	metricContainersOOMTotal      prometheus.Counter
+	metricContainersOOM           *prometheus.CounterVec
 }
+
+var instance *Metrics
 
 // New creates a new metrics instance.
 func New(config *libconfig.MetricsConfig) *Metrics {
-	return &Metrics{config}
+	instance = &Metrics{
+		config: config,
+		metricOperations: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOOperationsKey,
+				Help:      "Cumulative number of CRI-O operations by operation type.",
+			},
+			[]string{"operation_type"},
+		),
+		metricOperationsLatency: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Subsystem: subsystem,
+				Name:      CRIOOperationsLatencyKey,
+				Help:      "Latency in microseconds of individual CRI calls for CRI-O operations. Broken down by operation type.",
+			},
+			[]string{"operation_type"},
+		),
+		metricOperationsLatencyTotal: prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Subsystem: subsystem,
+				Name:      CRIOOperationsLatencyTotalKey,
+				Help:      "Latency in microseconds of CRI-O operations. Broken down by operation type.",
+			},
+			[]string{"operation_type"},
+		),
+		metricOperationsErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOOperationsErrorsKey,
+				Help:      "Cumulative number of CRI-O operation errors by operation type.",
+			},
+			[]string{"operation_type"},
+		),
+		metricImagePullsByDigest: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOImagePullsByDigestKey,
+				Help:      "Bytes transferred by CRI-O image pulls by digest",
+			},
+			[]string{"name", "digest", "mediatype", "size"},
+		),
+		metricImagePullsByName: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOImagePullsByNameKey,
+				Help:      "Bytes transferred by CRI-O image pulls by name",
+			},
+			[]string{"name", "size"},
+		),
+		metricImagePullsByNameSkipped: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOImagePullsByNameSkippedKey,
+				Help:      "Bytes skipped by CRI-O image pulls by name",
+			},
+			[]string{"name"},
+		),
+		metricImagePullsFailures: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOImagePullsFailuresKey,
+				Help:      "Cumulative number of CRI-O image pull failures by error.",
+			},
+			[]string{"name", "error"},
+		),
+		metricImagePullsSuccesses: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOImagePullsSuccessesKey,
+				Help:      "Cumulative number of CRI-O image pull successes.",
+			},
+			[]string{"name"},
+		),
+		metricImageLayerReuse: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOImageLayerReuseKey,
+				Help:      "Reused (not pulled) local image layer count by name",
+			},
+			[]string{"name"},
+		),
+		metricContainersOOMTotal: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOContainersOOMTotalKey,
+				Help:      "Amount of containers killed because they ran out of memory (OOM)",
+			},
+		),
+		metricContainersOOM: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      CRIOContainersOOMKey,
+				Help:      "Amount of containers killed because they ran out of memory (OOM) by their name",
+			},
+			[]string{"name"},
+		),
+	}
+	return Instance()
+}
+
+// Instance returns the singleton instance of the Metrics.
+func Instance() *Metrics {
+	if instance == nil {
+		return New(&libconfig.MetricsConfig{})
+	}
+	return instance
 }
 
 // Start starts serving the metrics in the background.
@@ -229,21 +225,124 @@ func (m *Metrics) Start(stop chan struct{}) error {
 	return nil
 }
 
+func (m *Metrics) MetricOperationsInc(operation string) {
+	c, err := m.metricOperations.GetMetricWithLabelValues(operation)
+	if err != nil {
+		logrus.Warnf("Unable to write operations metric: %v", err)
+		return
+	}
+	c.Inc()
+}
+
+func (m *Metrics) MetricOperationsLatencySet(operation string, start time.Time) {
+	g, err := m.metricOperationsLatency.GetMetricWithLabelValues(operation)
+	if err != nil {
+		logrus.Warnf("Unable to write operation latency metric: %v", err)
+		return
+	}
+	g.Set(SinceInMicroseconds(start))
+}
+
+func (m *Metrics) MetricOperationsLatencyTotalObserve(operation string, start time.Time) {
+	o, err := m.metricOperationsLatencyTotal.GetMetricWithLabelValues(operation)
+	if err != nil {
+		logrus.Warnf("Unable to write operation latency (total) metric: %v", err)
+		return
+	}
+	o.Observe(SinceInMicroseconds(start))
+}
+
+func (m *Metrics) MetricOperationsErrorsInc(operation string) {
+	c, err := m.metricOperationsErrors.GetMetricWithLabelValues(operation)
+	if err != nil {
+		logrus.Warnf("Unable to write operation errors metric: %v", err)
+		return
+	}
+	c.Inc()
+}
+
+func (m *Metrics) MetricContainersOOMInc(name string) {
+	c, err := m.metricContainersOOM.GetMetricWithLabelValues(name)
+	if err != nil {
+		logrus.Warnf("Unable to write container OOM metric: %v", err)
+		return
+	}
+	c.Inc()
+}
+
+func (m *Metrics) MetricContainersOOMTotalInc() {
+	m.metricContainersOOMTotal.Inc()
+}
+
+func (m *Metrics) MetricImagePullsByNameSkippedAdd(add float64, name string) {
+	c, err := m.metricImagePullsByNameSkipped.GetMetricWithLabelValues(name)
+	if err != nil {
+		logrus.Warnf("Unable to write image pulls by name skipped metric: %v", err)
+		return
+	}
+	c.Add(add)
+}
+
+func (m *Metrics) MetricImagePullsFailuresInc(image, label string) {
+	c, err := m.metricImagePullsFailures.GetMetricWithLabelValues(image, label)
+	if err != nil {
+		logrus.Warnf("Unable to write image pull failures metric: %v", err)
+		return
+	}
+	c.Inc()
+}
+
+func (m *Metrics) MetricImageLayerReuseInc(layer string) {
+	c, err := m.metricImageLayerReuse.GetMetricWithLabelValues(layer)
+	if err != nil {
+		logrus.Warnf("Unable to write image layer reuse metric: %v", err)
+		return
+	}
+	c.Inc()
+}
+
+func (m *Metrics) MetricImagePullsSuccessesInc(name string) {
+	c, err := m.metricImagePullsSuccesses.GetMetricWithLabelValues(name)
+	if err != nil {
+		logrus.Warnf("Unable to write image pull successes metric: %v", err)
+		return
+	}
+	c.Inc()
+}
+
+func (m *Metrics) MetricImagePullsByDigestAdd(add float64, values ...string) {
+	c, err := m.metricImagePullsByDigest.GetMetricWithLabelValues(values...)
+	if err != nil {
+		logrus.Warnf("Unable to write image pulls by digest metric: %v", err)
+		return
+	}
+	c.Add(add)
+}
+
+func (m *Metrics) MetricImagePullsByNameAdd(add float64, values ...string) {
+	c, err := m.metricImagePullsByName.GetMetricWithLabelValues(values...)
+	if err != nil {
+		logrus.Warnf("Unable to write image pulls by name metric: %v", err)
+		return
+	}
+	c.Add(add)
+}
+
 // createEndpoint creates a /metrics endpoint for prometheus monitoring.
 func (m *Metrics) createEndpoint() (*http.ServeMux, error) {
 	for _, collector := range []prometheus.Collector{
-		CRIOOperations,
-		CRIOOperationsLatency,
-		CRIOOperationsLatencyTotal,
-		CRIOOperationsErrors,
-		CRIOImagePullsByDigest,
-		CRIOImagePullsByName,
-		CRIOImagePullsByNameSkipped,
-		CRIOImagePullsFailures,
-		CRIOImagePullsSuccesses,
-		CRIOImageLayerReuse,
-		CRIOContainersOOMTotal,
-		CRIOContainersOOM,
+		m.metricOperations,
+		m.metricOperationsLatency,
+		m.metricOperationsLatencyTotal,
+		m.metricOperationsErrors,
+		m.metricImagePullsByDigest,
+		m.metricImagePullsByName,
+		m.metricImagePullsByNameSkipped,
+		m.metricImagePullsFailures,
+		m.metricImagePullsSuccesses,
+		m.metricImageLayerReuse,
+		m.metricContainersOOMTotal,
+		m.metricContainersOOM,
 	} {
 		if err := prometheus.Register(collector); err != nil {
 			return nil, errors.Wrap(err, "register metric")

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -58,8 +58,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 		return nil, nil, fmt.Errorf("failed to create pod network sandbox %s(%s): %v", sb.Name(), sb.ID(), err)
 	}
 	// metric about the CNI network setup operation
-	metrics.CRIOOperationsLatency.WithLabelValues("network_setup_pod").
-		Set(metrics.SinceInMicroseconds(podSetUpStart))
+	metrics.Instance().MetricOperationsLatencySet("network_setup_pod", podSetUpStart)
 
 	podNetworkStatus, err := s.config.CNIPlugin().GetPodNetworkStatusWithContext(startCtx, podNetwork)
 	if err != nil {
@@ -120,8 +119,7 @@ func (s *Server) networkStart(ctx context.Context, sb *sandbox.Sandbox) (podIPs 
 	log.Debugf(ctx, "Found POD IPs: %v", podIPs)
 
 	// metric about the whole network setup operation
-	metrics.CRIOOperationsLatency.WithLabelValues("network_setup_overall").
-		Set(metrics.SinceInMicroseconds(overallStart))
+	metrics.Instance().MetricOperationsLatencySet("network_setup_overall", overallStart)
 	return podIPs, result, err
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We now provide an `Instance()` singleton for metrics as well as
modification helper functions to be able to enable/disable them in
further patches.


#### Which issue(s) this PR fixes:

Part of https://github.com/cri-o/cri-o/issues/4982

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
