### PR TITLE
runtimeVM: Enable shimv2 debug when CRI-O is on debug+ log level

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -188,7 +188,8 @@ func (r *runtimeVM) startRuntimeDaemon(ctx context.Context, c *Container) error 
 
 	// Prepare the command to run
 	args := []string{"-id", c.ID()}
-	if logrus.GetLevel() == logrus.DebugLevel {
+	switch logrus.GetLevel() {
+	case logrus.DebugLevel, logrus.TraceLevel:
 		args = append(args, "-debug")
 	}
 	args = append(args, "start")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently the shimv2 debug is only enabled when CRI-O is, specifically,
on debug mode.  However, it should be enabled whenever the CRI runtime
is on debug *or any other lower* mode, as in trace mode.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

A similar PR has been opened for the containerd side, so we ensure we behave the same as they do.
https://github.com/containerd/containerd/pull/5617

#### Does this PR introduce a user-facing change?

```release-note
None
```
