### PR TITLE
test: config tests should ignore default runtime environment variable

### DIFF
--- a/contrib/test/ci/integration.yml
+++ b/contrib/test/ci/integration.yml
@@ -54,7 +54,6 @@
         state: present
       loop: "{{ ['cgroups.bats'] | product(kata_skip_cgroups_tests) \
         + ['command.bats'] | product(kata_skip_command_tests) \
-        + ['config.bats'] | product(kata_skip_config_tests) \
         + ['reload_config.bats'] | product(kata_skip_reload_config) \
         + ['crio-wipe.bats'] | product(kata_skip_crio_wipe_tests) \
         + ['ctr.bats'] | product(kata_skip_ctr_tests) \

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -99,10 +99,6 @@ kata_skip_cgroups_tests:
 kata_skip_command_tests:
   - 'test "crio commands"'
   - 'test "log max boundary testing"'
-kata_skip_config_tests:
-  - 'test "choose different default runtime should succeed"'
-  - 'test "runc not existing when default_runtime changed should succeed"'
-  - 'test "retain default runtime should succeed"'
 kata_skip_reload_config:
   - 'test "reload config should remove pinned images when an empty list is provided"'
 kata_skip_crio_wipe_tests:

--- a/test/config.bats
+++ b/test/config.bats
@@ -55,6 +55,7 @@ function teardown() {
 @test "choose different default runtime should succeed" {
 	# when
 	unset CONTAINER_RUNTIMES
+	unset CONTAINER_DEFAULT_RUNTIME
 	RES=$("$CRIO_BINARY_PATH" -c "$TESTDATA"/50-crun-default.conf -d "" config 2>&1)
 
 	# then
@@ -66,6 +67,7 @@ function teardown() {
 @test "runc not existing when default_runtime changed should succeed" {
 	# when
 	unset CONTAINER_RUNTIMES
+	unset CONTAINER_DEFAULT_RUNTIME
 	cat << EOF > "$TESTDIR"/50-runc-new-path.conf
 [crio.runtime]
 default_runtime = "crun"
@@ -83,6 +85,7 @@ EOF
 }
 
 @test "retain default runtime should succeed" {
+	unset CONTAINER_DEFAULT_RUNTIME
 	# when
 	RES=$("$CRIO_BINARY_PATH" -c "$TESTDATA"/50-crun.conf -d "" config 2>&1)
 
@@ -93,9 +96,7 @@ EOF
 }
 
 @test "monitor fields should be translated" {
-	if [[ "$RUNTIME_TYPE" == "vm" ]]; then
-		skip "not applicable to vm runtime type"
-	fi
+	unset CONTAINER_DEFAULT_RUNTIME
 	# when
 	RES=$("$CRIO_BINARY_PATH" --conmon-cgroup="pod" --conmon="/bin/true" -c "" -d "" config 2>&1)
 


### PR DESCRIPTION

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:
Config tests are meant to verify the configuration code, by exercising it in specific configurations.
When run in an environment where the default runtime is modified, these tests fail because the configuration they use do not have this runtime defined.
As the runtime itself is not involved in these tests, it seems safe to unset the CONTAINER_DEFAULT_RUNTIME variable in their context.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
