### PR TITLE
server: properly handle duplicate requests

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -493,6 +493,11 @@ func (c *ContainerServer) ReserveContainerName(id, name string) (string, error) 
 	return name, nil
 }
 
+// ContainerIDForName gets the container ID given the container name from the ID Index
+func (c *ContainerServer) ContainerIDForName(name string) (string, error) {
+	return c.ctrNameIndex.Get(name)
+}
+
 // ReleaseContainerName releases a container name from the index so that it can
 // be used by other containers
 func (c *ContainerServer) ReleaseContainerName(name string) {
@@ -513,6 +518,11 @@ func (c *ContainerServer) ReservePodName(id, name string) (string, error) {
 // pods
 func (c *ContainerServer) ReleasePodName(name string) {
 	c.podNameIndex.Release(name)
+}
+
+// PodIDForName gets the pod ID given the pod name from the ID Index
+func (c *ContainerServer) PodIDForName(name string) (string, error) {
+	return c.podNameIndex.Get(name)
 }
 
 // recoverLogError recovers a runtime panic and logs the returned error if

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -451,6 +451,15 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 	}()
 
 	if _, err = s.ReserveContainerName(ctr.ID(), ctr.Name()); err != nil {
+		reservedID, getErr := s.ContainerIDForName(ctr.Name())
+		if getErr != nil {
+			return nil, errors.Wrapf(getErr, "Failed to get ID of container with reserved name (%s), after failing to reserve name with %v", ctr.Name(), getErr)
+		}
+		// if we're able to find the container, and it's created, this is actually a duplicate request
+		// from a client that does not behave like the kubelet (like crictl)
+		if reservedCtr := s.GetContainer(reservedID); reservedCtr != nil && reservedCtr.Created() {
+			return nil, err
+		}
 		cachedID, resourceErr := s.getResourceOrWait(ctx, ctr.Name(), "container")
 		if resourceErr == nil {
 			return &types.CreateContainerResponse{ContainerID: cachedID}, nil

--- a/test/timeout.bats
+++ b/test/timeout.bats
@@ -157,6 +157,14 @@ function wait_clean() {
 	crictl runp "$TESTDATA"/sandbox_config.json
 }
 
+@test "should not wait for actual duplicate pod request" {
+	start_crio
+	crictl runp "$TESTDATA"/sandbox_config.json
+	SECONDS=0
+	! crictl runp "$TESTDATA"/sandbox_config.json
+	[[ "$SECONDS" -lt 240 ]]
+}
+
 @test "should clean up container after timeout if not re-requested" {
 	start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
@@ -220,4 +228,14 @@ function wait_clean() {
 	! crictl exec "$created_ctr_id" ls
 	! crictl exec --sync "$created_ctr_id" ls
 	! crictl inspect "$created_ctr_id"
+}
+
+@test "should not wait for actual duplicate container request" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json
+	SECONDS=0
+	! crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json
+	[[ "$SECONDS" -lt 240 ]]
 }


### PR DESCRIPTION
before, if crictl sent a duplicate request (runp, wait till finish, runp), cri-o would stall crictl, thinking it was a timeout.

Now, we check whether the pod has been created before waiting on the already created resource

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where duplicate requests would stall even if the pod or container was already created
```
