### PR TITLE
Fix the amount of frames to be skipped in debug log

### DIFF
--- a/internal/log/hook_filename.go
+++ b/internal/log/hook_filename.go
@@ -61,10 +61,10 @@ func (w *wrapper) Format(entry *logrus.Entry) ([]byte, error) {
 func (f *FileNameHook) findCaller() (file, function string, line int) {
 	var pc uintptr
 	// The maximum amount of frames to be iterated
-	const maxFrames = 10
+	const maxFrames = 20
 	for i := 0; i < maxFrames; i++ {
 		// The amount of frames to be skipped to land at the actual caller
-		const skipFrames = 6
+		const skipFrames = 10
 		pc, file, line = caller(skipFrames + i)
 		if !f.shouldSkipPrefix(file) {
 			break


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We can skip even more frames to find the actual caller. This means we
also have to enhance the maximum amount of frames to search long enough
depending on how huge the frame stack is.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
