### PR TITLE
Bump c/storage to latest v1.20-stable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containers/image/v5 v5.5.4
 	github.com/containers/libpod v1.9.2
 	github.com/containers/ocicrypt v1.0.3
-	github.com/containers/storage v1.20.6-0.20210726142922-bcd609a5b19f
+	github.com/containers/storage v1.20.6-0.20210812201218-ec9d0ccd7e37
 	github.com/coreos/go-systemd/v22 v22.2.0
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty v1.1.11

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/containers/psgo v1.4.0/go.mod h1:ENXXLQ5E1At4K0EUsGogXBJi/C28gwqkONWe
 github.com/containers/storage v1.18.2/go.mod h1:WTBMf+a9ZZ/LbmEVeLHH2TX4CikWbO1Bt+/m58ZHVPg=
 github.com/containers/storage v1.19.1/go.mod h1:KbXjSwKnx17ejOsjFcCXSf78mCgZkQSLPBNTMRc3XrQ=
 github.com/containers/storage v1.20.2/go.mod h1:oOB9Ie8OVPojvoaKWEGSEtHbXUAs+tSyr7RO7ZGteMc=
-github.com/containers/storage v1.20.6-0.20210726142922-bcd609a5b19f h1:lPWhey0lrCqkOQ8Ife2h71kjlwlqwRZV34roR8eNidk=
-github.com/containers/storage v1.20.6-0.20210726142922-bcd609a5b19f/go.mod h1:L21V7HElfNsMeMdif5JdxtCvzS8LKKhv4movqpFbiOk=
+github.com/containers/storage v1.20.6-0.20210812201218-ec9d0ccd7e37 h1:Tcv4u6dapeVmNrJ7Frdm9cqETwNU6FJi/ZLtOAm+/hI=
+github.com/containers/storage v1.20.6-0.20210812201218-ec9d0ccd7e37/go.mod h1:L21V7HElfNsMeMdif5JdxtCvzS8LKKhv4movqpFbiOk=
 github.com/coredns/corefile-migration v1.0.10/go.mod h1:RMy/mXdeDlYwzt0vdMEJvT2hGJ2I86/eO0UdXmH9XNI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/vendor/github.com/containers/storage/layers.go
+++ b/vendor/github.com/containers/storage/layers.go
@@ -28,6 +28,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/archive/tar"
 	"github.com/vbatts/tar-split/tar/asm"
 	"github.com/vbatts/tar-split/tar/storage"
@@ -1290,6 +1291,9 @@ func (r *layerStore) ApplyDiff(to string, diff io.Reader) (size int64, err error
 	compressor, err := pgzip.NewWriterLevel(&tsdata, pgzip.BestSpeed)
 	if err != nil {
 		compressor = pgzip.NewWriter(&tsdata)
+	}
+	if err := compressor.SetConcurrency(1024*1024, 1); err != nil { // 1024*1024 is the hard-coded default; we're not changing that
+		logrus.Infof("error setting compression concurrency threads to 1: %v; ignoring", err)
 	}
 	metadata := storage.NewJSONPacker(compressor)
 	uncompressed, err := archive.DecompressStream(defragmented)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -253,7 +253,7 @@ github.com/containers/psgo/internal/dev
 github.com/containers/psgo/internal/host
 github.com/containers/psgo/internal/proc
 github.com/containers/psgo/internal/process
-# github.com/containers/storage v1.20.6-0.20210726142922-bcd609a5b19f
+# github.com/containers/storage v1.20.6-0.20210812201218-ec9d0ccd7e37
 ## explicit
 github.com/containers/storage
 github.com/containers/storage/drivers


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
To pull in the changes introduced in https://github.com/containers/storage/pull/992

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve memory usage during container image layer extraction.
```
