### PR TITLE
oci: chmod stdin pipe to 0777

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -358,6 +358,13 @@ func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []stri
 			if err != nil {
 				return err
 			}
+
+			u := c.Spec().Process.User
+			// Change the owner for the pipe to the user in the container
+			if err := unix.Fchown(int(r.Fd()), int(u.UID), int(u.GID)); err != nil {
+				return err
+			}
+
 			execCmd.Stdin = r
 			go func() {
 				_, copyError = pools.Copy(w, stdin)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:

fix running exec with crun with an user different than root.

#### Which issue(s) this PR fixes:

https://github.com/containers/crun/issues/745

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
chown the stdin pipe to the user running in the container, so accessing /dev/stdin from an exec session works with crun
```
