### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
 env:
   GO_VERSION: '1.18'
+permissions:
+  contents: read
+
 jobs:
   critest:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,6 +265,8 @@ jobs:
       - run: make codecov
 
   release-notes:
+    permissions:
+      contents: none
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
@@ -292,6 +294,8 @@ jobs:
           if-no-files-found: ignore
 
   dependencies:
+    permissions:
+      contents: none
     if: github.ref == 'refs/heads/main'
     needs: release-notes
     runs-on: ubuntu-latest
@@ -319,6 +323,8 @@ jobs:
           path: build/dependencies
 
   release-branch-forward:
+    permissions:
+      contents: none
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,8 +9,14 @@ on:
   pull_request:
 env:
   GO_VERSION: '1.18'
+permissions:
+  contents: read
+
 jobs:
   lint:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
