### PR TITLE
OWNERS: remove fgiudici

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,7 +10,6 @@ approvers:
   - kolyshkin
 reviewers:
   - wgahnagl
-  - fgiudici
   - QiWang19
   - klihub
 emeritus_approvers:


### PR DESCRIPTION
Hey CRI-O team, since I will not be able to fulfill the CRI-O reviewer duties (in the near future at least), I propose to demote myself from 'Reviewer' to 'Community Member', as per our [GOVERNANCE](https://github.com/cri-o/cri-o/blob/main/GOVERNANCE.md).
This PR will remove myself from the CRI-O OWNERS file.