### PR TITLE
[1.20] various deadlock backports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,7 @@ testunit-bin:
 	done
 
 mockgen: \
+	mock-cmdrunner \
 	mock-containerstorage \
 	mock-criostorage \
 	mock-lib-config \

--- a/internal/config/conmonmgr/conmonmgr.go
+++ b/internal/config/conmonmgr/conmonmgr.go
@@ -19,14 +19,10 @@ type ConmonManager struct {
 
 // this function is heavily based on github.com/containers/common#probeConmon
 func New(conmonPath string) (*ConmonManager, error) {
-	return newWithCommandRunner(conmonPath, &cmdrunner.RealCommandRunner{})
-}
-
-func newWithCommandRunner(conmonPath string, runner cmdrunner.CommandRunner) (*ConmonManager, error) {
 	if !path.IsAbs(conmonPath) {
 		return nil, errors.Errorf("conmon path is not absolute: %s", conmonPath)
 	}
-	out, err := runner.CombinedOutput(conmonPath, "--version")
+	out, err := cmdrunner.CombinedOutput(conmonPath, "--version")
 	if err != nil {
 		return nil, errors.Wrapf(err, "get conmon version")
 	}

--- a/internal/config/conmonmgr/conmonmgr_test.go
+++ b/internal/config/conmonmgr/conmonmgr_test.go
@@ -2,6 +2,7 @@ package conmonmgr
 
 import (
 	runnerMock "github.com/cri-o/cri-o/test/mocks/cmdrunner"
+	"github.com/cri-o/cri-o/utils/cmdrunner"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,6 +17,7 @@ var _ = t.Describe("ConmonManager", func() {
 	t.Describe("New", func() {
 		BeforeEach(func() {
 			runner = runnerMock.NewMockCommandRunner(mockCtrl)
+			cmdrunner.SetMocked(runner)
 		})
 		It("should fail when path not absolute", func() {
 			// Given
@@ -24,7 +26,7 @@ var _ = t.Describe("ConmonManager", func() {
 			)
 
 			// When
-			mgr, err := newWithCommandRunner("", runner)
+			mgr, err := New("")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -37,7 +39,7 @@ var _ = t.Describe("ConmonManager", func() {
 			)
 
 			// When
-			mgr, err := newWithCommandRunner(validPath, runner)
+			mgr, err := New(validPath)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -50,7 +52,7 @@ var _ = t.Describe("ConmonManager", func() {
 			)
 
 			// When
-			mgr, err := newWithCommandRunner(validPath, runner)
+			mgr, err := New(validPath)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -63,7 +65,7 @@ var _ = t.Describe("ConmonManager", func() {
 			)
 
 			// When
-			mgr, err := newWithCommandRunner(validPath, runner)
+			mgr, err := New(validPath)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -76,7 +78,7 @@ var _ = t.Describe("ConmonManager", func() {
 			)
 
 			// When
-			mgr, err := newWithCommandRunner(validPath, runner)
+			mgr, err := New(validPath)
 
 			// Then
 			Expect(err).To(BeNil())

--- a/internal/dbusmgr/user.go
+++ b/internal/dbusmgr/user.go
@@ -6,12 +6,12 @@ import (
 	"bufio"
 	"bytes"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/cri-o/cri-o/utils/cmdrunner"
 	dbus "github.com/godbus/dbus/v5"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/pkg/errors"
@@ -55,7 +55,7 @@ func DetectUID() (int, error) {
 	if !rsystem.RunningInUserNS() {
 		return os.Getuid(), nil
 	}
-	b, err := exec.Command("busctl", "--user", "--no-pager", "status").CombinedOutput()
+	b, err := cmdrunner.Command("busctl", "--user", "--no-pager", "status").CombinedOutput()
 	if err != nil {
 		return -1, errors.Wrapf(err, "could not execute `busctl --user --no-pager status`: %q", string(b))
 	}
@@ -91,7 +91,7 @@ func DetectUserDbusSessionBusAddress() (string, error) {
 			return busAddress, nil
 		}
 	}
-	b, err := exec.Command("systemctl", "--user", "--no-pager", "show-environment").CombinedOutput()
+	b, err := cmdrunner.Command("systemctl", "--user", "--no-pager", "show-environment").CombinedOutput()
 	if err != nil {
 		return "", errors.Wrapf(err, "could not execute `systemctl --user --no-pager show-environment`, output=%q", string(b))
 	}

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -118,8 +118,8 @@ func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) e
 		return nil
 	}
 
-	done := make(chan error)
-	chControl := make(chan struct{})
+	done := make(chan error, 1)
+	chControl := make(chan struct{}, 1)
 	go func() {
 		defer close(done)
 		for {

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -120,6 +120,7 @@ func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) e
 
 	done := make(chan error, 1)
 	chControl := make(chan struct{}, 1)
+	defer close(chControl)
 	go func() {
 		defer close(done)
 		for {
@@ -144,10 +145,8 @@ func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) e
 	case err = <-done:
 		break
 	case <-ctx.Done():
-		close(chControl)
 		return ctx.Err()
 	case <-time.After(time.Duration(r.config.CtrStopTimeout) * time.Second):
-		close(chControl)
 		return fmt.Errorf(
 			"failed to get container stopped status: %ds timeout reached",
 			r.config.CtrStopTimeout,

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cri-o/cri-o/pkg/config"
 	types "github.com/cri-o/cri-o/server/cri/types"
 	"github.com/cri-o/cri-o/utils"
+	"github.com/cri-o/cri-o/utils/cmdrunner"
 	"github.com/fsnotify/fsnotify"
 	json "github.com/json-iterator/go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
@@ -127,7 +128,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (retErr 
 		"args": args,
 	}).Debugf("running conmon: %s", r.config.Conmon)
 
-	cmd := exec.Command(r.config.Conmon, args...) // nolint: gosec
+	cmd := cmdrunner.Command(r.config.Conmon, args...) // nolint: gosec
 	cmd.Dir = c.bundlePath
 	cmd.SysProcAttr = sysProcAttrPlatform()
 	cmd.Stdin = os.Stdin
@@ -265,7 +266,12 @@ func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []stri
 	}
 	defer os.RemoveAll(processFile)
 
-	execCmd := r.constructExecCommand(ctx, c, processFile, "")
+	args := []string{rootFlag, r.root, "exec"}
+	args = append(args, "--process", processFile, c.ID())
+	execCmd := cmdrunner.Command(r.path, args...) // nolint: gosec
+	if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
+		execCmd.Env = append(execCmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", v))
+	}
 	var cmdErr, copyError error
 	if tty {
 		cmdErr = ttyCmd(execCmd, stdin, stdout, resize)
@@ -386,7 +392,7 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 		"--exec-process-spec", processFile,
 		"--runtime-arg", fmt.Sprintf("%s=%s", rootFlag, r.root))
 
-	cmd := exec.Command(r.config.Conmon, args...) // nolint: gosec
+	cmd := cmdrunner.Command(r.config.Conmon, args...) // nolint: gosec
 
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
@@ -617,7 +623,7 @@ func (r *runtimeOCI) UpdateContainer(c *Container, res *rspec.LinuxResources) er
 		return nil
 	}
 
-	cmd := exec.Command(r.path, rootFlag, r.root, "update", "--resources", "-", c.id) // nolint: gosec
+	cmd := cmdrunner.Command(r.path, rootFlag, r.root, "update", "--resources", "-", c.ID()) // nolint: gosec
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -792,7 +798,7 @@ func (r *runtimeOCI) UpdateContainerStatus(c *Container) error {
 	}
 
 	stateCmd := func() (*ContainerState, bool, error) {
-		cmd := exec.Command(r.path, rootFlag, r.root, "state", c.id) // nolint: gosec
+		cmd := cmdrunner.Command(r.path, rootFlag, r.root, "state", c.ID()) // nolint: gosec
 		if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", v))
 		}

--- a/internal/runtimehandlerhooks/high_performance_hooks.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	crioannotations "github.com/cri-o/cri-o/pkg/annotations"
+	"github.com/cri-o/cri-o/utils/cmdrunner"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/pkg/errors"
@@ -263,7 +264,7 @@ func setIRQLoadBalancing(c *oci.Container, enable bool, irqSmpAffinityFile, irqB
 			return nil
 		}
 		// run irqbalance in daemon mode, so this won't cause delay
-		cmd := exec.Command(irqBalancedName, "--oneshot")
+		cmd := cmdrunner.Command(irqBalancedName, "--oneshot")
 		additionalEnv := irqBalanceBannedCpus + "=" + newIRQBalanceSetting
 		cmd.Env = append(os.Environ(), additionalEnv)
 		return cmd.Run()

--- a/internal/runtimehandlerhooks/utils.go
+++ b/internal/runtimehandlerhooks/utils.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 	"unicode"
 
+	"github.com/cri-o/cri-o/utils/cmdrunner"
 	"github.com/sirupsen/logrus"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
@@ -138,11 +138,11 @@ func UpdateIRQSmpAffinityMask(cpus, current string, set bool) (cpuMask, bannedCP
 }
 
 func restartIrqBalanceService() error {
-	return exec.Command("systemctl", "restart", "irqbalance").Run()
+	return cmdrunner.Command("systemctl", "restart", "irqbalance").Run()
 }
 
 func isServiceEnabled(serviceName string) bool {
-	cmd := exec.Command("systemctl", "is-enabled", serviceName)
+	cmd := cmdrunner.Command("systemctl", "is-enabled", serviceName)
 	status, err := cmd.CombinedOutput()
 	if err != nil {
 		logrus.Infof("service %s is-enabled check returned with: %v", serviceName, err)

--- a/test/mocks/cmdrunner/cmdrunner.go
+++ b/test/mocks/cmdrunner/cmdrunner.go
@@ -5,34 +5,36 @@
 package cmdrunnermock
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	exec "os/exec"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockCommandRunner is a mock of CommandRunner interface
+// MockCommandRunner is a mock of CommandRunner interface.
 type MockCommandRunner struct {
 	ctrl     *gomock.Controller
 	recorder *MockCommandRunnerMockRecorder
 }
 
-// MockCommandRunnerMockRecorder is the mock recorder for MockCommandRunner
+// MockCommandRunnerMockRecorder is the mock recorder for MockCommandRunner.
 type MockCommandRunnerMockRecorder struct {
 	mock *MockCommandRunner
 }
 
-// NewMockCommandRunner creates a new mock instance
+// NewMockCommandRunner creates a new mock instance.
 func NewMockCommandRunner(ctrl *gomock.Controller) *MockCommandRunner {
 	mock := &MockCommandRunner{ctrl: ctrl}
 	mock.recorder = &MockCommandRunnerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCommandRunner) EXPECT() *MockCommandRunnerMockRecorder {
 	return m.recorder
 }
 
-// CombinedOutput mocks base method
+// CombinedOutput mocks base method.
 func (m *MockCommandRunner) CombinedOutput(arg0 string, arg1 ...string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -45,9 +47,28 @@ func (m *MockCommandRunner) CombinedOutput(arg0 string, arg1 ...string) ([]byte,
 	return ret0, ret1
 }
 
-// CombinedOutput indicates an expected call of CombinedOutput
+// CombinedOutput indicates an expected call of CombinedOutput.
 func (mr *MockCommandRunnerMockRecorder) CombinedOutput(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CombinedOutput", reflect.TypeOf((*MockCommandRunner)(nil).CombinedOutput), varargs...)
+}
+
+// Command mocks base method.
+func (m *MockCommandRunner) Command(arg0 string, arg1 ...string) *exec.Cmd {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Command", varargs...)
+	ret0, _ := ret[0].(*exec.Cmd)
+	return ret0
+}
+
+// Command indicates an expected call of Command.
+func (mr *MockCommandRunnerMockRecorder) Command(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommandRunner)(nil).Command), varargs...)
 }

--- a/utils/cmdrunner/cmdrunner.go
+++ b/utils/cmdrunner/cmdrunner.go
@@ -4,12 +4,68 @@ import (
 	"os/exec"
 )
 
+// Use a singleton instance because there are many modules that may want access
+// and having it all go through a shared object like the config or server would
+// add a lot of complexity.
+var commandRunner CommandRunner
+
+// CommandRunner is an interface for executing commands.
+// It gives the option to change the way commands are run server-wide.
 type CommandRunner interface {
+	Command(string, ...string) *exec.Cmd
 	CombinedOutput(string, ...string) ([]byte, error)
 }
 
-type RealCommandRunner struct{}
+// prependableCommandRunner is an implementation of CommandRunner.
+// It gives the option for all commands that are run to be prepended by another command
+// and arguments.
+type prependableCommandRunner struct {
+	prependCmd  string
+	prependArgs []string
+}
 
-func (c *RealCommandRunner) CombinedOutput(command string, args ...string) ([]byte, error) {
-	return exec.Command(command, args...).CombinedOutput()
+// PrependCommandsWith updates the commandRunner singleton to have the configured prepended args and command.
+func PrependCommandsWith(prependCmd string, prependArgs ...string) {
+	commandRunner = &prependableCommandRunner{
+		prependCmd:  prependCmd,
+		prependArgs: prependArgs,
+	}
+}
+
+// CombinedOutput calls CombinedOutput on the defined commandRunner,
+// or the default implementation in the exec package if there's no commandRunner defined.
+func CombinedOutput(command string, args ...string) ([]byte, error) {
+	if commandRunner == nil {
+		return exec.Command(command, args...).CombinedOutput()
+	}
+	return commandRunner.CombinedOutput(command, args...)
+}
+
+// CombinedOutput returns the combined output of the command, given the prepended cmd/args that were defined.
+func (c *prependableCommandRunner) CombinedOutput(command string, args ...string) ([]byte, error) {
+	return c.Command(command, args...).CombinedOutput()
+}
+
+// Command calls Command on the defined commandRunner,
+// or the default implementation in the exec package if there's no commandRunner defined.
+func Command(cmd string, args ...string) *exec.Cmd {
+	if commandRunner == nil {
+		return exec.Command(cmd, args...)
+	}
+	return commandRunner.Command(cmd, args...)
+}
+
+// Command creates an exec.Cmd object. If prependCmd is defined, the command will be prependCmd
+// and the args will be prependArgs + cmd + args.
+// Otherwise, cmd and args will be as inputted.
+func (c *prependableCommandRunner) Command(cmd string, args ...string) *exec.Cmd {
+	realCmd := cmd
+	realArgs := args
+	if c.prependCmd != "" {
+		realCmd = c.prependCmd
+		realArgs = c.prependArgs
+		realArgs = append(realArgs, cmd)
+		realArgs = append(realArgs, args...)
+	}
+	return exec.Command(realCmd, realArgs...)
 }

--- a/utils/cmdrunner/cmdrunner_test.go
+++ b/utils/cmdrunner/cmdrunner_test.go
@@ -1,0 +1,53 @@
+package cmdrunner_test
+
+import (
+	"os/exec"
+
+	"github.com/cri-o/cri-o/utils/cmdrunner"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = t.Describe("CommandRunner", func() {
+	It("command should not prepend if not configured", func() {
+		// Given
+		cmd := "ls"
+		baseline, err := exec.Command(cmd).CombinedOutput()
+		Expect(err).To(BeNil())
+
+		// When
+		output, err := cmdrunner.CombinedOutput(cmd)
+		Expect(err).To(BeNil())
+
+		// Then
+		Expect(output).To(Equal(baseline))
+	})
+	It("command should prepend if configured", func() {
+		// Given
+		cmd := "ls"
+		cmdrunner.PrependCommandsWith("which")
+		baseline, err := exec.Command(cmd).CombinedOutput()
+		Expect(err).To(BeNil())
+
+		// When
+		output, err := cmdrunner.CombinedOutput(cmd)
+		Expect(err).To(BeNil())
+
+		// Then
+		Expect(output).NotTo(Equal(baseline))
+	})
+	It("command should not prepend if only args are configured", func() {
+		// Given
+		cmd := "ls"
+		cmdrunner.PrependCommandsWith("", "-l")
+		baseline, err := exec.Command(cmd).CombinedOutput()
+		Expect(err).To(BeNil())
+
+		// When
+		output, err := cmdrunner.CombinedOutput(cmd)
+		Expect(err).To(BeNil())
+
+		// Then
+		Expect(output).To(Equal(baseline))
+	})
+})

--- a/utils/cmdrunner/cmdrunner_test_inject.go
+++ b/utils/cmdrunner/cmdrunner_test_inject.go
@@ -1,0 +1,11 @@
+//go:build test
+// +build test
+
+// All *_inject.go files are meant to be used by tests only. Purpose of this
+// files is to provide a way to inject mocked data into the current setup.
+
+package cmdrunner
+
+func SetMocked(runner CommandRunner) {
+	commandRunner = runner
+}

--- a/utils/cmdrunner/suite_test.go
+++ b/utils/cmdrunner/suite_test.go
@@ -1,0 +1,26 @@
+package cmdrunner_test
+
+import (
+	"testing"
+
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestCommandRunner runs the created specs
+func TestCommandRunner(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "CommandRunner")
+}
+
+var t *TestFramework
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/containers/libpod/v2/pkg/lookup"
 	"github.com/cri-o/cri-o/internal/dbusmgr"
+	"github.com/cri-o/cri-o/utils/cmdrunner"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/pkg/errors"
@@ -31,7 +31,7 @@ import (
 // ExecCmd executes a command with args and returns its output as a string along
 // with an error, if any
 func ExecCmd(name string, args ...string) (string, error) {
-	cmd := exec.Command(name, args...)
+	cmd := cmdrunner.Command(name, args...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/containers/libpod/v2/pkg/lookup"
 	"github.com/cri-o/cri-o/internal/dbusmgr"
@@ -68,23 +69,26 @@ func RunUnderSystemdScope(mgr *dbusmgr.DbusConnManager, pid int, slice, unitName
 		properties = append(properties, systemdDbus.PropSlice(slice))
 	}
 	ch := make(chan string)
-	for {
-		err := mgr.RetryOnDisconnect(func(c *systemdDbus.Conn) error {
-			_, err := c.StartTransientUnit(unitName, "replace", properties, ch)
-			return err
-		})
-
-		if err == nil {
-			break
-		}
-		if !errors.Is(err, syscall.EAGAIN) {
-			return err
-		}
+	if err := mgr.RetryOnDisconnect(func(c *systemdDbus.Conn) error {
+		_, err := c.StartTransientUnit(unitName, "replace", properties, ch)
+		return errors.Wrap(err, "start transient unit")
+	}); err != nil {
+		return err
 	}
 
 	// Block until job is started
-	<-ch
-	close(ch)
+	select {
+	case <-ch:
+		close(ch)
+	case <-time.After(time.Minute * 6):
+		// This case is a work around to catch situations where the dbus library sends the
+		// request but it unexpectedly disappears. We set the timeout very high to make sure
+		// we wait as long as possible to catch situations where dbus is overwhelmed.
+		// We also don't use the native context cancelling behavior of the dbus library,
+		// because experience has shown that it does not help.
+		// TODO: Find cause of the request being dropped in the dbus library and fix it.
+		return errors.Errorf("timed out moving conmon with pid %d to cgroup", pid)
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add functionality to use taskset to spawn new commands cri-o runs. Now, if InfraCtrCPUSet is called, all newly spawned commands will be placed in the InfraCtrCPUSet (as it's expected to be set to the reserved CPU set that system commands should run on).
```
