### PR TITLE
get script: fix conflist path

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -212,7 +212,7 @@ ARCH=${ARCH:-amd64}
 set -x
 install $SELINUX -d -m 755 "$DESTDIR$CNIDIR"
 install $SELINUX -D -m 755 -t "$DESTDIR$OPT_CNI_BIN_DIR" cni-plugins/*
-install $SELINUX -D -m 644 -t "$DESTDIR$CNIDIR" contrib/10-crio-bridge.conflist
+install $SELINUX -D -m 644 -t "$DESTDIR$CNIDIR" contrib/11-crio-ipv4-bridge.conflist
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/conmon
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crictl
 install $SELINUX -d -m 755 "$DESTDIR$BASHINSTALLDIR"


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Fix the `get-script` job caused by `install: cannot stat 'contrib/10-crio-bridge.conflist': No such file or directory`

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
None
```
