### PR TITLE
Add .containerenv file to containers

### DIFF
--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -60,6 +60,7 @@ type Sandbox struct {
 	privileged         bool
 	hostNetwork        bool
 	usernsMode         string
+	containerEnvPath   string
 }
 
 // DefaultShmSize is the default shm size
@@ -248,6 +249,11 @@ func (s *Sandbox) HostnamePath() string {
 	return s.hostnamePath
 }
 
+// ContainerEnvPath retrieves the .containerenv path from a sandbox
+func (s *Sandbox) ContainerEnvPath() string {
+	return s.containerEnvPath
+}
+
 // Hostname returns the hostname of the sandbox
 func (s *Sandbox) Hostname() string {
 	return s.hostname
@@ -347,6 +353,23 @@ func (s *Sandbox) SetNetworkStopped(createFile bool) error {
 			return fmt.Errorf("failed to create state file in container directory. Restores may fail: %v", err)
 		}
 	}
+	return nil
+}
+
+// SetContainerEnvFile sets the container environment file.
+func (s *Sandbox) SetContainerEnvFile() error {
+	if s.containerEnvPath != "" {
+		return nil
+	}
+
+	infra := s.InfraContainer()
+	filePath := filepath.Join(infra.Dir(), ".containerenv")
+
+	f, err := os.Create(filePath)
+	if err == nil {
+		f.Close()
+	}
+	s.containerEnvPath = filePath
 	return nil
 }
 

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -256,6 +256,18 @@ var _ = t.Describe("Sandbox", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 		})
+
+		It("should set containerenv file", func() {
+			// Given
+			Expect(testSandbox.ContainerEnvPath()).To(BeEmpty())
+			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
+
+			// When
+			Expect(testSandbox.SetContainerEnvFile()).To(BeNil())
+
+			// Then
+			Expect(testSandbox.ContainerEnvPath()).To(ContainSubstring(".containerenv"))
+		})
 	})
 	t.Describe("NeedsInfra", func() {
 		It("should not need when managing NS and NS mode NODE", func() {

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -591,6 +591,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 		})
 	}
 
+	if sb.ContainerEnvPath() != "" {
+		ctr.SpecAddMount(rspec.Mount{
+			Destination: "/run/.containerenv",
+			Type:        "bind",
+			Source:      sb.ContainerEnvPath(),
+			Options:     append(options, "bind"),
+		})
+	}
+
 	if !isInCRIMounts("/etc/hosts", containerConfig.Mounts) && hostNet {
 		// Only bind mount for host netns and when CRI does not give us any hosts file
 		ctr.SpecAddMount(rspec.Mount{

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -863,6 +863,10 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
+	if err := sb.SetContainerEnvFile(); err != nil {
+		return nil, err
+	}
+
 	if err = g.SaveToFile(filepath.Join(podContainer.Dir, "config.json"), saveOptions); err != nil {
 		return nil, fmt.Errorf("failed to save template configuration for pod sandbox %s(%s): %v", sb.Name(), sbox.ID(), err)
 	}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -920,3 +920,12 @@ function check_oci_annotation() {
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	! crictl create "$pod_id" "$TESTDIR/config" "$TESTDATA"/sandbox_config.json
 }
+
+@test "ctr has containerenv" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	crictl exec --sync "$ctr_id" sh -c "stat /run/.containerenv"
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

This aligns CRI-O with podman, by adding a specific file to help programs running inside its containers to detected they are in fact running inside a container.

#### Which issue(s) this PR fixes:

Fixes #5461

#### Special notes for your reviewer:

Decided to use the same file name as podman, given that docker's approach is vendor specific.


#### Does this PR introduce a user-facing change?

```release-note
Containers now have a `/run/.containerenv` file to help applications identify that they are running inside a container.
```
