### PR TITLE
Add annotations to allow power management configuration

### DIFF
--- a/internal/runtimehandlerhooks/runtime_handler_hooks.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks.go
@@ -34,7 +34,9 @@ func highPerformanceAnnotationsSpecified(annotations map[string]string) bool {
 	for k := range annotations {
 		if strings.HasPrefix(k, crioann.CPULoadBalancingAnnotation) ||
 			strings.HasPrefix(k, crioann.CPUQuotaAnnotation) ||
-			strings.HasPrefix(k, crioann.IRQLoadBalancingAnnotation) {
+			strings.HasPrefix(k, crioann.IRQLoadBalancingAnnotation) ||
+			strings.HasPrefix(k, crioann.CPUCStatesAnnotation) ||
+			strings.HasPrefix(k, crioann.CPUFreqGovernorAnnotation) {
 			return true
 		}
 	}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -38,6 +38,12 @@ const (
 	// TrySkipVolumeSELinuxLabelAnnotation is the annotation used for optionally skipping relabeling a volume
 	// with the specified SELinux label.  The relabeling will be skipped if the top layer is already labeled correctly.
 	TrySkipVolumeSELinuxLabelAnnotation = "io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel"
+
+	// CPUCStatesAnnotation indicates that c-states should be enabled or disabled for CPUs used by the container
+	CPUCStatesAnnotation = "cpu-c-states.crio.io"
+
+	// CPUFreqGovernorAnnotation sets the cpufreq governor for CPUs used by the container
+	CPUFreqGovernorAnnotation = "cpu-freq-governor.crio.io"
 )
 
 var AllAllowedAnnotations = []string{
@@ -52,4 +58,6 @@ var AllAllowedAnnotations = []string{
 	OCISeccompBPFHookAnnotation,
 	rdt.RdtContainerAnnotation,
 	TrySkipVolumeSELinuxLabelAnnotation,
+	CPUCStatesAnnotation,
+	CPUFreqGovernorAnnotation,
 }


### PR DESCRIPTION
Adding the following high performance feature annotations:

cpu-c-states.crio.io: \<enable|disable>
This annotation will enable or disable c-states for each cpu by writing to the
power/pm_qos_resume_latency_us for the cpu under sysfs.

cpu-freq-governor.crio.io: \<any supported cpu frequency governor>
This annotation will set the cpufreq governor for each cpu by writing to the
cpufreq/scaling_governor for the cpu under sysfs.

When a container is stopped, the original pm_qos_resume_latency_us and
scaling_governor values are restored.

As with the other high performance feature annotations, the new annotations
are only considered for pods with a guaranteed QoS Class.

Signed-off-by: Bart Wensley <bwensley@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature

#### What this PR does / why we need it:

In order to support high performance (i.e. low latency) containers on a server, the user will typically configure the BIOS and/or kernel options to disable c-states and use the performance cpufreq governor for all CPUs in the server. This ensures the best performance and lowest latency for all containers run on that server, but it also has the effect of consuming a large amount of power.

In many cases, users do not need all their containers to run in this high performance (and high power consumption) mode. To allow for power savings in cases where there is a mix of high performance and regular containers, we need to allow the server to be configured for lower power usage by default (e.g. by enabling some c-states or by using a cpufreq governor like schedutil) and then only configure specific containers for high performance. This can be done by introducing annotations that allow c-states and the cpufreq governor to be configured for individual pods/containers. This is similar to existing high performance annotations like cpu-load-balancing.crio.io (for example) that improve the performance of a container by disabling functions that could impact performance of the cpus the container is using.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
This PR introduces additional annotations that can be optionally used to configure power management features for containers. It does not impact existing users who do not use the new annotations.
```
