### PR TITLE
[1.24] Bump c/storage to v1.37.3 (OCPBUGS-4470)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/containers/image/v5 v5.17.0
 	github.com/containers/ocicrypt v1.1.2
 	github.com/containers/podman/v3 v3.2.0-rc1.0.20211005134800-8bcc086b1b9d
-	github.com/containers/storage v1.37.2
+	github.com/containers/storage v1.37.3
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty v1.1.17

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/containers/storage v1.24.8/go.mod h1:YC+2pY8SkfEAcZkwycxYbpK8EiRbx5so
 github.com/containers/storage v1.35.0/go.mod h1:qzYhasQP2/V9D9XdO+vRwkHBhsBO0oznMLzzRDQ8s20=
 github.com/containers/storage v1.36.0/go.mod h1:vbd3SKVQNHdmU5qQI6hTEcKPxnZkGqydG4f6uwrI5a8=
 github.com/containers/storage v1.37.0/go.mod h1:kqeJeS0b7DO2ZT1nVWs0XufrmPFbgV3c+Q/45RlH6r4=
-github.com/containers/storage v1.37.2 h1:sHLL9LEZA/PvFAeCQ9lOxJohL5t5PqYCa5eTZMpZVO4=
-github.com/containers/storage v1.37.2/go.mod h1:kqeJeS0b7DO2ZT1nVWs0XufrmPFbgV3c+Q/45RlH6r4=
+github.com/containers/storage v1.37.3 h1:H1KVTBuynjQNlmWer38n9RgXE9Vp6947Z2zMl+ntyI0=
+github.com/containers/storage v1.37.3/go.mod h1:kqeJeS0b7DO2ZT1nVWs0XufrmPFbgV3c+Q/45RlH6r4=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
 github.com/coredns/corefile-migration v1.0.14/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/vendor/github.com/containers/storage/drivers/quota/projectquota.go
+++ b/vendor/github.com/containers/storage/drivers/quota/projectquota.go
@@ -1,3 +1,4 @@
+//go:build linux && !exclude_disk_quota && cgo
 // +build linux,!exclude_disk_quota,cgo
 
 //
