### PR TITLE
server: fix a potential NULL-pointer dereference.

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -401,7 +401,7 @@ func setupCapabilities(specgen *generate.Generator, caps *types.Capability, defa
 
 // CreateContainer creates a new container in specified PodSandbox
 func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainerRequest) (res *types.CreateContainerResponse, retErr error) {
-	log.Infof(ctx, "Creating container: %s", translateLabelsToDescription(req.Config.Labels))
+	log.Infof(ctx, "Creating container: %s", translateLabelsToDescription(req.GetConfig().GetLabels()))
 
 	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
 	if err != nil {

--- a/server/container_create_test.go
+++ b/server/container_create_test.go
@@ -114,7 +114,6 @@ var _ = t.Describe("ContainerCreate", func() {
 			response, err := sut.CreateContainer(context.Background(),
 				&types.CreateContainerRequest{
 					PodSandboxId:  testSandbox.ID(),
-					Config:        newContainerConfig(),
 					SandboxConfig: newPodSandboxConfig(),
 				})
 


### PR DESCRIPTION
Fix a potential NULL-pointer dereference in a log message.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a potential NULL-pointer dereference in a log message that could crash the daemon.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None


```release-note
Fix a potential crash caused by a log message NULL-pointer dereference.
```
