### PR TITLE
Drop `ENABLE_POD_EVENTS` var from e2e installer script

### DIFF
--- a/scripts/node_e2e_installer
+++ b/scripts/node_e2e_installer
@@ -3,7 +3,6 @@ set -euo pipefail
 
 # Commit to run upstream node e2e tests
 NODE_E2E_COMMIT=81b5d18822a48c7038ab7ac64b21eec60ef2de69
-ENABLE_POD_EVENTS=${ENABLE_POD_EVENTS:-"false"}
 
 enable_selinux() {
     # Make sure SELinux is enabled
@@ -48,20 +47,9 @@ EOF
 [crio.runtime]
 drop_infra_ctr = false
 EOF
-
-    for condition in "true" "True" "TRUE"; do
-        if [[ "${ENABLE_POD_EVENTS}" = "$condition" ]]; then
-            cat <<EOF >/etc/crio/crio.conf.d/40-evented-pleg.conf
-[crio.runtime]
-enable_pod_events = true
-EOF
-            break
-        fi
-    done
 }
 
 enable_selinux
-
 install_crio
 
 # Finally start crio


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
The variable is not used any more since we can create them directly via butane / ignition:

- https://github.com/kubernetes/test-infra/blob/6c3045e/jobs/e2e_node/crio/templates/base/crio-enable-pod-events.yaml
- https://github.com/kubernetes/test-infra/blob/6c3045e/jobs/e2e_node/crio/templates/base/40-evented-pleg.conf

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
