### PR TITLE
Take MaskedPaths and ReadonlyPaths from checkpointed container

### DIFF
--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -231,6 +231,16 @@ func (s *Server) CRImportCheckpoint(
 		containerConfig.Linux.SecurityContext = createConfig.Linux.SecurityContext
 	}
 
+	if dumpSpec.Linux != nil {
+		if dumpSpec.Linux.MaskedPaths != nil {
+			containerConfig.Linux.SecurityContext.MaskedPaths = dumpSpec.Linux.MaskedPaths
+		}
+
+		if dumpSpec.Linux.ReadonlyPaths != nil {
+			containerConfig.Linux.SecurityContext.ReadonlyPaths = dumpSpec.Linux.ReadonlyPaths
+		}
+	}
+
 	ignoreMounts := map[string]bool{
 		"/proc":              true,
 		"/dev":               true,

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -443,7 +443,8 @@ var _ = t.Describe("ContainerRestore", func() {
 					`"io.kubernetes.cri-o.SandboxID": "sandboxID"},`+
 					`"mounts": [{"destination": "/proc"},`+
 					`{"destination":"/data","source":"/data","options":`+
-					`["rw","ro","rbind","rprivate","rshared","rslaved"]}]}`),
+					`["rw","ro","rbind","rprivate","rshared","rslaved"]}],`+
+					`"linux": {"maskedPaths": ["/proc/acpi"], "readonlyPaths": ["/proc/asound"]}}`),
 				0o644,
 			)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

With this change the restored container has the same MaskedPaths and ReadonlyPaths as the originally checkpointed container.

#### Which issue(s) this PR fixes:

Fixes #6374


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```