### PR TITLE
utils/RunUnderSystemdScope: fix

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -87,8 +87,6 @@ func RunUnderSystemdScope(mgr *dbusmgr.DbusConnManager, pid int, slice, unitName
 		if s != "done" {
 			return fmt.Errorf("error moving conmon with pid %d to systemd unit %s: got %s", pid, unitName, s)
 		}
-	case <-ch:
-		close(ch)
 	case <-time.After(time.Minute * 6):
 		// This case is a work around to catch situations where the dbus library sends the
 		// request but it unexpectedly disappears. We set the timeout very high to make sure


### PR DESCRIPTION
A slightly incorrect porting of https://github.com/cri-o/cri-o/pull/5914/commits/343bcdd8f793af
to main branch resulted in duplicated case statement in a switch. Remove it.

Fixes: 1e277b8364eb8e
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
