### PR TITLE
internal/process: add functionality to clean up zombie children

### DIFF
--- a/internal/process/defunct_processes.go
+++ b/internal/process/defunct_processes.go
@@ -16,50 +16,60 @@ const ProcessFS = "/proc"
 
 // Stat represents status information of a process from /proc/[pid]/stat.
 type Stat struct {
+	// Pid is the PID of the process
+	Pid int
+
 	// Comm is the command name (usually the executable filename).
 	Comm string
 
 	// State is the state of the process.
 	State string
+
+	// PPid is the parent PID of the process
+	PPid int
 }
 
-// DefunctProcesses returns the number of zombie processes in the node.
-func DefunctProcesses() (defunctCount uint, retErr error) {
-	return DefunctProcessesForPath(ProcessFS)
+// ParseDefunctProcesses returns the number of defunct processes on the node,
+// as well as the number of defunct children of the current running process.
+func ParseDefunctProcesses() (defunctCount uint, defunctChildren []int, retErr error) {
+	return ParseDefunctProcessesForPathAndParent(ProcessFS, os.Getpid())
 }
 
-// DefunctProcessesForPath retrieves the number of zombie processes from
-// a specific process filesystem.
-func DefunctProcessesForPath(path string) (defunctCount uint, retErr error) {
+// ParseDefunctProcessesForPath retrieves the number of zombie processes from
+// a specific process filesystem, as well as the number of defunct children of a given parent.
+func ParseDefunctProcessesForPathAndParent(path string, parent int) (defunctCount uint, defunctChildren []int, retErr error) {
 	directories, err := os.Open(path)
 	if err != nil {
-		return 0, err
+		return 0, defunctChildren, err
 	}
 	defer directories.Close()
 
 	names, err := directories.Readdirnames(-1)
 	if err != nil {
-		return 0, err
+		return 0, defunctChildren, err
 	}
 
 	for _, name := range names {
 		// Processes have numeric names. If the name cannot
 		// be parsed to an int, it is not a process name.
-		if _, err := strconv.ParseInt(name, 10, 0); err != nil {
+		pid, err := strconv.ParseInt(name, 10, 0)
+		if err != nil {
 			continue
 		}
 
 		stat, err := processStats(path, name)
 		if err != nil {
-			logrus.Debugf("Failed to get the status of process with PID %s: %v", name, err)
 			continue
 		}
 		if stat.State == "Z" {
-			logrus.Warnf("Found defunct process with PID %s (%s)", name, stat.Comm)
 			defunctCount++
+			logrus.Warnf("Found defunct process with PID %s (%s)", name, stat.Comm)
+			if stat.PPid == parent {
+				defunctChildren = append(defunctChildren, int(pid))
+			}
 		}
 	}
-	return defunctCount, nil
+	return defunctCount, defunctChildren, nil
 }
 
 // processStats returns status information of a process as defined in /proc/[pid]/stat
@@ -73,14 +83,25 @@ func processStats(fsPath, pid string) (*Stat, error) {
 	// /proc/[PID]/stat format is described in proc(5). The second field is process name,
 	// enclosed in parentheses, and it can contain parentheses inside. No other fields
 	// can have parentheses, so look for the last ')'.
-	i := strings.LastIndexByte(data, ')')
-	if i <= 2 || i >= len(data)-1 {
+	commEnd := strings.LastIndexByte(data, ')')
+	if commEnd <= 2 || commEnd >= len(data)-1 {
 		return nil, errors.Errorf("invalid stat data (no comm): %q", data)
 	}
 
-	parts := strings.SplitN(data[:i], " (", 2)
+	parts := strings.SplitN(data[:commEnd], " (", 2)
 	if len(parts) != 2 {
 		return nil, errors.Errorf("invalid stat data (no comm): %q", data)
+	}
+
+	stateIdx := commEnd + 2
+
+	// the fourth field is PPid, and we can start looking after the space after State
+	ppidBegin := stateIdx + 2
+	ppidEnd := strings.IndexByte(data[ppidBegin:], ' ')
+
+	ppid, err := strconv.ParseInt(data[ppidBegin:ppidBegin+ppidEnd], 10, 0)
+	if err != nil {
+		return nil, errors.Errorf("invalid stat data (invalid ppid): %q", data[stateIdx+2:ppidEnd])
 	}
 
 	return &Stat{
@@ -88,6 +109,8 @@ func processStats(fsPath, pid string) (*Stat, error) {
 		Comm: parts[1],
 
 		// The state is field 3, which is the first two fields and a space after.
-		State: string(data[i+2]),
+		State: string(data[stateIdx]),
+
+		PPid: int(ppid),
 	}, nil
 }

--- a/internal/process/defunct_processes_test.go
+++ b/internal/process/defunct_processes_test.go
@@ -11,28 +11,34 @@ import (
 
 // The actual test suite
 var _ = t.Describe("Process", func() {
-	t.Describe("DefunctProcessesForPath", func() {
+	t.Describe("ParseDefunctProcessesForPathAndParent", func() {
 		Context("Should succeed", func() {
 			It("when given a valid path name and there are defunct processes", func() {
-				defunctCount, err := process.DefunctProcessesForPath("./testing/proc_success_1")
+				defunctCount, _, err := process.ParseDefunctProcessesForPathAndParent("./testing/proc_success_1", 0)
 
 				Expect(err).To(BeNil())
 				Expect(defunctCount).To(Equal(uint(7)))
 			})
+			It("to get children when given a valid path name and there are defunct processes", func() {
+				_, children, err := process.ParseDefunctProcessesForPathAndParent("./testing/proc_success_1", 1)
+
+				Expect(err).To(BeNil())
+				Expect(len(children)).To(Equal(2))
+			})
 			It("when given a valid path name but there are no defunct processes", func() {
-				defunctCount, err := process.DefunctProcessesForPath("./testing/proc_success_2")
+				defunctCount, _, err := process.ParseDefunctProcessesForPathAndParent("./testing/proc_success_2", 0)
 
 				Expect(err).To(BeNil())
 				Expect(defunctCount).To(Equal(uint(0)))
 			})
 			It("when given a valid path name but there are no processes", func() {
-				defunctCount, err := process.DefunctProcessesForPath("./testing/proc_success_3")
+				defunctCount, _, err := process.ParseDefunctProcessesForPathAndParent("./testing/proc_success_3", 0)
 
 				Expect(err).To(BeNil())
 				Expect(defunctCount).To(Equal(uint(0)))
 			})
 			It("when given a valid path name but there are no directories", func() {
-				defunctCount, err := process.DefunctProcessesForPath("./testing/proc_success_4")
+				defunctCount, _, err := process.ParseDefunctProcessesForPathAndParent("./testing/proc_success_4", 0)
 
 				Expect(err).To(BeNil())
 				Expect(defunctCount).To(Equal(uint(0)))
@@ -40,14 +46,14 @@ var _ = t.Describe("Process", func() {
 		})
 		Context("Should fail", func() {
 			It("when given an invalid path name", func() {
-				defunctCount, err := process.DefunctProcessesForPath("./test/proc")
+				defunctCount, _, err := process.ParseDefunctProcessesForPathAndParent("./test/proc", 0)
 				formattedErr := fmt.Sprintf("%v", err)
 
 				Expect(formattedErr).To(Equal("open ./test/proc: no such file or directory"))
 				Expect(defunctCount).To(Equal(uint(0)))
 			})
 			It("when the given path name does not belong to a directory", func() {
-				defunctCount, err := process.DefunctProcessesForPath("./testing/proc_fail")
+				defunctCount, _, err := process.ParseDefunctProcessesForPathAndParent("./testing/proc_fail", 0)
 				formattedErr := fmt.Sprintf("%v", err)
 
 				Expect(formattedErr).To(Equal("readdirent ./testing/proc_fail: not a directory"))

--- a/internal/process/zombie_monitor.go
+++ b/internal/process/zombie_monitor.go
@@ -1,0 +1,53 @@
+package process
+
+import (
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ZombieMonitor is a structure for watching and cleaning up zombies on the node.
+// It is responsible for cleaning up zombies that are children of the currently running process.
+// It does so by occasionally polling for the zombie processes.
+// If any zombies are found, there is a delay between when they're identified and when they're cleaned.
+// This is to ensure ZombieMonitor doesn't interfere with the go runtime's own child management.
+type ZombieMonitor struct {
+	closeChan chan struct{}
+}
+
+// NewZombieMonitor creates and starts the zombie monitor.
+func NewZombieMonitor() *ZombieMonitor {
+	monitor := &ZombieMonitor{
+		closeChan: make(chan struct{}, 1),
+	}
+	go monitor.Start()
+	return monitor
+}
+
+// Shutdown instructs the zombie monitor to stop listening and exit.
+func (zm *ZombieMonitor) Shutdown() {
+	zm.closeChan <- struct{}{}
+}
+
+// Start begins the zombie monitor. It will populate the zombie count,
+// as well as begin the zombie cleaning process.
+func (zm *ZombieMonitor) Start() {
+	for {
+		_, zombieChildren, err := ParseDefunctProcesses()
+		if err != nil {
+			logrus.Warnf("Failed to get defunct process information: %v", err)
+		}
+		select {
+		case <-zm.closeChan:
+			// Since the process will soon shutdown, and its children will be reparented, no need to delay the shutdown to cleanup.
+			return
+		case <-time.After(defaultZombieChildReapPeriod):
+		}
+		for _, child := range zombieChildren {
+			if _, err := syscall.Wait4(child, nil, syscall.WNOHANG, nil); err != nil {
+				logrus.Errorf("Failed to reap child process %d: %v", child, err)
+			}
+		}
+	}
+}

--- a/internal/process/zombie_monitor_defaults.go
+++ b/internal/process/zombie_monitor_defaults.go
@@ -1,0 +1,10 @@
+//go:build !test
+// +build !test
+
+package process
+
+import "time"
+
+// defaultZombieChildReapPeriod is the period
+// the zombie monitor will reap defunct children
+var defaultZombieChildReapPeriod = time.Minute * 5

--- a/internal/process/zombie_monitor_test.go
+++ b/internal/process/zombie_monitor_test.go
@@ -1,0 +1,38 @@
+package process_test
+
+import (
+	"os/exec"
+	"time"
+
+	"github.com/cri-o/cri-o/internal/process"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The actual test suite
+var _ = t.Describe("ZombieMonitor", func() {
+	It("should clean zombie", func() {
+		cmd := createZombie()
+		defer cmd.Wait() // nolint:errcheck
+
+		monitor := process.NewZombieMonitor()
+		defer monitor.Shutdown()
+
+		Eventually(func() int {
+			_, defunctChildren, err := process.ParseDefunctProcesses()
+			Expect(err).To(BeNil())
+			return len(defunctChildren)
+		}, time.Second*10, time.Second).Should(Equal(0))
+	})
+})
+
+func createZombie() *exec.Cmd {
+	cmd := exec.Command("true")
+	err := cmd.Start()
+	Expect(err).To(BeNil())
+
+	_, defunctChildren, err := process.ParseDefunctProcesses()
+	Expect(err).To(BeNil())
+	Expect(len(defunctChildren)).To(Equal(1))
+	return cmd
+}

--- a/internal/process/zombie_monitor_test_inject.go
+++ b/internal/process/zombie_monitor_test_inject.go
@@ -1,0 +1,13 @@
+//go:build test
+// +build test
+
+// All *_inject.go files are meant to be used by tests only. Purpose of this
+// files is to provide a way to inject mocked data into the current setup.
+
+package process
+
+import "time"
+
+// defaultZombieChildReapPeriod reduces the time waited to reap the children
+// for testing purposes
+var defaultZombieChildReapPeriod = time.Second * 5

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -176,12 +176,8 @@ func New(config *libconfig.MetricsConfig) *Metrics {
 				Help:      "Total number of defunct processes in the node",
 			},
 			func() float64 {
-				total, err := process.DefunctProcesses()
-				if err == nil {
-					return float64(total)
-				}
-				logrus.Warn(err)
-				return 0
+				count, _, _ := process.ParseDefunctProcesses() // nolint:errcheck
+				return float64(count)
 			},
 		),
 	}


### PR DESCRIPTION
Now that exec sync requests are run by conmon, there are more processes in the mix and more possibility for zombies

this commit adds a zombie monitor to the defunct process metrics collection flow. it is a little clunky, but it would be weird
to have two different /proc parsers for very similar uses

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add a zombie monitor to cleanup CRI-O's defunct children
```
