### PR TITLE
contrib/test: don't cache the cri-o content

### DIFF
--- a/contrib/test/ci/critest.yml
+++ b/contrib/test/ci/critest.yml
@@ -1,4 +1,7 @@
 ---
+- name: build and install cri-o
+  include: "build/cri-o.yml"
+
 # critest tests expect cgroupfs
 - name: set manage network ns lifecycle
   copy:

--- a/contrib/test/ci/e2e-base.yml
+++ b/contrib/test/ci/e2e-base.yml
@@ -1,4 +1,7 @@
 ---
+- name: build and install cri-o
+  include: "build/cri-o.yml"
+
 # only fixup paths for e2e tests which expect to be able to pass 'test-handler' as the runtime handler
 - name: add test-handler runtime handler for Runtimes test
   become: yes

--- a/contrib/test/ci/integration-main.yml
+++ b/contrib/test/ci/integration-main.yml
@@ -8,6 +8,9 @@
   vars_files:
     - "{{ playbook_dir }}/vars.yml"
   tasks:
+    - name: build and install cri-o
+      include: "build/cri-o.yml"
+
     - name: enable and start CRI-O
       become: yes
       systemd:

--- a/contrib/test/ci/setup.yml
+++ b/contrib/test/ci/setup.yml
@@ -49,10 +49,7 @@
 - name: clone build and install kubetest                                                                     
   include: "build/kubetest.yml"                                                                              
   vars:                                                                                                      
-    force_clone: true  
-
-- name: clone and build crio 
-  include: build/cri-o.yml
+    force_clone: true
 
 - name: Ensures crio conf dir exists
   file: path=/etc/crio/crio.conf.d state=directory


### PR DESCRIPTION
This change fixes the cri-o CI which will now pick the PR content for testing.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
/kind ci

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
