### PR TITLE
[1.20] Bump c/storage to latest release-1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/containers/image/v5 v5.10.6
 	github.com/containers/libpod/v2 v2.0.6
 	github.com/containers/ocicrypt v1.0.3
-	github.com/containers/storage v1.24.9-0.20210517181311-aa7e38beb07f
+	github.com/containers/storage v1.24.9-0.20210713175558-2ba85b4c68b1
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty v1.1.11

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/containers/storage v1.23.5/go.mod h1:ha26Q6ngehFNhf3AWoXldvAvwI4jFe3E
 github.com/containers/storage v1.23.6/go.mod h1:haFs0HRowKwyzvWEx9EgI3WsL8XCSnBDb5f8P5CAxJY=
 github.com/containers/storage v1.23.7/go.mod h1:cUT2zHjtx+WlVri30obWmM2gpqpi8jfPsmIzP1TVpEI=
 github.com/containers/storage v1.24.8/go.mod h1:YC+2pY8SkfEAcZkwycxYbpK8EiRbx5soPPwz9dxe4IQ=
-github.com/containers/storage v1.24.9-0.20210517181311-aa7e38beb07f h1:Oemu2jT9YtJs/wG+CAqkxekfOQi11+ADVV/eFcTwJmU=
-github.com/containers/storage v1.24.9-0.20210517181311-aa7e38beb07f/go.mod h1:5Gjxx8EqRRuTC6J2dbQ/5SMs43SHhe3Ky+BzyeNVPZM=
+github.com/containers/storage v1.24.9-0.20210713175558-2ba85b4c68b1 h1:IWIHmVkO4vQpXyerXYcTSWhs6ODnb+rjNvdEeJoR30k=
+github.com/containers/storage v1.24.9-0.20210713175558-2ba85b4c68b1/go.mod h1:5Gjxx8EqRRuTC6J2dbQ/5SMs43SHhe3Ky+BzyeNVPZM=
 github.com/coredns/corefile-migration v1.0.10/go.mod h1:RMy/mXdeDlYwzt0vdMEJvT2hGJ2I86/eO0UdXmH9XNI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -245,7 +245,7 @@ github.com/containers/psgo/internal/dev
 github.com/containers/psgo/internal/host
 github.com/containers/psgo/internal/proc
 github.com/containers/psgo/internal/process
-# github.com/containers/storage v1.24.9-0.20210517181311-aa7e38beb07f
+# github.com/containers/storage v1.24.9-0.20210713175558-2ba85b4c68b1
 ## explicit
 github.com/containers/storage
 github.com/containers/storage/drivers


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Fixes a runtime panic if the layers lockfile parent directory got removed.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/containers/storage/pull/965
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed runtime panic if container storage layers lockfile parent directory got removed.
```
