### PR TITLE
[release-1.24] do not wipe images by default

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,9 +1,7 @@
 package version
 
 import (
-	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -56,14 +54,12 @@ func ShouldCrioWipe(versionFileName string) (bool, error) {
 
 // shouldCrioWipe is an internal function for testing purposes
 func shouldCrioWipe(versionFileName, versionString string) (bool, error) {
-	f, err := os.Open(versionFileName)
+	if versionFileName == "" {
+		return false, nil
+	}
+	versionBytes, err := os.ReadFile(versionFileName)
 	if err != nil {
 		return true, errors.Errorf("version file %s not found: %v", versionFileName, err)
-	}
-	r := bufio.NewReader(f)
-	versionBytes, err := ioutil.ReadAll(r)
-	if err != nil {
-		return true, errors.Errorf("reading version file %s failed: %v", versionFileName, err)
 	}
 
 	// parse the version that was laid down by a previous invocation of crio
@@ -99,6 +95,9 @@ func LogVersion() {
 
 // writeVersionFile is an internal function for testing purposes
 func writeVersionFile(file, gitCommit, version string) error {
+	if file == "" {
+		return nil
+	}
 	current, err := parseVersionConstant(version, gitCommit)
 	// Sanity check-this should never happen
 	if err != nil {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -74,10 +74,10 @@ var _ = t.Describe("Version", func() {
 			_, err = ioutil.ReadFile(filename)
 			Expect(err).To(BeNil())
 		})
-		It("should fail to upgrade with unspecified version", func() {
+		It("should not wipe with empty version file", func() {
 			upgrade, err := shouldCrioWipe("", tempVersion)
-			Expect(upgrade).To(BeTrue())
-			Expect(err).ToNot(BeNil())
+			Expect(upgrade).To(BeFalse())
+			Expect(err).To(BeNil())
 		})
 		It("should fail to upgrade with empty version file", func() {
 			tempFileName := tempFileName


### PR DESCRIPTION
This is a manual backport of 935652c90c9f87e001f9453a5b102d538edc06f7

```release-note
Do not wipe images when the filename is empty.
```