### PR TITLE
Remove remnants of CONTAINER_MANAGE_NS_LIFECYCLE

### DIFF
--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -31,7 +31,7 @@ function teardown() {
 		skip "not yet supported by conmonrs"
 	fi
 
-	CONTAINER_CGROUP_MANAGER="systemd" CONTAINER_DROP_INFRA_CTR=false CONTAINER_MANAGE_NS_LIFECYCLE=false CONTAINER_CONMON_CGROUP="customcrioconmon.slice" start_crio
+	CONTAINER_CGROUP_MANAGER="systemd" CONTAINER_DROP_INFRA_CTR=false CONTAINER_CONMON_CGROUP="customcrioconmon.slice" start_crio
 
 	jq '	  .linux.cgroup_parent = "Burstablecriotest123.slice"' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_config_slice.json

--- a/test/drop_infra.bats
+++ b/test/drop_infra.bats
@@ -3,13 +3,13 @@
 load helpers
 
 function setup() {
-	# TODO: drop this skip once userns works with CONTAINER_MANAGE_NS_LIFECYCLE=true
+	# TODO: drop this skip once userns works with pinned namespaces
 	if test -n "$CONTAINER_UID_MAPPINGS"; then
 		skip "userNS enabled"
 	fi
 
 	setup_test
-	CONTAINER_MANAGE_NS_LIFECYCLE=true CONTAINER_DROP_INFRA_CTR=true start_crio
+	CONTAINER_DROP_INFRA_CTR=true start_crio
 }
 
 function teardown() {

--- a/test/network.bats
+++ b/test/network.bats
@@ -124,9 +124,7 @@ function check_networking() {
 	CONMON_BINARY="$TESTDIR"/conmon
 	cp "$(command -v conmon)" "$CONMON_BINARY"
 	CNI_DEFAULT_NETWORK="crio-${TESTDIR: -10}"
-	CONTAINER_MANAGE_NS_LIFECYCLE=false \
-		CONTAINER_DROP_INFRA_CTR=false \
-		start_crio
+	CONTAINER_DROP_INFRA_CTR=false start_crio
 
 	# make conmon non-executable to cause the sandbox setup to fail after
 	# networking has been configured

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -204,7 +204,7 @@ function teardown() {
 }
 
 @test "crio restore first not managing then managing" {
-	CONTAINER_MANAGE_NS_LIFECYCLE=false CONTAINER_DROP_INFRA_CTR=false start_crio
+	CONTAINER_DROP_INFRA_CTR=false start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	pod_list_info=$(crictl pods --quiet --id "$pod_id")
 
@@ -221,7 +221,7 @@ function teardown() {
 
 	stop_crio
 
-	CONTAINER_MANAGE_NS_LIFECYCLE=true start_crio
+	start_crio
 	output=$(crictl pods --quiet)
 	[[ "${output}" == "${pod_id}" ]]
 
@@ -246,7 +246,7 @@ function teardown() {
 }
 
 @test "crio restore first managing then not managing" {
-	CONTAINER_MANAGE_NS_LIFECYCLE=true CONTAINER_DROP_INFRA_CTR=true start_crio
+	CONTAINER_DROP_INFRA_CTR=true start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	pod_list_info=$(crictl pods --quiet --id "$pod_id")
 
@@ -262,7 +262,7 @@ function teardown() {
 
 	stop_crio
 
-	CONTAINER_MANAGE_NS_LIFECYCLE=false CONTAINER_DROP_INFRA_CTR=false start_crio
+	CONTAINER_DROP_INFRA_CTR=false start_crio
 	output=$(crictl pods --quiet)
 	[[ "${output}" == "${pod_id}" ]]
 
@@ -287,7 +287,7 @@ function teardown() {
 }
 
 @test "crio restore changing managing dir" {
-	CONTAINER_MANAGE_NS_LIFECYCLE=true CONTAINER_NAMESPACE_DIR="$TESTDIR/ns1" start_crio
+	CONTAINER_NAMESPACE_DIR="$TESTDIR/ns1" start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	pod_list_info=$(crictl pods --quiet --id "$pod_id")
 
@@ -302,7 +302,7 @@ function teardown() {
 
 	stop_crio
 
-	CONTAINER_MANAGE_NS_LIFECYCLE=true CONTAINER_NAMESPACE_DIR="$TESTDIR/ns2" start_crio
+	CONTAINER_NAMESPACE_DIR="$TESTDIR/ns2" start_crio
 	output=$(crictl pods --quiet)
 	[[ "${output}" == "${pod_id}" ]]
 


### PR DESCRIPTION
We removed that option in https://github.com/cri-o/cri-o/pull/4428/files

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>


#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

Remove remnants of CONTAINER_MANAGE_NS_LIFECYCLE that are no longer applicable.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
