### PR TITLE
namespace: drop and replace stop method

### DIFF
--- a/internal/config/nsmgr/types.go
+++ b/internal/config/nsmgr/types.go
@@ -52,10 +52,7 @@ type Namespace interface {
 	// Type returns the namespace type (net, ipc, user, pid or uts).
 	Type() NSType
 
-	// Close ensures this namespace is closed.
-	Close() error
-
-	// Remove ensures this namespace is removed.
+	// Remove ensures this namespace is closed and removed.
 	Remove() error
 }
 
@@ -88,13 +85,13 @@ func (n *namespace) Type() NSType {
 	return n.nsType
 }
 
-// Close ensures this namespace is closed.
-func (n *namespace) Close() error {
+// Remove ensures this namespace is closed and removed.
+func (n *namespace) Remove() error {
 	n.Lock()
 	defer n.Unlock()
 
 	if n.closed {
-		// Close() can be called multiple
+		// Remove() can be called multiple
 		// times without returning an error.
 		return nil
 	}
@@ -105,29 +102,16 @@ func (n *namespace) Close() error {
 
 	n.closed = true
 
-	if n.nsPath == "" {
+	fp := n.Path()
+	if fp == "" {
 		return nil
 	}
 
 	// try to unmount, ignoring "not mounted" (EINVAL) error.
-	if err := unix.Unmount(n.nsPath, unix.MNT_DETACH); err != nil && err != unix.EINVAL {
-		return errors.Wrapf(err, "unable to unmount %s", n.nsPath)
+	if err := unix.Unmount(fp, unix.MNT_DETACH); err != nil && err != unix.EINVAL {
+		return errors.Wrapf(err, "unable to unmount %s", fp)
 	}
-	return nil
-}
-
-// Remove ensures this namespace is closed and removed.
-func (n *namespace) Remove() error {
-	n.Lock()
-	defer n.Unlock()
-	if !n.closed {
-		return errors.New("Namespace must be closed before it can be removed")
-	}
-
-	if n.nsPath == "" {
-		return nil
-	}
-	return os.Remove(n.nsPath)
+	return os.Remove(fp)
 }
 
 // GetNamespace takes a path and type, checks if it is a namespace, and if so
@@ -135,10 +119,6 @@ func (n *namespace) Remove() error {
 func GetNamespace(nsPath string, nsType NSType) (Namespace, error) {
 	ns, err := nspkg.GetNS(nsPath)
 	if err != nil {
-		// path exists but is not an NS, the namespace must have been closed
-		if _, ok := err.(nspkg.NSPathNotNSErr); ok {
-			return &namespace{nsType: nsType, nsPath: nsPath, closed: true}, nil
-		}
 		return nil, err
 	}
 

--- a/internal/config/nsmgr/types.go
+++ b/internal/config/nsmgr/types.go
@@ -119,7 +119,8 @@ func (n *namespace) Remove() error {
 func GetNamespace(nsPath string, nsType NSType) (Namespace, error) {
 	ns, err := nspkg.GetNS(nsPath)
 	if err != nil {
-		return nil, err
+		// Failed to GetNS. It's possible this is expected (pod is stopped).
+		return &namespace{nsType: nsType, nsPath: nsPath, closed: true}, err
 	}
 
 	return &namespace{ns: ns, nsType: nsType, nsPath: nsPath}, nil

--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -90,21 +90,10 @@ func (s *Sandbox) NamespacePaths() []*ManagedNamespace {
 	return typesAndPaths
 }
 
-// CloseManagedNamespaces cleans up after managing the namespaces.
-// It unmounts all of the namespaces, but does not remove their parent directory.
-func (s *Sandbox) CloseManagedNamespaces() error {
-	return s.runFunctionOnNamespaces(func(ns nsmgr.Namespace) error {
-		return ns.Close()
-	})
-}
-
 // RemoveManagedNamespaces removes the formerly mounted namespace.
 // Must be stopped first or this will fail.
 func (s *Sandbox) RemoveManagedNamespaces() error {
 	return s.runFunctionOnNamespaces(func(ns nsmgr.Namespace) error {
-		if err := ns.Close(); err != nil {
-			return err
-		}
 		return ns.Remove()
 	})
 }

--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -130,10 +130,12 @@ func (s *Sandbox) NetNsPath() string {
 // This will fail if the sandbox is already part of a network namespace
 func (s *Sandbox) NetNsJoin(nspath string) error {
 	ns, err := nsJoin(nspath, nsmgr.NETNS, s.netns)
-	if err != nil {
+	// Regardless of error, set the namespace
+	s.netns = ns
+	// Only error if the sandbox is not stopped
+	if err != nil && !s.stopped {
 		return err
 	}
-	s.netns = ns
 	return nil
 }
 
@@ -148,12 +150,17 @@ func (s *Sandbox) IpcNsPath() string {
 // IpcNsJoin attempts to join the sandbox to an existing IPC namespace
 // This will fail if the sandbox is already part of a IPC namespace
 func (s *Sandbox) IpcNsJoin(nspath string) error {
+	if s.stopped {
+		return nil
+	}
 	ns, err := nsJoin(nspath, nsmgr.IPCNS, s.ipcns)
-	if err != nil {
+	// Regardless of error, set the namespace
+	s.ipcns = ns
+	// Only error if the sandbox is not stopped
+	if err != nil && !s.stopped {
 		return err
 	}
-	s.ipcns = ns
-	return err
+	return nil
 }
 
 // UtsNs specific functions
@@ -167,12 +174,17 @@ func (s *Sandbox) UtsNsPath() string {
 // UtsNsJoin attempts to join the sandbox to an existing UTS namespace
 // This will fail if the sandbox is already part of a UTS namespace
 func (s *Sandbox) UtsNsJoin(nspath string) error {
+	if s.stopped {
+		return nil
+	}
 	ns, err := nsJoin(nspath, nsmgr.UTSNS, s.utsns)
-	if err != nil {
+	// Regardless of error, set the namespace
+	s.utsns = ns
+	// Only error if the sandbox is not stopped
+	if err != nil && !s.stopped {
 		return err
 	}
-	s.utsns = ns
-	return err
+	return nil
 }
 
 // UserNs specific functions
@@ -187,11 +199,13 @@ func (s *Sandbox) UserNsPath() string {
 // This will fail if the sandbox is already part of a User namespace
 func (s *Sandbox) UserNsJoin(nspath string) error {
 	ns, err := nsJoin(nspath, nsmgr.USERNS, s.userns)
-	if err != nil {
+	// Regardless of error, set the namespace
+	s.userns = ns
+	// Only error if the sandbox is not stopped
+	if err != nil && !s.stopped {
 		return err
 	}
-	s.userns = ns
-	return err
+	return nil
 }
 
 // PidNs specific functions

--- a/internal/lib/sandbox/namespaces_test.go
+++ b/internal/lib/sandbox/namespaces_test.go
@@ -178,6 +178,39 @@ var _ = t.Describe("SandboxManagedNamespaces", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 		})
+		It("should fail when asked to join a non-namespace", func() {
+			// Given
+			// When
+			err := testSandbox.NetNsJoin("/tmp")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+		It("should fail when asked to join a non-namespace", func() {
+			// Given
+
+			// When
+			err := testSandbox.IpcNsJoin("/tmp")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+		It("should fail when asked to join a non-namespace", func() {
+			// Given
+			// When
+			err := testSandbox.UtsNsJoin("/tmp")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+		It("should fail when asked to join a non-namespace", func() {
+			// Given
+			// When
+			err := testSandbox.UserNsJoin("/tmp")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
 	})
 	t.Describe("*NsPath", func() {
 		It("should get nothing when network not set", func() {

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -600,8 +600,5 @@ func (c *Container) RemoveManagedPIDNamespace() error {
 	if c.pidns == nil {
 		return nil
 	}
-	if err := c.pidns.Close(); err != nil {
-		return errors.Wrapf(err, "close PID namespace for container %s", c.ID())
-	}
 	return errors.Wrapf(c.pidns.Remove(), "remove PID namespace for container %s", c.ID())
 }

--- a/pkg/container/namespaces_test.go
+++ b/pkg/container/namespaces_test.go
@@ -194,7 +194,6 @@ var _ = t.Describe("Container:SpecAddNamespaces", func() {
 		Expect(sut.SetConfig(ctrConfig, sboxConfig)).To(BeNil())
 		sut.Spec().ClearLinuxNamespaces()
 		Expect(sut.SpecAddNamespaces(sb, targetCtr, cfg)).To(BeNil())
-		defer Expect(sut.PidNamespace().Close()).To(BeNil())
 		defer Expect(sut.PidNamespace().Remove()).To(BeNil())
 
 		// Then

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -86,6 +86,10 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		}
 	}
 
+	if err := sb.RemoveManagedNamespaces(); err != nil {
+		return errors.Wrap(err, "unable to remove managed namespaces")
+	}
+
 	if err := sb.UnmountShm(); err != nil {
 		return err
 	}

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -86,10 +86,6 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		}
 	}
 
-	if err := sb.CloseManagedNamespaces(); err != nil {
-		return errors.Wrap(err, "unable to close managed namespaces")
-	}
-
 	if err := sb.UnmountShm(); err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -520,18 +520,56 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []string)
 	if !s.config.InternalWipe {
 		return
 	}
+	var (
+		shouldWipeContainers, shouldWipeImages bool
+		err                                    error
+	)
+
 	// Check if our persistent version file is out of date.
 	// If so, we have upgrade, and we should wipe images.
-	shouldWipeImages, err := version.ShouldCrioWipe(s.config.VersionFilePersist)
+	shouldWipeImages, err = version.ShouldCrioWipe(s.config.VersionFilePersist)
 	if err != nil {
 		log.Warnf(ctx, "Error encountered when checking whether cri-o should wipe images: %v", err)
+	}
+
+	// Unconditionally wipe containers if we should wipe images.
+	if shouldWipeImages {
+		shouldWipeContainers = true
+	} else {
+		// Check if our version file is out of date.
+		// If so, we rebooted, and we should wipe containers.
+		shouldWipeContainers, err = version.ShouldCrioWipe(s.config.VersionFile)
+		if err != nil {
+			log.Warnf(ctx, "Error encountered when checking whether cri-o should wipe containers: %v", err)
+		}
+	}
+
+	// Translate to a map so the images are only attempted to be deleted once.
+	imageMapToDelete := make(map[string]struct{})
+	for _, img := range imagesToDelete {
+		imageMapToDelete[img] = struct{}{}
+	}
+
+	// Attempt to wipe containers, adding the images that were removed on the way.
+	if shouldWipeContainers {
+		// Best-effort append to imageMapToDelete
+		if ctrs, err := s.ContainerServer.ListContainers(); err == nil {
+			for _, ctr := range ctrs {
+				imageMapToDelete[ctr.ImageRef()] = struct{}{}
+			}
+		}
+		for _, sb := range s.ContainerServer.ListSandboxes() {
+			if err := s.removePodSandbox(ctx, sb); err != nil {
+				log.Warnf(ctx, "Failed to remove sandbox %s: %v", sb.ID(), err)
+			}
+		}
 	}
 
 	// Note: some of these will fail if some aspect of the pod cleanup failed as well,
 	// but this is best-effort anyway, as the Kubelet will eventually cleanup images when
 	// disk usage gets too high.
 	if shouldWipeImages {
-		for _, img := range imagesToDelete {
+		for img := range imageMapToDelete {
 			if err := s.removeImage(ctx, img); err != nil {
 				log.Warnf(ctx, "Failed to remove image %s: %v", img, err)
 			}

--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -228,13 +228,24 @@ function start_crio_with_stopped_pod() {
 	test_crio_wiped_images
 }
 
-@test "internal_wipe remove containers when remove temporary" {
+@test "internal_wipe remove containers when remove temporary and node reboots" {
 	start_crio_with_stopped_pod
 	stop_crio_no_clean
 
 	rm "$CONTAINER_VERSION_FILE"
 	# simulate a reboot by having a removable namespaces dir
 	cleanup_namespaces_dir
+
+	CONTAINER_INTERNAL_WIPE=true start_crio_no_setup
+	test_crio_wiped_containers
+	test_crio_did_not_wipe_images
+}
+
+@test "internal_wipe remove containers when remove temporary" {
+	start_crio_with_stopped_pod
+	stop_crio_no_clean
+
+	rm "$CONTAINER_VERSION_FILE"
 
 	CONTAINER_INTERNAL_WIPE=true start_crio_no_setup
 	test_crio_wiped_containers

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -53,6 +53,22 @@ function teardown() {
 	[[ "${output}" == "${ctr_status_info}" ]]
 }
 
+@test "crio restore with pod stopped" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	crictl stopp "$pod_id"
+
+	output1=$(crictl pods -o json)
+
+	stop_crio
+
+	start_crio
+	output2=$(crictl pods -o json)
+
+	[[ "$output1" == "$output2" ]]
+}
+
 @test "crio restore with bad state and pod stopped" {
 	start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
Unfortunately, having an unmounted namespace in /var/run/netns causes `ip a` to report `Error: Peer netns reference is invalid`. To fix this, we need to partially revert https://github.com/cri-o/cri-o/pull/5336/commits/efcf8afe6a7b7f942833746a1b357e591000153c and replace it.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
related to https://bugzilla.redhat.com/show_bug.cgi?id=2035969
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix bug where `ip a` reports `Error: Peer netns reference is invalid`
```
