### PR TITLE
add "add_inheritable_capabilities" option

### DIFF
--- a/completions/bash/crio
+++ b/completions/bash/crio
@@ -13,6 +13,7 @@ wipe
 help
 h
 --absent-mount-sources-to-reject
+--add-inheritable-capabilities
 --additional-devices
 --address
 --allowed-devices

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -10,6 +10,7 @@ function __fish_crio_no_subcommand --description 'Test if there has been any sub
 end
 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l absent-mount-sources-to-reject -r -d 'A list of paths that, when absent from the host, will cause a container creation to fail (as opposed to the current behavior of creating a directory).'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l add-inheritable-capabilities -d 'Add capabilities to the inheritable set, as well as the default group of permitted, bounding and effective.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l additional-devices -r -d 'Devices to add to the containers.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l allowed-devices -r -d 'Devices a user is allowed to specify with the "io.kubernetes.cri-o.Devices" allowed annotation.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l apparmor-profile -r -d 'Name of the apparmor profile to be used as the runtime\'s default. This only takes effect if the user does not specify a profile via the Kubernetes Pod\'s metadata annotation.'

--- a/completions/zsh/_crio
+++ b/completions/zsh/_crio
@@ -20,6 +20,7 @@ it later with **--config**. Global options will modify the output.'
   local -a opts
   opts=(
         '--absent-mount-sources-to-reject'
+        '--add-inheritable-capabilities'
         '--additional-devices'
         '--address'
         '--allowed-devices'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -12,6 +12,7 @@ crio
 
 ```
 [--absent-mount-sources-to-reject]=[value]
+[--add-inheritable-capabilities]
 [--additional-devices]=[value]
 [--allowed-devices]=[value]
 [--apparmor-profile]=[value]
@@ -137,6 +138,8 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 # GLOBAL OPTIONS
 
 **--absent-mount-sources-to-reject**="": A list of paths that, when absent from the host, will cause a container creation to fail (as opposed to the current behavior of creating a directory). (default: [])
+
+**--add-inheritable-capabilities**: Add capabilities to the inheritable set, as well as the default group of permitted, bounding and effective.
 
 **--additional-devices**="": Devices to add to the containers. (default: [])
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -183,6 +183,10 @@ the container runtime configuration.
   ]
 ```
 
+**add_inheritable_capabilities**=false
+ Add capabilities to the inheritable set, as well as the default group of permitted, bounding and effective.
+ If capabilities are expected to work for non-root users, this option should be set.
+
 **default_sysctls**=[]
  List of default sysctls. If it is empty or commented out, only the sysctls defined in the container json file by the user/kube will be added.
 

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -200,6 +200,9 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 	if ctx.IsSet("default-capabilities") {
 		config.DefaultCapabilities = StringSliceTrySplit(ctx, "default-capabilities")
 	}
+	if ctx.IsSet("add-inheritable-capabilities") {
+		config.AddInheritableCapabilities = ctx.Bool("add-inheritable-capabilities")
+	}
 	if ctx.IsSet("default-sysctls") {
 		config.DefaultSysctls = StringSliceTrySplit(ctx, "default-sysctls")
 	}
@@ -712,6 +715,12 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 			Usage:   "Capabilities to add to the containers.",
 			EnvVars: []string{"CONTAINER_DEFAULT_CAPABILITIES"},
 			Value:   cli.NewStringSlice(defConf.DefaultCapabilities...),
+		},
+		&cli.BoolFlag{
+			Name:    "add-inheritable-capabilities",
+			Usage:   "Add capabilities to the inheritable set, as well as the default group of permitted, bounding and effective.",
+			EnvVars: []string{"CONTAINER_ADD_INHERITABLE_CAPABILITIES"},
+			Value:   defConf.AddInheritableCapabilities,
 		},
 		&cli.StringSliceFlag{
 			Name:    "default-sysctls",

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -551,7 +551,7 @@ var _ = t.Describe("Container", func() {
 			var caps *types.Capability
 			serverCaps := capabilities.Default()
 
-			Expect(sut.SpecSetupCapabilities(caps, serverCaps)).To(BeNil())
+			Expect(sut.SpecSetupCapabilities(caps, serverCaps, false)).To(BeNil())
 			verifyCapValues(sut.Spec().Config.Process.Capabilities, len(serverCaps))
 		})
 		It("AddCapabilities should add capability", func() {
@@ -561,7 +561,7 @@ var _ = t.Describe("Container", func() {
 			}
 			serverCaps := []string{}
 
-			Expect(sut.SpecSetupCapabilities(caps, serverCaps)).To(BeNil())
+			Expect(sut.SpecSetupCapabilities(caps, serverCaps, false)).To(BeNil())
 			verifyCapValues(sut.Spec().Config.Process.Capabilities, len(serverCaps)+1)
 		})
 		It("DropCapabilities should drop capability", func() {
@@ -571,7 +571,7 @@ var _ = t.Describe("Container", func() {
 			}
 			serverCaps := []string{"CHOWN"}
 
-			Expect(sut.SpecSetupCapabilities(caps, serverCaps)).To(BeNil())
+			Expect(sut.SpecSetupCapabilities(caps, serverCaps, false)).To(BeNil())
 			verifyCapValues(sut.Spec().Config.Process.Capabilities, len(serverCaps)-1)
 		})
 		It("AddCapabilities ALL DropCapabilities one should drop that one", func() {
@@ -581,7 +581,7 @@ var _ = t.Describe("Container", func() {
 			}
 			serverCaps := []string{}
 
-			Expect(sut.SpecSetupCapabilities(caps, serverCaps)).To(BeNil())
+			Expect(sut.SpecSetupCapabilities(caps, serverCaps, false)).To(BeNil())
 			verifyCapValues(sut.Spec().Config.Process.Capabilities, len(capability.List())-1)
 		})
 		It("AddCapabilities one DropCapabilities ALL should add that one", func() {
@@ -591,7 +591,7 @@ var _ = t.Describe("Container", func() {
 			}
 			serverCaps := []string{}
 
-			Expect(sut.SpecSetupCapabilities(caps, serverCaps)).To(BeNil())
+			Expect(sut.SpecSetupCapabilities(caps, serverCaps, false)).To(BeNil())
 			verifyCapValues(sut.Spec().Config.Process.Capabilities, 1)
 		})
 		It("AddCapabilities ALL DropCapabilities ALL should drop all", func() {
@@ -601,7 +601,7 @@ var _ = t.Describe("Container", func() {
 			}
 			serverCaps := []string{}
 
-			Expect(sut.SpecSetupCapabilities(caps, serverCaps)).To(BeNil())
+			Expect(sut.SpecSetupCapabilities(caps, serverCaps, false)).To(BeNil())
 			verifyCapValues(sut.Spec().Config.Process.Capabilities, 0)
 		})
 		It("Invalid values should fail", func() {
@@ -610,7 +610,17 @@ var _ = t.Describe("Container", func() {
 			}
 			serverCaps := []string{}
 
-			Expect(sut.SpecSetupCapabilities(caps, serverCaps)).NotTo(BeNil())
+			Expect(sut.SpecSetupCapabilities(caps, serverCaps, false)).NotTo(BeNil())
+		})
+		It("Should add inheritable capabilities if set", func() {
+			caps := &types.Capability{
+				AddCapabilities:  []string{"CHOWN"},
+				DropCapabilities: []string{"ALL"},
+			}
+			serverCaps := []string{}
+
+			Expect(sut.SpecSetupCapabilities(caps, serverCaps, true)).To(BeNil())
+			Expect(len(sut.Spec().Config.Process.Capabilities.Inheritable)).To(Equal(1))
 		})
 	})
 })

--- a/internal/factory/sandbox/infra.go
+++ b/internal/factory/sandbox/infra.go
@@ -50,7 +50,7 @@ func (s *sandbox) InitInfraContainer(serverConfig *libconfig.Config, podContaine
 	}
 
 	// Add capabilities from crio.conf if default_capabilities is defined
-	if err := s.infra.SpecSetupCapabilities(&types.Capability{}, serverConfig.DefaultCapabilities); err != nil {
+	if err := s.infra.SpecSetupCapabilities(&types.Capability{}, serverConfig.DefaultCapabilities, serverConfig.AddInheritableCapabilities); err != nil {
 		return err
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -252,6 +252,10 @@ type RuntimeConfig struct {
 	// Capabilities to add to all containers.
 	DefaultCapabilities capabilities.Capabilities `toml:"default_capabilities"`
 
+	// AddInheritableCapabilities can be set to add inheritable capabilities. They were pre-1.23 by default, and were dropped in 1.24.
+	// This can cause a regression with non-root users not getting capabilities as they previously did.
+	AddInheritableCapabilities bool `toml:"add_inheritable_capabilities"`
+
 	// Additional environment variables to set for all the
 	// containers. These are overridden if set in the
 	// container image spec or in the container runtime configuration.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -283,6 +283,11 @@ func initCrioTemplateConfig(c *Config) ([]*templateConfigValue, error) {
 			isDefaultValue: stringSliceEqual(dc.DefaultCapabilities, c.DefaultCapabilities),
 		},
 		{
+			templateString: templateStringCrioRuntimeAddInheritableCapabilities,
+			group:          crioRuntimeConfig,
+			isDefaultValue: simpleEqual(dc.AddInheritableCapabilities, c.AddInheritableCapabilities),
+		},
+		{
 			templateString: templateStringCrioRuntimeDefaultSysctls,
 			group:          crioRuntimeConfig,
 			isDefaultValue: stringSliceEqual(dc.DefaultSysctls, c.DefaultSysctls),
@@ -869,6 +874,12 @@ const templateStringCrioRuntimeDefaultCapabilities = `# List of default capabili
 # will be added.
 {{ $.Comment }}default_capabilities = [
 {{ range $capability := .DefaultCapabilities}}{{ $.Comment }}{{ printf "\t%q,\n" $capability}}{{ end }}{{ $.Comment }}]
+
+`
+
+const templateStringCrioRuntimeAddInheritableCapabilities = `# Add capabilities to the inheritable set, as well as the default group of permitted, bounding and effective.
+# If capabilities are expected to work for non-root users, this option should be set.
+{{ $.Comment }}add_inheritable_capabilities = {{ .AddInheritableCapabilities }}
 
 `
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -437,7 +437,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 			specgen.SetupPrivileged(true)
 		} else {
 			capabilities := securityContext.Capabilities
-			if err := ctr.SpecSetupCapabilities(capabilities, s.config.DefaultCapabilities); err != nil {
+			if err := ctr.SpecSetupCapabilities(capabilities, s.config.DefaultCapabilities, s.config.AddInheritableCapabilities); err != nil {
 				return nil, err
 			}
 		}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -698,6 +698,18 @@ function check_oci_annotation() {
 	[[ "$output" =~ 00000000002020db ]]
 }
 
+@test "ctr with add_inheritable_capabilities has inheritable capabilities" {
+	CONTAINER_ADD_INHERITABLE_CAPABILITIES=true start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .linux.security_context.run_as_username = "redis"' \
+		"$TESTDATA"/container_redis.json > "$newconfig"
+	ctr_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	crictl exec --sync "$ctr_id" grep "CapEff:\s0000000000000000" /proc/1/status
+}
+
 @test "ctr oom" {
 	start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature
#### What this PR does / why we need it:
add an option to re-add the inheritable capabilities. there are situations where users previously expected non-root users to get these capabilities, which adding them to the inheritable list enabled. 

related to https://github.com/kubernetes/kubernetes/issues/111196 and https://github.com/cri-o/cri-o/security/advisories/GHSA-4hj2-r2pm-3hc6
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add an option "add_inheritable_capabilities" which adds added capabilities to the inheritable list as well. As of CRI-O 1.24.0, CRI-O drops the inheritable capabilities to fix CVE-2022-27652 . However, this can cause regressions in workloads that attempt to pass capabilities to non-root users through inheritable capabilities. 
```
