### PR TITLE
WIP: Fix generated event name on stop container action.

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -635,6 +635,13 @@ func (r *runtimeVM) updateContainerStatus(ctx context.Context, c *Container) err
 		addressPath := filepath.Join(c.BundlePath(), "address")
 		data, err := os.ReadFile(addressPath)
 		if err != nil {
+			// If the container is actually removed, this error is expected and should be ignored.
+			// In this case, the container's status should be "Stopped".
+			if c.state.Status == ContainerStateStopped {
+				log.Debugf(ctx, "Skipping status update for: %+v", c.state)
+				return nil
+			}
+
 			log.Warnf(ctx, "Failed to read shim address: %v", err)
 			return errors.New("runtime not correctly setup")
 		}

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -42,7 +42,7 @@ func (s *Server) StopContainer(ctx context.Context, req *types.StopContainerRequ
 		log.Warnf(ctx, "NRI stop failed for container %q: %v", c.ID(), err)
 	}
 
-	s.generateCRIEvent(ctx, c, types.ContainerEventType_CONTAINER_DELETED_EVENT)
+	s.generateCRIEvent(ctx, c, types.ContainerEventType_CONTAINER_STOPPED_EVENT)
 	log.Infof(ctx, "Stopped container %s: %s", c.ID(), c.Description())
 	return &types.StopContainerResponse{}, nil
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Found this while working on kata CI - the job failed the integration tests on :
"ctr pod lifecycle with evented pleg enabled"


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
