### PR TITLE
Pin nix version to fix static builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
 env:
   GO_VERSION: '1.20'
+  NIX_VERSION: '2.13.3'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -126,6 +127,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v19
+        with:
+          install_url: https://releases.nixos.org/nix/nix-${{ env.NIX_VERSION }}/install
       - uses: cachix/cachix-action@v12
         with:
           name: cri-o-static
@@ -146,6 +149,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v19
+        with:
+          install_url: https://releases.nixos.org/nix/nix-${{ env.NIX_VERSION }}/install
       - uses: cachix/cachix-action@v12
         with:
           name: cri-o-static

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -78,3 +78,9 @@ dependencies:
     refPaths:
       - path: Makefile
         match: ZEITGEIST_VERSION
+
+  - name: nix
+    version: 2.13.3
+    refPaths:
+      - path: .github/workflows/test.yml
+        match: NIX_VERSION


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
We have to pin nix to v2.13.3 to avoid having the regression mentioned in https://github.com/cachix/cachix-action/issues/138#issuecomment-1448952201.

This should fix the static builds.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
