### PR TITLE
Add additional metadata to inspect and checkpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/Microsoft/go-winio v0.6.0
 	github.com/blang/semver/v4 v4.0.0
-	github.com/checkpoint-restore/checkpointctl v0.0.0-20220321135231-33f4a66335f0
+	github.com/checkpoint-restore/checkpointctl v0.0.0-20221220135617-5b24f461ba2f
 	github.com/checkpoint-restore/go-criu/v6 v6.3.0
 	github.com/container-orchestrated-devices/container-device-interface v0.5.3
 	github.com/containerd/cgroups v1.0.5-0.20220816231112-7083cd60b721

--- a/go.sum
+++ b/go.sum
@@ -425,9 +425,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
-github.com/checkpoint-restore/checkpointctl v0.0.0-20220321135231-33f4a66335f0 h1:txB5jvhzUCSiiQmqmMWpo5CEB7Gj/Hq5Xqi7eaPl8ko=
-github.com/checkpoint-restore/checkpointctl v0.0.0-20220321135231-33f4a66335f0/go.mod h1:67kWC1PXQLR3lM/mmNnu3Kzn7K4TSWZAGUuQP1JSngk=
-github.com/checkpoint-restore/go-criu/v5 v5.2.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
+github.com/checkpoint-restore/checkpointctl v0.0.0-20221220135617-5b24f461ba2f h1:WHi5EdyciXKZgYkrSb6AMT+da4uL752/CLtSD9rH88o=
+github.com/checkpoint-restore/checkpointctl v0.0.0-20221220135617-5b24f461ba2f/go.mod h1:rZPubvdqxUqsIfF1dUZg/T3kis2FQ79OHqsh3/VfVEk=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
 github.com/checkpoint-restore/go-criu/v6 v6.3.0 h1:mIdrSO2cPNWQY1truPg6uHLXyKHk3Z5Odx4wjKOASzA=
 github.com/checkpoint-restore/go-criu/v6 v6.3.0/go.mod h1:rrRTN/uSwY2X+BPRl/gkulo9gsKOSAeVp9/K2tv7xZI=

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -114,6 +114,8 @@ type ContainerState struct {
 	// This is used to track whether the PID we have stored
 	// is the same as the corresponding PID on the host.
 	InitStartTime string `json:"initStartTime,omitempty"`
+	// Checkpoint/Restore related states
+	CheckpointedAt time.Time `json:"checkpointedTime,omitempty"`
 }
 
 // NewContainer creates a container object.
