### PR TITLE
Update golangci-lint and config

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.0
+          version: v1.45.0
 
           # Only show new issues for a pull request.
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,13 +17,16 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bidichk
     - bodyclose
     - deadcode
+    - decorder
     - depguard
     - dogsled
     - dupl
     - durationcheck
     - errcheck
+    - errchkjson
     - exportloopref
     - forcetypeassert
     - gochecknoinits
@@ -37,6 +40,7 @@ linters:
     - goprintffuncname
     - gosimple
     - govet
+    - grouper
     - importas
     - ineffassign
     - makezero
@@ -49,6 +53,7 @@ linters:
     - staticcheck
     - structcheck
     - stylecheck
+    - tenv
     - tparallel
     - typecheck
     - unconvert
@@ -56,7 +61,10 @@ linters:
     - unused
     - varcheck
     - whitespace
+    # - containedctx
+    # - contextcheck
     # - cyclop
+    # - errname
     # - errorlint
     # - exhaustive
     # - exhaustivestruct
@@ -73,9 +81,12 @@ linters:
     # - gomodguard
     # - gosec
     # - ifshort
+    # - ireturn
     # - lll
+    # - maintidx
     # - nestif
     # - nilerr
+    # - nilnil
     # - nlreturn
     # - noctx
     # - paralleltest
@@ -85,6 +96,7 @@ linters:
     # - tagliatelle
     # - testpackage
     # - thelper
+    # - varnamelen
     # - wastedassign
     # - wrapcheck
     # - wsl
@@ -97,31 +109,57 @@ linters-settings:
       # Diagnostic
       - appendAssign
       - argOrder
+      - badCall
       - badCond
+      - badLock
+      - badRegexp
+      - badSorting
+      - builtinShadowDecl
       - caseOrder
       - codegenComment
       - commentedOutCode
+      - deferInLoop
       - deprecatedComment
       - dupArg
       - dupBranchBody
       - dupCase
       - dupSubExpr
+      - dynamicFmtString
+      - emptyDecl
+      - evalOrder
       - exitAfterDefer
+      - externalErrorReassign
       - flagDeref
       - flagName
+      - mapKey
       - nilValReturn
       - offBy1
+      - regexpPattern
+      - returnAfterHttpError
       - sloppyReassign
+      - sloppyTypeAssert
+      - sortSlice
+      - sprintfQuotedString
+      - sqlQuery
+      - syncMapLoadAndDelete
+      - truncateCmp
+      - unnecessaryDefer
       - weakCond
-      # - octalLiteral
+      # - filepathJoin
 
       # Performance
       - appendCombine
       - equalFold
       - hugeParam
       - indexAlloc
+      - preferDecodeRune
+      - preferFprint
+      - preferStringWriter
+      - preferWriteByte
       - rangeExprCopy
       - rangeValCopy
+      - sliceClear
+      - stringXbytes
 
       # Style
       - assignOp
@@ -130,19 +168,32 @@ linters-settings:
       - commentFormatting
       - commentedOutImport
       - defaultCaseOrder
+      - deferUnlambda
       - docStub
+      - dupImport
       - elseif
       - emptyFallthrough
       - emptyStringTest
+      - exposedSyncMutex
       - hexLiteral
+      - httpNoBody
       - ifElseChain
       - methodExprCall
+      - newDeref
+      - octalLiteral
+      - preferFilepathJoin
+      - redundantSprint
       - regexpMust
+      - regexpSimplify
+      - ruleguard
       - singleCaseSwitch
       - sloppyLen
-      - stringXbytes
+      - stringConcatSimplify
       - switchTrue
+      - timeExprSimplify
+      - tooManyResultsChecker
       - typeAssertChain
+      - typeDefFirst
       - typeSwitchVar
       - underef
       - unlabelStmt
@@ -151,6 +202,8 @@ linters-settings:
       - valSwap
       - wrapperFunc
       - yodaStyleExpr
+      # - ioutilDeprecated
+      # - whyNoLint
 
       # Opinionated
       - builtinShadow

--- a/Makefile
+++ b/Makefile
@@ -139,13 +139,13 @@ endif
 lint: .gopathok ${GOLANGCI_LINT}
 	${GOLANGCI_LINT} version
 	${GOLANGCI_LINT} linters
