### PR TITLE
Generate proper signature check

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -164,8 +164,10 @@ if command -v cosign >/dev/null; then
     for BLOB in "${BLOBS[@]}"; do
         echo "Verifying blob $BLOB"
         COSIGN_EXPERIMENTAL=1 cosign verify-blob "$BLOB" \
-            --certificate-identity-regexp '.*' \
-            --certificate-oidc-issuer-regexp '.*' \
+            --certificate-identity https://github.com/cri-o/cri-o/.github/workflows/test.yml@refs/tags/$VERSION \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-github-workflow-repository cri-o/cri-o \
+            --certificate-github-workflow-ref refs/tags/$VERSION \
             --signature "$BLOB.sig" \
             --certificate "$BLOB.cert"
     done

--- a/scripts/get
+++ b/scripts/get
@@ -157,6 +157,10 @@ if command -v cosign >/dev/null; then
         curl_retry "$BASE_URL/$FILE" -o "$FILE"
     done
 
+    GIT_REF=refs/heads/main
+    if git ls-remote --exit-code --tags https://github.com/cri-o/cri-o "refs/tags/$VERSION" >/dev/null; then
+        GIT_REF="refs/tags/$VERSION"
+    fi
     BLOBS=(
         "$TARBALL"
         "$SPDX"
@@ -164,10 +168,10 @@ if command -v cosign >/dev/null; then
     for BLOB in "${BLOBS[@]}"; do
         echo "Verifying blob $BLOB"
         COSIGN_EXPERIMENTAL=1 cosign verify-blob "$BLOB" \
-            --certificate-identity "https://github.com/cri-o/cri-o/.github/workflows/test.yml@refs/tags/$VERSION" \
+            --certificate-identity "https://github.com/cri-o/cri-o/.github/workflows/test.yml@$GIT_REF" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-github-workflow-repository cri-o/cri-o \
-            --certificate-github-workflow-ref "refs/tags/$VERSION" \
+            --certificate-github-workflow-ref "$GIT_REF" \
             --signature "$BLOB.sig" \
             --certificate "$BLOB.cert"
     done

--- a/scripts/get
+++ b/scripts/get
@@ -164,10 +164,10 @@ if command -v cosign >/dev/null; then
     for BLOB in "${BLOBS[@]}"; do
         echo "Verifying blob $BLOB"
         COSIGN_EXPERIMENTAL=1 cosign verify-blob "$BLOB" \
-            --certificate-identity https://github.com/cri-o/cri-o/.github/workflows/test.yml@refs/tags/$VERSION \
+            --certificate-identity "https://github.com/cri-o/cri-o/.github/workflows/test.yml@refs/tags/$VERSION" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-github-workflow-repository cri-o/cri-o \
-            --certificate-github-workflow-ref refs/tags/$VERSION \
+            --certificate-github-workflow-ref "refs/tags/$VERSION" \
             --signature "$BLOB.sig" \
             --certificate "$BLOB.cert"
     done

--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -134,8 +134,10 @@ To verify the artifact signatures via [cosign](https://github.com/sigstore/cosig
 `+"```"+`console
 > export COSIGN_EXPERIMENTAL=1
 > cosign verify-blob cri-o.amd64.%s.tar.gz \
-    --certificate-identity-regexp '.*' \
-    --certificate-oidc-issuer-regexp '.*' \
+    --certificate-identity https://github.com/cri-o/cri-o/.github/workflows/test.yml@refs/tags/v%s \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-github-workflow-repository cri-o/cri-o \
+    --certificate-github-workflow-ref refs/tags/v%s \
     --signature cri-o.amd64.%s.tar.gz.sig \
     --certificate cri-o.amd64.%s.tar.gz.cert
 `+"```"+`

--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -134,10 +134,10 @@ To verify the artifact signatures via [cosign](https://github.com/sigstore/cosig
 `+"```"+`console
 > export COSIGN_EXPERIMENTAL=1
 > cosign verify-blob cri-o.amd64.%s.tar.gz \
-    --certificate-identity https://github.com/cri-o/cri-o/.github/workflows/test.yml@refs/tags/v%s \
+    --certificate-identity https://github.com/cri-o/cri-o/.github/workflows/test.yml@refs/tags/%s \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
     --certificate-github-workflow-repository cri-o/cri-o \
-    --certificate-github-workflow-ref refs/tags/v%s \
+    --certificate-github-workflow-ref refs/tags/%s \
     --signature cri-o.amd64.%s.tar.gz.sig \
     --certificate cri-o.amd64.%s.tar.gz.cert
 `+"```"+`
@@ -169,6 +169,7 @@ To verify the bill of materials (SBOM) in [SPDX](https://spdx.org) format using 
 		startTag, shortHead,
 		startTag, endRev,
 		time.Now().Format(time.RFC1123),
+		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

The check of the cosign-based keyless signature check accepted any valid signature. This opens the attack vector that a malicious file with a valid signature passes the check when executing the command from the release notes.

Values as per [rekor record for `cri-o.arm64.v1.26.3.tar.gz`](https://search.sigstore.dev/?hash=f2fee35b23b4fda0a32c79b7eacdff96258cd84655899a0a7f6012e2b257f293)

#### Which issue(s) this PR fixes:

Fixed #6781 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None