### PR TITLE
Fix kubeadm.md typo

### DIFF
--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -15,7 +15,7 @@ If you're using a flannel network, set
 To configure the Kubelet, you can use the [yq](https://github.com/mikefarah/yq) tool, as is shown below.
 You can also manually configure a kubeadm configuration.
 
-Run the following stript, passing the location you'd like the kubeadm configuration to be as the first argument:
+Run the following script, passing the location you'd like the kubeadm configuration to be as the first argument:
 
 ```bash
 #!/bin/bash                                                                                                                                                                                                                                   


### PR DESCRIPTION
Fixed a typo in the kubeadm.md file. The `script` word.

Signed-off-by: Imanol Valiente <me@imanol.dev>

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

It fixes a little typo in the kubeadm.md documentation file.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

None
