### PR TITLE
Raise DefaultPidsLimit from 1024 to 4096

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,7 +114,7 @@ const (
 const (
 	// DefaultPidsLimit is the default value for maximum number of processes
 	// allowed inside a container
-	DefaultPidsLimit = 1024
+	DefaultPidsLimit = 4096
 
 	// DefaultLogSizeMax is the default value for the maximum log size
 	// allowed for a container. Negative values mean that no limit is imposed.


### PR DESCRIPTION
To match some workloads such as databases with default configuration, increase the default pid_limit to 4096.

Signed-off-by: Robb Manes <rmanes@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind feature
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

The default `pids_limit` was defined at 1024, which is no longer suitable for many out-of-the-box workloads (notably we've seen database workloads deployed that easily exceed this).  Raising this to 4096 should no longer be of as much concern as it was previously as the defaults elsewhere, such as within `systemd`, are also 4096, as well as other container engines. 

#### Which issue(s) this PR fixes:
Fixes: https://github.com/cri-o/cri-o/issues/1921
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

Feedback appreciated.  We have quite a number of issues regarding the defaults needing to be overridden, and quite a few requests to have the defaults just be larger as some common application deployments are exceeding 1024 (databases, mostly).

#### Does this PR introduce a user-facing change?

None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
