### PR TITLE
[1.22] workloads: fix if resources are empty

### DIFF
--- a/pkg/config/workloads.go
+++ b/pkg/config/workloads.go
@@ -96,6 +96,9 @@ func resourcesFromAnnotation(prefix, ctrName string, annotations map[string]stri
 }
 
 func (r *Resources) ValidateDefaults() error {
+	if r == nil {
+		return nil
+	}
 	if r.CPUSet == "" {
 		return nil
 	}
@@ -104,6 +107,9 @@ func (r *Resources) ValidateDefaults() error {
 }
 
 func (r *Resources) MutateSpec(specgen *generate.Generator) {
+	if r == nil {
+		return
+	}
 	if r.CPUSet != "" {
 		specgen.SetLinuxResourcesCPUCpus(r.CPUSet)
 	}

--- a/test/workloads.bats
+++ b/test/workloads.bats
@@ -269,3 +269,20 @@ function check_conmon_fields() {
 	ctr_id=$(crictl run "$ctrconfig" "$sboxconfig")
 	check_conmon_fields "$ctr_id" "$shares" "$set"
 }
+
+@test "should succeed to create workload with empty resources" {
+	cat << EOF > "$CRIO_CONFIG_DIR/01-workload.conf"
+[crio.runtime.workloads.management]
+activation_annotation = "$activation"
+annotation_prefix = "$prefix"
+EOF
+	start_crio
+
+	jq --arg act "$activation" ' .annotations[$act] = "true"' \
+		"$TESTDATA"/sandbox_config.json > "$sboxconfig"
+
+	jq --arg act "$activation" ' .annotations[$act] = "true"' \
+		"$TESTDATA"/container_sleep.json > "$ctrconfig"
+
+	ctr_id=$(crictl run "$ctrconfig" "$sboxconfig")
+}


### PR DESCRIPTION
Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a segfault if a workload is configured without the resources table
```
