### PR TITLE
utils: Sync: use f.Sync

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/containers/podman/v3/pkg/lookup"
@@ -378,7 +377,7 @@ func Sync(path string) error {
 	}
 	defer f.Close()
 
-	if err := syscall.Fsync(int(f.Fd())); err != nil {
+	if err := f.Sync(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This is easier, and as an added bonus `f.Sync()` retries on `EINTR`.