### PR TITLE
pinns: Pass sysctls as repeated '-s' arguments

### DIFF
--- a/pinns/src/pinns.c
+++ b/pinns/src/pinns.c
@@ -49,7 +49,8 @@ int main(int argc, char **argv) {
   bool bind_user = false;
   bool bind_cgroup = false;
   bool bind_mount = false;
-  char *sysctls = NULL;
+  char **sysctls = NULL;
+  int sysctls_count = 0;
   char res;
 
   static const struct option long_options[] = {
@@ -66,6 +67,8 @@ int main(int argc, char **argv) {
       {"gid-mapping", optional_argument, NULL, GID_MAPPING},
       {"sysctl", optional_argument, NULL, 's'},
   };
+
+  sysctls = calloc(argc/2, sizeof(char *));
 
   while ((c = getopt_long(argc, argv, "mpchuUind:f:s:", long_options, NULL)) != -1) {
     switch (c) {
@@ -113,7 +116,8 @@ int main(int argc, char **argv) {
       pin_path = optarg;
       break;
     case 's':
-	  sysctls = optarg;
+      sysctls[sysctls_count] = optarg;
+      sysctls_count++;
       break;
     case 'f':
       filename = optarg;
@@ -239,7 +243,7 @@ int main(int argc, char **argv) {
     close(p[0]);
   }
 
-  if (sysctls && configure_sysctls(sysctls) < 0) {
+  if (sysctls_count != 0 && configure_sysctls(sysctls, sysctls_count) < 0) {
     pexit("Failed to configure sysctls after unshare");
   }
 

--- a/pinns/src/sysctl.h
+++ b/pinns/src/sysctl.h
@@ -2,6 +2,6 @@
 #if !defined(SYSCTL_H)
 #define SYSCTL_H
 
-int configure_sysctls (char * const sysctls);
+int configure_sysctls (char ** const sysctls, int size);
 
 #endif // SYSCTL_H


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Use repeated '-s' arguments to pass sysctls keys and values to pinns to replace the serialization in cri-o and parsing in pinns.

To simplify the logic, this allocates an 'argc/2' sized array to store the pointers to the sysctls `k=v` pairs. This array will in most cases be much bigger than what is really needed but this should be safe as argc is limited in size on Linux.

This is a followup fix for https://github.com/cri-o/cri-o/security/advisories/GHSA-6x2m-w449-qwx7.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```