### PR TITLE
revert d06cae7: contrib/cni - use cniVersion 1.0.0 for ipv4 bridge config

### DIFF
--- a/contrib/cni/11-crio-ipv4-bridge.conflist
+++ b/contrib/cni/11-crio-ipv4-bridge.conflist
@@ -1,5 +1,5 @@
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "name": "crio",
   "plugins": [
     {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Revert d06cae7 commit. cc @haircommander 

We have updated the [other CNI files](https://github.com/cri-o/cri-o/tree/main/contrib/cni) to version `1.0.0`, ipv4 bridge config version was reverted back to 0.3.1 to fix the build issue. The build issue has been identified and [fixed](https://github.com/cri-o/cri-o/pull/6476). Hence reverting this change.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
