### PR TITLE
Add sha256sum bundle files to uploaded artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: bundle
-          path: build/bundle/*.tar.gz
+          path: build/bundle/*.tar.gz*
 
   bundle-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This fixes the availablility of the SHA files in the bucket.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/5600
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
