### PR TITLE
OCPNODE-1336: Enable upstream CI to test node e2e with evented pleg feature

### DIFF
--- a/scripts/node_e2e_installer
+++ b/scripts/node_e2e_installer
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Commit to run upstream node e2e tests
 NODE_E2E_COMMIT=085e3a03cf17d8a97e14551ec83137954328f627
+ENABLE_POD_EVENTS=${ENABLE_POD_EVENTS:-"false"}
 
 enable_selinux() {
     # Make sure SELinux is enabled
@@ -48,6 +49,15 @@ EOF
 drop_infra_ctr = false
 EOF
 
+    for condition in "true" "True" "TRUE"; do
+        if [[ "${ENABLE_POD_EVENTS}" = "$condition" ]]; then
+            cat <<EOF >/etc/crio/crio.conf.d/40-evented-pleg.conf
+[crio.runtime]
+enable_pod_events = true
+EOF
+            break
+        fi
+    done
 }
 
 enable_selinux


### PR DESCRIPTION
Signed-off-by: Sai Ramesh Vanka <svanka@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind ci
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
This code change helps in enabling the evented pleg feature in cri-o while running the CI(node e2e tests) jobs in the upstream k8s/test-infra

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
