### PR TITLE
Relabel containerenv files

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -589,6 +589,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 	}
 
 	if sb.ContainerEnvPath() != "" {
+		if err := securityLabel(sb.ContainerEnvPath(), mountLabel, false, false); err != nil {
+			return nil, err
+		}
 		ctr.SpecAddMount(rspec.Mount{
 			Destination: "/run/.containerenv",
 			Type:        "bind",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This adds a relabelling of the containerenv file that is missing in #5463. This is needed to run kata-containers on an SELinux enabled host.

#### Which issue(s) this PR fixes:

Fixes #5483 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

Change comes from code inspection. I haven't had time to try this fix yet but I'm proposing it anyway for review, as it is currently blocking our downstream workflow.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
