### PR TITLE
Sign static binary bundle via cosign

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,7 @@ jobs:
             ~/.cache/go-build
           key: go-integration-${{ hashFiles('**/go.sum') }}
           restore-keys: go-integration-
+      - uses: sigstore/cosign-installer@v2
       - run: scripts/github-actions-packages
       - run: scripts/github-actions-setup
       - run: make all test-binaries

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,15 +213,42 @@ jobs:
             moby-runc
       - run: make bundle-test-e2e
 
+  sign-artifacts:
+    if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      COSIGN_EXPERIMENTAL: 1
+    needs: bundle-test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: sigstore/cosign-installer@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: bundle
+          path: build/bundle
+      - run: make sign-artifacts
+      - uses: actions/upload-artifact@v3
+        with:
+          name: signatures
+          path: |
+            build/bundle/*.sig
+            build/bundle/*.cert
+
   upload-artifacts:
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
-    needs: bundle-test
+    needs: sign-artifacts
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: bundle
+          path: build/bundle
+      - uses: actions/download-artifact@v3
+        with:
+          name: signatures
           path: build/bundle
       - run: make upload-artifacts
         env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -96,6 +96,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # TODO: enable cosign once we sign the artifacts on main
+      # - uses: sigstore/cosign-installer@v2
       - run: |
           make get-script
           hack/tree_status.sh

--- a/Makefile
+++ b/Makefile
@@ -500,6 +500,9 @@ release-branch-forward:
 upload-artifacts:
 	./scripts/upload-artifacts
 
+sign-artifacts:
+	./scripts/sign-artifacts
+
 bin/metrics-exporter:
 	$(GO_BUILD) -o $@ \
 		-ldflags '-linkmode external -extldflags "-static -lm"' \
@@ -544,6 +547,7 @@ metrics-exporter: bin/metrics-exporter
 	bin/pinns \
 	dependencies \
 	upload-artifacts \
+	sign-artifacts \
 	bin/metrics-exporter \
 	metrics-exporter \
 	release \

--- a/scripts/get
+++ b/scripts/get
@@ -65,6 +65,10 @@ verify_requirements() {
     done
 }
 
+curl_retry() {
+    curl -sSfL --retry 5 --retry-delay 3 "$@"
+}
+
 latest_version() {
     GH_API_URL="https://api.github.com/repos/cri-o/cri-o/actions/runs?per_page=100"
 
@@ -75,7 +79,7 @@ latest_version() {
 
     if [[ $VERSION == "" ]]; then
         echo Searching for latest version via marker file
-        COMMIT=$(curl -sSfL --retry 5 --retry-delay 3 "$GCB_URL/latest-main.txt")
+        COMMIT=$(curl_retry "$GCB_URL/latest-main.txt")
         if [[ "$COMMIT" != "" ]]; then
             VERSION=$COMMIT
             echo "Found latest version $VERSION"
@@ -90,7 +94,7 @@ latest_version() {
             echo Searching GitHub actions page $PAGE
 
             URL="${GH_API_URL}&page=$PAGE"
-            JSON=$(curl -sSfL --retry 5 --retry-delay 3 "${GH_HEADERS[@]}" "$URL")
+            JSON=$(curl_retry "${GH_HEADERS[@]}" "$URL")
 
             if echo "$JSON" | jq -e '.workflow_runs | length == 0' >/dev/null; then
                 echo No more GitHub action runs available to search
@@ -124,13 +128,35 @@ prepare() {
 
 prepare "$@"
 
-TARBALL_URL=$GCB_URL/artifacts/cri-o.$ARCH.$VERSION.tar.gz
+TARBALL=cri-o.$ARCH.$VERSION.tar.gz
+BASE_URL=$GCB_URL/artifacts
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf -- "$TMPDIR"' EXIT
 
-echo "Downloading $TARBALL_URL to $TMPDIR"
-curl -sSfL --retry 5 --retry-delay 3 "$TARBALL_URL" | tar xfz - --strip-components=1 -C "$TMPDIR"
+if command -v cosign >/dev/null; then
+    echo "Found cosign, verifying signatures"
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf $TMPDIR' EXIT
+    pushd "$TMPDIR" >/dev/null
+
+    FILES=("$TARBALL" "$TARBALL.sig" "$TARBALL.cert")
+    for FILE in "${FILES[@]}"; do
+        echo "Downloading $FILE"
+        curl_retry "$BASE_URL/$FILE" -o "$FILE"
+    done
+
+    COSIGN_EXPERIMENTAL=1 cosign verify-blob "$TARBALL" \
+        --signature "$TARBALL.sig" \
+        --certificate "$TARBALL.cert"
+
+    tar xfz "$TARBALL" --strip-components=1 -C "$TMPDIR"
+    popd >/dev/null
+else
+    TARBALL_URL=$BASE_URL/$TARBALL
+    echo "Downloading $TARBALL_URL to $TMPDIR"
+    curl_retry "$TARBALL_URL" | tar xfz - --strip-components=1 -C "$TMPDIR"
+fi
 
 echo Installing CRI-O
 pushd "$TMPDIR"

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -63,7 +63,7 @@ install_conmon() {
 
 install_conmonrs() {
     curl https://raw.githubusercontent.com/containers/conmon-rs/main/scripts/get |
-        sudo bash -s -- -o /usr/bin/conmonrs
+        sudo -E PATH="$PATH" bash -s -- -o /usr/bin/conmonrs
 }
 
 install_critools() {

--- a/scripts/sign-artifacts
+++ b/scripts/sign-artifacts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for TARBALL in build/bundle/*.tar.gz; do
+    cosign sign-blob "$TARBALL" \
+        --output-signature "$TARBALL.sig" \
+        --output-certificate "$TARBALL.cert"
+done


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:

We now sign our static binary bundle via cosign keyless signing.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
We now sign the static binary bundle via sigstore signatures. This also includes support for the [get script](https://github.com/cri-o/cri-o/blob/main/scripts/get).
```
