### PR TITLE
Remove SELinux policy download

### DIFF
--- a/contrib/custom-node-e2e/create-ignition-config.sh
+++ b/contrib/custom-node-e2e/create-ignition-config.sh
@@ -138,15 +138,6 @@ set -euo pipefail
 # Commit to run upstream node e2e tests
 NODE_E2E_COMMIT=${CRIO_SHA}
 
-enable_selinux() {
-    # Make sure SELinux is enabled
-    setenforce 1
-
-    # Get the SELinux package
-    curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /tmp/kubelet-e2e.pp https://storage.googleapis.com/cri-o/selinux/kubelet-e2e.pp
-    semodule -i /tmp/kubelet-e2e.pp
-}
-
 install_crio() {
     # Download and install CRIO
     curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-install.sh https://raw.githubusercontent.com/cri-o/cri-o/main/scripts/get
@@ -184,8 +175,6 @@ EOF
 
 ${CONF_CONTENT}
 }
-
-enable_selinux
 
 install_crio
 

--- a/scripts/node_e2e_installer
+++ b/scripts/node_e2e_installer
@@ -4,15 +4,6 @@ set -euo pipefail
 # Commit to run upstream node e2e tests
 NODE_E2E_COMMIT=81b5d18822a48c7038ab7ac64b21eec60ef2de69
 
-enable_selinux() {
-    # Make sure SELinux is enabled
-    setenforce 1
-
-    # Get the SELinux package
-    curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /tmp/kubelet-e2e.pp https://storage.googleapis.com/cri-o/selinux/kubelet-e2e.pp
-    semodule -i /tmp/kubelet-e2e.pp
-}
-
 install_crio() {
     # Download and install CRIO
     curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /usr/local/crio-install.sh https://raw.githubusercontent.com/cri-o/cri-o/main/scripts/get
@@ -49,7 +40,6 @@ drop_infra_ctr = false
 EOF
 }
 
-enable_selinux
 install_crio
 
 # Finally start crio


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We handle the SELinux policies directly in the test-infra repo after the merge of https://github.com/kubernetes/test-infra/pull/28988

Means we now can remove the double work and skip an additional test setup within the CRI-O repository.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
PTAL @harche @sairameshv @haircommander
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
