### PR TITLE
oci: Enable checkpointing of file locks

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1502,6 +1502,7 @@ func (r *runtimeOCI) CheckpointContainer(ctx context.Context, c *Container, spec
 	args = append(
 		args,
 		"checkpoint",
+		"--file-locks",
 		"--image-path",
 		imagePath,
 		"--work-path",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Since https://github.com/checkpoint-restore/criu/pull/1357, CRIU would fail if it finds file locks being used by the application that is being checkpointed and the --file-locks option has not been specified. This pull request enables checkpointing of file locks by default.


cc: @adrianreber 
```release-note
none
```
