### PR TITLE
Bump shellcheck to 0.8.0, fix or suppress new warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,9 +268,9 @@ ${GOLANGCI_LINT}:
 
 ${SHELLCHECK}:
 	mkdir -p ${BUILD_BIN_PATH} && \
-	VERSION=v0.7.0 \
+	VERSION=v0.8.0 \
 	URL=https://github.com/koalaman/shellcheck/releases/download/$$VERSION/shellcheck-$$VERSION.linux.x86_64.tar.xz \
-	SHA256SUM=c37d4f51e26ec8ab96b03d84af8c050548d7288a47f755ffb57706c6c458e027 && \
+	SHA256SUM=f4bce23c11c3919c1b20bcb0f206f6b44c44e26f2bc95f8aa708716095fa0651 && \
 	curl -sSfL $$URL | tar xfJ - -C ${BUILD_BIN_PATH} --strip 1 shellcheck-$$VERSION/shellcheck && \
 	sha256sum ${SHELLCHECK} | grep -q $$SHA256SUM
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,7 +20,7 @@ dependencies:
       match: VERSION
 
   - name: shellcheck
-    version: v0.7.0
+    version: v0.8.0
     refPaths:
     - path: Makefile
       match: VERSION

--- a/test/apparmor.bats
+++ b/test/apparmor.bats
@@ -7,6 +7,7 @@ function teardown() {
 }
 
 # AppArmor tests have to run in sequence since they modify the system state
+# shellcheck disable=SC2030
 @test "apparmor tests (in sequence)" {
 	if ! is_apparmor_enabled; then
 		skip "apparmor not enabled"
@@ -39,6 +40,7 @@ load_default_apparmor_profile_and_run_a_container_with_it() {
 
 # 2. test running with loading a specific apparmor profile as crio default apparmor profile.
 # test that we can run with a specific apparmor profile which will block touching a file in `.` as crio default apparmor profile.
+# shellcheck disable=SC2031
 load_a_specific_apparmor_profile_as_default_apparmor_and_run_a_container_with_it() {
 	local output status
 
@@ -64,6 +66,7 @@ load_a_specific_apparmor_profile_as_default_apparmor_and_run_a_container_with_it
 
 # 3. test running with loading a specific apparmor profile but not as crio default apparmor profile.
 # test that we can run with a specific apparmor profile which will block touching a file in `.`
+# shellcheck disable=SC2031
 load_default_apparmor_profile_and_run_a_container_with_another_apparmor_profile() {
 	local output status
 

--- a/test/cni_plugin_helper.bash
+++ b/test/cni_plugin_helper.bash
@@ -44,7 +44,7 @@ FOUND_K8S_POD_NAME="${K8S_POD_NAME}"
 FOUND_K8S_POD_UID="${K8S_POD_UID}"
 EOT
 
-# shellcheck disable=1090
+# shellcheck disable=SC1091
 . "$TEST_DIR"/cni_plugin_helper_input.env
 rm -f "$TEST_DIR"/cni_plugin_helper_input.env
 

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -22,14 +22,14 @@ fi
 
 function execute() {
     echo >&2 ++ "$@"
-    eval "$@"
+    time "$@"
 }
 
-# Tests to run. Defaults to all.
-TESTS=${*:-.}
+# Tests to run. Default is "." (i.e. the current directory).
+TESTS=("${@:-.}")
 
 # The number of parallel jobs to execute
 export JOBS=${JOBS:-$(($(nproc --all) * 4))}
 
 # Run the tests.
-execute time bats --jobs "$JOBS" --tap "$TESTS"
+execute bats --jobs "$JOBS" --tap "${TESTS[@]}"


### PR DESCRIPTION
#### What type of PR is this?

/kind ci
/kind cleanup

#### What this PR does / why we need it:

Bumps shellcheck to 0.8.0, fixes or suppresses new warnings.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Please review commit-by-commit.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
