### PR TITLE
Deny empty `localhost/` AppArmor profiles

### DIFF
--- a/internal/config/apparmor/apparmor.go
+++ b/internal/config/apparmor/apparmor.go
@@ -99,6 +99,10 @@ func (c *Config) Apply(profile string) (string, error) {
 	}
 	profile = strings.TrimPrefix(profile, v1.AppArmorBetaProfileNamePrefix)
 
+	if profile == "" {
+		return "", errors.New("empty localhost AppArmor profile is forbidden")
+	}
+
 	// reload the profile if default
 	if profile == DefaultProfile {
 		if err := reloadDefaultProfile(); err != nil {

--- a/test/apparmor.bats
+++ b/test/apparmor.bats
@@ -17,6 +17,7 @@ function teardown() {
 	load_default_apparmor_profile_and_run_a_container_with_another_apparmor_profile
 	run_a_container_with_wrong_apparmor_profile_name
 	run_a_container_after_unloading_default_apparmor_profile
+	run_a_container_with_invalid_localhost_apparmor_profile_name
 }
 
 # 1. test running with loading the default apparmor profile.
@@ -126,6 +127,26 @@ run_a_container_after_unloading_default_apparmor_profile() {
 	pod_id=$(crictl runp "$TESTDIR"/apparmor5.json)
 
 	crictl create "$pod_id" "$TESTDIR"/apparmor_container5.json "$TESTDIR"/apparmor5.json && fail
+
+	cleanup_test
+}
+
+# 6. test running with empty localhost profile name.
+run_a_container_with_invalid_localhost_apparmor_profile_name() {
+	local output status
+
+	setup_test
+	start_crio
+
+	jq '.linux.security_context.apparmor_profile = "localhost/"' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/apparmor4.json
+
+	jq '.linux.security_context.apparmor_profile = "localhost/"' \
+		"$TESTDATA"/container_redis.json > "$TESTDIR"/apparmor_container4.json
+
+	pod_id=$(crictl runp "$TESTDIR"/apparmor4.json)
+
+	! crictl create "$pod_id" "$TESTDIR"/apparmor_container4.json "$TESTDIR"/apparmor4.json
 
 	cleanup_test
 }


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Specifying a `localhost/` profile for AppArmor would run containers as
unconfined and not the selected default profile. This means we now check
that case explicitly and error if so.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Forbid AppArmor profiles with the name `localhost/`.
```
