### PR TITLE
Bug 2064741: Disable systemd-mode cgroup detection if /sys/fs/cgroup is bind mounted from the host

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -37,6 +37,11 @@ import (
 	"github.com/intel/goresctrl/pkg/blockio"
 )
 
+const (
+	cgroupSysFsPath        = "/sys/fs/cgroup"
+	cgroupSysFsSystemdPath = "/sys/fs/cgroup/systemd"
+)
+
 // createContainerPlatform performs platform dependent intermediate steps before calling the container's oci.Runtime().CreateContainer()
 func (s *Server) createContainerPlatform(ctx context.Context, container *oci.Container, cgroupParent string, idMappings *idtools.IDMappings) error {
 	if idMappings != nil && !container.Spoofed() {
@@ -508,7 +513,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 			})
 			ctr.SpecAddMount(rspec.Mount{
-				Destination: "/sys/fs/cgroup",
+				Destination: cgroupSysFsPath,
 				Type:        "cgroup",
 				Source:      "cgroup",
 				Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
@@ -524,7 +529,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 			Options:     []string{"nosuid", "noexec", "nodev", "rw", "rslave"},
 		})
 		ctr.SpecAddMount(rspec.Mount{
-			Destination: "/sys/fs/cgroup",
+			Destination: cgroupSysFsPath,
 			Type:        "cgroup",
 			Source:      "cgroup",
 			Options:     []string{"nosuid", "noexec", "nodev", "rw", "relatime", "rslave"},
@@ -1009,7 +1014,7 @@ func addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container, mountLabel,
 
 	if _, mountSys := mountSet["/sys"]; !mountSys {
 		m := rspec.Mount{
-			Destination: "/sys/fs/cgroup",
+			Destination: cgroupSysFsPath,
 			Type:        "cgroup",
 			Source:      "cgroup",
 			Options:     []string{"nosuid", "noexec", "nodev", "relatime"},
@@ -1066,26 +1071,49 @@ func setupSystemd(mounts []rspec.Mount, g generate.Generator) {
 	}
 
 	if node.CgroupIsV2() {
-		g.RemoveMount("/sys/fs/cgroup")
+		g.RemoveMount(cgroupSysFsPath)
 
 		systemdMnt := rspec.Mount{
-			Destination: "/sys/fs/cgroup",
+			Destination: cgroupSysFsPath,
 			Type:        "cgroup",
 			Source:      "cgroup",
 			Options:     []string{"private", "rw"},
 		}
 		g.AddMount(systemdMnt)
 	} else {
-		systemdMnt := rspec.Mount{
-			Destination: "/sys/fs/cgroup/systemd",
-			Type:        "bind",
-			Source:      "/sys/fs/cgroup/systemd",
-			Options:     []string{"bind", "nodev", "noexec", "nosuid"},
+		// If the /sys/fs/cgroup is bind mounted from the host,
+		// then systemd-mode cgroup should be disabled
+		// https://bugzilla.redhat.com/show_bug.cgi?id=2064741
+		if NoCgroupMount(g.Mounts()) {
+			systemdMnt := rspec.Mount{
+				Destination: cgroupSysFsSystemdPath,
+				Type:        "bind",
+				Source:      cgroupSysFsSystemdPath,
+				Options:     []string{"bind", "nodev", "noexec", "nosuid"},
+			}
+			g.AddMount(systemdMnt)
 		}
-		g.AddMount(systemdMnt)
-		g.AddLinuxMaskedPaths("/sys/fs/cgroup/systemd/release_agent")
+		g.AddLinuxMaskedPaths(filepath.Join(cgroupSysFsSystemdPath, "release_agent"))
 	}
 	g.AddProcessEnv("container", "crio")
+}
+
+func NoCgroupMount(mounts []rspec.Mount) bool {
+	for _, m := range mounts {
+		if (m.Destination == cgroupSysFsPath || m.Destination == "/sys/fs" || m.Destination == "/sys") && isBindMount(m.Options) {
+			return false
+		}
+	}
+	return true
+}
+
+func isBindMount(mountOptions []string) bool {
+	for _, option := range mountOptions {
+		if option == "bind" || option == "rbind" {
+			return true
+		}
+	}
+	return false
 }
 
 func newLinuxContainerSecurityContext() *types.LinuxContainerSecurityContext {


### PR DESCRIPTION
Disable systemd-mode cgroup detection if /sys/fs/cgroup is bind mounted from the host 

Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind bug

#### What this PR does / why we need it:
Disable systemd-mode cgroup detection if /sys/fs/cgroup is bind mounted from the host

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2064741

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Disable systemd-mode cgroup detection if /sys/fs/cgroup is bind mounted from the host 
```
