### PR TITLE
Log HTTP response writer message instead an error

### DIFF
--- a/server/inspect.go
+++ b/server/inspect.go
@@ -126,8 +126,7 @@ func (s *Server) GetInfoMux(enableProfile bool) *bone.Mux {
 
 		w.Header().Set("Content-Type", "application/toml")
 		if _, err := w.Write(b); err != nil {
-			http.Error(w, fmt.Sprintf("unable to write TOML: %v", err),
-				http.StatusInternalServerError)
+			logrus.Errorf("Unable to write response TOML: %v", err)
 		}
 	}))
 
@@ -140,7 +139,7 @@ func (s *Server) GetInfoMux(enableProfile bool) *bone.Mux {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write(js); err != nil {
-			http.Error(w, fmt.Sprintf("unable to write JSON: %v", err), http.StatusInternalServerError)
+			logrus.Errorf("Unable to write response JSON: %v", err)
 		}
 	}))
 
@@ -167,7 +166,7 @@ func (s *Server) GetInfoMux(enableProfile bool) *bone.Mux {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write(js); err != nil {
-			http.Error(w, fmt.Sprintf("unable to write JSON: %v", err), http.StatusInternalServerError)
+			logrus.Errorf("Unable to write response JSON: %v", err)
 		}
 	}))
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We cannot throw an additional HTTP error if the response write fails,
because it already sets the http error code internally. This resulted in
an "http: superfluous response.WriteHeader call" error. To mitigate the
issue, we now only log the error.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://bugzilla.redhat.com/show_bug.cgi?id=2006654
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed superfluous response.WriteHeader error in HTTP endpoint 
```
