### PR TITLE
Fix propagation of annotations from sandbox to container

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -157,7 +157,7 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 	// The sandbox annotations are already filtered for the allowed
 	// annotations, there is no need to check it additionally here.
 	for k, v := range sb.Annotations() {
-		if strings.HasPrefix(k, crioann.OCISeccompBPFHookAnnotation) {
+		if k == crioann.OCISeccompBPFHookAnnotation+"/"+c.config.Metadata.Name {
 			// The OCI seccomp BPF hook
 			// (https://github.com/containers/oci-seccomp-bpf-hook)
 			// uses the annotation io.containers.trace-syscall as indicator
@@ -171,17 +171,14 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 			// 'io.containers.trace-syscall' if the metadata name is equal
 			// to 'container'. This allows us to trace containers into
 			// distinguishable files.
-			if strings.TrimPrefix(k, crioann.OCISeccompBPFHookAnnotation+"/") == c.config.Metadata.Name {
-				log.Debugf(ctx,
-					"Annotation key for container %q rewritten to %q (value is: %q)",
-					c.config.Metadata.Name, crioann.OCISeccompBPFHookAnnotation, v,
-				)
-				c.config.Annotations[crioann.OCISeccompBPFHookAnnotation] = v
-				c.spec.AddAnnotation(crioann.OCISeccompBPFHookAnnotation, v)
-			} else {
-				// Annotation not suffixed with the container name
-				c.spec.AddAnnotation(k, v)
-			}
+			log.Debugf(ctx,
+				"Annotation key for container %q rewritten to %q (value is: %q)",
+				c.config.Metadata.Name, crioann.OCISeccompBPFHookAnnotation, v,
+			)
+			c.config.Annotations[crioann.OCISeccompBPFHookAnnotation] = v
+			c.spec.AddAnnotation(crioann.OCISeccompBPFHookAnnotation, v)
+		} else {
+			c.spec.AddAnnotation(k, v)
 		}
 	}
 

--- a/test/testdata/sandbox_config.json
+++ b/test/testdata/sandbox_config.json
@@ -28,7 +28,8 @@
 	},
 	"annotations": {
 		"owner": "hmeng",
-		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
+		"security.alpha.kubernetes.io/seccomp/pod": "unconfined",
+		"com.example.test": "sandbox annotation"
 	},
 	"linux": {
 		"cgroup_parent": "pod_123-456.slice",


### PR DESCRIPTION
Commit 8cf32223a1dc1208b53167763638886fd23bde67 introduces some
extra processing of seccomp-related sandbox annotations.  But it
introduced a regression where most sandbox annotations are no longer
propagated to the container annotations.  Add an `else` clause to
ensure we propagate all the sandbox annotations to the container's
OCI configuration.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes: https://github.com/cri-o/cri-o/issues/5077

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
