### PR TITLE
[1.19] Bump c/storage to latest v1.20-stable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containers/image/v5 v5.5.4
 	github.com/containers/libpod v1.9.2
 	github.com/containers/ocicrypt v1.0.3
-	github.com/containers/storage v1.20.6-0.20210607204025-dc67d2fbc8c5
+	github.com/containers/storage v1.20.6-0.20210713190325-991af1d41568
 	github.com/coreos/go-systemd/v22 v22.2.0
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty v1.1.11

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/containers/psgo v1.4.0/go.mod h1:ENXXLQ5E1At4K0EUsGogXBJi/C28gwqkONWe
 github.com/containers/storage v1.18.2/go.mod h1:WTBMf+a9ZZ/LbmEVeLHH2TX4CikWbO1Bt+/m58ZHVPg=
 github.com/containers/storage v1.19.1/go.mod h1:KbXjSwKnx17ejOsjFcCXSf78mCgZkQSLPBNTMRc3XrQ=
 github.com/containers/storage v1.20.2/go.mod h1:oOB9Ie8OVPojvoaKWEGSEtHbXUAs+tSyr7RO7ZGteMc=
-github.com/containers/storage v1.20.6-0.20210607204025-dc67d2fbc8c5 h1:K99OLTHPGiQ28EM9r7i4OL9Vol6DK9Cxmr3JOwS7L1g=
-github.com/containers/storage v1.20.6-0.20210607204025-dc67d2fbc8c5/go.mod h1:L21V7HElfNsMeMdif5JdxtCvzS8LKKhv4movqpFbiOk=
+github.com/containers/storage v1.20.6-0.20210713190325-991af1d41568 h1:KeySO/6HAbuKy7YXJuMJTIGxLP655RJhOBnVF/BfenI=
+github.com/containers/storage v1.20.6-0.20210713190325-991af1d41568/go.mod h1:L21V7HElfNsMeMdif5JdxtCvzS8LKKhv4movqpFbiOk=
 github.com/coredns/corefile-migration v1.0.10/go.mod h1:RMy/mXdeDlYwzt0vdMEJvT2hGJ2I86/eO0UdXmH9XNI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/vendor/github.com/containers/storage/pkg/lockfile/lockfile_unix.go
+++ b/vendor/github.com/containers/storage/pkg/lockfile/lockfile_unix.go
@@ -5,6 +5,7 @@ package lockfile
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -33,11 +34,30 @@ type lockfile struct {
 // descriptor.  Note that the path is opened read-only when ro is set.  If ro
 // is unset, openLock will open the path read-write and create the file if
 // necessary.
-func openLock(path string, ro bool) (int, error) {
+func openLock(path string, ro bool) (fd int, err error) {
 	if ro {
-		return unix.Open(path, os.O_RDONLY, 0)
+		fd, err = unix.Open(path, os.O_RDONLY|unix.O_CLOEXEC, 0)
+	} else {
+		fd, err = unix.Open(path,
+			os.O_RDWR|unix.O_CLOEXEC|os.O_CREATE,
+			unix.S_IRUSR|unix.S_IWUSR|unix.S_IRGRP|unix.S_IROTH,
+		)
 	}
-	return unix.Open(path, os.O_RDWR|os.O_CREATE, unix.S_IRUSR|unix.S_IWUSR)
+
+	if err == nil {
+		return
+	}
+
+	// the directory of the lockfile seems to be removed, try to create it
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return fd, errors.Wrap(err, "creating locker directory")
+		}
+
+		return openLock(path, ro)
+	}
+
+	return
 }
 
 // createLockerForPath returns a Locker object, possibly (depending on the platform)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -253,7 +253,7 @@ github.com/containers/psgo/internal/dev
 github.com/containers/psgo/internal/host
 github.com/containers/psgo/internal/proc
 github.com/containers/psgo/internal/process
-# github.com/containers/storage v1.20.6-0.20210607204025-dc67d2fbc8c5
+# github.com/containers/storage v1.20.6-0.20210713190325-991af1d41568
 ## explicit
 github.com/containers/storage
 github.com/containers/storage/drivers


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Fixes a runtime panic if the layers lockfile parent directory got removed.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/containers/storage/pull/964
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed runtime panic if container storage layers lockfile parent directory got removed.
```
