### PR TITLE
irqbalance: fix padding of odd-sized cpu mask

### DIFF
--- a/internal/runtimehandlerhooks/utils_linux.go
+++ b/internal/runtimehandlerhooks/utils_linux.go
@@ -130,8 +130,8 @@ func UpdateIRQSmpAffinityMask(cpus, current string, set bool) (cpuMask, bannedCP
 		}
 	}
 
-	maskString := mapByteToHexChar(currentMaskArray)
-	invertedMaskString := mapByteToHexChar(invertedMaskArray)
+	maskString := fixMask(mapByteToHexChar(currentMaskArray), len(s))
+	invertedMaskString := fixMask(mapByteToHexChar(invertedMaskArray), len(s))
 
 	maskStringWithComma := maskString[0:8]
 	invertedMaskStringWithComma := invertedMaskString[0:8]
@@ -140,6 +140,13 @@ func UpdateIRQSmpAffinityMask(cpus, current string, set bool) (cpuMask, bannedCP
 		invertedMaskStringWithComma = invertedMaskStringWithComma + "," + invertedMaskString[i:i+8]
 	}
 	return maskStringWithComma, invertedMaskStringWithComma, nil
+}
+
+func fixMask(maskString string, maskLen int) string {
+	if maskLen >= len(maskString) {
+		return maskString
+	}
+	return strings.Repeat("0", len(maskString)-maskLen) + maskString[len(maskString)-maskLen:]
 }
 
 func restartIrqBalanceService() error {

--- a/internal/runtimehandlerhooks/utils_test.go
+++ b/internal/runtimehandlerhooks/utils_test.go
@@ -56,6 +56,19 @@ var _ = Describe("Utils", func() {
 				input:    Input{cpus: "2-3", mask: "ffffff", set: false},
 				expected: Expected{mask: "00fffff3", invMask: "0000000c"},
 			}),
+			Entry("handle cpus non multiple of 8", TestData{
+				input:    Input{cpus: "1,3", mask: "ff,ffffffff,ffffffff,ffffffff", set: false},
+				expected: Expected{mask: "000000ff,ffffffff,ffffffff,fffffff5", invMask: "00000000,00000000,00000000,0000000a"},
+			}),
+			Entry("handle minimal affinity mask - set", TestData{
+				input:    Input{cpus: "1,3", mask: "fff", set: false},
+				expected: Expected{mask: "00000000,00000ff5", invMask: "00000000,0000000a"},
+			}),
+			// acctually happened with CI machines
+			Entry("handle minimal affinity mask - set", TestData{
+				input:    Input{cpus: "1,3", mask: "f", set: false},
+				expected: Expected{mask: "00000000,00000005", invMask: "00000000,0000000a"},
+			}),
 		)
 
 		Context("UpdateIRQBalanceConfigFile", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The high performance hook support the dynamic IRQ balancing thanks some well known annotation.
Pods can opt out from IRQ handling exposing this annotation. On pod startup, crio will recompute the irqbalance ban mask and reapply irqbalance to make sure the cpus assigned to these pods will not handle IRQs - being added to
the irqbalance ban mask. This works only for guaranteed pods requesting integral CPUs.

To support this feature, crio needs to recompute the cpu ban mask. In turn, crio depends on encoding/hex.DecodeString for some of the heavy lifting. The function expects to deal with even-sized inbound strings (which are trivial
transformations of the irqbalance ban mask). 

So crio does left-aligned zero padding of the irq affinity mask at the beginning of computation.

The left-padded mask is then adjusted excluding any relevant cpu, and then inverted. 
Here lies the problem: the padding character should always be "0" (ASCII zero), not "f", which is obtained inverting the original correct zero character.

The outcome of this behavior is that stray 'f' end up in the IRQ ban list in the irqbalance config file, and they are never removed.

Fixing the padding or the mask inversion require relatively invasive code changes, for example to pass around the expected mask length and act accordingly. While not particularly challenging per se, these change don't fit smoothly in the current code.

Another option is to clamp the computed masks to the expected length once the computation and the inversion has been done. We pursue this approach in this change.

#### Which issue(s) this PR fixes:
Fixes #6145

#### Special notes for your reviewer:
This works, but I'm not not particularly fond of this approach, suggestions welcome :)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
