### PR TITLE
[1.20] BZ2015427 - Skip volume relabel for super privileged containers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -147,6 +147,6 @@ linters-settings:
       - unnamedResult
       - unnecessaryBlock
   gocyclo:
-    min-complexity: 122
+    min-complexity: 127
   nakedret:
     max-func-lines: 15

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package server
@@ -23,7 +24,7 @@ func TestAddOCIBindsForDev(t *testing.T) {
 			},
 		},
 	}
-	_, binds, err := addOCIBindMounts(context.Background(), "", config, &specgen, "")
+	_, binds, err := addOCIBindMounts(context.Background(), "", config, &specgen, "", false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -57,7 +58,7 @@ func TestAddOCIBindsForSys(t *testing.T) {
 			},
 		},
 	}
-	_, binds, err := addOCIBindMounts(context.Background(), "", config, &specgen, "")
+	_, binds, err := addOCIBindMounts(context.Background(), "", config, &specgen, "", false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/selinux.bats
+++ b/test/selinux.bats
@@ -20,3 +20,37 @@ function teardown() {
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/sandbox.json)
 	crictl start "$ctr_id"
 }
+
+@test "selinux skips relabeling for super priviliged container" {
+	if [[ $(getenforce) != "Enforcing" ]]; then
+		skip "not enforcing"
+	fi
+	VOLUME="$TESTDIR"/dir
+	mkdir -p "$VOLUME"
+
+	# shellcheck disable=SC2012
+	OLDLABEL=$(ls -dZ "$VOLUME" | awk '{ printf $1 }')
+
+	start_crio
+
+	jq '.linux.security_context.selinux_options = {"type": "spc_t"}' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
+
+	jq --arg path "$VOLUME" \
+		'.mounts = [{
+			host_path: $path,
+			container_path: "/tmp/path",
+			selinux_relabel: true
+		}]' \
+		"$TESTDATA"/container_redis.json > "$TESTDIR"/container.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDIR"/container.json "$TESTDIR"/sandbox.json)
+
+	crictl rm "$ctr_id"
+
+	# shellcheck disable=SC2012
+	NEWLABEL=$(ls -dZ "$VOLUME" | awk '{ printf $1 }')
+
+	[[ "$OLDLABEL" == "$NEWLABEL" ]]
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
If a container or pod specifies the SELinux type `spc_t`, then we skip
the volume relabel.

Cherry-picked: 13182e64be5dde0a96dd225094a7baedda3f7286

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/pull/5386

#### Special notes for your reviewer:
@cri-o/cri-o-maintainers PTAL
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Skip SELinux volume relabeling for super privileged containers (`securityContext.seLinuxOptions.type = "spc_t"`).
```
