### PR TITLE
test: silence a shellcheck SC1090.

### DIFF
--- a/test/cni_plugin_helper.bash
+++ b/test/cni_plugin_helper.bash
@@ -44,7 +44,7 @@ FOUND_K8S_POD_NAME="${K8S_POD_NAME}"
 FOUND_K8S_POD_UID="${K8S_POD_UID}"
 EOT
 
-# shellcheck disable=SC1091
+# shellcheck disable=SC1090,SC1091
 . "$TEST_DIR"/cni_plugin_helper_input.env
 rm -f "$TEST_DIR"/cni_plugin_helper_input.env
 


### PR DESCRIPTION
Silence an SC1090 shellcheck error that seems to have fallen through the cracks.

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Prevent shellcheck failing for a case where it can emit either SC1090,SC1091.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
