### PR TITLE
Generate self-signed metrics cert/key if provided ones are not available

### DIFF
--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1145,11 +1145,15 @@ metrics_socket = "{{ .MetricsSocket }}"
 `
 
 const templateStringCrioMetricsMetricsCert = `# The certificate for the secure metrics server.
+# If the certificate is not available on disk, then CRI-O will generate a
+# self-signed one. CRI-O also watches for changes of this path and reloads the
+# certificate on any modification event.
 metrics_cert = "{{ .MetricsCert }}"
 
 `
 
 const templateStringCrioMetricsMetricsKey = `# The certificate key for the secure metrics server.
+# Behaves in the same way as the metrics_cert.
 metrics_key = "{{ .MetricsKey }}"
 
 `

--- a/test/metrics.bats
+++ b/test/metrics.bats
@@ -61,6 +61,22 @@ function teardown() {
 	curl -sfk "https://localhost:$PORT/metrics" | grep crio_operations
 }
 
+@test "secure metrics with random port and missing cert/key" {
+	# start crio with custom port
+	PORT=$(free_port)
+
+	CONTAINER_ENABLE_METRICS=true \
+		CONTAINER_METRICS_CERT="$TESTDIR/sub/dir/cert.pem" \
+		CONTAINER_METRICS_KEY="$TESTDIR/another/dir/key.pem" \
+		CONTAINER_METRICS_PORT=$PORT \
+		start_crio
+
+	crictl run "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+
+	# get metrics
+	curl -sfk "https://localhost:$PORT/metrics" | grep crio_operations
+}
+
 @test "metrics container oom" {
 	PORT=$(free_port)
 	CONTAINER_ENABLE_METRICS=true CONTAINER_METRICS_PORT=$PORT start_crio


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This allows starting CRI-O without having the certificates on disk. A Kubernetes controller can later on reconcile their own certificates into the same location for reload.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added generation of self-signed certificates for the secure metrics endpoint
if the provided cert and key paths are not available on disk.
```
