### PR TITLE
Add conmon-rs e2e to ansible playbook

### DIFF
--- a/contrib/test/ci/build/conmon-rs.yml
+++ b/contrib/test/ci/build/conmon-rs.yml
@@ -1,0 +1,5 @@
+---
+- name: install conmon-rs
+  shell: curl -sSfL --retry 5 --retry-delay 3 https://raw.githubusercontent.com/containers/conmon-rs/main/scripts/get | bash -s -- -o /usr/bin/conmonrs
+  register: out
+- debug: var=out.stdout_lines

--- a/contrib/test/ci/build/cri-o.yml
+++ b/contrib/test/ci/build/cri-o.yml
@@ -1,8 +1,8 @@
 ---
 - name: create crio dir
-  file: 
-    path: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o" 
-    state: directory 
+  file:
+    path: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
+    state: directory
 
 ## extract source
 
@@ -11,8 +11,8 @@
     path: "/home/deadbeef/cri-o.tar.gz"
   register: source_tar
 
-- name: extract cri-o 
-  unarchive: 
+- name: extract cri-o
+  unarchive:
     src: "/home/deadbeef/cri-o.tar.gz"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
   when: source_tar.stat.exists
@@ -85,6 +85,19 @@
       runtime_root = "/run/crun"
   when: "build_crun | default(False) | bool"
 
+- name: use conmon-rs
+  copy:
+    dest: /etc/crio/crio.conf.d/99-conmonrs.conf
+    content: |
+      [crio.runtime.runtimes.runc]
+      runtime_type = "pod"
+
+      [crio.runtime.runtimes.crun]
+      runtime_type = "pod"
+      runtime_root = "/run/crun"
+
+  when: "use_conmonrs | default(False) | bool"
+
 - name: use kata
   copy:
     dest: /etc/crio/crio.conf.d/50-kata.conf
@@ -123,4 +136,3 @@
     content: |
       [crio.image]
       registries = [ "quay.io", "docker.io" ]
-

--- a/contrib/test/ci/setup.yml
+++ b/contrib/test/ci/setup.yml
@@ -9,7 +9,7 @@
 
 - name: clone build and install cri-o
   include: "build/cri-o.yml"
-  
+
 - name: clone build and install bats
   include: "build/bats.yml"
 
@@ -40,6 +40,9 @@
 
 - name: install conmon
   include: "build/conmon.yml"
+
+- name: install conmon-rs
+  include: "build/conmon-rs.yml"
 
 - name: install jq
   include: "build/jq.yml"

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -10,6 +10,7 @@ build_runc: True
 build_crun: False
 build_kata: False
 cgroupv2: False
+use_conmonrs: '{{ USE_CONMONRS | default(False) | bool }}'
 
 critest_mirror_repo: quay.io/crio
 
@@ -20,7 +21,7 @@ crio_integration_userns_filepath: "{{ artifacts }}/testout_userns.txt"
 crio_node_e2e_filepath: "{{ artifacts }}/junit_01.xml"
 result_dest_basedir: '{{ lookup("env","WORKSPACE") |
                          default(playbook_dir, True) }}/artifacts'
-# Environment variables to set when executing e2e tests 
+# Environment variables to set when executing e2e tests
 e2e_test_env:
     KUBECONFIG: /var/run/kubernetes/admin.kubeconfig
 


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
This adds the conmonrs installation as well as usage to the ansible playbook, if the `USE_CONMONRS` environment variable is set to `true`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

PTAL @wgahnagl @rphillips @haircommander 

Refers to https://github.com/openshift/release/pull/32276

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
