### PR TITLE
fix(stats): incorrect id on zfs driver

### DIFF
--- a/internal/lib/stats/stats_server.go
+++ b/internal/lib/stats/stats_server.go
@@ -2,7 +2,6 @@ package statsserver
 
 import (
 	"context"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -189,8 +188,11 @@ func (ss *StatsServer) writableLayerForContainer(container *oci.Container) (*typ
 	if err != nil {
 		return writableLayer, errors.Wrapf(err, "Unable to get graph driver for disk usage for container %s", container.ID())
 	}
-	id := filepath.Base(filepath.Dir(container.MountPoint()))
-	usage, err := driver.ReadWriteDiskUsage(id)
+	storageContainer, err := ss.Store().Container(container.ID())
+	if err != nil {
+		return writableLayer, errors.Wrapf(err, "Unable to get storage container for disk usage for container %s", container.ID())
+	}
+	usage, err := driver.ReadWriteDiskUsage(storageContainer.LayerID)
 	if err != nil {
 		return writableLayer, errors.Wrapf(err, "Unable to get disk usage for container %s", container.ID())
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix  broken container disk usage stats  on zfs driver

#### Which issue(s) this PR fixes:

Fixes #5820 

#### Special notes for your reviewer:

I'm not sure if the same problem happens with other drivers than `zfs` and `overlayfs`. may more tests required.

#### Does this PR introduce a user-facing change?

None

```release-note
fix filesystem stats on zfs driver.
```
