### PR TITLE
Bug 2043254: pass the main image mount point to fix crypto profiles binding

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -714,7 +714,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrIface.Contai
 		mountLabel,
 		containerInfo.RunDir,
 		s.config.DefaultMountsFile,
-		containerInfo.RunDir,
+		mountPoint,
 		0,
 		0,
 		rootless.IsRootless(),


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
createSandboxContainer is passing down the wrong root image path to MountsWithUIDGID. This results in the directory not being discoverable within the container image and have crio setup the bind for the directory.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix crypto-profile bind within RHEL based containers.
```
