### PR TITLE
Add bats test for zombie conmon cleanup

### DIFF
--- a/test/pod.bats
+++ b/test/pod.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# vim:set ft=bash :
 
 load helpers
 


### PR DESCRIPTION
In #5500, defensive code was added to ensure all child processes are
cleaned up when conmon early initialization fails.  This bats test
forces one of the error scenarios (by adding an unparseable workload
annotation to a container) and then ensures no zombies leak in this
failure scenario.

Verified by temporarily reverting #5500 (test fails with 10 zombies
created), then bringing back #5500 (test passes)

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds bats testing for the issue originally fixed in #5000

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
