### PR TITLE
display build tags in version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,8 @@ BASE_LDFLAGS = ${SHRINKFLAGS} \
 	-X ${PROJECT}/internal/pkg/criocli.DefaultsPath=${DEFAULTS_PATH} \
 	-X ${PROJECT}/internal/version.buildDate=${BUILD_DATE} \
 	-X ${PROJECT}/internal/version.gitCommit=${COMMIT_NO} \
-	-X ${PROJECT}/internal/version.gitTreeState=${GIT_TREE_STATE}
+	-X ${PROJECT}/internal/version.gitTreeState=${GIT_TREE_STATE} \
+	-X "${PROJECT}/internal/version.buildTags=${BUILDTAGS}"
 
 GO_LDFLAGS = -ldflags '${BASE_LDFLAGS} ${EXTRA_LDFLAGS}'
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,6 +28,7 @@ var (
 	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string // state of git tree, either "clean" or "dirty"
 	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildTags    string // build tags when compiling binaries
 )
 
 type Info struct {
@@ -39,6 +40,7 @@ type Info struct {
 	Compiler     string `json:"compiler,omitempty"`
 	Platform     string `json:"platform,omitempty"`
 	Linkmode     string `json:"linkmode,omitempty"`
+	BuildTags    string `json:"buildTags,omitempty"`
 }
 
 // ShouldCrioWipe opens the version file, and parses it and the version string
@@ -136,6 +138,13 @@ func parseVersionConstant(versionString, gitCommit string) (*semver.Version, err
 }
 
 func Get() *Info {
+	var formattedBuildTags []string
+	for _, tag := range strings.Split(buildTags, " ") {
+		if tag != "" {
+			formattedBuildTags = append(formattedBuildTags, tag)
+		}
+	}
+
 	return &Info{
 		Version:      Version,
 		GitCommit:    gitCommit,
@@ -145,6 +154,7 @@ func Get() *Info {
 		Compiler:     runtime.Compiler,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 		Linkmode:     getLinkmode(),
+		BuildTags:    strings.Join(formattedBuildTags, " "),
 	}
 }
 


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

When I install pre-compiled binary from distribution repo, there is no way to know whether some particular feature is compiled into the binary, e.g. is btrfs supported or excluded in purpose? The only way to know is to search the build script in the package src, which is very inconvenient.

This PR adds display of build tags information in `crio version`

```bash
$ ./bin/crio version
INFO[2021-08-03 11:54:02.066868576+08:00] Starting CRI-O, version: 1.22.0, git: 79a25c4c3123e1adb8511848564bcbcd0d853a3f(dirty) 
Version:       1.22.0
GitCommit:     79a25c4c3123e1adb8511848564bcbcd0d853a3f
GitTreeState:  dirty
BuildDate:     2021-08-03T03:53:21Z
GoVersion:     go1.16.6
Compiler:      gc
Platform:      linux/amd64
Linkmode:      dynamic
BuildTags:     containers_image_ostree_stub seccomp  #  <- new added
```