### PR TITLE
contrib/test/ci: clone kubenetes repo only once

### DIFF
--- a/contrib/test/ci/build/kubernetes.yml
+++ b/contrib/test/ci/build/kubernetes.yml
@@ -1,10 +1,19 @@
 ---
+- name: Check if kubernetes repo already exists
+  stat:
+    path: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+  register: kube_repo
+
+- name: Delete kubernetes repo if already exists
+  file:
+    state: absent
+    path: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+  when: kube_repo.stat.exists
 
 - name: clone kubernetes source repo
   git:
     repo: "https://github.com/{{ k8s_github_fork }}/kubernetes.git"
     dest: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
-    # based on kube v1.9.0-alpha.2, update as needed
     version: "{{ k8s_git_version }}"
     force: "{{ force_clone | default(False) | bool}}"
 


### PR DESCRIPTION
We need this change to avoid hitting an error when the cloning operation of the kuberenetes repo fails due to the local modifications ( addresses the failure while caching an image for CI)

Signed-off-by: Sohan Kunkerkar <sohank2602@gmail.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
