### PR TITLE
resource store: save stage of resource creation and report to callers

### DIFF
--- a/internal/resourcestore/resourcestore.go
+++ b/internal/resourcestore/resourcestore.go
@@ -34,6 +34,7 @@ type Resource struct {
 	watchers []chan struct{}
 	stale    bool
 	name     string
+	stage    string
 }
 
 // wasPut checks that a resource has been fully defined yet.
@@ -194,4 +195,21 @@ func (rc *ResourceStore) WatcherForResource(name string) chan struct{} {
 	}
 	r.watchers = append(r.watchers, watcher)
 	return watcher
+}
+
+func (rc *ResourceStore) SetStageForResource(name, stage string) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	r, ok := rc.resources[name]
+	if !ok {
+		logrus.Tracef("Initializing stage for resource %s to %s", name, stage)
+		rc.resources[name] = &Resource{
+			watchers: []chan struct{}{},
+			name:     name,
+			stage:    stage,
+		}
+		return
+	}
+	logrus.Tracef("Setting stage for resource %s from %s to %s", name, r.stage, stage)
+	r.stage = stage
 }

--- a/internal/resourcestore/resourcestore.go
+++ b/internal/resourcestore/resourcestore.go
@@ -8,7 +8,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const sleepTimeBeforeCleanup = 1 * time.Minute
+const (
+	sleepTimeBeforeCleanup = 1 * time.Minute
+	StageUnknown           = "unknown"
+)
 
 // ResourceStore is a structure that saves information about a recently created resource.
 // Resources can be added and retrieved from the store. A retrieval (Get) also removes the Resource from the store.
@@ -181,20 +184,20 @@ func (rc *ResourceStore) Put(name string, resource IdentifiableCreatable, cleane
 // This is useful for situations where clients retry requests quickly after they "fail" because
 // they've taken too long. Adding a watcher allows the server to slow down the client, but still
 // return the resource in a timely manner once it's actually created.
-func (rc *ResourceStore) WatcherForResource(name string) chan struct{} {
+func (rc *ResourceStore) WatcherForResource(name string) (watcher chan struct{}, stage string) {
 	rc.mutex.Lock()
 	defer rc.mutex.Unlock()
-	watcher := make(chan struct{}, 1)
+	watcher = make(chan struct{}, 1)
 	r, ok := rc.resources[name]
 	if !ok {
 		rc.resources[name] = &Resource{
 			watchers: []chan struct{}{watcher},
 			name:     name,
 		}
-		return watcher
+		return watcher, StageUnknown
 	}
 	r.watchers = append(r.watchers, watcher)
-	return watcher
+	return watcher, r.stage
 }
 
 func (rc *ResourceStore) SetStageForResource(name, stage string) {

--- a/internal/resourcestore/resourcestore_test.go
+++ b/internal/resourcestore/resourcestore_test.go
@@ -159,4 +159,49 @@ var _ = t.Describe("ResourceStore", func() {
 			Expect(didStoreWaitForPut).To(Equal(true))
 		})
 	})
+	Context("Stages", func() {
+		BeforeEach(func() {
+			sut = resourcestore.New()
+			cleaner = resourcestore.NewResourceCleaner()
+			e = &entry{
+				id: testID,
+			}
+		})
+		AfterEach(func() {
+			sut.Close()
+		})
+		It("should have stage unknown if watcher requested", func() {
+			// Given
+			_, stage := sut.WatcherForResource(testName)
+
+			// Then
+			Expect(stage).To(Equal(resourcestore.StageUnknown))
+		})
+		It("should add resource if not present", func() {
+			// Given
+			testStage := "test stage"
+			sut.SetStageForResource(testName, testStage)
+
+			// when
+			_, stage := sut.WatcherForResource(testName)
+
+			// Then
+			Expect(stage).To(Equal(testStage))
+		})
+		It("should update stage", func() {
+			// Given
+			stage1 := "test stage"
+			stage2 := "test stage2"
+			sut.SetStageForResource(testName, stage1)
+			_, stage := sut.WatcherForResource(testName)
+			Expect(stage).To(Equal(stage1))
+
+			// when
+			sut.SetStageForResource(testName, stage2)
+			_, stage = sut.WatcherForResource(testName)
+
+			// Then
+			Expect(stage).To(Equal(stage2))
+		})
+	})
 })

