### PR TITLE
server: return already created ID for duplicated requests

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -374,9 +374,9 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 			return nil, fmt.Errorf("failed to get ID of container with reserved name (%s), after failing to reserve name with %v: %w", ctr.Name(), getErr, getErr)
 		}
 		// if we're able to find the container, and it's created, this is actually a duplicate request
-		// from a client that does not behave like the kubelet (like crictl)
+		// Just return that container
 		if reservedCtr := s.GetContainer(reservedID); reservedCtr != nil && reservedCtr.Created() {
-			return nil, err
+			return &types.CreateContainerResponse{ContainerId: reservedID}, nil
 		}
 		cachedID, resourceErr := s.getResourceOrWait(ctx, ctr.Name(), "container")
 		if resourceErr == nil {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -368,9 +368,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 			return nil, fmt.Errorf("failed to get ID of pod with reserved name (%s), after failing to reserve name with %v: %w", sbox.Name(), getErr, getErr)
 		}
 		// if we're able to find the sandbox, and it's created, this is actually a duplicate request
-		// from a client that does not behave like the kubelet (like crictl)
+		// Just return that sandbox
 		if reservedSbox := s.GetSandbox(reservedID); reservedSbox != nil && reservedSbox.Created() {
-			return nil, err
+			return &types.RunPodSandboxResponse{PodSandboxId: reservedID}, nil
 		}
 		cachedID, resourceErr := s.getResourceOrWait(ctx, sbox.Name(), "sandbox")
 		if resourceErr == nil {

--- a/test/timeout.bats
+++ b/test/timeout.bats
@@ -159,10 +159,11 @@ function wait_clean() {
 
 @test "should not wait for actual duplicate pod request" {
 	start_crio
-	crictl runp "$TESTDATA"/sandbox_config.json
+	pod_1=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	SECONDS=0
-	! crictl runp "$TESTDATA"/sandbox_config.json
+	pod_2=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	[[ "$SECONDS" -lt 240 ]]
+	[[ "$pod_1" == "$pod_2" ]]
 }
 
 @test "should clean up container after timeout if not re-requested" {


### PR DESCRIPTION
turns out, kubelet does behave like this in some scenerios (static
pods). Instead of failing forever, return the already created pod.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
alternative to https://github.com/cri-o/cri-o/pull/6111

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where static pods cannot be created because they've already been created.
```
