### PR TITLE
[1.24] Fix cgroup leak for systemd cgroup driver

### DIFF
--- a/internal/config/cgmgr/cgmgr.go
+++ b/internal/config/cgmgr/cgmgr.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/podman/v3/pkg/cgroups"
 	"github.com/cri-o/cri-o/internal/config/node"
 	libctr "github.com/opencontainers/runc/libcontainer/cgroups"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
@@ -139,17 +138,6 @@ func VerifyMemoryIsEnough(memoryLimit int64) error {
 		return fmt.Errorf("set memory limit %d too low; should be at least %d", memoryLimit, minMemoryLimit)
 	}
 	return nil
-}
-
-// createSandboxCgroup takes the sandbox parent, and sandbox ID.
-// It creates a new cgroup for that sandbox, which is useful when spoofing an infra container.
-func createSandboxCgroup(sbParent, containerID string, mgr CgroupManager) error {
-	path, err := mgr.ContainerCgroupAbsolutePath(sbParent, containerID)
-	if err != nil {
-		return err
-	}
-	_, err = cgroups.New(path, &rspec.LinuxResources{})
-	return err
 }
 
 // MoveProcessToContainerCgroup moves process to the container cgroup

--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -180,6 +180,17 @@ func setWorkloadSettings(cgPath string, resources *rspec.LinuxResources) error {
 	return mgr.Set(cg.Resources)
 }
 
+// createSandboxCgroup takes the sandbox parent, and sandbox ID.
+// It creates a new cgroup for that sandbox, which is useful when spoofing an infra container.
+func createSandboxCgroup(sbParent, containerID string, mgr CgroupManager) error {
+	cgroupAbsolutePath, err := mgr.ContainerCgroupAbsolutePath(sbParent, containerID)
+	if err != nil {
+		return err
+	}
+	_, err = cgroups.New(cgroupAbsolutePath, &rspec.LinuxResources{})
+	return err
+}
+
 // CreateSandboxCgroup calls the helper function createSandboxCgroup for this manager.
 func (m *CgroupfsManager) CreateSandboxCgroup(sbParent, containerID string) error {
 	return createSandboxCgroup(sbParent, containerID, m)

--- a/internal/config/cgmgr/systemd.go
+++ b/internal/config/cgmgr/systemd.go
@@ -201,5 +201,7 @@ func convertCgroupFsNameToSystemd(cgroupfsName string) string {
 
 // CreateSandboxCgroup calls the helper function createSandboxCgroup for this manager.
 func (m *SystemdManager) CreateSandboxCgroup(sbParent, containerID string) error {
-	return createSandboxCgroup(sbParent, containerID, m)
+	// If we are running systemd as cgroup driver then we would rely on
+	// systemd to create cgroups for us, there's nothing to do here in this case
+	return nil
 }


### PR DESCRIPTION
Initial commit to get feedback from the maintainers, need to add integration tests

Closes #6349

Signed-off-by: Neeraj Shah <neerajx86@gmail.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
This PR fixes an issue whereby cgroups are not cleaned up after a Pod is terminated, this is an issue with cri-o versions prior to `1.26`

#### Which issue(s) this PR fixes:
Fixes #6349 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
This is a draft PR, I need to add integration tests for my changes.

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
