### PR TITLE
server: cleanup cleanup funcs

### DIFF
--- a/internal/resourcestore/resourcecleaner.go
+++ b/internal/resourcestore/resourcecleaner.go
@@ -28,14 +28,10 @@ func NewResourceCleaner() *ResourceCleaner {
 }
 
 // Add adds a new CleanupFunc to the ResourceCleaner
-func (r *ResourceCleaner) Add(
-	ctx context.Context,
-	description string,
-	fn func() error,
-) {
+func (r *ResourceCleaner) Add(ctx context.Context, description string, fn func() error) {
 	// Create a retry task on top of the provided function
 	task := func() error {
-		err := retry(ctx, fn)
+		err := retry(ctx, description, fn)
 		if err != nil {
 			log.Errorf(ctx,
 				"Retried cleanup function %q too often, giving up",
@@ -62,7 +58,7 @@ func (r *ResourceCleaner) Cleanup() error {
 
 // retry attempts to execute fn up to defaultRetryTimes if its failure meets
 // retryCondition.
-func retry(ctx context.Context, fn func() error) error {
+func retry(ctx context.Context, description string, fn func() error) error {
 	backoff := wait.Backoff{
 		Duration: 500 * time.Millisecond,
 		Factor:   1.5,
@@ -70,6 +66,7 @@ func retry(ctx context.Context, fn func() error) error {
 	}
 
 	waitErr := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		log.Infof(ctx, description)
 		if err := fn(); err != nil {
 			log.Errorf(ctx, "Failed to cleanup (probably retrying): %v", err)
 			return false, nil

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -345,9 +345,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 		return nil, errors.Wrapf(err, resourceErr.Error())
 	}
 
-	description := fmt.Sprintf("createCtr: releasing container name %s", ctr.Name())
-	resourceCleaner.Add(ctx, description, func() error {
-		log.Infof(ctx, description)
+	resourceCleaner.Add(ctx, "createCtr: releasing container name "+ctr.Name(), func() error {
 		s.ReleaseContainerName(ctr.Name())
 		return nil
 	})
@@ -356,20 +354,15 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 	if err != nil {
 		return nil, err
 	}
-	description = fmt.Sprintf("createCtr: deleting container %s from storage", ctr.ID())
-	resourceCleaner.Add(ctx, description, func() error {
-		log.Infof(ctx, description)
-		err2 := s.StorageRuntimeServer().DeleteContainer(ctr.ID())
-		if err2 != nil {
-			log.Warnf(ctx, "Failed to cleanup container storage: %v", err2)
+	resourceCleaner.Add(ctx, "createCtr: deleting container "+ctr.ID()+" from storage", func() error {
+		if err := s.StorageRuntimeServer().DeleteContainer(ctr.ID()); err != nil {
+			return fmt.Errorf("failed to cleanup container storage: %w", err)
 		}
-		return err2
+		return nil
 	})
 
 	s.addContainer(newContainer)
-	description = fmt.Sprintf("createCtr: removing container %s", newContainer.ID())
-	resourceCleaner.Add(ctx, description, func() error {
-		log.Infof(ctx, description)
+	resourceCleaner.Add(ctx, "createCtr: removing container "+newContainer.ID(), func() error {
 		s.removeContainer(newContainer)
 		return nil
 	})
@@ -377,18 +370,11 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 	if err := s.CtrIDIndex().Add(ctr.ID()); err != nil {
 		return nil, err
 	}
-	description = fmt.Sprintf("createCtr: deleting container ID %s from idIndex", ctr.ID())
-	resourceCleaner.Add(ctx, description, func() error {
-		log.Infof(ctx, description)
-		err := s.CtrIDIndex().Delete(ctr.ID())
-		if err != nil {
-			// already deleted
-			if strings.Contains(err.Error(), noSuchID) {
-				return nil
-			}
-			log.Warnf(ctx, "Couldn't delete ctr id %s from idIndex", ctr.ID())
+	resourceCleaner.Add(ctx, "createCtr: deleting container ID "+ctr.ID()+" from idIndex", func() error {
+		if err := s.CtrIDIndex().Delete(ctr.ID()); err != nil && !strings.Contains(err.Error(), noSuchID) {
+			return err
 		}
-		return err
+		return nil
 	})
 
 	mappings, err := s.getSandboxIDMappings(sb)
@@ -399,14 +385,9 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 	if err := s.createContainerPlatform(ctx, newContainer, sb.CgroupParent(), mappings); err != nil {
 		return nil, err
 	}
-	description = fmt.Sprintf("createCtr: removing container ID %s from runtime", ctr.ID())
-	resourceCleaner.Add(ctx, description, func() error {
-		if retErr != nil {
-			log.Infof(ctx, description)
-			if err := s.Runtime().DeleteContainer(ctx, newContainer); err != nil {
-				log.Warnf(ctx, "Failed to delete container in runtime %s: %v", ctr.ID(), err)
-				return err
-			}
+	resourceCleaner.Add(ctx, "createCtr: removing container ID "+ctr.ID()+" from runtime", func() error {
+		if err := s.Runtime().DeleteContainer(ctx, newContainer); err != nil {
+			return fmt.Errorf("failed to delete container in runtime %s: %w", ctr.ID(), err)
 		}
 		return nil
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind cleanup
#### What this PR does / why we need it:
- move cleanup func closer to the resource provisioning it is cleaning up
- deduplicate code by moving the logging into the retry func
- replace uses of fmt.Sprintf with string concatenation 
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