--- a/internal/resourcestore/resourcestore_test.go
+++ b/internal/resourcestore/resourcestore_test.go
@@ -79,16 +79,17 @@ var _ = t.Describe("ResourceStore", func() {
 		})
 		It("Should not fail to Get after retrieving Watcher", func() {
 			// When
-			_ = sut.WatcherForResource(testName)
+			_, stage := sut.WatcherForResource(testName)
 
 			// Then
 			id := sut.Get(testName)
 			Expect(id).To(BeEmpty())
+			Expect(stage).To(Equal(resourcestore.StageUnknown))
 		})
 		It("Should be able to get multiple Watchers", func() {
 			// Given
-			watcher1 := sut.WatcherForResource(testName)
-			watcher2 := sut.WatcherForResource(testName)
+			watcher1, _ := sut.WatcherForResource(testName)
+			watcher2, _ := sut.WatcherForResource(testName)
 
 			waitWatcherSet := func(watcher chan struct{}) bool {
 				<-watcher
@@ -142,7 +143,7 @@ var _ = t.Describe("ResourceStore", func() {
 			timeout := 2 * time.Second
 			sut = resourcestore.NewWithTimeout(timeout)
 
-			_ = sut.WatcherForResource(testName)
+			_, _ = sut.WatcherForResource(testName)
 
 			timedOutChan := make(chan bool)
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -385,6 +385,8 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 		return nil, fmt.Errorf("%v: %w", resourceErr, err)
 	}
 
+	s.resourceStore.SetStageForResource(ctr.Name(), "container creating")
+
 	resourceCleaner.Add(ctx, "createCtr: releasing container name "+ctr.Name(), func() error {
 		s.ReleaseContainerName(ctr.Name())
 		return nil
@@ -422,6 +424,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 		return nil, err
 	}
 
+	s.resourceStore.SetStageForResource(ctr.Name(), "container runtime creation")
 	if err := s.createContainerPlatform(ctx, newContainer, sb.CgroupParent(), mappings); err != nil {
 		return nil, err
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -383,6 +383,8 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil
 	})
 
+	s.resourceStore.SetStageForResource(sbox.Name(), "sandbox creating")
+
 	securityContext := sbox.Config().Linux.SecurityContext
 
 	if securityContext.NamespaceOptions == nil {
@@ -400,6 +402,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		}
 		log.Infof(ctx, "CNI plugin is now ready. Continuing to create %s", sbox.Name())
 	}
+	s.resourceStore.SetStageForResource(sbox.Name(), "sandbox network ready")
 
 	// validate the runtime handler
 	runtimeHandler, err := s.runtimeHandler(req)
@@ -437,6 +440,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 
 	privileged := s.privilegedSandbox(req)
 
+	s.resourceStore.SetStageForResource(sbox.Name(), "sandbox storage creation")
 	podContainer, err := s.StorageRuntimeServer().CreatePodSandbox(s.config.SystemContext,
 		sbox.Name(), sbox.ID(),
 		s.config.PauseImage,
@@ -537,6 +541,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	g.RemoveMount(libsandbox.DevShmPath)
 
 	// create shm mount for the pod containers.
+	s.resourceStore.SetStageForResource(sbox.Name(), "sandbox shm creation")
 	var shmPath string
 	if hostIPC {
 		shmPath = libsandbox.DevShmPath
@@ -561,6 +566,8 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 			return nil
 		})
 	}
+
+	s.resourceStore.SetStageForResource(sbox.Name(), "sandbox spec configuration")
 
 	mnt := spec.Mount{
 		Type:        "bind",
@@ -700,6 +707,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	sysctls := s.configureGeneratorForSysctls(ctx, g, hostNetwork, hostIPC, req.Config.Linux.Sysctls)
 
 	// set up namespaces
+	s.resourceStore.SetStageForResource(sbox.Name(), "sandbox namespace creation")
 	nsCleanupFuncs, err := s.configureGeneratorForSandboxNamespaces(hostNetwork, hostIPC, hostPID, sandboxIDMappings, sysctls, sb, g)
 	// We want to cleanup after ourselves if we are managing any namespaces and fail in this function.
 	// However, we don't immediately register this func with resourceCleaner because we need to pair the
@@ -723,6 +731,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	var ips []string
 	var result cnitypes.Result
 
+	s.resourceStore.SetStageForResource(sbox.Name(), "sandbox network creation")
 	ips, result, err = s.networkStart(ctx, sb)
 	if err != nil {
 		resourceCleaner.Add(ctx, nsCleanupDescription, nsCleanupFunc)
@@ -749,6 +758,18 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		}
 		g.AddAnnotation(annotations.CNIResult, string(cniResultJSON))
 	}
+	s.resourceStore.SetStageForResource(sbox.Name(), "sandbox storage start")
+
+	mountPoint, err := s.StorageRuntimeServer().StartContainer(sbox.ID())
+	if err != nil {
+		return nil, fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %w", containerName, sb.Name(), sbox.ID(), err)
+	}
+	resourceCleaner.Add(ctx, "runSandbox: stopping storage container for sandbox "+sbox.ID(), func() error {
+		if err := s.StorageRuntimeServer().StopContainer(sbox.ID()); err != nil {
+			return fmt.Errorf("could not stop storage container: %s: %w", sbox.ID(), err)
+		}
+		return nil
+	})
 
 	// Set OOM score adjust of the infra container to be very low
 	// so it doesn't get killed.
@@ -763,16 +784,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	}
 
 	saveOptions := generate.ExportOptions{}
-	mountPoint, err := s.StorageRuntimeServer().StartContainer(sbox.ID())
-	if err != nil {
-		return nil, fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %w", containerName, sb.Name(), sbox.ID(), err)
-	}
-	resourceCleaner.Add(ctx, "runSandbox: stopping storage container for sandbox "+sbox.ID(), func() error {
-		if err := s.StorageRuntimeServer().StopContainer(sbox.ID()); err != nil {
-			return fmt.Errorf("could not stop storage container: %s: %w", sbox.ID(), err)
-		}
-		return nil
-	})
 	g.AddAnnotation(annotations.MountPoint, mountPoint)
 
 	hostnamePath := fmt.Sprintf("%s/hostname", podContainer.RunDir)
@@ -925,6 +936,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		}
 	}
 
