### PR TITLE
Check `stdout` and `stderr` for linkmode

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -214,12 +214,18 @@ func getLinkmode() string {
 		return unknown
 	}
 
+	isStatic := func(input string) bool {
+		if strings.Contains(strings.ToLower(input), "not a dynamic executable") ||
+			strings.Contains(strings.ToLower(input), "not a valid dynamic program") {
+			return true
+		}
+		return false
+	}
+
 	if !out.Success() {
-		if strings.Contains(out.Error(), "not a dynamic executable") ||
-			strings.Contains(strings.ToLower(out.Error()), "not a valid dynamic program") {
+		if isStatic(out.Error()) || isStatic(out.Output()) {
 			return "static"
 		}
-		logrus.Warnf("Encountered error detecting link mode of binary: %s", out.Error())
 		return unknown
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We now check `stdout` as well as `stderr` for retrieving the linkmode of the
binary. If this does not work, then we do not warn and still report
`unknown`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/5165
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed linkmode detection by checking the `stderr` as well as `stdout` of the `ldd` command.
```
