### PR TITLE
pkg/container: fix container device GID fallback.

### DIFF
--- a/pkg/container/device.go
+++ b/pkg/container/device.go
@@ -110,7 +110,7 @@ func (c *container) specAddContainerConfigDevices(enableDeviceOwnershipFromSecur
 				Major: dev.Major,
 				Minor: dev.Minor,
 				UID:   getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsUser, dev.Uid, enableDeviceOwnershipFromSecurityContext),
-				GID:   getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsGroup, dev.Uid, enableDeviceOwnershipFromSecurityContext),
+				GID:   getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsGroup, dev.Gid, enableDeviceOwnershipFromSecurityContext),
 			}
 			c.Spec().AddDevice(rd)
 			sp.Linux.Resources.Devices = append(sp.Linux.Resources.Devices, rspec.LinuxDeviceCgroup{

--- a/pkg/container/device_test.go
+++ b/pkg/container/device_test.go
@@ -94,7 +94,16 @@ var _ = t.Describe("Container", func() {
 		hostDevices, err := devices.HostDevices()
 		Expect(err).To(BeNil())
 
+		// Find a host device with uid != gid using first device as fallback.
 		testDevice := hostDevices[0]
+		if testDevice.Uid == testDevice.Gid {
+			for _, d := range hostDevices {
+				if d.Uid != d.Gid {
+					testDevice = d
+					break
+				}
+			}
+		}
 
 		tests := []testdata{
 			{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes in some cases incorrectly chosen device node group ID in containers.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Pass host side GID, not UID, as fallback GID to getDeviceUserGroupID().
Update the corresponding unit tests to trigger/catch the original bug.

#### Does this PR introduce a user-facing change?

```release-note
None
```
