### PR TITLE
Do not set process label to privileged when host network is true

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -280,10 +280,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 		processLabel, mountLabel = "", ""
 	}
 
-	if hostNet {
-		processLabel = ""
-	}
-
 	maybeRelabel := false
 	if val, present := sb.Annotations()[crioann.TrySkipVolumeSELinuxLabelAnnotation]; present && val == "true" {
 		maybeRelabel = true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We do not set the process label any more on host network to increase the
default security.

Reverts 349b85a7f2b97d23fd65490289bf5d66e888e0f9

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/5501
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Do not set `spc_t` type for host network containers any more.
```
