### PR TITLE
[release-1.24] ci-verify: Run get-scripts only on main branch

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -91,6 +91,7 @@ jobs:
       - run: make check-config-template
 
   get-script:
+    if: ${{ github.base_ref == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is manual cherry-pick of https://github.com/cri-o/cri-o/pull/6528

Closes https://github.com/cri-o/cri-o/issues/6512

```release-note
None
```