### PR TITLE
Use -trimpath for builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ GO ?= go
 export GOPROXY=https://proxy.golang.org
 export GOSUMDB=https://sum.golang.org
 
-GO_BUILD ?= $(GO) build
+TRIMPATH ?= -trimpath
+GO_BUILD ?= $(GO) build $(TRIMPATH)
 GO_RUN ?= $(GO) run
 
 PROJECT := github.com/cri-o/cri-o


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
The flag removes all file system paths from the resulting executable.
Instead of absolute file system paths, the recorded file names will
begin with either "go" (for the standard library), or a module
path@version (when using modules), or a plain import path (when using
GOPATH).
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
