### PR TITLE
test/cgroups.bats: fix incorrect setup order.

### DIFF
--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -3,8 +3,8 @@
 load helpers
 
 function setup() {
-	newconfig="$TESTDIR/config.json"
 	setup_test
+	newconfig="$TESTDIR/config.json"
 }
 
 function teardown() {


### PR DESCRIPTION
Don't dereference $TESTDATA before the test case is set up. The incorrect setup order prevents `cgroups.bats`
tests from being properly isolated from each other, causing very often `localintegration` cgroups tests to fail in github workflows or OpenShift CI.

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Don't dereference $TESTDATA before the test case is set up.
Doing otherwise breaks proper isolation of test cases. This
manifests itself in many ways, since concurrently cgroups
BATS tests can now interfere with each other when mangling
test input data. The most typical symptom is the expected
memory limit being incorrect in one of the test cases like
this:

```
   not ok 14 cgroupv2 unified support
     (in test file ./cgroups.bats, line 103)
       `[[ "$output" == *"209715200"* ]]' failed
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Like the BATS installation fixing bits, this one was also split out from #5596,
so we can merge it ASAP without the remaining other a bit more problematic
bits there.

#### Does this PR introduce a user-facing change?

```release-note
None
```
