### PR TITLE
[OCPNODE-1208] Add scripts to run node e2e tests using custom cri-o builds

### DIFF
--- a/contrib/custom-node-e2e/README.md
+++ b/contrib/custom-node-e2e/README.md
@@ -1,0 +1,23 @@
+# Node e2e test with custom CRI-O builds
+
+The behaviour of [Kubernetes node e2e tests](https://github.com/kubernetes/community/blob/41289f0f7e1fdc559c24e09c8e66c1f805fdfd52/contributors/devel/sig-node/e2e-node-tests.md) that use [CRI-O as the CRI](https://github.com/kubernetes/test-infra/tree/859a94267c109ec709326f60cadf5add07e87cf4/jobs/e2e_node/crio) which run on k8s CI could be replicated locally through GCP VM(s).
+
+This could be helpful to debug node e2e test failures that would come up during developing CRI-O itself. The `create-ignition-config.sh` script builds CRI-O on the local system, creates an installation bundle tarball and uploads it to a GCS bucket of user's choice. While running the tests, a [GCP instance is created](https://github.com/kubernetes/community/blob/41289f0f7e1fdc559c24e09c8e66c1f805fdfd52/contributors/devel/sig-node/e2e-node-tests.md#remotely) and the [Fedora CoreOS machine](https://github.com/kubernetes/test-infra/tree/859a94267c109ec709326f60cadf5add07e87cf4/jobs/e2e_node/crio/latest) consumes the output ignition config which installs the custom CRI-O build and e2e tests are run against it.
+
+## Usage
+```sh
+./create-ignition-config.sh -d CRIO_DIR -i IGNITION_OUT_DIR -b GCS_BUCKET_NAME [ -s GCS_SA_PATH ] [ -e EXTRA_CONFIG_PATH ] [ -h ]
+```
+
+1. Required options:
+
+    a. `-d CRIO_DIR`: path to cri-o source
+
+    b. `-i IGNITION_OUT_DIR`: output directory for generated ignition config
+
+    c. `-b GCS_BUCKET_NAME`: valid GCS bucket name with upload permissions and [public read access set up](https://cloud.google.com/storage/docs/access-control/making-data-public)
+2. Optional flags:
+
+    a. `-s GCS_SA_PATH`: (optional) path to GCP service account file, if unused `gcloud` command should have auth correctly setup
+
+    b. `-e EXTRA_CONFIG_PATH`: (optional) path to directory containing additional set of cri-o config files

--- a/contrib/custom-node-e2e/create-ignition-config.sh
+++ b/contrib/custom-node-e2e/create-ignition-config.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    printf "Usage: %s -d CRIO_DIR -i IGNITION_OUT_DIR -b GCS_BUCKET_NAME [ -s GCS_SA_PATH ]  [ -e EXTRA_CONFIG_PATH ]  [ -h ]\n\n" "$(basename "$0")"
+    echo "Possible arguments:"
+
+    printf "  -d\tPath to cri-o source\n"
+    printf "  -i\tPath to output directory for generated ignition config\n"
+    printf "  -b\tName of the GCS bucket for uploading bundle artifacts\n"
+    printf "  -s\tPath to GCP service account file (defaults to '' when existing gcloud credentials are used)\n"
+    printf "  -e\tPath to directory for additional cri-o config files\n"
+    printf "  -h\tShow this help message\n"
+}
+
+CRIO_DIR=
+IGNITION_OUT_DIR=
+GCS_BUCKET_NAME=
+GCS_SA_PATH=
+EXTRA_CONFIG_PATH=
+
+required_arg_check() {
+    if [[ -z "$1" ]]; then
+        echo "Specifying $2 with $3 is required"
+        exit 1
+    fi
+}
+
+parse_args() {
+    echo "CRI-O build and generate ignition config script for kubernetes node e2e tests."
+
+    while getopts 'd:i:b:s:e:h' OPTION; do
+        case "$OPTION" in
+        d)
+            CRIO_DIR="$OPTARG"
+            echo "Using cri-o source from: $CRIO_DIR"
+            ;;
+        i)
+            IGNITION_OUT_DIR="$OPTARG"
+            echo "Generated ignition config file will be output to: $IGNITION_OUT_DIR"
+            ;;
+        b)
+            GCS_BUCKET_NAME="$OPTARG"
+            echo "Using GCS bucket: gs://$GCS_BUCKET_NAME"
+            ;;
+        s)
+            GCS_SA_PATH="$OPTARG"
+            echo "Using GCP service account from: $GCS_SA_PATH"
+            ;;
+        e)
+            EXTRA_CONFIG_PATH="$OPTARG"
+            echo "Using additional cri-o config files from: $EXTRA_CONFIG_PATH"
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        ?)
+            usage
+            exit 1
+            ;;
+        esac
+    done
+
+    required_arg_check "${CRIO_DIR}" "CRIO_DIR" "-d"
+    required_arg_check "${IGNITION_OUT_DIR}" "IGNITION_OUT_DIR" "-i"
+    required_arg_check "${GCS_BUCKET_NAME}" "GCS_BUCKET_NAME" "-b"
+}
+
+parse_args "$@"
+
+# Build and bundle cri-o from source
+cd "$CRIO_DIR"
+
+sudo -E make clean
+
+make bin/pinns
+
+sudo -E make build-static
+
+# Get the CPU architecture
+LOCAL_ARCH=$(uname -m)
+if [[ "$LOCAL_ARCH" == x86_64 ]]; then
+    ARCH="amd64"
+elif [[ "$LOCAL_ARCH" == aarch64 ]]; then
+    ARCH="arm64"
+else
+    echo "Unsupported local architecture: $LOCAL_ARCH"
+    exit 1
+fi
+
+sudo cp -r bin/static "bin/static-$ARCH"
+sudo chown "$USER" -R "bin/static-$ARCH"
+
+make docs
+make crio.conf
+
+make bundle
+
+# Upload cri-o bundle to GCS bucket
+export GCS_SA_PATH
+export GCS_BUCKET_NAME
+"$CRIO_DIR/contrib/custom-node-e2e/upload-artifacts.sh"
+
+# Verify cri-o commit SHAs with built artifact
+GIT_BRANCH=$(git branch --show-current)
+CRIO_TAR_FILE_PATH=$(find build/bundle/ -maxdepth 1 -regex ".*cri\-o.*\.tar\.gz" -printf "%T@ %p\n" | sort -n | head -1 | cut -d " " -f2)
+CRIO_SHA=$(echo "$CRIO_TAR_FILE_PATH" | sed "s/build\/bundle\/cri-o.$ARCH.//" | sed 's/.tar.gz//')
+
+if grep "$CRIO_SHA" <"latest-$GIT_BRANCH.txt"; then
+    echo "verified SHA id matches"
+fi
+
+# Recursively find all additional config files and get their contents
+CONFIG_FILES=$(find "$EXTRA_CONFIG_PATH" -not -type d)
+CONF_CONTENT=""
+if [[ -n "${CONFIG_FILES}" ]]; then
+    FILE_COUNTER=40
+    for CONFIG_FILE in $CONFIG_FILES; do
+        FILE_CONTENT=$(cat "$CONFIG_FILE")
+        CONF_CONTENT="$CONF_CONTENT
+cat <<EOF >/etc/crio/crio.conf.d/$FILE_COUNTER.conf
+$FILE_CONTENT
+EOF
+"
+        FILE_COUNTER=$((FILE_COUNTER + 1))
+    done
+fi
+
+# Create a custom node-e2e-installer script
+RAND_ID=crio-$USER-$(date +"%Y%m%d")-$(echo $RANDOM | md5sum | head -c 8)
+OUTPUT_SHELL_SCRIPT=node_e2e_installer-$RAND_ID.sh
+OUTPUT_SHELL_SCRIPT_PATH=/tmp/$OUTPUT_SHELL_SCRIPT
+cat <<END >"$OUTPUT_SHELL_SCRIPT_PATH"
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Commit to run upstream node e2e tests
+NODE_E2E_COMMIT=${CRIO_SHA}
+
+enable_selinux() {
+    # Make sure SELinux is enabled
+    setenforce 1
+
+    # Get the SELinux package
+    curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /tmp/kubelet-e2e.pp https://storage.googleapis.com/cri-o/selinux/kubelet-e2e.pp
+    semodule -i /tmp/kubelet-e2e.pp
+}
+
+install_crio() {
+    # Download and install CRIO
+    curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-install.sh https://raw.githubusercontent.com/cri-o/cri-o/main/scripts/get
+    bash /usr/local/crio-install.sh -t "\$NODE_E2E_COMMIT" -b ${GCS_BUCKET_NAME}
+
+    # Setup SELinux labels
+    mkdir -p /var/lib/kubelet
+    chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
+
+    mount /tmp /tmp -o remount,exec,suid
+
+    # Remove unwanted cni configuration files
+    rm -f /etc/cni/net.d/87-podman-bridge.conflist
+
+    # Setup log level
+    echo "CONTAINER_LOG_LEVEL=debug" >>/etc/sysconfig/crio
+
+    cat <<EOF >/etc/crio/crio.conf.d/10-crun.conf
+[crio.runtime]
+[crio.runtime.runtimes]
+[crio.runtime.runtimes.test-handler]
+EOF
+
+    cat <<EOF >/etc/crio/crio.conf.d/20-runc.conf
+[crio.runtime]
+default_runtime = "runc"
+[crio.runtime.runtimes]
+[crio.runtime.runtimes.runc]
+EOF
+
+    cat <<EOF >/etc/crio/crio.conf.d/30-infra-container.conf
+[crio.runtime]
+drop_infra_ctr = false
+EOF
+
+${CONF_CONTENT}
+}
+
+enable_selinux
+
+install_crio
+
+# Finally start crio
+systemctl enable crio.service
+systemctl start crio.service
+END
+
+# Upload the node-e2e-installer script to GCS bucket
+gsutil cp "$OUTPUT_SHELL_SCRIPT_PATH" "gs://$GCS_BUCKET_NAME/$OUTPUT_SHELL_SCRIPT"
+GCS_E2E_INSTALLER_SCRIPT_URL=https://storage.googleapis.com/$GCS_BUCKET_NAME/$OUTPUT_SHELL_SCRIPT
+
+# Create a custom ignition config file
+export IGN_FILE_PATH=$IGNITION_OUT_DIR/$RAND_ID.ign
+
+# Save the ignition config file to disk
+cat <<EOF >"$IGN_FILE_PATH"
+{
+  "ignition": {
+    "version": "3.3.0"
+  },
+  "kernelArguments": {
+    "shouldExist": [
+      "systemd.unified_cgroup_hierarchy=0"
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
+        "contents": {
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
+        },
+        "mode": 420
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "contents": "[Unit]\nDescription=Download and install dbus-tools.\nBefore=crio-install.service\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive dbus-tools\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "dbus-tools-install.service"
+      },
+      {
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/bash -c '/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-nodee2e-installer.sh  ${GCS_E2E_INSTALLER_SCRIPT_URL}; ln -s /usr/bin/runc /usr/local/bin/runc'\nExecStart=/usr/bin/bash /usr/local/crio-nodee2e-installer.sh\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "crio-install.service"
+      }
+    ]
+  }
+}
+EOF
+echo "Written custom cri-o ignition file to '$IGN_FILE_PATH'"

