### PR TITLE
Do not log on startup if Intel RDT is not supported

### DIFF
--- a/internal/config/rdt/rdt.go
+++ b/internal/config/rdt/rdt.go
@@ -34,7 +34,6 @@ func New() *Config {
 	rdt.SetLogger(logrus.StandardLogger())
 
 	if err := rdt.Initialize(ResctrlPrefix); err != nil {
-		logrus.Infof("RDT is not enabled: %v", err)
 		c.supported = false
 	}
 	return c


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This reduces the noise on systems not having Intel RDT enabled. We already log that RDT is not enabled on profile load.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Do not log on startup if Intel RDT is not supported.
```
