### PR TITLE
Use default token for stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          repo-token: ${{ secrets.GH_TOKEN }}
           stale-issue-message: 'A friendly reminder that this issue had no activity for 30 days.'
           stale-pr-message: 'A friendly reminder that this PR had no activity for 30 days.'
           stale-issue-label: 'lifecycle/stale'


### PR DESCRIPTION

#### What type of PR is this?


/kind ci

#### What this PR does / why we need it:
I wasn't completely sure if that works but the default token should point to the GitHub actions bot rather than my account-bound token.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
