### PR TITLE
Don't print `Dependencies` if `crio version` it not verbose

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -228,7 +228,7 @@ func (i *Info) String() string {
 			valueString = value.String()
 		}
 
-		if valueString != "" {
+		if strings.TrimSpace(valueString) != "" {
 			fmt.Fprintf(w, "%s:\t%s", field.Name, valueString)
 			if i+1 < t.NumField() {
 				fmt.Fprintf(w, "\n")


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We have to trim the field by whitespace, otherwise we will end up printing empty Dependencies, like:

```
> ./bin/crio version | tail -n3
AppArmorEnabled:  false
Dependencies:

```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Don't print `Dependencies` field if `crio version` it not verbose.
```
