### PR TITLE
Add dedicated security information

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+## Report a Vulnerability
+
+We're extremely grateful for security researchers and users that report
+vulnerabilities to the CRI-O community. All reports are thoroughly investigated
+by a set of community volunteers.
+
+To make a report, email your vulnerability to the private
+[cncf-crio-security@lists.cncf.io](mailto:cncf-crio-security@lists.cncf.io) list
+with the security details and the details expected for [all CRI-O bug
+reports](https://github.com/cri-o/cri-o/blob/main/.github/ISSUE_TEMPLATE/bug-report.yml).
+
+### When Should I Report a Vulnerability?
+
+- You think you discovered a potential security vulnerability in CRI-O
+- You are unsure how a vulnerability affects CRI-O
+- You think you discovered a vulnerability in another project that CRI-O depends
+  on (for projects with their own vulnerability reporting and disclosure
+  process, please report it directly there)
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help tuning CRI-O components for security
+- You need help applying security related updates
+- Your issue is not security related

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -4,12 +4,12 @@
 # to for triaging and handling of incoming issues.
 #
 # The below names agree to abide by the
-# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
 # and will be removed and replaced if they violate that agreement.
 #
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
-# INSTRUCTIONS AT https://kubernetes.io/security/
+# INSTRUCTIONS AT ./SECURITY.md
 
-rhatdan
+haircommander
 mrunalp
-runcom
+saschagrunert


### PR DESCRIPTION
#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
This also publishes the new CNCF security mailing list for reporting vulnerabilities.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
cc @mrunalp @haircommander 

We also remove @runcom and @rhatdan from the security contacts because they became emeritus approvers.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
