### PR TITLE
tests: use crictl binary directly when checking its capabilities

### DIFF
--- a/test/timeout.bats
+++ b/test/timeout.bats
@@ -3,7 +3,9 @@
 load helpers
 
 function setup() {
-	if ! crictl runp -h | grep -q "cancel-timeout"; then
+	# do not use the crictl() wrapper function here: we need to test the crictl
+	# features with no additional arg.
+	if ! "$CRICTL_BINARY" runp -h | grep -q "cancel-timeout"; then
 		skip "must have a crictl with the -T option to test CRI-O's timeout handling"
 	fi
 	setup_test


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The timeout.bats tests are all skipped with the message `must have a crictl with the -T option to test CRI-O's timeout handling`.

Looking into it, I think it started with https://github.com/cri-o/cri-o/commit/5cad5f287482c045ac7c6c1aa70a1352636b843a, where the `crictl()` wrapper was modified to use a config file in the `TESTDIR` folder.
Because of that, calling `crictl()` before `setup_test()` means calling it with a non-existing config file, causing an error.

This PR modifies the test to use the crictl binary directly, skipping the wrapper function.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
