### PR TITLE
server: close namespaces on sandbox stop

### DIFF
--- a/internal/config/nsmgr/types.go
+++ b/internal/config/nsmgr/types.go
@@ -52,7 +52,10 @@ type Namespace interface {
 	// Type returns the namespace type (net, ipc, user, pid or uts).
 	Type() NSType
 
-	// Remove ensures this namespace is closed and removed.
+	// Close ensures this namespace is closed.
+	Close() error
+
+	// Remove ensures this namespace is removed.
 	Remove() error
 }
 
@@ -85,13 +88,13 @@ func (n *namespace) Type() NSType {
 	return n.nsType
 }
 
-// Remove ensures this namespace is closed and removed.
-func (n *namespace) Remove() error {
+// Close ensures this namespace is closed.
+func (n *namespace) Close() error {
 	n.Lock()
 	defer n.Unlock()
 
 	if n.closed {
-		// Remove() can be called multiple
+		// Close() can be called multiple
 		// times without returning an error.
 		return nil
 	}
@@ -102,16 +105,29 @@ func (n *namespace) Remove() error {
 
 	n.closed = true
 
-	fp := n.Path()
-	if fp == "" {
+	if n.nsPath == "" {
 		return nil
 	}
 
 	// try to unmount, ignoring "not mounted" (EINVAL) error.
-	if err := unix.Unmount(fp, unix.MNT_DETACH); err != nil && err != unix.EINVAL {
-		return errors.Wrapf(err, "unable to unmount %s", fp)
+	if err := unix.Unmount(n.nsPath, unix.MNT_DETACH); err != nil && err != unix.EINVAL {
+		return errors.Wrapf(err, "unable to unmount %s", n.nsPath)
 	}
-	return os.RemoveAll(fp)
+	return nil
+}
+
+// Remove ensures this namespace is closed and removed.
+func (n *namespace) Remove() error {
+	n.Lock()
+	defer n.Unlock()
+	if !n.closed {
+		return errors.New("Namespace must be closed before it can be removed")
+	}
+
+	if n.nsPath == "" {
+		return nil
+	}
+	return os.Remove(n.nsPath)
 }
 
 // GetNamespace takes a path and type, checks if it is a namespace, and if so
@@ -119,6 +135,10 @@ func (n *namespace) Remove() error {
 func GetNamespace(nsPath string, nsType NSType) (Namespace, error) {
 	ns, err := nspkg.GetNS(nsPath)
 	if err != nil {
+		// path exists but is not an NS, the namespace must have been closed
+		if _, ok := err.(nspkg.NSPathNotNSErr); ok {
+			return &namespace{nsType: nsType, nsPath: nsPath, closed: true}, nil
+		}
 		return nil, err
 	}
 

--- a/internal/lib/sandbox/namespaces_test.go
+++ b/internal/lib/sandbox/namespaces_test.go
@@ -24,6 +24,10 @@ func (s *spoofedIface) Type() nsmgr.NSType {
 	return s.nsType
 }
 
+func (s *spoofedIface) Close() error {
+	return nil
+}
+
 func (s *spoofedIface) Remove() error {
 	s.removed = true
 	return nil
@@ -211,39 +215,6 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 
 			// When
 			err := testSandbox.UserNsJoin("/proc/self/ns/user")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-		It("should fail when asked to join a non-namespace", func() {
-			// Given
-			// When
-			err := testSandbox.NetNsJoin("/tmp")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-		It("should fail when asked to join a non-namespace", func() {
-			// Given
-
-			// When
-			err := testSandbox.IpcNsJoin("/tmp")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-		It("should fail when asked to join a non-namespace", func() {
-			// Given
-			// When
-			err := testSandbox.UtsNsJoin("/tmp")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-		It("should fail when asked to join a non-namespace", func() {
-			// Given
-			// When
-			err := testSandbox.UserNsJoin("/tmp")
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -86,6 +86,10 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		}
 	}
 
+	if err := sb.CloseManagedNamespaces(); err != nil {
+		return errors.Wrap(err, "unable to close managed namespaces")
+	}
+
 	if err := sb.UnmountShm(); err != nil {
 		return err
 	}


### PR DESCRIPTION
or else namespaces will appear to leak before kubelet GCs the associated pods.
To do so, do all of the namespace unmounting pieces on stop, but don't actually delete the file.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Move namespace cleanup from sandbox stop to sandbox remove. This allows veth entries in the network namespaces of pods to be cleaned up earlier
```
