### PR TITLE
server: Canonize selinux label for comparison with filesystem label

### DIFF
--- a/test/selinux.bats
+++ b/test/selinux.bats
@@ -40,7 +40,7 @@ function teardown() {
 	create_runtime_with_allowed_annotation "selinux" "io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel"
 	start_crio
 
-	jq '	  .linux.security_context.selinux_options = {"level": "s0:c100,c200"}
+	jq '	  .linux.security_context.selinux_options = {"level": "s0:c200,c100"}
 		|  .annotations["io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel"] = "true"' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
-->
/kind bug
<!--
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
If you try to use the annotation: io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel, It doesn't work because, the selinux label with the mcs from the annotation in the namespace, has the wrong order in the mcs.
```
$ oc get project test -o yaml | grep mcs
openshift.io/sa.scc.mcs: s0:c75,c35
```
The selinux label for the comparison with the label in the filesystem will be:  **system_u:object_r:container_file_t:s0:c75,c35**
but in the filesystem the label is: **system_u:object_r:container_file_t:s0:c35,c75**

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel` annotation usage with the OpenShift MCS.
```
