### PR TITLE
[1.19] utils/RunUnderSystemdScope: fix wrt channel deadlock

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -67,17 +67,23 @@ func RunUnderSystemdScope(mgr *dbusmgr.DbusConnManager, pid int, slice, unitName
 	if slice != "" {
 		properties = append(properties, systemdDbus.PropSlice(slice))
 	}
-	ch := make(chan string)
+	// Make a buffered channel so that the sender (go-systemd's jobComplete)
+	// won't be blocked on channel send while holding the jobListener lock
+	// (RHBZ#2082344).
+	ch := make(chan string, 1)
 	if err := mgr.RetryOnDisconnect(func(c *systemdDbus.Conn) error {
 		_, err = c.StartTransientUnit(unitName, "replace", properties, ch)
 		return err
 	}); err != nil {
-		return err
+		return fmt.Errorf("start transient unit %q: %w", unitName, err)
 	}
 
-	// Block until job is started
-	<-ch
+	// Block until job is started.
+	s := <-ch
 	close(ch)
+	if s != "done" {
+		return fmt.Errorf("error moving conmon with pid %d to systemd unit %s: got %s", pid, unitName, s)
+	}
 
 	return nil
 }


### PR DESCRIPTION
As seen in [1], sometimes coreos/go-systemd/dbus package deadlocks: the
jobCompete is stuck trying to send job result string to the channel
while holding the jobListener lock, while startJob (called by
StartTransientUnit) waits for the same lock.

Alas, it is not clear why the channel is not being read, nor was I able
to reproduce it locally.

Make the job result channel buffered, so jobJistener won't block on
channel send and thus StartTransientUnit won't be stuck either.

While at it,

 - wrap the error from StartTransientUnit, adding the systemd unit name
   (so we can check it in systemd log);

 - do check the job result string -- in case it is not "done",
   return an error back to the caller, which should help avoid other
   issues down the line.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2082344

This is a backport of commit 1e277b8364eb8ece.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

See above.

#### Which issue(s) this PR fixes:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2095390

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix a rare deadlock while communicating to systemd (RHBZ 2095390)
```
