### PR TITLE
Switch from klog to logrus in hostport manager

### DIFF
--- a/internal/hostport/hostport.go
+++ b/internal/hostport/hostport.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/klog/v2"
+	"github.com/sirupsen/logrus"
 
 	v1 "k8s.io/api/core/v1"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
@@ -112,7 +112,7 @@ func openLocalPort(hp *hostport) (closeable, error) {
 	default:
 		return nil, fmt.Errorf("unknown protocol %q", hp.protocol)
 	}
-	klog.V(3).Infof("Opened local port %s", hp.String())
+	logrus.Infof("Opened local port %s", hp.String())
 	return socket, nil
 }
 
@@ -128,7 +128,7 @@ func portMappingToHostport(portMapping *PortMapping, family ipFamily) hostport {
 
 // ensureKubeHostportChains ensures the KUBE-HOSTPORTS chain is setup correctly
 func ensureKubeHostportChains(iptables utiliptables.Interface, natInterfaceName string) error {
-	klog.V(4).Info("Ensuring kubelet hostport chains")
+	logrus.Info("Ensuring kubelet hostport chains")
 	// Ensure kubeHostportChain
 	if _, err := iptables.EnsureChain(utiliptables.TableNAT, kubeHostportsChain); err != nil {
 		return fmt.Errorf("failed to ensure that %s chain %s exists: %v", utiliptables.TableNAT, kubeHostportsChain, err)

--- a/internal/hostport/hostport_manager.go
+++ b/internal/hostport/hostport_manager.go
@@ -26,9 +26,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog/v2"
 	iptablesproxy "k8s.io/kubernetes/pkg/proxy/iptables"
 	"k8s.io/kubernetes/pkg/util/conntrack"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
@@ -68,7 +68,7 @@ func NewHostportManager(iptables utiliptables.Interface) HostPortManager {
 	}
 	h.conntrackFound = conntrack.Exists(h.execer)
 	if !h.conntrackFound {
-		klog.Warningf("The binary conntrack is not installed, this can cause failures in network connection cleanup.")
+		logrus.Warn("The binary conntrack is not installed, this can cause failures in network connection cleanup")
 	}
 	return h
 }
@@ -188,11 +188,11 @@ func (hm *hostportManager) Add(id string, podPortMapping *PodPortMapping, natInt
 	// create a new conntrack entry without any DNAT. That will result in blackhole of the traffic even after correct
 	// iptables rules have been added back.
 	if hm.execer != nil && hm.conntrackFound {
-		klog.Infof("Starting to delete udp conntrack entries: %v, isIPv6 - %v", conntrackPortsToRemove, isIPv6)
+		logrus.Infof("Starting to delete udp conntrack entries: %v, isIPv6 - %v", conntrackPortsToRemove, isIPv6)
 		for _, port := range conntrackPortsToRemove {
 			err = conntrack.ClearEntriesForPort(hm.execer, port, isIPv6, v1.ProtocolUDP)
 			if err != nil {
-				klog.Errorf("Failed to clear udp conntrack for port %d, error: %v", port, err)
+				logrus.Errorf("Failed to clear udp conntrack for port %d, error: %v", port, err)
 			}
 		}
 	}
@@ -267,7 +267,7 @@ func (hm *hostportManager) Remove(id string, podPortMapping *PodPortMapping) (er
 
 // syncIPTables executes iptables-restore with given lines
 func (hm *hostportManager) syncIPTables(lines []byte) error {
-	klog.V(3).Infof("Restoring iptables rules: %s", lines)
+	logrus.Infof("Restoring iptables rules: %s", lines)
 	err := hm.iptables.RestoreAll(lines, utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 	if err != nil {
 		return fmt.Errorf("failed to execute iptables-restore: %v", err)
@@ -309,7 +309,7 @@ func (hm *hostportManager) openHostports(podPortMapping *PodPortMapping) (map[ho
 	if retErr != nil {
 		for hp, socket := range ports {
 			if err := socket.Close(); err != nil {
-				klog.Errorf("Cannot clean up hostport %d for pod %s: %v", hp.port, getPodFullName(podPortMapping), err)
+				logrus.Errorf("Cannot clean up hostport %d for pod %s: %v", hp.port, getPodFullName(podPortMapping), err)
 			}
 		}
 		return nil, retErr
@@ -323,14 +323,14 @@ func (hm *hostportManager) closeHostports(hostportMappings []*PortMapping) error
 	for _, pm := range hostportMappings {
 		hp := portMappingToHostport(pm, hm.getIPFamily())
 		if socket, ok := hm.hostPortMap[hp]; ok {
-			klog.V(2).Infof("Closing host port %s", hp.String())
+			logrus.Infof("Closing host port %s", hp.String())
 			if err := socket.Close(); err != nil {
 				errList = append(errList, fmt.Errorf("failed to close host port %s: %v", hp.String(), err))
 				continue
 			}
 			delete(hm.hostPortMap, hp)
 		} else {
-			klog.V(5).Infof("host port %s does not have an open socket", hp.String())
+			logrus.Infof("Host port %s does not have an open socket", hp.String())
 		}
 	}
 	return utilerrors.NewAggregate(errList)

--- a/internal/hostport/meta_hostport_manager.go
+++ b/internal/hostport/meta_hostport_manager.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	iptablesproxy "k8s.io/kubernetes/pkg/proxy/iptables"
 
-	"k8s.io/klog/v2"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	utilexec "k8s.io/utils/exec"
 	utilnet "k8s.io/utils/net"
@@ -23,13 +23,13 @@ func NewMetaHostportManager() HostPortManager {
 	// Create IPv4 handler
 	iptInterface := utiliptables.New(exec, utiliptables.ProtocolIPv4)
 	if _, err := iptInterface.EnsureChain(utiliptables.TableNAT, iptablesproxy.KubeMarkMasqChain); err != nil {
-		klog.Warningf("unable to ensure iptables chain: %v", err)
+		logrus.Warnf("Unable to ensure iptables chain: %v", err)
 	}
 	hostportManagerv4 := NewHostportManager(iptInterface)
 	// Create IPv6 handler
 	ip6tInterface := utiliptables.New(exec, utiliptables.ProtocolIPv6)
 	if _, err := ip6tInterface.EnsureChain(utiliptables.TableNAT, iptablesproxy.KubeMarkMasqChain); err != nil {
-		klog.Warningf("unable to ensure ip6tables chain: %v", err)
+		logrus.Warnf("Unable to ensure ip6tables chain: %v", err)
 	}
 	hostportManagerv6 := NewHostportManager(ip6tInterface)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The klog messages can be converted to logrus to align with our general logging approach.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
