### PR TITLE
POC for CAP_CHECKPOINT_RESTORE

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -563,6 +563,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		Options:     []string{"rw", "bind"},
 	})
 
+	if inStringSlice(specgen.Config.Process.Capabilities.Effective, "CAP_CHECKPOINT_RESTORE") {
+		ctr.SpecAddMount(rspec.Mount{
+			Destination: "/proc/sys/kernel/ns_last_pid",
+			Type:        "bind",
+			Source:      "/proc/sys/kernel/ns_last_pid",
+			Options:     []string{"rw", "bind"},
+		})
+	}
+
 	options := []string{"rw"}
 	if readOnlyRootfs {
 		options = []string{"ro"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug

#### What this PR does / why we need it:
@mrunalp suggested I open this PoC PR for wider discussion with the CRI-O project. This PoC ensures that containers are able to make use of the [privileges granted](https://man7.org/linux/man-pages/man7/capabilities.7.html) by `CAP_CHECKPOINT_RESTORE`.  It also requires the following change to `runc`:
```
diff --git a/libcontainer/rootfs_linux.go b/libcontainer/rootfs_linux.go
index 51660f5e..3cfd2bf1 100644
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -577,6 +577,7 @@ func checkProcMount(rootfs, dest, source string) error {
                "/proc/loadavg",
                "/proc/slabinfo",
                "/proc/net/dev",
+               "/proc/sys/kernel/ns_last_pid",
        }
        for _, valid := range validProcMounts {
```
I would appreciate your thoughts/suggestions with regard to the behaviour for handling `CAP_CHECKPOINT_RESTORE`. Opening this as a draft PR as the primary intention is for discussion.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
