### PR TITLE
Pin upstream node e2e test to latest `main`

### DIFF
--- a/scripts/node_e2e_installer
+++ b/scripts/node_e2e_installer
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Commit to run upstream node e2e tests
-NODE_E2E_COMMIT=5aba68c31a81454b2f00cb5414817606bd2b66c0
+NODE_E2E_COMMIT=2c43fb8a34e1cf59266e2f9a903e9ce88bf4c8ef
 
 enable_selinux() {
     # Make sure SELinux is enabled


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Updating the latest node e2e commit to test.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/5202
#### Special notes for your reviewer:
We still have to update everything in test-infra:
https://cs.k8s.io/?q=40cdd9c2d97384eb5601c1af28e7092cdda3815e&i=nope&files=&excludeFiles=&repos=kubernetes/test-infra

I'm wondering why do do not point those to `main` at all. :thinking: 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
