### PR TITLE
Add Debian_11 OS variable on installation instructions of Debian

### DIFF
--- a/install.md
+++ b/install.md
@@ -51,6 +51,7 @@ CentOS 7
 Debian Unstable
 Debian Testing
 Debian 10
+Debian 11
 Rasbian 10
 xUbuntu 20.10
 xUbuntu 20.04


### PR DESCRIPTION
Signed-off-by: Wang Kai <persistence201306@gmail.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation



#### What this PR does / why we need it:

The installation instructions of Debian should be improved

#### Which issue(s) this PR fixes:

Fixes #5598 

add `Debian_11` OS variable 

```release-note
none
```
