### PR TITLE
Introduce CNIManager

### DIFF
--- a/internal/config/cnimgr/cnimgr.go
+++ b/internal/config/cnimgr/cnimgr.go
@@ -1,0 +1,69 @@
+package cnimgr
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cri-o/ocicni/pkg/ocicni"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type CNIManager struct {
+	// cniPlugin is the internal OCI CNI plugin
+	plugin    ocicni.CNIPlugin
+	lastError error
+	watchers  []chan struct{}
+	sync.RWMutex
+}
+
+func New(defaultNetwork, networkDir string, pluginDirs ...string) (*CNIManager, error) {
+	// Init CNI plugin
+	plugin, err := ocicni.InitCNI(
+		defaultNetwork, networkDir, pluginDirs...,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "initialize CNI plugin")
+	}
+	mgr := &CNIManager{
+		plugin: plugin,
+	}
+	go mgr.pollUntilReady()
+	return mgr, nil
+}
+
+func (c *CNIManager) pollUntilReady() {
+	// nolint:errcheck
+	_ = wait.PollInfinite(500*time.Millisecond, func() (bool, error) {
+		c.Lock()
+		defer c.Unlock()
+		if err := c.plugin.Status(); err != nil {
+			c.lastError = err
+			return false, nil
+		}
+		c.lastError = nil
+		for _, watcher := range c.watchers {
+			watcher <- struct{}{}
+		}
+		return true, nil
+	})
+}
+
+func (c *CNIManager) ReadyOrError() error {
+	c.RLock()
+	defer c.RUnlock()
+	return c.lastError
+}
+
+func (c *CNIManager) Plugin() ocicni.CNIPlugin {
+	return c.plugin
+}
+
+func (c *CNIManager) AddWatcher() chan struct{} {
+	c.Lock()
+	defer c.Unlock()
+	watcher := make(chan struct{}, 1)
+	c.watchers = append(c.watchers, watcher)
+
+	return watcher
+}

--- a/internal/config/cnimgr/cnimgr_test_inject.go
+++ b/internal/config/cnimgr/cnimgr_test_inject.go
@@ -1,0 +1,21 @@
+// +build test
+// All *_inject.go files are meant to be used by tests only. Purpose of this
+// files is to provide a way to inject mocked data into the current setup.
+
+package cnimgr
+
+import (
+	"github.com/cri-o/ocicni/pkg/ocicni"
+)
+
+// SetCNIPlugin sets the network plugin for the Configuration. The function
+// errors if a sane shutdown of the initially created network plugin failed.
+func (c *CNIManager) SetCNIPlugin(plugin ocicni.CNIPlugin) error {
+	if c.plugin != nil {
+		if err := c.plugin.Shutdown(); err != nil {
+			return err
+		}
+	}
+	c.plugin = plugin
+	return nil
+}

--- a/internal/config/cnimgr/cnimgr_test_inject.go
+++ b/internal/config/cnimgr/cnimgr_test_inject.go
@@ -17,5 +17,8 @@ func (c *CNIManager) SetCNIPlugin(plugin ocicni.CNIPlugin) error {
 		}
 	}
 	c.plugin = plugin
+	// initialize the poll, but don't run it continuously (or else the mocks will get weird)
+	//nolint:errcheck
+	_, _ = c.pollFunc()
 	return nil
 }

--- a/pkg/config/config_test_inject.go
+++ b/pkg/config/config_test_inject.go
@@ -5,11 +5,15 @@
 package config
 
 import (
+	"github.com/cri-o/cri-o/internal/config/cnimgr"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 )
 
 // SetCNIPlugin sets the network plugin for the Configuration. The function
 // errors if a sane shutdown of the initially created network plugin failed.
 func (c *Config) SetCNIPlugin(plugin ocicni.CNIPlugin) error {
+	if c.cniManager == nil {
+		c.cniManager = &cnimgr.CNIManager{}
+	}
 	return c.cniManager.SetCNIPlugin(plugin)
 }

--- a/pkg/config/config_test_inject.go
+++ b/pkg/config/config_test_inject.go
@@ -10,12 +10,6 @@ import (
 
 // SetCNIPlugin sets the network plugin for the Configuration. The function
 // errors if a sane shutdown of the initially created network plugin failed.
-func (c *NetworkConfig) SetCNIPlugin(plugin ocicni.CNIPlugin) error {
-	if c.CNIPlugin() != nil {
-		if err := c.CNIPlugin().Shutdown(); err != nil {
-			return err
-		}
-	}
-	c.cniPlugin = plugin
-	return nil
+func (c *Config) SetCNIPlugin(plugin ocicni.CNIPlugin) error {
+	return c.cniManager.SetCNIPlugin(plugin)
 }

--- a/server/runtime_status.go
+++ b/server/runtime_status.go
@@ -21,7 +21,7 @@ func (s *Server) Status(ctx context.Context, req *types.StatusRequest) (*types.S
 		Status: true,
 	}
 
-	if err := s.config.CNIPlugin().Status(); err != nil {
+	if err := s.config.CNIPluginReadyOrError(); err != nil {
 		networkCondition.Status = false
 		networkCondition.Reason = networkNotReadyReason
 		networkCondition.Message = fmt.Sprintf("Network plugin returns error: %v", err)

--- a/server/runtime_status_test.go
+++ b/server/runtime_status_test.go
@@ -38,11 +38,6 @@ var _ = t.Describe("Status", func() {
 		})
 
 		It("should succeed when CNI plugin status errors", func() {
-			// Given
-			gomock.InOrder(
-				cniPluginMock.EXPECT().Status().Return(t.TestError),
-			)
-
 			// When
 			response, err := sut.Status(context.Background(),
 				&types.StatusRequest{})

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -191,6 +191,10 @@ var setupSUT = func() {
 	// Inject the mock
 	sut.SetStorageImageServer(imageServerMock)
 	sut.SetStorageRuntimeServer(runtimeServerMock)
+
+	gomock.InOrder(
+		cniPluginMock.EXPECT().Status().Return(t.TestError),
+	)
 	Expect(sut.SetCNIPlugin(cniPluginMock)).To(BeNil())
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
The way kubernetes deals with networking infra is that it doesn't. it's mostly up to the cri impl to figure out how pods are connected to each other. the problem with not being networking aware is that the kubelet won't wait for the network to be ready before starting pods. in resource constrained environments, this can cause large delays in node bootstrap, as the a pod that is the cni plugin is competing to start with all others.

instead, we can rate limit the pod creation by waiting until the cniplugin is ready before starting a pod. since it won't make progress until the cni plugin is up anyway, this should only improve how quickly a node comes up

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Wait for CNI plugins to be ready before starting non-host-network pods, to allow pods that may run CNI plugins to start faster
```
