### PR TITLE
contrib/test: don't try to use dropped image.registries config option.

### DIFF
--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -82,10 +82,9 @@
 
 - name: add quay.io and docker.io as default registries
   copy:
-    dest: /etc/crio/crio.conf.d/01-registries.conf
+    dest: /etc/containers/registries.conf
     content: |
-      [crio.image]
-      registries = [ "quay.io", "docker.io" ]
+      unqualified-search-registries = [ "quay.io", "docker.io" ]
 
 - name: remove storage.conf to avoid configuration conflicts
   file:


### PR DESCRIPTION
Stop trying to use dropped crio.image.registries config file options in CI. Use `unqualified-search-registries` in `/etc/containers/registries.conf instead.` according to the guidelines:

```
klitkey1-mobl deprecated-registries $ git grep -B2 -A1 "'registries'" pkg/config
pkg/config/config.go-   if len(t.Crio.Image.Registries) > 0 {
pkg/config/config.go-           t.Crio.Image.Registries = nil
pkg/config/config.go:           logrus.Warnf("Support for the 'registries' option has been dropped but it is referenced in %q.  Please use containers-registries.conf(5) for configuring unqualified-search registries instead.", path)
pkg/config/config.go-   }

```

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Fixes failing metrics BATS test in CI.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```