### PR TITLE
add GCP vagrant environment and mirror critest images

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,13 +10,14 @@ Vagrant.configure("2") do |config|
     ## 4 to 8 CPUs seems to be about the minimum for e2e tests
     # domain.cpus = 8
     domain.machine_virtual_size = 40
-  end
 
-  config.vm.provision "shell", inline: <<-SHELL
+    config.vm.provision "shell", inline: <<-SHELL
       dnf install -y cloud-utils-growpart
       growpart /dev/vda 1
       xfs_growfs /dev/vda1
-  SHELL
+    SHELL
+
+  end
 
   config.vm.provision "shell", inline: <<-SCRIPT
     dnf install python39 -y
@@ -33,5 +34,29 @@ Vagrant.configure("2") do |config|
     ## only runs setup by default
     ansible-playbook contrib/test/ci/e2e-main.yml -i hosts -e "GOPATH=${GOPATH}" -e "TEST_AGENT=prow" --connection=local -vvv --tags setup
   SCRIPT
+
+  config.vm.provider :google do |google, override|
+    ## required environment variables
+    # GOOGLE_PROJECT_ID: the project id to run under
+    # SERVICE_ACCOUNT_FILE: the json credential filepath
+    # USER: the username to use for ssh
+    override.vm.box = "google/gce"
+
+    google.google_project_id = ENV['GOOGLE_PROJECT_ID']
+    google.google_json_key_location = ENV['SERVICE_ACCOUNT_FILE']
+
+    google.image_project_id = "rocky-linux-cloud"
+    google.image_family = 'rocky-linux-8'
+
+    google.disk_size = 40 # gb
+    google.disk_type = 'pd-ssd'
+    google.machine_type = 'n2-standard-8'
+
+    override.ssh.username = ENV['USER']
+    override.ssh.private_key_path = "~/.ssh/id_rsa"
+
+    # automatically shutdown after 8 hours
+    config.vm.provision "auto-shutdown", type: "shell", run: "always", inline: "shutdown -P +480" # = 60 minutes * 8 hours
+  end
 
 end

--- a/contrib/test/ci/critest.yml
+++ b/contrib/test/ci/critest.yml
@@ -36,8 +36,15 @@
 - name: Print critest version
   command: critest --version
 
+- name: Generate image mirror config
+  copy:
+    dest: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/critest-images.yml"
+    content: |
+      defaultTestContainerImage: {{ critest_mirror_repo }}/busybox:1
+      webServerTestImage: {{ critest_mirror_repo }}/nginx:1.18
+
 - name: run critest validation
-  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint unix:///var/run/crio/crio.sock --image-endpoint unix:///var/run/crio/crio.sock --ginkgo.flakeAttempts=3"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint unix:///var/run/crio/crio.sock --image-endpoint unix:///var/run/crio/crio.sock --ginkgo.flakeAttempts=3 --test-images-file=critest-images.yml"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
   async: 5400

--- a/contrib/test/ci/critest_images.yml
+++ b/contrib/test/ci/critest_images.yml
@@ -1,0 +1,13 @@
+# skopeo sync configuration
+
+docker.io:
+  images:
+    busybox:
+      - 1.26.2-glibc
+      - 1-uclibc
+      - 1
+      - 1-glibc
+      - 1-musl
+      - 1.28
+    nginx:
+      - 1.18

--- a/contrib/test/ci/sync_images.sh
+++ b/contrib/test/ci/sync_images.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+function error() {
+    echo "$@"
+    exit 1
+}
+
+[ -z "${DESTINATION_REPO}" ] && error "\$DESTINATION_REPO required"
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+skopeo sync \
+    --src yaml \
+    --dest docker \
+    "${SCRIPT_DIR}"/critest_images.yml \
+    "${DESTINATION_REPO}"

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -11,6 +11,8 @@ build_crun: False
 build_kata: False
 cgroupv2: False
 
+critest_mirror_repo: quay.io/crio
+
 # For results.yml Paths use rsync 'source' conventions
 artifacts: "/tmp/artifacts"  # Base-directory for collection
 crio_integration_filepath: "{{ artifacts }}/testout.txt"

--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -36,8 +36,15 @@
 - name: Print critest version
   command: critest --version
 
+- name: Generate image mirror config
+  copy:
+    dest: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/critest-images.yml"
+    content: |
+      defaultTestContainerImage: {{ critest_mirror_repo }}/busybox:1
+      webServerTestImage: {{ critest_mirror_repo }}/nginx:1.18
+
 - name: run critest validation
-  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint unix:///var/run/crio/crio.sock --image-endpoint unix:///var/run/crio/crio.sock --ginkgo.flakeAttempts=3"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint unix:///var/run/crio/crio.sock --image-endpoint unix:///var/run/crio/crio.sock --ginkgo.flakeAttempts=3 --test-images-file=critest-images.yml"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
   async: 5400

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -11,6 +11,8 @@ build_crun: False
 build_kata: False
 cgroupv2: False
 
+critest_mirror_repo: quay.io/crio
+
 # For results.yml Paths use rsync 'source' conventions
 artifacts: "/tmp/artifacts"  # Base-directory for collection
 crio_integration_filepath: "{{ artifacts }}/testout.txt"


### PR DESCRIPTION
Signed-off-by: Ryan Phillips <rphillips@redhat.com>

#### What type of PR is this?
/kind other

#### What this PR does / why we need it:
This change adds a GCP setup to the Vagrantfile for CI development. It also adds quay.io mirrors of test images, so we are not throttled by docker.io.

Adds a shell script to mirror critest images with skopeo:

```
DESTINATION_REPO=quay.io/crio contrib/test/ci/sync_images.sh
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
