### PR TITLE
Fix vm containers could not restore after CRI-O restart

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -241,10 +241,17 @@ func (r *Runtime) RuntimeImpl(c *Container) (RuntimeImpl, error) {
 	r.runtimeImplMapMutex.RLock()
 	impl, ok := r.runtimeImplMap[c.ID()]
 	r.runtimeImplMapMutex.RUnlock()
-	if !ok {
-		return r.newRuntimeImpl(c)
+	if ok {
+		return impl, nil
 	}
 
+	impl, err := r.newRuntimeImpl(c)
+	if err != nil {
+		return nil, err
+	}
+	r.runtimeImplMapMutex.Lock()
+	r.runtimeImplMap[c.ID()] = impl
+	r.runtimeImplMapMutex.Unlock()
 	return impl, nil
 }
 

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -3,6 +3,7 @@ package oci
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -13,6 +14,7 @@ import (
 
 	cgroups "github.com/containerd/cgroups/stats/v1"
 	tasktypes "github.com/containerd/containerd/api/types/task"
+	ctrio "github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/namespaces"
 	client "github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/containerd/containerd/runtime/v2/task"
@@ -87,6 +89,52 @@ func newRuntimeVM(path, root, configPath string) RuntimeImpl {
 		ctx:        context.Background(),
 		ctrs:       make(map[string]containerInfo),
 	}
+}
+
+func (r *runtimeVM) createContainerIO(ctx context.Context, c *Container, cioOpts ...cio.ContainerIOOpts) (_ *cio.ContainerIO, retErr error) {
+	// Create IO fifos
+	containerIO, err := cio.NewContainerIO(c.ID(), cioOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if retErr != nil {
+			containerIO.Close()
+		}
+	}()
+
+	f, err := os.OpenFile(c.LogPath(), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, err
+	}
+
+	var stdoutCh, stderrCh <-chan struct{}
+	wc := cioutil.NewSerialWriteCloser(f)
+	stdout, stdoutCh := cio.NewCRILogger(c.LogPath(), wc, cio.Stdout, -1)
+	stderr, stderrCh := cio.NewCRILogger(c.LogPath(), wc, cio.Stderr, -1)
+
+	go func() {
+		if stdoutCh != nil {
+			<-stdoutCh
+		}
+		if stderrCh != nil {
+			<-stderrCh
+		}
+		log.Debugf(ctx, "Finish redirecting log file %q, closing it", c.LogPath())
+		f.Close()
+	}()
+
+	containerIO.AddOutput(c.LogPath(), stdout, stderr)
+	containerIO.Pipe()
+
+	r.Lock()
+	r.ctrs[c.ID()] = containerInfo{
+		cio: containerIO,
+	}
+	r.Unlock()
+
+	return containerIO, nil
 }
 
 // CreateContainer creates a container.
@@ -657,6 +705,50 @@ func (r *runtimeVM) UpdateContainerStatus(ctx context.Context, c *Container) err
 	return r.updateContainerStatus(ctx, c)
 }
 
+func (r *runtimeVM) restoreContainerIO(ctx context.Context, c *Container, state *task.StateResponse) error {
+	r.Lock()
+	_, ok := r.ctrs[c.ID()]
+	if ok {
+		r.Unlock()
+		return nil
+	}
+	r.Unlock()
+
+	cioCfg := ctrio.Config{
+		Terminal: state.Terminal,
+		Stdin:    state.Stdin,
+		Stdout:   state.Stdout,
+		Stderr:   state.Stderr,
+	}
+	// The existing fifos is created by NewFIFOSetInDir. stdin, stdout, stderr should exist
+	// in a same temporary directory under r.fifoDir. crio is responsible for removing these
+	// files after container io is closed.
+	var iofiles []string
+	if cioCfg.Stdin != "" {
+		iofiles = append(iofiles, cioCfg.Stdin)
+	}
+	if cioCfg.Stdout != "" {
+		iofiles = append(iofiles, cioCfg.Stdout)
+	}
+	if cioCfg.Stderr != "" {
+		iofiles = append(iofiles, cioCfg.Stderr)
+	}
+	closer := func() error {
+		for _, f := range iofiles {
+			if err := os.Remove(f); err != nil {
+				return err
+			}
+		}
+		// Also try to remove the parent dir if it is empty.
+		for _, f := range iofiles {
+			_ = os.Remove(filepath.Dir(f))
+		}
+		return nil
+	}
+	_, err := r.createContainerIO(ctx, c, cio.WithFIFOs(ctrio.NewFIFOSet(cioCfg, closer)))
+	return err
+}
+
 // updateContainerStatus is a UpdateContainerStatus helper, which actually does the container's
 // status refresh.
 // It does **not** Lock the container, thus it's the caller responsibility to do so, when needed.
@@ -664,10 +756,24 @@ func (r *runtimeVM) updateContainerStatus(ctx context.Context, c *Container) err
 	log.Debugf(ctx, "RuntimeVM.updateContainerStatus() start")
 	defer log.Debugf(ctx, "RuntimeVM.updateContainerStatus() end")
 
-	// This can happen on restore, for example if we switch the runtime type
-	// for a container from "oci" to "vm" for the same runtime.
+	// This can happen on restore. We need to read shim address from the bundle path.
+	// And then connect to the existing gRPC server with this address.
 	if r.task == nil {
-		return errors.New("runtime not correctly setup")
+		addressPath := filepath.Join(c.BundlePath(), "address")
+		data, err := ioutil.ReadFile(addressPath)
+		if err != nil {
+			log.Warnf(ctx, "Failed to read shim address: %v", err)
+			return errors.New("runtime not correctly setup")
+		}
+		address := strings.TrimSpace(string(data))
+		conn, err := client.Connect(address, client.AnonDialer)
+		if err != nil {
+			return err
+		}
+		options := ttrpc.WithOnClose(func() { conn.Close() })
+		cl := ttrpc.NewClient(conn, options)
+		r.client = cl
+		r.task = task.NewTaskClient(cl)
 	}
 
 	response, err := r.task.State(r.ctx, &task.StateRequest{
@@ -678,6 +784,10 @@ func (r *runtimeVM) updateContainerStatus(ctx context.Context, c *Container) err
 			return errdefs.FromGRPC(err)
 		}
 		return errdefs.ErrNotFound
+	}
+
+	if err = r.restoreContainerIO(ctx, c, response); err != nil {
+		return errors.Wrapf(err, "failed to restore container io")
 	}
 
 	status := c.state.Status


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug

#### What this PR does / why we need it:

When cri-o is running with kata runtime, cri-o could not restore containers correctly after it restarts. The `containerd-shim-kata-v2` and `qemu-system-x86_64` processes are leak every time.

This PR attempts to restore containers properly with the existing `containerd-shim-kata-v2` and `qemu-system-x86_64` processes. `containerd-shim-kata-v2` writes the gRPC socket address under container bundle path with a file named `address`. After cri-o restarts, we can read from that file for shim socket address and connect to. Besides, we also need to restore the container io so that we can exec or attach the container.

I tested these changes on our internal cluster, everything worked well.

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/2112 https://github.com/cri-o/cri-o/issues/5569

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix vm containers couldn't restore after cri-o restart
```
