### PR TITLE
test: avoid concurrent crictl config writes.

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -172,6 +172,13 @@ function setup_test() {
     #
     # A test case that requires an image not listed in $IMAGES
     # should either do an explicit "crictl pull", or use --with-pull.
+    #
+    # Make sure concurrent test cases don't stomp on each other by
+    # updating the configuration file in place while another test
+    # case is using it.
+
+    CRICTL_CONFIG_FILE="$TESTDIR"/crictl.yaml
+    touch "$CRICTL_CONFIG_FILE"
     crictl config \
         --set pull-image-on-create=false \
         --set disable-pull-on-run=true
@@ -187,7 +194,7 @@ function crio() {
 
 # Run crictl using the binary specified by $CRICTL_BINARY.
 function crictl() {
-    "$CRICTL_BINARY" -r "unix://$CRIO_SOCKET" -i "unix://$CRIO_SOCKET" "$@"
+    "$CRICTL_BINARY" --config "$CRICTL_CONFIG_FILE" -r "unix://$CRIO_SOCKET" -i "unix://$CRIO_SOCKET" "$@"
 }
 
 # Run the runtime binary with the specified RUNTIME_ROOT


### PR DESCRIPTION
Use per-test crictl configuration files to ensure concurrent
tests don't stumble upon each other while updating the crictl
(othrewise global) configuration file.

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

During test setup `crictl config --set` is used to alter/disable the default image pulling
logic. By default the configuration file where this information is written to and subsequently
read from is `/etc/crictl.yaml` and it is shared among all test cases. `crictl` uses golang's
`ioutil/os.WriteFile()` to update the file content in place. This is suspected to cause occasional
failures where multiple test cases are being run/set up in parallel and read/write concurrently
that single shared file. The error manifests itself with occasional failures like this: 

```
not ok 72 ctr /etc/resolv.conf rw/ro mode
# (from function `crictl' in file ./helpers.bash, line 190,
#  from function `setup_test' in file ./helpers.bash, line 175,
#  from function `setup' in test file ./ctr.bats, line 6)
#   `setup_test' failed
# time="2022-02-23T21:47:51Z" level=fatal msg="load config file: yaml: line 7: could not find expected ':'"
```

This PR changes the tests to read/write dedicated per-test `crictl` configuration files to eliminate that
potential source of cross-test conflict.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
