### PR TITLE
[1.23] server: update container status if state has bogus information

### DIFF
--- a/server/container_status_test.go
+++ b/server/container_status_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
@@ -55,22 +56,30 @@ var _ = t.Describe("ContainerStatus", func() {
 			Expect(response.Info["info"]).To(ContainSubstring(`"ociVersion":"1.0.0"`))
 		},
 			Entry("Created", &oci.ContainerState{
-				State: specs.State{Status: oci.ContainerStateCreated},
+				State:   specs.State{Status: oci.ContainerStateCreated},
+				Created: time.Now(),
 			}, types.ContainerState_CONTAINER_CREATED),
+			Entry("Created with zero created at should refresh", &oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateCreated},
+			}, types.ContainerState_CONTAINER_EXITED),
 			Entry("Running", &oci.ContainerState{
-				State: specs.State{Status: oci.ContainerStateRunning},
+				State:   specs.State{Status: oci.ContainerStateRunning},
+				Created: time.Now(),
 			}, types.ContainerState_CONTAINER_RUNNING),
 			Entry("Stopped: ExitCode 0", &oci.ContainerState{
 				ExitCode: utils.Int32Ptr(0),
 				State:    specs.State{Status: oci.ContainerStateStopped},
+				Created:  time.Now(),
 			}, types.ContainerState_CONTAINER_EXITED),
 			Entry("Stopped: ExitCode -1", &oci.ContainerState{
 				ExitCode: utils.Int32Ptr(-1),
 				State:    specs.State{Status: oci.ContainerStateStopped},
+				Created:  time.Now(),
 			}, types.ContainerState_CONTAINER_EXITED),
 			Entry("Stopped: OOMKilled", &oci.ContainerState{
 				OOMKilled: true,
 				State:     specs.State{Status: oci.ContainerStateStopped},
+				Created:   time.Now(),
 			}, types.ContainerState_CONTAINER_EXITED),
 		)
 


### PR DESCRIPTION
if CreatedAt is zero, the Kubelet will complain and also be confused by the container.
Attempt to update in this case.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
/kind bug
```release-note
fix a bug where the status of a container ends up being bogus, causing Kubelet to print `verify ContainerStatus failed" err="status.CreatedAt is not set` repeatedly.
```
