### PR TITLE
oci/server: store container status in the container object

### DIFF
--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -95,7 +95,7 @@ type Container interface {
 	SpecAddMount(rspec.Mount)
 
 	// SpecAddAnnotations adds annotations to the spec.
-	SpecAddAnnotations(ctx context.Context, sandbox *sandbox.Sandbox, containerVolume []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool) error
+	SpecAddAnnotations(ctx context.Context, sandbox *sandbox.Sandbox, criMounts []*types.Mount, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool) error
 
 	// SpecAddDevices adds devices from the server config, and container CRI config
 	SpecAddDevices([]device.Device, []device.Device, bool, bool) error
@@ -150,7 +150,7 @@ func (c *container) SpecAddMount(r rspec.Mount) {
 }
 
 // SpecAddAnnotation adds all annotations to the spec
-func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox, containerVolumes []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool) (err error) {
+func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox, criMounts []*types.Mount, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool) (err error) {
 	// Copied from k8s.io/kubernetes/pkg/kubelet/kuberuntime/labels.go
 	const podTerminationGracePeriodLabel = "io.kubernetes.pod.terminationGracePeriod"
 
@@ -227,7 +227,7 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 	}
 	c.spec.AddAnnotation(annotations.Labels, string(labelsJSON))
 
-	volumesJSON, err := json.Marshal(containerVolumes)
+	volumesJSON, err := json.Marshal(criMounts)
 	if err != nil {
 		return err
 	}

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
-	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
 	crioann "github.com/cri-o/cri-o/pkg/annotations"
 	. "github.com/onsi/ginkgo/v2"
