### PR TITLE
[1.25] Bump runtime-tools to v0.9.1-0.20230110161035-a6a073817ab0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
 	github.com/opencontainers/runc v1.1.4
 	github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
-	github.com/opencontainers/runtime-tools v0.9.1-0.20221014010322-58c91d646d86
+	github.com/opencontainers/runtime-tools v0.9.1-0.20230110161035-a6a073817ab0
 	github.com/opencontainers/selinux v1.10.2
 	github.com/prometheus/client_golang v1.13.0
 	github.com/psampaz/go-mod-outdated v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1719,8 +1719,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.m
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb h1:1xSVPOd7/UA+39/hXEGnBJ13p6JFB0E1EvQFlrRDOXI=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/opencontainers/runtime-tools v0.9.1-0.20221014010322-58c91d646d86 h1:AaK4/fBxOmEFtb1bs/7KrJsQIgVPnhIrtgJ92RaqM60=
-github.com/opencontainers/runtime-tools v0.9.1-0.20221014010322-58c91d646d86/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
+github.com/opencontainers/runtime-tools v0.9.1-0.20230110161035-a6a073817ab0 h1:C1EbGtbEhyGJN6XkYHjmRm5lmmGo9UT+vGj0Rn8lF5E=
+github.com/opencontainers/runtime-tools v0.9.1-0.20230110161035-a6a073817ab0/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=

--- a/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
@@ -10,7 +10,7 @@ import (
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate/seccomp"
-	"github.com/opencontainers/runtime-tools/validate"
+	capsCheck "github.com/opencontainers/runtime-tools/validate/capabilities"
 	"github.com/syndtr/gocapability/capability"
 )
 
