### PR TITLE
Fix cluster.yaml for kubectl create

### DIFF
--- a/contrib/metrics-exporter/cluster.yaml
+++ b/contrib/metrics-exporter/cluster.yaml
@@ -121,6 +121,6 @@ spec:
   selector:
     app: cri-o-metrics-exporter
   ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 8080
+  - protocol: TCP
+    port: 80
+    targetPort: 8080


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The yaml parser fails if the indentation is not on the same level as the key.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/5285
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `contrib/metrics-exporter/cluster.yaml` for `kubectl create`.
```
