### PR TITLE
clarify some error messages

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -94,11 +94,11 @@ func (s *Server) configureSandboxIDMappings(mode string, sc *types.LinuxSandboxS
 	if uidMappingsPresent || gidMappingsPresent {
 		user := sc.RunAsUser
 		if user == nil {
-			return nil, errors.New("cannot use uidmapping or gidmapping if not running as root")
+			return nil, errors.New("cannot use uidmapping or gidmapping if RunAsUser is not set")
 		}
 		if user.Value != 0 {
 			if minimumMappableUID < 0 {
-				return nil, errors.New("cannot use uidmapping or gidmapping if not running as root")
+				return nil, errors.New("cannot use uidmapping or gidmapping if not running as root and minimum mappable ID is not set")
 			}
 			if user.Value < minimumMappableUID {
 				return nil, errors.Errorf("cannot use uidmapping or gidmapping if running as a UID below minimum mappable ID %d", minimumMappableUID)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Some error messages related to userns mappings do not quite match
CRI-O's behaviour.  Furthermore, the same error message was used for
two different conditions.  Make the error messages clearer and more
actionable.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Improved some error messages related to user namespaces.
```