-	${GOLANGCI_LINT} run
+	GL_DEBUG=gocritic ${GOLANGCI_LINT} run
 
 check-log-lines:
 	./hack/log-capitalized.sh
 	./hack/tree_status.sh
 
-check-config-template: 
+check-config-template:
 	./hack/validate-config.sh
 
 shellfiles: ${SHFMT}
@@ -262,7 +262,7 @@ ${ZEITGEIST}:
 	$(call go-build,./vendor/sigs.k8s.io/zeitgeist)
 
 ${GOLANGCI_LINT}:
-	export VERSION=v1.44.0 \
+	export VERSION=v1.45.0 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
 	curl -sSfL $$URL/$$VERSION/install.sh | sh -s $$VERSION

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -12,7 +12,7 @@ dependencies:
       match: version
 
   - name: golangci-lint
-    version: v1.44.0
+    version: v1.45.0
     refPaths:
     - path: .github/workflows/verify.yml
       match: version

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -58,7 +58,7 @@ func New(crioSocketPath string) (CrioClient, error) {
 }
 
 func (c *crioClientImpl) getRequest(path string) (*http.Request, error) {
-	req, err := http.NewRequest("GET", path, nil)
+	req, err := http.NewRequest("GET", path, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/hostport/fake_iptables.go
+++ b/internal/hostport/fake_iptables.go
@@ -211,7 +211,7 @@ func (f *fakeIPTables) EnsureRule(position utiliptables.RulePosition, tableName 
 	for _, arg := range args {
 		// quote args with internal spaces (like comments)
 		if strings.Contains(arg, " ") {
-			arg = fmt.Sprintf("\"%s\"", arg)
+			arg = fmt.Sprintf("%q", arg)
 		}
 		ruleArgs = append(ruleArgs, arg)
 	}

--- a/internal/hostport/meta_hostport_manager.go
+++ b/internal/hostport/meta_hostport_manager.go
@@ -1,7 +1,7 @@
 package hostport
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -61,7 +61,7 @@ func (mh *metaHostportManager) Remove(id string, podPortMapping *PodPortMapping)
 		errstrings = append(errstrings, err.Error())
 	}
 	if len(errstrings) > 0 {
-		return fmt.Errorf(strings.Join(errstrings, "\n"))
+		return errors.New(strings.Join(errstrings, "\n"))
 	}
 	return nil
 }

--- a/internal/lib/stats/stats_server.go
+++ b/internal/lib/stats/stats_server.go
@@ -27,7 +27,7 @@ type StatsServer struct {
 	sboxStats        map[string]*types.PodSandboxStats
 	ctrStats         map[string]*types.ContainerStats
 	parentServerIface
-	sync.Mutex
+	mutex sync.Mutex
 }
 
 // parentServerIface is an interface for requesting information from the parent ContainerServer.
@@ -76,8 +76,8 @@ func (ss *StatsServer) updateLoop() {
 // It does so by updating the stats of every sandbox, which in turn
 // updates the stats for each container it has.
 func (ss *StatsServer) update() {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mutex.Lock()
+	defer ss.mutex.Unlock()
 
 	for _, sb := range ss.ListSandboxes() {
 		ss.updateSandbox(sb)
@@ -249,15 +249,15 @@ func linkToInterface(link netlink.Link) (*types.NetworkInterfaceUsage, error) {
 
 // StatsForSandbox returns the stats for the given sandbox
 func (ss *StatsServer) StatsForSandbox(sb *sandbox.Sandbox) *types.PodSandboxStats {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mutex.Lock()
+	defer ss.mutex.Unlock()
 	return ss.statsForSandbox(sb)
 }
 
 // StatsForSandboxes returns the stats for the given list of sandboxes
 func (ss *StatsServer) StatsForSandboxes(sboxes []*sandbox.Sandbox) []*types.PodSandboxStats {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mutex.Lock()
+	defer ss.mutex.Unlock()
 	stats := make([]*types.PodSandboxStats, 0, len(sboxes))
 	for _, sb := range sboxes {
 		if stat := ss.statsForSandbox(sb); stat != nil {
@@ -284,22 +284,22 @@ func (ss *StatsServer) statsForSandbox(sb *sandbox.Sandbox) *types.PodSandboxSta
 // RemoveStatsForSandbox removes the saved entry for the specified sandbox
 // to prevent the map from always growing.
 func (ss *StatsServer) RemoveStatsForSandbox(sb *sandbox.Sandbox) {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mutex.Lock()
+	defer ss.mutex.Unlock()
 	delete(ss.sboxStats, sb.ID())
 }
 
 // StatsForContainer returns the stats for the given container
 func (ss *StatsServer) StatsForContainer(c *oci.Container, sb *sandbox.Sandbox) *types.ContainerStats {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mutex.Lock()
+	defer ss.mutex.Unlock()
 	return ss.statsForContainer(c, sb)
 }
 
 // StatsForContainers returns the stats for the given list of containers
 func (ss *StatsServer) StatsForContainers(ctrs []*oci.Container) []*types.ContainerStats {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mutex.Lock()
+	defer ss.mutex.Unlock()
 	stats := make([]*types.ContainerStats, 0, len(ctrs))
 	for _, c := range ctrs {
 		sb := ss.GetSandbox(c.Sandbox())
@@ -331,8 +331,8 @@ func (ss *StatsServer) statsForContainer(c *oci.Container, sb *sandbox.Sandbox) 
 // RemoveStatsForContainer removes the saved entry for the specified container
 // to prevent the map from always growing.
 func (ss *StatsServer) RemoveStatsForContainer(c *oci.Container) {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mutex.Lock()
+	defer ss.mutex.Unlock()
 	delete(ss.ctrStats, c.ID())
 }
 

--- a/internal/log/klog.go
+++ b/internal/log/klog.go
@@ -51,7 +51,7 @@ func writeKeysAndValues(b *strings.Builder, keysAndValues ...interface{}) {
 			b.WriteString(" (")
 		}
 		if i > 0 {
-			b.WriteRune(' ')
+			b.WriteByte(' ')
 		}
 
 		switch v.(type) {
@@ -68,7 +68,7 @@ func writeKeysAndValues(b *strings.Builder, keysAndValues ...interface{}) {
 		}
 
 		if i == len(keysAndValues) {
-			b.WriteRune(')')
+			b.WriteByte(')')
 		}
 	}
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -564,7 +564,7 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 			Stdout:   stdoutBuf,
 			Stderr:   stderrBuf,
 			ExitCode: -1,
-			Err:      fmt.Errorf(ec.Message),
+			Err:      errors.New(ec.Message),
 		}
 	}
 

--- a/internal/oci/runtime_oci_test.go
+++ b/internal/oci/runtime_oci_test.go
@@ -149,7 +149,8 @@ func waitContainerStopAndFailAfterTimeout(ctx context.Context,
 	sut *oci.Container,
 	waitContainerStopTimeout int64,
 	failAfterTimeout int64,
-	ignoreKill bool) {
+	ignoreKill bool,
+) {
 	select {
 	case stoppedChan <- oci.WaitContainerStop(ctx, sut, inSeconds(waitContainerStopTimeout), ignoreKill):
 	case <-time.After(inSeconds(failAfterTimeout)):

--- a/internal/process/defunct_processes_test.go
+++ b/internal/process/defunct_processes_test.go
@@ -1,8 +1,6 @@
 package process_test
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -41,16 +39,12 @@ var _ = t.Describe("Process", func() {
 		Context("Should fail", func() {
 			It("when given an invalid path name", func() {
 				defunctCount, err := process.DefunctProcessesForPath("./test/proc")
-				formattedErr := fmt.Sprintf("%v", err)
-
-				Expect(formattedErr).To(Equal("open ./test/proc: no such file or directory"))
+				Expect(err.Error()).To(Equal("open ./test/proc: no such file or directory"))
 				Expect(defunctCount).To(Equal(uint(0)))
 			})
 			It("when the given path name does not belong to a directory", func() {
 				defunctCount, err := process.DefunctProcessesForPath("./testing/proc_fail")
-				formattedErr := fmt.Sprintf("%v", err)
-
-				Expect(formattedErr).To(Equal("readdirent ./testing/proc_fail: not a directory"))
+				Expect(err.Error()).To(Equal("readdirent ./testing/proc_fail: not a directory"))
 				Expect(defunctCount).To(Equal(uint(0)))
 			})
 		})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,16 +82,6 @@ type Iface interface {
 	GetData() *Config
 }
 
-// GetStore returns the container storage for a given configuration
-func (c *RootConfig) GetStore() (storage.Store, error) {
-	return storage.GetStore(storage.StoreOptions{
-		RunRoot:            c.RunRoot,
-		GraphRoot:          c.Root,
-		GraphDriverName:    c.Storage,
-		GraphDriverOptions: c.StorageOptions,
-	})
-}
-
 // GetData returns the Config of a Iface
 func (c *Config) GetData() *Config {
 	return c
@@ -172,6 +162,16 @@ type RootConfig struct {
 	// If set to false, one must use the external command `crio wipe` to wipe the containers and images in these situations.
 	// The option InternalWipe is deprecated, and will be removed in a future release.
 	InternalWipe bool `toml:"internal_wipe"`
+}
+
+// GetStore returns the container storage for a given configuration
+func (c *RootConfig) GetStore() (storage.Store, error) {
+	return storage.GetStore(storage.StoreOptions{
+		RunRoot:            c.RunRoot,
+		GraphRoot:          c.Root,
+		GraphDriverName:    c.Storage,
+		GraphDriverOptions: c.StorageOptions,
+	})
 }
 
 // RuntimeHandler represents each item of the "crio.runtime.runtimes" TOML

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -144,7 +144,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 			tryIncrementImagePullFailureMetric(img, err)
 			continue
 		}
-		defer tmpImg.Close()
+		defer tmpImg.Close() // nolint:gocritic
 
 		var storedImage *storage.ImageResult
 		storedImage, err = s.StorageImageServer().ImageStatus(s.config.SystemContext, img)
@@ -175,7 +175,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 
 		// Pull by collecting progress metrics
 		progress := make(chan imageTypes.ProgressProperties)
-		defer close(progress)
+		defer close(progress) // nolint:gocritic
 		go func() {
 			for p := range progress {
 				if p.Event == imageTypes.ProgressEventSkipped {

--- a/server/inspect_ginkgo_test.go
+++ b/server/inspect_ginkgo_test.go
@@ -32,7 +32,7 @@ var _ = t.Describe("Inspect", func() {
 		It("should succeed with /info route", func() {
 			// Given
 			// When
-			request, err := http.NewRequest("GET", "/info", nil)
+			request, err := http.NewRequest("GET", "/info", http.NoBody)
 			mux.ServeHTTP(recorder, request)
 
 			// Then
@@ -50,7 +50,7 @@ var _ = t.Describe("Inspect", func() {
 
 			// When
 			request, err := http.NewRequest("GET",
-				"/containers/"+testContainer.ID(), nil)
+				"/containers/"+testContainer.ID(), http.NoBody)
 			mux.ServeHTTP(recorder, request)
 
 			// Then
@@ -69,7 +69,7 @@ var _ = t.Describe("Inspect", func() {
 
 			// When
 			request, err := http.NewRequest("GET",
-				"/containers/"+testContainer.ID(), nil)
+				"/containers/"+testContainer.ID(), http.NoBody)
 			mux.ServeHTTP(recorder, request)
 
 			// Then
@@ -87,7 +87,7 @@ var _ = t.Describe("Inspect", func() {
 
 			// When
 			request, err := http.NewRequest("GET",
-				"/containers/"+testContainer.ID(), nil)
+				"/containers/"+testContainer.ID(), http.NoBody)
 			mux.ServeHTTP(recorder, request)
 
 			// Then
@@ -100,7 +100,7 @@ var _ = t.Describe("Inspect", func() {
 		It("should fail with empty with /containers route", func() {
 			// Given
 			// When
-			request, err := http.NewRequest("GET", "/containers", nil)
+			request, err := http.NewRequest("GET", "/containers", http.NoBody)
 			mux.ServeHTTP(recorder, request)
 
 			// Then
@@ -112,7 +112,7 @@ var _ = t.Describe("Inspect", func() {
 		It("should fail with invalid container ID on /containers route", func() {
 			// Given
 			// When
-			request, err := http.NewRequest("GET", "/containers/123", nil)
+			request, err := http.NewRequest("GET", "/containers/123", http.NoBody)
 			mux.ServeHTTP(recorder, request)
 
 			// Then


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now update the golangci-lint version to the latest release as well as
the configuration. This enables the linters bidichk, decorder, errchkjson,
grouper, tenv as well as new gocritic linters and fixes their reports.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
