### PR TITLE
Bug 2012838: fix override storage options from storage.conf

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -573,6 +573,10 @@ func (c *Config) UpdateFromFile(path string) error {
 // Returns errors encountered when reading or parsing the files, or nil
 // otherwise.
 func (c *Config) UpdateFromDropInFile(path string) error {
+	// keeps the storage options from storage.conf and merge it to crio config
+	var storageOpts []string
+	storageOpts = append(storageOpts, c.StorageOptions...)
+
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
@@ -592,6 +596,10 @@ func (c *Config) UpdateFromDropInFile(path string) error {
 		delete(c.Runtimes, defaultRuntime)
 	}
 
+	storageOpts = append(storageOpts, t.Crio.RootConfig.StorageOptions...)
+	storageOpts = removeDupStorageOpts(storageOpts)
+	t.Crio.RootConfig.StorageOptions = storageOpts
+
 	// Registries are deprecated in cri-o.conf and turned into a NOP.
 	// Users should use registries.conf instead, so let's log it.
 	if len(t.Crio.Image.Registries) > 0 {
@@ -601,6 +609,24 @@ func (c *Config) UpdateFromDropInFile(path string) error {
 
 	t.toConfig(c)
 	return nil
+}
+
+// removeDupStorageOpts removes duplicated storage option from the list
+// keeps the last appearance
+func removeDupStorageOpts(storageOpts []string) []string {
+	var resOpts []string
+	opts := make(map[string]bool)
+	for i := len(storageOpts) - 1; i >= 0; i-- {
+		if ok := opts[storageOpts[i]]; ok {
+			continue
+		}
+		opts[storageOpts[i]] = true
+		resOpts = append(resOpts, storageOpts[i])
+	}
+	for i, j := 0, len(resOpts)-1; i < j; i, j = i+1, j-1 {
+		resOpts[i], resOpts[j] = resOpts[j], resOpts[i]
+	}
+	return resOpts
 }
 
 // UpdateFromPath recursively iterates the provided path and updates the


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=2012838

Merge in the storage_option from drop-in crio.conf to the storage.conf, do not override the configs from storage.conf.
The override leads to configuration of containerruntimeconfig not working.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change

/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2012838
The storage_option from /etc/crio/crio.conf.d/00-default overrides the configurations from /etc/containers/storage.conf.
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Merge storage_option from drop-in files to sttorage_option from storage.conf
```
