### PR TITLE
Add Spoofed Container Runtime

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -183,6 +183,10 @@ func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
 		return newRuntimePod(r, rh, c)
 	}
 
+	if rh.RuntimeType == config.RuntimeTypeSpoofed {
+		return newRuntimeSpoofed(r, rh), nil
+	}
+
 	// If the runtime type is different from "vm", then let's fallback
 	// onto the OCI implementation by default.
 	return newRuntimeOCI(r, rh), nil

--- a/internal/oci/runtime_spoofed.go
+++ b/internal/oci/runtime_spoofed.go
@@ -58,7 +58,7 @@ func (r *runtimeSpoofed) CreateContainer(ctx context.Context, c *Container, cgro
 	}
 	err := cmd.Start()
 	if err != nil {
-		return fmt.Errorf("error creating spoofed process: %v", err)
+		return fmt.Errorf("Error creating spoofed process: %v", err)
 	}
 	pid := cmd.Process.Pid
 	logrus.Infof("Setting spoofed Pid to %d", pid)
@@ -147,7 +147,7 @@ func (r *runtimeSpoofed) StopContainer(ctx context.Context, c *Container, timeou
 	}
 
 	if err = proc.Kill(); err != nil {
-		log.Warnf(ctx, "failed to kill process: %s", err)
+		log.Warnf(ctx, "Failed to kill process: %s", err)
 	}
 
 	c.state.Status = ContainerStateStopped

