### PR TITLE
oci: properly handle tty on execsync

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -265,54 +265,8 @@ func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []stri
 		return err
 	}
 	defer os.RemoveAll(processFile)
-
 	execCmd := r.constructExecCommand(ctx, c, processFile, "")
-	var cmdErr, copyError error
-	if tty {
-		cmdErr = ttyCmd(execCmd, stdin, stdout, resize)
-	} else {
-		var r, w *os.File
-		if stdin != nil {
-			// Use an os.Pipe here as it returns true *os.File objects.
-			// This way, if you run 'kubectl exec <pod> -i bash' (no tty) and type 'exit',
-			// the call below to execCmd.Run() can unblock because its Stdin is the read half
-			// of the pipe.
-			r, w, err = os.Pipe()
-			if err != nil {
-				return err
-			}
-			execCmd.Stdin = r
-			go func() {
-				_, copyError = pools.Copy(w, stdin)
-				w.Close()
-			}()
-		}
-
-		if stdout != nil {
-			execCmd.Stdout = stdout
-		}
-
-		if stderr != nil {
-			execCmd.Stderr = stderr
-		}
-
-		if err := execCmd.Start(); err != nil {
-			return err
-		}
-
-		// The read side of the pipe should be closed after the container process has been started.
-		if r != nil {
-			if err := r.Close(); err != nil {
-				return err
-			}
-		}
-
-		cmdErr = execCmd.Wait()
-	}
-
-	if copyError != nil {
-		return copyError
-	}
+	cmdErr := r.executeExec(execCmd, stdin, stdout, stderr, tty, resize)
 	if exitErr, ok := cmdErr.(*exec.ExitError); ok {
 		return &utilexec.ExitErrorWrapper{ExitError: exitErr}
 	}
@@ -342,9 +296,9 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 	cmd := r.constructExecCommand(ctx, c, processFile, pidFile)
 	cmd.SysProcAttr = sysProcAttrPlatform()
 
-	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
+	stdoutBuf := nopWriteCloser{&bytes.Buffer{}}
+	stderrBuf := nopWriteCloser{&bytes.Buffer{}}
+	resize := make(chan remotecommand.TerminalSize)
 
 	pidFileCreatedDone := make(chan struct{}, 1)
 	pidFileCreatedCh, err := WatchForFile(pidFile, pidFileCreatedDone, notify.InModify, notify.InMovedTo)
@@ -352,15 +306,10 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 		return nil, errors.Wrapf(err, "failed to watch %s", pidFile)
 	}
 
-	doneErr := cmd.Start()
-	if doneErr != nil {
-		return nil, err
-	}
-
 	// wait till the command is done
 	done := make(chan error, 1)
 	go func() {
-		done <- cmd.Wait()
+		done <- r.executeExec(cmd, nil, stdoutBuf, stderrBuf, c.terminal, resize)
 		close(done)
 	}()
 
@@ -368,6 +317,7 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 	// When it is, the timer begins for the exec process.
 	// If the command fails before that happens, however,
 	// that needs to be caught.
+	var doneErr error
 	select {
 	case <-pidFileCreatedCh:
 	case doneErr = <-done:
@@ -417,6 +367,65 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 		Stderr:   stderrBuf.Bytes(),
 		ExitCode: exitCode,
 	}, nil
+}
+
+func (r *runtimeOCI) executeExec(execCmd *exec.Cmd, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	var cmdErr, copyError error
+	if tty {
+		return ttyCmd(execCmd, stdin, stdout, resize)
+	}
+	var rd, w *os.File
+	var err error
+	if stdin != nil {
+		// Use an os.Pipe here as it returns true *os.File objects.
+		// This way, if you run 'kubectl exec <pod> -i bash' (no tty) and type 'exit',
+		// the call below to execCmd.Run() can unblock because its Stdin is the read half
+		// of the pipe.
+		rd, w, err = os.Pipe()
+		if err != nil {
+			return err
+		}
+		execCmd.Stdin = rd
+		go func() {
+			_, copyError = pools.Copy(w, stdin)
+			w.Close()
+		}()
+	}
+
+	if stdout != nil {
+		execCmd.Stdout = stdout
+	}
+
+	if stderr != nil {
+		execCmd.Stderr = stderr
+	}
+
+	if err := execCmd.Start(); err != nil {
+		return err
+	}
+
+	// The read side of the pipe should be closed after the container process has been started.
+	if rd != nil {
+		if err := rd.Close(); err != nil {
+			return err
+		}
+	}
+
+	cmdErr = execCmd.Wait()
+
+	if copyError != nil {
+		return copyError
+	}
+	return cmdErr
+}
+
+// Needed because https://github.com/golang/go/issues/22823 was denied
+type nopWriteCloser struct {
+	*bytes.Buffer
+}
+
+func (nopWriteCloser) Close() error {
+	return nil
 }
 
 func (r *runtimeOCI) constructExecCommand(ctx context.Context, c *Container, processFile, pidFile string) *exec.Cmd {

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -467,6 +467,15 @@ function wait_until_exit() {
 	crictl rm -f "$ctr_id"
 }
 
+@test "ctr execsync should succeed if container has a terminal" {
+	start_crio
+
+	jq ' .tty = true' "$TESTDATA"/container_sleep.json > "$newconfig"
+
+	ctr_id=$(crictl run "$newconfig" "$TESTDATA"/sandbox_config.json)
+	crictl exec --sync "$ctr_id" /bin/sh -c "[[ -t 1 ]]"
+}
+
 @test "ctr device add" {
 	# In an user namespace we can only bind mount devices from the host, not mknod
 	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
or else containers may have trouble accessing the terminal

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
The background here is a bit weird. I tried figuring out why we actually specified this in the first place. It seems we first introduced this when adding initial support for execsync with conmon: https://github.com/cri-o/cri-o/pull/310

As the file before that was just https://github.com/cri-o/cri-o/blob/61e60bfe4740c0a5f2a574d259f98ba9834fa4e6/oci/oci.go#L181 which makes no mention of tty.

let's see what the tests think.

related to https://bugzilla.redhat.com/show_bug.cgi?id=1983205

edit: Turns out this is needed, for https://github.com/cri-o/cri-o/pull/1386/files and https://bugzilla.redhat.com/show_bug.cgi?id=1549029. changed the PR to account for this case
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix an issue where a container started with a terminal fails on exec sync calls
```
