### PR TITLE
Add bats test to measure goroutine stability

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -688,3 +688,10 @@ function has_criu() {
         skip "CRIU too old. At least 3.16 needed."
     fi
 }
+
+function goroutine_count() {
+    raw=$(curl --silent --fail --show-error 'http://localhost:6060/debug/pprof/goroutine?debug=1')
+    header=$(head -n 1 <<<"$raw")
+    count=${header#goroutine profile: total }
+    echo "$count"
+}

--- a/test/stability.bats
+++ b/test/stability.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# vim:set ft=bash :
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "goroutine stability: 100-pod" {
+	CONTAINER_PROFILE=true start_crio
+
+	initial_count=$count
+	for i in {1..100}; do
+		sbxconfig="$TESTDIR/sbx-$i.json"
+		jq --arg name "podsandbox$i" '.metadata.name = $name' "$TESTDATA"/sandbox_config.json > "$sbxconfig"
+		ctrconfig="$TESTDIR/ctr-$i.json"
+		jq --arg name "container$i" '.metadata.name = $name' "$TESTDATA"/container_sleep.json > "$ctrconfig"
+		crictl run "$ctrconfig" "$sbxconfig"
+		count=$(goroutine_count)
+		echo "Count with $i pods running: $count"
+		if [[ $i == 1 ]]; then
+			initial_count=$count
+		fi
+	done
+
+	cleanup_ctrs
+	cleanup_pods
+
+	count=$(goroutine_count)
+	echo "After shutdown: $count"
+	[[ $count -le $initial_count ]]
+}


### PR DESCRIPTION
This test measures 100 container start/stop, and ensures the final total
of goroutines at the end does not exceed the goroutine count after
starting the first container.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

This adds some initial testing around goroutine stability; trying to ensure
that we don't have any common cases where the number of goroutines grow without
bounds.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
