### PR TITLE
nri: add protection against nil dereference

### DIFF
--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -31,6 +31,9 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *types.Update
 		if err != nil {
 			return nil, err
 		}
+		if updated == nil {
+			updated = req.Linux
+		}
 		resources := toOCIResources(updated)
 		if err := s.Runtime().UpdateContainer(ctx, c, resources); err != nil {
 			return nil, err

--- a/server/container_update_resources_test.go
+++ b/server/container_update_resources_test.go
@@ -13,16 +13,14 @@ import (
 
 // The actual test suite
 var _ = t.Describe("UpdateContainerResources", func() {
-	// Prepare the sut
-	BeforeEach(func() {
-		beforeEach()
-		mockRuncInLibConfig()
-		setupSUT()
-	})
-
 	AfterEach(afterEach)
-
 	t.Describe("UpdateContainerResources", func() {
+		// Prepare the sut
+		BeforeEach(func() {
+			beforeEach()
+			mockRuncInLibConfig()
+			setupSUT()
+		})
 		It("should succeed", func() {
 			// Given
 			testContainer.SetSpec(&specs.Spec{
@@ -118,6 +116,38 @@ var _ = t.Describe("UpdateContainerResources", func() {
 
 			// Then
 			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	t.Describe("UpdateContainerResources with nri enabled", func() {
+		// Prepare the sut
+		BeforeEach(func() {
+			beforeEach()
+			serverConfig.NRI.Enabled = true
+			mockRuncInLibConfig()
+			setupSUT()
+		})
+		It("should succeed", func() {
+			// Given
+			testContainer.SetSpec(&specs.Spec{
+				Linux: &specs.Linux{
+					Resources: &specs.LinuxResources{},
+				},
+			})
+			testContainer.SetState(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateRunning},
+			})
+			addContainerAndSandbox()
+
+			// When
+			_, err := sut.UpdateContainerResources(context.Background(),
+				&types.UpdateContainerResourcesRequest{
+					ContainerId: testContainer.ID(),
+				},
+			)
+
+			// Then
+			Expect(err).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

If `nil` returned from nri call, set the current `LinuxContainerResources` data.

Integration test: Enabling nri in the server config. 
If the protection is valid, tests should pass.

Additional info in the issue itself 
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
https://github.com/cri-o/cri-o/issues/6642
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
