### PR TITLE
[1.21] ci/gha: fixup golangci-lint job

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,7 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.16'
+      - uses: golangci/golangci-lint-action@v3
         with:
           # must be specified without patch version
           version: v1.35


### PR DESCRIPTION
Apparently, ubuntu-latest now comes with a recent version of golang,
which is too new for golangci-lint we use in this branch. As a result,
we have errors like

	 ...could not import internal/goarch (-: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool)))))]]"

Explicitly installing golang 1.16 and upgrading the action itself should fix the issue.

/kind ci

```release-note
NONE
```
