### PR TITLE
Fix runtime panic on pod sandbox stats retrieval

### DIFF
--- a/internal/lib/stats/stats_server.go
+++ b/internal/lib/stats/stats_server.go
@@ -98,6 +98,7 @@ func (ss *StatsServer) updateSandbox(sb *sandbox.Sandbox) *types.PodSandboxStats
 			Metadata:    sb.Metadata(),
 			Annotations: sb.Annotations(),
 		},
+		Linux: &types.LinuxPodSandboxStats{},
 	}
 	if err := ss.Config().CgroupManager().PopulateSandboxCgroupStats(sb.CgroupParent(), sandboxStats); err != nil {
 		logrus.Errorf("Error getting sandbox stats %s: %v", sb.ID(), err)


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
The `Linux` field of the pod sandbox stats is accessed in multiple
places while we do not init it before. This caused a runtime panic with
the following backtrace:

```
DEBU[2022-02-02 13:49:20.074139178+01:00] Request: &ListPodSandboxStatsRequest{Filter:&PodSandboxStatsFilter{Id:,LabelSelector:map[string]string{},},}  file="go-grpc-middleware@v1.3.0/chain.go:25" id=bf81646b-e1d7-4fd8-a312-3e84fdef3cfe name=/runtime.v1.RuntimeService/ListPodSandboxStats
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf77ca9]

goroutine 807 [running]:
github.com/cri-o/cri-o/internal/config/cgmgr.populateSandboxCgroupStatsFromPath({0xc00074ca40, 0x20}, 0xc0002f1740)
        github.com/cri-o/cri-o/internal/config/cgmgr/stats.go:25 +0x109
github.com/cri-o/cri-o/internal/config/cgmgr.(*SystemdManager).PopulateSandboxCgroupStats(0xc0004dd040, {0xc000332030, 0xc000f836b8}, 0x4c36db)
        github.com/cri-o/cri-o/internal/config/cgmgr/systemd.go:180 +0x4e
github.com/cri-o/cri-o/internal/lib/stats.(*StatsServer).updateSandbox(0xc00064e2c0, 0xc0007b2fc0)
        github.com/cri-o/cri-o/internal/lib/stats/stats_server.go:102 +0x194
github.com/cri-o/cri-o/internal/lib/stats.(*StatsServer).statsForSandbox(0x10000000059a501, 0xc000f83880)
        github.com/cri-o/cri-o/internal/lib/stats/stats_server.go:273 +0x74
github.com/cri-o/cri-o/internal/lib/stats.(*StatsServer).StatsForSandboxes(0xc00064e2c0, {0xc000114108, 0x1, 0xc000f838e0})
        github.com/cri-o/cri-o/internal/lib/stats/stats_server.go:262 +0x136
github.com/cri-o/cri-o/server.(*Server).ListPodSandboxStats(0xc0005e0000, {0x22e4ba0, 0xc000a80300}, 0xc00054f210)
        github.com/cri-o/cri-o/server/sandbox_stats_list.go:21 +0xec
github.com/cri-o/cri-o/server/cri/v1.(*service).ListPodSandboxStats(0xc000000005, {0x22e4ba0, 0xc000a80300}, 0xc000f839f0)
        github.com/cri-o/cri-o/server/cri/v1/rpc_list_pod_sandbox_stats.go:12 +0x26
k8s.io/cri-api/pkg/apis/runtime/v1._RuntimeService_ListPodSandboxStats_Handler.func1({0x22e4ba0, 0xc000a80300}, {0x1e9e4a0, 0xc00054f210})
        k8s.io/cri-api@v0.23.0-alpha.3/pkg/apis/runtime/v1/api.pb.go:9253 +0x78
github.com/cri-o/cri-o/internal/log.UnaryInterceptor.func1({0x22e4ba0, 0xc000571ad0}, {0x1e9e4a0, 0xc00054f210}, 0xc000f83a40, 0xc000129458)
        github.com/cri-o/cri-o/internal/log/interceptors.go:56 +0xc3
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x22e4ba0, 0xc000571ad0}, {0x1e9e4a0, 0xc00054f210})
        github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
github.com/cri-o/cri-o/server/metrics.UnaryInterceptor.func1({0x22e4ba0, 0xc000571ad0}, {0x1e9e4a0, 0xc00054f210}, 0xc0002f16c0, 0xc0002f16e0)
        github.com/cri-o/cri-o/server/metrics/interceptors.go:24 +0xb2
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x22e4ba0, 0xc000571ad0}, {0x1e9e4a0, 0xc00054f210})
        github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1({0x22e4ba0, 0xc000571ad0}, {0x1e9e4a0, 0xc00054f210}, 0xc0007fdbb8, 0x1cf06a0)
        github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0xbf
k8s.io/cri-api/pkg/apis/runtime/v1._RuntimeService_ListPodSandboxStats_Handler({0x1f2b200, 0xc000010078}, {0x22e4ba0, 0xc000571ad0}, 0xc000dda5a0, 0xc00062a870)
        k8s.io/cri-api@v0.23.0-alpha.3/pkg/apis/runtime/v1/api.pb.go:9255 +0x138
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003e5dc0, {0x231f420, 0xc0008a91e0}, 0xc000dfe5a0, 0xc0005703f0, 0x3334c58, 0x0)
        google.golang.org/grpc@v1.43.0/server.go:1282 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc0003e5dc0, {0x231f420, 0xc0008a91e0}, 0xc000dfe5a0, 0x0)
        google.golang.org/grpc@v1.43.0/server.go:1616 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        google.golang.org/grpc@v1.43.0/server.go:921 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.43.0/server.go:919 +0x294
```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed possible runtime panic on pod sandbox stats retrieval.
```
