### PR TITLE
Add Go 1.17+ go:build tags

### DIFF
--- a/cmd/crio/daemon_linux.go
+++ b/cmd/crio/daemon_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package main
 
 import (

--- a/cmd/crio/daemon_unsupported.go
+++ b/cmd/crio/daemon_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package main

--- a/internal/config/cgmgr/cgmgr.go
+++ b/internal/config/cgmgr/cgmgr.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cgmgr

--- a/internal/config/cgmgr/cgmgr_unsupported.go
+++ b/internal/config/cgmgr/cgmgr_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package cgmgr

--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cgmgr

--- a/internal/config/cgmgr/systemd.go
+++ b/internal/config/cgmgr/systemd.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cgmgr

--- a/internal/config/cnimgr/cnimgr_test_inject.go
+++ b/internal/config/cnimgr/cnimgr_test_inject.go
@@ -1,4 +1,6 @@
+//go:build test
 // +build test
+
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.
 

--- a/internal/config/node/cgroups.go
+++ b/internal/config/node/cgroups.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package node

--- a/internal/config/node/node.go
+++ b/internal/config/node/node.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package node

--- a/internal/config/node/node_unsupported.go
+++ b/internal/config/node/node_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package node

--- a/internal/config/node/systemd.go
+++ b/internal/config/node/systemd.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package node

--- a/internal/config/nsmgr/types.go
+++ b/internal/config/nsmgr/types.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package nsmgr

--- a/internal/dbusmgr/dbusmgr.go
+++ b/internal/dbusmgr/dbusmgr.go
@@ -1,4 +1,6 @@
+//go:build linux
 // +build linux
+
 // Code in this package is heavily adapted from https://github.com/opencontainers/runc/blob/7362fa2d282feffb9b19911150e01e390a23899d/libcontainer/cgroups/systemd
 // Credit goes to the runc authors.
 

--- a/internal/lib/container_server_linux.go
+++ b/internal/lib/container_server_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package lib
 
 import (

--- a/internal/lib/container_server_test_inject.go
+++ b/internal/lib/container_server_test_inject.go
@@ -1,4 +1,6 @@
+//go:build test
 // +build test
+
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.
 

--- a/internal/lib/container_server_unsupported.go
+++ b/internal/lib/container_server_unsupported.go
@@ -1,11 +1,10 @@
+//go:build !linux
 // +build !linux
 
 package lib
 
 import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
-	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/pkg/errors"
 )
 
 func (c *ContainerServer) addSandboxPlatform(sb *sandbox.Sandbox) {

--- a/internal/lib/sandbox/sandbox_unsupported.go
+++ b/internal/lib/sandbox/sandbox_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package sandbox

--- a/internal/oci/container_test_inject.go
+++ b/internal/oci/container_test_inject.go
@@ -1,4 +1,6 @@
+//go:build test
 // +build test
+
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.
 

--- a/internal/oci/finished.go
+++ b/internal/oci/finished.go
@@ -1,3 +1,4 @@
+//go:build linux && !arm && !386
 // +build linux,!arm,!386
 
 package oci

--- a/internal/oci/finished_32.go
+++ b/internal/oci/finished_32.go
@@ -1,3 +1,4 @@
+//go:build (linux && arm) || (linux && 386)
 // +build linux,arm linux,386
 
 package oci

--- a/internal/oci/finished_unsupported.go
+++ b/internal/oci/finished_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package oci

--- a/internal/oci/oci_linux.go
+++ b/internal/oci/oci_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package oci
 
 import (

--- a/internal/oci/oci_unix.go
+++ b/internal/oci/oci_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package oci

--- a/internal/oci/oci_unsupported.go
+++ b/internal/oci/oci_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package oci

--- a/internal/oci/oci_windows.go
+++ b/internal/oci/oci_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package oci
 
 import (

--- a/internal/resourcestore/resourcecleaner_defaults.go
+++ b/internal/resourcestore/resourcecleaner_defaults.go
@@ -1,3 +1,4 @@
+//go:build !test
 // +build !test
 
 package resourcestore

--- a/internal/resourcestore/resourcecleaner_test_inject.go
+++ b/internal/resourcestore/resourcecleaner_test_inject.go
@@ -1,4 +1,6 @@
+//go:build test
 // +build test
+
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.
 

--- a/internal/signals/signal_unix.go
+++ b/internal/signals/signal_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package signals

--- a/internal/signals/signal_windows.go
+++ b/internal/signals/signal_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package signals
 
 import (

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools

--- a/internal/version/buildtag_apparmor.go
+++ b/internal/version/buildtag_apparmor.go
@@ -1,3 +1,4 @@
+//go:build apparmor
 // +build apparmor
 
 package version

--- a/internal/version/buildtag_devicemapper.go
+++ b/internal/version/buildtag_devicemapper.go
@@ -1,3 +1,4 @@
+//go:build exclude_graphdriver_devicemapper
 // +build exclude_graphdriver_devicemapper
 
 package version

--- a/internal/version/buildtag_openpgp.go
+++ b/internal/version/buildtag_openpgp.go
@@ -1,3 +1,4 @@
+//go:build containers_image_openpgp
 // +build containers_image_openpgp
 
 package version

--- a/internal/version/buildtag_ostree.go
+++ b/internal/version/buildtag_ostree.go
@@ -1,3 +1,4 @@
+//go:build containers_image_ostree_stub
 // +build containers_image_ostree_stub
 
 package version

--- a/internal/version/buildtag_seccomp.go
+++ b/internal/version/buildtag_seccomp.go
@@ -1,3 +1,4 @@
+//go:build seccomp
 // +build seccomp
 
 package version

--- a/internal/version/buildtag_selinux.go
+++ b/internal/version/buildtag_selinux.go
@@ -1,3 +1,4 @@
+//go:build selinux
 // +build selinux
 
 package version

--- a/internal/version/linkmode_dynamic.go
+++ b/internal/version/linkmode_dynamic.go
@@ -1,3 +1,4 @@
+//go:build !static
 // +build !static
 
 package version

--- a/internal/version/linkmode_static.go
+++ b/internal/version/linkmode_static.go
@@ -1,3 +1,4 @@
+//go:build static
 // +build static
 
 package version

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package config
 
 import selinux "github.com/opencontainers/selinux/go-selinux"

--- a/pkg/config/config_test_inject.go
+++ b/pkg/config/config_test_inject.go
@@ -1,4 +1,6 @@
+//go:build test
 // +build test
+
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.
 

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package config

--- a/pkg/config/config_unsupported.go
+++ b/pkg/config/config_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package config

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,7 +1,5 @@
 package config
 
-import "github.com/cri-o/cri-o/internal/oci"
-
 // Defaults for linux/unix if none are specified
 const (
 	cniConfigDir             = "C:\\cni\\etc\\net.d\\"

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package config
 
 import "github.com/cri-o/cri-o/internal/oci"

--- a/server/container_create_generic.go
+++ b/server/container_create_generic.go
@@ -1,3 +1,4 @@
+//go:build windows || darwin
 // +build windows darwin
 
 package server

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 package server
 
 import (

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 package server
 
 import (

--- a/server/container_create_unsupported.go
+++ b/server/container_create_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package server

--- a/server/listen_unix.go
+++ b/server/listen_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package server

--- a/server/listen_windows.go
+++ b/server/listen_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package server
 
 import (

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 package server
 
 import (

--- a/server/sandbox_run_unsupported.go
+++ b/server/sandbox_run_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package server

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package server
 
 import (

--- a/server/sandbox_stop_unsupported.go
+++ b/server/sandbox_stop_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package server

--- a/server/server_test_inject.go
+++ b/server/server_test_inject.go
@@ -1,4 +1,6 @@
+//go:build test
 // +build test
+
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

1. Remove redundant build tags
    
    The tags being removed are redundant because the file names already have
    them (e.g. specifying +build linux is redundant in foo_linux.go).

2. Add go 1.17+ go:build tags

    Go 1.17 introduced this new (and better) way to specify build tags.
    For more info, see https://golang.org/design/draft-gobuild.
    
    As a way to seamlessly switch from old to new build tags, gofmt (and
    gopls, and goimports) from go 1.17 adds the new tags along with the old
    ones.
    
    Later, when go < 1.17 is no longer supported, the old build tags
    can be removed.
    
    Now, as I started to use latest gopls (v0.7.1), it adds these tags
    while I edit. Rather than to randomly add new build tags in new PRs,
    I guess it is better to do it once for all files.
    
    Brought to you by goimports -w. It also did some other minor changes
    (whitespace fixes, removing unused imports), which looks OK to me.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
