### PR TITLE
OCPBUGS-10970: Fix the interrupt mask width when encoding

### DIFF
--- a/internal/runtimehandlerhooks/utils.go
+++ b/internal/runtimehandlerhooks/utils.go
@@ -51,12 +51,16 @@ func mapHexCharToByte(h string) ([]byte, error) {
 }
 
 func mapByteToHexChar(b []byte) string {
+	// The kernel will not accept longer bit mask than the count of cpus
+	// on the system rounded up to the closest 32 bit multiple.
+	// See https://bugzilla.redhat.com/show_bug.cgi?id=2181546
+
 	var breversed []byte
 	var rindex int
 	l := len(b)
-	// align it to 8 byte
-	if l%8 != 0 {
-		lfill := 8 - l%8
+	// align it to 4 byte
+	if l%4 != 0 {
+		lfill := 4 - l%4
 		l += lfill
 		for i := 0; i < lfill; i++ {
 			b = append(b, byte(0))
@@ -107,6 +111,8 @@ func UpdateIRQSmpAffinityMask(cpus, current string, set bool) (cpuMask, bannedCP
 	s := strings.ReplaceAll(current, ",", "")
 
 	// the index 0 corresponds to the cpu 0-7
+	// the LSb (right-most bit) represents the lowest cpu id from the byte
+	// and the MSb (left-most bit) represents the highest cpu id from the byte
 	currentMaskArray, err := mapHexCharToByte(s)
 	if err != nil {
 		return cpus, "", err

--- a/internal/runtimehandlerhooks/utils_test.go
+++ b/internal/runtimehandlerhooks/utils_test.go
@@ -48,6 +48,14 @@ var _ = Describe("Utils", func() {
 				input:    Input{cpus: "4-13", mask: "ffff,ffffc00f", set: true},
 				expected: Expected{mask: "0000ffff,ffffffff", invMask: "00000000,00000000"},
 			}),
+			Entry("clear a single bit that was one when odd mask is present", TestData{
+				input:    Input{cpus: "9", mask: "fff", set: false},
+				expected: Expected{mask: "00000dff", invMask: "0000f200"},
+			}),
+			Entry("clear two bits from a short mask", TestData{
+				input:    Input{cpus: "2-3", mask: "ffffff", set: false},
+				expected: Expected{mask: "00fffff3", invMask: "0000000c"},
+			}),
 		)
 
 		Context("UpdateIRQBalanceConfigFile", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

<!--
/kind api-change

/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Kernel got more strict in parsing the interrupt cpu mask strings, we are no longer allowed to pass in more 4B (32 bit) words than necessary to cover all cpus on a given system.

See https://bugzilla.redhat.com/show_bug.cgi?id=2181546 for more detail about what kernel accepts and what gets rejected.

The logic of mapByteToHexChar (from internal/runtimehandlerhooks/utils.go) was rounding to 8 bytes (64 bits) which triggered the linked bug.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://issues.redhat.com/browse/OCPBUGS-10970

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
