### PR TITLE
test/crio-wipe.bats: fix test case teardown ordering.

### DIFF
--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -22,9 +22,9 @@ function run_podman_with_args() {
 }
 
 function teardown() {
-	cleanup_test
 	run_podman_with_args stop -a
 	run_podman_with_args rm -fa
+	cleanup_test
 	cleanup_namespaces_dir
 }
 


### PR DESCRIPTION

Delay running `cleanup_test()`, and thus removing $TESTDIR,
after having stopped and removed containers using a podman
wrapper function, which in turn uses directories relative
to $TESTDIR.

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

The order of calling `cleanup_test()` and the test-specific podman
wrapper function is the wrong way around. The latter tries to use
directories relative to $TESTDIR which is removed by the former.

It is not known if this causes any GH workflow or CI test failures
but it is probably a good idea to fix the ordering anyway.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
