### PR TITLE
[1.23] oci: kill children of container if it is in the host pid namespace

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -609,3 +609,16 @@ func (c *Container) RemoveManagedPIDNamespace() error {
 	}
 	return errors.Wrapf(c.pidns.Remove(), "remove PID namespace for container %s", c.ID())
 }
+
+// nodeLevelPIDNamespace searches through the container spec to see if there is
+// a PID namespace specified. If not, it returns `true` (because the runtime spec
+// defines a node level namespace as being absent from the Namespaces list)
+func (c *Container) nodeLevelPIDNamespace() bool {
+	for i := range c.spec.Linux.Namespaces {
+		// If it's specified in the namespace list, then it is something other than Node level
+		if c.spec.Linux.Namespaces[i].Type == specs.PIDNamespace {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -939,7 +939,12 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 		// Collect metric by container name
 		metrics.Instance().MetricContainersOOMCountTotalInc(c.Name())
 	}
-
+	// If this container had a node level PID namespace, then any children processes will be leaked to init.
+	// Eventually, the processes will get cleaned up when the pod cgroup is cleaned by the kubelet,
+	// but this situation is atypical and should be avoided.
+	if c.nodeLevelPIDNamespace() {
+		return r.signalContainer(c, syscall.SIGKILL, true)
+	}
 	return nil
 }
 
@@ -993,8 +998,21 @@ func (r *runtimeOCI) SignalContainer(ctx context.Context, c *Container, sig sysc
 		return errors.Errorf("unable to find signal %s", sig.String())
 	}
 
+	return r.signalContainer(c, sig, false)
+}
+
+func (r *runtimeOCI) signalContainer(c *Container, sig syscall.Signal, all bool) error {
+	args := []string{
+		rootFlag,
+		r.root,
+		"kill",
+	}
+	if all {
+		args = append(args, "-a")
+	}
+	args = append(args, c.ID(), strconv.Itoa(int(sig)))
 	_, err := utils.ExecCmd(
-		r.path, rootFlag, r.root, "kill", c.ID(), strconv.Itoa(int(sig)),
+		r.path, args...,
 	)
 	return err
 }

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -27,6 +27,18 @@ function wait_until_exit() {
 	return 1
 }
 
+# list_all_children lists children of a process recursively
+function list_all_children {
+	children=$(pgrep -P "$1")
+	for i in ${children}; do
+		if [ -z "$i" ]; then
+			exit
+		fi
+		echo -n "$i "
+		list_all_children "$i"
+	done
+}
+
 function check_oci_annotation() {
 	# check for OCI annotation in container's config.json
 	local ctr_id="$1"
@@ -964,4 +976,40 @@ function check_oci_annotation() {
 		sleep .1
 	done
 	crictl stop "$ctr_id"
+}
+
+@test "ctr with node level pid namespace should not leak children" {
+	if [[ "$RUNTIME_TYPE" == "vm" ]]; then
+		skip "not applicable to vm runtime type"
+	fi
+	if [[ -n "$TEST_USERNS" ]]; then
+		skip "test fails in a user namespace"
+	fi
+	newsandbox="$TESTDIR/sandbox.json"
+	start_crio
+
+	jq '	  .linux.security_context.namespace_options.pid = 2' \
+		"$TESTDATA"/sandbox_config.json > "$newsandbox"
+
+	jq '	  .image.image = "quay.io/crio/redis:alpine"
+		| .linux.security_context.namespace_options.pid = 2
+		| .command = ["/bin/sh", "-c", "sleep 1m& exec sleep 2m"]' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+
+	ctr_id=$(crictl run "$newconfig" "$newsandbox")
+	processes=$(list_all_children "$(pidof conmon)")
+
+	pid=$(runtime list -f json | jq .[].pid)
+	[[ "$pid" -gt 0 ]]
+	kill -9 "$pid"
+
+	EXPECTED_EXIT_STATUS=137 wait_until_exit "$ctr_id"
+
+	# make sure crio syncs state
+	for process in ${processes}; do
+		# Ignore Z state (zombies) as the process has just been killed and reparented. Systemd will get to it.
+		# `pgrep` doesn't have a good mechanism for ignoring Z state, but including all others, so:
+		# shellcheck disable=SC2009
+		! ps -p "$process" o pid=,stat= | grep -v 'Z'
+	done
 }


### PR DESCRIPTION
When PID 1 of a PID namespace is killed, all of the remaining processes are also killed.
However, for containers with a host PID namespace, this does not happen.

While we will eventually kill these processes when the kubelet tears down the sandbox's cgroup,
it looks like a leak (and could cause weird situations with duplicated processes running)

Fix it by killing the processes in this case.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
cherry-pick of https://github.com/cri-o/cri-o/pull/5943
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where child processes of containers in the host's PID namespace appear to leak after the child exits
```
