### PR TITLE
Extend distributed tracing

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -30,6 +30,7 @@ import (
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
+	"github.com/uptrace/opentelemetry-go-extra/otellogrus"
 	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -172,6 +173,15 @@ func main() {
 		}
 		logrus.SetLevel(level)
 		logrus.AddHook(log.NewFilenameHook())
+		logrus.AddHook(otellogrus.NewHook(otellogrus.WithLevels(
+			logrus.PanicLevel,
+			logrus.FatalLevel,
+			logrus.ErrorLevel,
+			logrus.WarnLevel,
+			logrus.InfoLevel,
+			logrus.DebugLevel,
+			logrus.TraceLevel,
+		)))
 
 		filterHook, err := log.NewFilterHook(config.LogFilter)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.8.0
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+	github.com/uptrace/opentelemetry-go-extra/otellogrus v0.1.17
 	github.com/urfave/cli/v2 v2.20.2
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.3
@@ -333,6 +334,7 @@ require (
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/transparency-dev/merkle v0.0.1 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/uptrace/opentelemetry-go-extra/otelutil v0.1.17 // indirect
 	github.com/urfave/cli v1.22.9 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/vbauerster/mpb/v7 v7.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2396,6 +2396,10 @@ github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0o
 github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/funlen v0.0.3/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
+github.com/uptrace/opentelemetry-go-extra/otellogrus v0.1.17 h1:FeCTrRenM5ucXWMpq3u4Wh2nWov9Co68aM2gINGlJRU=
+github.com/uptrace/opentelemetry-go-extra/otellogrus v0.1.17/go.mod h1:CXKQH9iiW89FahjDENpC7ES9iUQTIyTE2V2aQlLQme8=
+github.com/uptrace/opentelemetry-go-extra/otelutil v0.1.17 h1:fcKgoKi1dGCFr1zTP0mKzZDGcMliY2hBmBjpGVf/ee4=
+github.com/uptrace/opentelemetry-go-extra/otelutil v0.1.17/go.mod h1:wl/W+O/95rYcMa67D9qQ+8/IJEztbyYSUkdT7L6t+p4=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.19.1/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -210,6 +210,8 @@ func (c *Config) setupFromPath(
 	specGenerator *generate.Generator,
 	profilePath string,
 ) (*Notifier, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	log.Debugf(ctx, "Setup seccomp from profile path: %s", profilePath)
 
 	if profilePath == "" {
@@ -297,6 +299,8 @@ func (c *Config) setupFromField(
 	specGenerator *generate.Generator,
 	profileField *types.SecurityProfile,
 ) (*Notifier, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	log.Debugf(ctx, "Setup seccomp from profile field: %+v", profileField)
 
 	if c.IsDisabled() {

--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -161,6 +161,8 @@ func (c *container) SpecAddMount(r rspec.Mount) {
 
 // SpecAddAnnotation adds all annotations to the spec
 func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox, containerVolumes []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool) (err error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	// Copied from k8s.io/kubernetes/pkg/kubelet/kuberuntime/labels.go
 	const podTerminationGracePeriodLabel = "io.kubernetes.pod.terminationGracePeriod"
 

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -75,7 +75,7 @@ func (c *ContainerServer) ContainerCheckpoint(ctx context.Context, opts *Contain
 		for _, del := range cleanup {
 			file := filepath.Join(ctr.Dir(), del)
 			if err := os.Remove(file); err != nil {
-				logrus.Debugf("Unable to remove file %s", file)
+				logrus.WithContext(ctx).Debugf("Unable to remove file %s", file)
 			}
 		}
 	}

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -13,10 +13,10 @@ import (
 	"github.com/containers/podman/v4/pkg/annotations"
 	"github.com/containers/podman/v4/pkg/checkpoint/crutils"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/sirupsen/logrus"
 )
 
 type ContainerCheckpointRestoreOptions struct {
@@ -62,7 +62,7 @@ func (c *ContainerServer) ContainerCheckpoint(ctx context.Context, opts *Contain
 		return "", fmt.Errorf("failed to unmount container %s: %w", ctr.ID(), err)
 	}
 	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
-		logrus.WithContext(ctx).Warnf("Unable to write containers %s state to disk: %v", ctr.ID(), err)
+		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
 
 	if !opts.Keep {
@@ -75,7 +75,7 @@ func (c *ContainerServer) ContainerCheckpoint(ctx context.Context, opts *Contain
 		for _, del := range cleanup {
 			file := filepath.Join(ctr.Dir(), del)
 			if err := os.Remove(file); err != nil {
-				logrus.WithContext(ctx).Debugf("Unable to remove file %s", file)
+				log.Debugf(ctx, "Unable to remove file %s", file)
 			}
 		}
 	}
@@ -220,7 +220,7 @@ func (c *ContainerServer) prepareCheckpointExport(ctr *oci.Container) error {
 func (c *ContainerServer) exportCheckpoint(ctx context.Context, ctr *oci.Container, specgen *rspec.Spec, export string) error {
 	id := ctr.ID()
 	dest := ctr.Dir()
-	logrus.WithContext(ctx).Debugf("Exporting checkpoint image of container %q to %q", id, dest)
+	log.Debugf(ctx, "Exporting checkpoint image of container %q to %q", id, dest)
 
 	includeFiles := []string{
 		stats.StatsDump,

--- a/internal/lib/container.go
+++ b/internal/lib/container.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"fmt"
 
 	cstorage "github.com/containers/storage"
@@ -10,8 +11,8 @@ import (
 )
 
 // GetStorageContainer searches for a container with the given name or ID in the given store
-func (c *ContainerServer) GetStorageContainer(container string) (*cstorage.Container, error) {
-	ociCtr, err := c.LookupContainer(container)
+func (c *ContainerServer) GetStorageContainer(ctx context.Context, container string) (*cstorage.Container, error) {
+	ociCtr, err := c.LookupContainer(ctx, container)
 	if err != nil {
 		return nil, err
 	}
@@ -19,8 +20,8 @@ func (c *ContainerServer) GetStorageContainer(container string) (*cstorage.Conta
 }
 
 // GetContainerTopLayerID gets the ID of the top layer of the given container
-func (c *ContainerServer) GetContainerTopLayerID(containerID string) (string, error) {
-	ctr, err := c.GetStorageContainer(containerID)
+func (c *ContainerServer) GetContainerTopLayerID(ctx context.Context, containerID string) (string, error) {
+	ctr, err := c.GetStorageContainer(ctx, containerID)
 	if err != nil {
 		return "", err
 	}
@@ -28,7 +29,7 @@ func (c *ContainerServer) GetContainerTopLayerID(containerID string) (string, er
 }
 
 // GetContainerFromShortID gets an oci container matching the specified full or partial id
-func (c *ContainerServer) GetContainerFromShortID(cid string) (*oci.Container, error) {
+func (c *ContainerServer) GetContainerFromShortID(ctx context.Context, cid string) (*oci.Container, error) {
 	if cid == "" {
 		return nil, fmt.Errorf("container ID should not be empty")
 	}
@@ -38,7 +39,7 @@ func (c *ContainerServer) GetContainerFromShortID(cid string) (*oci.Container, e
 		return nil, fmt.Errorf("container with ID starting with %s not found: %w", cid, err)
 	}
 
-	ctr := c.GetContainer(containerID)
+	ctr := c.GetContainer(ctx, containerID)
 	if ctr == nil {
 		return nil, fmt.Errorf("specified container not found: %s", containerID)
 	}
@@ -51,7 +52,7 @@ func (c *ContainerServer) GetContainerFromShortID(cid string) (*oci.Container, e
 }
 
 // LookupContainer returns the container with the given name or full or partial id
-func (c *ContainerServer) LookupContainer(idOrName string) (*oci.Container, error) {
+func (c *ContainerServer) LookupContainer(ctx context.Context, idOrName string) (*oci.Container, error) {
 	if idOrName == "" {
 		return nil, fmt.Errorf("container ID or name should not be empty")
 	}
@@ -65,7 +66,7 @@ func (c *ContainerServer) LookupContainer(idOrName string) (*oci.Container, erro
 		}
 	}
 
-	return c.GetContainerFromShortID(ctrID)
+	return c.GetContainerFromShortID(ctx, ctrID)
 }
 
 func (c *ContainerServer) getSandboxFromRequest(pid string) (*sandbox.Sandbox, error) {

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -144,6 +144,8 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 
 // LoadSandbox loads a sandbox from the disk into the sandbox store
 func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandbox.Sandbox, retErr error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	config, err := c.store.FromContainerDirectory(id, "config.json")
 	if err != nil {
 		return nil, err
@@ -353,6 +355,8 @@ var ErrIsNonCrioContainer = errors.New("non CRI-O container")
 
 // LoadContainer loads a container from the disk into the container store
 func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	config, err := c.store.FromContainerDirectory(id, "config.json")
 	if err != nil {
 		return err
@@ -463,6 +467,8 @@ func isTrue(annotaton string) bool {
 // ContainerStateFromDisk retrieves information on the state of a running container
 // from the disk
 func (c *ContainerServer) ContainerStateFromDisk(ctx context.Context, ctr *oci.Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if err := ctr.FromDisk(); err != nil {
 		return err
 	}

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -614,7 +614,7 @@ func (c *ContainerServer) RemoveContainer(ctx context.Context, ctr *oci.Containe
 	sb.RemoveContainer(ctx, ctr)
 	c.RemoveStatsForContainer(ctr)
 	if err := ctr.RemoveManagedPIDNamespace(); err != nil {
-		logrus.WithContext(ctx).Errorf("Failed to remove container %s PID namespace: %v", ctr.ID(), err)
+		log.Errorf(ctx, "Failed to remove container %s PID namespace: %v", ctr.ID(), err)
 	}
 	c.state.containers.Delete(ctr.ID())
 }

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -19,6 +19,7 @@ import (
 
 // The actual test suite
 var _ = t.Describe("ContainerServer", func() {
+	ctx := context.TODO()
 	// Prepare the sut
 	BeforeEach(beforeEach)
 
@@ -413,7 +414,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed", func() {
 			// Given
 			createDummyState()
-			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
 			mockDirs(testManifest)
 
 			// When
@@ -440,7 +441,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with failing ContainerRunDirectory", func() {
 			// Given
-			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
 			gomock.InOrder(
 				storeMock.EXPECT().
 					FromContainerDirectory(gomock.Any(), gomock.Any()).
@@ -458,7 +459,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail with failing ContainerDirectory", func() {
 			// Given
-			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
 			gomock.InOrder(
 				storeMock.EXPECT().
 					FromContainerDirectory(gomock.Any(), gomock.Any()).
@@ -679,8 +680,8 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("AddContainer/AddSandbox", func() {
 		It("should succeed", func() {
 			// Given
-			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
-			sut.AddContainer(myContainer)
+			Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
+			sut.AddContainer(ctx, myContainer)
 
 			// When
 			hasSandbox := sut.HasSandbox(mySandbox.ID())
@@ -694,7 +695,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail when sandbox not available", func() {
 			// Given
-			sut.AddContainer(myContainer)
+			sut.AddContainer(ctx, myContainer)
 
 			// When
 			hasSandbox := sut.HasSandbox(mySandbox.ID())
@@ -709,10 +710,10 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("RemoveContainer/RemoveSandbox", func() {
 		It("should succeed", func() {
 			// Given
-			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
-			sut.AddContainer(myContainer)
-			sut.RemoveContainer(myContainer)
-			Expect(sut.RemoveSandbox(mySandbox.ID())).To(BeNil())
+			Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
+			sut.AddContainer(ctx, myContainer)
+			sut.RemoveContainer(ctx, myContainer)
+			Expect(sut.RemoveSandbox(ctx, mySandbox.ID())).To(BeNil())
 
 			// When
 			hasSandbox := sut.HasSandbox(mySandbox.ID())
@@ -726,10 +727,10 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail to remove container when sandbox not available", func() {
 			// Given
-			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
-			sut.AddContainer(myContainer)
-			Expect(sut.RemoveSandbox(mySandbox.ID())).To(BeNil())
-			sut.RemoveContainer(myContainer)
+			Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
+			sut.AddContainer(ctx, myContainer)
+			Expect(sut.RemoveSandbox(ctx, mySandbox.ID())).To(BeNil())
+			sut.RemoveContainer(ctx, myContainer)
 
 			// When
 			hasSandbox := sut.HasSandbox(mySandbox.ID())
@@ -742,7 +743,7 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should fail to remove sandbox when not available", func() {
 			// Given
-			Expect(sut.RemoveSandbox(mySandbox.ID())).To(BeNil())
+			Expect(sut.RemoveSandbox(ctx, mySandbox.ID())).To(BeNil())
 
 			// When
 			hasSandbox := sut.HasSandbox(mySandbox.ID())
@@ -755,8 +756,8 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("ListContainer/ListSandbox", func() {
 		It("should succeed", func() {
 			// Given
-			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
-			sut.AddContainer(myContainer)
+			Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
+			sut.AddContainer(ctx, myContainer)
 
 			// When
 			sandboxes := sut.ListSandboxes()
@@ -770,8 +771,8 @@ var _ = t.Describe("ContainerServer", func() {
 
 		It("should succeed filtered", func() {
 			// Given
-			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
-			sut.AddContainer(myContainer)
+			Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
+			sut.AddContainer(ctx, myContainer)
 
 			// When
 			sandboxes := sut.ListSandboxes()
@@ -793,10 +794,10 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("AddInfraContainer", func() {
 		It("should succeed", func() {
 			// Given
-			sut.AddInfraContainer(myContainer)
+			sut.AddInfraContainer(ctx, myContainer)
 
 			// When
-			container := sut.GetInfraContainer(myContainer.ID())
+			container := sut.GetInfraContainer(ctx, myContainer.ID())
 
 			// Then
 			Expect(container).NotTo(BeNil())
@@ -806,11 +807,11 @@ var _ = t.Describe("ContainerServer", func() {
 	t.Describe("RemoveInfraContainer", func() {
 		It("should succeed", func() {
 			// Given
-			sut.AddInfraContainer(myContainer)
-			sut.RemoveInfraContainer(myContainer)
+			sut.AddInfraContainer(ctx, myContainer)
+			sut.RemoveInfraContainer(ctx, myContainer)
 
 			// When
-			container := sut.GetInfraContainer(myContainer.ID())
+			container := sut.GetInfraContainer(ctx, myContainer.ID())
 
 			// Then
 			Expect(container).To(BeNil())

--- a/internal/lib/container_test.go
+++ b/internal/lib/container_test.go
@@ -1,12 +1,15 @@
 package lib_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 // The actual test suite
 var _ = t.Describe("ContainerServer", func() {
+	ctx := context.TODO()
 	// Prepare the sut
 	BeforeEach(beforeEach)
 
@@ -16,7 +19,7 @@ var _ = t.Describe("ContainerServer", func() {
 			addContainerAndSandbox()
 
 			// When
-			container, err := sut.LookupContainer(containerID)
+			container, err := sut.LookupContainer(ctx, containerID)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -27,7 +30,7 @@ var _ = t.Describe("ContainerServer", func() {
 			// Given
 
 			// When
-			container, err := sut.LookupContainer("")
+			container, err := sut.LookupContainer(ctx, "")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -41,7 +44,7 @@ var _ = t.Describe("ContainerServer", func() {
 			addContainerAndSandbox()
 
 			// When
-			container, err := sut.GetContainerFromShortID(containerID)
+			container, err := sut.GetContainerFromShortID(ctx, containerID)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -52,7 +55,7 @@ var _ = t.Describe("ContainerServer", func() {
 			// Given
 
 			// When
-			container, err := sut.GetContainerFromShortID("")
+			container, err := sut.GetContainerFromShortID(ctx, "")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -63,7 +66,7 @@ var _ = t.Describe("ContainerServer", func() {
 			// Given
 
 			// When
-			container, err := sut.GetContainerFromShortID("invalid")
+			container, err := sut.GetContainerFromShortID(ctx, "invalid")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -71,14 +74,15 @@ var _ = t.Describe("ContainerServer", func() {
 		})
 
 		It("should fail if container is not created", func() {
+			ctx := context.TODO()
 			// Given
-			Expect(sut.AddSandbox(mySandbox)).To(BeNil())
-			sut.AddContainer(myContainer)
+			Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
+			sut.AddContainer(ctx, myContainer)
 			Expect(sut.CtrIDIndex().Add(containerID)).To(BeNil())
 			Expect(sut.PodIDIndex().Add(sandboxID)).To(BeNil())
 
 			// When
-			container, err := sut.GetContainerFromShortID(containerID)
+			container, err := sut.GetContainerFromShortID(ctx, containerID)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -38,12 +38,12 @@ func (c *ContainerServer) ContainerRestore(ctx context.Context, opts *ContainerC
 	// During checkpointing the container is unmounted. This mounts the container again.
 	mountPoint, err := c.StorageImageServer().GetStore().Mount(ctr.ID(), ctrSpec.Config.Linux.MountLabel)
 	if err != nil {
-		logrus.Debugf("Failed to mount container %q: %v", ctr.ID(), err)
+		logrus.WithContext(ctx).Debugf("Failed to mount container %q: %v", ctr.ID(), err)
 		return "", err
 	}
-	logrus.Debugf("Container mountpoint %v", mountPoint)
-	logrus.Debugf("Sandbox %v", ctr.Sandbox())
-	logrus.Debugf("Specgen.Config.Annotations[io.kubernetes.cri-o.SandboxID] %v", ctrSpec.Config.Annotations["io.kubernetes.cri-o.SandboxID"])
+	logrus.WithContext(ctx).Debugf("Container mountpoint %v", mountPoint)
+	logrus.WithContext(ctx).Debugf("Sandbox %v", ctr.Sandbox())
+	logrus.WithContext(ctx).Debugf("Specgen.Config.Annotations[io.kubernetes.cri-o.SandboxID] %v", ctrSpec.Config.Annotations["io.kubernetes.cri-o.SandboxID"])
 	// If there was no podID specified this will restore the container
 	// in its original sandbox
 	if opts.Pod == "" {
@@ -212,7 +212,7 @@ func (c *ContainerServer) ContainerRestore(ctx context.Context, opts *ContainerC
 		return "", fmt.Errorf("failed to restore container %s: %w", ctr.ID(), err)
 	}
 	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
-		logrus.Warnf("Unable to write containers %s state to disk: %v", ctr.ID(), err)
+		logrus.WithContext(ctx).Warnf("Unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
 
 	if !opts.Keep {
@@ -222,7 +222,7 @@ func (c *ContainerServer) ContainerRestore(ctx context.Context, opts *ContainerC
 		// failed. Starting with the checkpoint directory
 		err = os.RemoveAll(ctr.CheckpointPath())
 		if err != nil {
-			logrus.Debugf("Non-fatal: removal of checkpoint directory (%s) failed: %v", ctr.CheckpointPath(), err)
+			logrus.WithContext(ctx).Debugf("Non-fatal: removal of checkpoint directory (%s) failed: %v", ctr.CheckpointPath(), err)
 		}
 		cleanup := [...]string{
 			metadata.RestoreLogFile,
@@ -247,7 +247,7 @@ func (c *ContainerServer) ContainerRestore(ctx context.Context, opts *ContainerC
 			}
 			err = os.Remove(file)
 			if err != nil {
-				logrus.Debugf("Non-fatal: removal of checkpoint file (%s) failed: %v", file, err)
+				logrus.WithContext(ctx).Debugf("Non-fatal: removal of checkpoint file (%s) failed: %v", file, err)
 			}
 		}
 	}

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -19,7 +19,7 @@ import (
 func (c *ContainerServer) ContainerRestore(ctx context.Context, opts *ContainerCheckpointRestoreOptions) (string, error) {
 	var ctr *oci.Container
 	var err error
-	ctr, err = c.LookupContainer(opts.Container)
+	ctr, err = c.LookupContainer(ctx, opts.Container)
 	if err != nil {
 		return "", fmt.Errorf("failed to find container %s: %w", opts.Container, err)
 	}

--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -345,7 +345,7 @@ func (s *Sandbox) SetStopped(ctx context.Context, createFile bool) {
 	s.stopped = true
 	if createFile {
 		if err := s.createFileInInfraDir(ctx, sbStoppedFilename); err != nil {
-			logrus.WithContext(ctx).Errorf("Failed to create stopped file in container state. Restore may fail: %v", err)
+			log.Errorf(ctx, "Failed to create stopped file in container state. Restore may fail: %v", err)
 		}
 	}
 }

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -1,6 +1,7 @@
 package sandbox_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/cri-o/cri-o/internal/hostport"
@@ -102,11 +103,12 @@ var _ = t.Describe("Sandbox", func() {
 
 	t.Describe("Stopped", func() {
 		It("should succeed", func() {
+			ctx := context.TODO()
 			// Given
 			Expect(testSandbox.Stopped()).To(BeFalse())
 
 			// When
-			testSandbox.SetStopped(false)
+			testSandbox.SetStopped(ctx, false)
 
 			// Then
 			Expect(testSandbox.Stopped()).To(BeTrue())
@@ -115,11 +117,12 @@ var _ = t.Describe("Sandbox", func() {
 
 	t.Describe("NetworkStopped", func() {
 		It("should succeed", func() {
+			ctx := context.TODO()
 			// Given
 			Expect(testSandbox.NetworkStopped()).To(BeFalse())
 
 			// When
-			Expect(testSandbox.SetNetworkStopped(false)).To(BeNil())
+			Expect(testSandbox.SetNetworkStopped(ctx, false)).To(BeNil())
 
 			// Then
 			Expect(testSandbox.NetworkStopped()).To(BeTrue())
@@ -210,21 +213,22 @@ var _ = t.Describe("Sandbox", func() {
 		})
 
 		It("should succeed to add and remove a container", func() {
+			ctx := context.TODO()
 			// Given
-			Expect(testSandbox.GetContainer(testContainer.Name())).To(BeNil())
+			Expect(testSandbox.GetContainer(ctx, testContainer.Name())).To(BeNil())
 
 			// When
-			testSandbox.AddContainer(testContainer)
+			testSandbox.AddContainer(ctx, testContainer)
 
 			// Then
-			Expect(testSandbox.GetContainer(testContainer.Name())).
+			Expect(testSandbox.GetContainer(ctx, testContainer.Name())).
 				To(Equal(testContainer))
 
 			// And When
-			testSandbox.RemoveContainer(testContainer)
+			testSandbox.RemoveContainer(ctx, testContainer)
 
 			// Then
-			Expect(testSandbox.GetContainer(testContainer.Name())).To(BeNil())
+			Expect(testSandbox.GetContainer(ctx, testContainer.Name())).To(BeNil())
 		})
 
 		It("should succeed to add and remove an infra container", func() {
@@ -276,12 +280,13 @@ var _ = t.Describe("Sandbox", func() {
 		})
 
 		It("should set containerenv file", func() {
+			ctx := context.TODO()
 			// Given
 			Expect(testSandbox.ContainerEnvPath()).To(BeEmpty())
 			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
 
 			// When
-			Expect(testSandbox.SetContainerEnvFile()).To(BeNil())
+			Expect(testSandbox.SetContainerEnvFile(ctx)).To(BeNil())
 
 			// Then
 			Expect(testSandbox.ContainerEnvPath()).To(ContainSubstring(".containerenv"))

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -177,8 +177,9 @@ func mockDirs(manifest []byte) {
 }
 
 func addContainerAndSandbox() {
-	Expect(sut.AddSandbox(mySandbox)).To(BeNil())
-	sut.AddContainer(myContainer)
+	ctx := context.TODO()
+	Expect(sut.AddSandbox(ctx, mySandbox)).To(BeNil())
+	sut.AddContainer(ctx, myContainer)
 	Expect(sut.CtrIDIndex().Add(containerID)).To(BeNil())
 	Expect(sut.PodIDIndex().Add(sandboxID)).To(BeNil())
 	myContainer.SetCreated()

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -3,11 +3,7 @@ package log
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/sirupsen/logrus"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type (
@@ -16,46 +12,27 @@ type (
 )
 
 func Debugf(ctx context.Context, format string, args ...interface{}) {
-	logSpanf(ctx, "DEBUG", format, args...)
 	entry(ctx).Debugf(format, args...)
 }
 
 func Infof(ctx context.Context, format string, args ...interface{}) {
-	logSpanf(ctx, "INFO", format, args...)
 	entry(ctx).Infof(format, args...)
 }
 
 func Warnf(ctx context.Context, format string, args ...interface{}) {
-	logSpanf(ctx, "WARN", format, args...)
 	entry(ctx).Warnf(format, args...)
 }
 
 func Errorf(ctx context.Context, format string, args ...interface{}) {
-	logSpanf(ctx, "ERROR", format, args...)
 	entry(ctx).Errorf(format, args...)
 }
 
 func Fatalf(ctx context.Context, format string, args ...interface{}) {
-	logSpanf(ctx, "FATAL", format, args...)
 	entry(ctx).Fatalf(format, args...)
 }
 
 func WithFields(ctx context.Context, fields map[string]interface{}) *logrus.Entry {
 	return entry(ctx).WithFields(fields)
-}
-
-func logSpanf(ctx context.Context, level, format string, args ...interface{}) {
-	id := "unknown"
-	if ctx != nil {
-		ctxID, idOk := ctx.Value(ID{}).(string)
-		if idOk {
-			id = ctxID
-		}
-	}
-	trace.SpanFromContext(ctx).AddEvent(fmt.Sprintf(format, args...), trace.WithAttributes(
-		attribute.String("level", level),
-		attribute.String("rpc.id", id),
-	))
 }
 
 func entry(ctx context.Context) *logrus.Entry {
@@ -67,8 +44,8 @@ func entry(ctx context.Context) *logrus.Entry {
 	id, idOk := ctx.Value(ID{}).(string)
 	name, nameOk := ctx.Value(Name{}).(string)
 	if idOk && nameOk {
-		return logger.WithField("id", id).WithField("name", name)
+		return logger.WithField("id", id).WithField("name", name).WithContext(ctx)
 	}
 
-	return logrus.NewEntry(logger)
+	return logrus.NewEntry(logger).WithContext(ctx)
 }

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -316,11 +316,11 @@ func (c *Container) CleanupConmonCgroup(ctx context.Context) {
 	}
 	cg, err := cgroups.Load(path)
 	if err != nil {
-		logrus.WithContext(ctx).Infof("Error loading conmon cgroup of container %s: %v", c.ID(), err)
+		log.Infof(ctx, "Error loading conmon cgroup of container %s: %v", c.ID(), err)
 		return
 	}
 	if err := cg.Delete(); err != nil {
-		logrus.WithContext(ctx).Infof("Error deleting conmon cgroup of container %s: %v", c.ID(), err)
+		log.Infof(ctx, "Error deleting conmon cgroup of container %s: %v", c.ID(), err)
 	}
 }
 

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/pkg/config"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
@@ -208,6 +209,8 @@ func (r *Runtime) RuntimeImpl(c *Container) (RuntimeImpl, error) {
 
 // CreateContainer creates a container.
 func (r *Runtime) CreateContainer(ctx context.Context, c *Container, cgroupParent string, restore bool) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	// Instantiate a new runtime implementation for this new container
 	impl, err := r.newRuntimeImpl(c)
 	if err != nil {
@@ -224,6 +227,8 @@ func (r *Runtime) CreateContainer(ctx context.Context, c *Container, cgroupParen
 
 // StartContainer starts a container.
 func (r *Runtime) StartContainer(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -234,6 +239,8 @@ func (r *Runtime) StartContainer(ctx context.Context, c *Container) error {
 
 // ExecContainer prepares a streaming endpoint to execute a command in the container.
 func (r *Runtime) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -244,6 +251,8 @@ func (r *Runtime) ExecContainer(ctx context.Context, c *Container, cmd []string,
 
 // ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
 func (r *Runtime) ExecSyncContainer(ctx context.Context, c *Container, command []string, timeout int64) (*types.ExecSyncResponse, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return nil, err
@@ -254,6 +263,8 @@ func (r *Runtime) ExecSyncContainer(ctx context.Context, c *Container, command [
 
 // UpdateContainer updates container resources
 func (r *Runtime) UpdateContainer(ctx context.Context, c *Container, res *rspec.LinuxResources) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -264,6 +275,8 @@ func (r *Runtime) UpdateContainer(ctx context.Context, c *Container, res *rspec.
 
 // StopContainer stops a container. Timeout is given in seconds.
 func (r *Runtime) StopContainer(ctx context.Context, c *Container, timeout int64) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -274,6 +287,8 @@ func (r *Runtime) StopContainer(ctx context.Context, c *Container, timeout int64
 
 // DeleteContainer deletes a container.
 func (r *Runtime) DeleteContainer(ctx context.Context, c *Container) (err error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	r.runtimeImplMapMutex.RLock()
 	impl, ok := r.runtimeImplMap[c.ID()]
 	r.runtimeImplMapMutex.RUnlock()
@@ -296,6 +311,8 @@ func (r *Runtime) DeleteContainer(ctx context.Context, c *Container) (err error)
 
 // UpdateContainerStatus refreshes the status of the container.
 func (r *Runtime) UpdateContainerStatus(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -306,6 +323,8 @@ func (r *Runtime) UpdateContainerStatus(ctx context.Context, c *Container) error
 
 // PauseContainer pauses a container.
 func (r *Runtime) PauseContainer(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -316,6 +335,8 @@ func (r *Runtime) PauseContainer(ctx context.Context, c *Container) error {
 
 // UnpauseContainer unpauses a container.
 func (r *Runtime) UnpauseContainer(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -326,6 +347,8 @@ func (r *Runtime) UnpauseContainer(ctx context.Context, c *Container) error {
 
 // ContainerStats provides statistics of a container.
 func (r *Runtime) ContainerStats(ctx context.Context, c *Container, cgroup string) (*types.ContainerStats, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return nil, err
@@ -336,6 +359,8 @@ func (r *Runtime) ContainerStats(ctx context.Context, c *Container, cgroup strin
 
 // SignalContainer sends a signal to a container process.
 func (r *Runtime) SignalContainer(ctx context.Context, c *Container, sig syscall.Signal) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -346,6 +371,8 @@ func (r *Runtime) SignalContainer(ctx context.Context, c *Container, sig syscall
 
 // AttachContainer attaches IO to a running container.
 func (r *Runtime) AttachContainer(ctx context.Context, c *Container, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -356,6 +383,8 @@ func (r *Runtime) AttachContainer(ctx context.Context, c *Container, inputStream
 
 // PortForwardContainer forwards the specified port provides statistics of a container.
 func (r *Runtime) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
@@ -366,6 +395,8 @@ func (r *Runtime) PortForwardContainer(ctx context.Context, c *Container, netNsP
 
 // ReopenContainerLog reopens the log file of a container.
 func (r *Runtime) ReopenContainerLog(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -140,7 +140,7 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 		args = append(args, "-i")
 	}
 	if restore {
-		logrus.Debugf("Restore is true %v", restore)
+		logrus.WithContext(ctx).Debugf("Restore is true %v", restore)
 		args = append(args, "--restore", c.CheckpointPath())
 		if c.Spec().Process.SelinuxLabel != "" {
 			args = append(
@@ -164,7 +164,7 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 		}
 	}
 
-	logrus.WithFields(logrus.Fields{
+	logrus.WithContext(ctx).WithFields(logrus.Fields{
 		"args": args,
 	}).Debugf("running conmon: %s", r.handler.MonitorPath)
 
@@ -1459,8 +1459,8 @@ func (r *runtimeOCI) CheckpointContainer(ctx context.Context, c *Container, spec
 	// imagePath is used by CRIU to store the actual checkpoint files
 	imagePath := c.CheckpointPath()
 
-	logrus.Debugf("Writing checkpoint to %s", imagePath)
-	logrus.Debugf("Writing checkpoint logs to %s", workPath)
+	logrus.WithContext(ctx).Debugf("Writing checkpoint to %s", imagePath)
+	logrus.WithContext(ctx).Debugf("Writing checkpoint logs to %s", workPath)
 	args := []string{}
 	args = append(
 		args,

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -143,7 +143,7 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 		args = append(args, "-i")
 	}
 	if restore {
-		logrus.WithContext(ctx).Debugf("Restore is true %v", restore)
+		log.Debugf(ctx, "Restore is true %v", restore)
 		args = append(args, "--restore", c.CheckpointPath())
 		if c.Spec().Process.SelinuxLabel != "" {
 			args = append(
@@ -167,7 +167,7 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 		}
 	}
 
-	logrus.WithContext(ctx).WithFields(logrus.Fields{
+	log.WithFields(ctx, logrus.Fields{
 		"args": args,
 	}).Debugf("running conmon: %s", r.handler.MonitorPath)
 
@@ -1496,8 +1496,8 @@ func (r *runtimeOCI) CheckpointContainer(ctx context.Context, c *Container, spec
 	// imagePath is used by CRIU to store the actual checkpoint files
 	imagePath := c.CheckpointPath()
 
-	logrus.WithContext(ctx).Debugf("Writing checkpoint to %s", imagePath)
-	logrus.WithContext(ctx).Debugf("Writing checkpoint logs to %s", workPath)
+	log.Debugf(ctx, "Writing checkpoint to %s", imagePath)
+	log.Debugf(ctx, "Writing checkpoint logs to %s", workPath)
 	args := []string{}
 	args = append(
 		args,

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -86,6 +86,9 @@ type exitCodeInfo struct {
 
 // CreateContainer creates a container.
 func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupParent string, restore bool) (retErr error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	if c.Spoofed() {
 		return nil
 	}
@@ -309,6 +312,8 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 
 // StartContainer starts a container.
 func (r *runtimeOCI) StartContainer(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -343,6 +348,8 @@ func prepareExec() (pidFileName string, parentPipe, childPipe *os.File, _ error)
 }
 
 func parseLog(ctx context.Context, l []byte) (stdout, stderr []byte) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	// Split the log on newlines, which is what separates entries.
 	lines := bytes.SplitAfter(l, []byte{'\n'})
 	for _, line := range lines {
@@ -388,6 +395,9 @@ func parseLog(ctx context.Context, l []byte) (stdout, stderr []byte) {
 
 // ExecContainer prepares a streaming endpoint to execute a command in the container.
 func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	if c.Spoofed() {
 		return nil
 	}
@@ -468,6 +478,9 @@ func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []stri
 
 // ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
 func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, command []string, timeout int64) (*types.ExecSyncResponse, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	if c.Spoofed() {
 		return nil, nil
 	}
@@ -725,6 +738,8 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 }
 
 func TruncateAndReadFile(ctx context.Context, path string, size int64) ([]byte, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -740,6 +755,9 @@ func TruncateAndReadFile(ctx context.Context, path string, size int64) ([]byte, 
 
 // UpdateContainer updates container resources
 func (r *runtimeOCI) UpdateContainer(ctx context.Context, c *Container, res *rspec.LinuxResources) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -768,6 +786,9 @@ func (r *runtimeOCI) UpdateContainer(ctx context.Context, c *Container, res *rsp
 }
 
 func WaitContainerStop(ctx context.Context, c *Container, timeout time.Duration, ignoreKill bool) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	done := make(chan struct{})
 	// we could potentially re-use "done" channel to exit the loop on timeout,
 	// but we use another channel "chControl" so that we never panic
@@ -847,6 +868,8 @@ func WaitContainerStop(ctx context.Context, c *Container, timeout time.Duration,
 
 // StopContainer stops a container. Timeout is given in seconds.
 func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout int64) (retErr error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if c.SetAsStopping(timeout) {
 		return nil
 	}
@@ -908,6 +931,8 @@ func checkProcessGone(c *Container) {
 
 // DeleteContainer deletes a container.
 func (r *runtimeOCI) DeleteContainer(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -943,6 +968,8 @@ func updateContainerStatusFromExitFile(c *Container) error {
 
 // UpdateContainerStatus refreshes the status of the container.
 func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -1077,6 +1104,8 @@ func (r *runtimeOCI) UnpauseContainer(ctx context.Context, c *Container) error {
 
 // ContainerStats provides statistics of a container.
 func (r *runtimeOCI) ContainerStats(ctx context.Context, c *Container, cgroup string) (*types.ContainerStats, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 	return r.containerStats(c, cgroup)
@@ -1084,6 +1113,8 @@ func (r *runtimeOCI) ContainerStats(ctx context.Context, c *Container, cgroup st
 
 // SignalContainer sends a signal to a container process.
 func (r *runtimeOCI) SignalContainer(ctx context.Context, c *Container, sig syscall.Signal) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -1112,6 +1143,8 @@ func (r *runtimeOCI) signalContainer(c *Container, sig syscall.Signal, all bool)
 
 // AttachContainer attaches IO to a running container.
 func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if c.Spoofed() {
 		return nil
 	}
@@ -1190,6 +1223,8 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 
 // PortForwardContainer forwards the specified port into the provided container.
 func (r *runtimeOCI) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	log.Infof(ctx,
 		"Starting port forward for %s in network namespace %s", c.ID(), netNsPath,
 	)
@@ -1281,6 +1316,8 @@ func (r *runtimeOCI) PortForwardContainer(ctx context.Context, c *Container, net
 
 // ReopenContainerLog reopens the log file of a container.
 func (r *runtimeOCI) ReopenContainerLog(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if c.Spoofed() {
 		return nil
 	}

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -312,7 +312,7 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 
 // StartContainer starts a container.
 func (r *runtimeOCI) StartContainer(ctx context.Context, c *Container) error {
-	ctx, span := log.StartSpan(ctx)
+	_, span := log.StartSpan(ctx)
 	defer span.End()
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
@@ -395,7 +395,7 @@ func parseLog(ctx context.Context, l []byte) (stdout, stderr []byte) {
 
 // ExecContainer prepares a streaming endpoint to execute a command in the container.
 func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
-	ctx, span := log.StartSpan(ctx)
+	_, span := log.StartSpan(ctx)
 	defer span.End()
 
 	if c.Spoofed() {
@@ -755,7 +755,7 @@ func TruncateAndReadFile(ctx context.Context, path string, size int64) ([]byte, 
 
 // UpdateContainer updates container resources
 func (r *runtimeOCI) UpdateContainer(ctx context.Context, c *Container, res *rspec.LinuxResources) error {
-	ctx, span := log.StartSpan(ctx)
+	_, span := log.StartSpan(ctx)
 	defer span.End()
 
 	c.opLock.Lock()
@@ -931,7 +931,7 @@ func checkProcessGone(c *Container) {
 
 // DeleteContainer deletes a container.
 func (r *runtimeOCI) DeleteContainer(ctx context.Context, c *Container) error {
-	ctx, span := log.StartSpan(ctx)
+	_, span := log.StartSpan(ctx)
 	defer span.End()
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
@@ -1104,7 +1104,7 @@ func (r *runtimeOCI) UnpauseContainer(ctx context.Context, c *Container) error {
 
 // ContainerStats provides statistics of a container.
 func (r *runtimeOCI) ContainerStats(ctx context.Context, c *Container, cgroup string) (*types.ContainerStats, error) {
-	ctx, span := log.StartSpan(ctx)
+	_, span := log.StartSpan(ctx)
 	defer span.End()
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
@@ -1113,7 +1113,7 @@ func (r *runtimeOCI) ContainerStats(ctx context.Context, c *Container, cgroup st
 
 // SignalContainer sends a signal to a container process.
 func (r *runtimeOCI) SignalContainer(ctx context.Context, c *Container, sig syscall.Signal) error {
-	ctx, span := log.StartSpan(ctx)
+	_, span := log.StartSpan(ctx)
 	defer span.End()
 	c.opLock.Lock()
 	defer c.opLock.Unlock()

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/common/pkg/resize"
 	conmonClient "github.com/containers/conmon-rs/pkg/client"
 	conmonconfig "github.com/containers/conmon/runner/config"
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/pkg/config"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -97,7 +98,8 @@ func (r *runtimePod) CreateContainer(ctx context.Context, c *Container, cgroupPa
 			v.Tag = "none"
 		}
 
-		logrus.WithContext(ctx).Debugf(
+		log.Debugf(
+			ctx,
 			"Using conmonrs version: %s, tag: %s, commit: %s, build: %s, target: %s, %s, %s",
 			v.Version, v.Tag, v.Commit, v.BuildDate, v.Target, v.RustVersion, v.CargoVersion,
 		)

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -97,7 +97,7 @@ func (r *runtimePod) CreateContainer(ctx context.Context, c *Container, cgroupPa
 			v.Tag = "none"
 		}
 
-		logrus.Debugf(
+		logrus.WithContext(ctx).Debugf(
 			"Using conmonrs version: %s, tag: %s, commit: %s, build: %s, target: %s, %s, %s",
 			v.Version, v.Tag, v.Commit, v.BuildDate, v.Target, v.RustVersion, v.CargoVersion,
 		)

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -1043,16 +1043,16 @@ func (r *runtimeVM) closeIO(ctrID, execID string) error {
 
 // CheckpointContainer not implemented for runtimeVM
 func (r *runtimeVM) CheckpointContainer(ctx context.Context, c *Container, specgen *rspec.Spec, leaveRunning bool) error {
-	logrus.Debug("runtimeVM.CheckpointContainer() start")
-	defer logrus.Debug("runtimeVM.CheckpointContainer() end")
+	log.Debugf(ctx, "RuntimeVM.CheckpointContainer() start")
+	defer log.Debugf(ctx, "RuntimeVM.CheckpointContainer() end")
 
 	return errors.New("checkpointing not implemented for runtimeVM")
 }
 
 // RestoreContainer not implemented for runtimeVM
 func (r *runtimeVM) RestoreContainer(ctx context.Context, c *Container, sbSpec *rspec.Spec, infraPid int, cgroupParent string) error {
-	logrus.Debug("runtimeVM.RestoreContainer() start")
-	defer logrus.Debug("runtimeVM.RestoreContainer() end")
+	log.Debugf(ctx, "RuntimeVM.RestoreContainer() start")
+	defer log.Debugf(ctx, "RuntimeVM.RestoreContainer() end")
 
 	return errors.New("restoring not implemented for runtimeVM")
 }

--- a/internal/resourcestore/resourcestore.go
+++ b/internal/resourcestore/resourcestore.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -206,7 +207,7 @@ func (rc *ResourceStore) SetStageForResource(ctx context.Context, name, stage st
 	defer rc.mutex.Unlock()
 	r, ok := rc.resources[name]
 	if !ok {
-		logrus.WithContext(ctx).Tracef("Initializing stage for resource %s to %s", name, stage)
+		log.Debugf(ctx, "Initializing stage for resource %s to %s", name, stage)
 		rc.resources[name] = &Resource{
 			watchers: []chan struct{}{},
 			name:     name,
@@ -214,6 +215,6 @@ func (rc *ResourceStore) SetStageForResource(ctx context.Context, name, stage st
 		}
 		return
 	}
-	logrus.WithContext(ctx).Tracef("Setting stage for resource %s from %s to %s", name, r.stage, stage)
+	log.Debugf(ctx, "Setting stage for resource %s from %s to %s", name, r.stage, stage)
 	r.stage = stage
 }

--- a/internal/resourcestore/resourcestore.go
+++ b/internal/resourcestore/resourcestore.go
@@ -1,6 +1,7 @@
 package resourcestore
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -200,12 +201,12 @@ func (rc *ResourceStore) WatcherForResource(name string) (watcher chan struct{},
 	return watcher, r.stage
 }
 
-func (rc *ResourceStore) SetStageForResource(name, stage string) {
+func (rc *ResourceStore) SetStageForResource(ctx context.Context, name, stage string) {
 	rc.mutex.Lock()
 	defer rc.mutex.Unlock()
 	r, ok := rc.resources[name]
 	if !ok {
-		logrus.Tracef("Initializing stage for resource %s to %s", name, stage)
+		logrus.WithContext(ctx).Tracef("Initializing stage for resource %s to %s", name, stage)
 		rc.resources[name] = &Resource{
 			watchers: []chan struct{}{},
 			name:     name,
@@ -213,6 +214,6 @@ func (rc *ResourceStore) SetStageForResource(name, stage string) {
 		}
 		return
 	}
-	logrus.Tracef("Setting stage for resource %s from %s to %s", name, r.stage, stage)
+	logrus.WithContext(ctx).Tracef("Setting stage for resource %s from %s to %s", name, r.stage, stage)
 	r.stage = stage
 }

--- a/internal/resourcestore/resourcestore_test.go
+++ b/internal/resourcestore/resourcestore_test.go
@@ -160,12 +160,14 @@ var _ = t.Describe("ResourceStore", func() {
 		})
 	})
 	Context("Stages", func() {
+		var ctx context.Context
 		BeforeEach(func() {
 			sut = resourcestore.New()
 			cleaner = resourcestore.NewResourceCleaner()
 			e = &entry{
 				id: testID,
 			}
+			ctx = context.Background()
 		})
 		AfterEach(func() {
 			sut.Close()
@@ -180,7 +182,7 @@ var _ = t.Describe("ResourceStore", func() {
 		It("should add resource if not present", func() {
 			// Given
 			testStage := "test stage"
-			sut.SetStageForResource(testName, testStage)
+			sut.SetStageForResource(ctx, testName, testStage)
 
 			// when
 			_, stage := sut.WatcherForResource(testName)
@@ -192,12 +194,12 @@ var _ = t.Describe("ResourceStore", func() {
 			// Given
 			stage1 := "test stage"
 			stage2 := "test stage2"
-			sut.SetStageForResource(testName, stage1)
+			sut.SetStageForResource(ctx, testName, stage1)
 			_, stage := sut.WatcherForResource(testName)
 			Expect(stage).To(Equal(stage1))
 
 			// when
-			sut.SetStageForResource(testName, stage2)
+			sut.SetStageForResource(ctx, testName, stage2)
 			_, stage = sut.WatcherForResource(testName)
 
 			// Then

--- a/internal/runtimehandlerhooks/high_performance_hooks.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks.go
@@ -127,6 +127,8 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 }
 
 func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	log.Infof(ctx, "Run %q runtime handler pre-stop hook for the container %q", HighPerformance, c.ID())
 
 	if isCgroupParentBurstable(s) {

--- a/internal/runtimehandlerhooks/runtime_handler_hooks.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks.go
@@ -18,6 +18,8 @@ type RuntimeHandlerHooks interface {
 
 // GetRuntimeHandlerHooks returns RuntimeHandlerHooks implementation by the runtime handler name
 func GetRuntimeHandlerHooks(ctx context.Context, config *libconfig.Config, handler string, annotations map[string]string) (RuntimeHandlerHooks, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if strings.Contains(handler, HighPerformance) {
 		log.Warnf(ctx, "The usage of the handler %q without adding high-performance feature annotations under allowed_annotations will be deprecated under 1.21", HighPerformance)
 		return &HighPerformanceHooks{config.IrqBalanceConfigFile}, nil

--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
+	"github.com/cri-o/cri-o/internal/log"
 	json "github.com/json-iterator/go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
@@ -82,7 +83,7 @@ type RuntimeServer interface {
 	// omitted, but not both.  All other arguments are required.
 	CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error)
 	// DeleteContainer deletes a container, unmounting it first if need be.
-	DeleteContainer(idOrName string) error
+	DeleteContainer(ctx context.Context, idOrName string) error
 
 	// StartContainer makes sure a container's filesystem is mounted, and
 	// returns the location of its root filesystem, which is not guaranteed
@@ -90,7 +91,7 @@ type RuntimeServer interface {
 	StartContainer(idOrName string) (string, error)
 	// StopContainer attempts to unmount a container's root filesystem,
 	// freeing up any kernel resources which may be limited.
-	StopContainer(idOrName string) error
+	StopContainer(ctx context.Context, idOrName string) error
 
 	// GetWorkDir returns the path of a nonvolatile directory on the
 	// filesystem (somewhere under the Store's Root directory) which can be
@@ -378,7 +379,9 @@ func (r *runtimeService) deleteLayerIfMapped(imageID, layerID string) {
 	}
 }
 
-func (r *runtimeService) DeleteContainer(idOrName string) error {
+func (r *runtimeService) DeleteContainer(ctx context.Context, idOrName string) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if idOrName == "" {
 		return ErrInvalidContainerID
 	}
@@ -392,11 +395,11 @@ func (r *runtimeService) DeleteContainer(idOrName string) error {
 	}
 	layer, err := r.storageImageServer.GetStore().Layer(container.LayerID)
 	if err != nil {
-		logrus.Debugf("Failed to retrieve layer %q: %v", container.LayerID, err)
+		logrus.WithContext(ctx).Debugf("Failed to retrieve layer %q: %v", container.LayerID, err)
 	}
 	err = r.storageImageServer.GetStore().DeleteContainer(container.ID)
 	if err != nil {
-		logrus.Debugf("Failed to delete container %q: %v", container.ID, err)
+		logrus.WithContext(ctx).Debugf("Failed to delete container %q: %v", container.ID, err)
 		return err
 	}
 	if layer != nil {
@@ -447,7 +450,9 @@ func (r *runtimeService) StartContainer(idOrName string) (string, error) {
 	return mountPoint, nil
 }
 
-func (r *runtimeService) StopContainer(idOrName string) error {
+func (r *runtimeService) StopContainer(ctx context.Context, idOrName string) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if idOrName == "" {
 		return ErrInvalidContainerID
 	}
@@ -457,10 +462,10 @@ func (r *runtimeService) StopContainer(idOrName string) error {
 	}
 	_, err = r.storageImageServer.GetStore().Unmount(container.ID, false)
 	if err != nil {
-		logrus.Debugf("Failed to unmount container %q: %v", container.ID, err)
+		logrus.WithContext(ctx).Debugf("Failed to unmount container %q: %v", container.ID, err)
 		return err
 	}
-	logrus.Debugf("Unmounted container %q", container.ID)
+	logrus.WithContext(ctx).Debugf("Unmounted container %q", container.ID)
 	return nil
 }
 

--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -395,11 +395,11 @@ func (r *runtimeService) DeleteContainer(ctx context.Context, idOrName string) e
 	}
 	layer, err := r.storageImageServer.GetStore().Layer(container.LayerID)
 	if err != nil {
-		logrus.WithContext(ctx).Debugf("Failed to retrieve layer %q: %v", container.LayerID, err)
+		log.Debugf(ctx, "Failed to retrieve layer %q: %v", container.LayerID, err)
 	}
 	err = r.storageImageServer.GetStore().DeleteContainer(container.ID)
 	if err != nil {
-		logrus.WithContext(ctx).Debugf("Failed to delete container %q: %v", container.ID, err)
+		log.Debugf(ctx, "Failed to delete container %q: %v", container.ID, err)
 		return err
 	}
 	if layer != nil {
@@ -462,10 +462,10 @@ func (r *runtimeService) StopContainer(ctx context.Context, idOrName string) err
 	}
 	_, err = r.storageImageServer.GetStore().Unmount(container.ID, false)
 	if err != nil {
-		logrus.WithContext(ctx).Debugf("Failed to unmount container %q: %v", container.ID, err)
+		log.Debugf(ctx, "Failed to unmount container %q: %v", container.ID, err)
 		return err
 	}
-	logrus.WithContext(ctx).Debugf("Unmounted container %q", container.ID)
+	log.Debugf(ctx, "Unmounted container %q", container.ID)
 	return nil
 }
 

--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -25,6 +25,8 @@ var _ = t.Describe("Runtime", func() {
 	// The system under test
 	var sut storage.RuntimeServer
 
+	var ctx context.Context
+
 	// Prepare the system under test and register a test name and key before
 	// each test
 	BeforeEach(func() {
@@ -35,6 +37,8 @@ var _ = t.Describe("Runtime", func() {
 
 		sut = storage.GetRuntimeService(context.Background(), imageServerMock)
 		Expect(sut).NotTo(BeNil())
+
+		ctx = context.TODO()
 	})
 	AfterEach(func() {
 		mockCtrl.Finish()
@@ -175,7 +179,7 @@ var _ = t.Describe("Runtime", func() {
 			)
 
 			// When
-			err := sut.StopContainer("id")
+			err := sut.StopContainer(ctx, "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -184,7 +188,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to stop a container on empty ID", func() {
 			// Given
 			// When
-			err := sut.StopContainer("")
+			err := sut.StopContainer(ctx, "")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -200,7 +204,7 @@ var _ = t.Describe("Runtime", func() {
 			)
 
 			// When
-			err := sut.StopContainer("id")
+			err := sut.StopContainer(ctx, "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -218,7 +222,7 @@ var _ = t.Describe("Runtime", func() {
 			)
 
 			// When
-			err := sut.StopContainer("id")
+			err := sut.StopContainer(ctx, "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -415,7 +419,7 @@ var _ = t.Describe("Runtime", func() {
 			)
 
 			// When
-			err := sut.DeleteContainer("id")
+			err := sut.DeleteContainer(ctx, "id")
 
 			// Then
 			Expect(err).To(BeNil())
@@ -424,7 +428,7 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to delete a container on invalid ID", func() {
 			// Given
 			// When
-			err := sut.DeleteContainer("")
+			err := sut.DeleteContainer(ctx, "")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -440,7 +444,7 @@ var _ = t.Describe("Runtime", func() {
 			)
 
 			// When
-			err := sut.DeleteContainer("id")
+			err := sut.DeleteContainer(ctx, "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -460,7 +464,7 @@ var _ = t.Describe("Runtime", func() {
 			)
 
 			// When
-			err := sut.DeleteContainer("id")
+			err := sut.DeleteContainer(ctx, "id")
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -24,7 +25,9 @@ func (s *Server) Attach(ctx context.Context, req *types.AttachRequest) (*types.A
 
 // Attach endpoint for streaming.Runtime
 func (s StreamService) Attach(containerID string, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
-	c, err := s.runtimeServer.GetContainerFromShortID(containerID)
+	ctx, span := log.StartSpan(context.TODO())
+	defer span.End()
+	c, err := s.runtimeServer.GetContainerFromShortID(ctx, containerID)
 	if err != nil {
 		return status.Errorf(codes.NotFound, "could not find container %q: %v", containerID, err)
 	}

--- a/server/container_checkpoint.go
+++ b/server/container_checkpoint.go
@@ -88,7 +88,7 @@ func (s *Server) CheckpointContainer(ctx context.Context, req *types.CheckpointC
 		}
 		defer func() {
 			if err := os.RemoveAll(podCheckpointDirectory); err != nil {
-				logrus.Errorf("Could not recursively remove %s: %q", podCheckpointDirectory, err)
+				logrus.WithContext(ctx).Errorf("Could not recursively remove %s: %q", podCheckpointDirectory, err)
 			}
 		}()
 

--- a/server/container_checkpoint.go
+++ b/server/container_checkpoint.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/log"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -88,7 +87,7 @@ func (s *Server) CheckpointContainer(ctx context.Context, req *types.CheckpointC
 		}
 		defer func() {
 			if err := os.RemoveAll(podCheckpointDirectory); err != nil {
-				logrus.WithContext(ctx).Errorf("Could not recursively remove %s: %q", podCheckpointDirectory, err)
+				log.Errorf(ctx, "Could not recursively remove %s: %q", podCheckpointDirectory, err)
 			}
 		}()
 

--- a/server/container_checkpoint.go
+++ b/server/container_checkpoint.go
@@ -28,7 +28,7 @@ func (s *Server) CheckpointContainer(ctx context.Context, req *types.CheckpointC
 	var podCheckpointDirectory string
 	var checkpointedPodOptions metadata.CheckpointedPodOptions
 
-	_, err := s.GetContainerFromShortID(req.ContainerId)
+	_, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
 		// Maybe the user specified a Pod
 		sb, err := s.LookupSandbox(req.ContainerId)

--- a/server/container_checkpoint_test.go
+++ b/server/container_checkpoint_test.go
@@ -49,7 +49,7 @@ var _ = t.Describe("ContainerCheckpoint", func() {
 			testContainer.SetSpec(&specs.Spec{Version: "1.0.0"})
 
 			gomock.InOrder(
-				runtimeServerMock.EXPECT().StopContainer(gomock.Any()).
+				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).
 					Return(nil),
 			)
 
@@ -100,7 +100,7 @@ var _ = t.Describe("ContainerCheckpoint", func() {
 				storeMock.EXPECT().Changes(gomock.Any(), gomock.Any()).Return([]archive.Change{}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Mount(gomock.Any(), gomock.Any()).Return("/tmp/", nil),
-				runtimeServerMock.EXPECT().StopContainer(gomock.Any()).Return(nil),
+				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil),
 			)
 			// When
 			err := sut.CheckpointContainer(context.Background(),
@@ -149,7 +149,7 @@ var _ = t.Describe("ContainerCheckpoint", func() {
 				storeMock.EXPECT().Changes(gomock.Any(), gomock.Any()).Return([]archive.Change{}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().Mount(gomock.Any(), gomock.Any()).Return("/tmp/", nil),
-				runtimeServerMock.EXPECT().StopContainer(gomock.Any()).Return(nil),
+				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil),
 			)
 			// When
 			err := sut.CheckpointContainer(context.Background(),

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -117,6 +117,9 @@ func ensureSharedOrSlave(path string, mountInfos []*mount.Info) error {
 }
 
 func addImageVolumes(ctx context.Context, rootfs string, s *Server, containerInfo *storage.ContainerInfo, mountLabel string, specgen *generate.Generator) ([]rspec.Mount, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	mounts := []rspec.Mount{}
 	for dest := range containerInfo.Config.Config.Volumes {
 		fp, err := securejoin.SecureJoin(rootfs, dest)
@@ -184,6 +187,9 @@ func resolveSymbolicLink(scope, path string) (string, error) {
 
 // setupContainerUser sets the UID, GID and supplemental groups in OCI runtime config
 func setupContainerUser(ctx context.Context, specgen *generate.Generator, rootfs, mountLabel, ctrRunDir string, sc *types.LinuxContainerSecurityContext, imageConfig *v1.Image) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	if sc == nil {
 		return nil
 	}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -43,6 +43,8 @@ const (
 
 // createContainerPlatform performs platform dependent intermediate steps before calling the container's oci.Runtime().CreateContainer()
 func (s *Server) createContainerPlatform(ctx context.Context, container *oci.Container, cgroupParent string, idMappings *idtools.IDMappings) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if idMappings != nil && !container.Spoofed() {
 		rootPair := idMappings.RootPair()
 		for _, path := range []string{container.BundlePath(), container.MountPoint()} {
@@ -139,6 +141,8 @@ func (s *Server) finalizeUserMapping(sb *sandbox.Sandbox, specgen *generate.Gene
 }
 
 func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Container, sb *sandbox.Sandbox) (cntr *oci.Container, retErr error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	// TODO: simplify this function (cyclomatic complexity here is high)
 	// TODO: factor generating/updating the spec into something other projects can vendor
 
@@ -873,6 +877,9 @@ func clearReadOnly(m *rspec.Mount) {
 }
 
 func addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container, mountLabel, bindMountPrefix string, absentMountSourcesToReject []string, maybeRelabel, skipRelabel, cgroup2RW bool) ([]oci.ContainerVolume, []rspec.Mount, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	volumes := []oci.ContainerVolume{}
 	ociMounts := []rspec.Mount{}
 	containerConfig := ctr.Config()

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -992,7 +992,7 @@ func addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container, mountLabel,
 
 		if m.SelinuxRelabel {
 			if skipRelabel {
-				logrus.Debugf("Skipping relabel for %s because of super privileged container (type: spc_t)", src)
+				logrus.WithContext(ctx).Debugf("Skipping relabel for %s because of super privileged container (type: spc_t)", src)
 			} else if err := securityLabel(src, mountLabel, false, maybeRelabel); err != nil {
 				return nil, nil, err
 			}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -28,7 +28,6 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -999,7 +998,7 @@ func addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container, mountLabel,
 
 		if m.SelinuxRelabel {
 			if skipRelabel {
-				logrus.WithContext(ctx).Debugf("Skipping relabel for %s because of super privileged container (type: spc_t)", src)
+				log.Debugf(ctx, "Skipping relabel for %s because of super privileged container (type: spc_t)", src)
 			} else if err := securityLabel(src, mountLabel, false, maybeRelabel); err != nil {
 				return nil, nil, err
 			}

--- a/server/container_create_test.go
+++ b/server/container_create_test.go
@@ -124,9 +124,10 @@ var _ = t.Describe("ContainerCreate", func() {
 		})
 
 		It("should fail when container is stopped", func() {
+			ctx := context.TODO()
 			// Given
 			addContainerAndSandbox()
-			testSandbox.SetStopped(false)
+			testSandbox.SetStopped(ctx, false)
 
 			// When
 			response, err := sut.CreateContainer(context.Background(),
@@ -142,9 +143,10 @@ var _ = t.Describe("ContainerCreate", func() {
 		})
 
 		It("should fail when container checkpoint archive is empty", func() {
+			ctx := context.TODO()
 			// Given
 			addContainerAndSandbox()
-			testSandbox.SetStopped(false)
+			testSandbox.SetStopped(ctx, false)
 
 			request := &types.CreateContainerRequest{
 				PodSandboxId:  testSandbox.ID(),

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -24,7 +25,9 @@ func (s *Server) Exec(ctx context.Context, req *types.ExecRequest) (*types.ExecR
 
 // Exec endpoint for streaming.Runtime
 func (s StreamService) Exec(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
-	c, err := s.runtimeServer.GetContainerFromShortID(containerID)
+	ctx, span := log.StartSpan(context.TODO())
+	defer span.End()
+	c, err := s.runtimeServer.GetContainerFromShortID(ctx, containerID)
 	if err != nil {
 		return status.Errorf(codes.NotFound, "could not find container %q: %v", containerID, err)
 	}

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 
+	"github.com/cri-o/cri-o/internal/log"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,9 @@ import (
 
 // ExecSync runs a command in a container synchronously.
 func (s *Server) ExecSync(ctx context.Context, req *types.ExecSyncRequest) (*types.ExecSyncResponse, error) {
-	c, err := s.GetContainerFromShortID(req.ContainerId)
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	c, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -35,7 +35,7 @@ func (s *Server) filterContainerList(ctx context.Context, filter *types.Containe
 	defer span.End()
 	// Filter using container id and pod id first.
 	if filter.Id != "" {
-		c, err := s.ContainerServer.GetContainerFromShortID(filter.Id)
+		c, err := s.ContainerServer.GetContainerFromShortID(ctx, filter.Id)
 		if err != nil {
 			// If we don't find a container ID with a filter, it should not
 			// be considered an error.  Log a warning and return an empty struct
@@ -51,7 +51,7 @@ func (s *Server) filterContainerList(ctx context.Context, filter *types.Containe
 			return nil
 		}
 	} else if filter.PodSandboxId != "" {
-		sb, err := s.getPodSandboxFromRequest(filter.PodSandboxId)
+		sb, err := s.getPodSandboxFromRequest(ctx, filter.PodSandboxId)
 		if err != nil {
 			return nil
 		}
@@ -63,6 +63,8 @@ func (s *Server) filterContainerList(ctx context.Context, filter *types.Containe
 
 // ListContainers lists all containers by filters.
 func (s *Server) ListContainers(ctx context.Context, req *types.ListContainersRequest) (*types.ListContainersResponse, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	var ctrs []*types.Container
 	filter := req.Filter
 	ctrList, err := s.ContainerServer.ListContainers()

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -31,6 +31,8 @@ func filterContainer(c *types.Container, filter *types.ContainerFilter) bool {
 // filterContainerList applies a protobuf-defined filter to retrieve only intended containers. Not matching
 // the filter is not considered an error but will return an empty response.
 func (s *Server) filterContainerList(ctx context.Context, filter *types.ContainerFilter, origCtrList []*oci.Container) []*oci.Container {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	// Filter using container id and pod id first.
 	if filter.Id != "" {
 		c, err := s.ContainerServer.GetContainerFromShortID(filter.Id)

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -46,6 +46,8 @@ func (s *Server) RemoveContainer(ctx context.Context, req *types.RemoveContainer
 }
 
 func (s *Server) removeContainerInPod(ctx context.Context, sb *sandbox.Sandbox, c *oci.Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if !sb.Stopped() {
 		if err := s.stopContainer(ctx, c, int64(10)); err != nil {
 			return fmt.Errorf("failed to stop container for removal")

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -19,14 +19,16 @@ import (
 // RemoveContainer removes the container. If the container is running, the container
 // should be force removed.
 func (s *Server) RemoveContainer(ctx context.Context, req *types.RemoveContainerRequest) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	log.Infof(ctx, "Removing container: %s", req.ContainerId)
 	// save container description to print
-	c, err := s.GetContainerFromShortID(req.ContainerId)
+	c, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
 		return status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
-	sb := s.getSandbox(c.Sandbox())
+	sb := s.getSandbox(ctx, c.Sandbox())
 
 	if err := s.removeContainerInPod(ctx, sb, c); err != nil {
 		return err
@@ -62,23 +64,23 @@ func (s *Server) removeContainerInPod(ctx context.Context, sb *sandbox.Sandbox, 
 		return fmt.Errorf("failed to remove container exit file %s: %w", c.ID(), err)
 	}
 
-	c.CleanupConmonCgroup()
+	c.CleanupConmonCgroup(ctx)
 
-	if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && err != storage.ErrContainerUnknown {
+	if err := s.StorageRuntimeServer().StopContainer(ctx, c.ID()); err != nil && err != storage.ErrContainerUnknown {
 		// assume container already umounted
 		log.Warnf(ctx, "Failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 	}
 
-	if err := s.StorageRuntimeServer().DeleteContainer(c.ID()); err != nil && err != storage.ErrContainerUnknown {
+	if err := s.StorageRuntimeServer().DeleteContainer(ctx, c.ID()); err != nil && err != storage.ErrContainerUnknown {
 		return fmt.Errorf("failed to delete container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 	}
 
-	s.ReleaseContainerName(c.Name())
-	s.removeContainer(c)
+	s.ReleaseContainerName(ctx, c.Name())
+	s.removeContainer(ctx, c)
 	if err := s.CtrIDIndex().Delete(c.ID()); err != nil {
 		return fmt.Errorf("failed to delete container %s in pod sandbox %s from index: %v", c.Name(), sb.ID(), err)
 	}
-	sb.RemoveContainer(c)
+	sb.RemoveContainer(ctx, c)
 
 	return nil
 }

--- a/server/container_remove_test.go
+++ b/server/container_remove_test.go
@@ -30,9 +30,9 @@ var _ = t.Describe("ContainerRemove", func() {
 				State: specs.State{Status: oci.ContainerStateStopped},
 			})
 			gomock.InOrder(
-				runtimeServerMock.EXPECT().StopContainer(gomock.Any()).
+				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).
 					Return(nil),
-				runtimeServerMock.EXPECT().DeleteContainer(gomock.Any()).
+				runtimeServerMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).
 					Return(nil),
 			)
 

--- a/server/container_reopen_log.go
+++ b/server/container_reopen_log.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	"golang.org/x/net/context"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -10,7 +11,9 @@ import (
 
 // ReopenContainerLog reopens the containers log file
 func (s *Server) ReopenContainerLog(ctx context.Context, req *types.ReopenContainerLogRequest) error {
-	c, err := s.GetContainerFromShortID(req.ContainerId)
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	c, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
 		return fmt.Errorf("could not find container %s: %w", req.ContainerId, err)
 	}

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -69,7 +69,7 @@ func (s *Server) CRImportCheckpoint(
 	}
 
 	if checkpointIsOCIImage {
-		logrus.Debugf("Restoring from oci image %s\n", input)
+		logrus.WithContext(ctx).Debugf("Restoring from oci image %s\n", input)
 
 		imageRef, err := istorage.Transport.ParseStoreReference(s.ContainerServer.StorageImageServer().GetStore(), input)
 		if err != nil {
@@ -124,7 +124,7 @@ func (s *Server) CRImportCheckpoint(
 		if err != nil {
 			return "", fmt.Errorf("unpacking of checkpoint archive %s failed: %w", mountPoint, err)
 		}
-		logrus.Debugf("Unpacked checkpoint in %s", mountPoint)
+		logrus.WithContext(ctx).Debugf("Unpacked checkpoint in %s", mountPoint)
 	}
 
 	// Load spec.dump from temporary directory
@@ -266,7 +266,7 @@ func (s *Server) CRImportCheckpoint(
 			}
 		}
 
-		logrus.Debugf("Adding mounts %#v", mount)
+		logrus.WithContext(ctx).Debugf("Adding mounts %#v", mount)
 		containerConfig.Mounts = append(containerConfig.Mounts, mount)
 	}
 	sandboxConfig := &types.PodSandboxConfig{

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -187,7 +187,7 @@ func (s *Server) CRImportCheckpoint(
 		}
 	}
 
-	sb, err := s.getPodSandboxFromRequest(sbID)
+	sb, err := s.getPodSandboxFromRequest(ctx, sbID)
 	if err != nil {
 		if err == sandbox.ErrIDEmpty {
 			return "", err
@@ -294,7 +294,7 @@ func (s *Server) CRImportCheckpoint(
 	defer func() {
 		if retErr != nil {
 			log.Infof(ctx, "RestoreCtr: releasing container name %s", ctr.Name())
-			s.ReleaseContainerName(ctr.Name())
+			s.ReleaseContainerName(ctx, ctr.Name())
 		}
 	}()
 	ctr.SetRestore(true)
@@ -306,19 +306,19 @@ func (s *Server) CRImportCheckpoint(
 	defer func() {
 		if retErr != nil {
 			log.Infof(ctx, "RestoreCtr: deleting container %s from storage", ctr.ID())
-			err2 := s.StorageRuntimeServer().DeleteContainer(ctr.ID())
+			err2 := s.StorageRuntimeServer().DeleteContainer(ctx, ctr.ID())
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
 			}
 		}
 	}()
 
-	s.addContainer(newContainer)
+	s.addContainer(ctx, newContainer)
 
 	defer func() {
 		if retErr != nil {
 			log.Infof(ctx, "RestoreCtr: removing container %s", newContainer.ID())
-			s.removeContainer(newContainer)
+			s.removeContainer(ctx, newContainer)
 		}
 	}()
 

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -69,7 +69,7 @@ func (s *Server) CRImportCheckpoint(
 	}
 
 	if checkpointIsOCIImage {
-		logrus.WithContext(ctx).Debugf("Restoring from oci image %s\n", input)
+		log.Debugf(ctx, "Restoring from oci image %s\n", input)
 
 		imageRef, err := istorage.Transport.ParseStoreReference(s.ContainerServer.StorageImageServer().GetStore(), input)
 		if err != nil {
@@ -124,7 +124,7 @@ func (s *Server) CRImportCheckpoint(
 		if err != nil {
 			return "", fmt.Errorf("unpacking of checkpoint archive %s failed: %w", mountPoint, err)
 		}
-		logrus.WithContext(ctx).Debugf("Unpacked checkpoint in %s", mountPoint)
+		log.Debugf(ctx, "Unpacked checkpoint in %s", mountPoint)
 	}
 
 	// Load spec.dump from temporary directory
@@ -266,7 +266,7 @@ func (s *Server) CRImportCheckpoint(
 			}
 		}
 
-		logrus.WithContext(ctx).Debugf("Adding mounts %#v", mount)
+		log.Debugf(ctx, "Adding mounts %#v", mount)
 		containerConfig.Mounts = append(containerConfig.Mounts, mount)
 	}
 	sandboxConfig := &types.PodSandboxConfig{

--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cri-o/cri-o/internal/log"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // ContainerStats returns stats of the container. If the container does not
 // exist, the call returns an error.
 func (s *Server) ContainerStats(ctx context.Context, req *types.ContainerStatsRequest) (*types.ContainerStatsResponse, error) {
-	container, err := s.GetContainerFromShortID(req.ContainerId)
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	container, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -22,7 +22,9 @@ const (
 
 // ContainerStatus returns status of the container.
 func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatusRequest) (*types.ContainerStatusResponse, error) {
-	c, err := s.GetContainerFromShortID(req.ContainerId)
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	c, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cri-o/cri-o/internal/config/node"
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/gogo/protobuf/proto"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
@@ -14,7 +15,9 @@ import (
 
 // UpdateContainerResources updates ContainerConfig of the container.
 func (s *Server) UpdateContainerResources(ctx context.Context, req *types.UpdateContainerResourcesRequest) error {
-	c, err := s.GetContainerFromShortID(req.ContainerId)
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	c, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
 		return err
 	}

--- a/server/container_update_resources_test.go
+++ b/server/container_update_resources_test.go
@@ -75,7 +75,8 @@ var _ = t.Describe("UpdateContainerResources", func() {
 			// Then
 			Expect(err).To(BeNil())
 
-			c := sut.GetContainer(testContainer.ID())
+			ctx := context.TODO()
+			c := sut.GetContainer(ctx, testContainer.ID())
 			Expect(int(*c.Spec().Linux.Resources.CPU.Period)).To(Equal(100000))
 			Expect(int(*c.Spec().Linux.Resources.CPU.Quota)).To(Equal(20000))
 			Expect(int(*c.Spec().Linux.Resources.CPU.Shares)).To(Equal(1024))

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/storage"
 	"golang.org/x/net/context"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -8,6 +9,8 @@ import (
 
 // ListImages lists existing images.
 func (s *Server) ListImages(ctx context.Context, req *types.ListImagesRequest) (*types.ListImagesResponse, error) {
+	_, span := log.StartSpan(ctx)
+	defer span.End()
 	filter := ""
 	reqFilter := req.Filter
 	if reqFilter != nil {

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -21,6 +21,8 @@ var localRegistryPrefix = "localhost/"
 
 // PullImage pulls a image with authentication config.
 func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*types.PullImageResponse, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	// TODO: what else do we need here? (Signatures when the story isn't just pulling from docker://)
 	var err error
 	image := ""
@@ -105,6 +107,9 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 // readability and maintainability.
 func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string, error) {
 	var err error
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	sourceCtx := *s.config.SystemContext   // A shallow copy we can modify
 	sourceCtx.DockerLogMirrorChoice = true // Add info level log of the pull source
 	if pullArgs.credentials.Username != "" {

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -11,6 +11,8 @@ import (
 
 // RemoveImage removes the image.
 func (s *Server) RemoveImage(ctx context.Context, req *types.RemoveImageRequest) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	imageRef := ""
 	img := req.Image
 	if img != nil {
@@ -24,6 +26,9 @@ func (s *Server) RemoveImage(ctx context.Context, req *types.RemoveImageRequest)
 
 func (s *Server) removeImage(ctx context.Context, imageRef string) error {
 	var deleted bool
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	images, err := s.StorageImageServer().ResolveNames(s.config.SystemContext, imageRef)
 	if err != nil {
 		if err == storage.ErrCannotParseImageID {

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -17,6 +17,8 @@ import (
 
 // ImageStatus returns the status of the image.
 func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest) (*types.ImageStatusResponse, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	var resp *types.ImageStatusResponse
 	image := ""
 	img := req.Image

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -75,7 +75,7 @@ func (s *Server) getContainerInfo(ctx context.Context, id string, getContainerFu
 	}
 	sb := getSandboxFunc(ctx, ctr.Sandbox())
 	if sb == nil {
-		logrus.WithContext(ctx).Debugf("Can't find sandbox %s for container %s", ctr.Sandbox(), id)
+		log.Debugf(ctx, "Can't find sandbox %s for container %s", ctr.Sandbox(), id)
 		return types.ContainerInfo{}, errSandboxNotFound
 	}
 

--- a/server/inspect_ginkgo_test.go
+++ b/server/inspect_ginkgo_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 
@@ -44,11 +45,12 @@ var _ = t.Describe("Inspect", func() {
 		})
 
 		It("should succeed with valid /containers route", func() {
+			ctx := context.TODO()
 			// Given
-			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, testSandbox)).To(BeNil())
 			testContainer.SetStateAndSpoofPid(&oci.ContainerState{})
 			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
-			sut.AddContainer(testContainer)
+			sut.AddContainer(ctx, testContainer)
 
 			// When
 			request, err := http.NewRequest(http.MethodGet,
@@ -62,12 +64,13 @@ var _ = t.Describe("Inspect", func() {
 		})
 
 		It("should fail if sandbox not found on /containers route", func() {
+			ctx := context.TODO()
 			// Given
-			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, testSandbox)).To(BeNil())
 			testContainer.SetStateAndSpoofPid(&oci.ContainerState{})
 			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
-			sut.AddContainer(testContainer)
-			Expect(sut.RemoveSandbox(testSandbox.ID())).To(BeNil())
+			sut.AddContainer(ctx, testContainer)
+			Expect(sut.RemoveSandbox(ctx, testSandbox.ID())).To(BeNil())
 
 			// When
 			request, err := http.NewRequest(http.MethodGet,
@@ -81,11 +84,12 @@ var _ = t.Describe("Inspect", func() {
 		})
 
 		It("should fail if container state is nil on /containers route", func() {
+			ctx := context.TODO()
 			// Given
-			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, testSandbox)).To(BeNil())
 			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
 			testContainer.SetState(nil)
-			sut.AddContainer(testContainer)
+			sut.AddContainer(ctx, testContainer)
 
 			// When
 			request, err := http.NewRequest(http.MethodGet,

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ func TestGetInfo(t *testing.T) {
 }
 
 func TestGetContainerInfo(t *testing.T) {
+	ctx := context.TODO()
 	s := &Server{}
 	created := time.Now()
 	labels := map[string]string{
@@ -47,7 +49,7 @@ func TestGetContainerInfo(t *testing.T) {
 		"io.kubernetes.test":  "value",
 		"io.kubernetes.test1": "value1",
 	}
-	getContainerFunc := func(id string) *oci.Container {
+	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
 		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", "imageName", "imageRef", &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
@@ -61,15 +63,15 @@ func TestGetContainerInfo(t *testing.T) {
 		container.SetState(cstate)
 		return container
 	}
-	getInfraContainerFunc := func(id string) *oci.Container {
+	getInfraContainerFunc := func(ctx context.Context, id string) *oci.Container {
 		return nil
 	}
-	getSandboxFunc := func(id string) *sandbox.Sandbox {
+	getSandboxFunc := func(ctx context.Context, id string) *sandbox.Sandbox {
 		s := &sandbox.Sandbox{}
 		s.AddIPs([]string{"1.1.1.42"})
 		return s
 	}
-	ci, err := s.getContainerInfo("", getContainerFunc, getInfraContainerFunc, getSandboxFunc)
+	ci, err := s.getContainerInfo(ctx, "", getContainerFunc, getInfraContainerFunc, getSandboxFunc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,17 +142,18 @@ func TestGetContainerInfo(t *testing.T) {
 }
 
 func TestGetContainerInfoCtrNotFound(t *testing.T) {
+	ctx := context.TODO()
 	s := &Server{}
-	getContainerFunc := func(id string) *oci.Container {
+	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
 		return nil
 	}
-	getInfraContainerFunc := func(id string) *oci.Container {
+	getInfraContainerFunc := func(ctx context.Context, id string) *oci.Container {
 		return nil
 	}
-	getSandboxFunc := func(id string) *sandbox.Sandbox {
+	getSandboxFunc := func(ctx context.Context, id string) *sandbox.Sandbox {
 		return nil
 	}
-	_, err := s.getContainerInfo("", getContainerFunc, getInfraContainerFunc, getSandboxFunc)
+	_, err := s.getContainerInfo(ctx, "", getContainerFunc, getInfraContainerFunc, getSandboxFunc)
 	if err == nil {
 		t.Fatal("expected an error but got nothing")
 	}
@@ -160,11 +163,12 @@ func TestGetContainerInfoCtrNotFound(t *testing.T) {
 }
 
 func TestGetContainerInfoCtrStateNil(t *testing.T) {
+	ctx := context.TODO()
 	s := &Server{}
 	created := time.Now()
 	labels := map[string]string{}
 	annotations := map[string]string{}
-	getContainerFunc := func(id string) *oci.Container {
+	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
 		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
@@ -173,15 +177,15 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 		container.SetState(nil)
 		return container
 	}
-	getInfraContainerFunc := func(id string) *oci.Container {
+	getInfraContainerFunc := func(ctx context.Context, id string) *oci.Container {
 		return nil
 	}
-	getSandboxFunc := func(id string) *sandbox.Sandbox {
+	getSandboxFunc := func(ctx context.Context, id string) *sandbox.Sandbox {
 		s := &sandbox.Sandbox{}
 		s.AddIPs([]string{"1.1.1.42"})
 		return s
 	}
-	_, err := s.getContainerInfo("", getContainerFunc, getInfraContainerFunc, getSandboxFunc)
+	_, err := s.getContainerInfo(ctx, "", getContainerFunc, getInfraContainerFunc, getSandboxFunc)
 	if err == nil {
 		t.Fatal("expected an error but got nothing")
 	}
@@ -191,11 +195,12 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 }
 
 func TestGetContainerInfoSandboxNotFound(t *testing.T) {
+	ctx := context.TODO()
 	s := &Server{}
 	created := time.Now()
 	labels := map[string]string{}
 	annotations := map[string]string{}
-	getContainerFunc := func(id string) *oci.Container {
+	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
 		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
@@ -203,13 +208,13 @@ func TestGetContainerInfoSandboxNotFound(t *testing.T) {
 		container.SetMountPoint("/var/foo/container")
 		return container
 	}
-	getInfraContainerFunc := func(id string) *oci.Container {
+	getInfraContainerFunc := func(ctx context.Context, id string) *oci.Container {
 		return nil
 	}
-	getSandboxFunc := func(id string) *sandbox.Sandbox {
+	getSandboxFunc := func(ctx context.Context, id string) *sandbox.Sandbox {
 		return nil
 	}
-	_, err := s.getContainerInfo("", getContainerFunc, getInfraContainerFunc, getSandboxFunc)
+	_, err := s.getContainerInfo(ctx, "", getContainerFunc, getInfraContainerFunc, getSandboxFunc)
 	if err == nil {
 		t.Fatal("expected an error but got nothing")
 	}

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -10,6 +10,8 @@ import (
 
 // ListPodSandbox returns a list of SandBoxes.
 func (s *Server) ListPodSandbox(ctx context.Context, req *types.ListPodSandboxRequest) (*types.ListPodSandboxResponse, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	podList := s.filterSandboxList(ctx, req.Filter, s.ContainerServer.ListSandboxes())
 	respList := make([]*types.PodSandbox, 0, len(podList))
 
@@ -34,6 +36,9 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *types.ListPodSandboxRe
 // filterSandboxList applies a protobuf-defined filter to retrieve only intended pod sandboxes. Not matching
 // the filter is not considered an error but will return an empty response.
 func (s *Server) filterSandboxList(ctx context.Context, filter *types.PodSandboxFilter, podList []*sandbox.Sandbox) []*sandbox.Sandbox {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	// Filter by pod id first.
 	if filter == nil {
 		return podList
@@ -47,7 +52,7 @@ func (s *Server) filterSandboxList(ctx context.Context, filter *types.PodSandbox
 			log.Warnf(ctx, "Unable to find pod %s with filter", filter.Id)
 			return []*sandbox.Sandbox{}
 		}
-		sb := s.getSandbox(id)
+		sb := s.getSandbox(ctx, id)
 		if sb == nil {
 			podList = []*sandbox.Sandbox{}
 		} else {

--- a/server/sandbox_list_test.go
+++ b/server/sandbox_list_test.go
@@ -12,6 +12,7 @@ import (
 
 // The actual test suite
 var _ = t.Describe("ListPodSandbox", func() {
+	ctx := context.TODO()
 	// Prepare the sut
 	BeforeEach(func() {
 		beforeEach()
@@ -23,7 +24,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 	t.Describe("ListPodSandbox", func() {
 		It("should succeed", func() {
 			// Given
-			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, testSandbox)).To(BeNil())
 			testContainer.SetState(&oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateRunning},
 			})
@@ -42,7 +43,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 
 		It("should succeed without infra container", func() {
 			// Given
-			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, testSandbox)).To(BeNil())
 			testSandbox.SetCreated()
 
 			// When
@@ -58,7 +59,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 
 		It("should skip not created sandboxes", func() {
 			// Given
-			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, testSandbox)).To(BeNil())
 			Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
 
 			// When
@@ -134,7 +135,7 @@ var _ = t.Describe("ListPodSandbox", func() {
 
 		It("should succeed with filter but when not finding id", func() {
 			// Given
-			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, testSandbox)).To(BeNil())
 
 			// When
 			response, err := sut.ListPodSandbox(context.Background(),

--- a/server/sandbox_remove_test.go
+++ b/server/sandbox_remove_test.go
@@ -9,6 +9,7 @@ import (
 
 // The actual test suite
 var _ = t.Describe("PodSandboxRemove", func() {
+	ctx := context.TODO()
 	// Prepare the sut
 	BeforeEach(func() {
 		beforeEach()
@@ -20,7 +21,7 @@ var _ = t.Describe("PodSandboxRemove", func() {
 	t.Describe("PodSandboxRemove", func() {
 		It("should fail when sandbox is not created", func() {
 			// Given
-			Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+			Expect(sut.AddSandbox(ctx, testSandbox)).To(BeNil())
 			Expect(sut.PodIDIndex().Add(testSandbox.ID())).To(BeNil())
 
 			// When

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/cri-o/cri-o/internal/hostport"
+	"github.com/cri-o/cri-o/internal/log"
 	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -101,7 +102,9 @@ func getHostname(id, hostname string, hostNetwork bool) (string, error) {
 	return hostname, nil
 }
 
-func (s *Server) setPodSandboxMountLabel(id, mountLabel string) error {
+func (s *Server) setPodSandboxMountLabel(ctx context.Context, id, mountLabel string) error {
+	_, span := log.StartSpan(ctx)
+	defer span.End()
 	storageMetadata, err := s.StorageRuntimeServer().GetContainerMetadata(id)
 	if err != nil {
 		return err

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -40,7 +40,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 					Return(storage.RuntimeContainerMetadata{}, nil),
 				runtimeServerMock.EXPECT().SetContainerMetadata(gomock.Any(),
 					gomock.Any()).Return(nil),
-				runtimeServerMock.EXPECT().DeleteContainer(gomock.Any()).
+				runtimeServerMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).
 					Return(nil),
 			)
 
@@ -115,7 +115,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any()).
 					Return(storage.ContainerInfo{}, nil),
-				runtimeServerMock.EXPECT().DeleteContainer(gomock.Any()).
+				runtimeServerMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).
 					Return(nil),
 			)
 

--- a/server/sandbox_stats.go
+++ b/server/sandbox_stats.go
@@ -3,12 +3,15 @@ package server
 import (
 	"context"
 
+	"github.com/cri-o/cri-o/internal/log"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // PodSandboxStats returns stats of the sandbox. If the sandbox does not exist, the call returns an error.
 func (s *Server) PodSandboxStats(ctx context.Context, req *types.PodSandboxStatsRequest) (*types.PodSandboxStatsResponse, error) {
-	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	sb, err := s.getPodSandboxFromRequest(ctx, req.PodSandboxId)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	json "github.com/json-iterator/go"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -14,7 +15,9 @@ import (
 
 // PodSandboxStatus returns the Status of the PodSandbox.
 func (s *Server) PodSandboxStatus(ctx context.Context, req *types.PodSandboxStatusRequest) (*types.PodSandboxStatusResponse, error) {
-	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	sb, err := s.getPodSandboxFromRequest(ctx, req.PodSandboxId)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "could not find pod %q: %v", req.PodSandboxId, err)
 	}

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -12,9 +12,11 @@ import (
 // StopPodSandbox stops the sandbox. If there are any running containers in the
 // sandbox, they should be force terminated.
 func (s *Server) StopPodSandbox(ctx context.Context, req *types.StopPodSandboxRequest) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	// platform dependent call
 	log.Infof(ctx, "Stopping pod sandbox: %s", req.PodSandboxId)
-	sb, err := s.getPodSandboxFromRequest(req.PodSandboxId)
+	sb, err := s.getPodSandboxFromRequest(ctx, req.PodSandboxId)
 	if err != nil {
 		if err == sandbox.ErrIDEmpty {
 			return err

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -14,6 +14,8 @@ import (
 )
 
 func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	stopMutex := sb.StopMutex()
 	stopMutex.Lock()
 	defer stopMutex.Unlock()
@@ -78,12 +80,12 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		return fmt.Errorf("unable to remove managed namespaces: %w", err)
 	}
 
-	if err := sb.UnmountShm(); err != nil {
+	if err := sb.UnmountShm(ctx); err != nil {
 		return err
 	}
 
 	log.Infof(ctx, "Stopped pod sandbox: %s", sb.ID())
-	sb.SetStopped(true)
+	sb.SetStopped(ctx, true)
 
 	return nil
 }

--- a/server/sandbox_stop_test.go
+++ b/server/sandbox_stop_test.go
@@ -21,10 +21,11 @@ var _ = t.Describe("PodSandboxStatus", func() {
 
 	t.Describe("PodSandboxStatus", func() {
 		It("should succeed with already stopped sandbox", func() {
+			ctx := context.TODO()
 			// Given
 			addContainerAndSandbox()
-			testSandbox.SetStopped(false)
-			Expect(testSandbox.SetNetworkStopped(false)).To(BeNil())
+			testSandbox.SetStopped(ctx, false)
+			Expect(testSandbox.SetNetworkStopped(ctx, false)).To(BeNil())
 
 			// When
 			err := sut.StopPodSandbox(context.Background(),

--- a/server/server.go
+++ b/server/server.go
@@ -520,7 +520,7 @@ func New(
 		logrus.Debug("Metrics are disabled")
 	}
 
-	if err := s.startSeccompNotifierWatcher(); err != nil {
+	if err := s.startSeccompNotifierWatcher(ctx); err != nil {
 		return nil, fmt.Errorf("start seccomp notifier watcher: %w", err)
 	}
 
@@ -684,7 +684,7 @@ func (s *Server) MonitorsCloseChan() chan struct{} {
 	return s.monitorsChan
 }
 
-func (s *Server) startSeccompNotifierWatcher() error {
+func (s *Server) startSeccompNotifierWatcher(ctx context.Context) error {
 	logrus.Info("Starting seccomp notifier watcher")
 	s.seccompNotifierChan = make(chan seccomp.Notification)
 
@@ -707,7 +707,7 @@ func (s *Server) startSeccompNotifierWatcher() error {
 				return nil
 			}
 
-			ctr, err := s.ContainerServer.GetContainerFromShortID(id)
+			ctr, err := s.ContainerServer.GetContainerFromShortID(ctx, id)
 			if err != nil {
 				logrus.Warnf("Skipping not existing seccomp notifier container ID: %s", id)
 				return nil
@@ -763,7 +763,7 @@ func (s *Server) startSeccompNotifierWatcher() error {
 			}
 			notifier.AddSyscall(syscall)
 
-			ctr := s.ContainerServer.GetContainer(id)
+			ctr := s.ContainerServer.GetContainer(ctx, id)
 			usedSyscalls := notifier.UsedSyscalls()
 
 			if notifier.StopContainers() {

--- a/server/server.go
+++ b/server/server.go
@@ -169,6 +169,8 @@ func (s *Server) getPortForward(req *types.PortForwardRequest) (*types.PortForwa
 // For every container it fails to restore, it returns that containers image, so that
 // it can be cleaned up (if we're using internal_wipe).
 func (s *Server) restore(ctx context.Context) []string {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	containersAndTheirImages := map[string]string{}
 	containers, err := s.Store().Containers()
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -211,7 +213,7 @@ func (s *Server) restore(ctx context.Context) []string {
 			}
 			// Release the infra container name and the pod name for future use
 			if strings.Contains(n, oci.InfraContainerName) {
-				s.ReleaseContainerName(n)
+				s.ReleaseContainerName(ctx, n)
 			} else {
 				s.ReleasePodName(n)
 			}
@@ -227,7 +229,7 @@ func (s *Server) restore(ctx context.Context) []string {
 					log.Warnf(ctx, "Unable to delete container %s: %v", n, err)
 				}
 				// Release the container name for future use
-				s.ReleaseContainerName(n)
+				s.ReleaseContainerName(ctx, n)
 			}
 			// Remove the container from the list of podContainers, or else we'll retry the delete later,
 			// causing a useless debug message.
@@ -254,7 +256,7 @@ func (s *Server) restore(ctx context.Context) []string {
 				log.Warnf(ctx, "Unable to delete container %s: %v", n, err)
 			}
 			// Release the container name
-			s.ReleaseContainerName(n)
+			s.ReleaseContainerName(ctx, n)
 		}
 	}
 
@@ -282,7 +284,7 @@ func (s *Server) restore(ctx context.Context) []string {
 
 	// Restore sandbox IPs
 	for _, sb := range s.ListSandboxes() {
-		ips, err := s.getSandboxIPs(sb)
+		ips, err := s.getSandboxIPs(ctx, sb)
 		if err != nil {
 			log.Warnf(ctx, "Could not restore sandbox IP for %v: %v", sb.ID(), err)
 			continue
@@ -540,6 +542,8 @@ func useDefaultUmask() {
 // indicates an upgrade has happened, it attempts to wipe that list of images.
 // This attempt is best-effort.
 func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []string) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if !s.config.InternalWipe {
 		return
 	}
@@ -600,39 +604,57 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []string)
 	}
 }
 
-func (s *Server) addSandbox(sb *sandbox.Sandbox) error {
-	return s.ContainerServer.AddSandbox(sb)
+func (s *Server) addSandbox(ctx context.Context, sb *sandbox.Sandbox) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	return s.ContainerServer.AddSandbox(ctx, sb)
 }
 
-func (s *Server) getSandbox(id string) *sandbox.Sandbox {
+func (s *Server) getSandbox(ctx context.Context, id string) *sandbox.Sandbox {
+	_, span := log.StartSpan(ctx)
+	defer span.End()
 	return s.ContainerServer.GetSandbox(id)
 }
 
-func (s *Server) removeSandbox(id string) error {
-	return s.ContainerServer.RemoveSandbox(id)
+func (s *Server) removeSandbox(ctx context.Context, id string) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	return s.ContainerServer.RemoveSandbox(ctx, id)
 }
 
-func (s *Server) addContainer(c *oci.Container) {
-	s.ContainerServer.AddContainer(c)
+func (s *Server) addContainer(ctx context.Context, c *oci.Container) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	s.ContainerServer.AddContainer(ctx, c)
 }
 
-func (s *Server) addInfraContainer(c *oci.Container) {
-	s.ContainerServer.AddInfraContainer(c)
+func (s *Server) addInfraContainer(ctx context.Context, c *oci.Container) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	s.ContainerServer.AddInfraContainer(ctx, c)
 }
 
-func (s *Server) getInfraContainer(id string) *oci.Container {
-	return s.ContainerServer.GetInfraContainer(id)
+func (s *Server) getInfraContainer(ctx context.Context, id string) *oci.Container {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	return s.ContainerServer.GetInfraContainer(ctx, id)
 }
 
-func (s *Server) removeContainer(c *oci.Container) {
-	s.ContainerServer.RemoveContainer(c)
+func (s *Server) removeContainer(ctx context.Context, c *oci.Container) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	s.ContainerServer.RemoveContainer(ctx, c)
 }
 
-func (s *Server) removeInfraContainer(c *oci.Container) {
-	s.ContainerServer.RemoveInfraContainer(c)
+func (s *Server) removeInfraContainer(ctx context.Context, c *oci.Container) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	s.ContainerServer.RemoveInfraContainer(ctx, c)
 }
 
-func (s *Server) getPodSandboxFromRequest(podSandboxID string) (*sandbox.Sandbox, error) {
+func (s *Server) getPodSandboxFromRequest(ctx context.Context, podSandboxID string) (*sandbox.Sandbox, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	if podSandboxID == "" {
 		return nil, sandbox.ErrIDEmpty
 	}
@@ -642,7 +664,7 @@ func (s *Server) getPodSandboxFromRequest(podSandboxID string) (*sandbox.Sandbox
 		return nil, fmt.Errorf("PodSandbox with ID starting with %s not found: %w", podSandboxID, err)
 	}
 
-	sb := s.getSandbox(sandboxID)
+	sb := s.getSandbox(ctx, sandboxID)
 	if sb == nil {
 		return nil, fmt.Errorf("specified pod sandbox not found: %s", sandboxID)
 	}
@@ -803,13 +825,15 @@ func (s *Server) monitorExits(ctx context.Context, watcher *fsnotify.Watcher, do
 }
 
 func (s *Server) handleExit(ctx context.Context, event fsnotify.Event) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
 	log.Debugf(ctx, "Event: %v", event)
 	if event.Op&fsnotify.Create != fsnotify.Create {
 		return
 	}
 	containerID := filepath.Base(event.Name)
 	log.Debugf(ctx, "Container or sandbox exited: %v", containerID)
-	c := s.GetContainer(containerID)
+	c := s.GetContainer(ctx, containerID)
 	resource := "container"
 	if c == nil {
 		sb := s.GetSandbox(containerID)

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -207,9 +207,10 @@ func mockNewServer() {
 }
 
 func addContainerAndSandbox() {
-	Expect(sut.AddSandbox(testSandbox)).To(BeNil())
+	ctx := context.TODO()
+	Expect(sut.AddSandbox(ctx, testSandbox)).To(BeNil())
 	Expect(testSandbox.SetInfraContainer(testContainer)).To(BeNil())
-	sut.AddContainer(testContainer)
+	sut.AddContainer(ctx, testContainer)
 	Expect(sut.CtrIDIndex().Add(testContainer.ID())).To(BeNil())
 	Expect(sut.PodIDIndex().Add(testSandbox.ID())).To(BeNil())
 	testContainer.SetCreated()

--- a/server/utils.go
+++ b/server/utils.go
@@ -155,6 +155,9 @@ func (s *Server) getResourceOrWait(ctx context.Context, name, resourceType strin
 	// This is really to catch an unlikely case where the kubelet doesn't cancel the context.
 	// Adding on top of the specified deadline ensures this deadline will be respected, regardless of
 	// how Kubelet's runtime-request-timeout changes.
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
 	resourceCreationWaitTime := time.Minute * 4
 	if initialDeadline, ok := ctx.Deadline(); ok {
 		resourceCreationWaitTime += time.Until(initialDeadline)

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -5,6 +5,7 @@
 package criostoragemock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	types "github.com/containers/image/v5/types"
@@ -194,17 +195,17 @@ func (mr *MockRuntimeServerMockRecorder) CreatePodSandbox(arg0, arg1, arg2, arg3
 }
 
 // DeleteContainer mocks base method.
-func (m *MockRuntimeServer) DeleteContainer(arg0 string) error {
+func (m *MockRuntimeServer) DeleteContainer(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteContainer", arg0)
+	ret := m.ctrl.Call(m, "DeleteContainer", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteContainer indicates an expected call of DeleteContainer.
-func (mr *MockRuntimeServerMockRecorder) DeleteContainer(arg0 interface{}) *gomock.Call {
+func (mr *MockRuntimeServerMockRecorder) DeleteContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContainer", reflect.TypeOf((*MockRuntimeServer)(nil).DeleteContainer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContainer", reflect.TypeOf((*MockRuntimeServer)(nil).DeleteContainer), arg0, arg1)
 }
 
 // GetContainerMetadata mocks base method.
@@ -282,15 +283,15 @@ func (mr *MockRuntimeServerMockRecorder) StartContainer(arg0 interface{}) *gomoc
 }
 
 // StopContainer mocks base method.
-func (m *MockRuntimeServer) StopContainer(arg0 string) error {
+func (m *MockRuntimeServer) StopContainer(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StopContainer", arg0)
+	ret := m.ctrl.Call(m, "StopContainer", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StopContainer indicates an expected call of StopContainer.
-func (mr *MockRuntimeServerMockRecorder) StopContainer(arg0 interface{}) *gomock.Call {
+func (mr *MockRuntimeServerMockRecorder) StopContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainer", reflect.TypeOf((*MockRuntimeServer)(nil).StopContainer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainer", reflect.TypeOf((*MockRuntimeServer)(nil).StopContainer), arg0, arg1)
 }

--- a/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/LICENSE
+++ b/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2020 github.com/uptrace/opentelemetry-go-extra Contributors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/README.md
+++ b/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/README.md
@@ -1,0 +1,50 @@
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/uptrace/opentelemetry-go-extra/otellogrus)](https://pkg.go.dev/github.com/uptrace/opentelemetry-go-extra/otellogrus)
+
+# OpenTelemetry Go instrumentation for logrus logging
+
+This instrumentation records logrus log messages as events on the existing span that is passed via a
+`context.Context`. It does not record anything if a context does not contain a span.
+
+## Installation
+
+```shell
+go get github.com/uptrace/opentelemetry-go-extra/otellogrus
+```
+
+## Usage
+
+You need to install an `otellogrus.Hook` and use `logrus.WithContext` to propagate the active span.
+
+```go
+import (
+    "github.com/uptrace/opentelemetry-go-extra/otellogrus"
+    "github.com/sirupsen/logrus"
+)
+
+// Instrument logrus.
+logrus.AddHook(otellogrus.NewHook(otellogrus.WithLevels(
+	logrus.PanicLevel,
+	logrus.FatalLevel,
+	logrus.ErrorLevel,
+	logrus.WarnLevel,
+)))
+
+// Use ctx to pass the active span.
+logrus.WithContext(ctx).
+	WithError(errors.New("hello world")).
+	WithField("foo", "bar").
+	Error("something failed")
+```
+
+See [example](/example/) for details.
+
+## Options
+
+[otellogrus.NewHook](https://pkg.go.dev/github.com/uptrace/opentelemetry-go-extra/otellogrus#NewHook)
+accepts the following
+[options](https://pkg.go.dev/github.com/uptrace/opentelemetry-go-extra/otellogrus#Option):
+
+- `otellogrus.WithLevels(logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel)`
+  sets the logrus logging levels on which the hook is fired.
+- `WithErrorStatusLevel(logrus.ErrorLevel)` sets the minimal logrus logging level on which the span
+  status is set to codes.Error.

--- a/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/option.go
+++ b/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/option.go
@@ -1,0 +1,25 @@
+package otellogrus
+
+import "github.com/sirupsen/logrus"
+
+// Option applies a configuration to the given config.
+type Option func(h *Hook)
+
+// WithLevels sets the logrus logging levels on which the hook is fired.
+//
+// The default is all levels between logrus.PanicLevel and logrus.WarnLevel inclusive.
+func WithLevels(levels ...logrus.Level) Option {
+	return func(h *Hook) {
+		h.levels = levels
+	}
+}
+
+// WithErrorStatusLevel sets the minimal logrus logging level on which
+// the span status is set to codes.Error.
+//
+// The default is <= logrus.ErrorLevel.
+func WithErrorStatusLevel(level logrus.Level) Option {
+	return func(h *Hook) {
+		h.errorStatusLevel = level
+	}
+}

--- a/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/otellogrus.go
+++ b/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/otellogrus.go
@@ -1,0 +1,109 @@
+package otellogrus
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/uptrace/opentelemetry-go-extra/otelutil"
+)
+
+var (
+	logSeverityKey = attribute.Key("log.severity")
+	logMessageKey  = attribute.Key("log.message")
+)
+
+// Hook is a logrus hook that adds logs to the active span as events.
+type Hook struct {
+	levels           []logrus.Level
+	errorStatusLevel logrus.Level
+}
+
+var _ logrus.Hook = (*Hook)(nil)
+
+// NewHook returns a logrus hook.
+func NewHook(opts ...Option) *Hook {
+	hook := &Hook{
+		levels: []logrus.Level{
+			logrus.PanicLevel,
+			logrus.FatalLevel,
+			logrus.ErrorLevel,
+			logrus.WarnLevel,
+		},
+		errorStatusLevel: logrus.ErrorLevel,
+	}
+
+	for _, fn := range opts {
+		fn(hook)
+	}
+
+	return hook
+}
+
+// Fire is a logrus hook that is fired on a new log entry.
+func (hook *Hook) Fire(entry *logrus.Entry) error {
+	ctx := entry.Context
+	if ctx == nil {
+		return nil
+	}
+
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return nil
+	}
+
+	attrs := make([]attribute.KeyValue, 0, len(entry.Data)+2+3)
+
+	attrs = append(attrs, logSeverityKey.String(levelString(entry.Level)))
+	attrs = append(attrs, logMessageKey.String(entry.Message))
+
+	if entry.Caller != nil {
+		if entry.Caller.Function != "" {
+			attrs = append(attrs, semconv.CodeFunctionKey.String(entry.Caller.Function))
+		}
+		if entry.Caller.File != "" {
+			attrs = append(attrs, semconv.CodeFilepathKey.String(entry.Caller.File))
+			attrs = append(attrs, semconv.CodeLineNumberKey.Int(entry.Caller.Line))
+		}
+	}
+
+	for k, v := range entry.Data {
+		if k == "error" {
+			if err, ok := v.(error); ok {
+				typ := reflect.TypeOf(err).String()
+				attrs = append(attrs, semconv.ExceptionTypeKey.String(typ))
+				attrs = append(attrs, semconv.ExceptionMessageKey.String(err.Error()))
+				continue
+			}
+		}
+
+		attrs = append(attrs, otelutil.Attribute(k, v))
+	}
+
+	span.AddEvent("log", trace.WithAttributes(attrs...))
+
+	if entry.Level <= hook.errorStatusLevel {
+		span.SetStatus(codes.Error, entry.Message)
+	}
+
+	return nil
+}
+
+// Levels returns logrus levels on which this hook is fired.
+func (hook *Hook) Levels() []logrus.Level {
+	return hook.levels
+}
+
+func levelString(lvl logrus.Level) string {
+	s := lvl.String()
+	if s == "warning" {
+		s = "warn"
+	}
+	return strings.ToUpper(s)
+}

--- a/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/version.go
+++ b/vendor/github.com/uptrace/opentelemetry-go-extra/otellogrus/version.go
@@ -1,0 +1,6 @@
+package otellogrus
+
+// Version is the current release version.
+func Version() string {
+	return "0.1.17"
+}

--- a/vendor/github.com/uptrace/opentelemetry-go-extra/otelutil/LICENSE
+++ b/vendor/github.com/uptrace/opentelemetry-go-extra/otelutil/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2020 github.com/uptrace/opentelemetry-go-extra Contributors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/uptrace/opentelemetry-go-extra/otelutil/attribute.go
+++ b/vendor/github.com/uptrace/opentelemetry-go-extra/otelutil/attribute.go
@@ -1,0 +1,65 @@
+package otelutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func Attribute(key string, value interface{}) attribute.KeyValue {
+	switch value := value.(type) {
+	case nil:
+		return attribute.String(key, "<nil>")
+	case string:
+		return attribute.String(key, value)
+	case int:
+		return attribute.Int(key, value)
+	case int64:
+		return attribute.Int64(key, value)
+	case uint64:
+		return attribute.Int64(key, int64(value))
+	case float64:
+		return attribute.Float64(key, value)
+	case bool:
+		return attribute.Bool(key, value)
+	case fmt.Stringer:
+		return attribute.String(key, value.String())
+	}
+
+	rv := reflect.ValueOf(value)
+
+	switch rv.Kind() {
+	case reflect.Array:
+		rv = rv.Slice(0, rv.Len())
+		fallthrough
+	case reflect.Slice:
+		switch reflect.TypeOf(value).Elem().Kind() {
+		case reflect.Bool:
+			return attribute.BoolSlice(key, rv.Interface().([]bool))
+		case reflect.Int:
+			return attribute.IntSlice(key, rv.Interface().([]int))
+		case reflect.Int64:
+			return attribute.Int64Slice(key, rv.Interface().([]int64))
+		case reflect.Float64:
+			return attribute.Float64Slice(key, rv.Interface().([]float64))
+		case reflect.String:
+			return attribute.StringSlice(key, rv.Interface().([]string))
+		default:
+			return attribute.KeyValue{Key: attribute.Key(key)}
+		}
+	case reflect.Bool:
+		return attribute.Bool(key, rv.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return attribute.Int64(key, rv.Int())
+	case reflect.Float64:
+		return attribute.Float64(key, rv.Float())
+	case reflect.String:
+		return attribute.String(key, rv.String())
+	}
+	if b, err := json.Marshal(value); b != nil && err == nil {
+		return attribute.String(key, string(b))
+	}
+	return attribute.String(key, fmt.Sprint(value))
+}

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/doc.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/doc.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package semconv implements OpenTelemetry semantic conventions.
+//
+// OpenTelemetry semantic conventions are agreed standardized naming
+// patterns for OpenTelemetry things. This package represents the conventions
+// as of the v1.10.0 version of the OpenTelemetry specification.
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.10.0"

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/exception.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/exception.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.10.0"
+
+const (
+	// ExceptionEventName is the name of the Span event representing an exception.
+	ExceptionEventName = "exception"
+)

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/http.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/http.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.10.0"
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/semconv/internal"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// HTTP scheme attributes.
+var (
+	HTTPSchemeHTTP  = HTTPSchemeKey.String("http")
+	HTTPSchemeHTTPS = HTTPSchemeKey.String("https")
+)
+
+var sc = &internal.SemanticConventions{
+	EnduserIDKey:                EnduserIDKey,
+	HTTPClientIPKey:             HTTPClientIPKey,
+	HTTPFlavorKey:               HTTPFlavorKey,
+	HTTPHostKey:                 HTTPHostKey,
+	HTTPMethodKey:               HTTPMethodKey,
+	HTTPRequestContentLengthKey: HTTPRequestContentLengthKey,
+	HTTPRouteKey:                HTTPRouteKey,
+	HTTPSchemeHTTP:              HTTPSchemeHTTP,
+	HTTPSchemeHTTPS:             HTTPSchemeHTTPS,
+	HTTPServerNameKey:           HTTPServerNameKey,
+	HTTPStatusCodeKey:           HTTPStatusCodeKey,
+	HTTPTargetKey:               HTTPTargetKey,
+	HTTPURLKey:                  HTTPURLKey,
+	HTTPUserAgentKey:            HTTPUserAgentKey,
+	NetHostIPKey:                NetHostIPKey,
+	NetHostNameKey:              NetHostNameKey,
+	NetHostPortKey:              NetHostPortKey,
+	NetPeerIPKey:                NetPeerIPKey,
+	NetPeerNameKey:              NetPeerNameKey,
+	NetPeerPortKey:              NetPeerPortKey,
+	NetTransportIP:              NetTransportIP,
+	NetTransportOther:           NetTransportOther,
+	NetTransportTCP:             NetTransportTCP,
+	NetTransportUDP:             NetTransportUDP,
+	NetTransportUnix:            NetTransportUnix,
+}
+
+// NetAttributesFromHTTPRequest generates attributes of the net
+// namespace as specified by the OpenTelemetry specification for a
+// span.  The network parameter is a string that net.Dial function
+// from standard library can understand.
+func NetAttributesFromHTTPRequest(network string, request *http.Request) []attribute.KeyValue {
+	return sc.NetAttributesFromHTTPRequest(network, request)
+}
+
+// EndUserAttributesFromHTTPRequest generates attributes of the
+// enduser namespace as specified by the OpenTelemetry specification
+// for a span.
+func EndUserAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
+	return sc.EndUserAttributesFromHTTPRequest(request)
+}
+
+// HTTPClientAttributesFromHTTPRequest generates attributes of the
+// http namespace as specified by the OpenTelemetry specification for
+// a span on the client side.
+func HTTPClientAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
+	return sc.HTTPClientAttributesFromHTTPRequest(request)
+}
+
+// HTTPServerMetricAttributesFromHTTPRequest generates low-cardinality attributes
+// to be used with server-side HTTP metrics.
+func HTTPServerMetricAttributesFromHTTPRequest(serverName string, request *http.Request) []attribute.KeyValue {
+	return sc.HTTPServerMetricAttributesFromHTTPRequest(serverName, request)
+}
+
+// HTTPServerAttributesFromHTTPRequest generates attributes of the
+// http namespace as specified by the OpenTelemetry specification for
+// a span on the server side. Currently, only basic authentication is
+// supported.
+func HTTPServerAttributesFromHTTPRequest(serverName, route string, request *http.Request) []attribute.KeyValue {
+	return sc.HTTPServerAttributesFromHTTPRequest(serverName, route, request)
+}
+
+// HTTPAttributesFromHTTPStatusCode generates attributes of the http
+// namespace as specified by the OpenTelemetry specification for a
+// span.
+func HTTPAttributesFromHTTPStatusCode(code int) []attribute.KeyValue {
+	return sc.HTTPAttributesFromHTTPStatusCode(code)
+}
+
+// SpanStatusFromHTTPStatusCode generates a status code and a message
+// as specified by the OpenTelemetry specification for a span.
+func SpanStatusFromHTTPStatusCode(code int) (codes.Code, string) {
+	return internal.SpanStatusFromHTTPStatusCode(code)
+}
+
+// SpanStatusFromHTTPStatusCodeAndSpanKind generates a status code and a message
+// as specified by the OpenTelemetry specification for a span.
+// Exclude 4xx for SERVER to set the appropriate status.
+func SpanStatusFromHTTPStatusCodeAndSpanKind(code int, spanKind trace.SpanKind) (codes.Code, string) {
+	return internal.SpanStatusFromHTTPStatusCodeAndSpanKind(code, spanKind)
+}

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/resource.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/resource.go
@@ -1,0 +1,981 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.10.0"
+
+import "go.opentelemetry.io/otel/attribute"
+
+// A cloud environment (e.g. GCP, Azure, AWS)
+const (
+	// Name of the cloud provider.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	CloudProviderKey = attribute.Key("cloud.provider")
+	// The cloud account ID the resource is assigned to.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '111111111111', 'opentelemetry'
+	CloudAccountIDKey = attribute.Key("cloud.account.id")
+	// The geographical region the resource is running.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-central1', 'us-east-1'
+	// Note: Refer to your provider's docs to see the available regions, for example
+	// [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-
+	// detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-
+	// infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-
+	// us/global-infrastructure/geographies/), [Google Cloud
+	// regions](https://cloud.google.com/about/locations), or [Tencent Cloud
+	// regions](https://intl.cloud.tencent.com/document/product/213/6091).
+	CloudRegionKey = attribute.Key("cloud.region")
+	// Cloud regions often have multiple, isolated locations known as zones to
+	// increase availability. Availability zone represents the zone where the resource
+	// is running.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-east-1c'
+	// Note: Availability zones are called "zones" on Alibaba Cloud and Google Cloud.
+	CloudAvailabilityZoneKey = attribute.Key("cloud.availability_zone")
+	// The cloud platform in use.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: The prefix of the service SHOULD match the one specified in
+	// `cloud.provider`.
+	CloudPlatformKey = attribute.Key("cloud.platform")
+)
+
+var (
+	// Alibaba Cloud
+	CloudProviderAlibabaCloud = CloudProviderKey.String("alibaba_cloud")
+	// Amazon Web Services
+	CloudProviderAWS = CloudProviderKey.String("aws")
+	// Microsoft Azure
+	CloudProviderAzure = CloudProviderKey.String("azure")
+	// Google Cloud Platform
+	CloudProviderGCP = CloudProviderKey.String("gcp")
+	// Tencent Cloud
+	CloudProviderTencentCloud = CloudProviderKey.String("tencent_cloud")
+)
+
+var (
+	// Alibaba Cloud Elastic Compute Service
+	CloudPlatformAlibabaCloudECS = CloudPlatformKey.String("alibaba_cloud_ecs")
+	// Alibaba Cloud Function Compute
+	CloudPlatformAlibabaCloudFc = CloudPlatformKey.String("alibaba_cloud_fc")
+	// AWS Elastic Compute Cloud
+	CloudPlatformAWSEC2 = CloudPlatformKey.String("aws_ec2")
+	// AWS Elastic Container Service
+	CloudPlatformAWSECS = CloudPlatformKey.String("aws_ecs")
+	// AWS Elastic Kubernetes Service
+	CloudPlatformAWSEKS = CloudPlatformKey.String("aws_eks")
+	// AWS Lambda
+	CloudPlatformAWSLambda = CloudPlatformKey.String("aws_lambda")
+	// AWS Elastic Beanstalk
+	CloudPlatformAWSElasticBeanstalk = CloudPlatformKey.String("aws_elastic_beanstalk")
+	// AWS App Runner
+	CloudPlatformAWSAppRunner = CloudPlatformKey.String("aws_app_runner")
+	// Azure Virtual Machines
+	CloudPlatformAzureVM = CloudPlatformKey.String("azure_vm")
+	// Azure Container Instances
+	CloudPlatformAzureContainerInstances = CloudPlatformKey.String("azure_container_instances")
+	// Azure Kubernetes Service
+	CloudPlatformAzureAKS = CloudPlatformKey.String("azure_aks")
+	// Azure Functions
+	CloudPlatformAzureFunctions = CloudPlatformKey.String("azure_functions")
+	// Azure App Service
+	CloudPlatformAzureAppService = CloudPlatformKey.String("azure_app_service")
+	// Google Cloud Compute Engine (GCE)
+	CloudPlatformGCPComputeEngine = CloudPlatformKey.String("gcp_compute_engine")
+	// Google Cloud Run
+	CloudPlatformGCPCloudRun = CloudPlatformKey.String("gcp_cloud_run")
+	// Google Cloud Kubernetes Engine (GKE)
+	CloudPlatformGCPKubernetesEngine = CloudPlatformKey.String("gcp_kubernetes_engine")
+	// Google Cloud Functions (GCF)
+	CloudPlatformGCPCloudFunctions = CloudPlatformKey.String("gcp_cloud_functions")
+	// Google Cloud App Engine (GAE)
+	CloudPlatformGCPAppEngine = CloudPlatformKey.String("gcp_app_engine")
+	// Tencent Cloud Cloud Virtual Machine (CVM)
+	CloudPlatformTencentCloudCvm = CloudPlatformKey.String("tencent_cloud_cvm")
+	// Tencent Cloud Elastic Kubernetes Service (EKS)
+	CloudPlatformTencentCloudEKS = CloudPlatformKey.String("tencent_cloud_eks")
+	// Tencent Cloud Serverless Cloud Function (SCF)
+	CloudPlatformTencentCloudScf = CloudPlatformKey.String("tencent_cloud_scf")
+)
+
+// Resources used by AWS Elastic Container Service (ECS).
+const (
+	// The Amazon Resource Name (ARN) of an [ECS container instance](https://docs.aws.
+	// amazon.com/AmazonECS/latest/developerguide/ECS_instances.html).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9'
+	AWSECSContainerARNKey = attribute.Key("aws.ecs.container.arn")
+	// The ARN of an [ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/develo
+	// perguide/clusters.html).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AWSECSClusterARNKey = attribute.Key("aws.ecs.cluster.arn")
+	// The [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/l
+	// aunch_types.html) for an ECS task.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AWSECSLaunchtypeKey = attribute.Key("aws.ecs.launchtype")
+	// The ARN of an [ECS task definition](https://docs.aws.amazon.com/AmazonECS/lates
+	// t/developerguide/task_definitions.html).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AWSECSTaskARNKey = attribute.Key("aws.ecs.task.arn")
+	// The task definition family this task definition is a member of.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-family'
+	AWSECSTaskFamilyKey = attribute.Key("aws.ecs.task.family")
+	// The revision for this task definition.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '8', '26'
+	AWSECSTaskRevisionKey = attribute.Key("aws.ecs.task.revision")
+)
+
+var (
+	// ec2
+	AWSECSLaunchtypeEC2 = AWSECSLaunchtypeKey.String("ec2")
+	// fargate
+	AWSECSLaunchtypeFargate = AWSECSLaunchtypeKey.String("fargate")
+)
+
+// Resources used by AWS Elastic Kubernetes Service (EKS).
+const (
+	// The ARN of an EKS cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AWSEKSClusterARNKey = attribute.Key("aws.eks.cluster.arn")
+)
+
+// Resources specific to Amazon Web Services.
+const (
+	// The name(s) of the AWS log group(s) an application is writing to.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '/aws/lambda/my-function', 'opentelemetry-service'
+	// Note: Multiple log groups must be supported for cases like multi-container
+	// applications, where a single application has sidecar containers, and each write
+	// to their own log group.
+	AWSLogGroupNamesKey = attribute.Key("aws.log.group.names")
+	// The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*'
+	// Note: See the [log group ARN format
+	// documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-
+	// access-control-overview-cwl.html#CWL_ARN_Format).
+	AWSLogGroupARNsKey = attribute.Key("aws.log.group.arns")
+	// The name(s) of the AWS log stream(s) an application is writing to.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AWSLogStreamNamesKey = attribute.Key("aws.log.stream.names")
+	// The ARN(s) of the AWS log stream(s).
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-
+	// stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	// Note: See the [log stream ARN format
+	// documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-
+	// access-control-overview-cwl.html#CWL_ARN_Format). One log group can contain
+	// several log streams, so these ARNs necessarily identify both a log group and a
+	// log stream.
+	AWSLogStreamARNsKey = attribute.Key("aws.log.stream.arns")
+)
+
+// A container instance.
+const (
+	// Container name used by container runtime.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-autoconf'
+	ContainerNameKey = attribute.Key("container.name")
+	// Container ID. Usually a UUID, as for example used to [identify Docker
+	// containers](https://docs.docker.com/engine/reference/run/#container-
+	// identification). The UUID might be abbreviated.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'a3bf90e006b2'
+	ContainerIDKey = attribute.Key("container.id")
+	// The container runtime managing this container.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'docker', 'containerd', 'rkt'
+	ContainerRuntimeKey = attribute.Key("container.runtime")
+	// Name of the image the container was built on.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'gcr.io/opentelemetry/operator'
+	ContainerImageNameKey = attribute.Key("container.image.name")
+	// Container image tag.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.1'
+	ContainerImageTagKey = attribute.Key("container.image.tag")
+)
+
+// The software deployment.
+const (
+	// Name of the [deployment
+	// environment](https://en.wikipedia.org/wiki/Deployment_environment) (aka
+	// deployment tier).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'staging', 'production'
+	DeploymentEnvironmentKey = attribute.Key("deployment.environment")
+)
+
+// The device on which the process represented by this resource is running.
+const (
+	// A unique identifier representing the device
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2ab2916d-a51f-4ac8-80ee-45ac31a28092'
+	// Note: The device identifier MUST only be defined using the values outlined
+	// below. This value is not an advertising identifier and MUST NOT be used as
+	// such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor id
+	// entifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-iden
+	// tifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the
+	// Firebase Installation ID or a globally unique UUID which is persisted across
+	// sessions in your application. More information can be found
+	// [here](https://developer.android.com/training/articles/user-data-ids) on best
+	// practices and exact implementation details. Caution should be taken when
+	// storing personal data or anything which can identify a user. GDPR and data
+	// protection laws may apply, ensure you do your own due diligence.
+	DeviceIDKey = attribute.Key("device.id")
+	// The model identifier for the device
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iPhone3,4', 'SM-G920F'
+	// Note: It's recommended this value represents a machine readable version of the
+	// model identifier rather than the market or consumer-friendly name of the
+	// device.
+	DeviceModelIdentifierKey = attribute.Key("device.model.identifier")
+	// The marketing name for the device model
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iPhone 6s Plus', 'Samsung Galaxy S6'
+	// Note: It's recommended this value represents a human readable version of the
+	// device model rather than a machine readable alternative.
+	DeviceModelNameKey = attribute.Key("device.model.name")
+	// The name of the device manufacturer
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Apple', 'Samsung'
+	// Note: The Android OS provides this field via
+	// [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER).
+	// iOS apps SHOULD hardcode the value `Apple`.
+	DeviceManufacturerKey = attribute.Key("device.manufacturer")
+)
+
+// A serverless instance.
+const (
+	// The name of the single function that this runtime instance executes.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'my-function'
+	// Note: This is the name of the function as configured/deployed on the FaaS
+	// platform and is usually different from the name of the callback function (which
+	// may be stored in the
+	// [`code.namespace`/`code.function`](../../trace/semantic_conventions/span-
+	// general.md#source-code-attributes) span attributes).
+	FaaSNameKey = attribute.Key("faas.name")
+	// The unique ID of the single function that this runtime instance executes.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:lambda:us-west-2:123456789012:function:my-function'
+	// Note: Depending on the cloud provider, use:
+
+	// * **AWS Lambda:** The function
+	// [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-
+	// namespaces.html).
+	// Take care not to use the "invoked ARN" directly but replace any
+	// [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-
+	// aliases.html) with the resolved function version, as the same runtime instance
+	// may be invokable with multiple
+	// different aliases.
+	// * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-
+	// resource-names)
+	// * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-
+	// us/rest/api/resources/resources/get-by-id).
+
+	// On some providers, it may not be possible to determine the full ID at startup,
+	// which is why this field cannot be made required. For example, on AWS the
+	// account ID
+	// part of the ARN is not available without calling another AWS API
+	// which may be deemed too slow for a short-running lambda function.
+	// As an alternative, consider setting `faas.id` as a span attribute instead.
+	FaaSIDKey = attribute.Key("faas.id")
+	// The immutable version of the function being executed.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '26', 'pinkfroid-00002'
+	// Note: Depending on the cloud provider and platform, use:
+
+	// * **AWS Lambda:** The [function
+	// version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-
+	// versions.html)
+	//   (an integer represented as a decimal string).
+	// * **Google Cloud Run:** The
+	// [revision](https://cloud.google.com/run/docs/managing/revisions)
+	//   (i.e., the function name plus the revision suffix).
+	// * **Google Cloud Functions:** The value of the
+	//   [`K_REVISION` environment
+	// variable](https://cloud.google.com/functions/docs/env-
+	// var#runtime_environment_variables_set_automatically).
+	// * **Azure Functions:** Not applicable. Do not set this attribute.
+	FaaSVersionKey = attribute.Key("faas.version")
+	// The execution environment ID as a string, that will be potentially reused for
+	// other invocations to the same function/function version.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de'
+	// Note: * **AWS Lambda:** Use the (full) log stream name.
+	FaaSInstanceKey = attribute.Key("faas.instance")
+	// The amount of memory available to the serverless function in MiB.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 128
+	// Note: It's recommended to set this attribute since e.g. too little memory can
+	// easily stop a Java AWS Lambda function from working correctly. On AWS Lambda,
+	// the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this
+	// information.
+	FaaSMaxMemoryKey = attribute.Key("faas.max_memory")
+)
+
+// A host is defined as a general computing instance.
+const (
+	// Unique host ID. For Cloud, this must be the instance_id assigned by the cloud
+	// provider.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-test'
+	HostIDKey = attribute.Key("host.id")
+	// Name of the host. On Unix systems, it may contain what the hostname command
+	// returns, or the fully qualified hostname, or another name specified by the
+	// user.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-test'
+	HostNameKey = attribute.Key("host.name")
+	// Type of host. For Cloud, this must be the machine type.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'n1-standard-1'
+	HostTypeKey = attribute.Key("host.type")
+	// The CPU architecture the host system is running on.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	HostArchKey = attribute.Key("host.arch")
+	// Name of the VM image or OS install the host was instantiated from.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'infra-ami-eks-worker-node-7d4ec78312', 'CentOS-8-x86_64-1905'
+	HostImageNameKey = attribute.Key("host.image.name")
+	// VM image ID. For Cloud, this value is from the provider.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'ami-07b06b442921831e5'
+	HostImageIDKey = attribute.Key("host.image.id")
+	// The version string of the VM image as defined in [Version
+	// Attributes](README.md#version-attributes).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.1'
+	HostImageVersionKey = attribute.Key("host.image.version")
+)
+
+var (
+	// AMD64
+	HostArchAMD64 = HostArchKey.String("amd64")
+	// ARM32
+	HostArchARM32 = HostArchKey.String("arm32")
+	// ARM64
+	HostArchARM64 = HostArchKey.String("arm64")
+	// Itanium
+	HostArchIA64 = HostArchKey.String("ia64")
+	// 32-bit PowerPC
+	HostArchPPC32 = HostArchKey.String("ppc32")
+	// 64-bit PowerPC
+	HostArchPPC64 = HostArchKey.String("ppc64")
+	// IBM z/Architecture
+	HostArchS390x = HostArchKey.String("s390x")
+	// 32-bit x86
+	HostArchX86 = HostArchKey.String("x86")
+)
+
+// A Kubernetes Cluster.
+const (
+	// The name of the cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-cluster'
+	K8SClusterNameKey = attribute.Key("k8s.cluster.name")
+)
+
+// A Kubernetes Node object.
+const (
+	// The name of the Node.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'node-1'
+	K8SNodeNameKey = attribute.Key("k8s.node.name")
+	// The UID of the Node.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2'
+	K8SNodeUIDKey = attribute.Key("k8s.node.uid")
+)
+
+// A Kubernetes Namespace.
+const (
+	// The name of the namespace that the pod is running in.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'default'
+	K8SNamespaceNameKey = attribute.Key("k8s.namespace.name")
+)
+
+// A Kubernetes Pod object.
+const (
+	// The UID of the Pod.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SPodUIDKey = attribute.Key("k8s.pod.uid")
+	// The name of the Pod.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-pod-autoconf'
+	K8SPodNameKey = attribute.Key("k8s.pod.name")
+)
+
+// A container in a [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
+const (
+	// The name of the Container from Pod specification, must be unique within a Pod.
+	// Container runtime usually uses different globally unique name
+	// (`container.name`).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'redis'
+	K8SContainerNameKey = attribute.Key("k8s.container.name")
+	// Number of times the container was restarted. This attribute can be used to
+	// identify a particular container (running or stopped) within a container spec.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 0, 2
+	K8SContainerRestartCountKey = attribute.Key("k8s.container.restart_count")
+)
+
+// A Kubernetes ReplicaSet object.
+const (
+	// The UID of the ReplicaSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SReplicaSetUIDKey = attribute.Key("k8s.replicaset.uid")
+	// The name of the ReplicaSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SReplicaSetNameKey = attribute.Key("k8s.replicaset.name")
+)
+
+// A Kubernetes Deployment object.
+const (
+	// The UID of the Deployment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SDeploymentUIDKey = attribute.Key("k8s.deployment.uid")
+	// The name of the Deployment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SDeploymentNameKey = attribute.Key("k8s.deployment.name")
+)
+
+// A Kubernetes StatefulSet object.
+const (
+	// The UID of the StatefulSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SStatefulSetUIDKey = attribute.Key("k8s.statefulset.uid")
+	// The name of the StatefulSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SStatefulSetNameKey = attribute.Key("k8s.statefulset.name")
+)
+
+// A Kubernetes DaemonSet object.
+const (
+	// The UID of the DaemonSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SDaemonSetUIDKey = attribute.Key("k8s.daemonset.uid")
+	// The name of the DaemonSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SDaemonSetNameKey = attribute.Key("k8s.daemonset.name")
+)
+
+// A Kubernetes Job object.
+const (
+	// The UID of the Job.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SJobUIDKey = attribute.Key("k8s.job.uid")
+	// The name of the Job.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SJobNameKey = attribute.Key("k8s.job.name")
+)
+
+// A Kubernetes CronJob object.
+const (
+	// The UID of the CronJob.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SCronJobUIDKey = attribute.Key("k8s.cronjob.uid")
+	// The name of the CronJob.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SCronJobNameKey = attribute.Key("k8s.cronjob.name")
+)
+
+// The operating system (OS) on which the process represented by this resource is running.
+const (
+	// The operating system type.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	OSTypeKey = attribute.Key("os.type")
+	// Human readable (not intended to be parsed) OS version information, like e.g.
+	// reported by `ver` or `lsb_release -a` commands.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Microsoft Windows [Version 10.0.18363.778]', 'Ubuntu 18.04.1 LTS'
+	OSDescriptionKey = attribute.Key("os.description")
+	// Human readable operating system name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iOS', 'Android', 'Ubuntu'
+	OSNameKey = attribute.Key("os.name")
+	// The version string of the operating system as defined in [Version
+	// Attributes](../../resource/semantic_conventions/README.md#version-attributes).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '14.2.1', '18.04.1'
+	OSVersionKey = attribute.Key("os.version")
+)
+
+var (
+	// Microsoft Windows
+	OSTypeWindows = OSTypeKey.String("windows")
+	// Linux
+	OSTypeLinux = OSTypeKey.String("linux")
+	// Apple Darwin
+	OSTypeDarwin = OSTypeKey.String("darwin")
+	// FreeBSD
+	OSTypeFreeBSD = OSTypeKey.String("freebsd")
+	// NetBSD
+	OSTypeNetBSD = OSTypeKey.String("netbsd")
+	// OpenBSD
+	OSTypeOpenBSD = OSTypeKey.String("openbsd")
+	// DragonFly BSD
+	OSTypeDragonflyBSD = OSTypeKey.String("dragonflybsd")
+	// HP-UX (Hewlett Packard Unix)
+	OSTypeHPUX = OSTypeKey.String("hpux")
+	// AIX (Advanced Interactive eXecutive)
+	OSTypeAIX = OSTypeKey.String("aix")
+	// Oracle Solaris
+	OSTypeSolaris = OSTypeKey.String("solaris")
+	// IBM z/OS
+	OSTypeZOS = OSTypeKey.String("z_os")
+)
+
+// An operating system process.
+const (
+	// Process identifier (PID).
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 1234
+	ProcessPIDKey = attribute.Key("process.pid")
+	// The name of the process executable. On Linux based systems, can be set to the
+	// `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of
+	// `GetProcessImageFileNameW`.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'otelcol'
+	ProcessExecutableNameKey = attribute.Key("process.executable.name")
+	// The full path to the process executable. On Linux based systems, can be set to
+	// the target of `proc/[pid]/exe`. On Windows, can be set to the result of
+	// `GetProcessImageFileNameW`.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: '/usr/bin/cmd/otelcol'
+	ProcessExecutablePathKey = attribute.Key("process.executable.path")
+	// The command used to launch the process (i.e. the command name). On Linux based
+	// systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows,
+	// can be set to the first parameter extracted from `GetCommandLineW`.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'cmd/otelcol'
+	ProcessCommandKey = attribute.Key("process.command")
+	// The full command used to launch the process as a single string representing the
+	// full command. On Windows, can be set to the result of `GetCommandLineW`. Do not
+	// set this if you have to assemble it just for monitoring; use
+	// `process.command_args` instead.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'C:\\cmd\\otecol --config="my directory\\config.yaml"'
+	ProcessCommandLineKey = attribute.Key("process.command_line")
+	// All the command arguments (including the command/executable itself) as received
+	// by the process. On Linux-based systems (and some other Unixoid systems
+	// supporting procfs), can be set according to the list of null-delimited strings
+	// extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be
+	// the full argv vector passed to `main`.
+	//
+	// Type: string[]
+	// Required: See below
+	// Stability: stable
+	// Examples: 'cmd/otecol', '--config=config.yaml'
+	ProcessCommandArgsKey = attribute.Key("process.command_args")
+	// The username of the user that owns the process.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'root'
+	ProcessOwnerKey = attribute.Key("process.owner")
+)
+
+// The single (language) runtime instance which is monitored.
+const (
+	// The name of the runtime of this process. For compiled native binaries, this
+	// SHOULD be the name of the compiler.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'OpenJDK Runtime Environment'
+	ProcessRuntimeNameKey = attribute.Key("process.runtime.name")
+	// The version of the runtime of this process, as returned by the runtime without
+	// modification.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '14.0.2'
+	ProcessRuntimeVersionKey = attribute.Key("process.runtime.version")
+	// An additional description about the runtime of the process, for example a
+	// specific vendor customization of the runtime environment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0'
+	ProcessRuntimeDescriptionKey = attribute.Key("process.runtime.description")
+)
+
+// A service instance.
+const (
+	// Logical name of the service.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'shoppingcart'
+	// Note: MUST be the same for all instances of horizontally scaled services. If
+	// the value was not specified, SDKs MUST fallback to `unknown_service:`
+	// concatenated with [`process.executable.name`](process.md#process), e.g.
+	// `unknown_service:bash`. If `process.executable.name` is not available, the
+	// value MUST be set to `unknown_service`.
+	ServiceNameKey = attribute.Key("service.name")
+	// A namespace for `service.name`.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Shop'
+	// Note: A string value having a meaning that helps to distinguish a group of
+	// services, for example the team name that owns a group of services.
+	// `service.name` is expected to be unique within the same namespace. If
+	// `service.namespace` is not specified in the Resource then `service.name` is
+	// expected to be unique for all services that have no explicit namespace defined
+	// (so the empty/unspecified namespace is simply one more valid namespace). Zero-
+	// length namespace string is assumed equal to unspecified namespace.
+	ServiceNamespaceKey = attribute.Key("service.namespace")
+	// The string ID of the service instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '627cc493-f310-47de-96bd-71410b7dec09'
+	// Note: MUST be unique for each instance of the same
+	// `service.namespace,service.name` pair (in other words
+	// `service.namespace,service.name,service.instance.id` triplet MUST be globally
+	// unique). The ID helps to distinguish instances of the same service that exist
+	// at the same time (e.g. instances of a horizontally scaled service). It is
+	// preferable for the ID to be persistent and stay the same for the lifetime of
+	// the service instance, however it is acceptable that the ID is ephemeral and
+	// changes during important lifetime events for the service (e.g. service
+	// restarts). If the service has no inherent unique ID that can be used as the
+	// value of this attribute it is recommended to generate a random Version 1 or
+	// Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use
+	// Version 5, see RFC 4122 for more recommendations).
+	ServiceInstanceIDKey = attribute.Key("service.instance.id")
+	// The version string of the service API or implementation.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2.0.0'
+	ServiceVersionKey = attribute.Key("service.version")
+)
+
+// The telemetry SDK used to capture data recorded by the instrumentation libraries.
+const (
+	// The name of the telemetry SDK as defined above.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	TelemetrySDKNameKey = attribute.Key("telemetry.sdk.name")
+	// The language of the telemetry SDK.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	TelemetrySDKLanguageKey = attribute.Key("telemetry.sdk.language")
+	// The version string of the telemetry SDK.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1.2.3'
+	TelemetrySDKVersionKey = attribute.Key("telemetry.sdk.version")
+	// The version string of the auto instrumentation agent, if used.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1.2.3'
+	TelemetryAutoVersionKey = attribute.Key("telemetry.auto.version")
+)
+
+var (
+	// cpp
+	TelemetrySDKLanguageCPP = TelemetrySDKLanguageKey.String("cpp")
+	// dotnet
+	TelemetrySDKLanguageDotnet = TelemetrySDKLanguageKey.String("dotnet")
+	// erlang
+	TelemetrySDKLanguageErlang = TelemetrySDKLanguageKey.String("erlang")
+	// go
+	TelemetrySDKLanguageGo = TelemetrySDKLanguageKey.String("go")
+	// java
+	TelemetrySDKLanguageJava = TelemetrySDKLanguageKey.String("java")
+	// nodejs
+	TelemetrySDKLanguageNodejs = TelemetrySDKLanguageKey.String("nodejs")
+	// php
+	TelemetrySDKLanguagePHP = TelemetrySDKLanguageKey.String("php")
+	// python
+	TelemetrySDKLanguagePython = TelemetrySDKLanguageKey.String("python")
+	// ruby
+	TelemetrySDKLanguageRuby = TelemetrySDKLanguageKey.String("ruby")
+	// webjs
+	TelemetrySDKLanguageWebjs = TelemetrySDKLanguageKey.String("webjs")
+	// swift
+	TelemetrySDKLanguageSwift = TelemetrySDKLanguageKey.String("swift")
+)
+
+// Resource describing the packaged software running the application code. Web engines are typically executed using process.runtime.
+const (
+	// The name of the web engine.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'WildFly'
+	WebEngineNameKey = attribute.Key("webengine.name")
+	// The version of the web engine.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '21.0.0'
+	WebEngineVersionKey = attribute.Key("webengine.version")
+	// Additional description of the web engine (e.g. detailed version and edition
+	// information).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final'
+	WebEngineDescriptionKey = attribute.Key("webengine.description")
+)

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/schema.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/schema.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.10.0"
+
+// SchemaURL is the schema URL that matches the version of the semantic conventions
+// that this package defines. Semconv packages starting from v1.4.0 must declare
+// non-empty schema URL in the form https://opentelemetry.io/schemas/<version>
+const SchemaURL = "https://opentelemetry.io/schemas/1.10.0"

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/trace.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.10.0/trace.go
@@ -1,0 +1,1700 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.10.0"
+
+import "go.opentelemetry.io/otel/attribute"
+
+// Span attributes used by AWS Lambda (in addition to general `faas` attributes).
+const (
+	// The full invoked ARN as provided on the `Context` passed to the function
+	// (`Lambda-Runtime-Invoked-Function-ARN` header on the `/runtime/invocation/next`
+	// applicable).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:lambda:us-east-1:123456:function:myfunction:myalias'
+	// Note: This may be different from `faas.id` if an alias is involved.
+	AWSLambdaInvokedARNKey = attribute.Key("aws.lambda.invoked_arn")
+)
+
+// This document defines attributes for CloudEvents. CloudEvents is a specification on how to define event data in a standard way. These attributes can be attached to spans when performing operations with CloudEvents, regardless of the protocol being used.
+const (
+	// The [event_id](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec
+	// .md#id) uniquely identifies the event.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '123e4567-e89b-12d3-a456-426614174000', '0001'
+	CloudeventsEventIDKey = attribute.Key("cloudevents.event_id")
+	// The [source](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.m
+	// d#source-1) identifies the context in which an event happened.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'https://github.com/cloudevents', '/cloudevents/spec/pull/123', 'my-
+	// service'
+	CloudeventsEventSourceKey = attribute.Key("cloudevents.event_source")
+	// The [version of the CloudEvents specification](https://github.com/cloudevents/s
+	// pec/blob/v1.0.2/cloudevents/spec.md#specversion) which the event uses.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '1.0'
+	CloudeventsEventSpecVersionKey = attribute.Key("cloudevents.event_spec_version")
+	// The [event_type](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/sp
+	// ec.md#type) contains a value describing the type of event related to the
+	// originating occurrence.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'com.github.pull_request.opened', 'com.example.object.deleted.v2'
+	CloudeventsEventTypeKey = attribute.Key("cloudevents.event_type")
+	// The [subject](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.
+	// md#subject) of the event in the context of the event producer (identified by
+	// source).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'mynewfile.jpg'
+	CloudeventsEventSubjectKey = attribute.Key("cloudevents.event_subject")
+)
+
+// This document defines semantic conventions for the OpenTracing Shim
+const (
+	// Parent-child Reference type
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: The causal relationship between a child Span and a parent Span.
+	OpentracingRefTypeKey = attribute.Key("opentracing.ref_type")
+)
+
+var (
+	// The parent Span depends on the child Span in some capacity
+	OpentracingRefTypeChildOf = OpentracingRefTypeKey.String("child_of")
+	// The parent Span does not depend in any way on the result of the child Span
+	OpentracingRefTypeFollowsFrom = OpentracingRefTypeKey.String("follows_from")
+)
+
+// This document defines the attributes used to perform database client calls.
+const (
+	// An identifier for the database management system (DBMS) product being used. See
+	// below for a list of well-known identifiers.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	DBSystemKey = attribute.Key("db.system")
+	// The connection string used to connect to the database. It is recommended to
+	// remove embedded credentials.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Server=(localdb)\\v11.0;Integrated Security=true;'
+	DBConnectionStringKey = attribute.Key("db.connection_string")
+	// Username for accessing the database.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'readonly_user', 'reporting_user'
+	DBUserKey = attribute.Key("db.user")
+	// The fully-qualified class name of the [Java Database Connectivity
+	// (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver
+	// used to connect.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'org.postgresql.Driver',
+	// 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
+	DBJDBCDriverClassnameKey = attribute.Key("db.jdbc.driver_classname")
+	// This attribute is used to report the name of the database being accessed. For
+	// commands that switch the database, this should be set to the target database
+	// (even if the command fails).
+	//
+	// Type: string
+	// Required: Required, if applicable.
+	// Stability: stable
+	// Examples: 'customers', 'main'
+	// Note: In some SQL databases, the database name to be used is called "schema
+	// name". In case there are multiple layers that could be considered for database
+	// name (e.g. Oracle instance name and schema name), the database name to be used
+	// is the more specific layer (e.g. Oracle schema name).
+	DBNameKey = attribute.Key("db.name")
+	// The database statement being executed.
+	//
+	// Type: string
+	// Required: Required if applicable and not explicitly disabled via
+	// instrumentation configuration.
+	// Stability: stable
+	// Examples: 'SELECT * FROM wuser_table', 'SET mykey "WuValue"'
+	// Note: The value may be sanitized to exclude sensitive information.
+	DBStatementKey = attribute.Key("db.statement")
+	// The name of the operation being executed, e.g. the [MongoDB command
+	// name](https://docs.mongodb.com/manual/reference/command/#database-operations)
+	// such as `findAndModify`, or the SQL keyword.
+	//
+	// Type: string
+	// Required: Required, if `db.statement` is not applicable.
+	// Stability: stable
+	// Examples: 'findAndModify', 'HMSET', 'SELECT'
+	// Note: When setting this to an SQL keyword, it is not recommended to attempt any
+	// client-side parsing of `db.statement` just to get this property, but it should
+	// be set if the operation name is provided by the library being instrumented. If
+	// the SQL statement has an ambiguous operation, or performs more than one
+	// operation, this value may be omitted.
+	DBOperationKey = attribute.Key("db.operation")
+)
+
+var (
+	// Some other SQL database. Fallback only. See notes
+	DBSystemOtherSQL = DBSystemKey.String("other_sql")
+	// Microsoft SQL Server
+	DBSystemMSSQL = DBSystemKey.String("mssql")
+	// MySQL
+	DBSystemMySQL = DBSystemKey.String("mysql")
+	// Oracle Database
+	DBSystemOracle = DBSystemKey.String("oracle")
+	// IBM DB2
+	DBSystemDB2 = DBSystemKey.String("db2")
+	// PostgreSQL
+	DBSystemPostgreSQL = DBSystemKey.String("postgresql")
+	// Amazon Redshift
+	DBSystemRedshift = DBSystemKey.String("redshift")
+	// Apache Hive
+	DBSystemHive = DBSystemKey.String("hive")
+	// Cloudscape
+	DBSystemCloudscape = DBSystemKey.String("cloudscape")
+	// HyperSQL DataBase
+	DBSystemHSQLDB = DBSystemKey.String("hsqldb")
+	// Progress Database
+	DBSystemProgress = DBSystemKey.String("progress")
+	// SAP MaxDB
+	DBSystemMaxDB = DBSystemKey.String("maxdb")
+	// SAP HANA
+	DBSystemHanaDB = DBSystemKey.String("hanadb")
+	// Ingres
+	DBSystemIngres = DBSystemKey.String("ingres")
+	// FirstSQL
+	DBSystemFirstSQL = DBSystemKey.String("firstsql")
+	// EnterpriseDB
+	DBSystemEDB = DBSystemKey.String("edb")
+	// InterSystems Caché
+	DBSystemCache = DBSystemKey.String("cache")
+	// Adabas (Adaptable Database System)
+	DBSystemAdabas = DBSystemKey.String("adabas")
+	// Firebird
+	DBSystemFirebird = DBSystemKey.String("firebird")
+	// Apache Derby
+	DBSystemDerby = DBSystemKey.String("derby")
+	// FileMaker
+	DBSystemFilemaker = DBSystemKey.String("filemaker")
+	// Informix
+	DBSystemInformix = DBSystemKey.String("informix")
+	// InstantDB
+	DBSystemInstantDB = DBSystemKey.String("instantdb")
+	// InterBase
+	DBSystemInterbase = DBSystemKey.String("interbase")
+	// MariaDB
+	DBSystemMariaDB = DBSystemKey.String("mariadb")
+	// Netezza
+	DBSystemNetezza = DBSystemKey.String("netezza")
+	// Pervasive PSQL
+	DBSystemPervasive = DBSystemKey.String("pervasive")
+	// PointBase
+	DBSystemPointbase = DBSystemKey.String("pointbase")
+	// SQLite
+	DBSystemSqlite = DBSystemKey.String("sqlite")
+	// Sybase
+	DBSystemSybase = DBSystemKey.String("sybase")
+	// Teradata
+	DBSystemTeradata = DBSystemKey.String("teradata")
+	// Vertica
+	DBSystemVertica = DBSystemKey.String("vertica")
+	// H2
+	DBSystemH2 = DBSystemKey.String("h2")
+	// ColdFusion IMQ
+	DBSystemColdfusion = DBSystemKey.String("coldfusion")
+	// Apache Cassandra
+	DBSystemCassandra = DBSystemKey.String("cassandra")
+	// Apache HBase
+	DBSystemHBase = DBSystemKey.String("hbase")
+	// MongoDB
+	DBSystemMongoDB = DBSystemKey.String("mongodb")
+	// Redis
+	DBSystemRedis = DBSystemKey.String("redis")
+	// Couchbase
+	DBSystemCouchbase = DBSystemKey.String("couchbase")
+	// CouchDB
+	DBSystemCouchDB = DBSystemKey.String("couchdb")
+	// Microsoft Azure Cosmos DB
+	DBSystemCosmosDB = DBSystemKey.String("cosmosdb")
+	// Amazon DynamoDB
+	DBSystemDynamoDB = DBSystemKey.String("dynamodb")
+	// Neo4j
+	DBSystemNeo4j = DBSystemKey.String("neo4j")
+	// Apache Geode
+	DBSystemGeode = DBSystemKey.String("geode")
+	// Elasticsearch
+	DBSystemElasticsearch = DBSystemKey.String("elasticsearch")
+	// Memcached
+	DBSystemMemcached = DBSystemKey.String("memcached")
+	// CockroachDB
+	DBSystemCockroachdb = DBSystemKey.String("cockroachdb")
+)
+
+// Connection-level attributes for Microsoft SQL Server
+const (
+	// The Microsoft SQL Server [instance name](https://docs.microsoft.com/en-
+	// us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15)
+	// connecting to. This name is used to determine the port of a named instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'MSSQLSERVER'
+	// Note: If setting a `db.mssql.instance_name`, `net.peer.port` is no longer
+	// required (but still recommended if non-standard).
+	DBMSSQLInstanceNameKey = attribute.Key("db.mssql.instance_name")
+)
+
+// Call-level attributes for Cassandra
+const (
+	// The fetch size used for paging, i.e. how many rows will be returned at once.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5000
+	DBCassandraPageSizeKey = attribute.Key("db.cassandra.page_size")
+	// The consistency level of the query. Based on consistency values from
+	// [CQL](https://docs.datastax.com/en/cassandra-
+	// oss/3.0/cassandra/dml/dmlConfigConsistency.html).
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	DBCassandraConsistencyLevelKey = attribute.Key("db.cassandra.consistency_level")
+	// The name of the primary table that the operation is acting upon, including the
+	// keyspace name (if applicable).
+	//
+	// Type: string
+	// Required: Recommended if available.
+	// Stability: stable
+	// Examples: 'mytable'
+	// Note: This mirrors the db.sql.table attribute but references cassandra rather
+	// than sql. It is not recommended to attempt any client-side parsing of
+	// `db.statement` just to get this property, but it should be set if it is
+	// provided by the library being instrumented. If the operation is acting upon an
+	// anonymous table, or more than one table, this value MUST NOT be set.
+	DBCassandraTableKey = attribute.Key("db.cassandra.table")
+	// Whether or not the query is idempotent.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	DBCassandraIdempotenceKey = attribute.Key("db.cassandra.idempotence")
+	// The number of times a query was speculatively executed. Not set or `0` if the
+	// query was not executed speculatively.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 0, 2
+	DBCassandraSpeculativeExecutionCountKey = attribute.Key("db.cassandra.speculative_execution_count")
+	// The ID of the coordinating node for a query.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'be13faa2-8574-4d71-926d-27f16cf8a7af'
+	DBCassandraCoordinatorIDKey = attribute.Key("db.cassandra.coordinator.id")
+	// The data center of the coordinating node for a query.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-west-2'
+	DBCassandraCoordinatorDCKey = attribute.Key("db.cassandra.coordinator.dc")
+)
+
+var (
+	// all
+	DBCassandraConsistencyLevelAll = DBCassandraConsistencyLevelKey.String("all")
+	// each_quorum
+	DBCassandraConsistencyLevelEachQuorum = DBCassandraConsistencyLevelKey.String("each_quorum")
+	// quorum
+	DBCassandraConsistencyLevelQuorum = DBCassandraConsistencyLevelKey.String("quorum")
+	// local_quorum
+	DBCassandraConsistencyLevelLocalQuorum = DBCassandraConsistencyLevelKey.String("local_quorum")
+	// one
+	DBCassandraConsistencyLevelOne = DBCassandraConsistencyLevelKey.String("one")
+	// two
+	DBCassandraConsistencyLevelTwo = DBCassandraConsistencyLevelKey.String("two")
+	// three
+	DBCassandraConsistencyLevelThree = DBCassandraConsistencyLevelKey.String("three")
+	// local_one
+	DBCassandraConsistencyLevelLocalOne = DBCassandraConsistencyLevelKey.String("local_one")
+	// any
+	DBCassandraConsistencyLevelAny = DBCassandraConsistencyLevelKey.String("any")
+	// serial
+	DBCassandraConsistencyLevelSerial = DBCassandraConsistencyLevelKey.String("serial")
+	// local_serial
+	DBCassandraConsistencyLevelLocalSerial = DBCassandraConsistencyLevelKey.String("local_serial")
+)
+
+// Call-level attributes for Redis
+const (
+	// The index of the database being accessed as used in the [`SELECT`
+	// command](https://redis.io/commands/select), provided as an integer. To be used
+	// instead of the generic `db.name` attribute.
+	//
+	// Type: int
+	// Required: Required, if other than the default database (`0`).
+	// Stability: stable
+	// Examples: 0, 1, 15
+	DBRedisDBIndexKey = attribute.Key("db.redis.database_index")
+)
+
+// Call-level attributes for MongoDB
+const (
+	// The collection being accessed within the database stated in `db.name`.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'customers', 'products'
+	DBMongoDBCollectionKey = attribute.Key("db.mongodb.collection")
+)
+
+// Call-level attributes for SQL databases
+const (
+	// The name of the primary table that the operation is acting upon, including the
+	// database name (if applicable).
+	//
+	// Type: string
+	// Required: Recommended if available.
+	// Stability: stable
+	// Examples: 'public.users', 'customers'
+	// Note: It is not recommended to attempt any client-side parsing of
+	// `db.statement` just to get this property, but it should be set if it is
+	// provided by the library being instrumented. If the operation is acting upon an
+	// anonymous table, or more than one table, this value MUST NOT be set.
+	DBSQLTableKey = attribute.Key("db.sql.table")
+)
+
+// This document defines the attributes used to report a single exception associated with a span.
+const (
+	// The type of the exception (its fully-qualified class name, if applicable). The
+	// dynamic type of the exception should be preferred over the static type in
+	// languages that support it.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'java.net.ConnectException', 'OSError'
+	ExceptionTypeKey = attribute.Key("exception.type")
+	// The exception message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Division by zero', "Can't convert 'int' object to str implicitly"
+	ExceptionMessageKey = attribute.Key("exception.message")
+	// A stacktrace as a string in the natural representation for the language
+	// runtime. The representation is to be determined and documented by each language
+	// SIG.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Exception in thread "main" java.lang.RuntimeException: Test
+	// exception\\n at '
+	//  'com.example.GenerateTrace.methodB(GenerateTrace.java:13)\\n at '
+	//  'com.example.GenerateTrace.methodA(GenerateTrace.java:9)\\n at '
+	//  'com.example.GenerateTrace.main(GenerateTrace.java:5)'
+	ExceptionStacktraceKey = attribute.Key("exception.stacktrace")
+	// SHOULD be set to true if the exception event is recorded at a point where it is
+	// known that the exception is escaping the scope of the span.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	// Note: An exception is considered to have escaped (or left) the scope of a span,
+	// if that span is ended while the exception is still logically "in flight".
+	// This may be actually "in flight" in some languages (e.g. if the exception
+	// is passed to a Context manager's `__exit__` method in Python) but will
+	// usually be caught at the point of recording the exception in most languages.
+
+	// It is usually not possible to determine at the point where an exception is
+	// thrown
+	// whether it will escape the scope of a span.
+	// However, it is trivial to know that an exception
+	// will escape, if one checks for an active exception just before ending the span,
+	// as done in the [example above](#recording-an-exception).
+
+	// It follows that an exception may still escape the scope of the span
+	// even if the `exception.escaped` attribute was not set or set to false,
+	// since the event might have been recorded at a time where it was not
+	// clear whether the exception will escape.
+	ExceptionEscapedKey = attribute.Key("exception.escaped")
+)
+
+// This semantic convention describes an instance of a function that runs without provisioning or managing of servers (also known as serverless functions or Function as a Service (FaaS)) with spans.
+const (
+	// Type of the trigger which caused this function execution.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: For the server/consumer span on the incoming side,
+	// `faas.trigger` MUST be set.
+
+	// Clients invoking FaaS instances usually cannot set `faas.trigger`,
+	// since they would typically need to look in the payload to determine
+	// the event type. If clients set it, it should be the same as the
+	// trigger that corresponding incoming would have (i.e., this has
+	// nothing to do with the underlying transport used to make the API
+	// call to invoke the lambda, which is often HTTP).
+	FaaSTriggerKey = attribute.Key("faas.trigger")
+	// The execution ID of the current function execution.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28'
+	FaaSExecutionKey = attribute.Key("faas.execution")
+)
+
+var (
+	// A response to some data source operation such as a database or filesystem read/write
+	FaaSTriggerDatasource = FaaSTriggerKey.String("datasource")
+	// To provide an answer to an inbound HTTP request
+	FaaSTriggerHTTP = FaaSTriggerKey.String("http")
+	// A function is set to be executed when messages are sent to a messaging system
+	FaaSTriggerPubsub = FaaSTriggerKey.String("pubsub")
+	// A function is scheduled to be executed regularly
+	FaaSTriggerTimer = FaaSTriggerKey.String("timer")
+	// If none of the others apply
+	FaaSTriggerOther = FaaSTriggerKey.String("other")
+)
+
+// Semantic Convention for FaaS triggered as a response to some data source operation such as a database or filesystem read/write.
+const (
+	// The name of the source on which the triggering operation was performed. For
+	// example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos
+	// DB to the database name.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myBucketName', 'myDBName'
+	FaaSDocumentCollectionKey = attribute.Key("faas.document.collection")
+	// Describes the type of the operation that was performed on the data.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	FaaSDocumentOperationKey = attribute.Key("faas.document.operation")
+	// A string containing the time when the data was accessed in the [ISO
+	// 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed
+	// in [UTC](https://www.w3.org/TR/NOTE-datetime).
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '2020-01-23T13:47:06Z'
+	FaaSDocumentTimeKey = attribute.Key("faas.document.time")
+	// The document name/table subjected to the operation. For example, in Cloud
+	// Storage or S3 is the name of the file, and in Cosmos DB the table name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'myFile.txt', 'myTableName'
+	FaaSDocumentNameKey = attribute.Key("faas.document.name")
+)
+
+var (
+	// When a new object is created
+	FaaSDocumentOperationInsert = FaaSDocumentOperationKey.String("insert")
+	// When an object is modified
+	FaaSDocumentOperationEdit = FaaSDocumentOperationKey.String("edit")
+	// When an object is deleted
+	FaaSDocumentOperationDelete = FaaSDocumentOperationKey.String("delete")
+)
+
+// Semantic Convention for FaaS scheduled to be executed regularly.
+const (
+	// A string containing the function invocation time in the [ISO
+	// 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed
+	// in [UTC](https://www.w3.org/TR/NOTE-datetime).
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '2020-01-23T13:47:06Z'
+	FaaSTimeKey = attribute.Key("faas.time")
+	// A string containing the schedule period as [Cron Expression](https://docs.oracl
+	// e.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0/5 * * * ? *'
+	FaaSCronKey = attribute.Key("faas.cron")
+)
+
+// Contains additional attributes for incoming FaaS spans.
+const (
+	// A boolean that is true if the serverless function is executed for the first
+	// time (aka cold-start).
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	FaaSColdstartKey = attribute.Key("faas.coldstart")
+)
+
+// Contains additional attributes for outgoing FaaS spans.
+const (
+	// The name of the invoked function.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'my-function'
+	// Note: SHOULD be equal to the `faas.name` resource attribute of the invoked
+	// function.
+	FaaSInvokedNameKey = attribute.Key("faas.invoked_name")
+	// The cloud provider of the invoked function.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	// Note: SHOULD be equal to the `cloud.provider` resource attribute of the invoked
+	// function.
+	FaaSInvokedProviderKey = attribute.Key("faas.invoked_provider")
+	// The cloud region of the invoked function.
+	//
+	// Type: string
+	// Required: For some cloud providers, like AWS or GCP, the region in which a
+	// function is hosted is essential to uniquely identify the function and also part
+	// of its endpoint. Since it's part of the endpoint being called, the region is
+	// always known to clients. In these cases, `faas.invoked_region` MUST be set
+	// accordingly. If the region is unknown to the client or not required for
+	// identifying the invoked function, setting `faas.invoked_region` is optional.
+	// Stability: stable
+	// Examples: 'eu-central-1'
+	// Note: SHOULD be equal to the `cloud.region` resource attribute of the invoked
+	// function.
+	FaaSInvokedRegionKey = attribute.Key("faas.invoked_region")
+)
+
+var (
+	// Alibaba Cloud
+	FaaSInvokedProviderAlibabaCloud = FaaSInvokedProviderKey.String("alibaba_cloud")
+	// Amazon Web Services
+	FaaSInvokedProviderAWS = FaaSInvokedProviderKey.String("aws")
+	// Microsoft Azure
+	FaaSInvokedProviderAzure = FaaSInvokedProviderKey.String("azure")
+	// Google Cloud Platform
+	FaaSInvokedProviderGCP = FaaSInvokedProviderKey.String("gcp")
+	// Tencent Cloud
+	FaaSInvokedProviderTencentCloud = FaaSInvokedProviderKey.String("tencent_cloud")
+)
+
+// These attributes may be used for any network related operation.
+const (
+	// Transport protocol used. See note below.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	NetTransportKey = attribute.Key("net.transport")
+	// Remote address of the peer (dotted decimal for IPv4 or
+	// [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6)
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '127.0.0.1'
+	NetPeerIPKey = attribute.Key("net.peer.ip")
+	// Remote port number.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 80, 8080, 443
+	NetPeerPortKey = attribute.Key("net.peer.port")
+	// Remote hostname or similar, see note below.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'example.com'
+	NetPeerNameKey = attribute.Key("net.peer.name")
+	// Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '192.168.0.1'
+	NetHostIPKey = attribute.Key("net.host.ip")
+	// Like `net.peer.port` but for the host port.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 35555
+	NetHostPortKey = attribute.Key("net.host.port")
+	// Local hostname or similar, see note below.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'localhost'
+	NetHostNameKey = attribute.Key("net.host.name")
+	// The internet connection type currently being used by the host.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Examples: 'wifi'
+	NetHostConnectionTypeKey = attribute.Key("net.host.connection.type")
+	// This describes more details regarding the connection.type. It may be the type
+	// of cell technology connection, but it could be used for describing details
+	// about a wifi connection.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Examples: 'LTE'
+	NetHostConnectionSubtypeKey = attribute.Key("net.host.connection.subtype")
+	// The name of the mobile carrier.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'sprint'
+	NetHostCarrierNameKey = attribute.Key("net.host.carrier.name")
+	// The mobile carrier country code.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '310'
+	NetHostCarrierMccKey = attribute.Key("net.host.carrier.mcc")
+	// The mobile carrier network code.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '001'
+	NetHostCarrierMncKey = attribute.Key("net.host.carrier.mnc")
+	// The ISO 3166-1 alpha-2 2-character country code associated with the mobile
+	// carrier network.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'DE'
+	NetHostCarrierIccKey = attribute.Key("net.host.carrier.icc")
+)
+
+var (
+	// ip_tcp
+	NetTransportTCP = NetTransportKey.String("ip_tcp")
+	// ip_udp
+	NetTransportUDP = NetTransportKey.String("ip_udp")
+	// Another IP-based protocol
+	NetTransportIP = NetTransportKey.String("ip")
+	// Unix Domain socket. See below
+	NetTransportUnix = NetTransportKey.String("unix")
+	// Named or anonymous pipe. See note below
+	NetTransportPipe = NetTransportKey.String("pipe")
+	// In-process communication
+	NetTransportInProc = NetTransportKey.String("inproc")
+	// Something else (non IP-based)
+	NetTransportOther = NetTransportKey.String("other")
+)
+
+var (
+	// wifi
+	NetHostConnectionTypeWifi = NetHostConnectionTypeKey.String("wifi")
+	// wired
+	NetHostConnectionTypeWired = NetHostConnectionTypeKey.String("wired")
+	// cell
+	NetHostConnectionTypeCell = NetHostConnectionTypeKey.String("cell")
+	// unavailable
+	NetHostConnectionTypeUnavailable = NetHostConnectionTypeKey.String("unavailable")
+	// unknown
+	NetHostConnectionTypeUnknown = NetHostConnectionTypeKey.String("unknown")
+)
+
+var (
+	// GPRS
+	NetHostConnectionSubtypeGprs = NetHostConnectionSubtypeKey.String("gprs")
+	// EDGE
+	NetHostConnectionSubtypeEdge = NetHostConnectionSubtypeKey.String("edge")
+	// UMTS
+	NetHostConnectionSubtypeUmts = NetHostConnectionSubtypeKey.String("umts")
+	// CDMA
+	NetHostConnectionSubtypeCdma = NetHostConnectionSubtypeKey.String("cdma")
+	// EVDO Rel. 0
+	NetHostConnectionSubtypeEvdo0 = NetHostConnectionSubtypeKey.String("evdo_0")
+	// EVDO Rev. A
+	NetHostConnectionSubtypeEvdoA = NetHostConnectionSubtypeKey.String("evdo_a")
+	// CDMA2000 1XRTT
+	NetHostConnectionSubtypeCdma20001xrtt = NetHostConnectionSubtypeKey.String("cdma2000_1xrtt")
+	// HSDPA
+	NetHostConnectionSubtypeHsdpa = NetHostConnectionSubtypeKey.String("hsdpa")
+	// HSUPA
+	NetHostConnectionSubtypeHsupa = NetHostConnectionSubtypeKey.String("hsupa")
+	// HSPA
+	NetHostConnectionSubtypeHspa = NetHostConnectionSubtypeKey.String("hspa")
+	// IDEN
+	NetHostConnectionSubtypeIden = NetHostConnectionSubtypeKey.String("iden")
+	// EVDO Rev. B
+	NetHostConnectionSubtypeEvdoB = NetHostConnectionSubtypeKey.String("evdo_b")
+	// LTE
+	NetHostConnectionSubtypeLte = NetHostConnectionSubtypeKey.String("lte")
+	// EHRPD
+	NetHostConnectionSubtypeEhrpd = NetHostConnectionSubtypeKey.String("ehrpd")
+	// HSPAP
+	NetHostConnectionSubtypeHspap = NetHostConnectionSubtypeKey.String("hspap")
+	// GSM
+	NetHostConnectionSubtypeGsm = NetHostConnectionSubtypeKey.String("gsm")
+	// TD-SCDMA
+	NetHostConnectionSubtypeTdScdma = NetHostConnectionSubtypeKey.String("td_scdma")
+	// IWLAN
+	NetHostConnectionSubtypeIwlan = NetHostConnectionSubtypeKey.String("iwlan")
+	// 5G NR (New Radio)
+	NetHostConnectionSubtypeNr = NetHostConnectionSubtypeKey.String("nr")
+	// 5G NRNSA (New Radio Non-Standalone)
+	NetHostConnectionSubtypeNrnsa = NetHostConnectionSubtypeKey.String("nrnsa")
+	// LTE CA
+	NetHostConnectionSubtypeLteCa = NetHostConnectionSubtypeKey.String("lte_ca")
+)
+
+// Operations that access some remote service.
+const (
+	// The [`service.name`](../../resource/semantic_conventions/README.md#service) of
+	// the remote service. SHOULD be equal to the actual `service.name` resource
+	// attribute of the remote service if any.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'AuthTokenCache'
+	PeerServiceKey = attribute.Key("peer.service")
+)
+
+// These attributes may be used for any operation with an authenticated and/or authorized enduser.
+const (
+	// Username or client_id extracted from the access token or
+	// [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the
+	// inbound request from outside the system.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'username'
+	EnduserIDKey = attribute.Key("enduser.id")
+	// Actual/assumed role the client is making the request under extracted from token
+	// or application security context.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'admin'
+	EnduserRoleKey = attribute.Key("enduser.role")
+	// Scopes or granted authorities the client currently possesses extracted from
+	// token or application security context. The value would come from the scope
+	// associated with an [OAuth 2.0 Access
+	// Token](https://tools.ietf.org/html/rfc6749#section-3.3) or an attribute value
+	// in a [SAML 2.0 Assertion](http://docs.oasis-
+	// open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'read:message, write:files'
+	EnduserScopeKey = attribute.Key("enduser.scope")
+)
+
+// These attributes may be used for any operation to store information about a thread that started a span.
+const (
+	// Current "managed" thread ID (as opposed to OS thread ID).
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 42
+	ThreadIDKey = attribute.Key("thread.id")
+	// Current thread name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'main'
+	ThreadNameKey = attribute.Key("thread.name")
+)
+
+// These attributes allow to report this unit of code and therefore to provide more context about the span.
+const (
+	// The method or function name, or equivalent (usually rightmost part of the code
+	// unit's name).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'serveRequest'
+	CodeFunctionKey = attribute.Key("code.function")
+	// The "namespace" within which `code.function` is defined. Usually the qualified
+	// class or module name, such that `code.namespace` + some separator +
+	// `code.function` form a unique identifier for the code unit.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'com.example.MyHTTPService'
+	CodeNamespaceKey = attribute.Key("code.namespace")
+	// The source code file name that identifies the code unit as uniquely as possible
+	// (preferably an absolute file path).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/usr/local/MyApplication/content_root/app/index.php'
+	CodeFilepathKey = attribute.Key("code.filepath")
+	// The line number in `code.filepath` best representing the operation. It SHOULD
+	// point within the code unit named in `code.function`.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 42
+	CodeLineNumberKey = attribute.Key("code.lineno")
+)
+
+// This document defines semantic conventions for HTTP client and server Spans.
+const (
+	// HTTP request method.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'GET', 'POST', 'HEAD'
+	HTTPMethodKey = attribute.Key("http.method")
+	// Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`.
+	// Usually the fragment is not transmitted over HTTP, but if it is known, it
+	// should be included nevertheless.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'https://www.foo.bar/search?q=OpenTelemetry#SemConv'
+	// Note: `http.url` MUST NOT contain credentials passed via URL in form of
+	// `https://username:password@www.example.com/`. In such case the attribute's
+	// value should be `https://www.example.com/`.
+	HTTPURLKey = attribute.Key("http.url")
+	// The full request target as passed in a HTTP request line or equivalent.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/path/12314/?q=ddds#123'
+	HTTPTargetKey = attribute.Key("http.target")
+	// The value of the [HTTP host
+	// header](https://tools.ietf.org/html/rfc7230#section-5.4). An empty Host header
+	// should also be reported, see note.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'www.example.org'
+	// Note: When the header is present but empty the attribute SHOULD be set to the
+	// empty string. Note that this is a valid situation that is expected in certain
+	// cases, according the aforementioned [section of RFC
+	// 7230](https://tools.ietf.org/html/rfc7230#section-5.4). When the header is not
+	// set the attribute MUST NOT be set.
+	HTTPHostKey = attribute.Key("http.host")
+	// The URI scheme identifying the used protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'http', 'https'
+	HTTPSchemeKey = attribute.Key("http.scheme")
+	// [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).
+	//
+	// Type: int
+	// Required: If and only if one was received/sent.
+	// Stability: stable
+	// Examples: 200
+	HTTPStatusCodeKey = attribute.Key("http.status_code")
+	// Kind of HTTP protocol used.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: If `net.transport` is not specified, it can be assumed to be `IP.TCP`
+	// except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+	HTTPFlavorKey = attribute.Key("http.flavor")
+	// Value of the [HTTP User-
+	// Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the
+	// client.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'CERN-LineMode/2.15 libwww/2.17b3'
+	HTTPUserAgentKey = attribute.Key("http.user_agent")
+	// The size of the request payload body in bytes. This is the number of bytes
+	// transferred excluding headers and is often, but not always, present as the
+	// [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For
+	// requests using transport encoding, this should be the compressed size.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 3495
+	HTTPRequestContentLengthKey = attribute.Key("http.request_content_length")
+	// The size of the uncompressed request payload body after transport decoding. Not
+	// set if transport encoding not used.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5493
+	HTTPRequestContentLengthUncompressedKey = attribute.Key("http.request_content_length_uncompressed")
+	// The size of the response payload body in bytes. This is the number of bytes
+	// transferred excluding headers and is often, but not always, present as the
+	// [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For
+	// requests using transport encoding, this should be the compressed size.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 3495
+	HTTPResponseContentLengthKey = attribute.Key("http.response_content_length")
+	// The size of the uncompressed response payload body after transport decoding.
+	// Not set if transport encoding not used.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5493
+	HTTPResponseContentLengthUncompressedKey = attribute.Key("http.response_content_length_uncompressed")
+	// The ordinal number of request re-sending attempt.
+	//
+	// Type: int
+	// Required: If and only if a request was retried.
+	// Stability: stable
+	// Examples: 3
+	HTTPRetryCountKey = attribute.Key("http.retry_count")
+)
+
+var (
+	// HTTP 1.0
+	HTTPFlavorHTTP10 = HTTPFlavorKey.String("1.0")
+	// HTTP 1.1
+	HTTPFlavorHTTP11 = HTTPFlavorKey.String("1.1")
+	// HTTP 2
+	HTTPFlavorHTTP20 = HTTPFlavorKey.String("2.0")
+	// SPDY protocol
+	HTTPFlavorSPDY = HTTPFlavorKey.String("SPDY")
+	// QUIC protocol
+	HTTPFlavorQUIC = HTTPFlavorKey.String("QUIC")
+)
+
+// Semantic Convention for HTTP Server
+const (
+	// The primary server name of the matched virtual host. This should be obtained
+	// via configuration. If no such configuration can be obtained, this attribute
+	// MUST NOT be set ( `net.host.name` should be used instead).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'example.com'
+	// Note: `http.url` is usually not readily available on the server side but would
+	// have to be assembled in a cumbersome and sometimes lossy process from other
+	// information (see e.g. open-telemetry/opentelemetry-python/pull/148). It is thus
+	// preferred to supply the raw data that is available.
+	HTTPServerNameKey = attribute.Key("http.server_name")
+	// The matched route (path template).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/users/:userID?'
+	HTTPRouteKey = attribute.Key("http.route")
+	// The IP address of the original client behind all proxies, if known (e.g. from
+	// [X-Forwarded-For](https://developer.mozilla.org/en-
+	// US/docs/Web/HTTP/Headers/X-Forwarded-For)).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '83.164.160.102'
+	// Note: This is not necessarily the same as `net.peer.ip`, which would
+	// identify the network-level peer, which may be a proxy.
+
+	// This attribute should be set when a source of information different
+	// from the one used for `net.peer.ip`, is available even if that other
+	// source just confirms the same value as `net.peer.ip`.
+	// Rationale: For `net.peer.ip`, one typically does not know if it
+	// comes from a proxy, reverse proxy, or the actual client. Setting
+	// `http.client_ip` when it's the same as `net.peer.ip` means that
+	// one is at least somewhat confident that the address is not that of
+	// the closest proxy.
+	HTTPClientIPKey = attribute.Key("http.client_ip")
+)
+
+// Attributes that exist for multiple DynamoDB request types.
+const (
+	// The keys in the `RequestItems` object field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'Users', 'Cats'
+	AWSDynamoDBTableNamesKey = attribute.Key("aws.dynamodb.table_names")
+	// The JSON-serialized value of each item in the `ConsumedCapacity` response
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : {
+	// "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number } },
+	// "ReadCapacityUnits": number, "Table": { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName":
+	// "string", "WriteCapacityUnits": number }'
+	AWSDynamoDBConsumedCapacityKey = attribute.Key("aws.dynamodb.consumed_capacity")
+	// The JSON-serialized value of the `ItemCollectionMetrics` response field.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob,
+	// "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" :
+	// "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S":
+	// "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }'
+	AWSDynamoDBItemCollectionMetricsKey = attribute.Key("aws.dynamodb.item_collection_metrics")
+	// The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
+	//
+	// Type: double
+	// Required: No
+	// Stability: stable
+	// Examples: 1.0, 2.0
+	AWSDynamoDBProvisionedReadCapacityKey = attribute.Key("aws.dynamodb.provisioned_read_capacity")
+	// The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
+	//
+	// Type: double
+	// Required: No
+	// Stability: stable
+	// Examples: 1.0, 2.0
+	AWSDynamoDBProvisionedWriteCapacityKey = attribute.Key("aws.dynamodb.provisioned_write_capacity")
+	// The value of the `ConsistentRead` request parameter.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AWSDynamoDBConsistentReadKey = attribute.Key("aws.dynamodb.consistent_read")
+	// The value of the `ProjectionExpression` request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Title', 'Title, Price, Color', 'Title, Description, RelatedItems,
+	// ProductReviews'
+	AWSDynamoDBProjectionKey = attribute.Key("aws.dynamodb.projection")
+	// The value of the `Limit` request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AWSDynamoDBLimitKey = attribute.Key("aws.dynamodb.limit")
+	// The value of the `AttributesToGet` request parameter.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'lives', 'id'
+	AWSDynamoDBAttributesToGetKey = attribute.Key("aws.dynamodb.attributes_to_get")
+	// The value of the `IndexName` request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'name_to_group'
+	AWSDynamoDBIndexNameKey = attribute.Key("aws.dynamodb.index_name")
+	// The value of the `Select` request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'ALL_ATTRIBUTES', 'COUNT'
+	AWSDynamoDBSelectKey = attribute.Key("aws.dynamodb.select")
+)
+
+// DynamoDB.CreateTable
+const (
+	// The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request
+	// field
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits":
+	// number, "WriteCapacityUnits": number } }'
+	AWSDynamoDBGlobalSecondaryIndexesKey = attribute.Key("aws.dynamodb.global_secondary_indexes")
+	// The JSON-serialized value of each item of the `LocalSecondaryIndexes` request
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "IndexARN": "string", "IndexName": "string", "IndexSizeBytes":
+	// number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" } }'
+	AWSDynamoDBLocalSecondaryIndexesKey = attribute.Key("aws.dynamodb.local_secondary_indexes")
+)
+
+// DynamoDB.ListTables
+const (
+	// The value of the `ExclusiveStartTableName` request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Users', 'CatsTable'
+	AWSDynamoDBExclusiveStartTableKey = attribute.Key("aws.dynamodb.exclusive_start_table")
+	// The the number of items in the `TableNames` response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 20
+	AWSDynamoDBTableCountKey = attribute.Key("aws.dynamodb.table_count")
+)
+
+// DynamoDB.Query
+const (
+	// The value of the `ScanIndexForward` request parameter.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AWSDynamoDBScanForwardKey = attribute.Key("aws.dynamodb.scan_forward")
+)
+
+// DynamoDB.Scan
+const (
+	// The value of the `Segment` request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AWSDynamoDBSegmentKey = attribute.Key("aws.dynamodb.segment")
+	// The value of the `TotalSegments` request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 100
+	AWSDynamoDBTotalSegmentsKey = attribute.Key("aws.dynamodb.total_segments")
+	// The value of the `Count` response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AWSDynamoDBCountKey = attribute.Key("aws.dynamodb.count")
+	// The value of the `ScannedCount` response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 50
+	AWSDynamoDBScannedCountKey = attribute.Key("aws.dynamodb.scanned_count")
+)
+
+// DynamoDB.UpdateTable
+const (
+	// The JSON-serialized value of each item in the `AttributeDefinitions` request
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "AttributeName": "string", "AttributeType": "string" }'
+	AWSDynamoDBAttributeDefinitionsKey = attribute.Key("aws.dynamodb.attribute_definitions")
+	// The JSON-serialized value of each item in the the `GlobalSecondaryIndexUpdates`
+	// request field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "Create": { "IndexName": "string", "KeySchema": [ {
+	// "AttributeName": "string", "KeyType": "string" } ], "Projection": {
+	// "NonKeyAttributes": [ "string" ], "ProjectionType": "string" },
+	// "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }'
+	AWSDynamoDBGlobalSecondaryIndexUpdatesKey = attribute.Key("aws.dynamodb.global_secondary_index_updates")
+)
+
+// This document defines the attributes used in messaging systems.
+const (
+	// A string identifying the messaging system.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'kafka', 'rabbitmq', 'rocketmq', 'activemq', 'AmazonSQS'
+	MessagingSystemKey = attribute.Key("messaging.system")
+	// The message destination name. This might be equal to the span name but is
+	// required nevertheless.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'MyQueue', 'MyTopic'
+	MessagingDestinationKey = attribute.Key("messaging.destination")
+	// The kind of message destination
+	//
+	// Type: Enum
+	// Required: Required only if the message destination is either a `queue` or
+	// `topic`.
+	// Stability: stable
+	MessagingDestinationKindKey = attribute.Key("messaging.destination_kind")
+	// A boolean that is true if the message destination is temporary.
+	//
+	// Type: boolean
+	// Required: If missing, it is assumed to be false.
+	// Stability: stable
+	MessagingTempDestinationKey = attribute.Key("messaging.temp_destination")
+	// The name of the transport protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'AMQP', 'MQTT'
+	MessagingProtocolKey = attribute.Key("messaging.protocol")
+	// The version of the transport protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.9.1'
+	MessagingProtocolVersionKey = attribute.Key("messaging.protocol_version")
+	// Connection string.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'tibjmsnaming://localhost:7222',
+	// 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue'
+	MessagingURLKey = attribute.Key("messaging.url")
+	// A value used by the messaging system as an identifier for the message,
+	// represented as a string.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '452a7c7c7c7048c2f887f61572b18fc2'
+	MessagingMessageIDKey = attribute.Key("messaging.message_id")
+	// The [conversation ID](#conversations) identifying the conversation to which the
+	// message belongs, represented as a string. Sometimes called "Correlation ID".
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'MyConversationID'
+	MessagingConversationIDKey = attribute.Key("messaging.conversation_id")
+	// The (uncompressed) size of the message payload in bytes. Also use this
+	// attribute if it is unknown whether the compressed or uncompressed payload size
+	// is reported.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2738
+	MessagingMessagePayloadSizeBytesKey = attribute.Key("messaging.message_payload_size_bytes")
+	// The compressed size of the message payload in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2048
+	MessagingMessagePayloadCompressedSizeBytesKey = attribute.Key("messaging.message_payload_compressed_size_bytes")
+)
+
+var (
+	// A message sent to a queue
+	MessagingDestinationKindQueue = MessagingDestinationKindKey.String("queue")
+	// A message sent to a topic
+	MessagingDestinationKindTopic = MessagingDestinationKindKey.String("topic")
+)
+
+// Semantic convention for a consumer of messages received from a messaging system
+const (
+	// A string identifying the kind of message consumption as defined in the
+	// [Operation names](#operation-names) section above. If the operation is "send",
+	// this attribute MUST NOT be set, since the operation can be inferred from the
+	// span kind in that case.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	MessagingOperationKey = attribute.Key("messaging.operation")
+	// The identifier for the consumer receiving a message. For Kafka, set it to
+	// `{messaging.kafka.consumer_group} - {messaging.kafka.client_id}`, if both are
+	// present, or only `messaging.kafka.consumer_group`. For brokers, such as
+	// RabbitMQ and Artemis, set it to the `client_id` of the client consuming the
+	// message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'mygroup - client-6'
+	MessagingConsumerIDKey = attribute.Key("messaging.consumer_id")
+)
+
+var (
+	// receive
+	MessagingOperationReceive = MessagingOperationKey.String("receive")
+	// process
+	MessagingOperationProcess = MessagingOperationKey.String("process")
+)
+
+// Attributes for RabbitMQ
+const (
+	// RabbitMQ message routing key.
+	//
+	// Type: string
+	// Required: Unless it is empty.
+	// Stability: stable
+	// Examples: 'myKey'
+	MessagingRabbitmqRoutingKeyKey = attribute.Key("messaging.rabbitmq.routing_key")
+)
+
+// Attributes for Apache Kafka
+const (
+	// Message keys in Kafka are used for grouping alike messages to ensure they're
+	// processed on the same partition. They differ from `messaging.message_id` in
+	// that they're not unique. If the key is `null`, the attribute MUST NOT be set.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'myKey'
+	// Note: If the key type is not string, it's string representation has to be
+	// supplied for the attribute. If the key has no unambiguous, canonical string
+	// form, don't include its value.
+	MessagingKafkaMessageKeyKey = attribute.Key("messaging.kafka.message_key")
+	// Name of the Kafka Consumer Group that is handling the message. Only applies to
+	// consumers, not producers.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'my-group'
+	MessagingKafkaConsumerGroupKey = attribute.Key("messaging.kafka.consumer_group")
+	// Client ID for the Consumer or Producer that is handling the message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'client-5'
+	MessagingKafkaClientIDKey = attribute.Key("messaging.kafka.client_id")
+	// Partition the message is sent to.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2
+	MessagingKafkaPartitionKey = attribute.Key("messaging.kafka.partition")
+	// A boolean that is true if the message is a tombstone.
+	//
+	// Type: boolean
+	// Required: If missing, it is assumed to be false.
+	// Stability: stable
+	MessagingKafkaTombstoneKey = attribute.Key("messaging.kafka.tombstone")
+)
+
+// Attributes for Apache RocketMQ
+const (
+	// Namespace of RocketMQ resources, resources in different namespaces are
+	// individual.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myNamespace'
+	MessagingRocketmqNamespaceKey = attribute.Key("messaging.rocketmq.namespace")
+	// Name of the RocketMQ producer/consumer group that is handling the message. The
+	// client type is identified by the SpanKind.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myConsumerGroup'
+	MessagingRocketmqClientGroupKey = attribute.Key("messaging.rocketmq.client_group")
+	// The unique identifier for each client.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myhost@8742@s8083jm'
+	MessagingRocketmqClientIDKey = attribute.Key("messaging.rocketmq.client_id")
+	// Type of message.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	MessagingRocketmqMessageTypeKey = attribute.Key("messaging.rocketmq.message_type")
+	// The secondary classifier of message besides topic.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'tagA'
+	MessagingRocketmqMessageTagKey = attribute.Key("messaging.rocketmq.message_tag")
+	// Key(s) of message, another way to mark message besides message id.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'keyA', 'keyB'
+	MessagingRocketmqMessageKeysKey = attribute.Key("messaging.rocketmq.message_keys")
+	// Model of message consumption. This only applies to consumer spans.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	MessagingRocketmqConsumptionModelKey = attribute.Key("messaging.rocketmq.consumption_model")
+)
+
+var (
+	// Normal message
+	MessagingRocketmqMessageTypeNormal = MessagingRocketmqMessageTypeKey.String("normal")
+	// FIFO message
+	MessagingRocketmqMessageTypeFifo = MessagingRocketmqMessageTypeKey.String("fifo")
+	// Delay message
+	MessagingRocketmqMessageTypeDelay = MessagingRocketmqMessageTypeKey.String("delay")
+	// Transaction message
+	MessagingRocketmqMessageTypeTransaction = MessagingRocketmqMessageTypeKey.String("transaction")
+)
+
+var (
+	// Clustering consumption model
+	MessagingRocketmqConsumptionModelClustering = MessagingRocketmqConsumptionModelKey.String("clustering")
+	// Broadcasting consumption model
+	MessagingRocketmqConsumptionModelBroadcasting = MessagingRocketmqConsumptionModelKey.String("broadcasting")
+)
+
+// This document defines semantic conventions for remote procedure calls.
+const (
+	// A string identifying the remoting system. See below for a list of well-known
+	// identifiers.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	RPCSystemKey = attribute.Key("rpc.system")
+	// The full (logical) name of the service being called, including its package
+	// name, if applicable.
+	//
+	// Type: string
+	// Required: No, but recommended
+	// Stability: stable
+	// Examples: 'myservice.EchoService'
+	// Note: This is the logical name of the service from the RPC interface
+	// perspective, which can be different from the name of any implementing class.
+	// The `code.namespace` attribute may be used to store the latter (despite the
+	// attribute name, it may include a class name; e.g., class with method actually
+	// executing the call on the server side, RPC client stub class on the client
+	// side).
+	RPCServiceKey = attribute.Key("rpc.service")
+	// The name of the (logical) method being called, must be equal to the $method
+	// part in the span name.
+	//
+	// Type: string
+	// Required: No, but recommended
+	// Stability: stable
+	// Examples: 'exampleMethod'
+	// Note: This is the logical name of the method from the RPC interface
+	// perspective, which can be different from the name of any implementing
+	// method/function. The `code.function` attribute may be used to store the latter
+	// (e.g., method actually executing the call on the server side, RPC client stub
+	// method on the client side).
+	RPCMethodKey = attribute.Key("rpc.method")
+)
+
+var (
+	// gRPC
+	RPCSystemGRPC = RPCSystemKey.String("grpc")
+	// Java RMI
+	RPCSystemJavaRmi = RPCSystemKey.String("java_rmi")
+	// .NET WCF
+	RPCSystemDotnetWcf = RPCSystemKey.String("dotnet_wcf")
+	// Apache Dubbo
+	RPCSystemApacheDubbo = RPCSystemKey.String("apache_dubbo")
+)
+
+// Tech-specific attributes for gRPC.
+const (
+	// The [numeric status
+	// code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC
+	// request.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	RPCGRPCStatusCodeKey = attribute.Key("rpc.grpc.status_code")
+)
+
+var (
+	// OK
+	RPCGRPCStatusCodeOk = RPCGRPCStatusCodeKey.Int(0)
+	// CANCELLED
+	RPCGRPCStatusCodeCancelled = RPCGRPCStatusCodeKey.Int(1)
+	// UNKNOWN
+	RPCGRPCStatusCodeUnknown = RPCGRPCStatusCodeKey.Int(2)
+	// INVALID_ARGUMENT
+	RPCGRPCStatusCodeInvalidArgument = RPCGRPCStatusCodeKey.Int(3)
+	// DEADLINE_EXCEEDED
+	RPCGRPCStatusCodeDeadlineExceeded = RPCGRPCStatusCodeKey.Int(4)
+	// NOT_FOUND
+	RPCGRPCStatusCodeNotFound = RPCGRPCStatusCodeKey.Int(5)
+	// ALREADY_EXISTS
+	RPCGRPCStatusCodeAlreadyExists = RPCGRPCStatusCodeKey.Int(6)
+	// PERMISSION_DENIED
+	RPCGRPCStatusCodePermissionDenied = RPCGRPCStatusCodeKey.Int(7)
+	// RESOURCE_EXHAUSTED
+	RPCGRPCStatusCodeResourceExhausted = RPCGRPCStatusCodeKey.Int(8)
+	// FAILED_PRECONDITION
+	RPCGRPCStatusCodeFailedPrecondition = RPCGRPCStatusCodeKey.Int(9)
+	// ABORTED
+	RPCGRPCStatusCodeAborted = RPCGRPCStatusCodeKey.Int(10)
+	// OUT_OF_RANGE
+	RPCGRPCStatusCodeOutOfRange = RPCGRPCStatusCodeKey.Int(11)
+	// UNIMPLEMENTED
+	RPCGRPCStatusCodeUnimplemented = RPCGRPCStatusCodeKey.Int(12)
+	// INTERNAL
+	RPCGRPCStatusCodeInternal = RPCGRPCStatusCodeKey.Int(13)
+	// UNAVAILABLE
+	RPCGRPCStatusCodeUnavailable = RPCGRPCStatusCodeKey.Int(14)
+	// DATA_LOSS
+	RPCGRPCStatusCodeDataLoss = RPCGRPCStatusCodeKey.Int(15)
+	// UNAUTHENTICATED
+	RPCGRPCStatusCodeUnauthenticated = RPCGRPCStatusCodeKey.Int(16)
+)
+
+// Tech-specific attributes for [JSON RPC](https://www.jsonrpc.org/).
+const (
+	// Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC
+	// 1.0 does not specify this, the value can be omitted.
+	//
+	// Type: string
+	// Required: If missing, it is assumed to be "1.0".
+	// Stability: stable
+	// Examples: '2.0', '1.0'
+	RPCJsonrpcVersionKey = attribute.Key("rpc.jsonrpc.version")
+	// `id` property of request or response. Since protocol allows id to be int,
+	// string, `null` or missing (for notifications), value is expected to be cast to
+	// string for simplicity. Use empty string in case of `null` value. Omit entirely
+	// if this is a notification.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '10', 'request-7', ''
+	RPCJsonrpcRequestIDKey = attribute.Key("rpc.jsonrpc.request_id")
+	// `error.code` property of response if it is an error response.
+	//
+	// Type: int
+	// Required: If missing, response is assumed to be successful.
+	// Stability: stable
+	// Examples: -32700, 100
+	RPCJsonrpcErrorCodeKey = attribute.Key("rpc.jsonrpc.error_code")
+	// `error.message` property of response if it is an error response.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Parse error', 'User already exists'
+	RPCJsonrpcErrorMessageKey = attribute.Key("rpc.jsonrpc.error_message")
+)
+
+// RPC received/sent message.
+const (
+	// Whether this is a received or sent message.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	MessageTypeKey = attribute.Key("message.type")
+	// MUST be calculated as two different counters starting from `1` one for sent
+	// messages and one for received message.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Note: This way we guarantee that the values will be consistent between
+	// different implementations.
+	MessageIDKey = attribute.Key("message.id")
+	// Compressed size of the message in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	MessageCompressedSizeKey = attribute.Key("message.compressed_size")
+	// Uncompressed size of the message in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	MessageUncompressedSizeKey = attribute.Key("message.uncompressed_size")
+)
+
+var (
+	// sent
+	MessageTypeSent = MessageTypeKey.String("SENT")
+	// received
+	MessageTypeReceived = MessageTypeKey.String("RECEIVED")
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2031,6 +2031,12 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/hash
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
+# github.com/uptrace/opentelemetry-go-extra/otellogrus v0.1.17
+## explicit; go 1.18
+github.com/uptrace/opentelemetry-go-extra/otellogrus
+# github.com/uptrace/opentelemetry-go-extra/otelutil v0.1.17
+## explicit; go 1.18
+github.com/uptrace/opentelemetry-go-extra/otelutil
 # github.com/urfave/cli v1.22.9
 ## explicit; go 1.11
 github.com/urfave/cli
@@ -2277,6 +2283,7 @@ go.opentelemetry.io/otel/internal/baggage
 go.opentelemetry.io/otel/internal/global
 go.opentelemetry.io/otel/propagation
 go.opentelemetry.io/otel/semconv/internal
+go.opentelemetry.io/otel/semconv/v1.10.0
 go.opentelemetry.io/otel/semconv/v1.12.0
 go.opentelemetry.io/otel/semconv/v1.4.0
 # go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.11.0


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR extends distributed tracing framework we already have in place:
* Ensures logrus messages are attached as events to trace via hook (instead of using custom function)
* Starts span when most functions are called and stops it when it ends, adds a handy function to `internal/log/log.go`
* Updates most functions to pass context to child functions to preserve parent trace reference (does this qualify as api change?)

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
![image](https://user-images.githubusercontent.com/114501/198540985-019af666-8b26-4fa7-a444-2ac878b53175.png)
![image](https://user-images.githubusercontent.com/114501/198541122-8e2d0efe-5ef0-40c1-827e-809777632936.png)



#### Does this PR introduce a user-facing change?
No

```release-note
More information available in tracing spans
```


