### PR TITLE
runtimeVM: fix Exec(sync) overwriting the initial spec args

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -378,10 +378,12 @@ func (r *runtimeVM) execContainerCommon(ctx context.Context, c *Container, cmd [
 		},
 	})
 
-	pSpec := c.Spec().Process
+	// It's important to make a spec copy here to not overwrite the initial
+	// process spec
+	pSpec := *c.Spec().Process
 	pSpec.Args = cmd
 
-	any, err := typeurl.MarshalAny(pSpec)
+	any, err := typeurl.MarshalAny(&pSpec)
 	if err != nil {
 		return execError, errdefs.FromGRPC(err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When running kata containers, the initial specs for the containers are overwritten by an Exec or ExecSync command.

It was fixed for the default runtime (see #3989), but the same fix must be applied on runtime_vm.go

This PR fixes the integration test "ctr execsync should not overwrite initial spec args" with the kata runtime.

#### Which issue(s) this PR fixes:

None


#### Does this PR introduce a user-facing change?

```release-note
- Fixed a bug when running kata containers, where exec sync requests (manually or automatically triggered via readiness/liveness probes)
  overwrite the runtime `info.runtimeSpec.process.args` of the container status (for example via `crictl inspect`).
```
