### PR TITLE
[1.22] Wipe faster and pass around timeouts

### DIFF
--- a/internal/lib/remove.go
+++ b/internal/lib/remove.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Remove removes a container
-func (c *ContainerServer) Remove(ctx context.Context, container string, force bool) (string, error) {
+func (c *ContainerServer) Remove(ctx context.Context, container string, force bool, timeout int64) (string, error) {
 	ctr, err := c.LookupContainer(container)
 	if err != nil {
 		return "", err
@@ -23,7 +23,7 @@ func (c *ContainerServer) Remove(ctx context.Context, container string, force bo
 		return "", errors.Errorf("cannot remove paused container %s", ctrID)
 	case oci.ContainerStateCreated, oci.ContainerStateRunning:
 		if force {
-			if err = c.StopContainer(ctx, ctr, 10); err != nil {
+			if err = c.StopContainer(ctx, ctr, timeout); err != nil {
 				return "", errors.Wrapf(err, "unable to stop container %s", ctrID)
 			}
 		} else {

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -18,7 +18,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *types.RemoveContainer
 		return status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerID, err)
 	}
 
-	if _, err := s.ContainerServer.Remove(ctx, req.ContainerID, true); err != nil {
+	if _, err := s.ContainerServer.Remove(ctx, req.ContainerID, true, defaultRemovalTimeoutSec); err != nil {
 		return err
 	}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package server
@@ -923,7 +924,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	resourceCleaner.Add(ctx, description, func() error {
 		// Clean-up steps from RemovePodSanbox
 		log.Infof(ctx, description)
-		if err := s.ContainerServer.StopContainer(ctx, container, int64(10)); err != nil {
+		if err := s.ContainerServer.StopContainer(ctx, container, defaultRemovalTimeoutSec); err != nil {
 			return errors.Errorf("failed to stop container for removal")
 		}
 

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -31,5 +31,5 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *types.StopPodSandboxRe
 		log.Debugf(ctx, "StopPodSandboxResponse %s", req.PodSandboxID)
 		return nil
 	}
-	return s.stopPodSandbox(ctx, sb)
+	return s.stopPodSandbox(ctx, sb, defaultRemovalTimeoutSec)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now define the default timeout in the server and pass it around directly from the RPC level. In CRI-O wipe we use a timeout of `0` to just wipe immediately rather than waiting the default 10 seconds.

Manual cherry-pick of e8ab5cad9532a03665057ba4d0fe4e5e5eaa7aee

Refers to: https://github.com/cri-o/cri-o/pull/6412

#### Which issue(s) this PR fixes:

Refers to https://issues.redhat.com/browse/OCPBUGS-3183

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Updated CRI-O wipe to stop containers immediately.
```