+	s.resourceStore.SetStageForResource(sbox.Name(), "sandbox container runtime creation")
 	if err := s.createContainerPlatform(ctx, container, sb.CgroupParent(), sandboxIDMappings); err != nil {
 		return nil, err
 	}

--- a/server/utils.go
+++ b/server/utils.go
@@ -164,11 +164,11 @@ func (s *Server) getResourceOrWait(ctx context.Context, name, resourceType strin
 		log.Infof(ctx, "Found %s %s with ID %s in resource cache; using it", resourceType, name, cachedID)
 		return cachedID, nil
 	}
-	watcher := s.resourceStore.WatcherForResource(name)
+	watcher, stage := s.resourceStore.WatcherForResource(name)
 	if watcher == nil {
 		return "", fmt.Errorf("error attempting to watch for %s %s: no longer found", resourceType, name)
 	}
-	log.Infof(ctx, "Creation of %s %s not yet finished. Waiting up to %v for it to finish", resourceType, name, resourceCreationWaitTime)
+	log.Infof(ctx, "Creation of %s %s not yet finished. Currently at stage %v. Waiting up to %v for it to finish", resourceType, name, stage, resourceCreationWaitTime)
 	var err error
 	select {
 	// We should wait as long as we can (within reason), thus stalling the kubelet's sync loop.
@@ -196,7 +196,7 @@ func (s *Server) getResourceOrWait(ctx context.Context, name, resourceType strin
 		err = fmt.Errorf("the requested %s %s is now ready and will be provided to the kubelet on next retry", resourceType, name)
 	}
 
-	return "", fmt.Errorf("kubelet may be retrying requests that are timing out in CRI-O due to system load: %w", err)
+	return "", fmt.Errorf("kubelet may be retrying requests that are timing out in CRI-O due to system load. Currently at stage %v: %w", stage, err)
 }
 
 // FilterDisallowedAnnotations is a common place to have a map of annotations filtered for both runtimes and workloads.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature
#### What this PR does / why we need it:
Often, users are met with the error "Kubelet may be retrying requests that are timing out in CRI-O..." but aren't provided with any details as to why.

This PR adds functionality that saves the stage of container and pod creations, as well as logs them. Now, users will be able to see where their pod or container is
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
CRI-O now logs the stage of container or pod creation under system load. This allows users to find why their creation requests are stalling.
```
