### PR TITLE
[1.20] oci: add support for capping memory and disk usage from exec sync output

### DIFF
--- a/internal/config/conmonmgr/conmonmgr.go
+++ b/internal/config/conmonmgr/conmonmgr.go
@@ -11,10 +11,12 @@ import (
 )
 
 var versionSupportsSync = semver.MustParse("2.0.19")
+var versionSupportsLogGlobalSizeMax = semver.MustParse("2.1.2")
 
 type ConmonManager struct {
-	conmonVersion *semver.Version
-	supportsSync  bool
+	conmonVersion            *semver.Version
+	supportsSync             bool
+	supportsLogGlobalSizeMax bool
 }
 
 // this function is heavily based on github.com/containers/common#probeConmon
@@ -37,6 +39,7 @@ func New(conmonPath string) (*ConmonManager, error) {
 	}
 
 	c.initializeSupportsSync()
+	c.initializeSupportsLogGlobalSizeMax()
 	return c, nil
 }
 
@@ -47,6 +50,20 @@ func (c *ConmonManager) parseConmonVersion(versionString string) error {
 	}
 	c.conmonVersion = parsedVersion
 	return nil
+}
+
+func (c *ConmonManager) initializeSupportsLogGlobalSizeMax() {
+	c.supportsLogGlobalSizeMax = c.conmonVersion.GTE(versionSupportsLogGlobalSizeMax)
+	verb := "does not"
+	if c.supportsLogGlobalSizeMax {
+		verb = "does"
+	}
+
+	logrus.Infof("Conmon %s support the --log-global-size-max option", verb)
+}
+
+func (c *ConmonManager) SupportsLogGlobalSizeMax() bool {
+	return c.supportsLogGlobalSizeMax
 }
 
 func (c *ConmonManager) initializeSupportsSync() {

--- a/internal/config/conmonmgr/conmonmgr.go
+++ b/internal/config/conmonmgr/conmonmgr.go
@@ -1,6 +1,7 @@
 package conmonmgr
 
 import (
+	"bytes"
 	"path"
 	"strings"
 
@@ -39,7 +40,7 @@ func New(conmonPath string) (*ConmonManager, error) {
 	}
 
 	c.initializeSupportsSync()
-	c.initializeSupportsLogGlobalSizeMax()
+	c.initializeSupportsLogGlobalSizeMax(conmonPath)
 	return c, nil
 }
 
@@ -52,8 +53,14 @@ func (c *ConmonManager) parseConmonVersion(versionString string) error {
 	return nil
 }
 
-func (c *ConmonManager) initializeSupportsLogGlobalSizeMax() {
+func (c *ConmonManager) initializeSupportsLogGlobalSizeMax(conmonPath string) {
 	c.supportsLogGlobalSizeMax = c.conmonVersion.GTE(versionSupportsLogGlobalSizeMax)
+	if !c.supportsLogGlobalSizeMax {
+		// Read help output as a fallback in case the feature was backported to conmon,
+		// but the version wasn't bumped.
+		helpOutput, err := cmdrunner.CombinedOutput(conmonPath, "--help")
+		c.supportsLogGlobalSizeMax = err == nil && bytes.Contains(helpOutput, []byte("--log-global-size-max"))
+	}
 	verb := "does not"
 	if c.supportsLogGlobalSizeMax {
 		verb = "does"

--- a/internal/config/conmonmgr/conmonmgr_test.go
+++ b/internal/config/conmonmgr/conmonmgr_test.go
@@ -61,20 +61,7 @@ var _ = t.Describe("ConmonManager", func() {
 		It("should succeed when output expected", func() {
 			// Given
 			gomock.InOrder(
-				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte("conmon version 2.0.0"), nil),
-			)
-
-			// When
-			mgr, err := New(validPath)
-
-			// Then
-			Expect(err).To(BeNil())
-			Expect(mgr).ToNot(BeNil())
-		})
-		It("should succeed when output expected", func() {
-			// Given
-			gomock.InOrder(
-				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte("conmon version 2.0.0"), nil),
+				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte("conmon version 2.2.2"), nil),
 			)
 
 			// When
@@ -172,6 +159,110 @@ var _ = t.Describe("ConmonManager", func() {
 
 			// Then
 			Expect(mgr.SupportsSync()).To(Equal(true))
+		})
+	})
+	t.Describe("initializeSupportsLogGlobalSizeMax", func() {
+		var mgr *ConmonManager
+		BeforeEach(func() {
+			runner = runnerMock.NewMockCommandRunner(mockCtrl)
+			cmdrunner.SetMocked(runner)
+			mgr = new(ConmonManager)
+		})
+		It("should be false when major version less", func() {
+			// Given
+			gomock.InOrder(
+				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte{}, errors.New("cmd failed")),
+			)
+			err := mgr.parseConmonVersion("1.1.2")
+			Expect(err).To(BeNil())
+			// When
+			mgr.initializeSupportsLogGlobalSizeMax("")
+
+			// Then
+			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(false))
+		})
+		It("should be true when major version greater", func() {
+			// Given
+			err := mgr.parseConmonVersion("3.1.1")
+			Expect(err).To(BeNil())
+
+			// When
+			mgr.initializeSupportsLogGlobalSizeMax("")
+
+			// Then
+			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
+		})
+		It("should be false when minor version less", func() {
+			// Given
+			gomock.InOrder(
+				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte{}, errors.New("cmd failed")),
+			)
+			err := mgr.parseConmonVersion("2.0.2")
+			Expect(err).To(BeNil())
+			// When
+			mgr.initializeSupportsLogGlobalSizeMax("")
+
+			// Then
+			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(false))
+		})
+		It("should be true when minor version greater", func() {
+			// Given
+			err := mgr.parseConmonVersion("2.2.2")
+			Expect(err).To(BeNil())
+
+			// When
+			mgr.initializeSupportsLogGlobalSizeMax("")
+
+			// Then
+			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
+		})
+		It("should be false when patch version less", func() {
+			// Given
+			gomock.InOrder(
+				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte{}, errors.New("cmd failed")),
+			)
+			err := mgr.parseConmonVersion("2.1.1")
+			Expect(err).To(BeNil())
+			// When
+			mgr.initializeSupportsLogGlobalSizeMax("")
+
+			// Then
+			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(false))
+		})
+		It("should be true when patch version greater", func() {
+			// Given
+			err := mgr.parseConmonVersion("2.1.3")
+			Expect(err).To(BeNil())
+
+			// When
+			mgr.initializeSupportsLogGlobalSizeMax("")
+
+			// Then
+			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
+		})
+		It("should be true when version equal", func() {
+			// Given
+			err := mgr.parseConmonVersion("2.1.2")
+			Expect(err).To(BeNil())
+
+			// When
+			mgr.initializeSupportsLogGlobalSizeMax("")
+			// Then
+			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
+		})
+		It("should be true if feature backported", func() {
+			// Given
+			gomock.InOrder(
+				runner.EXPECT().CombinedOutput(gomock.Any(), gomock.Any()).Return([]byte("--log-global-size-max"), nil),
+			)
+			err := mgr.parseConmonVersion("0.0.0")
+			Expect(err).To(BeNil())
+
+			// When
+			mgr.initializeSupportsLogGlobalSizeMax("")
+
+			// Then
+			Expect(mgr.SupportsLogGlobalSizeMax()).To(Equal(true))
 		})
 	})
 })

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -32,6 +32,11 @@ const (
 	// killContainerTimeout is the timeout that we wait for the container to
 	// be SIGKILLed.
 	killContainerTimeout = 2 * time.Minute
+
+	// maxExecSyncSize is the maximum size of exec sync output CRI-O will process.
+	// It is set to the amount of logs allowed in the dockershim implementation:
+	// https://github.com/kubernetes/kubernetes/pull/82514
+	maxExecSyncSize = 16 * 1024 * 1024
 )
 
 // Runtime is the generic structure holding both global and specific

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -491,7 +491,7 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 	// ExecSyncResponse we have to read the logfile.
 	// XXX: Currently runC dups the same console over both stdout and stderr,
 	//      so we can't differentiate between the two.
