### PR TITLE
seccomp: drop unshare syscall from default profile

### DIFF
--- a/internal/config/seccomp/seccomp_test.go
+++ b/internal/config/seccomp/seccomp_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io/ioutil"
 
-	containers_seccomp "github.com/containers/common/pkg/seccomp"
 	"github.com/cri-o/cri-o/internal/config/seccomp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -53,7 +52,7 @@ var _ = t.Describe("Config", func() {
 			res := sut.Profile()
 
 			// Then
-			Expect(res).To(Equal(containers_seccomp.DefaultProfile()))
+			Expect(res).To(Equal(seccomp.DefaultProfile()))
 		})
 	})
 

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -102,3 +102,14 @@ function teardown() {
 	crictl start "$ctr_id"
 	crictl exec --sync "$ctr_id" chmod 777 .
 }
+
+# 8. test running with ctr runtime/default don't allow unshare
+@test "ctr seccomp profiles runtime/default block unshare" {
+	unset CONTAINER_SECCOMP_PROFILE
+	restart_crio
+	jq '	.linux.security_context.seccomp_profile_path = ""' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR"/seccomp.json
+
+	ctr_id=$(crictl run "$TESTDIR"/seccomp.json "$TESTDATA"/sandbox_config.json)
+	! crictl exec --sync "$ctr_id" /bin/sh -c "unshare"
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind api-change
#### What this PR does / why we need it:
when it comes to confining processes, having a contained process have access to unshare has historically lead to a host of vulnerabilities. CRI-O attempts to be secure by default, so in addition to adding a seccomp profile by default, we should also drop unshare by default, unless a container has CAP_SYS_ADMIN

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Block containers without CAP_SYS_ADMIN on `unshare` syscall in the default seccomp profile, to better contain unprivileged container processes.
```