@@ -291,6 +293,16 @@ func (c *Container) StatePath() string {
 // CreatedAt returns the container creation time
 func (c *Container) CreatedAt() time.Time {
 	return c.state.Created
+}
+
+// CheckpointedAt returns the container checkpoint time
+func (c *Container) CheckpointedAt() time.Time {
+	return c.state.CheckpointedAt
+}
+
+// SetCheckpointedAt sets the time of checkpointing
+func (c *Container) SetCheckpointedAt(checkpointedAt time.Time) {
+	c.state.CheckpointedAt = checkpointedAt
 }
 
 // Name returns the name of the container.

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1518,10 +1518,11 @@ func (r *runtimeOCI) CheckpointContainer(ctx context.Context, c *Container, spec
 		return fmt.Errorf("running %q %q failed: %w", r.handler.RuntimePath, args, err)
 	}
 
+	c.SetCheckpointedAt(time.Now())
 	if !leaveRunning {
 		c.state.Status = ContainerStateStopped
 		c.state.ExitCode = utils.Int32Ptr(0)
-		c.state.Finished = time.Now()
+		c.state.Finished = c.CheckpointedAt()
 	}
 
 	return nil
@@ -1587,7 +1588,7 @@ func (r *runtimeOCI) RestoreContainer(ctx context.Context, c *Container, cgroupP
 	c.state.Pid = pid
 	// 3. Reset ExitCode (also needed for stopping)
 	c.state.ExitCode = nil
-	// 4. Set start time
+	// 4. Set start time (also restore time)
 	c.state.Started = time.Now()
 
 	return nil

--- a/server/container_checkpoint.go
+++ b/server/container_checkpoint.go
@@ -2,13 +2,8 @@ package server
 
 import (
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 
-	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/containers/podman/v4/libpod"
-	"github.com/containers/storage/pkg/archive"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/log"
 	"golang.org/x/net/context"
@@ -23,139 +18,27 @@ func (s *Server) CheckpointContainer(ctx context.Context, req *types.CheckpointC
 		return nil, fmt.Errorf("checkpoint/restore support not available")
 	}
 
-	var opts []*lib.ContainerCheckpointRestoreOptions
-	var podCheckpointDirectory string
-	var checkpointedPodOptions metadata.CheckpointedPodOptions
-
 	_, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
-		// Maybe the user specified a Pod
-		sb, err := s.LookupSandbox(req.ContainerId)
-		if err != nil {
-			return nil, status.Errorf(codes.NotFound, "could not find container or pod %q: %v", req.ContainerId, err)
-		}
-		if req.Location == "" {
-			return nil, status.Errorf(codes.NotFound, "Pod checkpointing requires a destination file")
-		}
-
-		log.Infof(ctx, "Checkpointing pod: %s", req.ContainerId)
-		// Create a temporary directory
-		podCheckpointDirectory, err = os.MkdirTemp("", "checkpoint")
-		if err != nil {
-			return nil, err
-		}
-		sandboxConfig := types.PodSandboxConfig{
-			Metadata: &types.PodSandboxMetadata{
-				Name:      sb.Metadata().Name,
-				Uid:       sb.Metadata().Uid,
-				Namespace: sb.Metadata().Namespace,
-				Attempt:   sb.Metadata().Attempt,
-			},
-			Hostname:     sb.Hostname(),
-			LogDirectory: sb.LogDir(),
-		}
-		var portMappings []*types.PortMapping
-		maps := sb.PortMappings()
-		for _, portMap := range maps {
-			pm := &types.PortMapping{
-				ContainerPort: portMap.ContainerPort,
-				HostPort:      portMap.HostPort,
-				HostIp:        portMap.HostIP,
-			}
-			switch portMap.Protocol {
-			case "TCP":
-				pm.Protocol = 0
-			case "UDP":
-				pm.Protocol = 1
-			case "SCTP":
-				pm.Protocol = 2
-			}
-
-			portMappings = append(portMappings, pm)
-		}
-		sandboxConfig.PortMappings = portMappings
-		if sb.DNSConfig() != nil {
-			dnsConfig := &types.DNSConfig{
-				Servers:  sb.DNSConfig().Servers,
-				Searches: sb.DNSConfig().Searches,
-				Options:  sb.DNSConfig().Options,
-			}
-			sandboxConfig.DnsConfig = dnsConfig
-		}
-		if _, err := metadata.WriteJSONFile(sandboxConfig, podCheckpointDirectory, metadata.PodDumpFile); err != nil {
-			return nil, err
-		}
-		defer func() {
-			if err := os.RemoveAll(podCheckpointDirectory); err != nil {
-				log.Errorf(ctx, "Could not recursively remove %s: %q", podCheckpointDirectory, err)
-			}
-		}()
-
-		for _, ctr := range sb.Containers().List() {
-			localOpts := &lib.ContainerCheckpointRestoreOptions{
-				Container: ctr.ID(),
-				ContainerCheckpointOptions: libpod.ContainerCheckpointOptions{
-					TargetFile:  filepath.Join(podCheckpointDirectory, ctr.Name()+".tar"),
-					KeepRunning: true,
-				},
-			}
-			opts = append(opts, localOpts)
-			// This should be ID
-			checkpointedPodOptions.Containers = append(checkpointedPodOptions.Containers, ctr.Name())
-		}
-		if len(opts) == 0 {
-			return nil, status.Errorf(codes.NotFound, "No containers found in Pod %q", req.ContainerId)
-		}
-		checkpointedPodOptions.Version = 1
-		checkpointedPodOptions.MountLabel = sb.MountLabel()
-		checkpointedPodOptions.ProcessLabel = sb.ProcessLabel()
-	} else {
-		log.Infof(ctx, "Checkpointing container: %s", req.ContainerId)
-		localOpts := &lib.ContainerCheckpointRestoreOptions{
-			Container: req.ContainerId,
-			ContainerCheckpointOptions: libpod.ContainerCheckpointOptions{
-				TargetFile: req.Location,
-				// For the forensic container checkpointing use case we
-				// keep the container running after checkpointing it.
-				KeepRunning: true,
-			},
-		}
-		opts = append(opts, localOpts)
+		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
+	}
+	log.Infof(ctx, "Checkpointing container: %s", req.ContainerId)
+	opts := &lib.ContainerCheckpointRestoreOptions{
+		Container: req.ContainerId,
+		ContainerCheckpointOptions: libpod.ContainerCheckpointOptions{
+			TargetFile: req.Location,
+			// For the forensic container checkpointing use case we
+			// keep the container running after checkpointing it.
+			KeepRunning: true,
+		},
 	}
 
-	for _, opt := range opts {
-		_, err = s.ContainerServer.ContainerCheckpoint(ctx, opt)
-		if err != nil {
-			return nil, err
-		}
+	_, err = s.ContainerServer.ContainerCheckpoint(ctx, opts)
+	if err != nil {
+		return nil, err
 	}
 
-	if podCheckpointDirectory != "" {
-		if podOptions, err := metadata.WriteJSONFile(checkpointedPodOptions, podCheckpointDirectory, metadata.PodOptionsFile); err != nil {
-			return nil, fmt.Errorf("error creating checkpointedContainers list file %q: %w", podOptions, err)
-		}
-		// It is a Pod checkpoint. Create the archive
-		podTar, err := archive.TarWithOptions(podCheckpointDirectory, &archive.TarOptions{
-			IncludeSourceDir: true,
-		})
-		if err != nil {
-			return nil, err
-		}
-		// The resulting tar archive should not readable by everyone as it contains
-		// every memory page of the checkpointed processes.
-		podTarFile, err := os.OpenFile(req.Location, os.O_RDWR|os.O_CREATE, 0o600)
-		if err != nil {
-			return nil, fmt.Errorf("error creating pod checkpoint archive %q: %w", req.Location, err)
-		}
-		defer podTarFile.Close()
-		_, err = io.Copy(podTarFile, podTar)
-		if err != nil {
-			return nil, fmt.Errorf("failed writing to pod tar archive %q: %w", req.Location, err)
-		}
-		log.Infof(ctx, "Checkpointed pod: %s", req.ContainerId)
-	} else {
-		log.Infof(ctx, "Checkpointed container: %s", req.ContainerId)
-	}
+	log.Infof(ctx, "Checkpointed container: %s", req.ContainerId)
 
 	return &types.CheckpointContainerResponse{}, nil
 }

--- a/server/container_checkpoint_test.go
+++ b/server/container_checkpoint_test.go
@@ -5,15 +5,11 @@ import (
 	"os"
 
 	"github.com/containers/podman/v4/pkg/criu"
-	cstorage "github.com/containers/storage"
-	"github.com/containers/storage/pkg/archive"
-	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"google.golang.org/grpc/status"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -54,10 +50,12 @@ var _ = t.Describe("ContainerCheckpoint", func() {
 			)
 
 			// When
-			_, err := sut.CheckpointContainer(context.Background(),
+			_, err := sut.CheckpointContainer(
+				context.Background(),
 				&types.CheckpointContainerRequest{
 					ContainerId: testContainer.ID(),
-				})
+				},
+			)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -66,122 +64,15 @@ var _ = t.Describe("ContainerCheckpoint", func() {
 		It("should fail with invalid container id", func() {
 			// Given
 			// When
-			_, err := sut.CheckpointContainer(context.Background(),
+			_, err := sut.CheckpointContainer(
+				context.Background(),
 				&types.CheckpointContainerRequest{
 					ContainerId: testContainer.ID(),
-				})
+				},
+			)
 
 			// Then
 			Expect(err).NotTo(BeNil())
-		})
-		It("should fail with valid pod id without archive", func() {
-			// Given
-			addContainerAndSandbox()
-			// When
-			_, err := sut.CheckpointContainer(context.Background(),
-				&types.CheckpointContainerRequest{
-					ContainerId: testSandbox.ID(),
-				})
-
-			// Then
-			Expect(status.Convert(err).Message()).To(Equal("Pod checkpointing requires a destination file"))
-		})
-		It("should succeed with valid pod id and archive", func() {
-			// Given
-			addContainerAndSandbox()
-
-			testContainer.SetState(&oci.ContainerState{
-				State: specs.State{Status: oci.ContainerStateRunning},
-			})
-			testContainer.SetSpec(&specs.Spec{Version: "1.0.0"})
-
-			gomock.InOrder(
-				storeMock.EXPECT().Container(gomock.Any()).Return(&cstorage.Container{}, nil),
-				storeMock.EXPECT().Changes(gomock.Any(), gomock.Any()).Return([]archive.Change{}, nil),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().Mount(gomock.Any(), gomock.Any()).Return("/tmp/", nil),
-				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil),
-			)
-			// When
-			_, err := sut.CheckpointContainer(context.Background(),
-				&types.CheckpointContainerRequest{
-					ContainerId: testSandbox.ID(),
-					Location:    "cp.tar",
-				})
-
-			// Then
-			Expect(err).To(BeNil())
-		})
-		It("should succeed with valid pod id and archive and DNSConfig and PortMapping", func() {
-			// Given
-			addContainerAndSandbox()
-
-			testContainer.SetState(&oci.ContainerState{
-				State: specs.State{Status: oci.ContainerStateRunning},
-			})
-			testContainer.SetSpec(&specs.Spec{Version: "1.0.0"})
-			testSandbox.SetDNSConfig(&types.DNSConfig{
-				Servers:  []string{"server1", "server2"},
-				Searches: []string{"searche1", "searches"},
-				Options:  []string{"option1", "option2"},
-			})
-			testSandbox.SetPortMappings([]*hostport.PortMapping{
-				{
-					ContainerPort: 2222,
-					HostPort:      1222,
-					Protocol:      "TCP",
-				},
-				{
-					ContainerPort: 2222,
-					HostPort:      1223,
-					Protocol:      "UDP",
-				},
-				{
-					ContainerPort: 2222,
-					HostIP:        "127.0.0.2",
-					HostPort:      1224,
-					Protocol:      "SCTP",
-				},
-			})
-
-			gomock.InOrder(
-				storeMock.EXPECT().Container(gomock.Any()).Return(&cstorage.Container{}, nil),
-				storeMock.EXPECT().Changes(gomock.Any(), gomock.Any()).Return([]archive.Change{}, nil),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().Mount(gomock.Any(), gomock.Any()).Return("/tmp/", nil),
-				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil),
-			)
-			// When
-			_, err := sut.CheckpointContainer(context.Background(),
-				&types.CheckpointContainerRequest{
-					ContainerId: testSandbox.ID(),
-					Location:    "cp.tar",
-				})
-
-			// Then
-			Expect(err).To(BeNil())
-		})
-		It("should fail with valid pod id and archive (with empty Container())", func() {
-			// Given
-			addContainerAndSandbox()
-
-			testContainer.SetState(&oci.ContainerState{
-				State: specs.State{Status: oci.ContainerStateRunning},
-			})
-			testContainer.SetSpec(&specs.Spec{Version: "1.0.0"})
-
-			gomock.InOrder(
-				storeMock.EXPECT().Container(gomock.Any()).Return(nil, t.TestError),
-			)
-			// When
-			_, err := sut.CheckpointContainer(context.Background(),
-				&types.CheckpointContainerRequest{
-					ContainerId: testSandbox.ID(),
-					Location:    "cp.tar",
-				})
-
-			// Then
-			Expect(err.Error()).To(Equal(`failed to write file system changes of container containerID: error exporting root file-system diff for "containerID": error`))
 		})
 	})
 })
