### PR TITLE
Skip volume relabel for super privileged containers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -163,6 +163,6 @@ linters-settings:
       - unnamedResult
       - unnecessaryBlock
   gocyclo:
-    min-complexity: 122
+    min-complexity: 127
   nakedret:
     max-func-lines: 15

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -34,6 +34,7 @@ import (
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 
 	"github.com/intel/goresctrl/pkg/blockio"
@@ -282,7 +283,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 		maybeRelabel = true
 	}
 
-	containerVolumes, ociMounts, err := addOCIBindMounts(ctx, ctr, mountLabel, s.config.RuntimeConfig.BindMountPrefix, s.config.AbsentMountSourcesToReject, maybeRelabel)
+	skipRelabel := false
+	const superPrivilegedType = "spc_t"
+	if securityContext.SelinuxOptions.Type == superPrivilegedType || // super privileged container
+		(ctr.SandboxConfig().Linux.SecurityContext.SelinuxOptions.Type == superPrivilegedType && // super privileged pod
+			securityContext.SelinuxOptions.Type == "") {
+		skipRelabel = true
+	}
+
+	containerVolumes, ociMounts, err := addOCIBindMounts(ctx, ctr, mountLabel, s.config.RuntimeConfig.BindMountPrefix, s.config.AbsentMountSourcesToReject, maybeRelabel, skipRelabel)
 	if err != nil {
 		return nil, err
 	}
@@ -834,7 +843,7 @@ func clearReadOnly(m *rspec.Mount) {
 	m.Options = append(m.Options, "rw")
 }
 
-func addOCIBindMounts(ctx context.Context, ctr ctrIface.Container, mountLabel, bindMountPrefix string, absentMountSourcesToReject []string, maybeRelabel bool) ([]oci.ContainerVolume, []rspec.Mount, error) {
+func addOCIBindMounts(ctx context.Context, ctr ctrIface.Container, mountLabel, bindMountPrefix string, absentMountSourcesToReject []string, maybeRelabel, skipRelabel bool) ([]oci.ContainerVolume, []rspec.Mount, error) {
 	volumes := []oci.ContainerVolume{}
 	ociMounts := []rspec.Mount{}
 	containerConfig := ctr.Config()
@@ -944,7 +953,9 @@ func addOCIBindMounts(ctx context.Context, ctr ctrIface.Container, mountLabel, b
 		}
 
 		if m.SelinuxRelabel {
-			if err := securityLabel(src, mountLabel, false, maybeRelabel); err != nil {
+			if skipRelabel {
+				logrus.Debugf("Skipping relabel for %s because of super privileged container (type: spc_t)", src)
+			} else if err := securityLabel(src, mountLabel, false, maybeRelabel); err != nil {
 				return nil, nil, err
 			}
 		}

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -34,7 +34,7 @@ func TestAddOCIBindsForDev(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, binds, err := addOCIBindMounts(context.Background(), ctr, "", "", nil, false)
+	_, binds, err := addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -78,7 +78,7 @@ func TestAddOCIBindsForSys(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, binds, err := addOCIBindMounts(context.Background(), ctr, "", "", nil, false)
+	_, binds, err := addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/server/label_linux.go
+++ b/server/label_linux.go
@@ -14,7 +14,7 @@ func securityLabel(path, secLabel string, shared, maybeRelabel bool) error {
 		currentLabel, err := label.FileLabel(path)
 		if err == nil && currentLabel == secLabel {
 			logrus.Debugf(
-				"Skipping relabel for %s, as TrySkipVolumeSELinuxRelabel is true and the label of the top level of the volume is already correct",
+				"Skipping relabel for %s, as TrySkipVolumeSELinuxLabel is true and the label of the top level of the volume is already correct",
 				path)
 			return nil
 		}

--- a/test/selinux.bats
+++ b/test/selinux.bats
@@ -73,3 +73,37 @@ function teardown() {
 	newlabel=$(ls -Z "$FILE" | grep -o '[a-z,_]*_u:[a-z,_]*_r:[a-z,_]*_t:[c,s,0-9,:,\,]* ')
 	[[ "$label" == "$newlabel" ]]
 }
+
+@test "selinux skips relabeling for super priviliged container" {
+	if [[ $(getenforce) != "Enforcing" ]]; then
+		skip "not enforcing"
+	fi
+	VOLUME="$TESTDIR"/dir
+	mkdir -p "$VOLUME"
+
+	# shellcheck disable=SC2012
+	OLDLABEL=$(ls -dZ "$VOLUME" | awk '{ printf $1 }')
+
+	start_crio
+
+	jq '.linux.security_context.selinux_options = {"type": "spc_t"}' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
+
+	jq --arg path "$VOLUME" \
+		'.mounts = [{
+			host_path: $path,
+			container_path: "/tmp/path",
+			selinux_relabel: true
+		}]' \
+		"$TESTDATA"/container_redis.json > "$TESTDIR"/container.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDIR"/container.json "$TESTDIR"/sandbox.json)
+
+	crictl rm "$ctr_id"
+
+	# shellcheck disable=SC2012
+	NEWLABEL=$(ls -dZ "$VOLUME" | awk '{ printf $1 }')
+
+	[[ "$OLDLABEL" == "$NEWLABEL" ]]
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

If a container or pod specifies the SELinux type `spc_t`, then we skip the volume relabel.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

cc @mrunalp 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Skip SELinux volume relabeling for super privileged containers (`securityContext.seLinuxOptions.type = "spc_t"`).
```
