### PR TITLE
RFC: Do not use repo digests as image references

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -220,9 +220,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 
 	imageName := imgResult.Name
 	imageRef := imgResult.ID
-	if len(imgResult.RepoDigests) > 0 {
-		imageRef = imgResult.RepoDigests[0]
-	}
 
 	labelOptions, err := ctr.SelinuxLabel(sb.ProcessLabel())
 	if err != nil {

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -257,12 +257,8 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 	if err != nil {
 		return "", err
 	}
-	imageRef := status.ID
-	if len(status.RepoDigests) > 0 {
-		imageRef = status.RepoDigests[0]
-	}
 
-	return imageRef, nil
+	return status.ID, nil
 }
 
 func tryIncrementImagePullFailureMetric(img string, err error) {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -317,7 +317,7 @@ function check_images() {
     eval "$(jq -r '.images[] |
         select(.repoTags[0] == "quay.io/crio/redis:alpine") |
         "REDIS_IMAGEID=" + .id + "\n" +
-	"REDIS_IMAGEREF=" + .repoDigests[0]' <<<"$json")"
+	"REDIS_IMAGEREF=" + .id' <<<"$json")"
 }
 
 function start_crio_no_setup() {

--- a/test/image.bats
+++ b/test/image.bats
@@ -88,7 +88,6 @@ function teardown() {
 	crictl start "$ctr_id"
 	output=$(crictl inspect -o yaml "$ctr_id")
 	[[ "$output" == *"image: $IMAGE_LIST_DIGEST"* ]]
-	[[ "$output" == *"imageRef: $IMAGE_LIST_DIGEST"* ]]
 }
 
 @test "image pull and list" {

--- a/test/inspect.bats
+++ b/test/inspect.bats
@@ -32,12 +32,12 @@ function teardown() {
 	out=$(echo -e "GET /containers/$ctr_id HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:"$CRIO_SOCKET")
 	[[ "$out" == *"\"sandbox\":\"$pod_id\""* ]]
 	[[ "$out" == *"\"image\":\"quay.io/crio/redis:alpine\""* ]]
-	[[ "$out" == *"\"image_ref\":\"$REDIS_IMAGEREF\""* ]]
+	[[ "$out" == *"\"image_ref\":\"$REDIS_IMAGEID\""* ]]
 
 	output=$(crictl inspect --output json "$ctr_id")
 	[[ "$output" == *"\"id\": \"$ctr_id\""* ]]
 	[[ "$output" == *"\"image\": \"quay.io/crio/redis:alpine\""* ]]
-	[[ "$output" == *"\"imageRef\": \"$REDIS_IMAGEREF\""* ]]
+	[[ "$output" == *"\"imageRef\": \"$REDIS_IMAGEID\""* ]]
 
 	output=$(crictl inspectp --output json "$pod_id")
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Repo digests can change on pull or tag, while we then invalidate the
`imageRef` in the container status. To avoid such scenarios, we now
always reference the image ID.

Ref: https://github.com/kubernetes/cri-api/blob/c4e249a/pkg/apis/runtime/v1/api.proto#L1048-L1050

#### Which issue(s) this PR fixes:

Fixes https://github.com/cri-o/cri-o/issues/5479

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where image references in container statuses are invalid digests because of an image pull or re-tag. We now always reference image ID's there.
```