--- a/contrib/custom-node-e2e/upload-artifacts.sh
+++ b/contrib/custom-node-e2e/upload-artifacts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GCS_SA_PATH=${GCS_SA_PATH:-}
+
+# Defaults to gs://cri-o bucket
+GCS_BUCKET_NAME=${GCS_BUCKET_NAME:-cri-o}
+
+if [[ -z $GCS_SA_PATH ]]; then
+    echo "Using existing credentials for gsutil"
+else
+    echo "Activating GCP service account using $GCS_SA_PATH"
+    gcloud auth activate-service-account --key-file="$GCS_SA_PATH"
+fi
+
+BUCKET=gs://$GCS_BUCKET_NAME
+
+echo "Uploading artifacts to Google Cloud Bucket"
+gsutil -m cp -n "build/bundle/*.tar.gz*" "$BUCKET/artifacts"
+
+# update the latest version marker file for the branch
+MARKER=$(git rev-parse --abbrev-ref HEAD)
+VERSION=$(git rev-parse HEAD)
+
+# if in detached head state, we assume we're on a tag
+if [[ $MARKER == HEAD ]]; then
+    # use the major.minor as marker
+    VERSION=$(git describe --tags --exact-match)
+    MARKER=$(echo "$VERSION" | cut -c 2-5)
+fi
+echo "$VERSION" >"latest-$MARKER.txt"
+gsutil cp "latest-$MARKER.txt" "$BUCKET"

