### PR TITLE
[release-1.21] network: pass pod UID to ocicni when performing network operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.1
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty v1.1.11
-	github.com/cri-o/ocicni v0.2.1-0.20210301205850-541cf7c703cf
+	github.com/cri-o/ocicni v0.2.1-0.20210623033107-4ea5fb8752cf
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/go-units v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,9 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cri-o/ocicni v0.2.1-0.20210301205850-541cf7c703cf h1:k2wrxBiBseRfOD7h+9fABEuesABBQuUuW5fWwpARbeI=
 github.com/cri-o/ocicni v0.2.1-0.20210301205850-541cf7c703cf/go.mod h1:vingr1ztOAzP2WyTgGbpMov9dFhbjNxdLtDv0+PhAvY=
+github.com/cri-o/ocicni v0.2.1-0.20210623033107-4ea5fb8752cf h1:2Ju8czUjjHavv6wIizDsCOvp2+d71o6VuM1VSwWfcuU=
+github.com/cri-o/ocicni v0.2.1-0.20210623033107-4ea5fb8752cf/go.mod h1:vingr1ztOAzP2WyTgGbpMov9dFhbjNxdLtDv0+PhAvY=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -223,6 +223,7 @@ func (s *Server) newPodNetwork(sb *sandbox.Sandbox) (ocicni.PodNetwork, error) {
 	return ocicni.PodNetwork{
 		Name:      sb.KubeName(),
 		Namespace: sb.Namespace(),
+		UID:       sb.Metadata().UID,
 		Networks:  []ocicni.NetAttachment{},
 		ID:        sb.ID(),
 		NetNS:     sb.NetNsPath(),

--- a/test/cni_plugin_helper.bash
+++ b/test/cni_plugin_helper.bash
@@ -20,6 +20,8 @@ for arg in "${array[@]}"; do
         K8S_POD_NAMESPACE="${item[1]}"
     elif [[ "${item[0]}" == "K8S_POD_NAME" ]]; then
         K8S_POD_NAME="${item[1]}"
+    elif [[ "${item[0]}" == "K8S_POD_UID" ]]; then
+        K8S_POD_UID="${item[1]}"
     fi
 done
 
@@ -29,6 +31,8 @@ elif [[ -z "${K8S_POD_NAMESPACE}" ]]; then
     exit 1
 elif [[ -z "${K8S_POD_NAME}" ]]; then
     exit 1
+elif [[ -z "${K8S_POD_UID}" ]]; then
+    exit 1
 fi
 
 TEST_DIR=%TEST_DIR%
@@ -37,6 +41,7 @@ cat <<EOT >"$TEST_DIR/plugin_test_args.out"
 FOUND_CNI_CONTAINERID="${CNI_CONTAINERID}"
 FOUND_K8S_POD_NAMESPACE="${K8S_POD_NAMESPACE}"
 FOUND_K8S_POD_NAME="${K8S_POD_NAME}"
+FOUND_K8S_POD_UID="${K8S_POD_UID}"
 EOT
 
 # shellcheck disable=1090

--- a/test/network.bats
+++ b/test/network.bats
@@ -76,6 +76,7 @@ function teardown() {
 	[ "$FOUND_CNI_CONTAINERID" != "podsandbox1" ]
 	[ "$FOUND_K8S_POD_NAMESPACE" = "redhat.test.crio" ]
 	[ "$FOUND_K8S_POD_NAME" = "podsandbox1" ]
+	[ "$FOUND_K8S_POD_UID" = "redhat-test-crio" ]
 }
 
 @test "Connect to pod hostport from the host" {

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/ocicni.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/ocicni.go
@@ -195,16 +195,21 @@ func (plugin *cniNetworkPlugin) monitorConfDir(start *sync.WaitGroup) {
 // If defaultNetName is empty, CNI config files should be reloaded real-time and
 // defaultNetName should be changeable and determined by file sorting.
 func InitCNI(defaultNetName string, confDir string, binDirs ...string) (CNIPlugin, error) {
-	return initCNI(nil, "", defaultNetName, confDir, binDirs...)
+	return initCNI(nil, "", defaultNetName, confDir, true, binDirs...)
 }
 
 // InitCNIWithCache works like InitCNI except that it takes the cni cache directory as third param.
 func InitCNIWithCache(defaultNetName, confDir, cacheDir string, binDirs ...string) (CNIPlugin, error) {
-	return initCNI(nil, cacheDir, defaultNetName, confDir, binDirs...)
+	return initCNI(nil, cacheDir, defaultNetName, confDir, true, binDirs...)
+}
+
+// InitCNINoInotify works like InitCNI except that it does not use inotify to watch for changes in the CNI config dir.
+func InitCNINoInotify(defaultNetName, confDir, cacheDir string, binDirs ...string) (CNIPlugin, error) {
+	return initCNI(nil, cacheDir, defaultNetName, confDir, false, binDirs...)
 }
 
 // Internal function to allow faking out exec functions for testing
-func initCNI(exec cniinvoke.Exec, cacheDir, defaultNetName string, confDir string, binDirs ...string) (CNIPlugin, error) {
+func initCNI(exec cniinvoke.Exec, cacheDir, defaultNetName string, confDir string, useInotify bool, binDirs ...string) (CNIPlugin, error) {
 	if confDir == "" {
 		confDir = DefaultConfDir
 	}
@@ -245,22 +250,26 @@ func initCNI(exec cniinvoke.Exec, cacheDir, defaultNetName string, confDir strin
 
 	plugin.syncNetworkConfig()
 
-	plugin.watcher, err = newWatcher(plugin.confDir)
-	if err != nil {
-		return nil, err
-	}
+	if useInotify {
+		plugin.watcher, err = newWatcher(plugin.confDir)
+		if err != nil {
+			return nil, err
+		}
 
-	startWg := sync.WaitGroup{}
-	startWg.Add(1)
-	go plugin.monitorConfDir(&startWg)
-	startWg.Wait()
+		startWg := sync.WaitGroup{}
+		startWg.Add(1)
+		go plugin.monitorConfDir(&startWg)
+		startWg.Wait()
+	}
 
 	return plugin, nil
 }
 
 func (plugin *cniNetworkPlugin) Shutdown() error {
 	close(plugin.shutdownChan)
-	plugin.watcher.Close()
+	if plugin.watcher != nil {
+		plugin.watcher.Close()
+	}
 	plugin.done.Wait()
 	return nil
 }
@@ -539,10 +548,11 @@ func (plugin *cniNetworkPlugin) SetUpPodWithContext(ctx context.Context, podNetw
 
 	results := make([]NetResult, 0)
 	if err := plugin.forEachNetwork(&podNetwork, false, func(network *cniNetwork, podNetwork *PodNetwork, rt *libcni.RuntimeConf) error {
+		fullPodName := buildFullPodName(*podNetwork)
+		logrus.Infof("Adding pod %s to CNI network %q (type=%v)", fullPodName, network.name, network.config.Plugins[0].Network.Type)
 		result, err := network.addToNetwork(ctx, rt, plugin.cniConfig)
 		if err != nil {
-			logrus.Errorf("Error while adding pod to CNI network %q: %s", network.name, err)
-			return err
+			return fmt.Errorf("error adding pod %s to CNI network %q: %v", fullPodName, network.name, err)
 		}
 		results = append(results, NetResult{
 			Result: result,
@@ -654,8 +664,10 @@ func (plugin *cniNetworkPlugin) TearDownPodWithContext(ctx context.Context, podN
 	}
 
 	return plugin.forEachNetwork(&podNetwork, true, func(network *cniNetwork, podNetwork *PodNetwork, rt *libcni.RuntimeConf) error {
+		fullPodName := buildFullPodName(*podNetwork)
+		logrus.Infof("Deleting pod %s from CNI network %q (type=%v)", fullPodName, network.name, network.config.Plugins[0].Network.Type)
 		if err := network.deleteFromNetwork(ctx, rt, plugin.cniConfig); err != nil {
-			return fmt.Errorf("Error while removing pod from CNI network %q: %s", network.name, err)
+			return fmt.Errorf("error removing pod %s from CNI network %q: %v", fullPodName, network.name, err)
 		}
 		return nil
 	})
@@ -680,10 +692,11 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatusWithContext(ctx context.Conte
 
 	results := make([]NetResult, 0)
 	if err := plugin.forEachNetwork(&podNetwork, true, func(network *cniNetwork, podNetwork *PodNetwork, rt *libcni.RuntimeConf) error {
+		fullPodName := buildFullPodName(*podNetwork)
+		logrus.Infof("Checking pod %s for CNI network %s (type=%v)", fullPodName, network.name, network.config.Plugins[0].Network.Type)
 		result, err := network.checkNetwork(ctx, rt, plugin.cniConfig, plugin.nsManager, podNetwork.NetNS)
 		if err != nil {
-			logrus.Errorf("Error while checking pod to CNI network %q: %s", network.name, err)
-			return err
+			return fmt.Errorf("error checking pod %s for CNI network %q: %v", fullPodName, network.name, err)
 		}
 		if result != nil {
 			results = append(results, NetResult{
@@ -703,19 +716,10 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatusWithContext(ctx context.Conte
 }
 
 func (network *cniNetwork) addToNetwork(ctx context.Context, rt *libcni.RuntimeConf, cni *libcni.CNIConfig) (cnitypes.Result, error) {
-	logrus.Infof("About to add CNI network %s (type=%v)", network.name, network.config.Plugins[0].Network.Type)
-	res, err := cni.AddNetworkList(ctx, network.config, rt)
-	if err != nil {
-		logrus.Errorf("Error adding network: %v", err)
-		return nil, err
-	}
-
-	return res, nil
+	return cni.AddNetworkList(ctx, network.config, rt)
 }
 
 func (network *cniNetwork) checkNetwork(ctx context.Context, rt *libcni.RuntimeConf, cni *libcni.CNIConfig, nsManager *nsManager, netns string) (cnitypes.Result, error) {
-	logrus.Infof("About to check CNI network %s (type=%v)", network.name, network.config.Plugins[0].Network.Type)
-
 	gtet, err := cniversion.GreaterThanOrEqualTo(network.config.CNIVersion, "0.4.0")
 	if err != nil {
 		return nil, err
@@ -786,11 +790,7 @@ func (network *cniNetwork) checkNetwork(ctx context.Context, rt *libcni.RuntimeC
 }
 
 func (network *cniNetwork) deleteFromNetwork(ctx context.Context, rt *libcni.RuntimeConf, cni *libcni.CNIConfig) error {
-	logrus.Infof("About to del CNI network %s (type=%v)", network.name, network.config.Plugins[0].Network.Type)
-	if err := cni.DelNetworkList(ctx, network.config, rt); err != nil {
-		return err
-	}
-	return nil
+	return cni.DelNetworkList(ctx, network.config, rt)
 }
 
 func buildCNIRuntimeConf(podNetwork *PodNetwork, ifName string, runtimeConfig RuntimeConfig) (*libcni.RuntimeConf, error) {
@@ -805,8 +805,16 @@ func buildCNIRuntimeConf(podNetwork *PodNetwork, ifName string, runtimeConfig Ru
 			{"K8S_POD_NAMESPACE", podNetwork.Namespace},
 			{"K8S_POD_NAME", podNetwork.Name},
 			{"K8S_POD_INFRA_CONTAINER_ID", podNetwork.ID},
+			{"K8S_POD_UID", podNetwork.UID},
 		},
 		CapabilityArgs: map[string]interface{}{},
+	}
+
+	// Propagate existing CNI_ARGS to non-k8s consumers
+	for _, kvpairs := range strings.Split(os.Getenv("CNI_ARGS"), ";") {
+		if keyval := strings.SplitN(kvpairs, "=", 2); len(keyval) == 2 {
+			rt.Args = append(rt.Args, [2]string{keyval[0], keyval[1]})
+		}
 	}
 
 	// Add requested static IP to CNI_ARGS

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/types.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/types.go
@@ -71,12 +71,14 @@ type BandwidthConfig struct {
 
 // PodNetwork configures the network of a pod sandbox.
 type PodNetwork struct {
-	// Name is the name of the sandbox.
+	// Name is the name of the pod.
 	Name string
-	// Namespace is the namespace of the sandbox.
+	// Namespace is the namespace of the pod.
 	Namespace string
 	// ID is the id of the sandbox container.
 	ID string
+	// UID is the UID of the pod that owns the sandbox.
+	UID string
 	// NetNS is the network namespace path of the sandbox.
 	NetNS string
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,7 +349,7 @@ github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/creack/pty v1.1.11
 ## explicit
 github.com/creack/pty
-# github.com/cri-o/ocicni v0.2.1-0.20210301205850-541cf7c703cf
+# github.com/cri-o/ocicni v0.2.1-0.20210623033107-4ea5fb8752cf
 ## explicit
 github.com/cri-o/ocicni/pkg/ocicni
 # github.com/cyphar/filepath-securejoin v0.2.2


### PR DESCRIPTION
Ongoing sandbox requests cannot be (or are not) canceled by kubelet, leading to a situation where short-lived pods (especially Kubernetes e2e tests for stateful sets) cause overlapping sandbox requests. If the CNI plugin needs to wait for network state to converge, it's pointless to wait for a sandbox who's pod has been deleted so the plugin should cancel the request and return to the runtime. However, it's impossible to do that race-free without the pod UID the sandbox was created for, since the there is a gap between when kubelet requests the sandbox creation and when the plugin gets the pod object from the apiserver when the pod could have been deleted and recreated, and the CNI plugin would retrieve information for the new pod, not the pod the sandbox was created for.

Passing the pod UID to the plugin allows the plugin to cancel the operation when the pod UID retrieved from the apiserver during plugin operation does not match the one the sandbox was created for.

@trozet @haircommander @mrunalp

Cherry-pick of https://github.com/cri-o/cri-o/pull/5026

/kind feature

```release-note
CNI plugins are now passed a K8S_POD_UID environment variable containing the pod UID this sandbox was started for.
```
