### PR TITLE
Disable checkpoint image check as early as possible

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -292,6 +292,11 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 
 	// Check if image is a file. If it is a file it might be a checkpoint archive.
 	checkpointImage, err := func() (bool, error) {
+		if !s.config.CheckpointRestore() {
+			// If CRIU support is not enabled return from
+			// this check as early as possible.
+			return false, nil
+		}
 		if req.Config == nil ||
 			req.Config.Image == nil ||
 			req.SandboxConfig == nil ||


### PR DESCRIPTION
#### What type of PR is this?

/kind other


#### What this PR does / why we need it:

To see if the specified container image is a checkpoint image, each image is checked, if it is a checkpoint image during container create. If checkpoint support is not enabled in CRI-O return as early as possible from this check without even looking at the image.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```