### PR TITLE
server: use syncfs instead of fsync

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -303,8 +303,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		return err
 	}
 
-	// first, make sure we sync all storage changes
-	if err := utils.Sync(s.Store().GraphRoot()); err != nil {
+	// first, make sure we sync all the changes to the file system holding
+	// the graph root
+	if err := utils.Syncfs(s.Store().GraphRoot()); err != nil {
 		return errors.Wrapf(err, "failed to sync graph root after shutting down")
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -382,3 +382,17 @@ func Sync(path string) error {
 	}
 	return nil
 }
+
+// Syncfs ensures the file system at path is synced to disk
+func Syncfs(path string) error {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0o755)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := unix.Syncfs(int(f.Fd())); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fsync is not enough when sync'ing the storage to disk, because it would sync only the directory inode metadata.

Instead use syncfs to persist all the changes to the underlying file system.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
None
```


Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>