### PR TITLE
oci: drop WaitContainerStateStopped

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -688,8 +688,8 @@ func (c *ContainerServer) StopContainerAndWait(ctx context.Context, ctr *oci.Con
 	if err := c.Runtime().StopContainer(ctx, ctr, timeout); err != nil {
 		return fmt.Errorf("failed to stop container %s: %v", ctr.Name(), err)
 	}
-	if err := c.Runtime().WaitContainerStateStopped(ctx, ctr); err != nil {
-		return fmt.Errorf("failed to get container 'stopped' status %s: %v", ctr.Name(), err)
+	if err := c.Runtime().UpdateContainerStatus(ctx, ctr); err != nil {
+		return fmt.Errorf("failed to update container status %s: %v", ctr.Name(), err)
 	}
 	return nil
 }

--- a/internal/lib/stop.go
+++ b/internal/lib/stop.go
@@ -21,8 +21,8 @@ func (c *ContainerServer) StopContainer(ctx context.Context, ctr *oci.Container,
 	} else {
 		// we only do these operations if StopContainer didn't fail (even if the failure
 		// was the container already being stopped)
-		if err := c.runtime.WaitContainerStateStopped(ctx, ctr); err != nil {
-			return errors.Wrapf(err, "failed to get container 'stopped' status %s", ctr.ID())
+		if err := c.runtime.UpdateContainerStatus(ctx, ctr); err != nil {
+			return errors.Wrapf(err, "failed to update container status %s", ctr.ID())
 		}
 		if err := c.storageRuntimeServer.StopContainer(ctr.ID()); err != nil {
 			return errors.Wrapf(err, "failed to unmount container %s", ctr.ID())

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -941,10 +941,6 @@ func (r *runtimeOCI) UnpauseContainer(ctx context.Context, c *Container) error {
 	return err
 }
 
-func (r *runtimeOCI) WaitContainerStateStopped(ctx context.Context, c *Container) error {
-	return nil
-}
-
 // ContainerStats provides statistics of a container.
 func (r *runtimeOCI) ContainerStats(ctx context.Context, c *Container, cgroup string) (*types.ContainerStats, error) {
 	c.opLock.Lock()

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -963,10 +963,6 @@ func (r *runtimeVM) ReopenContainerLog(ctx context.Context, c *Container) error 
 	return nil
 }
 
-func (r *runtimeVM) WaitContainerStateStopped(ctx context.Context, c *Container) error {
-	return nil
-}
-
 func (r *runtimeVM) start(ctrID, execID string) error {
 	if _, err := r.task.Start(r.ctx, &task.StartRequest{
 		ID:     ctrID,

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -251,17 +251,3 @@ func (mr *MockRuntimeImplMockRecorder) UpdateContainerStatus(arg0, arg1 interfac
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerStatus", reflect.TypeOf((*MockRuntimeImpl)(nil).UpdateContainerStatus), arg0, arg1)
 }
-
-// WaitContainerStateStopped mocks base method.
-func (m *MockRuntimeImpl) WaitContainerStateStopped(arg0 context.Context, arg1 *oci.Container) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitContainerStateStopped", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WaitContainerStateStopped indicates an expected call of WaitContainerStateStopped.
-func (mr *MockRuntimeImplMockRecorder) WaitContainerStateStopped(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitContainerStateStopped", reflect.TypeOf((*MockRuntimeImpl)(nil).WaitContainerStateStopped), arg0, arg1)
-}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind cleanup
#### What this PR does / why we need it:
both oci and vm runtimes do wait until the container state is stopped before returning
the only new piece of work WaitContainerStateStopped did was update container status.

Drop WaitContainerStateStopped and call UpdateContainerStatus in its place

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
