### PR TITLE
Add bats test to ensure namespaces are cleaned up on pod stop

### DIFF
--- a/test/pod.bats
+++ b/test/pod.bats
@@ -310,3 +310,11 @@ function teardown() {
 	pod_pause_image=$(echo "$output" | jq -e .info.image)
 	[[ "$conf_pause_image" == "$pod_pause_image" ]]
 }
+
+@test "pod stop cleans up all namespaces" {
+	export CONTAINER_NAMESPACES_DIR="$TESTDIR"/namespaces
+	start_crio
+	id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	crictl stopp "$id"
+	[[ $(find "$CONTAINER_NAMESPACES_DIR" -type f) -eq 0 ]]
+}


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Adds a bats test to ensure namespace cleanup happens as a result of pod stop.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
