### PR TITLE
Allow cross building from non-linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
       - run: scripts/github-actions-packages
       - run: make
       - run: bin/crio version
+      - run: make bin/crio.cross.linux.amd64
+      - run: bin/crio.cross.linux.amd64 version
       - uses: actions/upload-artifact@v3
         with:
           name: build

--- a/internal/config/seccomp/notifier.go
+++ b/internal/config/seccomp/notifier.go
@@ -1,3 +1,6 @@
+//go:build linux && cgo
+// +build linux,cgo
+
 package seccomp
 
 import (

--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -1,3 +1,6 @@
+//go:build linux && cgo
+// +build linux,cgo
+
 package seccomp
 
 import (

--- a/internal/config/seccomp/seccomp_unsupported.go
+++ b/internal/config/seccomp/seccomp_unsupported.go
@@ -1,0 +1,116 @@
+//go:build !(linux && cgo)
+// +build !linux !cgo
+
+package seccomp
+
+import (
+	"context"
+
+	"github.com/opencontainers/runtime-tools/generate"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// Config is the global seccomp configuration type
+type Config struct {
+	enabled bool
+}
+
+// Notifier wraps a seccomp notifier instance for a container.
+type Notifier struct {
+}
+
+// Notification is a seccomp notification which gets sent to the CRI-O server.
+type Notification struct {
+}
+
+// New creates a new default seccomp configuration instance
+func New() *Config {
+	return &Config{
+		enabled: false,
+	}
+}
+
+// Setup can be used to setup the seccomp profile.
+func (c *Config) Setup(
+	ctx context.Context,
+	msgChan chan Notification,
+	containerID string,
+	annotations map[string]string,
+	specGenerator *generate.Generator,
+	profileField *types.SecurityProfile,
+	profilePath string,
+) (notifier *Notifier, err error) {
+	return nil, nil
+}
+
+// SetUseDefaultWhenEmpty uses the default seccomp profile if true is passed as
+// argument, otherwise unconfined.
+func (c *Config) SetUseDefaultWhenEmpty(to bool) {
+}
+
+// Returns whether the seccomp config is set to
+// use default profile when the profile is empty
+func (c *Config) UseDefaultWhenEmpty() bool {
+	return false
+}
+
+// SetNotifierPath sets the default path for creating seccomp notifier sockets.
+func (c *Config) SetNotifierPath(path string) {
+}
+
+// NotifierPath returns the currently used seccomp notifier base path.
+func (c *Config) NotifierPath() string {
+	return ""
+}
+
+// LoadProfile can be used to load a seccomp profile from the provided path.
+// This method will not fail if seccomp is disabled.
+func (c *Config) LoadProfile(profilePath string) error {
+	return nil
+}
+
+// LoadDefaultProfile sets the internal default profile.
+func (c *Config) LoadDefaultProfile() error {
+	return nil
+}
+
+// NewNotifier starts the notifier for the provided arguments.
+func NewNotifier(
+	ctx context.Context,
+	msgChan chan Notification,
+	containerID, listenerPath string,
+	annotationMap map[string]string,
+) (*Notifier, error) {
+	return nil, nil
+}
+
+// Close can be used to close the notifier listener.
+func (*Notifier) Close() error {
+	return nil
+}
+
+func (*Notifier) AddSyscall(syscall string) {
+}
+
+func (*Notifier) UsedSyscalls() string {
+	return ""
+}
+
+func (*Notifier) StopContainers() bool {
+	return false
+}
+
+func (*Notifier) OnExpired(callback func()) {
+}
+
+func (*Notification) Ctx() context.Context {
+	return nil
+}
+
+func (*Notification) ContainerID() string {
+	return ""
+}
+
+func (*Notification) Syscall() string {
+	return ""
+}


### PR DESCRIPTION
This allows building crio.cross.linux.amd64 on non-linux platforms. The only thing which I needed to change was to add non-cgo stubs for seccomp. The main use-case for this is to avoid breaking the Linux build while refactoring to allow for a FreeBSD port of cri-o.

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is useful to support porting cri-o to non-linux platforms.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
