### PR TITLE
Monitor defunct processes in a node

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -261,7 +261,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--metrics-cert**="": Certificate for the secure metrics endpoint
 
-**--metrics-collectors**="": Enabled metrics collectors (default: [operations operations_latency_microseconds_total operations_latency_microseconds operations_errors image_pulls_by_digest image_pulls_by_name image_pulls_by_name_skipped image_pulls_failures image_pulls_successes image_pulls_layer_size image_layer_reuse containers_oom_total containers_oom])
+**--metrics-collectors**="": Enabled metrics collectors (default: [operations operations_latency_microseconds_total operations_latency_microseconds operations_errors image_pulls_by_digest image_pulls_by_name image_pulls_by_name_skipped image_pulls_failures image_pulls_successes image_pulls_layer_size image_layer_reuse containers_oom_total containers_oom processes_defunct])
 
 **--metrics-key**="": Certificate key for the secure metrics endpoint
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -341,7 +341,7 @@ The `crio.metrics` table containers settings pertaining to the Prometheus based 
 **enable_custom_shm_size**=false
 If set to true, enable users to set a custom shm size instead of using the default value of 64M. The shm size can be set through K8S annotation with the key "io.kubernetes.cri-o.ShmSize", and the value representing the size in human readable format. For example: "io.kubernetes.cri-o.ShmSize: 128Mi"
 
-**metrics_collectors**=["operations", "operations_latency_microseconds_total", "operations_latency_microseconds", "operations_errors", "image_pulls_by_digest", "image_pulls_by_name", "image_pulls_by_name_skipped", "image_pulls_failures", "image_pulls_successes", "image_pulls_layer_size", "image_layer_reuse", "containers_oom_total", "containers_oom"]
+**metrics_collectors**=["operations", "operations_latency_microseconds_total", "operations_latency_microseconds", "operations_errors", "image_pulls_by_digest", "image_pulls_by_name", "image_pulls_by_name_skipped", "image_pulls_failures", "image_pulls_successes", "image_pulls_layer_size", "image_layer_reuse", "containers_oom_total", "containers_oom", "processes_defunct"]
   Enabled metrics collectors
 
 **metrics_port**=9090

--- a/internal/process/defunct_processes.go
+++ b/internal/process/defunct_processes.go
@@ -1,0 +1,87 @@
+package process
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// ProcessFS is the process file system.
+const ProcessFS = "/proc"
+
+// Stat represents status information of a process from /proc/[pid]/stat.
+type Stat struct {
+	// Comm is the command name (usually the executable filename).
+	Comm string
+
+	// State is the state of the process.
+	State string
+}
+
+// DefunctProcesses returns the number of zombie processes in the node.
+func DefunctProcesses() (defunctCount uint, retErr error) {
+	directories, err := os.Open(ProcessFS)
+	if err != nil {
+		return 0, err
+	}
+	defer directories.Close()
+
+	names, err := directories.Readdirnames(-1)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, name := range names {
+		// Processes have numeric names. If the name cannot
+		// be parsed to an int, it is not a process name.
+		if _, err := strconv.ParseInt(name, 10, 0); err != nil {
+			continue
+		}
+
+		stat, err := processStats(name)
+		if err != nil {
+			logrus.Debugf("Failed to get the status of process with PID %s: %v", name, err)
+			continue
+		}
+		if stat.State == "Z" {
+			logrus.Warnf("Found defunct process with PID %s (%s)", name, stat.Comm)
+			defunctCount++
+		}
+	}
+	return defunctCount, nil
+}
+
+// processStats returns status information of a process as defined in /proc/[pid]/stat
+func processStats(pid string) (*Stat, error) {
+	bytes, err := ioutil.ReadFile(filepath.Join(ProcessFS, pid, "stat"))
+	if err != nil {
+		return nil, err
+	}
+	data := string(bytes)
+
+	// /proc/[PID]/stat format is described in proc(5). The second field is process name,
+	// enclosed in parentheses, and it can contain parentheses inside. No other fields
+	// can have parentheses, so look for the last ')'.
+	i := strings.LastIndexByte(data, ')')
+	if i <= 2 || i >= len(data)-1 {
+		return nil, errors.Errorf("invalid stat data (no comm): %q", data)
+	}
+
+	parts := strings.SplitN(data[:i], " (", 2)
+	if len(parts) != 2 {
+		return nil, errors.Errorf("invalid stat data (no comm): %q", data)
+	}
+
+	return &Stat{
+		// The command name is field 2.
+		Comm: parts[1],
+
+		// The state is field 3, which is the first two fields and a space after.
+		State: string(data[i+2]),
+	}, nil
+}

--- a/server/metrics/collectors/collectors.go
+++ b/server/metrics/collectors/collectors.go
@@ -54,6 +54,9 @@ const (
 
 	// ContainersOOM is the key for the CRI-O container out of memory metrics per container name.
 	ContainersOOM Collector = crioPrefix + "containers_oom"
+
+	// ProcessesDefunct is the key for the total number of defunct processes in a node.
+	ProcessesDefunct Collector = crioPrefix + "processes_defunct"
 )
 
 // FromSlice converts a string slice to a Collectors type.
@@ -89,6 +92,7 @@ func All() Collectors {
 		ImageLayerReuse.Stripped(),
 		ContainersOOMTotal.Stripped(),
 		ContainersOOM.Stripped(),
+		ProcessesDefunct.Stripped(),
 	}
 }
 

--- a/server/metrics/collectors/collectors_test.go
+++ b/server/metrics/collectors/collectors_test.go
@@ -49,11 +49,12 @@ var _ = t.Describe("Collectors", func() {
 				collectors.ImageLayerReuse,
 				collectors.ContainersOOMTotal,
 				collectors.ContainersOOM,
+				collectors.ProcessesDefunct,
 			} {
 				Expect(all.Contains(collector)).To(BeTrue())
 			}
 
-			Expect(all).To(HaveLen(13))
+			Expect(all).To(HaveLen(14))
 		})
 	})
 

--- a/tutorials/metrics.md
+++ b/tutorials/metrics.md
@@ -54,6 +54,7 @@ Beside the [default golang based metrics][2], CRI-O provides the following addit
 | `crio_image_layer_reuse`                     | `name`                                                                                                                                  | Counter   | Reused (not pulled) local image layer count by name.                                                 |
 | `crio_containers_oom_total`                  |                                                                                                                                         | Counter   | Total number of containers killed because they ran out of memory (OOM)                               |
 | `crio_containers_oom`                        | `name`                                                                                                                                  | Counter   | Containers killed because they ran out of memory (OOM) by their name                                 |
+| `crio_processes_defunct`                     |                                                                                                                                         | Gauge     | Total number of defunct processes in the node                                                        |
 
 - Available CRI-O RPC's from the [gRPC API][3]: `Attach`, `ContainerStats`, `ContainerStatus`,
   `CreateContainer`, `Exec`, `ExecSync`, `ImageFsInfo`, `ImageStatus`,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature
#### What this PR does / why we need it:

This patch adds `internal/process/defunct_processes.go` that retrieves the total number of defunct/zombie processes in a node and adds a new metric `crio_processes_defunct` that uses `internal/process/defunct_processes.go` to collect the total number of defunct processes.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `internal/process/defunct_processes.go` and `crio_processes_defunct` metric to collect the total number of defunct/zombie processes in a node.
```
