### PR TITLE
Makefile: avoid embedding version control information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GO_ARCH=$(shell $(GO) env GOARCH)
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
 GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
 GO_GT_1_17 := $(shell [ $(GO_MAJOR_VERSION) -ge 1 -a $(GO_MINOR_VERSION) -ge 17 ] && echo true)
-GO_FLAGS ?=
+GO_FLAGS ?= -buildvcs=false
 ifeq ($(GO_GT_1_17),true)
 ifeq ($(GO_ARCH),386)
 GO_FLAGS += -buildvcs=false


### PR DESCRIPTION
This change fixes the CI failure caused while running cri-o integration tests using ansible.

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

We're hitting the following issue while running integration tests using ansible for cri-o CI:
```
go build -trimpath  -ldflags '-s -w -X github.com/cri-o/cri-o/internal/pkg/criocli.DefaultsPath="" -X github.com/cri-o/cri-o/internal/version.buildDate='2022-06-10T19:04:18Z' -X github.com/cri-o/cri-o/internal/version.gitCommit=unknown -X github.com/cri-o/cri-o/internal/version.gitTreeState=unknown ' -tags "containers_image_ostree_stub      containers_image_openpgp seccomp selinux " -o bin/crio github.com/cri-o/cri-o/cmd/crio
error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
```
This change helps to skip version control information if the go command is invoked in a directory within a Git

Signed-off-by: Sohan Kunkerkar <sohank2602@gmail.com>

/cc @mrunalp 
