### PR TITLE
Log structured container/sandbox ID and PID on start

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -32,6 +32,10 @@ func Fatalf(ctx context.Context, format string, args ...interface{}) {
 	entry(ctx).Fatalf(format, args...)
 }
 
+func WithFields(ctx context.Context, fields map[string]interface{}) *logrus.Entry {
+	return entry(ctx).WithFields(fields)
+}
+
 func entry(ctx context.Context) *logrus.Entry {
 	logger := logrus.StandardLogger()
 	if ctx == nil {

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -58,6 +58,11 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 		return fmt.Errorf("failed to start container %s: %v", c.ID(), err)
 	}
 
-	log.Infof(ctx, "Started container %s: %s", c.ID(), c.Description())
+	log.WithFields(ctx, map[string]interface{}{
+		"description": c.Description(),
+		"containerID": c.ID(),
+		"sandboxID":   sandbox.ID(),
+		"PID":         state.Pid,
+	}).Infof("Started container")
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
We now correlate the container ID, sandbox ID as well as its process ID
together on container start log. This way consumers can rely on it and
easily parse the output.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Example log outout:

```
INFO[2021-07-28 09:33:46.768702002+02:00] Started container    PID=261797 containerID=6c86fb7717891971ec157702ec295cc4b77ef9c70e4332b95096869711e1914e description=// id=f009591f-fbb6-4245-b521-ce0022221ba8 name=/runtime.v1alpha2.RuntimeService/StartContainer sandboxID=b01b6b644c912a32ac97fdfd984b5b7733f57cac0f523950cfe41cd1606418cb
``` 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added structural logging of container ID, sandbox ID and process ID on container start.
```
