### PR TITLE
config: translate monitor fields when printing config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1092,6 +1092,10 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 		}
 	}
 
+	if err := c.TranslateMonitorFields(onExecution); err != nil {
+		return fmt.Errorf("monitor fields translation: %w", err)
+	}
+
 	return nil
 }
 
@@ -1148,11 +1152,6 @@ func (c *RuntimeConfig) ValidateRuntimes() error {
 			logrus.Warnf("'%s is being ignored due to: %q", name, err)
 			failedValidation = append(failedValidation, name)
 		}
-		if handler.RuntimeType == DefaultRuntimeType || handler.RuntimeType == "" {
-			if err := c.TranslateMonitorFields(handler); err != nil {
-				return fmt.Errorf("failed to translate monitor fields for runtime %s: %w", name, err)
-			}
-		}
 	}
 
 	for _, invalidHandlerName := range failedValidation {
@@ -1162,34 +1161,48 @@ func (c *RuntimeConfig) ValidateRuntimes() error {
 	return nil
 }
 
+func (c *RuntimeConfig) TranslateMonitorFields(onExecution bool) error {
+	for name, handler := range c.Runtimes {
+		if handler.RuntimeType == DefaultRuntimeType || handler.RuntimeType == "" {
+			if err := c.TranslateMonitorFieldsForHandler(handler, onExecution); err != nil {
+				return fmt.Errorf("failed to translate monitor fields for runtime %s: %w", name, err)
+			}
+		}
+	}
+	return nil
+}
+
 // TranslateMonitorFields is a transitional function that takes the configuration fields
 // previously held by the RuntimeConfig that are being moved inside of the runtime handler structure.
-func (c *RuntimeConfig) TranslateMonitorFields(handler *RuntimeHandler) error {
+func (c *RuntimeConfig) TranslateMonitorFieldsForHandler(handler *RuntimeHandler, onExecution bool) error {
 	if c.ConmonCgroup != "" {
+		logrus.Debugf("Monitor cgroup %s is becoming %s", handler.MonitorCgroup, c.ConmonCgroup)
 		handler.MonitorCgroup = c.ConmonCgroup
 	}
 	if c.Conmon != "" {
-		logrus.Warnf("'%s is becoming %s", c.Conmon, handler.MonitorPath)
+		logrus.Debugf("Monitor path %s is becoming %s", handler.MonitorPath, c.Conmon)
 		handler.MonitorPath = c.Conmon
 	}
 	if len(c.ConmonEnv) != 0 {
 		handler.MonitorEnv = c.ConmonEnv
 	}
-	if err := c.ValidateConmonPath("conmon", handler); err != nil {
-		return err
-	}
-	if !c.cgroupManager.IsSystemd() {
-		if handler.MonitorCgroup != utils.PodCgroupName && handler.MonitorCgroup != "" {
-			return errors.New("cgroupfs manager conmon cgroup should be 'pod' or empty")
-		}
-		return nil
-	}
 	// If empty, assume default
 	if handler.MonitorCgroup == "" {
 		handler.MonitorCgroup = defaultMonitorCgroup
 	}
-	if !(handler.MonitorCgroup == utils.PodCgroupName || strings.HasSuffix(handler.MonitorCgroup, ".slice")) {
-		return errors.New("conmon cgroup should be 'pod' or a systemd slice")
+	if onExecution {
+		if err := c.ValidateConmonPath("conmon", handler); err != nil {
+			return err
+		}
+		if !c.cgroupManager.IsSystemd() {
+			if handler.MonitorCgroup != utils.PodCgroupName && handler.MonitorCgroup != "" {
+				return errors.New("cgroupfs manager conmon cgroup should be 'pod' or empty")
+			}
+			return nil
+		}
+		if !(handler.MonitorCgroup == utils.PodCgroupName || strings.HasSuffix(handler.MonitorCgroup, ".slice")) {
+			return errors.New("conmon cgroup should be 'pod' or a systemd slice")
+		}
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -424,7 +424,7 @@ var _ = t.Describe("Config", func() {
 			sut.ConmonCgroup = "wrong"
 
 			// When
-			err := sut.RuntimeConfig.TranslateMonitorFields(handler)
+			err := sut.RuntimeConfig.TranslateMonitorFieldsForHandler(handler, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -436,7 +436,7 @@ var _ = t.Describe("Config", func() {
 			sut.ConmonCgroup = "invalid"
 
 			// When
-			err := sut.RuntimeConfig.TranslateMonitorFields(handler)
+			err := sut.RuntimeConfig.TranslateMonitorFieldsForHandler(handler, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -459,7 +459,7 @@ var _ = t.Describe("Config", func() {
 			handler := &config.RuntimeHandler{}
 
 			// When
-			err := sut.RuntimeConfig.TranslateMonitorFields(handler)
+			err := sut.RuntimeConfig.TranslateMonitorFieldsForHandler(handler, true)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -470,7 +470,7 @@ var _ = t.Describe("Config", func() {
 			handler := &config.RuntimeHandler{}
 
 			// When
-			err := sut.RuntimeConfig.TranslateMonitorFields(handler)
+			err := sut.RuntimeConfig.TranslateMonitorFieldsForHandler(handler, true)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -482,7 +482,7 @@ var _ = t.Describe("Config", func() {
 			handler := &config.RuntimeHandler{}
 
 			// When
-			err := sut.RuntimeConfig.TranslateMonitorFields(handler)
+			err := sut.RuntimeConfig.TranslateMonitorFieldsForHandler(handler, true)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -494,7 +494,7 @@ var _ = t.Describe("Config", func() {
 			handler := &config.RuntimeHandler{}
 
 			// When
-			err := sut.RuntimeConfig.TranslateMonitorFields(handler)
+			err := sut.RuntimeConfig.TranslateMonitorFieldsForHandler(handler, true)
 
 			// Then
 			Expect(err).To(BeNil())

--- a/test/config.bats
+++ b/test/config.bats
@@ -84,3 +84,15 @@ EOF
 	[[ "$RES" == *"crio.runtime.runtimes.runc"* ]]
 	[[ "$RES" == *"crio.runtime.runtimes.crun"* ]]
 }
+
+@test "monitor fields should be translated" {
+	if [[ "$RUNTIME_TYPE" == "vm" ]]; then
+		skip "not applicable to vm runtime type"
+	fi
+	# when
+	RES=$("$CRIO_BINARY_PATH" --conmon-cgroup="pod" --conmon="/bin/true" -c "" -d "" config 2>&1)
+
+	# then
+	[[ "$RES" == *"monitor_cgroup = \"pod\""* ]]
+	[[ "$RES" == *"monitor_path = \"/bin/true\""* ]]
+}


### PR DESCRIPTION
A situation arises when printing the config where
`translateMonitorFields` didn't previously run. This causes situations where the `conmon_cgroup` field looks like it's some other value, but the corresponding `monitor_cgroup` field does not reflect it

note: this is only a cosmetic change. The underlying config does eventually render correctly, just didn't print right.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a bug where `conmon_cgroup` and `monitor_path` became out of sync
```