-	logBytes, err := ioutil.ReadFile(logPath)
+	logBytes, err := TruncateAndReadFile(ctx, logPath, maxExecSyncSize)
 	if err != nil {
 		return nil, &ExecSyncError{
 			Stdout:   stdoutBuf,
@@ -628,6 +628,20 @@ func pidAndpgidFromFile(pidFile string) (pid, pgid int, _ error) {
 	}
 	pgid, err = syscall.Getpgid(pid)
 	return pid, pgid, err
+}
+
+func TruncateAndReadFile(ctx context.Context, path string, size int64) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > size {
+		log.Errorf(ctx, "exec sync output in file %s has size %d which is longer than expected size of %d", path, info.Size(), size)
+		if err := os.Truncate(path, size); err != nil {
+			return nil, err
+		}
+	}
+	return ioutil.ReadFile(path)
 }
 
 // UpdateContainer updates container resources

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -385,6 +385,9 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 	if r.config.ConmonSupportsSync() {
 		args = append(args, "--sync")
 	}
+	if r.config.ConmonSupportsLogGlobalSizeMax() {
+		args = append(args, "--log-global-size-max", strconv.Itoa(maxExecSyncSize))
+	}
 	if c.terminal {
 		args = append(args, "-t")
 	}

--- a/internal/oci/runtime_oci_test.go
+++ b/internal/oci/runtime_oci_test.go
@@ -1,0 +1,58 @@
+package oci_test
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/cri-o/cri-o/internal/oci"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	shortTimeout  int64 = 1
+	mediumTimeout int64 = 3
+	longTimeout   int64 = 15
+)
+
+// The actual test suite
+var _ = t.Describe("Oci", func() {
+	Context("TruncateAndReadFile", func() {
+		tests := []struct {
+			title    string
+			contents []byte
+			expected []byte
+			fail     bool
+			size     int64
+		}{
+			{
+				title:    "should read file if size is smaller than limit",
+				contents: []byte("abcd"),
+				expected: []byte("abcd"),
+				size:     5,
+			},
+			{
+				title:    "should read only size if size is same as limit",
+				contents: []byte("abcd"),
+				expected: []byte("abcd"),
+				size:     4,
+			},
+			{
+				title:    "should read only size if size is larger than limit",
+				contents: []byte("abcd"),
+				expected: []byte("abc"),
+				size:     3,
+			},
+		}
+		for _, test := range tests {
+			test := test
+			It(test.title, func() {
+				fileName := t.MustTempFile("to-read")
+				Expect(ioutil.WriteFile(fileName, test.contents, 0644)).To(BeNil())
+				found, err := oci.TruncateAndReadFile(context.Background(), fileName, test.size)
+				Expect(err).To(BeNil())
+				Expect(found).To(Equal(test.expected))
+			})
+		}
+	})
+})

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/sys/unix"
 	"k8s.io/client-go/tools/remotecommand"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	kioutil "k8s.io/kubernetes/pkg/kubelet/util/ioutils"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -309,8 +310,8 @@ func (r *runtimeVM) ExecSyncContainer(ctx context.Context, c *Container, command
 	defer logrus.Debug("runtimeVM.ExecSyncContainer() end")
 
 	var stdoutBuf, stderrBuf bytes.Buffer
-	stdout := cioutil.NewNopWriteCloser(&stdoutBuf)
-	stderr := cioutil.NewNopWriteCloser(&stderrBuf)
+	stdout := kioutil.WriteCloserWrapper(kioutil.LimitWriter(&stdoutBuf, maxExecSyncSize))
+	stderr := kioutil.WriteCloserWrapper(kioutil.LimitWriter(&stderrBuf, maxExecSyncSize))
 
 	exitCode, err := r.execContainerCommon(c, command, timeout, nil, stdout, stderr, c.terminal, nil)
 	if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version is the version of the build.
-const Version = "1.20.7"
+const Version = "1.20.8"
 
 // Variables injected during build-time
 var (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -993,6 +993,10 @@ func (c *RuntimeConfig) ConmonSupportsSync() bool {
 	return c.conmonManager.SupportsSync()
 }
 
+func (c *RuntimeConfig) ConmonSupportsLogGlobalSizeMax() bool {
+	return c.conmonManager.SupportsLogGlobalSizeMax()
+}
+
 func (c *RuntimeConfig) ValidatePinnsPath(executable string) error {
 	var err error
 	c.PinnsPath, err = validateExecutablePath(executable, c.PinnsPath)

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -457,6 +457,14 @@ function wait_until_exit() {
 	crictl rm -f "$ctr_id"
 }
 
+@test "ctr execsync should cap output" {
+	start_crio
+
+	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+
+	[[ $(crictl exec --sync "$ctr_id" /bin/sh -c "for i in $(seq 1 50000000); do echo -n 'a'; done" | wc -c) -le 16777216 ]]
+}
+
 @test "ctr device add" {
 	# In an user namespace we can only bind mount devices from the host, not mknod
 	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/util/ioutils/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/util/ioutils/BUILD
@@ -1,0 +1,29 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ioutils.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/util/ioutils",
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["ioutils_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//vendor/github.com/stretchr/testify/assert:go_default_library"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/util/ioutils/ioutils.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/util/ioutils/ioutils.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ioutils
+
+import "io"
+
+// writeCloserWrapper represents a WriteCloser whose closer operation is noop.
+type writeCloserWrapper struct {
+	Writer io.Writer
+}
+
+func (w *writeCloserWrapper) Write(buf []byte) (int, error) {
+	return w.Writer.Write(buf)
+}
+
+func (w *writeCloserWrapper) Close() error {
+	return nil
+}
+
+// WriteCloserWrapper returns a writeCloserWrapper.
+func WriteCloserWrapper(w io.Writer) io.WriteCloser {
+	return &writeCloserWrapper{w}
+}
+
+// LimitWriter is a copy of the standard library ioutils.LimitReader,
+// applied to the writer interface.
+// LimitWriter returns a Writer that writes to w
+// but stops with EOF after n bytes.
+// The underlying implementation is a *LimitedWriter.
+func LimitWriter(w io.Writer, n int64) io.Writer { return &LimitedWriter{w, n} }
+
+// A LimitedWriter writes to W but limits the amount of
+// data returned to just N bytes. Each call to Write
+// updates N to reflect the new amount remaining.
+// Write returns EOF when N <= 0 or when the underlying W returns EOF.
+type LimitedWriter struct {
+	W io.Writer // underlying writer
+	N int64     // max bytes remaining
+}
+
+func (l *LimitedWriter) Write(p []byte) (n int, err error) {
+	if l.N <= 0 {
+		return 0, io.ErrShortWrite
+	}
+	truncated := false
+	if int64(len(p)) > l.N {
+		p = p[0:l.N]
+		truncated = true
+	}
+	n, err = l.W.Write(p)
+	l.N -= int64(n)
+	if err == nil && truncated {
+		err = io.ErrShortWrite
+	}
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1270,6 +1270,7 @@ k8s.io/kubernetes/pkg/kubelet/cri/streaming/remotecommand
 k8s.io/kubernetes/pkg/kubelet/leaky
 k8s.io/kubernetes/pkg/kubelet/types
 k8s.io/kubernetes/pkg/kubelet/util/format
+k8s.io/kubernetes/pkg/kubelet/util/ioutils
 k8s.io/kubernetes/pkg/proxy
 k8s.io/kubernetes/pkg/proxy/config
 k8s.io/kubernetes/pkg/proxy/healthcheck


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where ExecSync requests (exec probes) could use an arbitrary amount of memory and disk. Output from ExecSync requests is now limited to 16MB (the amount that exec output was limited to in the dockershim). Disk limiting requires conmon 2.1.2 to work. See https://github.com/cri-o/cri-o/security/advisories/GHSA-fcm2-6c3h-pg6j and CVE-2022-1708 for more information.
```
