### PR TITLE
test/crio-wipe: fixups

### DIFF
--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -128,7 +128,7 @@ function start_crio_with_stopped_pod() {
 
 	run_crio_wipe
 
-	run_podman_with_args ps -a | grep test
+	run_podman_with_args container exists test
 }
 
 @test "do clear everything when shutdown file not found" {
@@ -163,8 +163,7 @@ function start_crio_with_stopped_pod() {
 
 	run_crio_wipe
 
-	run_podman_with_args ps -a
-	[[ ! "$output" =~ "test" ]]
+	! run_podman_with_args container exists test
 }
 
 @test "fail to clear podman containers when shutdown file not found but container still running" {


### PR DESCRIPTION
Commit 6c69b44953 remove bats "run" from `run_podman_with_args`, meaning
variables $output and $status are no longer set after using it.

Commit f48f90d365 added a new test case which checks $output. Most
probably the $output is not even set, so the check isn't working.

Fix by using podman container exists which is the most straightforward
check.

Use the same check in `start_crio_with_stopped_pod`.

```release-note
NONE
```