### PR TITLE
crio:fix a bug about log container

### DIFF
--- a/server/container_status.go
+++ b/server/container_status.go
@@ -62,19 +62,16 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 		cState = c.State()
 	}
 
-	created := c.CreatedAt().UnixNano()
+	resp.Status.CreatedAt = c.CreatedAt().UnixNano()
 	switch cState.Status {
 	case oci.ContainerStateCreated:
 		rStatus = types.ContainerState_CONTAINER_CREATED
-		resp.Status.CreatedAt = created
 	case oci.ContainerStateRunning:
 		rStatus = types.ContainerState_CONTAINER_RUNNING
-		resp.Status.CreatedAt = created
 		started := cState.Started.UnixNano()
 		resp.Status.StartedAt = started
 	case oci.ContainerStateStopped:
 		rStatus = types.ContainerState_CONTAINER_EXITED
-		resp.Status.CreatedAt = created
 		started := cState.Started.UnixNano()
 		resp.Status.StartedAt = started
 		finished := cState.Finished.UnixNano()


### PR DESCRIPTION
crio:fix a bug about log container

Signed-off-by: jiang wei <jwcesign@gmail.com>

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When container is in unknown state, will have this error when log it(using critl and kubectl).
![image](https://user-images.githubusercontent.com/19745536/166702141-f0de53ca-35ee-4476-898f-a6f6cc0bae8c.png)

fix bug to log container, in upper layer interface, we need `status.CreatedAt`

#### Which issue(s) this PR fixes:
none

```release-note
none
```
