### PR TITLE
main: Don't log an error if the clean shutdown file doesn't exist

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -243,8 +243,7 @@ func main() {
 
 		if config.CleanShutdownFile != "" {
 			// clear out the shutdown file
-			if err := os.Remove(config.CleanShutdownFile); err != nil {
-				// not a fatal error, as it could have been cleaned up
+			if err := os.Remove(config.CleanShutdownFile); err != nil && !os.IsNotExist(err) {
 				logrus.Error(err)
 			}
 


### PR DESCRIPTION
This showed up when I was grepping a journal for `error:`, and it's
not an error.

```release-note
NONE
```
