### PR TITLE
Added documentation to force the Go garbage collector for CRI-O

### DIFF
--- a/tutorials/debugging.md
+++ b/tutorials/debugging.md
@@ -12,3 +12,13 @@ systemctl kill -s USR1 crio.service
 ```
 
 CRI-O will catch the signal, and write the routine stacks to `/tmp/crio-goroutine-stacks-$timestamp.log`
+
+### Forcing Go Garbage Collection
+
+You may have a need to manully run Go garbage collection for CRI-O.  To force garbage collection send CRI-O SIGUSR2 using `kill` or `systemctl` (if running CRI-O as a systemd unit):
+
+```bash
+kill -s SIGUSR2 $crio-pid
+
+systemctl kill -s USR2 crio.service
+```

--- a/tutorials/debugging.md
+++ b/tutorials/debugging.md
@@ -15,7 +15,7 @@ CRI-O will catch the signal, and write the routine stacks to `/tmp/crio-goroutin
 
 ### Forcing Go Garbage Collection
 
-You may have a need to manully run Go garbage collection for CRI-O.  To force garbage collection send CRI-O SIGUSR2 using `kill` or `systemctl` (if running CRI-O as a systemd unit):
+You may have a need to manually run Go garbage collection for CRI-O.  To force garbage collection, send CRI-O SIGUSR2 using `kill` or `systemctl` (if running CRI-O as a systemd unit).
 
 ```bash
 kill -s SIGUSR2 $crio-pid


### PR DESCRIPTION
Closes #5900
Signed-off-by: Rory Chapman <rchap4@gmail.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind documentation

#### What this PR does / why we need it:
This PR add documentation to force Go garbage collection for CRI-O.  CRI-O has the functionally to catch signal SIGUSR2 and manually run garbage collection.  However, at present using this feature is undocumented.

#### Which issue(s) this PR fixes:
This fixes issues 5900, a request to document the use of this feature.
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes #5900

#### Special notes for your reviewer:
I was able to successfully test manually initiating Go garbage collection for CRI-O running as a Systemd using the `systemctl kill -s USR2 crio.service` approach.  The worker node for the test was OpenShift 4.10.43, CRI-O 1.23.3, and RHEL CoreOS.  Success was observed as a significant decrease in the Memory RSS used by CRI-O on the node.  However, in testing on the same worker, I observed no change in CRI-O's RSS when using `kill -s SIGUSR2.`  I don't have access to another running instance of CRI-O to test further.  

#### Does this PR introduce a user-facing change?
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
