### PR TITLE
go.{mod,sum}: update CDI dependency to v0.3.2.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.1.0
 	github.com/Microsoft/go-winio v0.5.1
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/container-orchestrated-devices/container-device-interface v0.0.0-20220224133719-e5457123010b
+	github.com/container-orchestrated-devices/container-device-interface v0.3.2
 	github.com/containerd/cgroups v1.0.2
 	github.com/containerd/containerd v1.5.8
 	github.com/containerd/cri-containerd v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/container-orchestrated-devices/container-device-interface v0.0.0-20210325223243-f99e8b6c10b9/go.mod h1:eQt66kIaJpUhCrjCtBFQGQxGLbAUl0OuuwjTH16ON4s=
-github.com/container-orchestrated-devices/container-device-interface v0.0.0-20220224133719-e5457123010b h1:kfww7SrumR0HoZTwEXRDy2CzwhhmigCWK3mvvhYDaUQ=
-github.com/container-orchestrated-devices/container-device-interface v0.0.0-20220224133719-e5457123010b/go.mod h1:E1zcucIkq9P3eyNmY+68dBQsTcsXJh9cgRo2IVNScKQ=
+github.com/container-orchestrated-devices/container-device-interface v0.3.2 h1:vZVaQwmFFddi7Y9mJgQTLPFxTWg81+OIHEMu/Th1wuw=
+github.com/container-orchestrated-devices/container-device-interface v0.3.2/go.mod h1:E1zcucIkq9P3eyNmY+68dBQsTcsXJh9cgRo2IVNScKQ=
 github.com/container-storage-interface/spec v1.5.0/go.mod h1:8K96oQNkJ7pFcC2R9Z1ynGGBB1I93kcS6PGg3SsOk8s=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=

--- a/vendor/github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/doc.go
+++ b/vendor/github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/doc.go
@@ -127,4 +127,24 @@
 // The default directories are '/etc/cdi' and '/var/run/cdi'. By putting
 // dynamically generated Spec files under '/var/run/cdi', those take
 // precedence over static ones in '/etc/cdi'.
+//
+// CDI Spec Validation
+//
+// This package performs both syntactic and semantic validation of CDI
+// Spec file data when a Spec file is loaded via the registry or using
+// the ReadSpec API function. As part of the semantic verification, the
+// Spec file is verified against the CDI Spec JSON validation schema.
+//
+// If a valid externally provided JSON validation schema is found in
+// the filesystem at /etc/cdi/schema/schema.json it is loaded and used
+// as the default validation schema. If such a file is not found or
+// fails to load, an embedded no-op schema is used.
+//
+// The used validation schema can also be changed programmatically using
+// the SetSchema API convenience function. This function also accepts
+// the special "builtin" (BuiltinSchemaName) and "none" (NoneSchemaName)
+// schema names which switch the used schema to the in-repo validation
+// schema embedded into the binary or the now default no-op schema
+// correspondingly. Other names are interpreted as the path to the actual
+/// validation schema to load and use.
 package cdi

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -126,7 +126,7 @@ github.com/cilium/ebpf/internal
 github.com/cilium/ebpf/internal/btf
 github.com/cilium/ebpf/internal/unix
 github.com/cilium/ebpf/link
-# github.com/container-orchestrated-devices/container-device-interface v0.0.0-20220224133719-e5457123010b
+# github.com/container-orchestrated-devices/container-device-interface v0.3.2
 ## explicit; go 1.17
 github.com/container-orchestrated-devices/container-device-interface/pkg
 github.com/container-orchestrated-devices/container-device-interface/pkg/cdi


### PR DESCRIPTION
Pin container-device-interface dependencies to the latest version tagged in upstream.

#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:

Pins container-device-interface dependencies to the latest tagged version in upstream.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
