### PR TITLE
Disable infra container drop on node e2e tests

### DIFF
--- a/scripts/node_e2e_installer
+++ b/scripts/node_e2e_installer
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NODE_E2E_COMMIT=4d14fd61d2d533a0bb81557b54d3505be830efa7 # Commit to run upstream node e2e tests
+# Commit to run upstream node e2e tests
+NODE_E2E_COMMIT=359c7f8df802bdcffc12436d07c238ef23e8990c
 
 enable_selinux() {
     # Make sure SELinux is enabled
@@ -33,6 +34,9 @@ install_crio() {
 
     # Setup log level
     echo "CONTAINER_LOG_LEVEL=debug" >>/etc/sysconfig/crio
+
+    # Disable the drop of the infra container because it seems to flake the e2e tests.
+    echo "CONTAINER_DROP_INFRA_CTR=false" >>/etc/sysconfig/crio
 
     # Setup secondary runtime
     cat <<EOF >/etc/crio/crio.conf.d/20-runc.conf


### PR DESCRIPTION


#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/5202
#### Special notes for your reviewer:
It's suspicious that the drop of the infra container corresponds to
fails/flakes of the Kubernetes node e2e tests. With this path we disable
the option for now while bumping the used CRI-O version.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
