### PR TITLE
Inherit capabilities for container execs

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1340,6 +1340,10 @@ func prepareProcessExec(c *Container, cmd []string, tty bool) (processFile strin
 	if tty {
 		pspec.Terminal = true
 	}
+	// Allow the same capabilities to be used as those from the actual container process.
+	if pspec.Capabilities != nil {
+		pspec.Capabilities.Inheritable = pspec.Capabilities.Bounding
+	}
 	processJSON, err := json.Marshal(pspec)
 	if err != nil {
 		return "", err

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -669,6 +669,18 @@ function check_oci_annotation() {
 	crictl create "$newconfig" "$TESTDATA"/sandbox_config.json
 }
 
+@test "ctr exec caps" {
+	start_crio
+
+	jq '.linux.security_context.capabilities = { "add_capabilities": ["net_admin"] }' \
+		"$TESTDATA"/container_redis.json > "$newconfig"
+
+	ctr_id=$(crictl run "$newconfig" "$TESTDATA"/sandbox_config.json)
+
+	cap_inh=$(crictl exec --sync "$ctr_id" cat /proc/self/status | grep CapInh: | cut -f2)
+	[[ "$cap_inh" != "0000000000000000"* ]]
+}
+
 @test "ctr with default list of capabilities from crio.conf" {
 	start_crio
 


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We dropped the inheritable capabilities support for the container creation in 3e9d7725714057d5fc2ce7eb9f905dc50c96647c to fix a security vulnerability. This had the side effect that all exec's within containers break the existing behavior if they rely on the initially set capabilities, because the exec process does not inherit the capabilities of the main container any more. We now explicitly set the inheritable capabilities for all exec's to restore the changed behavior.


#### Which issue(s) this PR fixes:

Fixes #6069

#### Special notes for your reviewer:

It feels that this slightly decreases security.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where the capabilities of containers are not applied to exec (sync) requests.
```
