### PR TITLE
Fix issues with PLEG events for kata

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -176,7 +176,7 @@ func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
 	}
 
 	if rh.RuntimeType == config.RuntimeTypeVM {
-		return newRuntimeVM(rh.RuntimePath, rh.RuntimeRoot, rh.RuntimeConfigPath), nil
+		return newRuntimeVM(rh.RuntimePath, rh.RuntimeRoot, rh.RuntimeConfigPath, r.config.RuntimeConfig.ContainerExitsDir), nil
 	}
 
 	if rh.RuntimeType == config.RuntimeTypePod {

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -642,6 +642,13 @@ func (r *runtimeVM) updateContainerStatus(ctx context.Context, c *Container) err
 		addressPath := filepath.Join(c.BundlePath(), "address")
 		data, err := os.ReadFile(addressPath)
 		if err != nil {
+			// If the container is actually removed, this error is expected and should be ignored.
+			// In this case, the container's status should be "Stopped".
+			if c.state.Status == ContainerStateStopped {
+				log.Debugf(ctx, "Skipping status update for: %+v", c.state)
+				return nil
+			}
+
 			log.Warnf(ctx, "Failed to read shim address: %v", err)
 			return errors.New("runtime not correctly setup")
 		}

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -50,6 +50,7 @@ type runtimeVM struct {
 	path       string
 	fifoDir    string
 	configPath string
+	exitsPath  string
 	ctx        context.Context
 	client     *ttrpc.Client
 	task       task.TaskService
@@ -68,7 +69,7 @@ const (
 )
 
 // newRuntimeVM creates a new runtimeVM instance
-func newRuntimeVM(path, root, configPath string) RuntimeImpl {
+func newRuntimeVM(path, root, configPath, exitsPath string) RuntimeImpl {
 	logrus.Debug("oci.newRuntimeVM() start")
 	defer logrus.Debug("oci.newRuntimeVM() end")
 
@@ -87,6 +88,7 @@ func newRuntimeVM(path, root, configPath string) RuntimeImpl {
 	return &runtimeVM{
 		path:       path,
 		configPath: configPath,
+		exitsPath:  exitsPath,
 		fifoDir:    filepath.Join(root, "crio", "fifo"),
 		ctx:        context.Background(),
 		ctrs:       make(map[string]containerInfo),
@@ -269,6 +271,11 @@ func (r *runtimeVM) StartContainer(ctx context.Context, c *Container) error {
 	go func() {
 		_, err := r.wait(c.ID(), "")
 		if err == nil {
+			// create a file on the exitsDir so that cri-o server can detect it
+			path := filepath.Join(r.exitsPath+"/", c.ID())
+			if fileErr := os.WriteFile(path, []byte("Exited"), 0o644); err != nil {
+				log.Warnf(ctx, "Unable to write exit file %v", fileErr)
+			}
 			if err1 := r.updateContainerStatus(ctx, c); err1 != nil {
 				log.Warnf(ctx, "Error updating container status %v", err1)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The integration test "ctr pod lifecycle with evented pleg enabled" is failing for kata containers.
This is because of how the container's exit is handled for kata.

For regular containers, the exit is detected by the `server.exitsMonitor()`, and it calls `handleExit()` for it, where the event `CONTAINER_STOPPED_EVENT` is generated.

For kata containers, the exit is detected by a wait function started when the container is started, and it doesn't send the event.

The event can be sent by calling the function `server.generateCRIEvent()`. But having a handle on the server in runtimeVM seems cumbersome.
Also I think runtimeVM containers could benefit from leveraging the handleExit() code in general - rather than handling the exit separately.

This is why I modified the code on the wait function for runtimeVM so that it just creates a file in the exitsPath, where exitsMonitor() is watching. This makes the watcher trigger the handleExit() function for kata containers too, and generates the event.


The second patch is fixing an issue that is triggered by the removal of the container: the code is updating the container status, but the container is already gone at that time, and this was triggering an error on the runtimeVM side, which prevented generating the `CONTAINER_DELETED_EVENT`. Ignoring the error on this specific situation seems to solve the issue.

#### Which issue(s) this PR fixes:

Fixes #6481 

#### Special notes for your reviewer:

This PR stems from the discussion that happened on #6531. While the original fix on this PR was wrong, the discussion helps understand the requirements for evented PLEG.

#### Does this PR introduce a user-facing change?

```release-note
none
```