@@ -50,6 +51,7 @@ struct fsxattr {
 */
 import "C"
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -78,6 +80,7 @@ type Control struct {
 	backingFsBlockDev string
 	nextProjectID     uint32
 	quotas            map[string]uint32
+	basePath          string
 }
 
 // Attempt to generate a unigue projectid.  Multiple directories
@@ -122,11 +125,9 @@ func generateUniqueProjectID(path string) (uint32, error) {
 // This is a way to prevent xfs_quota management from conflicting with
 // containers/storage.
 
-//
 // Then try to create a test directory with the next project id and set a quota
 // on it. If that works, continue to scan existing containers to map allocated
 // project ids.
-//
 func NewControl(basePath string) (*Control, error) {
 	//
 	// Get project id of parent dir as minimal id to be used by driver
@@ -160,20 +161,22 @@ func NewControl(basePath string) (*Control, error) {
 		Size:   0,
 		Inodes: 0,
 	}
-	if err := setProjectQuota(backingFsBlockDev, minProjectID, quota); err != nil {
-		return nil, err
-	}
 
 	q := Control{
 		backingFsBlockDev: backingFsBlockDev,
 		nextProjectID:     minProjectID + 1,
 		quotas:            make(map[string]uint32),
+		basePath:          basePath,
+	}
+
+	if err := q.setProjectQuota(minProjectID, quota); err != nil {
+		return nil, err
 	}
 
 	//
 	// get first project id to be used for next container
 	//
-	err = q.findNextProjectID(basePath)
+	err = q.findNextProjectID()
 	if err != nil {
 		return nil, err
 	}
@@ -206,11 +209,11 @@ func (q *Control) SetQuota(targetPath string, quota Quota) error {
 	// set the quota limit for the container's project id
 	//
 	logrus.Debugf("SetQuota path=%s, size=%d, inodes=%d, projectID=%d", targetPath, quota.Size, quota.Inodes, projectID)
-	return setProjectQuota(q.backingFsBlockDev, projectID, quota)
+	return q.setProjectQuota(projectID, quota)
 }
 
 // setProjectQuota - set the quota for project id on xfs block device
-func setProjectQuota(backingFsBlockDev string, projectID uint32, quota Quota) error {
+func (q *Control) setProjectQuota(projectID uint32, quota Quota) error {
 	var d C.fs_disk_quota_t
 	d.d_version = C.FS_DQUOT_VERSION
 	d.d_id = C.__u32(projectID)
@@ -227,15 +230,35 @@ func setProjectQuota(backingFsBlockDev string, projectID uint32, quota Quota) er
 		d.d_ino_softlimit = d.d_ino_hardlimit
 	}
 
-	var cs = C.CString(backingFsBlockDev)
+	var cs = C.CString(q.backingFsBlockDev)
 	defer C.free(unsafe.Pointer(cs))
 
-	_, _, errno := unix.Syscall6(unix.SYS_QUOTACTL, C.Q_XSETPQLIM,
-		uintptr(unsafe.Pointer(cs)), uintptr(d.d_id),
-		uintptr(unsafe.Pointer(&d)), 0, 0)
-	if errno != 0 {
-		return fmt.Errorf("Failed to set quota limit for projid %d on %s: %v",
-			projectID, backingFsBlockDev, errno.Error())
+	runQuotactl := func() syscall.Errno {
+		_, _, errno := unix.Syscall6(unix.SYS_QUOTACTL, C.Q_XSETPQLIM,
+			uintptr(unsafe.Pointer(cs)), uintptr(d.d_id),
+			uintptr(unsafe.Pointer(&d)), 0, 0)
+		return errno
+	}
+
+	errno := runQuotactl()
+
+	// If the backingFsBlockDev does not exist any more then try to recreate it.
+	if errors.Is(errno, unix.ENOENT) {
+		if _, err := makeBackingFsDev(q.basePath); err != nil {
+			return fmt.Errorf(
+				"failed to recreate missing backingFsBlockDev %s for projid %d: %w",
+				q.backingFsBlockDev, projectID, err,
+			)
+		}
+
+		if errno := runQuotactl(); errno != 0 {
+			return fmt.Errorf("failed to set quota limit for projid %d on %s after backingFsBlockDev recreation: %w",
+				projectID, q.backingFsBlockDev, errno)
+		}
+
+	} else if errno != 0 {
+		return fmt.Errorf("failed to set quota limit for projid %d on %s: %w",
+			projectID, q.backingFsBlockDev, errno)
 	}
 
 	return nil
@@ -334,16 +357,16 @@ func setProjectID(targetPath string, projectID uint32) error {
 
 // findNextProjectID - find the next project id to be used for containers
 // by scanning driver home directory to find used project ids
-func (q *Control) findNextProjectID(home string) error {
-	files, err := ioutil.ReadDir(home)
+func (q *Control) findNextProjectID() error {
+	files, err := ioutil.ReadDir(q.basePath)
 	if err != nil {
-		return fmt.Errorf("read directory failed : %s", home)
+		return fmt.Errorf("read directory failed : %s", q.basePath)
 	}
 	for _, file := range files {
 		if !file.IsDir() {
 			continue
 		}
-		path := filepath.Join(home, file.Name())
+		path := filepath.Join(q.basePath, file.Name())
 		projid, err := getProjectID(path)
 		if err != nil {
 			return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -397,7 +397,7 @@ github.com/containers/psgo/internal/dev
 github.com/containers/psgo/internal/host
 github.com/containers/psgo/internal/proc
 github.com/containers/psgo/internal/process
-# github.com/containers/storage v1.37.2
+# github.com/containers/storage v1.37.3
 ## explicit; go 1.14
 github.com/containers/storage
 github.com/containers/storage/drivers


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

Incorporates https://github.com/containers/storage/pull/1325 into release-1.24.

This allows us to test it in CI before 1.26 gets released.

#### Which issue(s) this PR fixes:

Refers to https://github.com/cri-o/cri-o/pull/6387 and https://github.com/cri-o/cri-o/pull/6390

#### Special notes for your reviewer:

/hold

for verification on release-1.25 branch.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug to restore `/var/lib/containers/storage/overlay/backingFsBlockDev` on XFS file systems.
```
