### PR TITLE
CI: always install required BATS version.

### DIFF
--- a/contrib/test/integration/build/bats.yml
+++ b/contrib/test/integration/build/bats.yml
@@ -16,3 +16,4 @@
     src: /usr/local/bin/bats
     dest: /usr/bin/bats
     state: link
+    force: true

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -117,6 +117,8 @@
   tasks:
     - name: install parallel
       include: build/parallel.yml
+    - name: clone build and install bats
+      include: "build/bats.yml"
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:


### PR DESCRIPTION

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Currently CI nodes are expected to be set up correctly by regularly scheduled
ansible runs with the `setup` tag. However, empirical evidence (logging BATS
version from `integration` runs on CI nodes) proves that many of the CI nodes
are still running older versions (1.2.1 or 1.2.1-dev).

So instead of relying nodes to get independently set up with the correct BATS
version this PR installs that one right before running the tests. Furthermore, it
makes sure that the freshly installed version is correctly symlinked in place, to
replace any previously present/distro-provided versions.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
