### PR TITLE
Update runtime-tools to mount '/dev' without the 'noexec' flag.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
 	github.com/opencontainers/runc v1.1.4
 	github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
-	github.com/opencontainers/runtime-tools v0.9.1-0.20221107153022-2802ff9ff545
+	github.com/opencontainers/runtime-tools v0.9.1-0.20230110161035-a6a073817ab0
 	github.com/opencontainers/selinux v1.10.2
 	github.com/prometheus/client_golang v1.14.0
 	github.com/psampaz/go-mod-outdated v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1592,8 +1592,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.m
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb h1:1xSVPOd7/UA+39/hXEGnBJ13p6JFB0E1EvQFlrRDOXI=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/opencontainers/runtime-tools v0.9.1-0.20221107153022-2802ff9ff545 h1:ftZiJi2Wy+U8Kvc6hdGMCcy+szWDjajN+idKlVHap+Y=
-github.com/opencontainers/runtime-tools v0.9.1-0.20221107153022-2802ff9ff545/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
+github.com/opencontainers/runtime-tools v0.9.1-0.20230110161035-a6a073817ab0 h1:C1EbGtbEhyGJN6XkYHjmRm5lmmGo9UT+vGj0Rn8lF5E=
+github.com/opencontainers/runtime-tools v0.9.1-0.20230110161035-a6a073817ab0/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=

--- a/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
@@ -182,7 +182,7 @@ func New(os string) (generator Generator, err error) {
 				Destination: "/dev",
 				Type:        "tmpfs",
 				Source:      "tmpfs",
-				Options:     []string{"nosuid", "noexec", "strictatime", "mode=755", "size=65536k"},
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
 			},
 			{
 				Destination: "/dev/pts",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1777,7 +1777,7 @@ github.com/opencontainers/runc/libcontainer/utils
 # github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
-# github.com/opencontainers/runtime-tools v0.9.1-0.20221107153022-2802ff9ff545
+# github.com/opencontainers/runtime-tools v0.9.1-0.20230110161035-a6a073817ab0
 ## explicit; go 1.16
 github.com/opencontainers/runtime-tools/error
 github.com/opencontainers/runtime-tools/filepath


### PR DESCRIPTION
Update runtime-tools to commit a6a073817ab0. This reverts commit 09d837b of the same repo (mount `/dev` with the `noexec` flag), which triggered problems when containers try to create Intel SGX enclaves.

#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:

Commit [09d837b](https://github.com/opencontainers/runtime-tools/commit/09d837bf40a7356a478e40642e36f5f7e1dea7d1) of runtime-tools changed `/dev` to be mounted by default with the `noexec` flag. This triggers problems when containers try to create Intel SGX enclaves. Please see [the revert commit](https://github.com/opencontainers/runtime-tools/commit/0524bb2cf613004f1cc291f81a68f308e83d846f) message for more details or the related [runtime-tools issue](https://github.com/opencontainers/runtime-tools/issues/759).

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
'/dev' is now mounted again without the 'noexec' flag.
```
