### PR TITLE
Reenable pod runtime in package spec

### DIFF
--- a/contrib/test/ci/cri-o.spec
+++ b/contrib/test/ci/cri-o.spec
@@ -84,7 +84,7 @@ popd
 
 ln -s vendor src
 export GOPATH=$(pwd)/_output:$(pwd)
-export BUILDTAGS="selinux seccomp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub skip_pod_runtime"
+export BUILDTAGS="selinux seccomp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
 make bin/crio bin/crio-status bin/pinns
 
 # build docs


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:
After the merge of https://github.com/openshift/release/pull/27332 we should be able to use the pod runtime again in the packages.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
