### PR TITLE
List build tags and seccomp/apparmor status on `version` subcommand

### DIFF
--- a/internal/version/buildtag_apparmor.go
+++ b/internal/version/buildtag_apparmor.go
@@ -1,0 +1,8 @@
+// +build apparmor
+
+package version
+
+// nolint: gochecknoinits
+func init() {
+	buildTags = append(buildTags, "apparmor")
+}

--- a/internal/version/buildtag_devicemapper.go
+++ b/internal/version/buildtag_devicemapper.go
@@ -1,0 +1,8 @@
+// +build exclude_graphdriver_devicemapper
+
+package version
+
+// nolint: gochecknoinits
+func init() {
+	buildTags = append(buildTags, "exclude_graphdriver_devicemapper")
+}

--- a/internal/version/buildtag_openpgp.go
+++ b/internal/version/buildtag_openpgp.go
@@ -1,0 +1,8 @@
+// +build containers_image_openpgp
+
+package version
+
+// nolint: gochecknoinits
+func init() {
+	buildTags = append(buildTags, "containers_image_openpgp")
+}

--- a/internal/version/buildtag_ostree.go
+++ b/internal/version/buildtag_ostree.go
@@ -1,0 +1,8 @@
+// +build containers_image_ostree_stub
+
+package version
+
+// nolint: gochecknoinits
+func init() {
+	buildTags = append(buildTags, "containers_image_ostree_stub")
+}

--- a/internal/version/buildtag_seccomp.go
+++ b/internal/version/buildtag_seccomp.go
@@ -1,0 +1,8 @@
+// +build seccomp
+
+package version
+
+// nolint: gochecknoinits
+func init() {
+	buildTags = append(buildTags, "seccomp")
+}

--- a/internal/version/buildtag_selinux.go
+++ b/internal/version/buildtag_selinux.go
@@ -1,0 +1,8 @@
+// +build selinux
+
+package version
+
+// nolint: gochecknoinits
+func init() {
+	buildTags = append(buildTags, "selinux")
+}

--- a/test/version.bats
+++ b/test/version.bats
@@ -21,6 +21,9 @@ load helpers
 	[[ "$output" == *"Compiler:"* ]]
 	[[ "$output" == *"Platform:"* ]]
 	[[ "$output" == *"Linkmode:"* ]]
+	[[ "$output" == *"BuildTags:"* ]]
+	[[ "$output" == *"SeccompEnabled:"* ]]
+	[[ "$output" == *"AppArmorEnabled:"* ]]
 }
 
 @test "version -j" {
@@ -43,4 +46,7 @@ load helpers
 	echo "$JSON" | jq -e '.gitTreeState != ""'
 	echo "$JSON" | jq -e '.version != ""'
 	echo "$JSON" | jq -e '.linkmode != ""'
+	echo "$JSON" | jq -e '.buildTags != ""'
+	echo "$JSON" | jq -e '.seccompEnabled != ""'
+	echo "$JSON" | jq -e '.appArmorEnabled != ""'
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now add the used build tags to the `crio version` output to enable
better debug abilities. Beside that, we also indicate if AppArmor and
seccomp are available on the local system (runtime check).

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Example output:
```
> ./bin/crio version
Version:          1.22.0
GitCommit:        fe4b22c64a6655759eb0a253ef6174fa1b4fc5d0
GitTreeState:     dirty
BuildDate:        1980-01-01T00:00:00Z
GoVersion:        go1.16.6
Compiler:         gc
Platform:         linux/amd64
Linkmode:         dynamic
BuildTags:        apparmor, containers_image_ostree_stub, seccomp, selinux
SeccompEnabled:   true
AppArmorEnabled:  false

> ./bin/crio version -j
{
  "version": "1.22.0",
  "gitCommit": "fe4b22c64a6655759eb0a253ef6174fa1b4fc5d0",
  "gitTreeState": "dirty",
  "buildDate": "1980-01-01T00:00:00Z",
  "goVersion": "go1.16.6",
  "compiler": "gc",
  "platform": "linux/amd64",
  "linkmode": "dynamic",
  "buildTags": [
    "apparmor",
    "containers_image_ostree_stub",
    "seccomp",
    "selinux"
  ],
  "seccompEnabled": true,
  "appArmorEnabled": false
}

```
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added build tags as well as AppArmor and seccomp status to `crio version` output.
```
