### PR TITLE
internal/storage.runtimeService.createContainerOrPodSandbox(): read ID maps correctly

### DIFF
--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -273,7 +273,8 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		return ContainerInfo{}, err
 	}
 	if idMappingsOptions != nil {
-		*idMappingsOptions = coptions.IDMappingOptions
+		idMappingsOptions.UIDMap = container.UIDMap
+		idMappingsOptions.GIDMap = container.GIDMap
 	}
 	if metadata.Pod {
 		logrus.Debugf("Created pod sandbox %q", container.ID)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When creating a storage library `Container`, read the ID mappings that are assigned to that container from the `Container` structure that `CreateContainer()` returns, rather than expecting the library to modify the options structure that we passed to `CreateContainer()`.  It will stop doing that in its 1.46 release.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
none
```