### PR TITLE
[1.20] pull: do check for blocked registries

### DIFF
--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -804,17 +804,7 @@ func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageN
 			rem = "library/" + rem
 		}
 		image := r + "/" + rem
-		registry, err := sysregistriesv2.FindRegistry(systemContext, image)
-		if err != nil {
-			return nil, err
-		}
-		if registry != nil && registry.Blocked {
-			continue
-		}
 		images = append(images, image)
-	}
-	if len(images) == 0 {
-		return nil, fmt.Errorf("all search registries for %q are blocked", remainder)
 	}
 	return imageNamesWithDigestOrTag(images)
 }

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -783,14 +783,6 @@ func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageN
 
 	domain, remainder := splitDockerDomain(imageName)
 	if domain != "" {
-		// this means the image is already fully qualified
-		registry, err := sysregistriesv2.FindRegistry(systemContext, imageName)
-		if err != nil {
-			return nil, err
-		}
-		if registry != nil && registry.Blocked {
-			return nil, fmt.Errorf("cannot use %q because it's blocked", imageName)
-		}
 		return imageNamesWithDigestOrTag([]string{imageName})
 	}
 	UnqualifiedSearchRegistries, err := sysregistriesv2.UnqualifiedSearchRegistries(systemContext)


### PR DESCRIPTION
Do not check whether a registry is blocked.  c/image is taking care of
that implicitly when attempting to copy an image.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
or else mirrored registries cannot resolve there
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a bug where CRI-O prematurely stopped pulling from a blocked registry, even if there was a mirror for that registry it was allowed to pull from.
```
