### PR TITLE
[1.24] Revert "capabilities: drop inheritable"

### DIFF
--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -578,8 +578,6 @@ func (c *container) SpecSetupCapabilities(caps *types.Capability, defaultCaps ca
 	// Make sure to remove all ambient capabilities. Kubernetes is not yet ambient capabilities aware
 	// and pods expect that switching to a non-root user results in the capabilities being
 	// dropped. This should be revisited in the future.
-	// Also be sure to remove all inheritable capabilities in accordance with CVE-2022-27652,
-	// as it's not idiomatic for a manager of processes to set them.
 	specgen := c.Spec()
 	// Clear default capabilities from spec
 	specgen.ClearProcessCapabilities()
@@ -624,6 +622,9 @@ func (c *container) SpecSetupCapabilities(caps *types.Capability, defaultCaps ca
 			if err := specgen.AddProcessCapabilityEffective(c); err != nil {
 				return err
 			}
+			if err := specgen.AddProcessCapabilityInheritable(c); err != nil {
+				return err
+			}
 			if err := specgen.AddProcessCapabilityPermitted(c); err != nil {
 				return err
 			}
@@ -635,6 +636,9 @@ func (c *container) SpecSetupCapabilities(caps *types.Capability, defaultCaps ca
 				return err
 			}
 			if err := specgen.DropProcessCapabilityEffective(c); err != nil {
+				return err
+			}
+			if err := specgen.DropProcessCapabilityInheritable(c); err != nil {
 				return err
 			}
 			if err := specgen.DropProcessCapabilityPermitted(c); err != nil {
@@ -658,6 +662,9 @@ func (c *container) SpecSetupCapabilities(caps *types.Capability, defaultCaps ca
 		if err := specgen.AddProcessCapabilityEffective(capPrefixed); err != nil {
 			return err
 		}
+		if err := specgen.AddProcessCapabilityInheritable(capPrefixed); err != nil {
+			return err
+		}
 		if err := specgen.AddProcessCapabilityPermitted(capPrefixed); err != nil {
 			return err
 		}
@@ -672,6 +679,9 @@ func (c *container) SpecSetupCapabilities(caps *types.Capability, defaultCaps ca
 			return fmt.Errorf("failed to drop cap %s %v", capPrefixed, err)
 		}
 		if err := specgen.DropProcessCapabilityEffective(capPrefixed); err != nil {
+			return fmt.Errorf("failed to drop cap %s %v", capPrefixed, err)
+		}
+		if err := specgen.DropProcessCapabilityInheritable(capPrefixed); err != nil {
 			return fmt.Errorf("failed to drop cap %s %v", capPrefixed, err)
 		}
 		if err := specgen.DropProcessCapabilityPermitted(capPrefixed); err != nil {

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -526,7 +526,7 @@ var _ = t.Describe("Container", func() {
 			Expect(len(caps.Bounding)).To(Equal(expected))
 			Expect(len(caps.Effective)).To(Equal(expected))
 			Expect(len(caps.Permitted)).To(Equal(expected))
-			Expect(len(caps.Inheritable)).To(Equal(0))
+			Expect(len(caps.Inheritable)).To(Equal(expected))
 			Expect(len(caps.Ambient)).To(Equal(0))
 		}
 		It("Empty capabilities should use server capabilities", func() {


### PR DESCRIPTION
This reverts commit 3e9d7725714057d5fc2ce7eb9f905dc50c96647c.

It causes problems with non-root users attempting to specify capabilities.

Signed-off-by: Peter Hunt~ <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind api-change
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug by re-adding the inheritable capabilities when adding capabilities. While it fixes an atypical unix environment, it causes a regression with non-root users using capabilities.
```
