### PR TITLE
create /etc/mtab safely

### DIFF
--- a/vendor/github.com/containers/podman/v3/libpod/container_internal.go
+++ b/vendor/github.com/containers/podman/v3/libpod/container_internal.go
@@ -37,6 +37,7 @@ import (
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -1531,14 +1532,49 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 		}()
 	}
 
+	rootUID, rootGID := c.RootUID(), c.RootGID()
+
+	dirfd, err := unix.Open(mountPoint, unix.O_RDONLY|unix.O_PATH, 0)
+	if err != nil {
+		return "", errors.Wrap(err, "open mount point")
+	}
+	defer unix.Close(dirfd)
+
+	err = unix.Mkdirat(dirfd, "etc", 0755)
+	if err != nil && !os.IsExist(err) {
+		return "", errors.Wrap(err, "create /etc")
+	}
+	// If the etc directory was created, chown it to root in the container
+	if err == nil && (rootUID != 0 || rootGID != 0) {
+		err = unix.Fchownat(dirfd, "etc", rootUID, rootGID, unix.AT_SYMLINK_NOFOLLOW)
+		if err != nil {
+			return "", errors.Wrap(err, "chown /etc")
+		}
+	}
+
+	etcInTheContainerPath, err := securejoin.SecureJoin(mountPoint, "etc")
+	if err != nil {
+		return "", errors.Wrap(err, "resolve /etc in the container")
+	}
+
+	etcInTheContainerFd, err := unix.Open(etcInTheContainerPath, unix.O_RDONLY|unix.O_PATH, 0)
+	if err != nil {
+		return "", errors.Wrap(err, "open /etc in the container")
+	}
+	defer unix.Close(etcInTheContainerFd)
+
 	// If /etc/mtab does not exist in container image, then we need to
 	// create it, so that mount command within the container will work.
-	mtab := filepath.Join(mountPoint, "/etc/mtab")
-	if err := idtools.MkdirAllAs(filepath.Dir(mtab), 0755, c.RootUID(), c.RootGID()); err != nil {
-		return "", errors.Wrap(err, "error creating mtab directory")
+	err = unix.Symlinkat("/proc/mounts", etcInTheContainerFd, "mtab")
+	if err != nil && !os.IsExist(err) {
+		return "", errors.Wrap(err, "creating /etc/mtab symlink")
 	}
-	if err = os.Symlink("/proc/mounts", mtab); err != nil && !os.IsExist(err) {
-		return "", err
+	// If the symlink was created, then also chown it to root in the container
+	if err == nil && (rootUID != 0 || rootGID != 0) {
+		err = unix.Fchownat(etcInTheContainerFd, "mtab", rootUID, rootGID, unix.AT_SYMLINK_NOFOLLOW)
+		if err != nil {
+			return "", errors.Wrap(err, "chown /etc/mtab")
+		}
 	}
 
 	// Request a mount of all named volumes


### PR DESCRIPTION
Closes: #5563

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
to allow android in container usage
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #5563
<!--
Fixes #5563
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make sure the /etc/mtab symlink is created inside the rootfs when /etc is a symlink (#5563)
```
