### PR TITLE
contrib/test: drop userns integration tests

### DIFF
--- a/contrib/test/ci/test.yml
+++ b/contrib/test/ci/test.yml
@@ -64,17 +64,3 @@
       environment: '{{ int_test_env }}'  # from vars.yml and main.yml
       async: '{{ int_test_timeout | default(60 * 30) }}'  # seconds
       poll: 30
-
-    - name: run integration tests with userNS enabled + alternate results file
-      become: yes
-      shell: make localintegration 2>&1 > /tmp/artifacts/testout_with_userns.txt
-      args:
-        executable: /bin/bash
-        chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
-      vars: 
-        ansible_async_dir: '/tmp/artifacts/async'
-      environment: '{{ int_test_env | combine(userns_int_test_env) }} '
-      async: '{{ int_test_timeout | default(60 * 30) }}'  # seconds
-      poll: 30    
-      when: userns_int_test_skip is not defined or not userns_int_test_skip
-

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -66,15 +66,6 @@
       async: '{{ int_test_timeout | default(60 * 30) }}'  # seconds
       poll: 30
 
-    - name: run integration tests with userNS enabled + alternate results file
-      shell: "make localintegration >& {{ crio_integration_userns_filepath }}"
-      args:
-        chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
-      environment: '{{ int_test_env | combine(userns_int_test_env) }} '
-      async: '{{ int_test_timeout | default(60 * 30) }}'  # seconds
-      poll: 30
-      when: userns_int_test_skip is not defined or not userns_int_test_skip
-
   always:
 
     - name: Re-enable SELinux after integration tests


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci
/kind cleanup

#### What this PR does / why we need it:

The `userns` implementation is already per-pod, so we can safely drop these tests.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