--- a/internal/oci/runtime_spoofed.go
+++ b/internal/oci/runtime_spoofed.go
@@ -1,0 +1,245 @@
+package oci
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/pkg/config"
+	"github.com/cri-o/cri-o/utils/cmdrunner"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	"k8s.io/client-go/tools/remotecommand"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+// runtimeSpoofed is the Runtime interface implementation relying on conmon to
+// interact with the container runtime.
+type runtimeSpoofed struct {
+	*Runtime
+
+	root    string
+	handler *config.RuntimeHandler
+}
+
+// newRuntimeSpoofed creates a new runtimeSpoofed instance
+func newRuntimeSpoofed(r *Runtime, handler *config.RuntimeHandler) RuntimeImpl {
+	runRoot := config.DefaultRuntimeRoot
+	if handler.RuntimeRoot != "" {
+		runRoot = handler.RuntimeRoot
+	}
+
+	return &runtimeSpoofed{
+		Runtime: r,
+		root:    runRoot,
+		handler: handler,
+	}
+}
+
+
+// CreateContainer creates a container.
+func (r *runtimeSpoofed) CreateContainer(ctx context.Context, c *Container, cgroupParent string, restore bool) (retErr error) {
+
+	// Start sleep command to create process space for container
+	cmd := cmdrunner.Command("/bin/sleep","infinity") // nolint: gosec
+	cmd.Dir = c.bundlePath
+	cmd.SysProcAttr = sysProcAttrPlatform()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if c.terminal {
+		var stderrBuf bytes.Buffer
+		cmd.Stderr = &stderrBuf
+	}
+	err := cmd.Start()
+	if err != nil {
+		return fmt.Errorf("error creating spoofed process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	logrus.Infof("Setting spoofed Pid to %d", pid)
+	if err := c.state.SetInitPid(pid); err != nil {
+		return err
+	}
+	return nil
+}
+
+// StartContainer starts a container.
+func (r *runtimeSpoofed) StartContainer(ctx context.Context, c *Container) error {
+	_, span := log.StartSpan(ctx)
+	defer span.End()
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	c.state.Started = time.Now()
+	return nil
+}
+
+// ExecContainer prepares a streaming endpoint to execute a command in the container.
+func (r *runtimeSpoofed) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	_, span := log.StartSpan(ctx)
+	defer span.End()
+
+	log.Debugf(ctx, "Can't Exec Spoofed Container")
+	return nil
+}
+
+// ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
+func (r *runtimeSpoofed) ExecSyncContainer(ctx context.Context, c *Container, command []string, timeout int64) (*types.ExecSyncResponse, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
+	log.Debugf(ctx, "Can't ExecSync Spoofed Container")
+	return &types.ExecSyncResponse{
+		Stdout:   []byte{},
+		Stderr:   []byte{},
+		ExitCode: 0,
+	}, nil
+}
+
+// UpdateContainer updates container resources
+func (r *runtimeSpoofed) UpdateContainer(ctx context.Context, c *Container, res *rspec.LinuxResources) error {
+	_, span := log.StartSpan(ctx)
+	defer span.End()
+
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	return nil
+}
+
+// StopContainer stops a container. Timeout is given in seconds.
+func (r *runtimeSpoofed) StopContainer(ctx context.Context, c *Container, timeout int64) (retErr error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	if c.SetAsStopping(timeout) {
+		return nil
+	}
+	defer func() {
+		// Failed to stop, set stopping to false.
+		// Otherwise, we won't actually
+		// attempt to stop when a new request comes in,
+		// even though we're not actively stopping anymore.
+		// Also, close the stopStoppingChan to tell
+		// routines waiting to change the stop timeout to give up.
+		close(c.stopStoppingChan)
+		c.SetAsNotStopping()
+	}()
+
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	if err := c.ShouldBeStopped(); err != nil {
+		return err
+	}
+
+	c.state.Status = ContainerStateStopped
+	c.state.Finished = time.Now()
+	return nil
+}
+
+// DeleteContainer deletes a container.
+func (r *runtimeSpoofed) DeleteContainer(ctx context.Context, c *Container) error {
+	_, span := log.StartSpan(ctx)
+	defer span.End()
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	return nil
+}
+
+// UpdateContainerStatus refreshes the status of the container.
+func (r *runtimeSpoofed) UpdateContainerStatus(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	status := c.state.Status
+	if c.state.InitPid != 0 && status == "" {
+		status = ContainerStateCreated
+	} else if !c.state.Started.IsZero() && status == ContainerStateCreated  {
+		status = ContainerStateRunning
+	} 
+	c.state.Status = status
+	return nil
+}
+
+// PauseContainer pauses a container.
+func (r *runtimeSpoofed) PauseContainer(ctx context.Context, c *Container) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	return nil
+}
+
+// UnpauseContainer unpauses a container.
+func (r *runtimeSpoofed) UnpauseContainer(ctx context.Context, c *Container) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	return nil
+}
+
+// ContainerStats provides statistics of a container.
+func (r *runtimeSpoofed) ContainerStats(ctx context.Context, c *Container, cgroup string) (*types.ContainerStats, error) {
+	_, span := log.StartSpan(ctx)
+	defer span.End()
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+
+	stats := &types.ContainerStats{
+		Attributes: c.CRIAttributes(),
+	}
+	return stats, nil
+}
+
+// SignalContainer sends a signal to a container process.
+func (r *runtimeSpoofed) SignalContainer(ctx context.Context, c *Container, sig syscall.Signal) error {
+	_, span := log.StartSpan(ctx)
+	defer span.End()
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	return nil
+}
+
+// AttachContainer attaches IO to a running container.
+func (r *runtimeSpoofed) AttachContainer(ctx context.Context, c *Container, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
+	return errors.New("Can't Attach IO to Spoofed Container")
+}
+
+// PortForwardContainer forwards the specified port into the provided container.
+func (r *runtimeSpoofed) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	return errors.New("Can't Port Forward Spoofed Container")
+}
+
+// ReopenContainerLog reopens the log file of a container.
+func (r *runtimeSpoofed) ReopenContainerLog(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+	return nil
+}
+
+// CheckpointContainer checkpoints a container.
+func (r *runtimeSpoofed) CheckpointContainer(ctx context.Context, c *Container, specgen *rspec.Spec, leaveRunning bool) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	return fmt.Errorf("configured runtime does not support checkpoint/restore")
+}
+
+// RestoreContainer restores a container.
+func (r *runtimeSpoofed) RestoreContainer(ctx context.Context, c *Container, sbSpec *rspec.Spec, infraPid int, cgroupParent string) error {
+	return fmt.Errorf("configured runtime does not support checkpoint/restore")
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ const (
 	OCIBufSize                 = 8192
 	RuntimeTypeVM              = "vm"
 	RuntimeTypePod             = "pod"
+	RuntimeTypeSpoofed         = "spoofed"
 	defaultCtrStopTimeout      = 30 // seconds
 	defaultNamespacesDir       = "/var/run"
 	RuntimeTypeVMBinaryPattern = "containerd-shim-([a-zA-Z0-9\\-\\+])+-v2"
@@ -1414,7 +1415,7 @@ func (r *RuntimeHandler) ValidateRuntimePath(name string) error {
 
 // ValidateRuntimeType checks if the `RuntimeType` is valid.
 func (r *RuntimeHandler) ValidateRuntimeType(name string) error {
-	if r.RuntimeType != "" && r.RuntimeType != DefaultRuntimeType && r.RuntimeType != RuntimeTypeVM && r.RuntimeType != RuntimeTypePod {
+	if r.RuntimeType != "" && r.RuntimeType != DefaultRuntimeType && r.RuntimeType != RuntimeTypeVM && r.RuntimeType != RuntimeTypePod && r.RuntimeType != RuntimeTypeSpoofed {
 		return fmt.Errorf("invalid `runtime_type` %q for runtime %q",
 			r.RuntimeType, name)
 	}

--- a/test/spoofed.bats
+++ b/test/spoofed.bats
@@ -1,0 +1,453 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_test
+	newconfig="$TESTDIR/config.json"
+	export RUNTIME_TYPE="spoofed"
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "spoofed not found correct error message" {
+	start_crio
+	! crictl inspect "container_not_exist"
+}
+
+@test "spoofed remove" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	crictl rm -f "$ctr_id"
+}
+
+@test "spoofed lifecycle" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	output=$(crictl pods --quiet)
+	[[ "$output" == "$pod_id" ]]
+
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	output=$(crictl ps --quiet --state created)
+	[[ "$output" == "$ctr_id" ]]
+
+	output=$(crictl inspect "$ctr_id")
+	[ -n "$output" ]
+	echo "$output" | jq -e ".info.privileged == false"
+
+	YEAR=$(date +"%Y")
+	CREATED=$(echo "$output" | jq -re '.status.createdAt')
+	echo "$output" | jq -e '.status.createdAt | startswith("'"$YEAR"'")'
+
+	echo "$output" | jq -e '.status.startedAt | startswith("'"$YEAR"'") | not'
+	echo "$output" | jq -e '.status.finishedAt | startswith("'"$YEAR"'") | not'
+
+	crictl start "$ctr_id"
+	output=$(crictl inspect "$ctr_id")
+	[[ "$CREATED" == $(echo "$output" | jq -re '.status.createdAt') ]]
+
+	STARTED=$(echo "$output" | jq -re '.status.startedAt')
+	echo "$output" | jq -e '.status.startedAt | startswith("'"$YEAR"'")'
+
+	echo "$output" | jq -e '.status.finishedAt | startswith("'"$YEAR"'") | not'
+
+	output=$(crictl ps --quiet --state running)
+	[[ "$output" == "$ctr_id" ]]
+
+	crictl stop "$ctr_id"
+	output=$(crictl inspect "$ctr_id")
+
+	[[ "$CREATED" == $(echo "$output" | jq -re '.status.createdAt') ]]
+	[[ "$STARTED" == $(echo "$output" | jq -re '.status.startedAt') ]]
+	echo "$output" | jq -e '.status.finishedAt | startswith("'"$YEAR"'")'
+
+	output=$(crictl ps --quiet --state exited)
+	[[ "$output" == "$ctr_id" ]]
+
+	crictl rm "$ctr_id"
+	crictl ps --quiet
+	crictl stopp "$pod_id"
+	output=$(crictl pods --quiet)
+	[[ "$output" == "$pod_id" ]]
+	output=$(crictl ps --quiet)
+	[[ "$output" == "" ]]
+
+	crictl rmp "$pod_id"
+	output=$(crictl pods --quiet)
+	[[ "$output" == "" ]]
+}
+
+# regression test for #127
+@test "spoofeds status for a pod" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	output=$(crictl ps --quiet --state created)
+	[ "$output" = "$ctr_id" ]
+
+	printf '%s\n' "$output" | while IFS= read -r id; do
+		crictl inspect "$id"
+	done
+}
+
+@test "spoofed list filtering" {
+	# start 3 redis sandbox
+	# pod1 ctr1 create & start
+	# pod2 ctr2 create
+	# pod3 ctr3 create & start & stop
+	start_crio
+	pod_config="$TESTDIR"/sandbox_config.json
+
+	jq '	  .metadata.name = "podsandbox1"
+		| .metadata.uid = "redhat-test-crio-1"' \
+		"$TESTDATA"/sandbox_config.json > "$pod_config"
+	pod1_id=$(crictl runp "$pod_config")
+	ctr1_id=$(crictl create "$pod1_id" "$TESTDATA"/container_redis.json "$pod_config")
+	crictl start "$ctr1_id"
+
+	jq '	  .metadata.name = "podsandbox2"
+		| .metadata.uid = "redhat-test-crio-2"' \
+		"$TESTDATA"/sandbox_config.json > "$pod_config"
+	pod2_id=$(crictl runp "$pod_config")
+	ctr2_id=$(crictl create "$pod2_id" "$TESTDATA"/container_redis.json "$pod_config")
+
+	jq '	  .metadata.name = "podsandbox3"
+		| .metadata.uid = "redhat-test-crio-3"' \
+		"$TESTDATA"/sandbox_config.json > "$pod_config"
+	pod3_id=$(crictl runp "$pod_config")
+	ctr3_id=$(crictl create "$pod3_id" "$TESTDATA"/container_redis.json "$pod_config")
+	crictl start "$ctr3_id"
+	crictl stop "$ctr3_id"
+
+	output=$(crictl ps --id "$ctr1_id" --quiet --all)
+	[ "$output" = "$ctr1_id" ]
+
+	output=$(crictl ps --id "${ctr1_id:0:4}" --quiet --all)
+	[ "$output" = "$ctr1_id" ]
+
+	output=$(crictl ps --id "$ctr2_id" --pod "$pod2_id" --quiet --all)
+	[ "$output" = "$ctr2_id" ]
+
+	output=$(crictl ps --id "$ctr2_id" --pod "$pod3_id" --quiet --all)
+	[ "$output" = "" ]
+
+	output=$(crictl ps --state created --quiet)
+	[ "$output" = "$ctr2_id" ]
+
+	output=$(crictl ps --state running --quiet)
+	[ "$output" = "$ctr1_id" ]
+
+	output=$(crictl ps --state exited --quiet)
+	[ "$output" = "$ctr3_id" ]
+
+	output=$(crictl ps --pod "$pod1_id" --quiet --all)
+	[ "$output" = "$ctr1_id" ]
+
+	output=$(crictl ps --pod "$pod2_id" --quiet --all)
+	[ "$output" == "$ctr2_id" ]
+
+	output=$(crictl ps --pod "$pod3_id" --quiet --all)
+	[ "$output" == "$ctr3_id" ]
+}
+
+@test "spoofed list label filtering" {
+	# start a pod with 3 containers
+	# ctr1 with labels: group=test container=redis version=v1.0.0
+	# ctr2 with labels: group=test container=redis version=v1.0.0
+	# ctr3 with labels: group=test container=redis version=v1.1.0
+	start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .metadata.name = "spoofed1"
+		| .labels.group = "test"
+		| .labels.name = "spoofed1"
+		| .labels.version = "v1.0.0"' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	ctr1_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .metadata.name = "spoofed2"
+		| .labels.group = "test"
+		| .labels.name = "spoofed2"
+		| .labels.version = "v1.0.0"' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	ctr2_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .metadata.name = "spoofed3"
+		| .labels.group = "test"
+		| .labels.name = "spoofed3"
+		| .labels.version = "v1.1.0"' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	ctr3_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+
+	output=$(crictl ps --label "group=test" --label "name=ctr1" --label "version=v1.0.0" --quiet --all)
+	[ "$output" = "$ctr1_id" ]
+
+	output=$(crictl ps --label "group=production" --quiet --all)
+	[ "$output" == "" ]
+
+	output=$(crictl ps --label "group=test" --label "version=v1.0.0" --quiet --all)
+	[[ "$output" != "" ]]
+	[[ "$output" == *"$ctr1_id"* ]]
+	[[ "$output" == *"$ctr2_id"* ]]
+	[[ "$output" != *"$ctr3_id"* ]]
+
+	output=$(crictl ps --label "group=test" --quiet --all)
+	[[ "$output" != "" ]]
+	[[ "$output" == *"$ctr1_id"* ]]
+	[[ "$output" == *"$ctr2_id"* ]]
+	[[ "$output" == *"$ctr3_id"* ]]
+}
+
+@test "spoofed metadata in list & status" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
+
+	output=$(crictl ps --id "$ctr_id" --output yaml --state created)
+	# TODO: expected value should not hard coded here
+	[[ "$output" == *"name: container1"* ]]
+	[[ "$output" == *"attempt: 1"* ]]
+
+	output=$(crictl inspect -o table "$ctr_id")
+	# TODO: expected value should not hard coded here
+	[[ "$output" == *"Name: container1"* ]]
+	[[ "$output" == *"Attempt: 1"* ]]
+}
+
+@test "spoofed execsync" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	output=$(crictl exec --sync "$ctr_id" echo HELLO)
+	[ "$output" = "" ]
+}
+
+# Devices are not emulated in spoofed runtime so these tests ensure devices are correctly spoofed
+@test "spoofed device add" {
+	# In an user namespace we can only bind mount devices from the host, not mknod
+	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .devices = [ {
+			host_path: "/dev/null",
+			container_path: "/dev/mynull",
+			permissions: "rwm"
+		} ]
+		| .linux.security_context.privileged = false' \
+		"$TESTDATA"/container_redis.json > "$newconfig"
+
+	ctr_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	output=$(crictl exec --sync "$ctr_id" ls /dev/mynull)
+	[[ "$output" == "" ]]
+}
+
+@test "privileged ctr device add" {
+	# In an user namespace we can only bind mount devices from the host, not mknod
+	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
+	start_crio
+	sandbox_config="$TESTDIR"/sandbox_config.json
+
+	jq '	  .linux.security_context.privileged = true' \
+		"$TESTDATA"/sandbox_config.json > "$sandbox_config"
+	pod_id=$(crictl runp "$sandbox_config")
+
+	jq '	  .devices = [ {
+			host_path: "/dev/null",
+			container_path: "/dev/mynull",
+			permissions: "rwm"
+		} ]
+		| .linux.security_context.privileged = true' \
+		"$TESTDATA"/container_redis.json > "$newconfig"
+
+	ctr_id=$(crictl create "$pod_id" "$newconfig" "$sandbox_config")
+	crictl start "$ctr_id"
+
+	output=$(crictl exec --sync "$ctr_id" ls /dev/mynull)
+	[[ "$output" == "" ]]
+}
+
+@test "privileged ctr add duplicate device as host" {
+	# In an user namespace we can only bind mount devices from the host, not mknod
+	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+
+	start_crio
+	sandbox_config="$TESTDIR"/sandbox_config.json
+
+	jq '	  .linux.security_context.privileged = true' \
+		"$TESTDATA"/sandbox_config.json > "$sandbox_config"
+	pod_id=$(crictl runp "$sandbox_config")
+
+	jq '	  .devices = [ {
+			host_path: "/dev/null",
+			container_path: "/dev/random",
+			permissions: "rwm"
+		} ]
+		| .linux.security_context.privileged = true
+		| del(.linux.security_context.capabilities)' \
+		"$TESTDATA"/container_redis.json > "$newconfig"
+
+	# Error is "configured with a device container path that already exists on the host"
+	! crictl create "$pod_id" "$newconfig" "$sandbox_config"
+}
+
+@test "spoofed execsync failure" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id="invalidid"
+	! crictl exec --sync "$ctr_id" doesnotexist
+}
+
+@test "spoofed stop idempotent" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	crictl stop "$ctr_id"
+	crictl stop "$ctr_id"
+}
+
+@test "spoofed caps drop" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .linux.security_context.capabilities = {
+			"add_capabilities": [],
+			"drop_capabilities": ["mknod", "kill", "sys_chroot", "setuid", "setgid"]
+		}' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+
+	crictl create "$newconfig" "$TESTDATA"/sandbox_config.json
+}
+
+@test "spoofed with default list of capabilities from crio.conf" {
+	start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	output=$(crictl exec --sync "$ctr_id" grep Cap /proc/1/status)
+
+	# This magic value originates from the output of
+	# `grep CapEff /proc/self/status`
+	#
+	# It represents the bitflag of the effective capabilities
+	# available to the process.
+	[[ "$output" = "" ]]
+}
+
+@test "spoofed with list of capabilities given by user in crio.conf" {
+	CONTAINER_DEFAULT_CAPABILITIES="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID" start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	output=$(crictl exec --sync "$ctr_id" grep Cap /proc/1/status)
+	[[ "$output" = "" ]]
+}
+
+@test "spoofed with add_inheritable_capabilities has inheritable capabilities" {
+	CONTAINER_ADD_INHERITABLE_CAPABILITIES=true start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .linux.security_context.run_as_username = "redis"' \
+		"$TESTDATA"/container_redis.json > "$newconfig"
+	ctr_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	crictl exec --sync "$ctr_id" grep "CapEff:\s0000000000000000" /proc/1/status
+}
+
+@test "spoofed create with non-existent command" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .command = ["nonexistent"]' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
+	[ "$status" -eq 0 ]
+}
+
+@test "spoofed create with non-existent command [tty]" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .command = ["nonexistent"]
+		| .tty = true' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
+	[ "$status" -eq 0 ]
+}
+
+@test "spoofed correctly setup working directory" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .working_dir = "/thisshouldntexistatall"' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	ctr_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	jq '	  .working_dir = "/etc/passwd"
+		| .metadata.name = "container2"' \
+		< "$TESTDATA"/container_config.json > "$newconfig"
+	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"not a directory"* ]]
+}
+
+@test "spoofed with low memory configured should not be created" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '	  .linux.resources.memory_limit_in_bytes = 2000' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	! crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
+}
+
+@test "spoofed with absent mount that should be rejected" {
+	ABSENT_DIR="$TESTDIR/notthere"
+	jq --arg path "$ABSENT_DIR" \
+		'  .mounts = [ {
+			host_path: $path,
+			container_path: $path
+		} ]' \
+		"$TESTDATA"/container_redis.json > "$TESTDIR/config"
+
+	CONTAINER_ABSENT_MOUNT_SOURCES_TO_REJECT="$ABSENT_DIR" start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	! crictl create "$pod_id" "$TESTDIR/config" "$TESTDATA"/sandbox_config.json
+}
+
+@test "spoofed stop timeouts should decrease" {
+	start_crio
+	jq '	  .command'='["/bin/sh", "-c", "trap \"echo hi\" INT; /bin/sleep 6000"]' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+
+	ctr_id=$(crictl run "$newconfig" "$TESTDATA"/sandbox_config.json)
+	for i in {150..1}; do
+		crictl stop --timeout "$i" "$ctr_id" &
+		sleep .1
+	done
+	crictl stop "$ctr_id"
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature

#### What this PR does / why we need it:
This PR adds support for a new spoofed CRIO runtime which can mock the creation of containers and sandboxes. These containers report status as usual and can be interacted with using crictl; however, they do not start runc containers saving resources and image pull time. The original idea behind this functionality was to speed up development and testing of [operators](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/), which require orchestrating a large number of pods that can have lengthy startup and image pull times. 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

This is my first PR for CRIO so any feedback would be greatly appreciated. I opened this PR after [some discussion on slack](https://kubernetes.slack.com/archives/CAZH62UR1/p1668093677867629?thread_ts=1668031829.089849&cid=CAZH62UR1) to get more feedback on the functionality.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
no user facing change but it does add more configuration options. I'm not sure if that counts as a user-facing change.
 
```release-note
None
```
