### PR TITLE
Add checksum details for artifacts

### DIFF
--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -154,7 +154,7 @@ TAR_DIR=cri-o
 tar cfz "$ARCHIVE" tmp --transform s/tmp/$TAR_DIR/
 rm -rf "$TMPDIR"
 echo "Created $ARCHIVE_PATH/$ARCHIVE"
-sha256sum "$ARCHIVE" > "$ARCHIVE_SHA256SUM"
+sha256sum "$ARCHIVE" >"$ARCHIVE_SHA256SUM"
 echo "Created $ARCHIVE_PATH/$ARCHIVE_SHA256SUM"
 
 # Test the archive

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -154,6 +154,8 @@ TAR_DIR=cri-o
 tar cfz "$ARCHIVE" tmp --transform s/tmp/$TAR_DIR/
 rm -rf "$TMPDIR"
 echo "Created $ARCHIVE_PATH/$ARCHIVE"
+sha256sum "$ARCHIVE" > "$ARCHIVE_SHA256SUM"
+echo "Created $ARCHIVE_PATH/$ARCHIVE_SHA256SUM"
 
 # Test the archive
 echo "Testing archive"

--- a/contrib/bundle/vars
+++ b/contrib/bundle/vars
@@ -8,5 +8,7 @@ mkdir -p "$ARCHIVE_PATH"
 
 ARCH=${1:-amd64}
 ARCHIVE="cri-o.$ARCH.$(git describe --tags --exact-match 2>/dev/null || git rev-parse HEAD).tar.gz"
+ARCHIVE_SHA256SUM="$ARCHIVE.sha256sum"
 
 export ARCHIVE
+export ARCHIVE_SHA256SUM

--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -114,7 +114,9 @@ The release notes have been generated for the commit range
 Download one of our static release bundles via our Google Cloud Bucket:
 
 - [cri-o.amd64.%s.tar.gz](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz)
+- [cri-o.amd64.%s.tar.gz.sha256sum](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz.sha256sum)
 - [cri-o.arm64.%s.tar.gz](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz)
+- [cri-o.arm64.%s.tar.gz.sha256sum](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz.sha256sum)
 
 ## Changelog since %s
 

--- a/scripts/upload-artifacts
+++ b/scripts/upload-artifacts
@@ -12,7 +12,7 @@ else
     gcloud auth activate-service-account --key-file=/tmp/key.json
 
     BUCKET=gs://cri-o
-    gsutil cp -n build/bundle/*.tar.gz $BUCKET/artifacts
+    gsutil cp -n build/bundle/*.tar.gz* $BUCKET/artifacts
 
     # update the latest version marker file for the branch
     MARKER=$(git rev-parse --abbrev-ref HEAD)
@@ -40,7 +40,7 @@ if TAG=$(git describe --exact-match --tags 2>/dev/null); then
             exit 1
         fi
         UPLOAD_URL=${UPLOAD_URL%"{?name,label}"}
-        for FILE in build/bundle/*.tar.gz; do
+        for FILE in build/bundle/*.tar.gz*; do
             curl -f \
                 -H "Authorization: token $GITHUB_TOKEN" \
                 -H "Content-Type: $(file -b --mime-type "$FILE")" \


### PR DESCRIPTION
#### What type of PR is this?
/kind ci

#### What this PR does / why we need it:
Provide checksum details for the uploaded artifacts.

#### Which issue(s) this PR fixes:

Fixes #5600

#### Special notes for your reviewer:
Following checksum files would be generated for each artifacts.
```

Download one of our static release bundles via our Google Cloud Bucket:

cri-o.amd64.9b7f5ae815c22a1d754abfbc2890d8d4c10e240d.tar.gz
cri-o.amd64.9b7f5ae815c22a1d754abfbc2890d8d4c10e240d.tar.gz.sha256sum
cri-o.arm64.9b7f5ae815c22a1d754abfbc2890d8d4c10e240d.tar.gz
cri-o.arm64.9b7f5ae815c22a1d754abfbc2890d8d4c10e240d.tar.gz.sha256sum
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
