### PR TITLE
oci: fix issues with exec

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -331,11 +331,13 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 	}
 	defer os.RemoveAll(processFile)
 
-	pidFile, err := createPidFile()
+	pidDir, err := ioutil.TempDir("", "pidfile")
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(pidFile)
+	defer os.RemoveAll(pidDir)
+
+	pidFile := filepath.Join(pidDir, c.id)
 
 	cmd := r.constructExecCommand(ctx, c, processFile, pidFile)
 	cmd.SysProcAttr = sysProcAttrPlatform()

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -361,7 +361,7 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 		select {
 		case <-time.After(time.Second * time.Duration(timeout)):
 			// Ensure the process is not left behind
-			killContainerExecProcess(ctx, pidFile)
+			killContainerExecProcess(ctx, pidFile, cmd)
 
 			// Make sure the runtime process has been cleaned up
 			<-done
@@ -419,13 +419,15 @@ func createPidFile() (string, error) {
 	return pidFileName, nil
 }
 
-func killContainerExecProcess(ctx context.Context, pidFile string) {
+func killContainerExecProcess(ctx context.Context, pidFile string, cmd *exec.Cmd) {
 	// Attempt to get the container PID and PGID from the file the runtime should have written.
-	// TODO(haircommander): There does exist a race that we could time out before the runtime actually creates the file.
-	// Should we do inotify on this file to ensure it exists? Is that overkill?
 	ctrPid, ctrPgid, err := pidAndpgidFromFile(pidFile)
-	if err != nil {
-		log.Errorf(ctx, "Failed to get pid (%d) or pgid (%d) from file %s: %v", ctrPid, ctrPgid, pidFile, err)
+	if err != nil && ctrPid <= 0 {
+		// only kill the runtime process if we failed to find a ctrPid
+		// as this means the runtime exec hasn't successfully written the pid file
+		if killErr := cmd.Process.Kill(); killErr != nil {
+			log.Errorf(ctx, "Error killing runtime exec process(%v) after error finding runtime pid: (%v)", killErr, err)
+		}
 	}
 
 	if ctrPgid > 1 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it
previously we had lots of instances of
`Failed to get pid (-1) or pgid (-1) from file /tmp/pidfile097828553: strconv.Atoi: parsing \"\": invalid syntax"`
because we precreated the pid file. stop doing this, and also kill the runtime process if we timeout an exec run

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where an exec sync timeout would fail to cleanup the runtime exec process
```
