### PR TITLE
support checkpointing to oci image

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -76,6 +76,7 @@ type Container struct {
 	pidns              nsmgr.Namespace
 	restore            bool
 	restoreArchive     string
+	restoreIsOCIImage  bool
 }
 
 func (c *Container) CRIAttributes() *types.ContainerAttributes {
@@ -680,4 +681,12 @@ func (c *Container) RestoreArchive() string {
 
 func (c *Container) SetRestoreArchive(restoreArchive string) {
 	c.restoreArchive = restoreArchive
+}
+
+func (c *Container) RestoreIsOCIImage() bool {
+	return c.restoreIsOCIImage
+}
+
+func (c *Container) SetRestoreIsOCIImage(restoreIsOCIImage bool) {
+	c.restoreIsOCIImage = restoreIsOCIImage
 }

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -55,6 +55,9 @@ var _ = t.Describe("Container", func() {
 		Expect(sut.CreatedAt().UnixNano()).
 			To(BeNumerically("<", time.Now().UnixNano()))
 		Expect(sut.Spoofed()).To(Equal(false))
+		Expect(sut.Restore()).To(Equal(false))
+		Expect(sut.RestoreArchive()).To(Equal(""))
+		Expect(sut.RestoreIsOCIImage()).To(Equal(false))
 	})
 
 	It("should succeed to set the spec", func() {
@@ -133,6 +136,39 @@ var _ = t.Describe("Container", func() {
 
 		// Then
 		Expect(sut.State().Error).To(Equal(err.Error()))
+	})
+
+	It("should succeed to set restore", func() {
+		// Given
+		restore := true
+
+		// When
+		sut.SetRestore(restore)
+
+		// Then
+		Expect(sut.Restore()).To(Equal(restore))
+	})
+
+	It("should succeed to set restore is oci image", func() {
+		// Given
+		restore := true
+
+		// When
+		sut.SetRestoreIsOCIImage(restore)
+
+		// Then
+		Expect(sut.RestoreIsOCIImage()).To(Equal(restore))
+	})
+
+	It("should succeed to set restore archive", func() {
+		// Given
+		restoreArchive := "image-name"
+
+		// When
+		sut.SetRestoreArchive(restoreArchive)
+
+		// Then
+		Expect(sut.RestoreArchive()).To(Equal(restoreArchive))
 	})
 
 	It("should succeed to set start failed with nil error", func() {

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -330,7 +330,7 @@ var _ = t.Describe("Oci", func() {
 
 			// Then
 			Expect(err).NotTo(BeNil())
-			Expect(err.Error()).To(ContainSubstring("failed to wait"))
+			Expect(err.Error()).To(ContainSubstring("failed"))
 		})
 		It("RestoreContainer should fail with missing inventory", func() {
 			if !criu.CheckForCriu(criu.PodCriuVersion) {

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -414,6 +414,18 @@ var _ = t.Describe("Image", func() {
 					}, nil),
 				// buildImageCacheItem
 				mockNewImage(storeMock, testNormalizedImageName, testSHA256),
+				storeMock.EXPECT().Image(testNormalizedImageName).
+					Return(&cs.Image{
+						ID: testSHA256,
+						Names: []string{
+							testNormalizedImageName,
+							"localhost/a@sha256:" + testSHA256,
+							"localhost/b@sha256:" + testSHA256,
+							"localhost/c:latest",
+						},
+					}, nil),
+				storeMock.EXPECT().ImageBigData(testSHA256, gomock.Any()).
+					Return(nil, nil),
 				// makeRepoDigests
 				storeMock.EXPECT().ImageBigDataDigest(testSHA256, gomock.Any()).
 					Return(digest.Digest("a:"+testSHA256), nil),
@@ -493,6 +505,15 @@ var _ = t.Describe("Image", func() {
 				return inOrder(
 					// buildImageCacheItem:
 					mockNewImage(storeMock, testSHA256, testSHA256),
+					storeMock.EXPECT().Image(gomock.Any()).
+						Return(&cs.Image{
+							ID: testSHA256,
+							Names: []string{
+								"localhost/c:latest",
+							},
+						}, nil),
+					storeMock.EXPECT().ImageBigData(testSHA256, gomock.Any()).
+						Return(nil, nil),
 					// makeRepoDigests:
 					storeMock.EXPECT().ImageBigDataDigest(testSHA256, gomock.Any()).
 						Return(digest.Digest(""), nil),
@@ -526,6 +547,17 @@ var _ = t.Describe("Image", func() {
 				mockGetStoreImage(storeMock, testNormalizedImageName, testSHA256),
 				// buildImageCacheItem:
 				mockNewImage(storeMock, testNormalizedImageName, testSHA256),
+
+				storeMock.EXPECT().Image(gomock.Any()).
+					Return(&cs.Image{
+						ID: testSHA256,
+						Names: []string{
+							testNormalizedImageName,
+						},
+					}, nil),
+				storeMock.EXPECT().ImageBigData(testSHA256, gomock.Any()).
+					Return(nil, nil),
+
 				// makeRepoDigests:
 				storeMock.EXPECT().ImageBigDataDigest(testSHA256, gomock.Any()).
 					Return(digest.Digest(""), nil),

--- a/pkg/annotations/checkpoint.go
+++ b/pkg/annotations/checkpoint.go
@@ -1,0 +1,32 @@
+package annotations
+
+const (
+	// CheckpointAnnotationName is used by Container Checkpoint when creating a checkpoint image to specify the
+	// original human-readable name for the container.
+	CheckpointAnnotationName = "io.kubernetes.cri-o.annotations.checkpoint.name"
+
+	// CheckpointAnnotationRawImageName is used by Container Checkpoint when
+	// creating a checkpoint image to specify the original unprocessed name of
+	// the image used to create the container (as specified by the user).
+	CheckpointAnnotationRawImageName = "io.kubernetes.cri-o.annotations.checkpoint.rawImageName"
+
+	// CheckpointAnnotationRootfsImageID is used by Container Checkpoint when
+	// creating a checkpoint image to specify the original ID of the image used
+	// to create the container.
+	CheckpointAnnotationRootfsImageID = "io.kubernetes.cri-o.annotations.checkpoint.rootfsImageID"
+
+	// CheckpointAnnotationRootfsImageName is used by Container Checkpoint when
+	// creating a checkpoint image to specify the original image name used to
+	// create the container.
+	CheckpointAnnotationRootfsImageName = "io.kubernetes.cri-o.annotations.checkpoint.rootfsImageName"
+
+	// CheckpointAnnotationCRIOVersion is used by Container Checkpoint when
+	// creating a checkpoint image to specify the version of CRI-O used on the
+	// host where the checkpoint was created.
+	CheckpointAnnotationCRIOVersion = "io.kubernetes.cri-o.annotations.checkpoint.cri-o.version"
+
+	// CheckpointAnnotationCriuVersion is used by Container Checkpoint when
+	// creating a checkpoint image to specify the version of CRIU used on the
+	// host where the checkpoint was created.
+	CheckpointAnnotationCriuVersion = "io.kubernetes.cri-o.annotations.checkpoint.criu.version"
+)

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -17,6 +17,7 @@ main() {
     install_ginkgo
     install_cni_plugins
     install_files
+    install_buildah
 }
 
 prepare_system() {
@@ -127,6 +128,19 @@ install_files() {
     sudo cp "$REPO_ROOT"/test/registries.conf /etc/containers/registries.conf
     sudo rm -rf /usr/share/containers/containers.conf
     sudo rm -rf /etc/containers/storage.conf
+}
+
+install_buildah() {
+    URL=https://github.com/containers/buildah.git
+
+    git clone $URL
+    pushd buildah
+    git checkout "${VERSIONS["buildah"]}"
+    make
+    sudo -E PATH="$PATH" make BINDIR=/usr/bin install
+    popd
+    sudo rm -rf buildah
+    sudo buildah --version
 }
 
 main "$@"

--- a/scripts/versions
+++ b/scripts/versions
@@ -9,5 +9,6 @@ declare -A VERSIONS=(
     ["runc"]=v1.1.4
     ["crun"]=1.5
     ["bats"]=v1.6.0
+    ["buildah"]=v1.28.0
 )
 export VERSIONS

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
+	istorage "github.com/containers/image/v5/storage"
 	"github.com/containers/podman/v4/pkg/annotations"
 	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/storage/pkg/archive"
@@ -13,12 +14,46 @@ import (
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
+	crioann "github.com/cri-o/cri-o/pkg/annotations"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
+
+func (s *Server) checkIfCheckpointOCIImage(ctx context.Context, input string) (bool, error) {
+	if _, err := os.Stat(input); err == nil {
+		return false, nil
+	}
+	imageStatusRespone, err := s.ImageStatus(
+		ctx,
+		&types.ImageStatusRequest{
+			Image: &types.ImageSpec{
+				Image: input,
+			},
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if imageStatusRespone == nil ||
+		imageStatusRespone.Image == nil ||
+		imageStatusRespone.Image.Spec == nil ||
+		imageStatusRespone.Image.Spec.Annotations == nil {
+		return false, nil
+	}
+
+	ann, ok := imageStatusRespone.Image.Spec.Annotations[crioann.CheckpointAnnotationName]
+	if !ok {
+		return false, nil
+	}
+
+	logrus.Debugf("Found checkpoint of container %v in %v", ann, input)
+
+	return true, nil
+}
 
 // taken from Podman
 func (s *Server) CRImportCheckpoint(
@@ -27,48 +62,81 @@ func (s *Server) CRImportCheckpoint(
 	createMounts []*types.Mount,
 	createAnnotations map[string]string,
 ) (ctrID string, retErr error) {
-	// First get the container definition from the
-	// tarball to a temporary directory
-	archiveFile, err := os.Open(input)
-	if err != nil {
-		return "", fmt.Errorf("failed to open checkpoint archive %s for import: %w", input, err)
-	}
-	defer errorhandling.CloseQuiet(archiveFile)
-	options := &archive.TarOptions{
-		// Here we only need the files config.dump and spec.dump
-		ExcludePatterns: []string{
-			"artifacts",
-			"ctr.log",
-			metadata.RootFsDiffTar,
-			metadata.NetworkStatusFile,
-			metadata.DeletedFilesFile,
-			metadata.CheckpointDirectory,
-		},
-	}
-	dir, err := os.MkdirTemp("", "checkpoint")
+	var mountPoint string
+
+	checkpointIsOCIImage, err := s.checkIfCheckpointOCIImage(ctx, input)
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			logrus.Errorf("Could not recursively remove %s: %q", dir, err)
+
+	if checkpointIsOCIImage {
+		logrus.Debugf("Restoring from oci image %s\n", input)
+
+		imageRef, err := istorage.Transport.ParseStoreReference(s.ContainerServer.StorageImageServer().GetStore(), input)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse image name: %s: %w", input, err)
 		}
-	}()
-	err = archive.Untar(archiveFile, dir, options)
-	if err != nil {
-		return "", fmt.Errorf("unpacking of checkpoint archive %s failed: %w", input, err)
+		img, err := istorage.Transport.GetStoreImage(s.ContainerServer.StorageImageServer().GetStore(), imageRef)
+		if err != nil {
+			return "", err
+		}
+		mountPoint, err = s.ContainerServer.StorageImageServer().GetStore().MountImage(img.ID, nil, "")
+		if err != nil {
+			return "", err
+		}
+		input = img.ID
+
+		logrus.Debugf("Checkpoint image %s mounted at %v\n", input, mountPoint)
+
+		defer func() {
+			if _, err := s.ContainerServer.StorageImageServer().GetStore().UnmountImage(input, true); err != nil {
+				logrus.Errorf("Could not unmount checkpoint image %s: %q", input, err)
+			}
+		}()
+	} else {
+		// First get the container definition from the
+		// tarball to a temporary directory
+		archiveFile, err := os.Open(input)
+		if err != nil {
+			return "", fmt.Errorf("failed to open checkpoint archive %s for import: %w", input, err)
+		}
+		defer errorhandling.CloseQuiet(archiveFile)
+		options := &archive.TarOptions{
+			// Here we only need the files config.dump and spec.dump
+			ExcludePatterns: []string{
+				"artifacts",
+				"ctr.log",
+				metadata.RootFsDiffTar,
+				metadata.NetworkStatusFile,
+				metadata.DeletedFilesFile,
+				metadata.CheckpointDirectory,
+			},
+		}
+		mountPoint, err = os.MkdirTemp("", "checkpoint")
+		if err != nil {
+			return "", err
+		}
+		defer func() {
+			if err := os.RemoveAll(mountPoint); err != nil {
+				logrus.Errorf("Could not recursively remove %s: %q", mountPoint, err)
+			}
+		}()
+		err = archive.Untar(archiveFile, mountPoint, options)
+		if err != nil {
+			return "", fmt.Errorf("unpacking of checkpoint archive %s failed: %w", mountPoint, err)
+		}
+		logrus.Debugf("Unpacked checkpoint in %s", mountPoint)
 	}
-	logrus.Debugf("Unpacked checkpoint in %s", dir)
 
 	// Load spec.dump from temporary directory
 	dumpSpec := new(spec.Spec)
-	if _, err := metadata.ReadJSONFile(dumpSpec, dir, metadata.SpecDumpFile); err != nil {
+	if _, err := metadata.ReadJSONFile(dumpSpec, mountPoint, metadata.SpecDumpFile); err != nil {
 		return "", fmt.Errorf("failed to read %q: %w", metadata.SpecDumpFile, err)
 	}
 
 	// Load config.dump from temporary directory
 	config := new(lib.ContainerConfig)
-	if _, err := metadata.ReadJSONFile(config, dir, metadata.ConfigDumpFile); err != nil {
+	if _, err := metadata.ReadJSONFile(config, mountPoint, metadata.ConfigDumpFile); err != nil {
 		return "", fmt.Errorf("failed to read %q: %w", metadata.ConfigDumpFile, err)
 	}
 
@@ -270,6 +338,7 @@ func (s *Server) CRImportCheckpoint(
 	newContainer.SetCreated()
 	newContainer.SetRestore(true)
 	newContainer.SetRestoreArchive(input)
+	newContainer.SetRestoreIsOCIImage(checkpointIsOCIImage)
 
 	if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
 		log.Infof(ctx, "RestoreCtr: context was either canceled or the deadline was exceeded: %v", ctx.Err())

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -67,6 +67,9 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 				RepoTags:    status.RepoTags,
 				RepoDigests: status.RepoDigests,
 				Size_:       size,
+				Spec: &types.ImageSpec{
+					Annotations: status.Annotations,
+				},
 			},
 		}
 		if req.Verbose {

--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -29,3 +29,49 @@ function teardown() {
 	crictl start "$ctr_id"
 	crictl rmp -f "$pod_id"
 }
+
+@test "checkpoint and restore one container into a new pod using --export to OCI image" {
+	has_buildah
+	CONTAINER_DROP_INFRA_CTR=false CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	crictl checkpoint --export="$TESTDIR"/cp.tar "$ctr_id"
+	crictl rm -f "$ctr_id"
+	crictl rmp -f "$pod_id"
+	newimage=$(run_buildah from scratch)
+	run_buildah add "$newimage" "$TESTDIR"/cp.tar /
+	run_buildah config --annotation io.kubernetes.cri-o.annotations.checkpoint.name=sleeper "$newimage"
+	run_buildah commit "$newimage" "checkpoint-image:tag1"
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	# Replace original container with checkpoint image
+	jq ".image.image=\"localhost/checkpoint-image:tag1\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
+	rm -f "$TESTDATA"/restore.json
+	crictl start "$ctr_id"
+	crictl rmp -f "$pod_id"
+}
+
+@test "checkpoint and restore one container into a new pod using --export to OCI image using repoDigest" {
+	has_buildah
+	CONTAINER_DROP_INFRA_CTR=false CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	crictl checkpoint --export="$TESTDIR"/cp.tar "$ctr_id"
+	crictl rm -f "$ctr_id"
+	crictl rmp -f "$pod_id"
+	newimage=$(run_buildah from scratch)
+	run_buildah add "$newimage" "$TESTDIR"/cp.tar /
+	run_buildah config --annotation io.kubernetes.cri-o.annotations.checkpoint.name=sleeper "$newimage"
+	run_buildah commit "$newimage" "checkpoint-image:tag1"
+	# Kubernetes uses the repoDigest to references images.
+	repo_digest=$(crictl inspecti --output go-template --template "{{(index .status.repoDigests 0)}}" "localhost/checkpoint-image:tag1")
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	# Replace original container with checkpoint image
+	jq ".image.image=\"$repo_digest\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
+	rm -f "$TESTDATA"/restore.json
+	crictl start "$ctr_id"
+	crictl rmp -f "$pod_id"
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -688,3 +688,14 @@ function has_criu() {
         skip "CRIU too old. At least 3.16 needed."
     fi
 }
+
+function has_buildah() {
+    if [ ! -e "$(command -v buildah)" ]; then
+        skip "buildah binary not found"
+    fi
+}
+
+# Run buildah with the specified root directory (same as CRI-O)
+function run_buildah() {
+    buildah --log-level debug --root "$TESTDIR/crio" "$@"
+}


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

This adds the Podman support to export checkpoints to OCI images which can be pushed to registry to CRI-O.

With this change it is possible to do something like this:
```shell
# crictl checkpoint --export=localhost/checkpoint-image:tag1 CTR-ID
# podman push localhost/checkpoint-image:tag1 quay.io/adrianreber/checkpoint-image:tag1
```
The image `quay.io/adrianreber/checkpoint-image:tag1` can then be used on the same or another system to restore the container using `crictl create` and `crictl start`.

The image `quay.io/adrianreber/checkpoint-image:tag1` can also be used in Kubernetes to start a container from a checkpoint image without Kubernetes knowing that it is restore.

This PR is not targeting the 1.25.0 CRI-O release.

A side effect from this PR is that `crictl inspecti` will contain `spec.annotations`.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
This introduces the ability to store checkpoint archives as OCI images and push the checkpoint images to a remote registry. Important to remember is that the checkpoint image contains all memory pages of the checkpoint and therefore might contain sensitive information (password, encryption keys, ...).
```
