### PR TITLE
server: Fix Unmasked ProcMountType

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -440,39 +440,13 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		specgen.SetProcessNoNewPrivileges(securityContext.NoNewPrivs)
 
 		if !ctr.Privileged() {
-			for _, mp := range []string{
-				"/proc/acpi",
-				"/proc/kcore",
-				"/proc/keys",
-				"/proc/latency_stats",
-				"/proc/timer_list",
-				"/proc/timer_stats",
-				"/proc/sched_debug",
-				"/proc/scsi",
-				"/sys/firmware",
-				"/sys/dev",
-			} {
-				specgen.AddLinuxMaskedPaths(mp)
-			}
 			if securityContext.MaskedPaths != nil {
-				specgen.Config.Linux.MaskedPaths = nil
 				for _, path := range securityContext.MaskedPaths {
 					specgen.AddLinuxMaskedPaths(path)
 				}
 			}
 
-			for _, rp := range []string{
-				"/proc/asound",
-				"/proc/bus",
-				"/proc/fs",
-				"/proc/irq",
-				"/proc/sys",
-				"/proc/sysrq-trigger",
-			} {
-				specgen.AddLinuxReadonlyPaths(rp)
-			}
 			if securityContext.ReadonlyPaths != nil {
-				specgen.Config.Linux.ReadonlyPaths = nil
 				for _, path := range securityContext.ReadonlyPaths {
 					specgen.AddLinuxReadonlyPaths(path)
 				}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Set masked and readonly paths based on the securityContext only.
Kubernetes as of v1.13 will always populate these based on
ProcMountType.

This can be used to allow running Docker within a container, with fewer contortions (particularly when combined with user namespaces this can be safer, as the container isn't root on the host, but root within a user namespace). Obviously there's other ways to achieve running containers within containers without this, but given this is an option the Kubernetes API supports (even if at alpha stage) it seems worthwhile supporting it.

#### Which issue(s) this PR fixes:

Fixes #6009.

#### Special notes for your reviewer:

The list in CRI-O has /sys/dev in it from #4072, note however the code as it was before this change overwrites it with the list supplied from Kubernetes, so I am fairly sure this is not used. (I don't see /sys/dev masked when running a container with CRI-O on Kubernetes 1.24).

The list in Kubernetes for comparison is: https://github.com/kubernetes/kubernetes/blob/master/pkg/securitycontext/util.go#L214-L235

#### Does this PR introduce a user-facing change?

```release-note
If the ProcMountType feature gate is enabled, CRI-O now honors the ProcMount securityContext set.
```
