### PR TITLE
Fix incorrect test setup order in cgroups bats test.

### DIFF
--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -3,8 +3,8 @@
 load helpers
 
 function setup() {
-	newconfig="$TESTDIR/config.json"
 	setup_test
+	newconfig="$TESTDIR/config.json"
 }
 
 function teardown() {

--- a/test/config_migrate.bats
+++ b/test/config_migrate.bats
@@ -4,13 +4,13 @@
 load helpers
 
 @test "config migrate should succeed with default config" {
-	output=$(crio -c "" -d "" config -m 1.17 2>&1)
+	output=$("$CRIO_BINARY_PATH" -c "" -d "" config -m 1.17 2>&1)
 	[[ "$output" != *"Changing"* ]]
 }
 
 @test "config migrate should succeed with 1.17 config" {
 	# when
-	output=$(crio -c "$TESTDATA/config/config-v1.17.0.toml" -d "" config -m 1.17 2>&1)
+	output=$("$CRIO_BINARY_PATH" -c "$TESTDATA/config/config-v1.17.0.toml" -d "" config -m 1.17 2>&1)
 
 	# then
 	[[ "$output" == *'Changing \"apparmor_profile\" to \"crio-default\"'* ]]
@@ -25,7 +25,7 @@ load helpers
 
 @test "config migrate should fail on invalid version" {
 	# when
-	run crio -c "" -d "" config -m 1.16
+	run "$CRIO_BINARY_PATH" -c "" -d "" config -m 1.16
 
 	# then
 	[[ "$output" == *"unsupported migration version"* ]]

--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -22,9 +22,9 @@ function run_podman_with_args() {
 }
 
 function teardown() {
-	cleanup_test
 	run_podman_with_args stop -a
 	run_podman_with_args rm -fa
+	cleanup_test
 	cleanup_namespaces_dir
 }
 

--- a/test/critest.bats
+++ b/test/critest.bats
@@ -3,7 +3,7 @@
 load helpers
 
 function setup() {
-	if [[ -z $RUN_CRITEST ]]; then
+	if [ ! -v RUN_CRITEST ]; then
 		skip "critest because RUN_CRITEST is not set"
 	fi
 
@@ -19,7 +19,7 @@ function teardown() {
 	critest --parallel 8 \
 		--runtime-endpoint "unix://${CRIO_SOCKET}" \
 		--image-endpoint "unix://${CRIO_SOCKET}" \
-		--ginkgo.focus="${CRI_FOCUS}" \
-		--ginkgo.skip="${CRI_SKIP}" \
+		--ginkgo.focus="${CRI_FOCUS:-}" \
+		--ginkgo.skip="${CRI_SKIP:-}" \
 		--ginkgo.flakeAttempts=3 >&3
 }

--- a/test/namespaces.bats
+++ b/test/namespaces.bats
@@ -35,7 +35,7 @@ function teardown() {
 }
 
 @test "pid namespace mode target test" {
-	if [[ -n "$TEST_USERNS" ]]; then
+	if [[ -v TEST_USERNS ]]; then
 		skip "test fails in a user namespace"
 	fi
 	start_crio


### PR DESCRIPTION
Fix a number of problems related to CI tests. Huge thanks to @haircommander in helping me narrow down the test setup ordering problem:

  - fix incorrect test setup order in cgroups BATS test
  - force BATS /usr/bin symlink in place (in case CI worker node has distro-specific BATS installed)
  - fix test cases trying to dereference unset variables (recent BATS runs tests with `set -u`) 

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

An incorrect order of calling `setup_test` and evaluating `$TESTDIR` causes cgroups test cases to share supposedly private test files and random test failures. This typically manifests itself as a conflict between the `ctr with swap should be configured` and `ctr with swap should fail when swap is lower` tests, with either one failing with a seemingly impossible condition. In reality this is caused by one of those test cases overwriting the container configuration input file generated by the other, before that file could be taken into use by the failing test case. 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
None
```
