### PR TITLE
Enforce umask on container and sandbox creation

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -298,6 +298,7 @@ func generateUserString(username, imageUser string, uid *types.Int64Value) strin
 // CreateContainer creates a new container in specified PodSandbox
 func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainerRequest) (res *types.CreateContainerResponse, retErr error) {
 	log.Infof(ctx, "Creating container: %s", translateLabelsToDescription(req.GetConfig().GetLabels()))
+	useDefaultUmask(ctx)
 
 	// Check if image is a file. If it is a file it might be a checkpoint archive.
 	checkpointImage, err := func() (bool, error) {

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -65,6 +65,8 @@ func (s *Server) runtimeHandler(req *types.RunPodSandboxRequest) (string, error)
 
 // RunPodSandbox creates and runs a pod-level sandbox.
 func (s *Server) RunPodSandbox(ctx context.Context, req *types.RunPodSandboxRequest) (*types.RunPodSandboxResponse, error) {
+	useDefaultUmask(ctx)
+
 	// platform dependent call
 	return s.runPodSandbox(ctx, req)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -402,7 +402,7 @@ func New(
 	}
 	config := configIface.GetData()
 
-	useDefaultUmask()
+	useDefaultUmask(context.Background())
 
 	config.SystemContext.AuthFilePath = config.GlobalAuthFile
 	config.SystemContext.SignaturePolicyPath = config.SignaturePolicyPath
@@ -565,11 +565,11 @@ func New(
 	return s, nil
 }
 
-func useDefaultUmask() {
+func useDefaultUmask(ctx context.Context) {
 	const defaultUmask = 0o022
 	oldUmask := unix.Umask(defaultUmask)
 	if oldUmask != defaultUmask {
-		logrus.Infof(
+		log.Warnf(ctx,
 			"Using default umask 0o%#o instead of 0o%#o",
 			defaultUmask, oldUmask,
 		)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Sometimes CRI-O runs as umask 0000 but starts with the default one 0022. We now double check that we have the right umask enforced on sandbox and container creation to mitigate that issue.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Enforce CRI-O default umask 0022 even on sandbox and container creation.
```
