### PR TITLE
Enter mount namespace if set in $KUBENSMNT environment

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -448,6 +448,18 @@ Shows a list of commands or help for one command
   Storage configuration file specifies all of the available container storage
   options for tools using shared container storage.
 
+# ENVIRONMENT
+
+All command-line options may also be specified as environment variables.
+The options detailed in this section, however, can only be set via
+environment variables.
+
+**KUBENSMNT**: Path to a bind-mounted mount namespace that CRI-O
+should join before launching any containers. If the path does not exist,
+or does not point to a mount namespace bindmount, CRI-O will run in its
+parent's mount namespace and log a warning that the requested namespace
+was not joined.
+
 # SEE ALSO
 
 crio.conf(5), crio.conf.d(5), oci-hooks(5), policy.json(5), registries.conf(5),

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.0.0-20220721132401-db9c3b244679
 	github.com/containers/image/v5 v5.21.2-0.20220714132403-2bb3f3e44c5c
+	github.com/containers/kubensmnt v1.1.2
 	github.com/containers/ocicrypt v1.1.5
 	github.com/containers/podman/v4 v4.2.0-rc1
 	github.com/containers/storage v1.41.1-0.20220718173332-b10c469fda0a

--- a/go.sum
+++ b/go.sum
@@ -641,6 +641,8 @@ github.com/containers/image/v5 v5.21.2-0.20220615100411-a78a00792916/go.mod h1:h
 github.com/containers/image/v5 v5.21.2-0.20220617075545-929f14a56f5c/go.mod h1:hEf8L08Hrh/3fK4vLf5l7988MJmij2swfCBUzqgnhF4=
 github.com/containers/image/v5 v5.21.2-0.20220714132403-2bb3f3e44c5c h1:ms1Vyzs9Eb17J38aFKrL0+ig2pVwQq3OleaO7VmQuV0=
 github.com/containers/image/v5 v5.21.2-0.20220714132403-2bb3f3e44c5c/go.mod h1:ykVAVRj4DhQNMHZDVU+KCtXjWBKpqiUe669eF0WBEEc=
+github.com/containers/kubensmnt v1.1.2 h1:QnIbura7mupLw7hnN+NWu5NH+PF1eA8/c907DzIMwAQ=
+github.com/containers/kubensmnt v1.1.2/go.mod h1:1/HG09N/a1+WSD3zkurzeWtqlKRSfUUnlIF/08zloqk=
 github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a h1:spAGlqziZjCJL25C6F1zsQY05tfCKE9F5YwtEWWe6hU=
 github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=

