### PR TITLE
Track bind mounts during checkpoint/restore

### DIFF
--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -17,17 +17,25 @@ function teardown() {
 @test "checkpoint and restore one container into a new pod using --export" {
 	CONTAINER_DROP_INFRA_CTR=false CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	BIND_MOUNT_FILE=$(mktemp)
+	BIND_MOUNT_DIR=$(mktemp -d)
+	jq ". +{mounts:[{\"container_path\":\"/etc/issue\",\"host_path\":\"$BIND_MOUNT_FILE\"},{\"container_path\":\"/data\",\"host_path\":\"$BIND_MOUNT_DIR\"}]}" "$TESTDATA"/container_sleep.json > "$TESTDATA"/checkpoint.json
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/checkpoint.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$ctr_id"
 	crictl checkpoint --export="$TESTDIR"/cp.tar "$ctr_id"
+	crictl rm -f "$ctr_id"
 	crictl rmp -f "$pod_id"
+	rm -f "$BIND_MOUNT_FILE"
+	rmdir "$BIND_MOUNT_DIR"
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# Replace original container with checkpoint image
 	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
 	rm -f "$TESTDATA"/restore.json
+	rm -f "$TESTDATA"/checkpoint.json
 	crictl start "$ctr_id"
-	crictl rmp -f "$pod_id"
+	rm -f "$BIND_MOUNT_FILE"
+	rmdir "$BIND_MOUNT_DIR"
 }
 
 @test "checkpoint and restore one container into a new pod using --export to OCI image" {
@@ -49,7 +57,6 @@ function teardown() {
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
 	rm -f "$TESTDATA"/restore.json
 	crictl start "$ctr_id"
-	crictl rmp -f "$pod_id"
 }
 
 @test "checkpoint and restore one container into a new pod using --export to OCI image using repoDigest" {
@@ -73,5 +80,4 @@ function teardown() {
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
 	rm -f "$TESTDATA"/restore.json
 	crictl start "$ctr_id"
-	crictl rmp -f "$pod_id"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

This change is especially helpful to restore containers checkpointed in Kubernetes.

During restore CRIU remounts all bind mounts which have been mounted in the container during checkpointing. If the source of the bind mount is missing, because the restore is on another system or if the restore happens outside of Kubernetes and Kubernetes specific mount points are missing, CRIU will fail during restore.

Interestingly CRI-O creates all missing bind mount sources during container start automatically. During container restore this is
disabled, as CRI-O creates all missing bind mounts as directories.

One very prominent case where this produces an error during restore, is /etc/resolv.conf. CRI-O would create the source of this bind mount as a directory and CRIU will try to mount the just created directory as on the container internal file /etc/resolv.conf. This will fail as the kernel does not bind mount a directory on a file.

If the container is restored as part of Kubernetes, then Kubernetes will create all the usual bind mount sources and tell CRI-O to create/restore the container with those new mount points. CRI-O will adapt the checkpointed container to mount the bind mounts from the new location.

If the container is restored outside of Kubernetes this information is missing. CRI-O will tell CRIU to restore the container, CRIU will try to remount the bind mount and fail if it is missing. The user will get an error message and needs to create the missing external bind mount source and then try the restore again. To avoid situations like this, CRI-O will now track all external bind mount sources and the type and recreate the external bind mount sources to make the restore successful.

Also reduces the time required for the checkpoint/restore tests from 30 seconds per test case to 10 seconds.

This PR depends on #6181 

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
Restoring Kubernetes containers outside of Kubernetes is now easier as CRI-O will re-create missing external bind mounts correctly.
```