### PR TITLE
[1.23] crio:fix a bug about log container

### DIFF
--- a/server/container_status.go
+++ b/server/container_status.go
@@ -64,19 +64,16 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 		cState = c.State()
 	}
 
-	created := c.CreatedAt().UnixNano()
+	resp.Status.CreatedAt = c.CreatedAt().UnixNano()
 	switch cState.Status {
 	case oci.ContainerStateCreated:
 		rStatus = types.ContainerState_CONTAINER_CREATED
-		resp.Status.CreatedAt = created
 	case oci.ContainerStateRunning:
 		rStatus = types.ContainerState_CONTAINER_RUNNING
-		resp.Status.CreatedAt = created
 		started := cState.Started.UnixNano()
 		resp.Status.StartedAt = started
 	case oci.ContainerStateStopped:
 		rStatus = types.ContainerState_CONTAINER_EXITED
-		resp.Status.CreatedAt = created
 		started := cState.Started.UnixNano()
 		resp.Status.StartedAt = started
 		finished := cState.Finished.UnixNano()


### PR DESCRIPTION
### What type of PR is this?
/kind bug


### What happened?

Pod stuck in terminating state indefinitely until the kubelet is restarted as the crio-o responds with below response during the deletion process. 
```
Type     Reason      Age                    From     Message
  ----     ------      ----                   ----     -------
  Warning  FailedSync  4m35s (x2331 over 8h)  kubelet  error determining status: status.CreatedAt is not set
  ```
This has larger impact when the nodes are being updated(or auto-scaled to low count) and they can't just go down as the pod is still at terminating state.

```
Nov 30 03:38:02  kubelet[5584]: I1130 03:38:02.145598    5584 kubelet.go:2142] "SyncLoop (PLEG): event for pod" pod="redacted POD NAME" event=&{ID:d522de36-73e7-4a24-a087-2a1dc4f85c31 Type:ContainerStarted Data:redacted}
Nov 30 03:38:02  kubelet[5584]: E1130 03:38:02.147723    5584 remote_runtime.go:343] "verify ContainerStatus failed" err="status.CreatedAt is not set" containerID="redacted"
Nov 30 03:38:02  systemd[266494]: Reached target Paths.
Nov 30 03:38:02 systemd[266494]: Starting D-Bus User Message Bus Socket.
Nov 30 03:38:02 systemd[266494]: Reached target Timers.
Nov 30 03:38:02  kubelet[5584]: E1130 03:38:02.643292    5584 pod_workers.go:951] "Error syncing pod, skipping" err="status.CreatedAt is not set" pod="redacted POD NAME" podUID=redacted
```


### What did you expect to happen?
Crio should not return error while terminating pod. 

### How can we reproduce it (as minimally and precisely as possible)?
Not totally sure. It happens intermittently and not all pods deleted are in this state.

### Anything else we need to know?
Fix provided [here](https://github.com/cri-o/cri-o/pull/5843) seem to have solved the issue. But it is available in 1.24 version and we would like to back-port it to 1.23 version in order to survive without noise. 
Hence, this request to cherry pick the fix into 1.23.

```
CRI-O and Kubernetes version
Details
$ crio --version
crio version 1.22.5
Version:          1.22.5
GitCommit:        bd7ea645cd7436edd6a5a07b11559906032f124f
GitTreeState:     clean
BuildDate:        2022-07-29T04:19:32Z
GoVersion:        go1.16.12
Compiler:         gc
Platform:         linux/amd64
Linkmode:         dynamic
[root@ip-10-117-140-141 ~]#
$ kubectl --version
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.14", GitCommit:"3321ffc07d2f046afdf613796f9032f4460de093", GitTreeState:"clean", BuildDate:"2022-11-09T13:40:19Z", GoVersion:"go1.17.13", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.14", GitCommit:"3321ffc07d2f046afdf613796f9032f4460de093", GitTreeState:"clean", BuildDate:"2022-11-09T13:32:47Z", GoVersion:"go1.17.13", Compiler:"gc", Platform:"linux/amd64"}```
</details>


### OS version

<details>

```console
# On Linux:
$ cat /etc/os-release
NAME="Rocky Linux"
VERSION="8.6 (Green Obsidian)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="8.6"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Rocky Linux 8.6 (Green Obsidian)"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:rocky:rocky:8:GA"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
ROCKY_SUPPORT_PRODUCT="Rocky Linux"
ROCKY_SUPPORT_PRODUCT_VERSION="8"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8"
$ uname -a
Linux ip-10-117-140-141.us-west-2.compute.internal 4.18.0-372.26.1.el8_6.x86_64 #1 SMP Tue Sep 13 18:09:48 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```
### Does this PR introduce a user-facing change?
```release-note
Fix a bug about log container
```
### Additional environment details (AWS, VirtualBox, physical, etc.)
<details>
Cluster is running on AWS