--- a/scripts/get
+++ b/scripts/get
@@ -9,17 +9,18 @@ GITHUB_TOKEN=${GITHUB_TOKEN:-}
 GCB_URL=https://storage.googleapis.com/cri-o
 
 usage() {
-    printf "Usage: %s [-a ARCH] [ -t TAG|SHA ] [ -h ]\n\n" "$(basename "$0")"
+    printf "Usage: %s [-a ARCH] [ -t TAG|SHA ] [ -b BUCKET ] [ -h ]\n\n" "$(basename "$0")"
     echo "Possible arguments:"
     printf "  -a\tArchitecture to retrieve (defaults to the local system)\n"
     printf "  -t\tVersion tag or full length SHA to be used (defaults to the latest available main)\n"
+    printf "  -b\tName of the GCS bucket for downloading artifacts (defaults to 'cri-o')\n"
     printf "  -h\tShow this help message\n"
 }
 
 parse_args() {
     echo "Welcome to the CRI-O install script!"
 
-    while getopts 'a:t:h' OPTION; do
+    while getopts 'a:b:t:h' OPTION; do
         case "$OPTION" in
         a)
             ARCH="$OPTARG"
@@ -28,6 +29,10 @@ parse_args() {
         t)
             VERSION="$OPTARG"
             echo "Using version: $VERSION"
+            ;;
+        b)
+            GCB_URL="https://storage.googleapis.com/$OPTARG"
+            echo "Using GCS bucket: gs://$OPTARG"
             ;;
         h)
             usage


### PR DESCRIPTION
Signed-off-by: Swarup Ghosh <swghosh@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:
Adds a script to generate a custom ignition config for running k8s-node-e2e test on Fedora CoreOS VM. It builds CRI-O locally in a container, prepares a bundle and uploads it to a GCP bucket for it to be used with the ignition config, which is consumed by the VM to install the custom cri-o build.

#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
