### PR TITLE
Fix possible panic in pod runtime attach

### DIFF
--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -224,6 +224,21 @@ func (r *runtimePod) AttachContainer(ctx context.Context, c *Container, inputStr
 		}
 	}()
 
+	var (
+		stdin          *conmonClient.In
+		stdout, stderr *conmonClient.Out
+	)
+
+	if inputStream != nil {
+		stdin = &conmonClient.In{Reader: inputStream}
+	}
+	if outputStream != nil {
+		stdout = &conmonClient.Out{WriteCloser: outputStream}
+	}
+	if errorStream != nil {
+		stderr = &conmonClient.Out{WriteCloser: errorStream}
+	}
+
 	return r.client.AttachContainer(ctx, &conmonClient.AttachConfig{
 		ID:                c.ID(),
 		SocketPath:        attachSocketPath,
@@ -231,9 +246,9 @@ func (r *runtimePod) AttachContainer(ctx context.Context, c *Container, inputStr
 		StopAfterStdinEOF: c.stdin && !c.StdinOnce() && !tty,
 		Resize:            libpodResize,
 		Streams: conmonClient.AttachStreams{
-			Stdin:  &conmonClient.In{Reader: inputStream},
-			Stdout: &conmonClient.Out{WriteCloser: outputStream},
-			Stderr: &conmonClient.Out{WriteCloser: errorStream},
+			Stdin:  stdin,
+			Stdout: stdout,
+			Stderr: stderr,
 		},
 	})
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If no stdin is provided, then we still wrapped the type in `&In{…}` which means that the nil check in `github.com/containers/conmon-rs/pkg/client/attach.go:204` cannot evaluate correctly. This caused a runtime panic like:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x293b0e9]

goroutine 695 [running]:
github.com/containers/conmon-rs/pkg/client.(*In).Read(0xc000fe7ec0?, {0xc0012f6000?, 0xc000fa6ef0?, 0x11846aa?})
        <autogenerated>:1 +0x29
github.com/containers/common/pkg/util.CopyDetachable({0x349a2c0, 0xc000b7a080}, {0x3495060, 0xc000960d10}, {0x0, 0x0, 0x1?})
        github.com/containers/common@v0.48.1-0.20220720100622-5e4fc04c2e94/pkg/util/copy.go:16 +0xa7
github.com/containers/conmon-rs/pkg/client.(*ConmonClient).setupStdioChannels.func2()
        github.com/containers/conmon-rs@v0.0.0-20220727163913-8698d2df0588/pkg/client/attach.go:204 +0xda
created by github.com/containers/conmon-rs/pkg/client.(*ConmonClient).setupStdioChannels
        github.com/containers/conmon-rs@v0.0.0-20220727163913-8698d2df0588/pkg/client/attach.go:199 +0x191
```

When running:

```
> sudo crictl attach $(sudo crictl run test/testdata/container_redis.json test/testdata/sandbox_config.json)
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed possible panic on attach when using `runtime_type = "pod"` if no stdin is being provided.
```
