### PR TITLE
[release-1.24] Fix unit test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,18 +250,19 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: unit
-          path: |
-            build/coverage
+          path: build/coverage
 
   coverage:
     needs: unit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v3
         with:
           name: unit
-          path: build
+          path: build/coverage
       - run: make codecov
 
   release-notes:


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:

Backport of https://github.com/cri-o/cri-o/pull/6012 `to release-1.24`.

Cherry-picked: 66d33db6b66c57dac4f3c6ff38d7da9cfd9b0559

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
