### PR TITLE
Allow runtime configs to be updated completely

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -291,7 +291,7 @@ the container runtime configuration.
   Enable CRIU integration, requires that the criu binary is available in $PATH. (default: false)
 
 ### CRIO.RUNTIME.RUNTIMES TABLE
-The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  The runtime to use is picked based on the runtime handler provided by the CRI.  If no runtime handler is provided, the runtime will be picked based on the level of trust of the workload. This option supports live configuration reload. Note that on reload runtimes can only be added to this table but not modified or removed.
+The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  The runtime to use is picked based on the runtime handler provided by the CRI.  If no runtime handler is provided, the runtime will be picked based on the level of trust of the workload. This option supports live configuration reload. This option supports live configuration reload.
 
 **runtime_path**=""
   Path to the OCI compatible runtime used for this runtime handler.

--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -244,13 +244,9 @@ func (c *Config) ReloadRdtConfig(newConfig *Config) error {
 // ReloadRuntimes reloads the runtimes configuration if changed
 func (c *Config) ReloadRuntimes(newConfig *Config) error {
 	var updated bool
-	for runtime := range newConfig.Runtimes {
-		if _, ok := c.Runtimes[runtime]; ok {
-			logrus.Warnf("Skipping existing runtime %q", runtime)
-			continue
-		}
-		c.Runtimes[runtime] = newConfig.Runtimes[runtime]
-		logrus.Infof("Registered new runtime %q", runtime)
+	if !RuntimesEqual(c.Runtimes, newConfig.Runtimes) {
+		logrus.Infof("Updating runtime configuration")
+		c.Runtimes = newConfig.Runtimes
 		updated = true
 	}
 

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -373,6 +373,7 @@ var _ = t.Describe("Config", func() {
 				RuntimePath: "/usr/bin/runc",
 			}
 			newConfig := &config.Config{}
+			newConfig.Runtimes = sut.Runtimes
 			newConfig.DefaultRuntime = "existing"
 
 			// When
@@ -383,26 +384,28 @@ var _ = t.Describe("Config", func() {
 			Expect(sut.DefaultRuntime).To(Equal("existing"))
 		})
 
-		It("should not add existing runtime", func() {
+		It("should overwrite existing runtime", func() {
 			// Given
 			existingRuntime := &config.RuntimeHandler{
 				RuntimePath: "/usr/bin/runc",
 			}
 			sut.Runtimes["existing"] = existingRuntime
-			newConfig := &config.Config{}
-			newConfig.Runtimes = make(config.Runtimes)
-			newConfig.Runtimes["existing"] = &config.RuntimeHandler{
+
+			newRuntime := &config.RuntimeHandler{
 				RuntimePath:                  "/usr/bin/runc",
 				PrivilegedWithoutHostDevices: true,
 			}
+			newConfig := &config.Config{}
+			newConfig.Runtimes = make(config.Runtimes)
+			newConfig.Runtimes["existing"] = newRuntime
 
 			// When
 			err := sut.ReloadRuntimes(newConfig)
 
 			// Then
 			Expect(err).To(BeNil())
-			Expect(sut.Runtimes).To(HaveKeyWithValue("existing", existingRuntime))
-			Expect(sut.Runtimes["existing"].PrivilegedWithoutHostDevices).To(BeFalse())
+			Expect(sut.Runtimes).To(HaveKeyWithValue("existing", newRuntime))
+			Expect(sut.Runtimes["existing"].PrivilegedWithoutHostDevices).To(BeTrue())
 		})
 	})
 })

--- a/test/reload_config.bats
+++ b/test/reload_config.bats
@@ -228,5 +228,5 @@ EOF
 	reload_crio
 
 	#then
-	wait_for_log '"registered new runtime \\"new\\""'
+	wait_for_log '"updating runtime configuration"'
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This feature extends the work done for #6056 to allow for complete updates of the runtime configuration. The previous work limited the changes to the runtimes config to adding runtimes and updating the default runtime. These changes allow the complete `crio.runtime.runtimes` table to be updated on reload.

This was originally discussed in #6036.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Allow `crio.runtime.runtimes` configuration to be updated on reload.
```
