### PR TITLE
Use ImageRef instead of ImageName for restore

### DIFF
--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -153,6 +153,8 @@ func (c *ContainerServer) prepareCheckpointExport(ctr *oci.Container) error {
 	config := &metadata.ContainerConfig{
 		ID:              ctr.ID(),
 		Name:            ctr.Name(),
+		RootfsImage:     ctr.Image(),
+		RootfsImageRef:  ctr.ImageRef(),
 		RootfsImageName: ctr.ImageName(),
 		CreatedTime:     ctr.CreatedAt(),
 		OCIRuntime: func() string {
@@ -174,7 +176,7 @@ func (c *ContainerServer) prepareCheckpointExport(ctr *oci.Container) error {
 	// directories. This is disabled during restore as CRIU requires the bind mount
 	// source to be of the same type. Directories need to be directories and regular
 	// files need to be regular files. CRIU will fail to bind mount a directory on
-	// a file. Especiallay when restoring a Kubernetes container outside of Kubernetes
+	// a file. Especially when restoring a Kubernetes container outside of Kubernetes
 	// a couple of bind mounts are files (e.g. /etc/resolv.conf). To solve this
 	// CRI-O is now tracking all bind mount types in the checkpoint archive. This
 	// way it is possible to know if a missing bind mount needs to be a file or a

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 
@@ -428,111 +429,118 @@ var _ = t.Describe("ContainerRestore", func() {
 		})
 	})
 	t.Describe("ContainerRestore from archive into new pod", func() {
-		It("should succeed", func() {
-			// Given
-			addContainerAndSandbox()
-			testContainer.SetStateAndSpoofPid(&oci.ContainerState{
-				State: specs.State{Status: oci.ContainerStateRunning},
-			})
+		images := []string{
+			`{"rootfsImageName": "image"}`,
+			`{"rootfsImageRef": "image"}`,
+		}
+		for _, image := range images {
+			loopImage := image
+			It(fmt.Sprintf("should succeed (%s)", image), func() {
+				// Given
+				addContainerAndSandbox()
+				testContainer.SetStateAndSpoofPid(&oci.ContainerState{
+					State: specs.State{Status: oci.ContainerStateRunning},
+				})
 
-			err := os.WriteFile(
-				"spec.dump",
-				[]byte(`{"annotations":{"io.kubernetes.cri-o.Metadata"`+
-					`:"{\"name\":\"container-to-restore\"}",`+
-					`"io.kubernetes.cri-o.Annotations": "{\"name\":\"NAME\",`+
-					`\"io.kubernetes.container.hash\":\"b4eeb97f\",`+
-					`\"io.kubernetes.pod.uid\":\"old-sandbox-uid\"}",`+
-					`"io.kubernetes.cri-o.Labels": "{\"io.kubernetes.container.name\":\"counter\",`+
-					`\"io.kubernetes.pod.uid\":\"old-sandbox-uid\"}",`+
-					`"io.kubernetes.cri-o.SandboxID": "sandboxID"},`+
-					`"mounts": [{"destination": "/proc"},`+
-					`{"destination":"/data","source":"/data","options":`+
-					`["rw","ro","rbind","rprivate","rshared","rslaved"]}],`+
-					`"linux": {"maskedPaths": ["/proc/acpi"], "readonlyPaths": ["/proc/asound"]}}`),
-				0o644,
-			)
-			Expect(err).To(BeNil())
-			defer os.RemoveAll("spec.dump")
-			err = os.WriteFile("config.dump", []byte(`{"rootfsImageName": "image"}`), 0o644)
-			Expect(err).To(BeNil())
-			defer os.RemoveAll("config.dump")
-			outFile, err := os.Create("archive.tar")
-			Expect(err).To(BeNil())
-			defer outFile.Close()
-			input, err := archive.TarWithOptions(".", &archive.TarOptions{
-				Compression:      archive.Uncompressed,
-				IncludeSourceDir: true,
-				IncludeFiles:     []string{"spec.dump", "config.dump"},
-			})
-			Expect(err).To(BeNil())
-			defer os.RemoveAll("archive.tar")
-			_, err = io.Copy(outFile, input)
-			Expect(err).To(BeNil())
-			containerConfig := &types.ContainerConfig{
-				Image: &types.ImageSpec{
-					Image: "archive.tar",
-				},
-				Linux: &types.LinuxContainerConfig{
-					Resources:       &types.LinuxContainerResources{},
-					SecurityContext: &types.LinuxContainerSecurityContext{},
-				},
-				Labels: map[string]string{
-					kubetypes.KubernetesContainerNameLabel: "NEW-NAME",
-				},
-				Annotations: map[string]string{
-					kubetypes.KubernetesPodUIDLabel: "new-sandbox-uid",
-					"io.kubernetes.container.hash":  "new-hash",
-				},
-				Metadata: &types.ContainerMetadata{
-					Name: "new-container-name",
-				},
-			}
+				err := os.WriteFile(
+					"spec.dump",
+					[]byte(`{"annotations":{"io.kubernetes.cri-o.Metadata"`+
+						`:"{\"name\":\"container-to-restore\"}",`+
+						`"io.kubernetes.cri-o.Annotations": "{\"name\":\"NAME\",`+
+						`\"io.kubernetes.container.hash\":\"b4eeb97f\",`+
+						`\"io.kubernetes.pod.uid\":\"old-sandbox-uid\"}",`+
+						`"io.kubernetes.cri-o.Labels": "{\"io.kubernetes.container.name\":\"counter\",`+
+						`\"io.kubernetes.pod.uid\":\"old-sandbox-uid\"}",`+
+						`"io.kubernetes.cri-o.SandboxID": "sandboxID"},`+
+						`"mounts": [{"destination": "/proc"},`+
+						`{"destination":"/data","source":"/data","options":`+
+						`["rw","ro","rbind","rprivate","rshared","rslaved"]}],`+
+						`"linux": {"maskedPaths": ["/proc/acpi"], "readonlyPaths": ["/proc/asound"]}}`),
+					0o644,
+				)
+				Expect(err).To(BeNil())
+				defer os.RemoveAll("spec.dump")
+				err = os.WriteFile("config.dump", []byte(loopImage), 0o644)
+				Expect(err).To(BeNil())
+				defer os.RemoveAll("config.dump")
+				outFile, err := os.Create("archive.tar")
+				Expect(err).To(BeNil())
+				defer outFile.Close()
+				input, err := archive.TarWithOptions(".", &archive.TarOptions{
+					Compression:      archive.Uncompressed,
+					IncludeSourceDir: true,
+					IncludeFiles:     []string{"spec.dump", "config.dump"},
+				})
+				Expect(err).To(BeNil())
+				defer os.RemoveAll("archive.tar")
+				_, err = io.Copy(outFile, input)
+				Expect(err).To(BeNil())
+				containerConfig := &types.ContainerConfig{
+					Image: &types.ImageSpec{
+						Image: "archive.tar",
+					},
+					Linux: &types.LinuxContainerConfig{
+						Resources:       &types.LinuxContainerResources{},
+						SecurityContext: &types.LinuxContainerSecurityContext{},
+					},
+					Labels: map[string]string{
+						kubetypes.KubernetesContainerNameLabel: "NEW-NAME",
+					},
+					Annotations: map[string]string{
+						kubetypes.KubernetesPodUIDLabel: "new-sandbox-uid",
+						"io.kubernetes.container.hash":  "new-hash",
+					},
+					Metadata: &types.ContainerMetadata{
+						Name: "new-container-name",
+					},
+				}
 
-			size := uint64(100)
-			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(
-					gomock.Any(), gomock.Any()).
-					Return([]string{"image"}, nil),
+				size := uint64(100)
+				gomock.InOrder(
+					imageServerMock.EXPECT().ResolveNames(
+						gomock.Any(), gomock.Any()).
+						Return([]string{"image"}, nil),
 
-				imageServerMock.EXPECT().ImageStatus(
-					gomock.Any(), gomock.Any()).
-					Return(&storage.ImageResult{
-						ID:   "image",
-						User: "10", Size: &size,
-						Annotations: map[string]string{
-							crioann.CheckpointAnnotationName: "foo",
-						},
-					}, nil),
+					imageServerMock.EXPECT().ImageStatus(
+						gomock.Any(), gomock.Any()).
+						Return(&storage.ImageResult{
+							ID:   "image",
+							User: "10", Size: &size,
+							Annotations: map[string]string{
+								crioann.CheckpointAnnotationName: "foo",
+							},
+						}, nil),
 
-				runtimeServerMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any()).
-					Return(storage.ContainerInfo{
-						Config: &v1.Image{
-							Config: v1.ImageConfig{
-								Entrypoint: []string{"sh"},
+					runtimeServerMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
+						gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+						gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+						gomock.Any(), gomock.Any()).
+						Return(storage.ContainerInfo{
+							Config: &v1.Image{
+								Config: v1.ImageConfig{
+									Entrypoint: []string{"sh"},
+								},
 							},
 						},
-					},
-						nil,
-					),
-				runtimeServerMock.EXPECT().StartContainer(gomock.Any()).
-					Return(emptyDir, nil),
-			)
+							nil,
+						),
+					runtimeServerMock.EXPECT().StartContainer(gomock.Any()).
+						Return(emptyDir, nil),
+				)
 
-			// When
+				// When
 
-			_, err = sut.CRImportCheckpoint(
-				context.Background(),
-				containerConfig,
-				"",
-				"new-sandbox-id",
-			)
+				_, err = sut.CRImportCheckpoint(
+					context.Background(),
+					containerConfig,
+					"",
+					"new-sandbox-id",
+				)
 
-			// Then
-			Expect(err).To(BeNil())
-		})
+				// Then
+				Expect(err).To(BeNil())
+			})
+		}
 	})
 	t.Describe("ContainerRestore from OCI archive", func() {
 		It("should fail because archive does not exist", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

Up until now CRI-O was using ImageName to remember the base image of the restored container. This works, but has two problems:

 * The output from the restored container was different, especially for the Kubernetes use case. The output of 'crictl ps' contains for the original container under 'IMAGE' something like 'registry/path/container@sha256:123444444...'. The restored container was, however, only displaying something like 'registry/path/container'.

 * More problematic, however, was that CRI-O might pull the wrong image from the registry.  If the container in the registry was updated (new latest tag for example) all of a sudden the wrong base image would be downloaded and the restore would potentially fail.

With this change the output of Kubernetes containers in 'crictl ps' 'IMAGE' does not change after restoring the container and the restored container will run on exactly the same base image.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
