### PR TITLE
Fix runtime handler docs

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -259,7 +259,7 @@ the container runtime configuration.
   Changes the default behavior of setting container devices uid/gid from CRI's SecurityContext (RunAsUser/RunAsGroup) instead of taking host's uid/gid.
 
 ### CRIO.RUNTIME.RUNTIMES TABLE
-The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  The runtime to use is picked based on the runtime_handler provided by the CRI.  If no runtime_handler is provided, the runtime will be picked based on the level of trust of the workload.
+The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  The runtime to use is picked based on the runtime handler provided by the CRI.  If no runtime handler is provided, the runtime will be picked based on the level of trust of the workload.
 
 **runtime_path**=""
   Path to the OCI compatible runtime used for this runtime handler.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -977,8 +977,8 @@ absent_mount_sources_to_reject = [
 `
 
 const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
-# The runtime to use is picked based on the runtime_handler provided by the CRI.
-# If no runtime_handler is provided, the runtime will be picked based on the level
+# The runtime to use is picked based on the runtime handler provided by the CRI.
+# If no runtime handler is provided, the runtime will be picked based on the level
 # of trust of the workload. Each entry in the table should follow the format:
 #
 #[crio.runtime.runtimes.runtime-handler]


### PR DESCRIPTION


#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:
We now use "runtime handler" instead of "runtime_handler", which was
only referencing an internal variable not visible to the user.


#### Which issue(s) this PR fixes:

Fixes https://github.com/cri-o/cri-o/issues/5393


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve runtime handler documentation to mention "runtime handler" in favor of the internal "runtime_handler" variable.
```