@@ -182,7 +182,7 @@ func New(os string) (generator Generator, err error) {
 				Destination: "/dev",
 				Type:        "tmpfs",
 				Source:      "tmpfs",
-				Options:     []string{"nosuid", "noexec", "strictatime", "mode=755", "size=65536k"},
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
 			},
 			{
 				Destination: "/dev/pts",
@@ -264,10 +264,6 @@ func New(os string) (generator Generator, err error) {
 
 // NewFromSpec creates a configuration Generator from a given
 // configuration.
-//
-// Deprecated: Replace with:
-//
-//   generator := Generator{Config: config}
 func NewFromSpec(config *rspec.Spec) Generator {
 	envCache := map[string]int{}
 	if config != nil && config.Process != nil {
@@ -1140,7 +1136,7 @@ func (g *Generator) SetupPrivileged(privileged bool) {
 	if privileged { // Add all capabilities in privileged mode.
 		var finalCapList []string
 		for _, cap := range capability.List() {
-			if g.HostSpecific && cap > validate.LastCap() {
+			if g.HostSpecific && cap > capsCheck.LastCap() {
 				continue
 			}
 			finalCapList = append(finalCapList, fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())))
@@ -1174,7 +1170,7 @@ func (g *Generator) ClearProcessCapabilities() {
 // AddProcessCapability adds a process capability into all 5 capability sets.
 func (g *Generator) AddProcessCapability(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1237,7 +1233,7 @@ func (g *Generator) AddProcessCapability(c string) error {
 // AddProcessCapabilityAmbient adds a process capability into g.Config.Process.Capabilities.Ambient.
 func (g *Generator) AddProcessCapabilityAmbient(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1261,7 +1257,7 @@ func (g *Generator) AddProcessCapabilityAmbient(c string) error {
 // AddProcessCapabilityBounding adds a process capability into g.Config.Process.Capabilities.Bounding.
 func (g *Generator) AddProcessCapabilityBounding(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1284,7 +1280,7 @@ func (g *Generator) AddProcessCapabilityBounding(c string) error {
 // AddProcessCapabilityEffective adds a process capability into g.Config.Process.Capabilities.Effective.
 func (g *Generator) AddProcessCapabilityEffective(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1307,7 +1303,7 @@ func (g *Generator) AddProcessCapabilityEffective(c string) error {
 // AddProcessCapabilityInheritable adds a process capability into g.Config.Process.Capabilities.Inheritable.
 func (g *Generator) AddProcessCapabilityInheritable(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1330,7 +1326,7 @@ func (g *Generator) AddProcessCapabilityInheritable(c string) error {
 // AddProcessCapabilityPermitted adds a process capability into g.Config.Process.Capabilities.Permitted.
 func (g *Generator) AddProcessCapabilityPermitted(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1383,7 +1379,7 @@ func (g *Generator) DropProcessCapability(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityAmbient drops a process capability from g.Config.Process.Capabilities.Ambient.
@@ -1399,7 +1395,7 @@ func (g *Generator) DropProcessCapabilityAmbient(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityBounding drops a process capability from g.Config.Process.Capabilities.Bounding.
@@ -1415,7 +1411,7 @@ func (g *Generator) DropProcessCapabilityBounding(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityEffective drops a process capability from g.Config.Process.Capabilities.Effective.
@@ -1431,7 +1427,7 @@ func (g *Generator) DropProcessCapabilityEffective(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityInheritable drops a process capability from g.Config.Process.Capabilities.Inheritable.
@@ -1447,7 +1443,7 @@ func (g *Generator) DropProcessCapabilityInheritable(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityPermitted drops a process capability from g.Config.Process.Capabilities.Permitted.
@@ -1463,7 +1459,7 @@ func (g *Generator) DropProcessCapabilityPermitted(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 func mapStrToNamespace(ns string, path string) (rspec.LinuxNamespace, error) {

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default.go
@@ -151,6 +151,9 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 				"io_submit",
 				"ipc",
 				"kill",
+				"landlock_add_rule",
+				"landlock_create_ruleset",
+				"landlock_restrict_self",
 				"lchown",
 				"lchown32",
 				"lgetxattr",
@@ -354,11 +357,23 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 					Value: 0x0,
 					Op:    rspec.OpEqualTo,
 				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: rspec.ActAllow,
+			Args: []rspec.LinuxSeccompArg{
 				{
 					Index: 0,
 					Value: 0x0008,
 					Op:    rspec.OpEqualTo,
 				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: rspec.ActAllow,
+			Args: []rspec.LinuxSeccompArg{
 				{
 					Index: 0,
 					Value: 0xffffffff,
@@ -513,7 +528,7 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 				Args: []rspec.LinuxSeccompArg{
 					{
 						Index:    sysCloneFlagsIndex,
-						Value:    CloneNewNS | CloneNewUTS | CloneNewIPC | CloneNewUser | CloneNewPID | CloneNewNet,
+						Value:    CloneNewNS | CloneNewUTS | CloneNewIPC | CloneNewUser | CloneNewPID | CloneNewNet | CloneNewCgroup,
 						ValueTwo: 0,
 						Op:       rspec.OpMaskedEqual,
 					},

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_linux.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_linux.go
@@ -3,14 +3,15 @@
 
 package seccomp
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
 // System values passed through on linux
 const (
-	CloneNewIPC  = syscall.CLONE_NEWIPC
-	CloneNewNet  = syscall.CLONE_NEWNET
-	CloneNewNS   = syscall.CLONE_NEWNS
-	CloneNewPID  = syscall.CLONE_NEWPID
-	CloneNewUser = syscall.CLONE_NEWUSER
-	CloneNewUTS  = syscall.CLONE_NEWUTS
+	CloneNewIPC    = unix.CLONE_NEWIPC
+	CloneNewNet    = unix.CLONE_NEWNET
+	CloneNewNS     = unix.CLONE_NEWNS
+	CloneNewPID    = unix.CLONE_NEWPID
+	CloneNewUser   = unix.CLONE_NEWUSER
+	CloneNewUTS    = unix.CLONE_NEWUTS
+	CloneNewCgroup = unix.CLONE_NEWCGROUP
 )

--- a/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate.go
+++ b/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate.go
@@ -1,0 +1,31 @@
+package capabilities
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/syndtr/gocapability/capability"
+)
+
+// CapValid checks whether a capability is valid
+func CapValid(c string, hostSpecific bool) error {
+	isValid := false
+
+	if !strings.HasPrefix(c, "CAP_") {
+		return fmt.Errorf("capability %s must start with CAP_", c)
+	}
+	for _, cap := range capability.List() {
+		if c == fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())) {
+			if hostSpecific && cap > LastCap() {
+				return fmt.Errorf("%s is not supported on the current host", c)
+			}
+			isValid = true
+			break
+		}
+	}
+
+	if !isValid {
+		return fmt.Errorf("invalid capability: %s", c)
+	}
+	return nil
+}

--- a/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_linux.go
+++ b/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_linux.go
@@ -1,0 +1,16 @@
+package capabilities
+
+import (
+	"github.com/syndtr/gocapability/capability"
+)
+
+// LastCap return last cap of system
+func LastCap() capability.Cap {
+	last := capability.CAP_LAST_CAP
+	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
+	if last == capability.Cap(63) {
+		last = capability.CAP_BLOCK_SUSPEND
+	}
+
+	return last
+}

--- a/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_unsupported.go
+++ b/vendor/github.com/opencontainers/runtime-tools/validate/capabilities/validate_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux
+// +build !linux
+
+package capabilities
+
+import (
+	"github.com/syndtr/gocapability/capability"
+)
+
+// LastCap return last cap of system
+func LastCap() capability.Cap {
+	return capability.Cap(-1)
+}

--- a/vendor/github.com/opencontainers/runtime-tools/validate/validate.go
+++ b/vendor/github.com/opencontainers/runtime-tools/validate/validate.go
@@ -20,8 +20,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	osFilepath "github.com/opencontainers/runtime-tools/filepath"
+	capsCheck "github.com/opencontainers/runtime-tools/validate/capabilities"
 	"github.com/sirupsen/logrus"
-	"github.com/syndtr/gocapability/capability"
 
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/xeipuuv/gojsonschema"
@@ -687,26 +687,10 @@ func (v *Validator) CheckAnnotations() (errs error) {
 }
 
 // CapValid checks whether a capability is valid
+//
+// Deprecated: use github.com/opencontainers/runtime-tools/validate/capabilities.CapValid directly.
 func CapValid(c string, hostSpecific bool) error {
-	isValid := false
-
-	if !strings.HasPrefix(c, "CAP_") {
-		return fmt.Errorf("capability %s must start with CAP_", c)
-	}
-	for _, cap := range capability.List() {
-		if c == fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())) {
-			if hostSpecific && cap > LastCap() {
-				return fmt.Errorf("%s is not supported on the current host", c)
-			}
-			isValid = true
-			break
-		}
-	}
-
-	if !isValid {
-		return fmt.Errorf("invalid capability: %s", c)
-	}
-	return nil
+	return capsCheck.CapValid(c, hostSpecific)
 }
 
 func envValid(env string) bool {

--- a/vendor/github.com/opencontainers/runtime-tools/validate/validate_linux.go
+++ b/vendor/github.com/opencontainers/runtime-tools/validate/validate_linux.go
@@ -11,26 +11,19 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/syndtr/gocapability/capability"
-
 	multierror "github.com/hashicorp/go-multierror"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	osFilepath "github.com/opencontainers/runtime-tools/filepath"
 	"github.com/opencontainers/runtime-tools/specerror"
+	capsCheck "github.com/opencontainers/runtime-tools/validate/capabilities"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
 )
 
 // LastCap return last cap of system
-func LastCap() capability.Cap {
-	last := capability.CAP_LAST_CAP
-	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
-	if last == capability.Cap(63) {
-		last = capability.CAP_BLOCK_SUSPEND
-	}
-
-	return last
-}
+//
+// Deprecated: use github.com/opencontainers/runtime-tools/validate/capabilities.LastCap directly.
+var LastCap = capsCheck.LastCap
 
 func deviceValid(d rspec.LinuxDevice) bool {
 	switch d.Type {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1704,7 +1704,7 @@ github.com/opencontainers/runc/libcontainer/utils
 # github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
-# github.com/opencontainers/runtime-tools v0.9.1-0.20221014010322-58c91d646d86
+# github.com/opencontainers/runtime-tools v0.9.1-0.20230110161035-a6a073817ab0
 ## explicit; go 1.16
 github.com/opencontainers/runtime-tools/error
 github.com/opencontainers/runtime-tools/filepath
@@ -1712,6 +1712,7 @@ github.com/opencontainers/runtime-tools/generate
 github.com/opencontainers/runtime-tools/generate/seccomp
 github.com/opencontainers/runtime-tools/specerror
 github.com/opencontainers/runtime-tools/validate
+github.com/opencontainers/runtime-tools/validate/capabilities
 # github.com/opencontainers/selinux v1.10.2
 ## explicit; go 1.13
 github.com/opencontainers/selinux/go-selinux


### PR DESCRIPTION
Update runtime-tools to latest HEAD. This reverts commit 09d837b in runtime-tools (mount /dev with 'noexec'), which triggered problems when containers try to create Intel SGX enclaves.

Signed-off-by: Krisztian Litkey krisztian.litkey@intel.com
Signed-off-by: Peter Hunt~ pehunt@redhat.com

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
/kind dependency-change
cherrry-pick of https://github.com/cri-o/cri-o/pull/6618
```release-note
'/dev' is now mounted again without the 'noexec' flag.
```
