### PR TITLE
[release-1.24] Add packit configuration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,22 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: cri-o.spec
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: cri-o
+upstream_tag_template: v{version}
+# downstream (Fedora) RPM package name
+downstream_package_name: cri-o
+actions:
+  post-upstream-clone: "wget https://src.fedoraproject.org/rpms/cri-o/raw/rawhide/f/cri-o.spec -O cri-o.spec"
+jobs:
+- job: copr_build
+  trigger: release
+  owner: "@OKD"
+  project: okd
+  targets:
+    - centos-stream-9-aarch64
+    - centos-stream-9-x86_64
+    - fedora-all-aarch64
+    - fedora-all-x86_64


### PR DESCRIPTION
#### What type of PR is this?
/kind ci

#### What this PR does / why we need it:
This change adds a config file for the Packit-as-a-Service GH app (see: https://packit.dev).
With this config, packit will automatically build an RPM for each new release tag.
The config has to exist only on the branches that are supposed to be built, i.e. currently `release-1.24`.
In the future, a copy of this config file will have to be added to `release-1.25`+ branches, too.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/cc @haircommander 

#### Does this PR introduce a user-facing change?
None