### PR TITLE
Add stale bot workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: stale
+
+# Please refer to https://github.com/actions/stale/blob/master/action.yml
+# to see all config knobs of the stale action.
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GH_TOKEN }}
+          stale-issue-message: 'A friendly reminder that this issue had no activity for 30 days.'
+          stale-pr-message: 'A friendly reminder that this PR had no activity for 30 days.'
+          stale-issue-label: 'lifecycle/stale'
+          stale-pr-label: 'lifecycle/stale'
+          close-issue-message: 'Closing this issue since it had no activity in the past 90 days.'
+          close-pr-message: 'Closing this PR since it had no activity in the past 90 days.'
+          close-issue-label: 'lifecycle/rotten'
+          close-pr-label: 'lifecycle/rotten'
+          days-before-stale: 30
+          days-before-close: 90
+          remove-stale-when-updated: false


### PR DESCRIPTION


#### What type of PR is this?

/kind ci


#### What this PR does / why we need it:
We now mark issues and PRs as stale after a while. We also close them and mark the mas rotten if there has been no acidity. 
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
