### PR TITLE
[release-1.24] Inject release-notes branch from GitHub actions 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -303,6 +303,11 @@ jobs:
             ~/.cache/go-build
           key: go-build-${{ hashFiles('**/go.sum') }}
           restore-keys: go-build-
+      - name: Set current branch
+        run: |
+          raw=$(git branch -r --contains ${{ github.ref }})
+          branch=${raw##*/}
+          echo "CURRENT_BRANCH=$branch" >> $GITHUB_ENV
       - run: make release-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/cri-o/cri-o/pull/6534

```release-note
None
```