### PR TITLE
server: notify user when network is not ready yet

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1335,8 +1335,13 @@ func (c *NetworkConfig) CNIPluginReadyOrError() error {
 }
 
 // CNIPluginAddWatcher returns the network configuration CNI plugin
-func (c *NetworkConfig) CNIPluginAddWatcher() chan struct{} {
+func (c *NetworkConfig) CNIPluginAddWatcher() chan bool {
 	return c.cniManager.AddWatcher()
+}
+
+// CNIManagerShutdown shuts down the CNI Manager
+func (c *NetworkConfig) CNIManagerShutdown() {
+	c.cniManager.Shutdown()
 }
 
 // SetSingleConfigPath set single config path for config

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -371,7 +371,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		// before proceeding
 		watcher := s.config.CNIPluginAddWatcher()
 		log.Infof(ctx, "CNI plugin not ready. Waiting to create %s as it is not host network", sbox.Name())
-		<-watcher
+		if ready := <-watcher; !ready {
+			return nil, errors.Wrapf(err, "server shutdown before network was ready")
+		}
 		log.Infof(ctx, "CNI plugin is now ready. Continuing to create %s", sbox.Name())
 	}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -370,7 +370,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		// if the cni plugin isn't ready yet, we should wait until it is
 		// before proceeding
 		watcher := s.config.CNIPluginAddWatcher()
+		log.Infof(ctx, "CNI plugin not ready. Waiting to create %s as it is not host network", sbox.Name())
 		<-watcher
+		log.Infof(ctx, "CNI plugin is now ready. Continuing to create %s", sbox.Name())
 	}
 
 	description := fmt.Sprintf("runSandbox: releasing pod sandbox name: %s", sbox.Name())

--- a/server/server.go
+++ b/server/server.go
@@ -296,6 +296,7 @@ func (s *Server) restore(ctx context.Context) []string {
 
 // Shutdown attempts to shut down the server's storage cleanly
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.config.CNIManagerShutdown()
 	s.resourceStore.Close()
 
 	if err := s.ContainerServer.Shutdown(); err != nil {


### PR DESCRIPTION
Or else they don't know why cri-o is waiting

also, catch server shutdown so the process does eventually shutdown.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a bug where CRI-O would never shutdown if the networking plugin wasn't configured correctly
```
