### PR TITLE
config: do not remove runc if different default runtime

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -645,15 +645,9 @@ func (c *Config) UpdateFromDropInFile(path string) error {
 	t := new(tomlConfig)
 	t.fromConfig(c)
 
-	metadata, err := toml.Decode(string(data), t)
+	_, err = toml.Decode(string(data), t)
 	if err != nil {
 		return fmt.Errorf("unable to decode configuration %v: %w", path, err)
-	}
-
-	runtimesKey := []string{"crio", "runtime", "default_runtime"}
-	if metadata.IsDefined(runtimesKey...) &&
-		t.Crio.Runtime.RuntimeConfig.DefaultRuntime != defaultRuntime {
-		delete(c.Runtimes, defaultRuntime)
 	}
 
 	storageOpts = append(storageOpts, t.Crio.RootConfig.StorageOptions...)

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1064,8 +1064,7 @@ const templateStringCrioRuntimeEnableCriuSupport = `# Globally enable/disable CR
 
 const templateStringCrioRuntimeDefaultRuntime = `# default_runtime is the _name_ of the OCI runtime to be used as the default.
 # default_runtime is the _name_ of the OCI runtime to be used as the default.
-# The name is matched against the runtimes map below. If this value is changed,
-# the corresponding existing entry from the runtimes map below will be ignored.
+# The name is matched against the runtimes map below.
 {{ $.Comment }}default_runtime = "{{ .DefaultRuntime }}"
 
 `

--- a/test/config.bats
+++ b/test/config.bats
@@ -45,14 +45,33 @@ function teardown() {
 	[[ "$output" == *"not a valid logrus"*"wrong-level"* ]]
 }
 
-@test "replace default runtime should succeed" {
+@test "choose different default runtime should succeed" {
 	# when
 	unset CONTAINER_RUNTIMES
 	RES=$("$CRIO_BINARY_PATH" -c "$TESTDATA"/50-crun-default.conf -d "" config 2>&1)
 
 	# then
 	[[ "$RES" == *"default_runtime = \"crun\""* ]]
-	[[ "$RES" != *"crio.runtime.runtimes.runc"* ]]
+	[[ "$RES" == *"crio.runtime.runtimes.runc"* ]]
+	[[ "$RES" == *"crio.runtime.runtimes.crun"* ]]
+}
+
+@test "runc not existing when default_runtime changed should succeed" {
+	# when
+	unset CONTAINER_RUNTIMES
+	cat << EOF > "$TESTDIR"/50-runc-new-path.conf
+[crio.runtime]
+default_runtime = "crun"
+[crio.runtime.runtimes.runc]
+runtime_path = "/not/there"
+[crio.runtime.runtimes.crun]
+runtime_path="/usr/bin/crun"
+EOF
+	RES=$("$CRIO_BINARY_PATH" -c "$TESTDIR"/50-runc-new-path.conf -d "" config 2>&1)
+
+	# then
+	[[ "$RES" == *"default_runtime = \"crun\""* ]]
+	[[ "$RES" == *"crio.runtime.runtimes.runc"* ]]
 	[[ "$RES" == *"crio.runtime.runtimes.crun"* ]]
 }
 


### PR DESCRIPTION
This commit reverts d2ded1d73c9ce282028ec2b4d6016546267322a9 and adds a test that maintains what it was trying to do.

When upgrading from a cluster that uses runc to one that uses crun, there may be workloads that specifically request the old default. Those workloads will fail on restart. To fix this, don't remove runc from the map. We've since added code that means we don't fail if one of the non-default runtimes fails validation (if the binary doesn't exist) so we can handle that situation, which
d2ded1d73c9ce282028ec2b4d6016546267322a9 meant to fix.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where updating `default_runtime` would cause the `runc` entry in the runtimes table to be deleted
```
