### PR TITLE
Add docs that `tracing-sampling-rate-per-million` set to 1000000 refers to always sample.

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -144,7 +144,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -l stream-tls-ca -r -d 'Path to 
 complete -c crio -n '__fish_crio_no_subcommand' -l stream-tls-cert -r -d 'Path to the x509 certificate file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes.'
 complete -c crio -n '__fish_crio_no_subcommand' -l stream-tls-key -r -d 'Path to the key file used to serve the encrypted stream. This file can change and CRI-O will automatically pick up the changes within 5 minutes.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l tracing-endpoint -r -d 'Address on which the gRPC tracing collector will listen.'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l tracing-sampling-rate-per-million -r -d 'Number of samples to collect per million OpenTelemetry spans.'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l tracing-sampling-rate-per-million -r -d 'Number of samples to collect per million OpenTelemetry spans. Set to 1000000 to always sample.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l uid-mappings -r -d 'Specify the UID mappings to use for the user namespace.'
 complete -c crio -n '__fish_crio_no_subcommand' -l version-file -r -d 'Location for CRI-O to lay down the temporary version file. It is used to check if crio wipe should wipe containers, which should always happen on a node reboot.'
 complete -c crio -n '__fish_crio_no_subcommand' -l version-file-persist -r -d 'Location for CRI-O to lay down the persistent version file. It is used to check if crio wipe should wipe images, which should only happen when CRI-O has been upgraded.'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -368,7 +368,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--tracing-endpoint**="": Address on which the gRPC tracing collector will listen. (default: 0.0.0.0:4317)
 
-**--tracing-sampling-rate-per-million**="": Number of samples to collect per million OpenTelemetry spans. (default: 0)
+**--tracing-sampling-rate-per-million**="": Number of samples to collect per million OpenTelemetry spans. Set to 1000000 to always sample. (default: 0)
 
 **--uid-mappings**="": Specify the UID mappings to use for the user namespace.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -429,7 +429,7 @@ The `crio.metrics` table containers settings pertaining to the Prometheus based 
   Address on which the gRPC trace collector will listen.
 
 **tracing_sampling_rate_per_million**=""
-  Number of samples to collect per million OpenTelemetry spans.
+  Number of samples to collect per million OpenTelemetry spans. Set to 1000000 to always sample.
 
 ## CRIO.STATS TABLE
 The `crio.stats` table specifies all necessary configuration for reporting container and pod stats.

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -805,7 +805,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		&cli.IntFlag{
 			Name:    "tracing-sampling-rate-per-million",
 			Value:   defConf.TracingSamplingRatePerMillion,
-			Usage:   "Number of samples to collect per million OpenTelemetry spans.",
+			Usage:   "Number of samples to collect per million OpenTelemetry spans. Set to 1000000 to always sample.",
 			EnvVars: []string{"CONTAINER_TRACING_SAMPLING_RATE_PER_MILLION"},
 		},
 		&cli.StringFlag{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -553,7 +553,7 @@ type TracingConfig struct {
 	// TracingEndpoint is the address on which the grpc tracing collector server will listen.
 	TracingEndpoint string `toml:"tracing_endpoint"`
 
-	// TracingSamplingRatePerMillion is the number of samples to collect per million spans.
+	// TracingSamplingRatePerMillion is the number of samples to collect per million spans. Set to 1000000 to always sample.
 	// Defaults to 0.
 	TracingSamplingRatePerMillion int `toml:"tracing_sampling_rate_per_million"`
 }

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1330,7 +1330,7 @@ const templateStringCrioTracingTracingEndpoint = `# Address on which the gRPC tr
 
 `
 
-const templateStringCrioTracingTracingSamplingRatePerMillion = `# Number of samples to collect per million spans.
+const templateStringCrioTracingTracingSamplingRatePerMillion = `# Number of samples to collect per million spans. Set to 1000000 to always sample.
 {{ $.Comment }}tracing_sampling_rate_per_million = {{ .TracingSamplingRatePerMillion }}
 
 `


### PR DESCRIPTION

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates the docs to hint how to enable sampling for every span.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Replaces https://github.com/cri-o/cri-o/pull/6322
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated CLI and config documentation to show how to enable Open Telemetry trace sampling for every span.
```
