### PR TITLE
[1.20] utils/RunUnderSystemdScope: fix wrt channel deadlock

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -68,18 +68,24 @@ func RunUnderSystemdScope(mgr *dbusmgr.DbusConnManager, pid int, slice, unitName
 	if slice != "" {
 		properties = append(properties, systemdDbus.PropSlice(slice))
 	}
-	ch := make(chan string)
+	// Make a buffered channel so that the sender (go-systemd's jobComplete)
+	// won't be blocked on channel send while holding the jobListener lock
+	// (RHBZ#2082344).
+	ch := make(chan string, 1)
 	if err := mgr.RetryOnDisconnect(func(c *systemdDbus.Conn) error {
 		_, err := c.StartTransientUnit(unitName, "replace", properties, ch)
-		return errors.Wrap(err, "start transient unit")
-	}); err != nil {
 		return err
+	}); err != nil {
+		return fmt.Errorf("start transient unit %q: %w", unitName, err)
 	}
 
-	// Block until job is started
+	// Wait for the job status.
 	select {
-	case <-ch:
+	case s := <-ch:
 		close(ch)
+		if s != "done" {
+			return fmt.Errorf("error moving conmon with pid %d to systemd unit %s: got %s", pid, unitName, s)
+		}
 	case <-time.After(time.Minute * 6):
 		// This case is a work around to catch situations where the dbus library sends the
 		// request but it unexpectedly disappears. We set the timeout very high to make sure
@@ -87,7 +93,7 @@ func RunUnderSystemdScope(mgr *dbusmgr.DbusConnManager, pid int, slice, unitName
 		// We also don't use the native context cancelling behavior of the dbus library,
 		// because experience has shown that it does not help.
 		// TODO: Find cause of the request being dropped in the dbus library and fix it.
-		return errors.Errorf("timed out moving conmon with pid %d to cgroup", pid)
+		return errors.Errorf("timed out moving conmon with pid %d to systemd unit %s", pid, unitName)
 	}
 
 	return nil


### PR DESCRIPTION
As seen in [1], sometimes coreos/go-systemd/dbus package deadlocks: the
jobCompete is stuck trying to send job result string to the channel
while holding the jobListener lock, while startJob (called by
StartTransientUnit) waits for the same lock.

Alas, it is not clear why the channel is not being read, nor was I able
to reproduce it locally.

Make the job result channel buffered, so jobJistener won't block on
channel send and thus StartTransientUnit won't be stuck either.

While at it,

 - move the error wrapping out of mgr.RetryOnDisconnect function,
   and use fmt.Errorf with %w instead of obsoleted errors.Wrap;

 - improve error messages, printing the systemd unit name (so we can
   check it in systemd log);

 - do check the job result string -- in case it is not "done",
   return an error back to the caller, which should help avoid other
   issues down the line.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2082344

Cherry picked from commit 343bcdd8f793af504144ddafa21de14ece47877b / https://github.com/cri-o/cri-o/pull/5914

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

See above.

#### Which issue(s) this PR fixes:

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2095389

#### Special notes for your reviewer:

None 

#### Does this PR introduce a user-facing change?


```release-note
Avoid a deadlock while moving conmon to a different system scope (RHBZ#2095389)
```
