### PR TITLE
[release-1.19] Add support to drop ALL and add back few capabilities

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/stringid"
+	"github.com/cri-o/cri-o/internal/config/capabilities"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/storage"
@@ -335,13 +336,13 @@ func generateUserString(username, imageUser string, uid *pb.Int64Value) string {
 }
 
 // setupCapabilities sets process.capabilities in the OCI runtime config.
-func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability) error {
+func setupCapabilities(specgen *generate.Generator, caps *pb.Capability, defaultCaps capabilities.Capabilities) error {
 	// Remove all ambient capabilities. Kubernetes is not yet ambient capabilities aware
 	// and pods expect that switching to a non-root user results in the capabilities being
 	// dropped. This should be revisited in the future.
 	specgen.Config.Process.Capabilities.Ambient = []string{}
 
-	if capabilities == nil {
+	if caps == nil {
 		return nil
 	}
 
@@ -352,12 +353,24 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 		return cap
 	}
 
+	addAll := inStringSlice(caps.AddCapabilities, "ALL")
+	dropAll := inStringSlice(caps.DropCapabilities, "ALL")
+
+	// Only add the default capabilities to the AddCapabilities list
+	// if neither add or drop are set to "ALL". If add is set to "ALL" it
+	// is a super set of the default capabilties. If drop is set to "ALL"
+	// then we first want to clear the entire list (including defaults)
+	// so the user may selectively add *only* the capabilities they need.
+	if !(addAll || dropAll) {
+		caps.AddCapabilities = append(caps.AddCapabilities, defaultCaps...)
+	}
+
 	// Add/drop all capabilities if "all" is specified, so that
 	// following individual add/drop could still work. E.g.
 	// AddCapabilities: []string{"ALL"}, DropCapabilities: []string{"CHOWN"}
 	// will be all capabilities without `CAP_CHOWN`.
 	// see https://github.com/kubernetes/kubernetes/issues/51980
-	if inStringSlice(capabilities.GetAddCapabilities(), "ALL") {
+	if addAll {
 		for _, c := range getOCICapabilitiesList() {
 			if err := specgen.AddProcessCapabilityBounding(c); err != nil {
 				return err
@@ -373,7 +386,7 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 			}
 		}
 	}
-	if inStringSlice(capabilities.GetDropCapabilities(), "ALL") {
+	if dropAll {
 		for _, c := range getOCICapabilitiesList() {
 			if err := specgen.DropProcessCapabilityBounding(c); err != nil {
 				return err
@@ -390,7 +403,7 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 		}
 	}
 
-	for _, cap := range capabilities.GetAddCapabilities() {
+	for _, cap := range caps.AddCapabilities {
 		if strings.EqualFold(cap, "ALL") {
 			continue
 		}
@@ -413,7 +426,7 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 		}
 	}
 
-	for _, cap := range capabilities.GetDropCapabilities() {
+	for _, cap := range caps.DropCapabilities {
 		if strings.EqualFold(cap, "ALL") {
 			continue
 		}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package server
@@ -466,8 +467,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 			}
 			// Clear default capabilities from spec
 			specgen.ClearProcessCapabilities()
-			capabilities.AddCapabilities = append(capabilities.AddCapabilities, s.config.DefaultCapabilities...)
-			err = setupCapabilities(&specgen, capabilities)
+			err = setupCapabilities(&specgen, capabilities, s.config.DefaultCapabilities)
 			if err != nil {
 				return nil, err
 			}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package server
@@ -231,11 +232,8 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	// Add capabilities from crio.conf if default_capabilities is defined
 	capabilities := &pb.Capability{}
-	if s.config.DefaultCapabilities != nil {
-		g.ClearProcessCapabilities()
-		capabilities.AddCapabilities = append(capabilities.AddCapabilities, s.config.DefaultCapabilities...)
-	}
-	if err := setupCapabilities(&g, capabilities); err != nil {
+	g.ClearProcessCapabilities()
+	if err := setupCapabilities(&g, capabilities, s.config.DefaultCapabilities); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Backport https://github.com/cri-o/cri-o/pull/4923 to release-1.19

The current implemention has an issue where we add the default
capabilties when the user does drop ALL and add few.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>
Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix drop ALL and add back few caps behavior to not include the default configured capabilities
```
