### PR TITLE
deep copy List{PodSandbox,Container} structs

### DIFF
--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -103,7 +103,10 @@ func New(id, namespace, name, kubeName, logDir string, labels, annotations map[s
 }
 
 func (s *Sandbox) CRISandbox() *types.PodSandbox {
-	return s.criSandbox
+	// Return a deep copy so the State field doesn't get mutated mid-request,
+	// causing a proto panic.
+	cpy := *s.criSandbox
+	return &cpy
 }
 
 func (s *Sandbox) CreatedAt() int64 {

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -169,7 +169,10 @@ func NewSpoofedContainer(id, name string, labels map[string]string, sandbox stri
 }
 
 func (c *Container) CRIContainer() *types.Container {
-	return c.criContainer
+	// Return a deep copy so the State field doesn't get mutated mid-request,
+	// causing a proto panic.
+	cpy := *c.criContainer
+	return &cpy
 }
 
 // SetSpec loads the OCI spec in the container struct


### PR DESCRIPTION
Unfortunately, since each struct has state, if we directly edit the structure then protobuf panics

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
/kind bug
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix an issue where protobuf panics when serializing ListContainer and ListPodSandbox calls
```
