### PR TITLE
[1.25] Enforce umask on container and sandbox creation

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -519,7 +519,7 @@ func useDefaultUmask() {
 	const defaultUmask = 0o022
 	oldUmask := unix.Umask(defaultUmask)
 	if oldUmask != defaultUmask {
-		logrus.Infof(
+		logrus.Warnf(
 			"Using default umask 0o%#o instead of 0o%#o",
 			defaultUmask, oldUmask,
 		)

--- a/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go
+++ b/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containers/common/pkg/umask"
 	"github.com/containers/storage/pkg/idtools"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -241,10 +240,6 @@ func addSubscriptionsFromMountsFile(filePath, mountLabel, containerRunDir string
 			if err != nil {
 				return nil, err
 			}
-
-			// Don't let the umask have any influence on the file and directory creation
-			oldUmask := umask.Set(0)
-			defer umask.Set(oldUmask)
 
 			switch mode := fileInfo.Mode(); {
 			case mode.IsDir():


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Sometimes CRI-O runs as umask 0000 but starts with the default one 0022. We now double check that we have the right umask enforced on sandbox and container creation to mitigate that issue.

#### Which issue(s) this PR fixes:

Cherry-pick of https://github.com/cri-o/cri-o/pull/6784

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Enforce CRI-O default umask 0022 even on sandbox and container creation.
```
