### PR TITLE
Minor Checkpoint/Restore improvements

### DIFF
--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -89,6 +89,7 @@ func (c *ContainerServer) ContainerRestore(ctx context.Context, opts *ContainerC
 				metadata.DeletedFilesFile,
 				metadata.PodOptionsFile,
 				metadata.PodDumpFile,
+				stats.StatsDump,
 				"bind.mounts",
 			}
 			for _, name := range checkpoint {

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/cri-o/cri-o/internal/factory/container"
-	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	crioann "github.com/cri-o/cri-o/pkg/annotations"
@@ -135,7 +134,7 @@ func (s *Server) CRImportCheckpoint(
 	}
 
 	// Load config.dump from temporary directory
-	config := new(lib.ContainerConfig)
+	config := new(metadata.ContainerConfig)
 	if _, err := metadata.ReadJSONFile(config, mountPoint, metadata.ConfigDumpFile); err != nil {
 		return "", fmt.Errorf("failed to read %q: %w", metadata.ConfigDumpFile, err)
 	}

--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -17,17 +17,25 @@ function teardown() {
 @test "checkpoint and restore one container into a new pod using --export" {
 	CONTAINER_DROP_INFRA_CTR=false CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	BIND_MOUNT_FILE=$(mktemp)
+	BIND_MOUNT_DIR=$(mktemp -d)
+	jq ". +{mounts:[{\"container_path\":\"/etc/issue\",\"host_path\":\"$BIND_MOUNT_FILE\"},{\"container_path\":\"/data\",\"host_path\":\"$BIND_MOUNT_DIR\"}]}" "$TESTDATA"/container_sleep.json > "$TESTDATA"/checkpoint.json
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/checkpoint.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$ctr_id"
 	crictl checkpoint --export="$TESTDIR"/cp.tar "$ctr_id"
+	crictl rm -f "$ctr_id"
 	crictl rmp -f "$pod_id"
+	rm -f "$BIND_MOUNT_FILE"
+	rmdir "$BIND_MOUNT_DIR"
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# Replace original container with checkpoint image
 	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
 	rm -f "$TESTDATA"/restore.json
+	rm -f "$TESTDATA"/checkpoint.json
 	crictl start "$ctr_id"
-	crictl rmp -f "$pod_id"
+	rm -f "$BIND_MOUNT_FILE"
+	rmdir "$BIND_MOUNT_DIR"
 }
 
 @test "checkpoint and restore one container into a new pod using --export to OCI image" {
@@ -49,7 +57,6 @@ function teardown() {
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
 	rm -f "$TESTDATA"/restore.json
 	crictl start "$ctr_id"
-	crictl rmp -f "$pod_id"
 }
 
 @test "checkpoint and restore one container into a new pod using --export to OCI image using repoDigest" {
@@ -73,5 +80,4 @@ function teardown() {
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
 	rm -f "$TESTDATA"/restore.json
 	crictl start "$ctr_id"
-	crictl rmp -f "$pod_id"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This commit has the following changes:
 * Use ContainerConfig from checkpointctl and populate all fields
 * Include stats-dump in the checkpoint archive to keep checkpointing statistics

Depends on: #6203

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
