### PR TITLE
packit: install wget before build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,6 +10,7 @@ upstream_tag_template: v{version}
 downstream_package_name: cri-o
 actions:
   post-upstream-clone: "wget https://src.fedoraproject.org/rpms/cri-o/raw/rawhide/f/cri-o.spec -O cri-o.spec"
+srpm_build_deps: ["wget"]
 jobs:
 - job: copr_build
   trigger: commit


### PR DESCRIPTION
In January 2023, Packit changed the way SRPMs are built. You can (and
have to) specify all dependencies that are utilized during the SRPM
build phase, in this case, wget.

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Get RPM builds working again.

#### Does this PR introduce a user-facing change?

no