### PR TITLE
Fix issue in gogo/protobuf code, causing a crash in cri-o.

### DIFF
--- a/vendor/github.com/gogo/protobuf/proto/table_unmarshal.go
+++ b/vendor/github.com/gogo/protobuf/proto/table_unmarshal.go
@@ -324,7 +324,9 @@ func (u *unmarshalInfo) computeUnmarshalInfo() {
 			}
 			panic("bad type for XXX_extensions field: " + f.Type.Name())
 		}
-		if f.Name == "XXX_NoUnkeyedLiteral" || f.Name == "XXX_sizecache" {
+		// ignore all fields that are not known to gogo/protobuf, to avoid panic
+		// this is a temporary hack, waiting for containerd removal of gogo/protobuf dependency
+		if f.Name == "XXX_NoUnkeyedLiteral" || f.Name == "XXX_sizecache" || f.Name == "state" || f.Name == "sizeCache" || f.Name == "unknownFields" {
 			continue
 		}
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Looking at what others did to fix the gogo/protobuf issue, I've found this suggestion:
https://github.com/jaegertracing/jaeger/pull/2857#issuecomment-791704993

The idea is to ignore the fields that were added to the problematic data structure, letting gogo/protobuf handle the ones it knows about.
I replicated this change in cri-o's vendored gogo/protobuf code, and it seems to do the trick - kata containers are still running, and when the kata shim returns an error, it is properly reported in the container's status, without crashing.

I don't think this is a proper fix, but it may be a good workaround for 1.25 and later releases, until we can rely on the containerd version where gogo/protobuf is removed from the shim v2 interface.


#### Which issue(s) this PR fixes:

Fixes: #6350

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
