### PR TITLE
main(): do not treat reexec.Init() == true as an error

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -111,8 +111,7 @@ func main() {
 	log.InitKlogShim()
 
 	if reexec.Init() {
-		fmt.Fprintf(os.Stderr, "unable to initialize container storage\n")
-		os.Exit(-1)
+		return
 	}
 	app := cli.NewApp()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`reexec.Init()` returning true is an indication that a handler was invoked and that we should return immediately because we're not the parent process.  It isn't an error condition, and we shouldn't be treating it as an error.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

h/t to @adrianreber who asked about this while working on something else.

#### Does this PR introduce a user-facing change?

```release-note
None
```