### PR TITLE
Use a default umask of `0o022`

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -378,6 +378,8 @@ func New(
 	}
 	config := configIface.GetData()
 
+	useDefaultUmask()
+
 	config.SystemContext.AuthFilePath = config.GlobalAuthFile
 	config.SystemContext.SignaturePolicyPath = config.SignaturePolicyPath
 
@@ -512,6 +514,17 @@ func New(
 	}
 
 	return s, nil
+}
+
+func useDefaultUmask() {
+	const defaultUmask = 0o022
+	oldUmask := unix.Umask(defaultUmask)
+	if oldUmask != defaultUmask {
+		logrus.Infof(
+			"Using default umask 0o%#o instead of 0o%#o",
+			defaultUmask, oldUmask,
+		)
+	}
 }
 
 // wipeIfAppropriate takes a list of images. If the config's VersionFilePersist


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test

/kind flake
/kind other
-->

#### What this PR does / why we need it:
There are environments where the umask of CRI-O is set to something more open, for example `0o000`. To have a standard behavior across all containers we now use a default umask of `0o022` while informing the user via an info log if that change has been done.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://bugzilla.redhat.com/show_bug.cgi?id=2040612
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use default umask `0o022` if CRI-O runs under a different umask value.
```
