### PR TITLE
Fix missing quantile in `latency_microseconds_total` metrics

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -71,9 +71,10 @@ func New(config *libconfig.MetricsConfig) *Metrics {
 		),
 		metricOperationsLatencyTotal: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
-				Subsystem: collectors.Subsystem,
-				Name:      collectors.OperationsLatencyTotal.String(),
-				Help:      "Latency in microseconds of CRI-O operations. Broken down by operation type.",
+				Subsystem:  collectors.Subsystem,
+				Name:       collectors.OperationsLatencyTotal.String(),
+				Help:       "Latency in microseconds of CRI-O operations. Broken down by operation type.",
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			},
 			[]string{"operation_type"},
 		),

--- a/test/metrics.bats
+++ b/test/metrics.bats
@@ -34,6 +34,21 @@ function teardown() {
 	curl -sf "http://localhost:$PORT/metrics" | grep crio_operations
 }
 
+@test "metrics with operations quantile" {
+	# start crio with custom port
+	PORT=$(free_port)
+	CONTAINER_ENABLE_METRICS=true CONTAINER_METRICS_PORT=$PORT start_crio
+
+	for ((i = 0; i < 100; i++)); do
+		crictl version
+	done
+
+	# get metrics
+	curl -sf "http://localhost:$PORT/metrics" | grep 'container_runtime_crio_operations_latency_microseconds_total{operation_type="Version",quantile="0.5"}'
+	curl -sf "http://localhost:$PORT/metrics" | grep 'container_runtime_crio_operations_latency_microseconds_total{operation_type="Version",quantile="0.9"}'
+	curl -sf "http://localhost:$PORT/metrics" | grep 'container_runtime_crio_operations_latency_microseconds_total{operation_type="Version",quantile="0.99"}'
+}
+
 @test "secure metrics with random port" {
 	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
 		-subj "/C=US/ST=State/L=City/O=Org/CN=Name" \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The quantile has to be added manually since a couple of prometheus
client releases and we missed that. Adding an integration test to ensure
that the quantile exist in the future.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed missing quantile values in `container_runtime_crio_operations_latency_microseconds_total` metrics
```
