### PR TITLE
Correctly extend $PATH before calling conmon during restore

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -189,7 +189,7 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 	if restore {
 		// The CRIU binary is usually in /usr/sbin/criu
 		if v, found := os.LookupEnv("PATH"); found {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=/usr/sbin/%s", v))
+			cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", v))
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The way I extended the PATH when calling conmon during restore was just wrong. This fixes the wrong PATH.

#### Which issue(s) this PR fixes:

Fixes: #6337

#### Does this PR introduce a user-facing change?

```release-note
None
```