### PR TITLE
contrib/test: set env variables for integration tests

### DIFF
--- a/contrib/test/ci/test.yml
+++ b/contrib/test/ci/test.yml
@@ -34,6 +34,11 @@
     path: "{{ artifacts }}"
     state: directory
 
+- name: set crun runtime if enabled
+  set_fact:
+    int_test_env: "{{ int_test_env | combine(crun_test_env) }}"
+  when: "build_crun | bool"
+
 - name: kata configuration
   block:
     - name: configure integration test suite for kata

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -33,6 +33,11 @@ int_test_env:
     STORAGE_OPTIONS: >
         --storage-driver=overlay
 
+# Environment variables to set when executing integration tests with crun (mixed with int_test_env)
+crun_test_env:
+    CONTAINER_DEFAULT_RUNTIME: "crun"
+    CONTAINER_RUNTIMES: "crun::/run/crun:oci"
+
 # for ssh ID generation
 ssh_user: "{{ lookup('env','USER') }}"
 ssh_location: "{{ lookup('env','HOME') }}/.ssh/id_rsa"


### PR DESCRIPTION
This is required to run a few integration tests with crun.

Signed-off-by: Sohan Kunkerkar <sohank2602@gmail.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
