### PR TITLE
add a version example: 1.25 not v1.25 or v1.25.0

### DIFF
--- a/install.md
+++ b/install.md
@@ -101,7 +101,7 @@ To install on the following operating systems, set the environment variable $OS 
 | Centos 8 Stream  | `CentOS_8_Stream` |
 | Centos 7         | `CentOS_7`        |
 
-And then run the following as root:
+And then run the following as root(for instance, $VERSION=`1.25`):
 
 ```shell
 curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/devel:kubic:libcontainers:stable.repo


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
For 1.25
**export VERSION=1.25**
https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/CentOS_7/devel:kubic:libcontainers:stable:cri-o:1.25.repo

For 1.25.0
**export VERSION=1.25:1.25.0**
https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25:/1.25.0/CentOS_7/devel:kubic:libcontainers:stable:cri-o:1.25:1.25.0.repo

#### Which issue(s) this PR fixes:


None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
