### PR TITLE
server: remove ineffective `updateLock`.

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -412,8 +412,6 @@ func hostNetwork(containerConfig *types.ContainerConfig) bool {
 func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainerRequest) (res *types.CreateContainerResponse, retErr error) {
 	log.Infof(ctx, "Creating container: %s", translateLabelsToDescription(req.Config.Labels))
 
-	s.updateLock.RLock()
-	defer s.updateLock.RUnlock()
 	sb, err := s.getPodSandboxFromRequest(req.PodSandboxID)
 	if err != nil {
 		if err == sandbox.ErrIDEmpty {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -269,9 +269,6 @@ func (s *Server) getSandboxIDMappings(sb *libsandbox.Sandbox) (*idtools.IDMappin
 }
 
 func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequest) (resp *types.RunPodSandboxResponse, retErr error) {
-	s.updateLock.RLock()
-	defer s.updateLock.RUnlock()
-
 	sbox := sandbox.New()
 	if err := sbox.SetConfig(req.Config); err != nil {
 		return nil, errors.Wrap(err, "setting sandbox config")

--- a/server/server.go
+++ b/server/server.go
@@ -65,8 +65,6 @@ type Server struct {
 	monitorsChan      chan struct{}
 	defaultIDMappings *idtools.IDMappings
 
-	updateLock sync.RWMutex
-
 	// pullOperationsInProgress is used to avoid pulling the same image in parallel. Goroutines
 	// will block on the pullResult.
 	pullOperationsInProgress map[pullArguments]*pullOperation


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:    
    Remove effectively unused Server.updateLock. It is only
    ever RLocked()/RUnlocked(). A leftover that should have
    been removed in b56da85fc.

### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None
