### PR TITLE
Readd layer image corruption test

### DIFF
--- a/test/image.bats
+++ b/test/image.bats
@@ -302,3 +302,27 @@ function teardown() {
 
 	cleanup_images
 }
+
+@test "layer index corrupted" {
+	start_crio
+	crictl pull "$IMAGE"
+
+	# corrupt the index
+	LAYERS_JSON=$(find "$TESTDIR" -name layers.json)
+
+	LAYERS=$(jq length "$LAYERS_JSON")
+
+	TMPFILE="$TESTDIR/layers.tmp.json"
+	jq -c 'del(.[] | select(."diff-digest" == "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"))' \
+		"$LAYERS_JSON" > "$TMPFILE"
+	mv "$TMPFILE" "$LAYERS_JSON"
+
+	# repull the image
+	crictl pull "$IMAGE"
+
+	# the index should be restored
+	LAYERS_NEW=$(jq length "$LAYERS_JSON")
+	[[ "$LAYERS" == "$LAYERS_NEW" ]]
+
+	cleanup_images
+}


### PR DESCRIPTION


#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

The test was originally introduced by testing via the PR: https://github.com/cri-o/cri-o/pull/5005

To avoid future regressions we now readd the test.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/containers/storage/pull/1322
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
