### PR TITLE
Add logs to OpenTelemetry traces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	go.opentelemetry.io/otel v1.10.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.10.0
 	go.opentelemetry.io/otel/sdk v1.10.0
+	go.opentelemetry.io/otel/trace v1.10.0
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8
@@ -366,7 +367,6 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.10.0 // indirect
-	go.opentelemetry.io/otel/trace v1.10.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.10.0 // indirect

--- a/hack/log-capitalized.sh
+++ b/hack/log-capitalized.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 go_files=$(find . -name "*.go" -not -path "./vendor/*" -not -path "./_output/*" -not -path "./test/mocks/*" -not -path "./utils/fifo/*")
-echo "$go_files" | xargs sed -i 's|log.\(.*\)f.ctx\, \"\([a-z]\)|log.\1f\(ctx\, \"\u\2|g'
+echo "$go_files" | xargs sed -i 's|log\.\(.*\)f.ctx\, \"\([a-z]\)|log.\1f\(ctx\, \"\u\2|g'
 echo "$go_files" | xargs sed -i 's|logrus.\(.*\)f.\"\([a-z]\)|logrus.\1f\(\"\u\2|g'

--- a/internal/log/interceptors.go
+++ b/internal/log/interceptors.go
@@ -3,6 +3,7 @@ package log
 import (
 	"context"
 
+	"github.com/cri-o/cri-o/internal/opentelemetry"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 )
@@ -50,7 +51,7 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		newCtx := AddRequestNameAndID(ctx, info.FullMethod)
+		newCtx, span := opentelemetry.Tracer().Start(AddRequestNameAndID(ctx, info.FullMethod), info.FullMethod)
 		Debugf(newCtx, "Request: %+v", req)
 
 		resp, err := handler(newCtx, req)
@@ -61,6 +62,7 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 			Debugf(newCtx, "Response: %+v", resp)
 		}
 
+		span.End()
 		return resp, err
 	}
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -3,8 +3,11 @@ package log
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type (
@@ -13,27 +16,46 @@ type (
 )
 
 func Debugf(ctx context.Context, format string, args ...interface{}) {
+	logSpanf(ctx, "DEBUG", format, args...)
 	entry(ctx).Debugf(format, args...)
 }
 
 func Infof(ctx context.Context, format string, args ...interface{}) {
+	logSpanf(ctx, "INFO", format, args...)
 	entry(ctx).Infof(format, args...)
 }
 
 func Warnf(ctx context.Context, format string, args ...interface{}) {
+	logSpanf(ctx, "WARN", format, args...)
 	entry(ctx).Warnf(format, args...)
 }
 
 func Errorf(ctx context.Context, format string, args ...interface{}) {
+	logSpanf(ctx, "ERROR", format, args...)
 	entry(ctx).Errorf(format, args...)
 }
 
 func Fatalf(ctx context.Context, format string, args ...interface{}) {
+	logSpanf(ctx, "FATAL", format, args...)
 	entry(ctx).Fatalf(format, args...)
 }
 
 func WithFields(ctx context.Context, fields map[string]interface{}) *logrus.Entry {
 	return entry(ctx).WithFields(fields)
+}
+
+func logSpanf(ctx context.Context, level, format string, args ...interface{}) {
+	id := "unknown"
+	if ctx != nil {
+		ctxID, idOk := ctx.Value(ID{}).(string)
+		if idOk {
+			id = ctxID
+		}
+	}
+	trace.SpanFromContext(ctx).AddEvent(fmt.Sprintf(format, args...), trace.WithAttributes(
+		attribute.String("level", level),
+		attribute.String("rpc.id", id),
+	))
 }
 
 func entry(ctx context.Context) *logrus.Entry {

--- a/internal/opentelemetry/tracing_config.go
+++ b/internal/opentelemetry/tracing_config.go
@@ -11,9 +11,16 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const tracingServiceName = "crio"
+
+var tracer = otel.Tracer(tracingServiceName)
+
+func Tracer() trace.Tracer {
+	return tracer
+}
 
 // InitTracing configures opentelemetry exporter and tracer provider
 func InitTracing(ctx context.Context, collectorAddress string, samplingRate int) (*sdktrace.TracerProvider, []otelgrpc.Option, error) {


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:

We now use the log interceptor to enrich the otel traces with additional data. For example we now have detailed logging information from CRI-O and propagate the error to the traces.


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:

For example, the output now looks like this on container creation:

![screenshot](https://user-images.githubusercontent.com/695473/195075572-446fedb9-0dc5-49b0-842c-b29deb8a7d68.png)

And the error propagation looks like this:

![screenshot](https://user-images.githubusercontent.com/695473/195076034-55692f8e-7a75-40ab-894b-20a00008d4e3.png)

Side note: We need the additional span to capture most of the logs, otherwise we will miss some information (see the error propagation).

cc @sallyom 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added logs and GRPC error codes to OpenTelemetry traces.
```
