### PR TITLE
config: avoid segfault when workloads.resources is nil

### DIFF
--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1172,9 +1172,9 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 {{ $.Comment }}[crio.runtime.workloads.{{ $workload_type }}]
 {{ $.Comment }}activation_annotation = "{{ $workload_config.ActivationAnnotation }}"
 {{ $.Comment }}annotation_prefix = "{{ $workload_config.AnnotationPrefix }}"
-{{ $.Comment }}[crio.runtime.workloads.{{ $workload_type }}.resources]
+{{ if $workload_config.Resources }}{{ $.Comment }}[crio.runtime.workloads.{{ $workload_type }}.resources]
 {{ $.Comment }}cpuset = "{{ $workload_config.Resources.CPUSet }}"
-{{ $.Comment }}cpushares = {{ $workload_config.Resources.CPUShares }}
+{{ $.Comment }}cpushares = {{ $workload_config.Resources.CPUShares }}{{ end }}
 {{ end }}
 `
 

--- a/test/config.bats
+++ b/test/config.bats
@@ -96,3 +96,16 @@ EOF
 	[[ "$RES" == *"monitor_cgroup = \"pod\""* ]]
 	[[ "$RES" == *"monitor_path = \"/bin/true\""* ]]
 }
+
+@test "handle nil workloads" {
+	# when
+	unset CONTAINER_DEFAULT_RUNTIME
+	cat << EOF >> "$TESTDIR"/workload.conf
+[crio.runtime.workloads.userns]
+activation_annotation = "io.kubernetes.cri-o.userns-mode"
+allowed_annotations = ["io.kubernetes.cri-o.userns-mode"]
+EOF
+
+	# then
+	"$CRIO_BINARY_PATH" -c "$TESTDIR"/workload.conf -d "" config
+}


### PR DESCRIPTION
Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
fixes https://github.com/cri-o/cri-o/issues/6188
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a segfault in `crio config` when `runtime.workloads.resources` is nil 
```
