### PR TITLE
[metrics] Fixed a problem where metricImagePullsBytesTotal was raising an error

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -521,13 +521,6 @@ func (m *Metrics) MetricImagePullsByDigestAdd(add float64, values ...string) {
 		return
 	}
 	c.Add(add)
-
-	c, err = m.metricImagePullsBytesTotal.GetMetricWithLabelValues(values...)
-	if err != nil {
-		logrus.Warnf("Unable to write image pulls by digest metric: %v", err)
-		return
-	}
-	c.Add(add)
 }
 
 func (m *Metrics) MetricImagePullsByNameAdd(add float64, values ...string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
Fixes a problem with image pull metrics that got introduced by https://github.com/cri-o/cri-o/pull/5487 accidentally.


#### Which issue(s) this PR fixes:

Following CI test job https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws/1474040369288056832 is reporting the following CRI-O metric error in the node logs.

```
Dec 23 16:31:43.856269 ip-10-0-152-30 crio[1336]: time="2021-12-23 16:31:43.856139768Z" level=warning msg="Unable to write image pulls by digest metric: inconsistent label cardinality: expected 2 label values but got 4 in []string{\"image-registry.openshift-image-registry.svc:5000/e2e-test-build-volumes-slncv/mydockerstream@sha256:4500255aeb9969639ccbc31a8e526c206b5072c39e633797a93f9634e28dec0a\", \"sha256:cca576824a92d289cb182049d9f8121f41e75ed9d25d7014f8db9a0fae1d0538\", \"application/vnd.docker.container.image.v1+json\", \"6397\"}"
Dec 23 16:31:43.862082 ip-10-0-152-30 crio[1336]: time="2021-12-23 16:31:43.862031782Z" level=warning msg="Unable to write image pulls by digest metric: inconsistent label cardinality: expected 2 label values but got 4 in []string{\"image-registry.openshift-image-registry.svc:5000/e2e-test-build-volumes-slncv/mydockerstream@sha256:4500255aeb9969639ccbc31a8e526c206b5072c39e633797a93f9634e28dec0a\", \"sha256:cca576824a92d289cb182049d9f8121f41e75ed9d25d7014f8db9a0fae1d0538\", \"application/vnd.docker.container.image.v1+json\", \"6397\"}" 
```

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer: 

#### Does this PR introduce a user-facing change?
No

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
