### PR TITLE
[Bug 2034296] Inherits storage configs from storage.conf if crio config does not set

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -597,6 +597,10 @@ func (c *Config) UpdateFromDropInFile(path string) error {
 	// keeps the storage options from storage.conf and merge it to crio config
 	var storageOpts []string
 	storageOpts = append(storageOpts, c.StorageOptions...)
+	// storage configurations from storage.conf, if crio config has no values for these, they will be merged to crio config
+	graphRoot := c.Root
+	runRoot := c.RunRoot
+	storageDriver := c.Storage
 
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -620,6 +624,16 @@ func (c *Config) UpdateFromDropInFile(path string) error {
 	storageOpts = append(storageOpts, t.Crio.RootConfig.StorageOptions...)
 	storageOpts = removeDupStorageOpts(storageOpts)
 	t.Crio.RootConfig.StorageOptions = storageOpts
+	// inherits storage configurations from storage.conf
+	if t.Crio.Root == "" {
+		t.Crio.Root = graphRoot
+	}
+	if t.Crio.RunRoot == "" {
+		t.Crio.RunRoot = runRoot
+	}
+	if t.Crio.Storage == "" {
+		t.Crio.Storage = storageDriver
+	}
 
 	// Registries are deprecated in cri-o.conf and turned into a NOP.
 	// Users should use registries.conf instead, so let's log it.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -872,6 +872,96 @@ var _ = t.Describe("Config", func() {
 			}
 		})
 
+		It("should inherit graphroot from storage.conf if crio root is empty", func() {
+			f := t.MustTempFile("config")
+			for _, tc := range []struct {
+				criocfg   []byte
+				graphRoot string
+				expect    string
+			}{
+				{[]byte(`
+				[crio]
+				root = ""
+				`,
+				), "/test/storage", "/test/storage"},
+				{[]byte(`
+				[crio]
+				root = "/test/crio/storage"
+				`,
+				), "/test/storage", "/test/crio/storage"},
+			} {
+				Expect(ioutil.WriteFile(f, tc.criocfg, 0)).To(BeNil())
+				// When
+				defaultcfg := defaultConfig()
+				defaultcfg.Root = tc.graphRoot
+				err := defaultcfg.UpdateFromFile(f)
+
+				// Then
+				Expect(err).To(BeNil())
+				Expect(defaultcfg.Root).To(Equal(tc.expect))
+			}
+		})
+
+		It("should inherit runroot from storage.conf if crio runroot is empty", func() {
+			f := t.MustTempFile("config")
+			for _, tc := range []struct {
+				criocfg []byte
+				runRoot string
+				expect  string
+			}{
+				{[]byte(`
+				[crio]
+				runroot = ""
+				`,
+				), "/test/storage", "/test/storage"},
+				{[]byte(`
+				[crio]
+				runroot = "/test/crio/storage"
+				`,
+				), "/test/storage", "/test/crio/storage"},
+			} {
+				Expect(ioutil.WriteFile(f, tc.criocfg, 0)).To(BeNil())
+				// When
+				defaultcfg := defaultConfig()
+				defaultcfg.RunRoot = tc.runRoot
+				err := defaultcfg.UpdateFromFile(f)
+
+				// Then
+				Expect(err).To(BeNil())
+				Expect(defaultcfg.RunRoot).To(Equal(tc.expect))
+			}
+		})
+
+		It("should inherit runroot from storage.conf if crio runroot is empty", func() {
+			f := t.MustTempFile("config")
+			for _, tc := range []struct {
+				criocfg       []byte
+				storageDriver string
+				expect        string
+			}{
+				{[]byte(`
+				[crio]
+				storage_driver = ""
+				`,
+				), "/test/storage", "/test/storage"},
+				{[]byte(`
+				[crio]
+				storage_driver = "/test/crio/storage"
+				`,
+				), "/test/storage", "/test/crio/storage"},
+			} {
+				Expect(ioutil.WriteFile(f, tc.criocfg, 0)).To(BeNil())
+				// When
+				defaultcfg := defaultConfig()
+				defaultcfg.Storage = tc.storageDriver
+				err := defaultcfg.UpdateFromFile(f)
+
+				// Then
+				Expect(err).To(BeNil())
+				Expect(defaultcfg.Storage).To(Equal(tc.expect))
+			}
+		})
+
 		It("should succeed with custom runtime", func() {
 			// Given
 			f := t.MustTempFile("config")


### PR DESCRIPTION
Inherits graphroot, runroot, storage_driver from storage.conf if these configs of crio.conf [crio] is "".
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2034296
Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Inherits storage configs from storage.conf if crio config does not set.
```
