### PR TITLE
server: configure MountPoint for dropped infra containers

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -853,10 +853,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 			}
 			g.SetProcessSelinuxLabel(processLabel)
 		}
-
-		container.SetMountPoint(mountPoint)
-
-		container.SetSpec(g.Config)
 	} else {
 		log.Debugf(ctx, "Dropping infra container for pod %s", sbox.ID())
 		container = oci.NewSpoofedContainer(sbox.ID(), containerName, labels, sbox.ID(), created, podContainer.RunDir)
@@ -865,6 +861,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 			return nil, errors.Wrapf(err, "create dropped infra %s cgroup", sbox.ID())
 		}
 	}
+	container.SetMountPoint(mountPoint)
+	container.SetSpec(g.Config)
+
 	// needed for getSandboxIDMappings()
 	container.SetIDMappings(sandboxIDMappings)
 

--- a/test/inspect.bats
+++ b/test/inspect.bats
@@ -59,6 +59,7 @@ function teardown() {
 	out=$(echo -e "GET /containers/$pod_id HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:"$CRIO_SOCKET")
 	[[ "$out" == *"\"sandbox\":\"$pod_id\""* ]]
 	[[ "$out" == *"\"pid\":0"* ]]
+	[[ "$out" == *"\"root\":\"$TESTDIR/crio/overlay/"* ]]
 
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$ctr_id"


### PR DESCRIPTION
Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
or else kubelet logs will be spammed with
```
hyperkube[1354]: E0727 15:45:29.058957    1354 fsHandler.go:114] failed to collect filesystem stats - rootDiskErr: could not stat "diff" to get inode usage: stat diff: no s

```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where cAdvisor couldn't read the disk usage of a pod with a dropped infra container
```
