### PR TITLE
Add unit test for the `server/sandbox_remove`.

### DIFF
--- a/server/sandbox_remove_test.go
+++ b/server/sandbox_remove_test.go
@@ -1,0 +1,43 @@
+package server_test
+
+import (
+	"github.com/cri-o/cri-o/server/cri/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"golang.org/x/net/context"
+)
+
+// The actual test suite
+var _ = t.Describe("PodSandboxRemove", func() {
+	// Prepare the sut
+	BeforeEach(func() {
+		beforeEach()
+		setupSUT()
+	})
+
+	AfterEach(afterEach)
+
+	t.Describe("PodSandboxRemove", func() {
+		It("should fail when sandbox is not created", func() {
+			// Given
+			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+			Expect(sut.PodIDIndex().Add(testSandbox.ID())).To(BeNil())
+
+			// When
+			err := sut.RemovePodSandbox(context.Background(),
+				&types.RemovePodSandboxRequest{PodSandboxID: testSandbox.ID()})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should fail with empty sandbox ID", func() {
+			// When
+			err := sut.StopPodSandbox(context.Background(),
+				&types.StopPodSandboxRequest{})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: utam0k <k0ma@utam0k.jp>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind other


#### What this PR does / why we need it:

Add unit test for the `server/sandbox_remove` to increase code coverage.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
