### PR TITLE
Exec cgroup

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -34,7 +34,7 @@ dependencies:
       match: version
 
   - name: conmon
-    version: v2.0.26
+    version: v2.0.27
     refPaths:
     - path: scripts/versions
       match: conmon

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,8 @@ const (
 	RuntimeTypeVMBinaryPattern = "containerd-shim-([a-zA-Z0-9\\-\\+])+-v2"
 	tasksetBinary              = "taskset"
 	defaultMonitorCgroup       = "system.slice"
+	MonitorExecCgroupDefault   = ""
+	MonitorExecCgroupContainer = "container"
 )
 
 // Config represents the entire set of configuration values that can be set for
@@ -205,6 +207,9 @@ type RuntimeHandler struct {
 	MonitorPath   string   `toml:"monitor_path,omitempty"`
 	MonitorCgroup string   `toml:"monitor_cgroup,omitempty"`
 	MonitorEnv    []string `toml:"monitor_env,omitempty"`
+
+	// MonitorExecCgroup indicates whether to move exec probes to the container's cgroup.
+	MonitorExecCgroup string `toml:"monitor_exec_cgroup,omitempty"`
 }
 
 // Multiple runtime Handlers in a map

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1093,6 +1093,8 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 #   "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
 #   "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
 #   "io.kubernetes.cri.rdt-class" for setting the RDT class of a container
+# - monitor_exec_cgroup (optional, string): if set to "container", indicates exec probes
+#   should be moved to the container's cgroup
 
 {{ range $runtime_name, $runtime_handler := .Runtimes  }}
 {{ $.Comment }}[crio.runtime.runtimes.{{ $runtime_name }}]
@@ -1113,6 +1115,7 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 {{ range $opt := $runtime_handler.MonitorEnv }}{{ $.Comment }}{{ printf "\t%q,\n" $opt }}{{ end }}{{ $.Comment }}]
 {{ $.Comment }}{{ end }}
 {{ $.Comment }}monitor_cgroup = "{{ $runtime_handler.MonitorCgroup }}"
+{{ $.Comment }}monitor_exec_cgroup = "{{ $runtime_handler.MonitorExecCgroup }}"
 {{ $.Comment }}{{ end }}
 
 # crun is a fast and lightweight fully featured OCI runtime and C library for

--- a/scripts/versions
+++ b/scripts/versions
@@ -4,7 +4,7 @@ set -euo pipefail
 # Versions to be used
 declare -A VERSIONS=(
     ["cni-plugins"]=v1.1.1
-    ["conmon"]=v2.0.26
+    ["conmon"]=v2.0.27
     ["cri-tools"]=v1.23.0
     ["runc"]=v1.0.2
     ["crun"]=0.20.1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently, exec sync containers are launched under the crio cgroup. For applications with a large number of exec probes, this can impact cpu usage for reserved platform cores, in addition to affecting accounting. To address this, this PR introduces an opt-in exec_cgroup option (defaults to false) that moves the exec probe process to the pod's cgroup. This ensures cpu usage and resource accounting are restricted to the pod's allowances.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add `monitor_exec_cgroup` to the configuration's runtime handler struct. This allows an admin to specify which cgroup the monitor for exec sync requests runs in (defaults to that of CRI-O).
```
