### PR TITLE
[release-1.20] Bug 2012838: Backport the fix override storage options from storage.conf

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -792,6 +792,37 @@ var _ = t.Describe("Config", func() {
 			Expect(sut.PidsLimit).To(BeEquivalentTo(2048))
 		})
 
+		It("should inherit storage_options from storage.conf and remove duplicates", func() {
+			f := t.MustTempFile("config")
+			// Given
+			Expect(ioutil.WriteFile(f,
+				[]byte(`
+					[crio]
+					storage_option = [
+						"foo=bar",
+					]`,
+				), 0),
+			).To(BeNil())
+			for _, tc := range []struct {
+				opts   []string
+				expect []string
+			}{
+				{[]string{"option1=v1", "option2=v2", "option3=v3"}, []string{"option1=v1", "option2=v2", "option3=v3", "foo=bar"}},
+				{[]string{"option1=v1", "option3=v3", "option2=v2", "option3=v3"}, []string{"option1=v1", "option2=v2", "option3=v3", "foo=bar"}},
+				{[]string{"option1=v1", "option2=v2", "option3=v3", "option1=v1"}, []string{"option2=v2", "option3=v3", "option1=v1", "foo=bar"}},
+				{[]string{"option1=v1", "option2=v2", "option3=v3", "option4=v4", "option3=v3", "option1=v1"}, []string{"option2=v2", "option4=v4", "option3=v3", "option1=v1", "foo=bar"}},
+			} {
+				// When
+				defaultcfg := defaultConfig()
+				defaultcfg.StorageOptions = tc.opts
+				err := defaultcfg.UpdateFromFile(f)
+
+				// Then
+				Expect(err).To(BeNil())
+				Expect(defaultcfg.RootConfig.StorageOptions).To(Equal(tc.expect))
+			}
+		})
+
 		It("should succeed with custom runtime", func() {
 			// Given
 			f := t.MustTempFile("config")


### PR DESCRIPTION
Backport 8daa9039aadf1bc3676f6b1e41f6937900503339.
Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=2020716 in 4.7
original bug: https://bugzilla.redhat.com/show_bug.cgi?id=2012838
Merge in the storage_option from drop-in crio.conf to the storage.conf, do not override the configs from storage.conf.
The override leads to configuration of containerruntimeconfig not working.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Backport the fix of merging storage_option from drop-in files to sttorage_option from storage.conf.

```
