### PR TITLE
restore: ensure containers are wiped on reboot

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -520,18 +520,56 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []string)
 	if !s.config.InternalWipe {
 		return
 	}
+	var (
+		shouldWipeContainers, shouldWipeImages bool
+		err                                    error
+	)
+
 	// Check if our persistent version file is out of date.
 	// If so, we have upgrade, and we should wipe images.
-	shouldWipeImages, err := version.ShouldCrioWipe(s.config.VersionFilePersist)
+	shouldWipeImages, err = version.ShouldCrioWipe(s.config.VersionFilePersist)
 	if err != nil {
 		log.Warnf(ctx, "Error encountered when checking whether cri-o should wipe images: %v", err)
+	}
+
+	// Unconditionally wipe containers if we should wipe images.
+	if shouldWipeImages {
+		shouldWipeContainers = true
+	} else {
+		// Check if our version file is out of date.
+		// If so, we rebooted, and we should wipe containers.
+		shouldWipeContainers, err = version.ShouldCrioWipe(s.config.VersionFile)
+		if err != nil {
+			log.Warnf(ctx, "Error encountered when checking whether cri-o should wipe containers: %v", err)
+		}
+	}
+
+	// Translate to a map so the images are only attempted to be deleted once.
+	imageMapToDelete := make(map[string]struct{})
+	for _, img := range imagesToDelete {
+		imageMapToDelete[img] = struct{}{}
+	}
+
+	// Attempt to wipe containers, adding the images that were removed on the way.
+	if shouldWipeContainers {
+		// Best-effort append to imageMapToDelete
+		if ctrs, err := s.ContainerServer.ListContainers(); err == nil {
+			for _, ctr := range ctrs {
+				imageMapToDelete[ctr.ImageRef()] = struct{}{}
+			}
+		}
+		for _, sb := range s.ContainerServer.ListSandboxes() {
+			if err := s.removePodSandbox(ctx, sb); err != nil {
+				log.Warnf(ctx, "Failed to remove sandbox %s: %v", sb.ID(), err)
+			}
+		}
 	}
 
 	// Note: some of these will fail if some aspect of the pod cleanup failed as well,
 	// but this is best-effort anyway, as the Kubelet will eventually cleanup images when
 	// disk usage gets too high.
 	if shouldWipeImages {
-		for _, img := range imagesToDelete {
+		for img := range imageMapToDelete {
 			if err := s.removeImage(ctx, img); err != nil {
 				log.Warnf(ctx, "Failed to remove image %s: %v", img, err)
 			}

--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -228,13 +228,24 @@ function start_crio_with_stopped_pod() {
 	test_crio_wiped_images
 }
 
-@test "internal_wipe remove containers when remove temporary" {
+@test "internal_wipe remove containers when remove temporary and node reboots" {
 	start_crio_with_stopped_pod
 	stop_crio_no_clean
 
 	rm "$CONTAINER_VERSION_FILE"
 	# simulate a reboot by having a removable namespaces dir
 	cleanup_namespaces_dir
+
+	CONTAINER_INTERNAL_WIPE=true start_crio_no_setup
+	test_crio_wiped_containers
+	test_crio_did_not_wipe_images
+}
+
+@test "internal_wipe remove containers when remove temporary" {
+	start_crio_with_stopped_pod
+	stop_crio_no_clean
+
+	rm "$CONTAINER_VERSION_FILE"
 
 	CONTAINER_INTERNAL_WIPE=true start_crio_no_setup
 	test_crio_wiped_containers


### PR DESCRIPTION
If pods were successfully restored, but the node rebooted, then the pods should be removed

Note: this currently doesn't happen, as the pod currently fails to restore because
the their namespaces are in a tmpfs, but eventually a pod will be able to exist without its namespace
existing.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