@@ -202,10 +93,12 @@ var _ = t.Describe("ContainerCheckpoint with CheckpointRestore set to false", fu
 		It("should fail with checkpoint/restore support not available", func() {
 			// Given
 			// When
-			_, err := sut.CheckpointContainer(context.Background(),
+			_, err := sut.CheckpointContainer(
+				context.Background(),
 				&types.CheckpointContainerRequest{
 					ContainerId: testContainer.ID(),
-				})
+				},
+			)
 
 			// Then
 			Expect(err.Error()).To(Equal(`checkpoint/restore support not available`))

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -348,6 +348,7 @@ func (s *Server) CRImportCheckpoint(
 	newContainer.SetRestore(true)
 	newContainer.SetRestoreArchive(input)
 	newContainer.SetRestoreIsOCIImage(checkpointIsOCIImage)
+	newContainer.SetCheckpointedAt(config.CheckpointedAt)
 
 	if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
 		log.Infof(ctx, "RestoreCtr: context was either canceled or the deadline was exceeded: %v", ctx.Err())

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -3,8 +3,8 @@ package server
 import (
 	"fmt"
 
+	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/containers/podman/v4/libpod"
-	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
@@ -32,12 +32,11 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 
 		ctr, err := s.ContainerServer.ContainerRestore(
 			ctx,
-			&lib.ContainerCheckpointRestoreOptions{
-				Container: c.ID(),
-				Pod:       s.getSandbox(ctx, c.Sandbox()).ID(),
-				ContainerCheckpointOptions: libpod.ContainerCheckpointOptions{
-					TargetFile: c.ImageName(),
-				},
+			&metadata.ContainerConfig{
+				ID: c.ID(),
+			},
+			&libpod.ContainerCheckpointOptions{
+				TargetFile: c.ImageName(),
 			},
 		)
 		if err != nil {

--- a/server/container_status_test.go
+++ b/server/container_status_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"errors"
 
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
@@ -18,7 +19,6 @@ var _ = t.Describe("ContainerStatus", func() {
 	// Prepare the sut
 	BeforeEach(func() {
 		beforeEach()
-		setupSUT()
 	})
 
 	AfterEach(afterEach)
@@ -27,8 +27,13 @@ var _ = t.Describe("ContainerStatus", func() {
 		DescribeTable("should succeed", func(
 			givenState *oci.ContainerState,
 			expectedState types.ContainerState,
+			checkpointingEnabled bool,
 		) {
 			// Given
+			if checkpointingEnabled {
+				serverConfig.SetCheckpointRestore(true)
+			}
+			setupSUT()
 			addContainerAndSandbox()
 			testContainer.AddVolume(oci.ContainerVolume{})
 			testContainer.SetStateAndSpoofPid(givenState)
@@ -38,7 +43,6 @@ var _ = t.Describe("ContainerStatus", func() {
 				runtimeServerMock.EXPECT().GetContainerMetadata(gomock.Any()).
 					Return(storage.RuntimeContainerMetadata{}, nil),
 			)
-
 			// When
 			response, err := sut.ContainerStatus(context.Background(),
 				&types.ContainerStatusRequest{
@@ -52,25 +56,35 @@ var _ = t.Describe("ContainerStatus", func() {
 			Expect(len(response.Status.Mounts)).To(BeEquivalentTo(1))
 			Expect(response.Status.State).To(Equal(expectedState))
 			Expect(response.Info["info"]).To(ContainSubstring(`"ociVersion":"1.0.0"`))
+			if checkpointingEnabled {
+				Expect(response).To(ContainSubstring(`checkpointedAt`))
+			}
 		},
 			Entry("Created", &oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateCreated},
-			}, types.ContainerState_CONTAINER_CREATED),
+			}, types.ContainerState_CONTAINER_CREATED, false),
 			Entry("Running", &oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateRunning},
-			}, types.ContainerState_CONTAINER_RUNNING),
+			}, types.ContainerState_CONTAINER_RUNNING, false),
+			Entry("Running with checkpointing enabled", &oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateRunning},
+			}, types.ContainerState_CONTAINER_RUNNING, true),
 			Entry("Stopped: ExitCode 0", &oci.ContainerState{
 				ExitCode: utils.Int32Ptr(0),
 				State:    specs.State{Status: oci.ContainerStateStopped},
-			}, types.ContainerState_CONTAINER_EXITED),
+			}, types.ContainerState_CONTAINER_EXITED, false),
 			Entry("Stopped: ExitCode -1", &oci.ContainerState{
 				ExitCode: utils.Int32Ptr(-1),
 				State:    specs.State{Status: oci.ContainerStateStopped},
-			}, types.ContainerState_CONTAINER_EXITED),
+			}, types.ContainerState_CONTAINER_EXITED, false),
 			Entry("Stopped: OOMKilled", &oci.ContainerState{
 				OOMKilled: true,
 				State:     specs.State{Status: oci.ContainerStateStopped},
-			}, types.ContainerState_CONTAINER_EXITED),
+			}, types.ContainerState_CONTAINER_EXITED, false),
+			Entry("Stopped: SeccompKilled", &oci.ContainerState{
+				SeccompKilled: true,
+				State:         specs.State{Status: oci.ContainerStateStopped},
+			}, types.ContainerState_CONTAINER_EXITED, false),
 		)
 
 		It("should fail with invalid container ID", func() {
@@ -78,6 +92,32 @@ var _ = t.Describe("ContainerStatus", func() {
 			// When
 			response, err := sut.ContainerStatus(context.Background(),
 				&types.ContainerStatusRequest{})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(response).To(BeNil())
+		})
+
+		It("should fail with invalid container metadata", func() {
+			// Given
+			setupSUT()
+			addContainerAndSandbox()
+			testContainer.AddVolume(oci.ContainerVolume{})
+			testContainer.SetStateAndSpoofPid(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateRunning},
+			})
+			testContainer.SetSpec(&specs.Spec{Version: "1.0.0"})
+
+			gomock.InOrder(
+				runtimeServerMock.EXPECT().GetContainerMetadata(gomock.Any()).
+					Return(storage.RuntimeContainerMetadata{}, errors.New("not implemented")),
+			)
+			// When
+			response, err := sut.ContainerStatus(context.Background(),
+				&types.ContainerStatusRequest{
+					Verbose:     true,
+					ContainerId: testContainer.ID(),
+				})
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -29,11 +29,14 @@ function teardown() {
 	rmdir "$BIND_MOUNT_DIR"
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# Replace original container with checkpoint image
-	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
-	rm -f "$TESTDATA"/restore.json
+	RESTORE_JSON=$(mktemp)
+	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$RESTORE_JSON"
+	ctr_id=$(crictl create "$pod_id" "$RESTORE_JSON" "$TESTDATA"/sandbox_config.json)
+	rm -f "$RESTORE_JSON"
 	rm -f "$TESTDATA"/checkpoint.json
 	crictl start "$ctr_id"
+	restored=$(crictl inspect --output go-template --template "{{(index .info.restored)}}" "$ctr_id")
+	[[ "$restored" == "true" ]]
 	rm -f "$BIND_MOUNT_FILE"
 	rmdir "$BIND_MOUNT_DIR"
 }
@@ -41,25 +44,18 @@ function teardown() {
 @test "checkpoint and restore one container into a new pod (drop infra:false)" {
 	CONTAINER_DROP_INFRA_CTR=false CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-	BIND_MOUNT_FILE=$(mktemp)
-	BIND_MOUNT_DIR=$(mktemp -d)
-	jq ". +{mounts:[{\"container_path\":\"/etc/issue\",\"host_path\":\"$BIND_MOUNT_FILE\"},{\"container_path\":\"/data\",\"host_path\":\"$BIND_MOUNT_DIR\"}]}" "$TESTDATA"/container_sleep.json > "$TESTDATA"/checkpoint.json
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/checkpoint.json "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$ctr_id"
 	crictl checkpoint --export="$TESTDIR"/cp.tar "$ctr_id"
 	crictl rm -f "$ctr_id"
 	crictl rmp -f "$pod_id"
-	rm -f "$BIND_MOUNT_FILE"
-	rmdir "$BIND_MOUNT_DIR"
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# Replace original container with checkpoint image
-	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
-	rm -f "$TESTDATA"/restore.json
-	rm -f "$TESTDATA"/checkpoint.json
+	RESTORE_JSON=$(mktemp)
+	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$RESTORE_JSON"
+	ctr_id=$(crictl create "$pod_id" "$RESTORE_JSON" "$TESTDATA"/sandbox_config.json)
+	rm -f "$RESTORE_JSON"
 	crictl start "$ctr_id"
-	rm -f "$BIND_MOUNT_FILE"
-	rmdir "$BIND_MOUNT_DIR"
 }
 
 @test "checkpoint and restore one container into a new pod using --export to OCI image" {
@@ -77,9 +73,10 @@ function teardown() {
 	run_buildah commit "$newimage" "checkpoint-image:tag1"
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# Replace original container with checkpoint image
-	jq ".image.image=\"localhost/checkpoint-image:tag1\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
-	rm -f "$TESTDATA"/restore.json
+	RESTORE_JSON=$(mktemp)
+	jq ".image.image=\"localhost/checkpoint-image:tag1\"" "$TESTDATA"/container_sleep.json > "$RESTORE_JSON"
+	ctr_id=$(crictl create "$pod_id" "$RESTORE_JSON" "$TESTDATA"/sandbox_config.json)
+	rm -f "$RESTORE_JSON"
 	crictl start "$ctr_id"
 }
 
@@ -100,8 +97,9 @@ function teardown() {
 	repo_digest=$(crictl inspecti --output go-template --template "{{(index .status.repoDigests 0)}}" "localhost/checkpoint-image:tag1")
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# Replace original container with checkpoint image
-	jq ".image.image=\"$repo_digest\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
-	rm -f "$TESTDATA"/restore.json
+	RESTORE_JSON=$(mktemp)
+	jq ".image.image=\"$repo_digest\"" "$TESTDATA"/container_sleep.json > "$RESTORE_JSON"
+	ctr_id=$(crictl create "$pod_id" "$RESTORE_JSON" "$TESTDATA"/sandbox_config.json)
+	rm -f "$RESTORE_JSON"
 	crictl start "$ctr_id"
 }

--- a/vendor/github.com/checkpoint-restore/checkpointctl/lib/metadata.go
+++ b/vendor/github.com/checkpoint-restore/checkpointctl/lib/metadata.go
@@ -5,7 +5,6 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -14,39 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type CheckpointedPod struct {
-	PodUID                 string                  `json:"io.kubernetes.pod.uid,omitempty"`
-	ID                     string                  `json:"SandboxID,omitempty"`
-	Name                   string                  `json:"io.kubernetes.pod.name,omitempty"`
-	TerminationGracePeriod int64                   `json:"io.kubernetes.pod.terminationGracePeriod,omitempty"`
-	Namespace              string                  `json:"io.kubernetes.pod.namespace,omitempty"`
-	ConfigSource           string                  `json:"kubernetes.io/config.source,omitempty"`
-	ConfigSeen             string                  `json:"kubernetes.io/config.seen,omitempty"`
-	Manager                string                  `json:"io.container.manager,omitempty"`
-	Containers             []CheckpointedContainer `json:"Containers"`
-	HostIP                 string                  `json:"hostIP,omitempty"`
-	PodIP                  string                  `json:"podIP,omitempty"`
-	PodIPs                 []string                `json:"podIPs,omitempty"`
-}
-
-type CheckpointedContainer struct {
-	Name                      string `json:"io.kubernetes.container.name,omitempty"`
-	ID                        string `json:"id,omitempty"`
-	TerminationMessagePath    string `json:"io.kubernetes.container.terminationMessagePath,omitempty"`
-	TerminationMessagePolicy  string `json:"io.kubernetes.container.terminationMessagePolicy,omitempty"`
-	RestartCounter            int32  `json:"io.kubernetes.container.restartCount,omitempty"`
-	TerminationMessagePathUID string `json:"terminationMessagePathUID,omitempty"`
-	Image                     string `json:"Image"`
-}
-
-type CheckpointMetadata struct {
-	Version          int `json:"version"`
-	CheckpointedPods []CheckpointedPod
-}
-
 const (
-	// kubelet archive
-	CheckpointedPodsFile = "checkpointed.pods"
 	// container archive
 	ConfigDumpFile             = "config.dump"
 	SpecDumpFile               = "spec.dump"
@@ -61,105 +28,32 @@ const (
 	// pod archive
 	PodOptionsFile = "pod.options"
 	PodDumpFile    = "pod.dump"
-)
-
-type CheckpointType int
-
-const (
-	// The checkpoint archive contains a kubelet checkpoint
-	// One or multiple pods and kubelet metadata (checkpointed.pods)
-	Kubelet CheckpointType = iota
-	// The checkpoint archive contains one pod including one or multiple containers
-	Pod
-	// The checkpoint archive contains a single container
-	Container
-	Unknown
+	// containerd only
+	StatusFile = "status"
 )
 
 // This is a reduced copy of what Podman uses to store checkpoint metadata
 type ContainerConfig struct {
 	ID              string    `json:"id"`
 	Name            string    `json:"name"`
+	RootfsImage     string    `json:"rootfsImage,omitempty"`
+	RootfsImageRef  string    `json:"rootfsImageRef,omitempty"`
 	RootfsImageName string    `json:"rootfsImageName,omitempty"`
 	OCIRuntime      string    `json:"runtime,omitempty"`
 	CreatedTime     time.Time `json:"createdTime"`
+	CheckpointedAt  time.Time `json:"checkpointedTime"`
+	RestoredAt      time.Time `json:"restoredTime"`
+	Restored        bool      `json:"restored"`
 }
 
-// This is metadata stored inside of a Pod checkpoint archive
-type CheckpointedPodOptions struct {
-	Version      int      `json:"version"`
-	Containers   []string `json:"containers,omitempty"`
-	MountLabel   string   `json:"mountLabel"`
-	ProcessLabel string   `json:"processLabel"`
-}
-
-// This is metadata stored inside of Pod checkpoint archive
-type PodSandboxConfig struct {
-	Metadata SandboxMetadta `json:"metadata"`
-	Hostname string         `json:"hostname"`
-}
-
-type SandboxMetadta struct {
-	Name      string `json:"name"`
-	UID       string `json:"uid"`
-	Namespace string `json:"namespace"`
-}
-
-func checkForFile(checkpointDirectory, file string) (bool, error) {
-	_, err := os.Stat(filepath.Join(checkpointDirectory, file))
-	if err != nil && !os.IsNotExist(err) {
-		return false, errors.Wrapf(err, "Failed to access %q\n", file)
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-func DetectCheckpointArchiveType(checkpointDirectory string) (CheckpointType, error) {
-	kubelet, err := checkForFile(checkpointDirectory, CheckpointedPodsFile)
-	if os.IsNotExist(err) {
-		return Unknown, err
-	}
-
-	container, err := checkForFile(checkpointDirectory, ConfigDumpFile)
-	if os.IsNotExist(err) {
-		return Unknown, err
-	}
-
-	pod, err := checkForFile(checkpointDirectory, PodDumpFile)
-	if os.IsNotExist(err) {
-		return Unknown, err
-	}
-
-	if pod && !container && !kubelet {
-		return Pod, nil
-	}
-
-	if !pod && container && !kubelet {
-		return Container, nil
-	}
-
-	if !pod && !container && kubelet {
-		return Kubelet, nil
-	}
-
-	return Unknown, nil
-}
-
-func ReadPodCheckpointDumpFile(checkpointDirectory string) (*PodSandboxConfig, string, error) {
-	var podSandboxConfig PodSandboxConfig
-	podDumpFile, err := ReadJSONFile(&podSandboxConfig, checkpointDirectory, PodDumpFile)
-
-	return &podSandboxConfig, podDumpFile, err
-}
-
-func ReadPodCheckpointOptionsFile(checkpointDirectory string) (*CheckpointedPodOptions, string, error) {
-	var checkpointedPodOptions CheckpointedPodOptions
-	podOptionsFile, err := ReadJSONFile(&checkpointedPodOptions, checkpointDirectory, PodOptionsFile)
-
-	return &checkpointedPodOptions, podOptionsFile, err
+type ContainerdStatus struct {
+	CreatedAt  int64
+	StartedAt  int64
+	FinishedAt int64
+	ExitCode   int32
+	Pid        uint32
+	Reason     string
+	Message    string
 }
 
 func ReadContainerCheckpointSpecDump(checkpointDirectory string) (*spec.Spec, string, error) {
@@ -183,11 +77,11 @@ func ReadContainerCheckpointDeletedFiles(checkpointDirectory string) ([]string, 
 	return deletedFiles, deletedFilesFile, err
 }
 
-func ReadKubeletCheckpoints(checkpointsDirectory string) (*CheckpointMetadata, string, error) {
-	var checkpointMetadata CheckpointMetadata
-	checkpointMetadataPath, err := ReadJSONFile(&checkpointMetadata, checkpointsDirectory, CheckpointedPodsFile)
+func ReadContainerCheckpointStatusFile(checkpointDirectory string) (*ContainerdStatus, string, error) {
+	var containerdStatus ContainerdStatus
+	statusFile, err := ReadJSONFile(&containerdStatus, checkpointDirectory, StatusFile)
 
-	return &checkpointMetadata, checkpointMetadataPath, err
+	return &containerdStatus, statusFile, err
 }
 
 // WriteJSONFile marshalls and writes the given data to a JSON file
@@ -197,7 +91,7 @@ func WriteJSONFile(v interface{}, dir, file string) (string, error) {
 		return "", errors.Wrapf(err, "Error marshalling JSON")
 	}
 	file = filepath.Join(dir, file)
-	if err := ioutil.WriteFile(file, fileJSON, 0o600); err != nil {
+	if err := os.WriteFile(file, fileJSON, 0o600); err != nil {
 		return "", errors.Wrapf(err, "Error writing to %q", file)
 	}
 
@@ -206,7 +100,7 @@ func WriteJSONFile(v interface{}, dir, file string) (string, error) {
 
 func ReadJSONFile(v interface{}, dir, file string) (string, error) {
 	file = filepath.Join(dir, file)
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to read %s", file)
 	}
@@ -215,12 +109,6 @@ func ReadJSONFile(v interface{}, dir, file string) (string, error) {
 	}
 
 	return file, nil
-}
-
-func WriteKubeletCheckpointsMetadata(checkpointMetadata *CheckpointMetadata, dir string) error {
-	_, err := WriteJSONFile(checkpointMetadata, dir, CheckpointedPodsFile)
-
-	return err
 }
 
 func ByteToString(b int64) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -447,8 +447,8 @@ github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.1.2
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/checkpoint-restore/checkpointctl v0.0.0-20220321135231-33f4a66335f0
-## explicit; go 1.15
+# github.com/checkpoint-restore/checkpointctl v0.0.0-20221220135617-5b24f461ba2f
+## explicit; go 1.18
 github.com/checkpoint-restore/checkpointctl/lib
 # github.com/checkpoint-restore/go-criu/v6 v6.3.0
 ## explicit; go 1.16


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds additional metadata to the inspect command if checkpointing support is active. The following three fields are added to inspect:

```json
  "checkpointedAt": "timestamp",
  "restored": "true or false",
```

With "checkpointedAt" it is possible to see when a checkpoint was created. With "restoredAt" is is possible to see when this container was restored from a checkpoint. "restored" is true if the container has been restored from a checkpoint for all other container this is set to false.

These information are also part of the checkpoint archive. If checkpoint archive contains a container that has been restored "restoredAt" will be empty but "checkpointedAt" will still contain the time of the checkpointing.

To add these additional fields it was necessary to pull in a newer version of checkpoint-restore/checkpointctl which also required to remove some unused checkpoint code concerning pods. The pod checkpointing code was a left over from the initial merge and the initial proof of concept about checkpointing and restoring pods.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Extended checkpoint archive metadata with time of checkpointing.
```