### PR TITLE
Update vendor of opencontainers/runtime-tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
 	github.com/opencontainers/runc v1.1.4
 	github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
-	github.com/opencontainers/runtime-tools v0.9.1-0.20221026201742-946c877fa809
+	github.com/opencontainers/runtime-tools v0.9.1-0.20221107153022-2802ff9ff545
 	github.com/opencontainers/selinux v1.10.2
 	github.com/prometheus/client_golang v1.14.0
 	github.com/psampaz/go-mod-outdated v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1649,8 +1649,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.m
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb h1:1xSVPOd7/UA+39/hXEGnBJ13p6JFB0E1EvQFlrRDOXI=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/opencontainers/runtime-tools v0.9.1-0.20221026201742-946c877fa809 h1:VLCrW5qA1ADIYmmJFhHtkzIRrUy6dTM5zEqiax68lBg=
-github.com/opencontainers/runtime-tools v0.9.1-0.20221026201742-946c877fa809/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
+github.com/opencontainers/runtime-tools v0.9.1-0.20221107153022-2802ff9ff545 h1:ftZiJi2Wy+U8Kvc6hdGMCcy+szWDjajN+idKlVHap+Y=
+github.com/opencontainers/runtime-tools v0.9.1-0.20221107153022-2802ff9ff545/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=

--- a/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_unsupported.go
+++ b/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_unsupported.go
@@ -1,7 +1,7 @@
 //go:build !linux
 // +build !linux
 
-package validate
+package capabilities
 
 import (
 	"github.com/syndtr/gocapability/capability"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1701,7 +1701,7 @@ github.com/opencontainers/runc/libcontainer/utils
 # github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
-# github.com/opencontainers/runtime-tools v0.9.1-0.20221026201742-946c877fa809
+# github.com/opencontainers/runtime-tools v0.9.1-0.20221107153022-2802ff9ff545
 ## explicit; go 1.16
 github.com/opencontainers/runtime-tools/error
 github.com/opencontainers/runtime-tools/filepath


### PR DESCRIPTION
This moves the hash one step forward to fix a package name mistake which affects non-linux builds.

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:

This allows code which depends on opencontainers/runtime-tools to build on non-linux platforms.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