--- a/internal/criocli/documentation.go
+++ b/internal/criocli/documentation.go
@@ -60,6 +60,19 @@ const markdownDocTemplate = `
   Storage configuration file specifies all of the available container storage
   options for tools using shared container storage.
 
+{{ with .App.Metadata.Env -}}
+# ENVIRONMENT
+
+All command-line options may also be specified as environment variables.
+The options detailed in this section, however, can only be set via
+environment variables.
+
+{{ range $envname, $helptext := . -}}
+**{{ $envname }}**: {{ $helptext }}
+
+{{ end -}}
+{{ end -}}
+
 # SEE ALSO
 
 crio.conf(5), crio.conf.d(5), oci-hooks(5), policy.json(5), registries.conf(5),

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -643,3 +643,12 @@ function check_conmon_cpuset() {
         fi
     fi
 }
+
+function setup_kubensmnt() {
+    if [[ -z $PIN_ROOT ]]; then
+        PIN_ROOT=$TESTDIR/kubens
+    fi
+    PINNED_MNT_NS=$PIN_ROOT/mntns/mnt
+    $PINNS_BINARY_PATH -d "$PIN_ROOT" -f mnt -m
+    export KUBENSMNT=$PINNED_MNT_NS
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -415,7 +415,10 @@ function cleanup_lvm() {
 
 function cleanup_testdir() {
     # shellcheck disable=SC2013
-    for mnt in $(awk '{print $2}' /proc/self/mounts | grep ^"$TESTDIR" | sort); do
+    # Note: By using 'sort -r' we're ensuring longer paths go first, which
+    # means that if there are nested mounts, the innermost mountpoints get
+    # unmounted first
+    for mnt in $(awk '{print $2}' /proc/self/mounts | grep ^"$TESTDIR" | sort -r); do
         umount "$mnt"
     done
     rm -rf "$TESTDIR" || true

--- a/vendor/github.com/containers/kubensmnt/LICENSE
+++ b/vendor/github.com/containers/kubensmnt/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/containers/kubensmnt/Makefile
+++ b/vendor/github.com/containers/kubensmnt/Makefile
@@ -1,0 +1,8 @@
+TEST_TARGETS := test-all test-integration shellcheck
+
+.PHONY: $(TEST_TARGETS)
+
+# Dispatch all test targets to every test Makefile
+$(TEST_TARGETS):
+	make -C test $@
+	make -C utils/kubensenter/test $@

--- a/vendor/github.com/containers/kubensmnt/README.md
+++ b/vendor/github.com/containers/kubensmnt/README.md
@@ -1,0 +1,57 @@
+# kubensmnt
+
+[![Integration Test](https://github.com/containers/kubensmnt/actions/workflows/integration-test.yml/badge.svg)](https://github.com/containers/kubensmnt/actions/workflows/integration-test.yml)
+[![ShellCheck](https://github.com/containers/kubensmnt/actions/workflows/shellcheck.yml/badge.svg)](https://github.com/containers/kubensmnt/actions/workflows/shellcheck.yml)
+
+A small library to enable go programs to join a new mount namespace, designed
+for helping get the Kubernetes control plane (kubelet and the container
+runtime) into a separate mountpoint.
+
+## Rationale
+
+There are benefits to hiding all of Kubernetes' mount points from the host OS,
+including cleanliness, safety from inspection, and reducing the load on system
+processes like systemd that may need to interact with all mount in the default
+namespace.
+
+# How to use
+
+Include this library in your main.go:
+
+```go
+import "github.com/containers/kubensmnt"
+```
+
+This will cause a C constructor function to run before the Go runtime fully
+initializes which will do the following:
+- If `$KUBENSMNT` is not set in the environment, do nothing.
+- If `$KUBENSMNT` is set in the environment, and it points at a valid path that
+  is a bind-mount to a mount namespace, join that mount namespace.
+  - If there is an error finding the bindmount path or joining the namespace,
+    the error is recorded and can be retrieved via the `Status` call.
+
+Inside the Go code, you can then check what happened during init and take
+actions accordingly:
+
+```go
+func main() {
+    path, err := kubensmnt.Status()
+    if err != nil {
+        panic(err)
+    }
+    if path == "" {
+        fmt.Println("No mount namespace was configured; no action was taken")
+    } else {
+        fmt.Printf("Successfully joined the namespace bound to %q\n", path)
+    }
+    // Go on to do more important things...
+}
+```
+
+# Running in a separate mount namespace
+
+See the explanation and systemd examples in [utils/systemd](utils/systemd/)
+
+# Testing
+
+See [test/README.md](test/README.md)

--- a/vendor/github.com/containers/kubensmnt/kubensmnt.c
+++ b/vendor/github.com/containers/kubensmnt/kubensmnt.c
@@ -1,0 +1,52 @@
+//go:build linux && cgo
+// +build linux,cgo
+/*
+ * Copyright 2022 Jim Ramsay <jramsay@redhat.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sched.h>
+#include "kubensmnt.h"
+
+char* getKubeNsMnt() {
+	return getenv(KUBENS_ENVNAME);
+}
+
+int joinMountNamespace(const char* namespace, char* errorMessage, size_t errlen) {
+	errorMessage[0] = '\0';
+	if (namespace == NULL) {
+		// No namespace requested; silently return
+		return 0;
+	}
+
+	int fd = open(namespace, O_RDONLY);
+	if (fd == -1) {
+		snprintf(errorMessage, errlen, "Could not open mount namespace \"%s\": %m", namespace);
+		return -1;
+	}
+
+	int res = setns(fd, CLONE_NEWNS);
+	if (res == -1) {
+		snprintf(errorMessage, errlen, "Could not join mount namespace \"%s\": %m", namespace);
+		// Fallthrough to clean up fd
+	}
+
+	close(fd);
+	return res;
+}

--- a/vendor/github.com/containers/kubensmnt/kubensmnt.go
+++ b/vendor/github.com/containers/kubensmnt/kubensmnt.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Jim Ramsay <jramsay@redhat.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kubensmnt
+
+// EnvName is the name of the environment variable where we check for a mount namespace bindmount.
+// If unset, no action is taken.  If set and points at a mount namespace
+// bindmount, enter that mount namespace before executing this Go program.  If
+// set and an error occurs, the Status function will report an error.
+const EnvName = "KUBENSMNT" // Note: Must be manually kept in-sync with the value in kubensmnt.h
+
+// Status returns the configured KubeNS mount namespace filename (or an empty
+// string if not configured), and an error representing whether the namespace
+// join succeeded.  The actual work of entering a mount namespace must be done
+// in a C init-function before any Go threads start up, so all we can do inside
+// Go is provide a report of what happened.
+func Status() (string, error) {
+	// Dispatch to the proper build-time instance (see kubensmnt_*.go)
+	return status()
+}

--- a/vendor/github.com/containers/kubensmnt/kubensmnt.h
+++ b/vendor/github.com/containers/kubensmnt/kubensmnt.h
@@ -1,0 +1,22 @@
+//go:build linux && cgo
+// +build linux,cgo
+/*
+ * Copyright 2022 Jim Ramsay <jramsay@redhat.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define KUBENS_ENVNAME "KUBENSMNT" // Note: Must be kept manually in-sync with common.go
+
+char* getKubeNsMnt();
+int joinMountNamespace(const char* namespace, char* errorMessage, size_t errlen);

--- a/vendor/github.com/containers/kubensmnt/kubensmnt_linux.go
+++ b/vendor/github.com/containers/kubensmnt/kubensmnt_linux.go
@@ -1,0 +1,50 @@
+//go:build linux && cgo
+// +build linux,cgo
+
+/*
+ * Copyright 2022 Jim Ramsay <jramsay@redhat.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kubensmnt
+
+/*
+#cgo CFLAGS: -Wall -D_GNU_SOURCE
+
+#include "kubensmnt.h"
+
+#define ERR_LIMIT 128
+
+char* nsenterConfig = "";
+int nsenterResult = -1;
+char _errorMessage[ERR_LIMIT];
+char* errorMessage = _errorMessage; // Use an intermediary because C.GoString can't work on an array
+
+void __attribute__((constructor)) kubensmnt_init() {
+	errorMessage[0] = '\0';
+	nsenterConfig = getKubeNsMnt();
+	nsenterResult = joinMountNamespace(nsenterConfig, errorMessage, ERR_LIMIT);
+}
+*/
+import "C"
+
+import "errors"
+
+func status() (string, error) {
+	config := C.GoString(C.nsenterConfig)
+	if C.nsenterResult == -1 {
+		return config, errors.New(C.GoString(C.errorMessage))
+	}
+	return config, nil
+}

--- a/vendor/github.com/containers/kubensmnt/kubensmnt_nonlinux.go
+++ b/vendor/github.com/containers/kubensmnt/kubensmnt_nonlinux.go
@@ -1,0 +1,34 @@
+//go:build !linux || !cgo
+// +build !linux !cgo
+
+/*
+ * Copyright 2022 Jim Ramsay <jramsay@redhat.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kubensmnt
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func status() (string, error) {
+	namespace := os.Getenv(EnvName)
+	if namespace == "" {
+		return "", nil
+	}
+	return namespace, errors.New(fmt.Sprintf("%s mount namespaces are not supported on this platform", EnvName))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -653,6 +653,9 @@ github.com/containers/image/v5/transports
 github.com/containers/image/v5/transports/alltransports
 github.com/containers/image/v5/types
 github.com/containers/image/v5/version
+# github.com/containers/kubensmnt v1.1.2
+## explicit; go 1.18
+github.com/containers/kubensmnt
 # github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a
 ## explicit
 github.com/containers/libtrust


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is in support of OpenShift Enhancement https://github.com/openshift/enhancements/pull/1127

CRI-O will now check whether `$KUBENSMNT` is set in the environment.  If this
environment variable is defined, assume the file it points at is a bindmount to
a mount namespace that CRI-O should join:
- If the environment variable is not set, take no action
- If the environment variable is set and points at a valid mount
  namespace, join that mount namespace.
- If the environment variable is set but points at a missing file, or
  the file is not a valid mount namespace, print a warning but continue
  to run in the original mount namespace.

The approach makes use of a cgo init block to ensure the namespace is
joined before any go threads start up.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Ready for final review. Includes CI and docs changes.

#### Does this PR introduce a user-facing change?

```release-note
If `$KUBENSMNT` is defined in the environment, assume the file it points at is
a bindmount to a mount namespace that CRI-O should join:
- If the environment variable is not set, take no action.
- If the environment variable is set and points at a valid mount
  namespace, CRI-O will join that mount namespace.
- If the environment variable is set but points at a missing file, or the file
  is not a valid mount namespace, CRI-O will print a warning but continue to
  run in the original mount namespace.
```
