### PR TITLE
Add container stats to the ListPodSandboxStats response

### DIFF
--- a/internal/lib/stats/stats_server.go
+++ b/internal/lib/stats/stats_server.go
@@ -120,6 +120,7 @@ func (ss *StatsServer) updateSandbox(sb *sandbox.Sandbox) *types.PodSandboxStats
 		if oldcStats, ok := ss.ctrStats[c.ID()]; ok {
 			updateUsageNanoCores(oldcStats.Cpu, cStats.Cpu)
 		}
+		containerStats = append(containerStats, cStats)
 	}
 	sandboxStats.Linux.Containers = containerStats
 	if old, ok := ss.sboxStats[sb.ID()]; ok {

--- a/test/stats.bats
+++ b/test/stats.bats
@@ -52,3 +52,19 @@ function teardown() {
 	echo "checking $ctr1_mem != $ctr2_mem"
 	[ "$ctr1_mem" != "$ctr2_mem" ]
 }
+
+@test "pod stats" {
+	# given
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	# when
+	json=$(crictl statsp --id "$pod_id" -o json)
+	echo "$json"
+	jq -e '.stats[0].attributes.id == "'"$pod_id"'"' <<< "$json"
+
+	# Check that the container is listed in the statsp response
+	jq -e '.stats[0].linux.containers[0].attributes.id == "'"$ctr_id"'"' <<< "$json"
+}


### PR DESCRIPTION
The stats were being collected but not added to the PodSandboxStats.Linux.Containers array. Closes #6563.

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #6563

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
