### PR TITLE
metrics: close listener on shutdown

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -602,9 +602,17 @@ func (m *Metrics) startEndpoint(
 					MinVersion:     tls.VersionTLS12,
 				},
 			}
+			go func() {
+				<-stop
+				l.Close()
+			}()
 			err = srv.ServeTLS(l, m.config.MetricsCert, m.config.MetricsKey)
 		} else {
 			logrus.Infof("Serving metrics on %s via HTTP", address)
+			go func() {
+				<-stop
+				l.Close()
+			}()
 			err = http.Serve(l, me)
 		}
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Shutdowns the metric listener on cri-o termination.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```
