### PR TITLE
Extend cpu-c-states.crio.io annotation to add max latency

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks_test.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_test.go
@@ -256,6 +256,17 @@ var _ = Describe("high_performance_hooks", func() {
 			})
 		})
 
+		Context("with 10 latency", func() {
+			BeforeEach(func() {
+				pmQosResumeLatencyUs = "n/a"
+				pmQosResumeLatencyUsOriginal = ""
+			})
+
+			It("should change the CPU PM QOS latency", func() {
+				verifySetCPUPMQOSResumeLatency("10", "10", "n/a", false)
+			})
+		})
+
 		Context("with missing latency file", func() {
 			BeforeEach(func() {
 				pmQosResumeLatencyUs = ""
@@ -491,6 +502,70 @@ var _ = Describe("high_performance_hooks", func() {
 
 			It("should restore irq balance config with content from banned cpu config file", func() {
 				verifyRestoreIrqBalanceConfig("00000000,00000000", "00000000,00000000")
+			})
+		})
+	})
+
+	Describe("convertAnnotationToLatency", func() {
+		verifyConvertAnnotationToLatency := func(annotation string, expected string, expect_error bool) {
+			latency, err := convertAnnotationToLatency(annotation)
+			if !expect_error {
+				Expect(err).ShouldNot(HaveOccurred())
+			} else {
+				Expect(err).Should(HaveOccurred())
+			}
+
+			if expected != "" {
+				Expect(err).To(BeNil())
+				Expect(latency).To(Equal(expected))
+			}
+		}
+
+		Context("with enable annotation", func() {
+			It("should result in latency: 0", func() {
+				verifyConvertAnnotationToLatency("enable", "0", false)
+			})
+		})
+
+		Context("with disable annotation", func() {
+			It("should result in latency: n/a", func() {
+				verifyConvertAnnotationToLatency("disable", "n/a", false)
+			})
+		})
+
+		Context("with max_latency:10 annotation", func() {
+			It("should result in latency: 10", func() {
+				verifyConvertAnnotationToLatency("max_latency:10", "10", false)
+			})
+		})
+
+		Context("with max_latency:1 annotation", func() {
+			It("should result in latency: 1", func() {
+				verifyConvertAnnotationToLatency("max_latency:1", "1", false)
+			})
+		})
+
+		Context("with max_latency:0 annotation", func() {
+			It("should result in error", func() {
+				verifyConvertAnnotationToLatency("max_latency:0", "", true)
+			})
+		})
+
+		Context("with max_latency:-1 annotation", func() {
+			It("should result in error", func() {
+				verifyConvertAnnotationToLatency("max_latency:-1", "", true)
+			})
+		})
+
+		Context("with max_latency:bad annotation", func() {
+			It("should result in error", func() {
+				verifyConvertAnnotationToLatency("max_latency:bad", "", true)
+			})
+		})
+
+		Context("with bad annotation", func() {
+			It("should result in error", func() {
+				verifyConvertAnnotationToLatency("bad", "", true)
 			})
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
The cpu-c-states.crio.io annotation currently allows c-states to be disabled for a pod (with guaranteed QoS). The annotation is defined as follows:
cpu-c-states.crio.io: <enable|disable>

This annotation enables or disables c-states for each cpu by writing to the power/pm_qos_resume_latency_us for the cpu under sysfs.

However, users of this new annotation now want to be able to have more control over the c-states for each pod - instead of just disabling c-states completely, they would like to be able to specify a maximum latency for the pod.

The cpu-c-states.crio.io annotation is being extended to support these values:
- enable: enable all c-states (cpu-c-states.crio.io: "enable")
- disable: disable all c-states (cpu-c-states.crio.io: "disable")
- max_latency: enable c-states with a maximum latency in microseconds (for example,  cpu-c-states.crio.io: "max_latency:10")

Note:
- The changes are 100% backwards compatible with the current annotation.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
This PR extends the existing cpu-c-states.crio.io annotation in a backwards compatible manner, by adding a new max_latency option. The cpu-c-states.crio.io annotation now supports these values:
- enable: enable all c-states (cpu-c-states.crio.io: "enable")
- disable: disable all c-states (cpu-c-states.crio.io: "disable")
- max_latency: enable c-states with a maximum latency in microseconds (for example,  cpu-c-states.crio.io: "max_latency:10")
```
