### PR TITLE
remove the external dependency on the conntrack binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,6 @@ jobs:
             containernetworking-plugins \
             crun \
             moby-runc
-          sudo apt-get install -y conntrack
       - run: make bundle-test-e2e
 
   upload-artifacts:

--- a/internal/hostport/hostport_manager_test.go
+++ b/internal/hostport/hostport_manager_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	"k8s.io/utils/exec"
 )
 
 func TestOpenCloseHostports(t *testing.T) {
@@ -132,7 +131,6 @@ func TestOpenCloseHostports(t *testing.T) {
 		hostPortMap: make(map[hostport]closeable),
 		iptables:    iptables,
 		portOpener:  portOpener.openFakeSocket,
-		execer:      exec.New(),
 	}
 
 	// open all hostports defined in the test cases
@@ -234,7 +232,6 @@ func TestHostportManager(t *testing.T) {
 		hostPortMap: make(map[hostport]closeable),
 		iptables:    iptables,
 		portOpener:  portOpener.openFakeSocket,
-		execer:      exec.New(),
 	}
 	testCases := []struct {
 		mapping     *PodPortMapping
@@ -541,7 +538,6 @@ func TestHostportManagerIPv6(t *testing.T) {
 		hostPortMap: make(map[hostport]closeable),
 		iptables:    iptables,
 		portOpener:  portOpener.openFakeSocket,
-		execer:      exec.New(),
 	}
 	testCases := []struct {
 		mapping     *PodPortMapping

--- a/internal/hostport/meta_hostport_manager_test.go
+++ b/internal/hostport/meta_hostport_manager_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	"k8s.io/utils/exec"
 )
 
 func TestMetaHostportManager(t *testing.T) {
@@ -27,13 +26,11 @@ func TestMetaHostportManager(t *testing.T) {
 			hostPortMap: make(map[hostport]closeable),
 			iptables:    iptables,
 			portOpener:  portOpener.openFakeSocket,
-			execer:      exec.New(),
 		},
 		ipv6HostportManager: &hostportManager{
 			hostPortMap: make(map[hostport]closeable),
 			iptables:    ip6tables,
 			portOpener:  port6Opener.openFakeSocket,
-			execer:      exec.New(),
 		},
 	}
 

--- a/scripts/github-actions-packages
+++ b/scripts/github-actions-packages
@@ -3,7 +3,6 @@ set -euo pipefail
 
 sudo apt update
 sudo apt install -y \
-    conntrack \
     libaio-dev \
     libapparmor-dev \
     libbtrfs-dev \


### PR DESCRIPTION
We can use netlink call directly


Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>

Fixes: #5807

/kind bug

```release-note
crio no longer requires the conntrack binary
```
