### PR TITLE
server: only start one resource store routine on network cleanup in r…

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -81,6 +81,7 @@ var _ = t.Describe("Server", func() {
 
 		It("should succeed with container restore", func() {
 			// Given
+			setCNIPlugin()
 			gomock.InOrder(
 				libMock.EXPECT().GetData().Times(2).Return(serverConfig),
 				libMock.EXPECT().GetStore().Return(storeMock, nil),

--- a/server/server_test_inject.go
+++ b/server/server_test_inject.go
@@ -6,17 +6,7 @@
 
 package server
 
-import (
-	"github.com/cri-o/ocicni/pkg/ocicni"
-)
-
 // SetStorageRuntimeServer sets the runtime server for the ContainerServer
 func (s *StreamService) SetRuntimeServer(server *Server) {
 	s.runtimeServer = server
-}
-
-// SetCNIPlugin sets the network plugin for the ContainerServer. The function
-// errors if a sane shutdown of the initially created network plugin failed.
-func (s *Server) SetCNIPlugin(plugin ocicni.CNIPlugin) error {
-	return s.config.SetCNIPlugin(plugin)
 }

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -184,6 +184,7 @@ var afterEach = func() {
 var setupSUT = func() {
 	var err error
 	mockNewServer()
+
 	sut, err = server.New(context.Background(), libMock)
 	Expect(err).To(BeNil())
 	Expect(sut).NotTo(BeNil())
@@ -191,12 +192,10 @@ var setupSUT = func() {
 	// Inject the mock
 	sut.SetStorageImageServer(imageServerMock)
 	sut.SetStorageRuntimeServer(runtimeServerMock)
-
-	gomock.InOrder(cniPluginMock.EXPECT().Status().Return(nil))
-	Expect(sut.SetCNIPlugin(cniPluginMock)).To(BeNil())
 }
 
 func mockNewServer() {
+	setCNIPlugin()
 	gomock.InOrder(
 		libMock.EXPECT().GetData().Times(2).Return(serverConfig),
 		libMock.EXPECT().GetStore().Return(storeMock, nil),
@@ -204,6 +203,13 @@ func mockNewServer() {
 		storeMock.EXPECT().Containers().
 			Return([]cstorage.Container{}, nil),
 	)
+}
+
+func setCNIPlugin() {
+	gomock.InOrder(
+		cniPluginMock.EXPECT().Status().Return(nil),
+	)
+	Expect(serverConfig.SetCNIPlugin(cniPluginMock)).To(BeNil())
 }
 
 func addContainerAndSandbox() {


### PR DESCRIPTION
…estore

to reduce the amount of CPU usage of many routines spinning and waiting for the CNI plugin to become ready

Signed-off-by: Peter Hunt~ <pehunt@redhat.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
