### PR TITLE
Fix release-notes tag determination

### DIFF
--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -94,12 +94,15 @@ func run() error {
 	shortHead := head[:7]
 	endRev := head
 	if output, err := command.New(
-		"git", "describe", "--exact-match",
+		"git", "describe", "--tags", "--exact-match",
 	).RunSilentSuccessOutput(); err == nil {
 		foundTag := output.OutputTrimNL()
+		logrus.Infof("Using tag via `git describe`: %s", foundTag)
 		bundleVersion = foundTag
 		shortHead = foundTag
 		endRev = foundTag
+	} else {
+		logrus.Infof("Not using git tag because `git describe` failed: %v", err)
 	}
 
 	if _, err := templateFile.WriteString(fmt.Sprintf(`# CRI-O %s


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:

I've tested this in a local environment by reproducing the checkout behavior of GitHub actions. This should fix the tag retrieval for the release notes generation.

#### Which issue(s) this PR fixes:

Fixes: https://github.com/cri-o/cri-o/issues/5687

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
