### PR TITLE
test: allow state of failing tests to be kept intact.

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -430,11 +430,21 @@ function cleanup_test() {
         cat "$CRIO_LOG"
         echo "# --- --- ---"
     fi
-    cleanup_ctrs
-    cleanup_pods
-    stop_crio
-    cleanup_lvm
-    cleanup_testdir
+
+    # Leave the test artifacts intact for failing tests if requested.
+    #
+    # BATS_TEST_COMPLETED is set by BATS to 1 if the test passed, otherwise
+    # it is left unset. The variable is also set if the test was skipped.
+    # See https://bats-core.readthedocs.io/en/stable/faq.html#how-can-i-check-if-a-test-failed-succeeded-during-teardown for more details.
+    if [ -z "$TEST_KEEP_ON_FAILURE" ] || [ "${BATS_TEST_COMPLETED:-}" = "1" ]; then
+        cleanup_ctrs
+        cleanup_pods
+        stop_crio
+        cleanup_lvm
+        cleanup_testdir
+    else
+        echo >&3 "* Failed \"$BATS_TEST_DESCRIPTION\", TESTDIR=$TESTDIR, LVM_DEVICE=${LVM_DEVICE:-}"
+    fi
 }
 
 function load_apparmor_profile() {

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -2,6 +2,7 @@
 set -e
 
 TEST_USERNS=${TEST_USERNS:-}
+TEST_KEEP_ON_FAILURE=${TEST_KEEP_ON_FAILURE:-}
 
 cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 


### PR DESCRIPTION
Allow tests to be kept intact upon failure for better debugging and diagnosing.

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Allow tests to be kept intact upon failure for better debugging and diagnosing. If set, the newly introduced `TEST_KEEP_ON_FAILURE` variable causes failing tests to skip their teardown phase, leaving all test artifacts and any related cri-o instances intact.

This should allow one to look for flakes locally with something like this:
`while true; do TEST_KEEP_ON_FAILURE=1 JOBS=8 ./test/test_runner.sh || break; done`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
None
```
