### PR TITLE
Enable `--seccomp-use-default-when-empty` by default

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -127,7 +127,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -l root -s r -r -d 'The CRI-O ro
 complete -c crio -n '__fish_crio_no_subcommand' -l runroot -r -d 'The CRI-O state directory'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l runtimes -r -d 'OCI runtimes, format is runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path'
 complete -c crio -n '__fish_crio_no_subcommand' -l seccomp-profile -r -d 'Path to the seccomp.json profile to be used as the runtime\'s default. If not specified, then the internal default seccomp profile will be used. (default: "")'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l seccomp-use-default-when-empty -r -d 'Use the default seccomp profile when an empty one is specified (default: false)'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l seccomp-use-default-when-empty -d 'Use the default seccomp profile when an empty one is specified'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l selinux -d 'Enable selinux support (default: false)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l separate-pull-cgroup -r -d '[EXPERIMENTAL] Pull in new cgroup (default: "")'
 complete -c crio -n '__fish_crio_no_subcommand' -l signature-policy -r -d 'Path to signature policy JSON file. (default: "", to use the system-wide default)'

--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -7,6 +7,7 @@
       [crio.runtime]
       cgroup_manager = "cgroupfs"
       conmon_cgroup = "pod"
+      seccomp_use_default_when_empty = false
 
 - name: enable and start CRI-O
   systemd:

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -89,7 +89,7 @@ crio
 [--runroot]=[value]
 [--runtimes]=[value]
 [--seccomp-profile]=[value]
-[--seccomp-use-default-when-empty]=[value]
+[--seccomp-use-default-when-empty]
 [--selinux]
 [--separate-pull-cgroup]=[value]
 [--signature-policy]=[value]
@@ -332,7 +332,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--seccomp-profile**="": Path to the seccomp.json profile to be used as the runtime's default. If not specified, then the internal default seccomp profile will be used. (default: "")
 
-**--seccomp-use-default-when-empty**="": Use the default seccomp profile when an empty one is specified (default: false)
+**--seccomp-use-default-when-empty**: Use the default seccomp profile when an empty one is specified
 
 **--selinux**: Enable selinux support (default: false)
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -131,7 +131,7 @@ the container runtime configuration.
 **seccomp_profile**=""
   Path to the seccomp.json profile which is used as the default seccomp profile for the runtime. If not specified, then the internal default seccomp profile will be used.
 
-**seccomp_use_default_when_empty**=false
+**seccomp_use_default_when_empty**=true
   Changes the meaning of an empty seccomp profile.  By default (and according to CRI spec), an empty profile means unconfined.
   This option tells CRI-O to treat an empty profile as the default profile, which might increase security.
 

