### PR TITLE
ResourceStore: cleanup created entries

### DIFF
--- a/internal/resourcestore/resourcestore.go
+++ b/internal/resourcestore/resourcestore.go
@@ -179,6 +179,15 @@ func (rc *ResourceStore) Put(name string, resource IdentifiableCreatable, cleane
 	return nil
 }
 
+// Delete deletes the specified resource from the store.
+// Any resource that has a stage set, but was never Put should have Delete called, or else it will leak.
+func (rc *ResourceStore) Delete(name string) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+
+	delete(rc.resources, name)
+}
+
 // WatcherForResource looks up a Resource by name, and gives it a watcher.
 // If no entry exists for that resource, a placeholder is created and a watcher is given to that
 // placeholder resource.

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -468,6 +468,9 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 		return nil, ctx.Err()
 	}
 
+	// Since it's not a context error, we can delete the resource from the store, it will be tracked in the server from now on.
+	s.resourceStore.Delete(ctr.Name())
+
 	newContainer.SetCreated()
 
 	log.Infof(ctx, "Created container %s: %s", newContainer.ID(), newContainer.Description())

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -988,6 +988,10 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		log.Infof(ctx, "RunSandbox: context was either canceled or the deadline was exceeded: %v", ctx.Err())
 		return nil, ctx.Err()
 	}
+
+	// Since it's not a context error, we can delete the resource from the store, it will be tracked in the server from now on.
+	s.resourceStore.Delete(sbox.Name())
+
 	sb.SetCreated()
 
 	log.Infof(ctx, "Ran pod sandbox %s with infra container: %s", container.ID(), container.Description())


### PR DESCRIPTION
ResourceStore leaks memory if entries added because the stage is saved are never removed. Fix this by deleting the entry after they're used

Signed-off-by: Peter Hunt~ <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where `internal/resourcestore.(*ResourceStore).SetStageForResource` leaks memory 
```
