### PR TITLE
highperfhooks: avoid unbound growth of irqbalance

### DIFF
--- a/internal/runtimehandlerhooks/utils.go
+++ b/internal/runtimehandlerhooks/utils.go
@@ -163,7 +163,7 @@ func updateIrqBalanceConfigFile(irqBalanceConfigFile, newIRQBalanceSetting strin
 	found := false
 	for i, line := range lines {
 		if strings.HasPrefix(line, irqBalanceBannedCpus+"=") {
-			lines[i] = irqBalanceBannedCpus + "=" + "\"" + newIRQBalanceSetting + "\"" + "\n"
+			lines[i] = irqBalanceBannedCpus + "=" + "\"" + newIRQBalanceSetting + "\""
 			found = true
 		}
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Make sure we do not add stray extra `\n` when the high performance hooks update the `/etc/sysconfig/irqbalance` file

#### Which issue(s) this PR fixes:

Fixes #6086

#### Special notes for your reviewer:
N/A
```release-note
none
```
