### PR TITLE
Switch to build tag for linkmode

### DIFF
--- a/internal/version/linkmode_dynamic.go
+++ b/internal/version/linkmode_dynamic.go
@@ -1,0 +1,5 @@
+// +build !static
+
+package version
+
+const linkmode = "dynamic"

--- a/internal/version/linkmode_static.go
+++ b/internal/version/linkmode_static.go
@@ -1,0 +1,5 @@
+// +build static
+
+package version
+
+const linkmode = "static"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
We now do not call `ldd` any more when finding out the linkmode of the
binary, instead we rely on build tags.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Closes https://github.com/cri-o/cri-o/issues/5165
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use build tag for `linkmode` detection on `crio version`.
```
