### PR TITLE
[1.24] version: don't wipe if filename is empty

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -56,6 +56,9 @@ func ShouldCrioWipe(versionFileName string) (bool, error) {
 
 // shouldCrioWipe is an internal function for testing purposes
 func shouldCrioWipe(versionFileName, versionString string) (bool, error) {
+	if versionFileName == "" {
+		return false, nil
+	}
 	f, err := os.Open(versionFileName)
 	if err != nil {
 		return true, errors.Errorf("version file %s not found: %v", versionFileName, err)
@@ -99,6 +102,9 @@ func LogVersion() {
 
 // writeVersionFile is an internal function for testing purposes
 func writeVersionFile(file, gitCommit, version string) error {
+	if file == "" {
+		return nil
+	}
 	current, err := parseVersionConstant(version, gitCommit)
 	// Sanity check-this should never happen
 	if err != nil {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -74,10 +74,10 @@ var _ = t.Describe("Version", func() {
 			_, err = ioutil.ReadFile(filename)
 			Expect(err).To(BeNil())
 		})
-		It("should fail to upgrade with unspecified version", func() {
+		It("should not wipe with empty version file", func() {
 			upgrade, err := shouldCrioWipe("", tempVersion)
-			Expect(upgrade).To(BeTrue())
-			Expect(err).ToNot(BeNil())
+			Expect(upgrade).To(BeFalse())
+			Expect(err).To(BeNil())
 		})
 		It("should fail to upgrade with empty version file", func() {
 			tempFileName := tempFileName


### PR DESCRIPTION
Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Automated wiping between upgrades can now be disabled by setting `version_file_persist` to `""`
```