@@ -85,7 +84,7 @@ var _ = t.Describe("Container", func() {
 			err := sut.SetConfig(containerConfig, sandboxConfig)
 			Expect(err).To(BeNil())
 			currentTime := time.Now()
-			volumes := []oci.ContainerVolume{}
+			mounts := []*types.Mount{}
 			imageResult := storage.ImageResult{}
 			mountPoint := "test"
 			configStopSignal := "test"
@@ -108,7 +107,7 @@ var _ = t.Describe("Container", func() {
 			labelsJSON, err := json.Marshal(sut.Config().Labels)
 			Expect(err).To(BeNil())
 
-			volumesJSON, err := json.Marshal(volumes)
+			mountsJSON, err := json.Marshal(mounts)
 			Expect(err).To(BeNil())
 
 			kubeAnnotationsJSON, err := json.Marshal(sut.Config().Annotations)
@@ -117,7 +116,7 @@ var _ = t.Describe("Container", func() {
 			Expect(currentTime).ToNot(BeNil())
 			Expect(sb).ToNot(BeNil())
 
-			err = sut.SpecAddAnnotations(context.Background(), sb, volumes, mountPoint, configStopSignal, &imageResult, false, false)
+			err = sut.SpecAddAnnotations(context.Background(), sb, mounts, mountPoint, configStopSignal, &imageResult, false, false)
 			Expect(err).To(BeNil())
 
 			Expect(sut.Spec().Config.Annotations[annotations.Image]).To(Equal(image))
@@ -139,7 +138,7 @@ var _ = t.Describe("Container", func() {
 			Expect(sut.Spec().Config.Annotations[annotations.Created]).ToNot(BeNil())
 			Expect(sut.Spec().Config.Annotations[annotations.Metadata]).To(Equal(string(metadataJSON)))
 			Expect(sut.Spec().Config.Annotations[annotations.Labels]).To(Equal(string(labelsJSON)))
-			Expect(sut.Spec().Config.Annotations[annotations.Volumes]).To(Equal(string(volumesJSON)))
+			Expect(sut.Spec().Config.Annotations[annotations.Volumes]).To(Equal(string(mountsJSON)))
 			Expect(sut.Spec().Config.Annotations[annotations.Annotations]).To(Equal(string(kubeAnnotationsJSON)))
 		})
 	})

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -268,12 +268,12 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 	scontainer.SetMountPoint(m.Annotations[annotations.MountPoint])
 
 	if m.Annotations[annotations.Volumes] != "" {
-		containerVolumes := []oci.ContainerVolume{}
-		if err = json.Unmarshal([]byte(m.Annotations[annotations.Volumes]), &containerVolumes); err != nil {
+		criMounts := []*types.Mount{}
+		if err = json.Unmarshal([]byte(m.Annotations[annotations.Volumes]), &criMounts); err != nil {
 			return sb, fmt.Errorf("failed to unmarshal container volumes: %w", err)
 		}
-		for _, cv := range containerVolumes {
-			scontainer.AddVolume(cv)
+		for _, cv := range criMounts {
+			scontainer.AddMount(cv)
 		}
 	}
 

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -44,7 +44,7 @@ var (
 // Container represents a runtime container.
 type Container struct {
 	criContainer   *types.Container
-	volumes        []ContainerVolume
+	mounts         []*types.Mount
 	name           string
 	logPath        string
 	runtimeHandler string
@@ -392,14 +392,14 @@ func (c *Container) StateNoLock() *ContainerState {
 	return c.state
 }
 
-// AddVolume adds a volume to list of container volumes.
-func (c *Container) AddVolume(v ContainerVolume) {
-	c.volumes = append(c.volumes, v)
+// AddMount adds a mount to list of container mounts.
+func (c *Container) AddMount(m *types.Mount) {
+	c.mounts = append(c.mounts, m)
 }
 
-// Volumes returns the list of container volumes.
-func (c *Container) Volumes() []ContainerVolume {
-	return c.volumes
+// Mounts returns the list of container mounts.
+func (c *Container) Mounts() []*types.Mount {
+	return c.mounts
 }
 
 // SetMountPoint sets the container mount point

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -297,8 +297,8 @@ func (c *Container) StatePath() string {
 }
 
 // CreatedAt returns the container creation time
-func (c *Container) CreatedAt() time.Time {
-	return c.state.Created
+func (c *Container) CreatedAt() int64 {
+	return c.criStatus.CreatedAt
 }
 
 // Name returns the name of the container.

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -89,16 +89,16 @@ var _ = t.Describe("Container", func() {
 		Expect(sut.IDMappings()).To(Equal(mappings))
 	})
 
-	It("should succeed to add a volume", func() {
+	It("should succeed to add a mount", func() {
 		// Given
-		volume := oci.ContainerVolume{ContainerPath: "/"}
+		mount := &types.Mount{ContainerPath: "/"}
 
 		// When
-		sut.AddVolume(volume)
+		sut.AddMount(mount)
 
 		// Then
-		Expect(len(sut.Volumes())).To(BeEquivalentTo(1))
-		Expect(sut.Volumes()[0]).To(Equal(volume))
+		Expect(len(sut.Mounts())).To(BeEquivalentTo(1))
+		Expect(sut.Mounts()[0]).To(Equal(mount))
 	})
 
 	It("should succeed to set the seccomp profile path", func() {

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -956,7 +956,7 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 	}
 
 	if state.Status != ContainerStateStopped {
-		*c.state = *state
+		c.state.Status = state.Status
 		return nil
 	}
 	// release the lock before waiting
@@ -985,7 +985,7 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 	if state == nil {
 		return fmt.Errorf("state command returned nil")
 	}
-	*c.state = *state
+	c.state.Status = state.Status
 	if err != nil {
 		log.Warnf(ctx, "Failed to find container exit file for %v: %v", c.ID(), err)
 	} else {

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -841,7 +841,7 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 		if _, err := utils.ExecCmd(
 			r.handler.RuntimePath, rootFlag, r.root, "kill", c.ID(), c.GetStopSignal(),
 		); err != nil {
-			checkProcessGone(c)
+			log.Debugf(ctx, "Failed to kill container %s with stop signal %s: %v", c.ID(), c.GetStopSignal(), err)
 		}
 		err := WaitContainerStop(ctx, c, time.Duration(timeout)*time.Second, true)
 		if err == nil {
@@ -853,18 +853,10 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 	if _, err := utils.ExecCmd(
 		r.handler.RuntimePath, rootFlag, r.root, "kill", c.ID(), "KILL",
 	); err != nil {
-		checkProcessGone(c)
+		log.Debugf(ctx, "Failed to kill container %s with stop signal %s: %v", c.ID(), c.GetStopSignal(), err)
 	}
 
 	return WaitContainerStop(ctx, c, killContainerTimeout, false)
-}
-
-func checkProcessGone(c *Container) {
-	if err := c.verifyPid(); err != nil {
-		// The initial container process either doesn't exist, or isn't ours.
-		// Set state accordingly.
-		c.state.Finished = time.Now()
-	}
 }
 
 // DeleteContainer deletes a container.

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -40,17 +40,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 		},
 	}
 
-	mounts := []*types.Mount{}
-	for _, cv := range c.Volumes() {
-		mounts = append(mounts, &types.Mount{
-			ContainerPath:  cv.ContainerPath,
-			HostPath:       cv.HostPath,
-			Readonly:       cv.Readonly,
-			Propagation:    cv.Propagation,
-			SelinuxRelabel: cv.SelinuxRelabel,
-		})
-	}
-	resp.Status.Mounts = mounts
+	resp.Status.Mounts = c.Mounts()
 
 	cState := c.StateNoLock()
 	rStatus := types.ContainerState_CONTAINER_UNKNOWN

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -3,7 +3,6 @@ package server
 import (
 	"fmt"
 
-	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	json "github.com/json-iterator/go"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -13,12 +12,6 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-const (
-	oomKilledReason = "OOMKilled"
-	completedReason = "Completed"
-	errorReason     = "Error"
-)
-
 // ContainerStatus returns status of the container.
 func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatusRequest) (*types.ContainerStatusResponse, error) {
 	c, err := s.GetContainerFromShortID(req.ContainerId)
@@ -26,67 +19,9 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
-	containerID := c.ID()
 	resp := &types.ContainerStatusResponse{
-		Status: &types.ContainerStatus{
-			Id:          containerID,
-			Metadata:    c.Metadata(),
-			Labels:      c.Labels(),
-			Annotations: c.Annotations(),
-			ImageRef:    c.ImageRef(),
-			Image: &types.ImageSpec{
-				Image: c.ImageName(),
-			},
-		},
+		Status: c.CRIStatus(),
 	}
-
-	resp.Status.Mounts = c.Mounts()
-
-	cState := c.StateNoLock()
-	rStatus := types.ContainerState_CONTAINER_UNKNOWN
-
-	// If we defaulted to exit code not set earlier then we attempt to
-	// get the exit code from the exit file again.
-	if cState.Status == oci.ContainerStateStopped && cState.ExitCode == nil {
-		err := s.Runtime().UpdateContainerStatus(ctx, c)
-		if err != nil {
-			log.Warnf(ctx, "Failed to UpdateStatus of container %s: %v", c.ID(), err)
-		}
-		cState = c.State()
-	}
-
-	resp.Status.CreatedAt = c.CreatedAt().UnixNano()
-	switch cState.Status {
-	case oci.ContainerStateCreated:
-		rStatus = types.ContainerState_CONTAINER_CREATED
-	case oci.ContainerStateRunning, oci.ContainerStatePaused:
-		rStatus = types.ContainerState_CONTAINER_RUNNING
-		started := cState.Started.UnixNano()
-		resp.Status.StartedAt = started
-	case oci.ContainerStateStopped:
-		rStatus = types.ContainerState_CONTAINER_EXITED
-		started := cState.Started.UnixNano()
-		resp.Status.StartedAt = started
-		finished := cState.Finished.UnixNano()
-		resp.Status.FinishedAt = finished
-		if cState.ExitCode == nil {
-			resp.Status.ExitCode = -1
-		} else {
-			resp.Status.ExitCode = *cState.ExitCode
-		}
-		switch {
-		case cState.OOMKilled:
-			resp.Status.Reason = oomKilledReason
-		case resp.Status.ExitCode == 0:
-			resp.Status.Reason = completedReason
-		default:
-			resp.Status.Reason = errorReason
-			resp.Status.Message = cState.Error
-		}
-	}
-
-	resp.Status.State = rStatus
-	resp.Status.LogPath = c.LogPath()
 
 	if req.Verbose {
 		info, err := s.createContainerInfo(c)

--- a/server/container_status_test.go
+++ b/server/container_status_test.go
@@ -30,7 +30,7 @@ var _ = t.Describe("ContainerStatus", func() {
 		) {
 			// Given
 			addContainerAndSandbox()
-			testContainer.AddVolume(oci.ContainerVolume{})
+			testContainer.AddMount(&types.Mount{})
 			testContainer.SetStateAndSpoofPid(givenState)
 			testContainer.SetSpec(&specs.Spec{Version: "1.0.0"})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind cleanup
#### What this PR does / why we need it:
this is part follow up of https://github.com/cri-o/cri-o/pull/5672, part alternative to https://github.com/cri-o/cri-o/pull/6023.

This came from investigation of #6023. Basically, it seems createdAt is subject to change because we return what is directly in the state. This got me thinking that we shouldn't be updating createdAt, finishedAt or startedAt, as they should be static.

That, paired with the effort in https://github.com/cri-o/cri-o/pull/5672 to reduce the number of new objects that are created, lead to this!

The idea is we know exactly when states change for containers. In UpdateContainerSTatus calls after we catch an exit, we know the time of exit, we know when we created the container and when we started it. Consulting `runc update` and updating our state can leave us in weird situations (like that in https://github.com/kubernetes/kubernetes/issues/105332 and https://bugzilla.redhat.com/show_bug.cgi?id=2094865).

Overall, this should make the flow simpler, and the number of objects created lower, at the cost of a decently heavy refactor.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a bug where the status of a container ends up being bogus, causing Kubelet to print `verify ContainerStatus failed" err="status.CreatedAt is not set` repeatedly.
```
