### PR TITLE
Automatically `chcon` and `restorecon` on get script

### DIFF
--- a/contrib/bundle/install
+++ b/contrib/bundle/install
@@ -29,3 +29,32 @@ install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crun
 if [ "$ARCH" = amd64 ]; then
     install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/runc
 fi
+
+if [ -n "$SELINUX" ]; then
+    if command -v chcon >/dev/null; then
+        chcon -u system_u -r object_r -t container_runtime_exec_t \
+            "$DESTDIR$BINDIR/crio" \
+            "$DESTDIR$BINDIR/crio-status" \
+            "$DESTDIR$BINDIR/crun"
+
+        if [ "$ARCH" = amd64 ]; then
+            chcon -u system_u -r object_r -t container_runtime_exec_t \
+                "$DESTDIR$BINDIR/runc"
+        fi
+
+        chcon -u system_u -r object_r -t bin_t \
+            "$DESTDIR$BINDIR/conmon" \
+            "$DESTDIR$BINDIR/crictl" \
+            "$DESTDIR$BINDIR/pinns"
+
+        chcon -R -u system_u -r object_r -t bin_t \
+            "$DESTDIR$OPT_CNI_BIN_DIR"
+
+        chcon -R -u system_u -r object_r -t container_config_t \
+            "$DESTDIR$ETCDIR/crio" \
+            "$DESTDIR$OCIDIR/crio-umount.conf"
+
+        chcon -R -u system_u -r object_r -t systemd_unit_file_t \
+            "$DESTDIR$SYSTEMDDIR/crio.service"
+    fi
+fi

--- a/scripts/get
+++ b/scripts/get
@@ -189,3 +189,32 @@ install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crun
 if [ "$ARCH" = amd64 ]; then
     install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/runc
 fi
+
+if [ -n "$SELINUX" ]; then
+    if command -v chcon >/dev/null; then
+        chcon -u system_u -r object_r -t container_runtime_exec_t \
+            "$DESTDIR$BINDIR/crio" \
+            "$DESTDIR$BINDIR/crio-status" \
+            "$DESTDIR$BINDIR/crun"
+
+        if [ "$ARCH" = amd64 ]; then
+            chcon -u system_u -r object_r -t container_runtime_exec_t \
+                "$DESTDIR$BINDIR/runc"
+        fi
+
+        chcon -u system_u -r object_r -t bin_t \
+            "$DESTDIR$BINDIR/conmon" \
+            "$DESTDIR$BINDIR/crictl" \
+            "$DESTDIR$BINDIR/pinns"
+
+        chcon -R -u system_u -r object_r -t bin_t \
+            "$DESTDIR$OPT_CNI_BIN_DIR"
+
+        chcon -R -u system_u -r object_r -t container_config_t \
+            "$DESTDIR$ETCDIR/crio" \
+            "$DESTDIR$OCIDIR/crio-umount.conf"
+
+        chcon -R -u system_u -r object_r -t systemd_unit_file_t \
+            "$DESTDIR$SYSTEMDDIR/crio.service"
+    fi
+fi

--- a/scripts/node_e2e_installer
+++ b/scripts/node_e2e_installer
@@ -21,11 +21,6 @@ install_crio() {
     # Setup SELinux labels
     mkdir -p /var/lib/kubelet
     chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
-    chcon -u system_u -r object_r -t container_runtime_exec_t /usr/local/bin/crio /usr/local/bin/crio-status /usr/local/bin/runc /usr/local/bin/crun
-    chcon -u system_u -r object_r -t bin_t /usr/local/bin/conmon /usr/local/bin/crictl /usr/local/bin/pinns
-    chcon -R -u system_u -r object_r -t bin_t /opt/cni/bin/
-    chcon -R -u system_u -r object_r -t container_config_t /etc/crio /etc/crio/crio.conf /usr/local/share/oci-umount/oci-umount.d/crio-umount.conf
-    chcon -R -u system_u -r object_r -t systemd_unit_file_t /usr/local/lib/systemd/system/crio.service
 
     mount /tmp /tmp -o remount,exec,suid
 


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows SELinux enabled distributions to automatically set the right contexts.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Automatically `chcon` and `restorecon` on get script for SELinux enabled distributions.
```
