### PR TITLE
Fix cgroup leak for systemd cgroup driver

### DIFF
--- a/internal/config/cgmgr/cgmgr.go
+++ b/internal/config/cgmgr/cgmgr.go
@@ -10,10 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/common/pkg/cgroups"
 	"github.com/cri-o/cri-o/internal/config/node"
 	libctr "github.com/opencontainers/runc/libcontainer/cgroups"
-	cgcfgs "github.com/opencontainers/runc/libcontainer/configs"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -138,21 +136,6 @@ func VerifyMemoryIsEnough(memoryLimit int64) error {
 		return fmt.Errorf("set memory limit %d too low; should be at least %d", memoryLimit, minMemoryLimit)
 	}
 	return nil
-}
-
-// createSandboxCgroup takes the sandbox parent, and sandbox ID.
-// It creates a new cgroup for that sandbox, which is useful when spoofing an infra container.
-func createSandboxCgroup(sbParent, containerID string, mgr CgroupManager) error {
-	path, err := mgr.ContainerCgroupAbsolutePath(sbParent, containerID)
-	if err != nil {
-		return err
-	}
-	if mgr.IsSystemd() {
-		_, err = cgroups.NewSystemd(path, &cgcfgs.Resources{})
-	} else {
-		_, err = cgroups.New(path, &cgcfgs.Resources{})
-	}
-	return err
 }
 
 // MoveProcessToContainerCgroup moves process to the container cgroup

--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -155,6 +155,17 @@ func setWorkloadSettings(cgPath string, resources *rspec.LinuxResources) (err er
 	return mgr.Set(cg.Resources)
 }
 
+// createSandboxCgroup takes the sandbox parent, and sandbox ID.
+// It creates a new cgroup for that sandbox, which is useful when spoofing an infra container.
+func createSandboxCgroup(sbParent, containerID string, mgr CgroupManager) error {
+	cgroupAbsolutePath, err := mgr.ContainerCgroupAbsolutePath(sbParent, containerID)
+	if err != nil {
+		return err
+	}
+	_, err = cgroups.New(cgroupAbsolutePath, &cgcfgs.Resources{})
+	return err
+}
+
 // CreateSandboxCgroup calls the helper function createSandboxCgroup for this manager.
 func (m *CgroupfsManager) CreateSandboxCgroup(sbParent, containerID string) error {
 	return createSandboxCgroup(sbParent, containerID, m)

--- a/internal/config/cgmgr/systemd.go
+++ b/internal/config/cgmgr/systemd.go
@@ -198,5 +198,7 @@ func convertCgroupFsNameToSystemd(cgroupfsName string) string {
 
 // CreateSandboxCgroup calls the helper function createSandboxCgroup for this manager.
 func (m *SystemdManager) CreateSandboxCgroup(sbParent, containerID string) error {
-	return createSandboxCgroup(sbParent, containerID, m)
+	// If we are running systemd as cgroup driver then we would rely on
+	// systemd to create cgroups for us, there's nothing to do here in this case
+	return nil
 }


### PR DESCRIPTION
Fix cgroup leak for systemd cgroup driver

- Removed redundant call to cgroup creation from `systemd.go:CreateSandboxCgroup`
- Cleaned-up `cgmgr.go:createSandboxCgroup` to handle cgroup creation only for `cgroupfs` driver

Closes #6349

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
This PR would make cgroup approach idiomatically uniform to all releases prior to `release-1.26`

#### Which issue(s) this PR fixes:
Fixes #6349 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
