### PR TITLE
[1.23] Revert "capabilities: drop inheritable"

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -292,9 +292,6 @@ func setupCapabilities(specgen *generate.Generator, caps *types.Capability, defa
 	// and pods expect that switching to a non-root user results in the capabilities being
 	// dropped. This should be revisited in the future.
 	specgen.Config.Process.Capabilities.Ambient = []string{}
-	// Also remove all inheritable capabilities in accordance with CVE-2022-27652,
-	// as it's not idiomatic for a manager of processes to set them.
-	specgen.Config.Process.Capabilities.Inheritable = []string{}
 
 	if caps == nil {
 		return nil
@@ -332,6 +329,9 @@ func setupCapabilities(specgen *generate.Generator, caps *types.Capability, defa
 			if err := specgen.AddProcessCapabilityEffective(c); err != nil {
 				return err
 			}
+			if err := specgen.AddProcessCapabilityInheritable(c); err != nil {
+				return err
+			}
 			if err := specgen.AddProcessCapabilityPermitted(c); err != nil {
 				return err
 			}
@@ -343,6 +343,9 @@ func setupCapabilities(specgen *generate.Generator, caps *types.Capability, defa
 				return err
 			}
 			if err := specgen.DropProcessCapabilityEffective(c); err != nil {
+				return err
+			}
+			if err := specgen.DropProcessCapabilityInheritable(c); err != nil {
 				return err
 			}
 			if err := specgen.DropProcessCapabilityPermitted(c); err != nil {
@@ -366,6 +369,9 @@ func setupCapabilities(specgen *generate.Generator, caps *types.Capability, defa
 		if err := specgen.AddProcessCapabilityEffective(capPrefixed); err != nil {
 			return err
 		}
+		if err := specgen.AddProcessCapabilityInheritable(capPrefixed); err != nil {
+			return err
+		}
 		if err := specgen.AddProcessCapabilityPermitted(capPrefixed); err != nil {
 			return err
 		}
@@ -380,6 +386,9 @@ func setupCapabilities(specgen *generate.Generator, caps *types.Capability, defa
 			return fmt.Errorf("failed to drop cap %s %v", capPrefixed, err)
 		}
 		if err := specgen.DropProcessCapabilityEffective(capPrefixed); err != nil {
+			return fmt.Errorf("failed to drop cap %s %v", capPrefixed, err)
+		}
+		if err := specgen.DropProcessCapabilityInheritable(capPrefixed); err != nil {
 			return fmt.Errorf("failed to drop cap %s %v", capPrefixed, err)
 		}
 		if err := specgen.DropProcessCapabilityPermitted(capPrefixed); err != nil {


### PR DESCRIPTION
This reverts commit cfef9b7b9f26ae0673d5936a682b2a353ba0b633.

Signed-off-by: Peter Hunt~ <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Revert fix for CVE-2022-27652 by re-adding inheritable capabilities. While there is a workaround, we believe this causes regression mid cycle with is contrary to CRI-O's backporting policy. The risk of the CVE is low, and so there is little risk in reverting here. 
```
