### PR TITLE
Bump required golang version for cri-o.spec

### DIFF
--- a/contrib/test/ci/cri-o.spec
+++ b/contrib/test/ci/cri-o.spec
@@ -13,7 +13,7 @@
 
 %if ! 0%{?centos} && 0%{?rhel}
 # Golang minor version
-%global gominver 10
+%global gominver 16
 %define gobuild(o:) scl enable go-toolset-1.%{gominver} -- go build -buildmode pie -compiler gc -tags="rpm_crashtraceback no_openssl ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
 %else
 %define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback no_openssl ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
@@ -45,7 +45,7 @@ Source6: %{service_name}.service
 %if ! 0%{?centos} && 0%{?rhel}
 BuildRequires: go-toolset-1.%{gominver}
 %else
-BuildRequires: %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}
+# Assume pre-installed golang (which is the case in our CI)
 BuildRequires: make
 %endif
 BuildRequires: git


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
We require golang 1.16 to build CRI-O.
#### Which issue(s) this PR fixes:

This change should only affect the test cases `ci/prow/e2e-agnostic`, `ci/prow/e2e-gcp` and `ci/prow/images`.

#### Special notes for your reviewer:
Follow-up of https://github.com/openshift/release/pull/20939
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