--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -26,15 +26,17 @@ type Config struct {
 // New creates a new default seccomp configuration instance
 func New() *Config {
 	return &Config{
-		enabled: seccomp.IsEnabled(),
-		profile: seccomp.DefaultProfile(),
+		enabled:          seccomp.IsEnabled(),
+		profile:          seccomp.DefaultProfile(),
+		defaultWhenEmpty: true,
 	}
 }
 
-// Set the seccomp config to use default profile
-// when the profile is empty
-func (c *Config) SetDefaultWhenEmpty() {
-	c.defaultWhenEmpty = true
+// SetUseDefaultWhenEmpty uses the default seccomp profile if true is passed as
+// argument, otherwise unconfined.
+func (c *Config) SetUseDefaultWhenEmpty(to bool) {
+	logrus.Infof("Using seccomp default profile when unspecified: %v", to)
+	c.defaultWhenEmpty = to
 }
 
 // Returns whether the seccomp config is set to

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -588,10 +588,11 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 			EnvVars:   []string{"CONTAINER_SECCOMP_PROFILE"},
 			TakesFile: true,
 		},
-		&cli.StringFlag{
+		&cli.BoolFlag{
 			Name:    "seccomp-use-default-when-empty",
-			Usage:   fmt.Sprintf("Use the default seccomp profile when an empty one is specified (default: %t)", defConf.SeccompUseDefaultWhenEmpty),
+			Usage:   "Use the default seccomp profile when an empty one is specified",
 			EnvVars: []string{"CONTAINER_SECCOMP_USE_DEFAULT_WHEN_EMPTY"},
+			Value:   defConf.Seccomp().UseDefaultWhenEmpty(),
 		},
 		&cli.StringFlag{
 			Name:    "apparmor-profile",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -732,6 +732,7 @@ func DefaultConfig() (*Config, error) {
 		return nil, err
 	}
 	cgroupManager := cgmgr.New()
+	seccompConfig := seccomp.New()
 	return &Config{
 		Comment: "# ",
 		SystemContext: &types.SystemContext{
@@ -771,34 +772,35 @@ func DefaultConfig() (*Config, error) {
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
-			ConmonCgroup:             "system.slice",
-			SELinux:                  selinuxEnabled(),
-			ApparmorProfile:          apparmor.DefaultProfile,
-			BlockIOConfigFile:        DefaultBlockIOConfigFile,
-			IrqBalanceConfigFile:     DefaultIrqBalanceConfigFile,
-			RdtConfigFile:            rdt.DefaultRdtConfigFile,
-			CgroupManagerName:        cgroupManager.Name(),
-			PidsLimit:                DefaultPidsLimit,
-			ContainerExitsDir:        containerExitsDir,
-			ContainerAttachSocketDir: conmonconfig.ContainerAttachSocketDir,
-			MinimumMappableUID:       -1,
-			MinimumMappableGID:       -1,
-			LogSizeMax:               DefaultLogSizeMax,
-			CtrStopTimeout:           defaultCtrStopTimeout,
-			DefaultCapabilities:      capabilities.Default(),
-			LogLevel:                 "info",
-			HooksDir:                 []string{hooks.DefaultDir},
-			CDISpecDirs:              cdi.DefaultSpecDirs,
-			NamespacesDir:            defaultNamespacesDir,
-			DropInfraCtr:             true,
-			seccompConfig:            seccomp.New(),
-			apparmorConfig:           apparmor.New(),
-			blockioConfig:            blockio.New(),
-			rdtConfig:                rdt.New(),
-			ulimitsConfig:            ulimits.New(),
-			cgroupManager:            cgroupManager,
-			deviceConfig:             device.New(),
-			namespaceManager:         nsmgr.New(defaultNamespacesDir, ""),
+			ConmonCgroup:               "system.slice",
+			SELinux:                    selinuxEnabled(),
+			ApparmorProfile:            apparmor.DefaultProfile,
+			BlockIOConfigFile:          DefaultBlockIOConfigFile,
+			IrqBalanceConfigFile:       DefaultIrqBalanceConfigFile,
+			RdtConfigFile:              rdt.DefaultRdtConfigFile,
+			CgroupManagerName:          cgroupManager.Name(),
+			PidsLimit:                  DefaultPidsLimit,
+			ContainerExitsDir:          containerExitsDir,
+			ContainerAttachSocketDir:   conmonconfig.ContainerAttachSocketDir,
+			MinimumMappableUID:         -1,
+			MinimumMappableGID:         -1,
+			LogSizeMax:                 DefaultLogSizeMax,
+			CtrStopTimeout:             defaultCtrStopTimeout,
+			DefaultCapabilities:        capabilities.Default(),
+			LogLevel:                   "info",
+			HooksDir:                   []string{hooks.DefaultDir},
+			CDISpecDirs:                cdi.DefaultSpecDirs,
+			NamespacesDir:              defaultNamespacesDir,
+			DropInfraCtr:               true,
+			SeccompUseDefaultWhenEmpty: seccompConfig.UseDefaultWhenEmpty(),
+			seccompConfig:              seccomp.New(),
+			apparmorConfig:             apparmor.New(),
+			blockioConfig:              blockio.New(),
+			rdtConfig:                  rdt.New(),
+			ulimitsConfig:              ulimits.New(),
+			cgroupManager:              cgroupManager,
+			deviceConfig:               device.New(),
+			namespaceManager:           nsmgr.New(defaultNamespacesDir, ""),
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport: "docker://",
@@ -1063,9 +1065,7 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 			return errors.Wrapf(err, "initialize nsmgr")
 		}
 
-		if c.SeccompUseDefaultWhenEmpty {
-			c.seccompConfig.SetDefaultWhenEmpty()
-		}
+		c.seccompConfig.SetUseDefaultWhenEmpty(c.SeccompUseDefaultWhenEmpty)
 
 		if err := c.seccompConfig.LoadProfile(c.SeccompProfile); err != nil {
 			return errors.Wrap(err, "unable to load seccomp profile")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -796,11 +796,11 @@ func DefaultConfig() (*Config, error) {
 			seccompConfig:              seccomp.New(),
 			apparmorConfig:             apparmor.New(),
 			blockioConfig:              blockio.New(),
-			rdtConfig:                  rdt.New(),
-			ulimitsConfig:              ulimits.New(),
 			cgroupManager:              cgroupManager,
 			deviceConfig:               device.New(),
 			namespaceManager:           nsmgr.New(defaultNamespacesDir, ""),
+			rdtConfig:                  rdt.New(),
+			ulimitsConfig:              ulimits.New(),
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport: "docker://",

--- a/test/critest.bats
+++ b/test/critest.bats
@@ -7,6 +7,7 @@ function setup() {
 		skip "critest because RUN_CRITEST is not set"
 	fi
 
+	export CONTAINER_SECCOMP_USE_DEFAULT_WHEN_EMPTY=false
 	setup_test
 	start_crio
 }


### PR DESCRIPTION
#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
This is a premature step before the graduation of the `seccompDefault`
feature planned for Kubernetes v1.25. We now use the `runtime/default`
profile for every workload specifying none (empty) in the pod manifest.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Enable `--seccomp-use-default-when-empty`/`seccomp_use_default_when_empty` by default.
This is a premature step before the graduation of the `seccompDefault` feature planned for
Kubernetes v1.25. We now use the `runtime/default` profile for every workload specifying 
none (empty) in the pod manifest. 
```
