### PR TITLE
[1.23] CI: use kubernetes 1.23, cri-tools 1.23

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -53,7 +53,7 @@
 
       # Whole script added by Ansible from build/kubernetes.yml
       export PATH=/usr/local/go/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/root/bin:{{ ansible_env.GOPATH }}/bin:{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes/third_party/etcd:{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes/_output/local/bin/linux/amd64/
-      export FEATURE_GATES="AllAlpha=false,RunAsGroup=true"
+      export FEATURE_GATES="AllAlpha=false"
       export CONTAINER_RUNTIME=remote
       export CGROUP_DRIVER=systemd
       export CONTAINER_RUNTIME_ENDPOINT='{{ crio_socket }}'

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -20,12 +20,12 @@
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:
-        cri_tools_git_version: "v1.22.0"
+        cri_tools_git_version: "v1.23.0"
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
       vars:
-        k8s_git_version: "release-1.21"
+        k8s_git_version: "release-1.23"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
       when: "(cgroupv2 is undefined) or (cgroupv2 == False) | bool"
@@ -33,7 +33,7 @@
     - name: clone build and install kubernetes for cgroup v2
       include: "build/kubernetes.yml"
       vars:
-        k8s_git_version: "release-1.21"
+        k8s_git_version: "release-1.23"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
       when: "cgroupv2 | bool"
@@ -121,7 +121,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: true
-        cri_tools_git_version: "v1.22.0"
+        cri_tools_git_version: "v1.23.0"
     - name: run cri-o integration tests
       include: test.yml
 
@@ -136,7 +136,7 @@
       include: "build/cri-tools.yml"
       vars:
         force_clone: true
-        cri_tools_git_version: "v1.22.0"
+        cri_tools_git_version: "v1.23.0"
     - name: run critest validation and benchmarks
       include: critest.yml
 
@@ -151,7 +151,7 @@
       include: "build/kubernetes.yml"
       vars:
         force_clone: true
-        k8s_git_version: "release-1.21"
+        k8s_git_version: "release-1.23"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
 
@@ -174,7 +174,7 @@
       include: "build/kubernetes.yml"
       vars:
         force_clone: true
-        k8s_git_version: "release-1.21"
+        k8s_git_version: "release-1.23"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
       when: "(cgroupv2 is undefined) or (cgroupv2 == False) | bool"
@@ -182,7 +182,7 @@
       include: "build/kubernetes.yml"
       vars:
         force_clone: true
-        k8s_git_version: "release-1.21"
+        k8s_git_version: "release-1.23"
         k8s_github_fork: "kubernetes"
         crio_socket: "/var/run/crio/crio.sock"
       when: "cgroupv2 | bool"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -40,7 +40,7 @@ dependencies:
       match: conmon
 
   - name: cri-tools
-    version: v1.22.0
+    version: v1.23.0
     refPaths:
     - path: scripts/versions
       match: cri-tools

--- a/scripts/versions
+++ b/scripts/versions
@@ -5,7 +5,7 @@ set -euo pipefail
 declare -A VERSIONS=(
     ["cni-plugins"]=v1.0.1
     ["conmon"]=v2.0.26
-    ["cri-tools"]=v1.22.0
+    ["cri-tools"]=v1.23.0
     ["runc"]=v1.0.2
     ["crun"]=0.20.1
     ["bats"]=v1.3.0


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Use kubernetes 1.23, cri-tools 1.23 in CI, since this is 1.23 branch.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
