### PR TITLE
Revert "Update runc to v1.0.0"

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -54,7 +54,7 @@ dependencies:
       match: cri_tools_git_version
 
   - name: runc
-    version: v1.0.0
+    version: v1.0.0-rc95
     refPaths:
     - path: scripts/versions
       match: runc

--- a/scripts/versions
+++ b/scripts/versions
@@ -6,7 +6,7 @@ declare -A VERSIONS=(
     ["cni-plugins"]=v0.9.1
     ["conmon"]=v2.0.26
     ["cri-tools"]=v1.21.0
-    ["runc"]=v1.0.0
+    ["runc"]=v1.0.0-rc95
     ["crun"]=0.20.1
     ["bats"]=v1.3.0
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
This reverts commit 3373b31094ba707a27d0d94caecdcf3146ed9f80.

Caused upstream kubernetes CI to fail: https://prow.k8s.io/?job=*ci-crio-cgroupv1-node-e2e*
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
