### PR TITLE
[#5240] update supported OS versions

### DIFF
--- a/install.md
+++ b/install.md
@@ -126,10 +126,13 @@ To install on the following operating systems, set the environment variable $OS 
 | ---------------- | ----------------- |
 | Debian Unstable  | `Debian_Unstable` |
 | Debian Testing   | `Debian_Testing`  |
+| Debian 11        | `Debian_11`       |
 | Debian 10        | `Debian_10`       |
 | Raspberry Pi OS  | `Raspbian_10`     |
 | Ubuntu 22.04     | `xUbuntu_22.04`   |
 | Ubuntu 21.10     | `xUbuntu_21.10`   |
+| Ubuntu 21.04     | `xUbuntu_21.04`   |
+| Ubuntu 20.10     | `xUbuntu_20.10`   |
 | Ubuntu 20.04     | `xUbuntu_20.04`   |
 | Ubuntu 18.04     | `xUbuntu_18.04`   |
 
@@ -613,9 +616,13 @@ To install on the following operating systems, set the environment variable $OS 
 | ---------------- | ----------------- |
 | Debian Unstable  | `Debian_Unstable` |
 | Debian Testing   | `Debian_Testing`  |
+| Debian 11        | `Debian_11`       |
+| Debian 10        | `Debian_10`       |
+| Ubuntu 22.04     | `xUbuntu_22.04`   |
+| Ubuntu 21.10     | `xUbuntu_21.10`   |
+| Ubuntu 21.04     | `xUbuntu_21.04`   |
+| Ubuntu 20.10     | `xUbuntu_20.10`   |
 | Ubuntu 20.04     | `xUbuntu_20.04`   |
-| Ubuntu 19.10     | `xUbuntu_19.10`   |
-| Ubuntu 19.04     | `xUbuntu_19.04`   |
 | Ubuntu 18.04     | `xUbuntu_18.04`   |
 
 To upgrade, choose a supported version for your operating system, and export it as a variable, like so:


### PR DESCRIPTION
update supported os versions according to package url: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/

#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
The supported OS versions info is out of date.

#### Which issue(s) this PR fixes:
Fixes #5240


#### Special notes for your reviewer:
Nothing.

#### Does this PR introduce a user-facing change?
No.

