### PR TITLE
Move WillRunSystemd call after iterating the mounts 

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -546,14 +546,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		return nil, err
 	}
 
-	if ctr.WillRunSystemd() {
-		processLabel, err = selinux.InitLabel(processLabel)
-		if err != nil {
-			return nil, err
-		}
-		setupSystemd(specgen.Mounts(), *specgen)
-	}
-
 	// When running on cgroupv2, automatically add a cgroup namespace for not privileged containers.
 	if !ctr.Privileged() && node.CgroupIsV2() {
 		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.CgroupNamespace), ""); err != nil {
@@ -739,6 +731,14 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 			Source:      m.Source,
 		}
 		ctr.SpecAddMount(rspecMount)
+	}
+
+	if ctr.WillRunSystemd() {
+		processLabel, err = selinux.InitLabel(processLabel)
+		if err != nil {
+			return nil, err
+		}
+		setupSystemd(specgen.Mounts(), *specgen)
 	}
 
 	if s.ContainerServer.Hooks != nil {
@@ -1084,7 +1084,7 @@ func setupSystemd(mounts []rspec.Mount, g generate.Generator) {
 		// If the /sys/fs/cgroup is bind mounted from the host,
 		// then systemd-mode cgroup should be disabled
 		// https://bugzilla.redhat.com/show_bug.cgi?id=2064741
-		if NoCgroupMount(g.Mounts()) {
+		if !hasCgroupMount(g.Mounts()) {
 			systemdMnt := rspec.Mount{
 				Destination: cgroupSysFsSystemdPath,
 				Type:        "bind",
@@ -1098,13 +1098,13 @@ func setupSystemd(mounts []rspec.Mount, g generate.Generator) {
 	g.AddProcessEnv("container", "crio")
 }
 
-func NoCgroupMount(mounts []rspec.Mount) bool {
+func hasCgroupMount(mounts []rspec.Mount) bool {
 	for _, m := range mounts {
 		if (m.Destination == cgroupSysFsPath || m.Destination == "/sys/fs" || m.Destination == "/sys") && isBindMount(m.Options) {
-			return false
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 func isBindMount(mountOptions []string) bool {


### PR DESCRIPTION
Signed-off-by: Harshal Patil <harpatil@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

The changes introduced in https://github.com/cri-o/cri-o/pull/5778 weren't perfect. When iterating over the mount options of the sysfs mount provided in the pod definition will not have `rbin` or `bind` set. This causes that fix to not work. I might have goofed up in testing and might have tested with https://github.com/cri-o/cri-o/compare/240e311ea8e9daeb2ba34a2e81000c4560215421..9a7037b9f87f94120e3f8df33e8cd3729a60bb38 instead of the final version by mistake. Apologies for that. 

But I just tested this patch with 4.10 and 4.11 nightlies and it seem to fix this issue now. 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2064741

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
