### PR TITLE
Fix conmonrs cgroup when infra container is dropped

### DIFF
--- a/internal/oci/oci_linux.go
+++ b/internal/oci/oci_linux.go
@@ -16,9 +16,6 @@ import (
 const InfraContainerName = "POD"
 
 func (r *runtimeOCI) createContainerPlatform(c *Container, cgroupParent string, pid int) error {
-	if c.Spoofed() {
-		return nil
-	}
 	g := &generate.Generator{
 		Config: &rspec.Spec{
 			Linux: &rspec.Linux{

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -225,8 +225,10 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 			}
 		}()
 		// Platform specific container setup
-		if err := r.createContainerPlatform(c, cgroupParent, cmd.Process.Pid); err != nil {
-			return err
+		if !c.Spoofed() {
+			if err := r.createContainerPlatform(c, cgroupParent, cmd.Process.Pid); err != nil {
+				return err
+			}
 		}
 
 		/* We set the cgroup, now the child can start creating children */

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -87,8 +87,10 @@ func newRuntimePod(r *Runtime, handler *config.RuntimeHandler, c *Container) (Ru
 }
 
 func (r *runtimePod) CreateContainer(ctx context.Context, c *Container, cgroupParent string, restore bool) error {
-	// If this container is the infra container, all that needs to be done is move conmonrs to the pod cgroup
-	if c.IsInfra() {
+	// If this container is the infra container or spoofed,
+	// then it is the pod container and we move conmonrs
+	// to the right configured cgroup.
+	if c.IsInfra() || c.Spoofed() {
 		v, err := r.client.Version(ctx, &conmonClient.VersionConfig{Verbose: false})
 		if err != nil {
 			return fmt.Errorf("failed to get version of client before moving server to cgroup: %w", err)

--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -26,6 +26,18 @@ function teardown() {
 	[[ "$output" == "1234" ]]
 }
 
+@test "conmon pod cgroup" {
+	CONTAINER_CGROUP_MANAGER="systemd" CONTAINER_DROP_INFRA_CTR=false CONTAINER_CONMON_CGROUP="pod" start_crio
+
+	jq '	  .linux.cgroup_parent = "Burstablecriotest123.slice"' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_config_slice.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_config_slice.json)
+
+	output=$(systemctl status "crio-conmon-$pod_id.scope")
+	[[ "$output" == *"Burstablecriotest123.slice"* ]]
+}
+
 @test "conmon custom cgroup" {
 	if [[ $RUNTIME_TYPE == pod ]]; then
 		skip "not yet supported by conmonrs"

--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -5,10 +5,28 @@ load helpers
 function setup() {
 	setup_test
 	newconfig="$TESTDIR/config.json"
+	if [[ $RUNTIME_TYPE == vm ]]; then
+		skip "not applicable to vm runtime type"
+	fi
+
 }
 
 function teardown() {
 	cleanup_test
+}
+
+function configure_monitor_cgroup_for_conmonrs() {
+	local MONITOR_CGROUP="$1"
+	local NAME=conmonrs
+	cat << EOF > "$CRIO_CONFIG_DIR/01-$NAME.conf"
+[crio.runtime]
+default_runtime = "$NAME"
+[crio.runtime.runtimes.$NAME]
+runtime_path = "$RUNTIME_BINARY_PATH"
+runtime_root = "$RUNTIME_ROOT"
+runtime_type = "$RUNTIME_TYPE"
+monitor_cgroup = "$MONITOR_CGROUP"
+EOF
 }
 
 @test "pids limit" {
@@ -44,6 +62,24 @@ function teardown() {
 	fi
 
 	CONTAINER_CGROUP_MANAGER="systemd" CONTAINER_DROP_INFRA_CTR=false CONTAINER_MANAGE_NS_LIFECYCLE=false CONTAINER_CONMON_CGROUP="customcrioconmon.slice" start_crio
+
+	jq '	  .linux.cgroup_parent = "Burstablecriotest123.slice"' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_config_slice.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_config_slice.json)
+
+	output=$(systemctl status "crio-conmon-$pod_id.scope")
+	[[ "$output" == *"customcrioconmon.slice"* ]]
+}
+
+@test "conmonrs custom cgroup with no infra container" {
+	if [[ $RUNTIME_TYPE != pod ]]; then
+		skip "not supported for conmon"
+	fi
+
+	configure_monitor_cgroup_for_conmonrs "customcrioconmon.slice"
+
+	CONTAINER_CGROUP_MANAGER="systemd" CONTAINER_DROP_INFRA_CTR=true start_crio
 
 	jq '	  .linux.cgroup_parent = "Burstablecriotest123.slice"' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_config_slice.json


### PR DESCRIPTION


#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
We didn't handle the case of moving conmonrs to the right
cgroup when infra container is dropped. This PR fixes that.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
Fix conmonrs cgroup when infra container is dropped
```
