### PR TITLE
test: use container_sleep for idempotent test

### DIFF
--- a/test/pod.bats
+++ b/test/pod.bats
@@ -233,7 +233,7 @@ function teardown() {
 @test "pod stop idempotent with ctrs already stopped" {
 	start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$ctr_id"
 	crictl stop "$ctr_id"
 	crictl stopp "$pod_id"


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
Every now and then, the kata-jenkins job is failing on "pod stop idempotent with ctrs already stopped".

Investigating it, I found it is due to a race condition, when the container completes while we are processing the "StopContainer" request. This results in the kata agent reporting an "cannot find init process!" error.

I don't think it is the intent of the test to check this kind of issue, so I used the longer-running "container_sleep.yaml" file, and verified the issue does not happen again.
An alternative would be to add a delay between the `crictl start` and `crictl stop` commands, making sure the container is actually done when we stop it, but that would make the test longer, so I preferred this method.

The race condition itself may be a problem, but I think the chances of seeing it are very small, and the only drawback is a failure on a "stop" command, followed by the status of the container actually reporting "stopped".


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
none
```
