### PR TITLE
WIP - Fix "runtime list" calls from helpers.bash

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -56,7 +56,6 @@ kata_skip_files:
   - "ctr_pause_unpause.bats"
   - "ctr_seccomp.bats"  # see https://github.com/kata-containers/tests/issues/4587
   - "ctr_userns.bats"
-  - "drop_infra.bats"   # infra ctr is not dropped on purpose with kata
   - "infra_ctr_cpuset.bats"
   - "inspect.bats"
   - "metrics.bats"

--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -160,7 +160,7 @@ EOF
 
 	ctr_id=$(crictl run "$newconfig" "$TESTDATA"/sandbox_config.json)
 	# verify CRI-O did not specify memory swap value
-	jq -e .linux.resources.memory.swap "$(runtime list | grep "$ctr_id" | awk '{ print $4 }')/config.json"
+	jq -e .linux.resources.memory.swap "$(runtime state "$ctr_id" | jq -r .bundle)/config.json"
 }
 
 @test "ctr with swap should succeed when swap is unlimited" {

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -980,9 +980,6 @@ function check_oci_annotation() {
 }
 
 @test "ctr with node level pid namespace should not leak children" {
-	if [[ "$RUNTIME_TYPE" == "vm" ]]; then
-		skip "not applicable to vm runtime type"
-	fi
 	if [[ -n "$TEST_USERNS" ]]; then
 		skip "test fails in a user namespace"
 	fi

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -999,7 +999,7 @@ function check_oci_annotation() {
 	ctr_id=$(crictl run "$newconfig" "$newsandbox")
 	processes=$(list_all_children "$(pidof conmon)")
 
-	pid=$(runtime list -f json | jq .[].pid)
+	pid=$(runtime_pid "$ctr_id")
 	[[ "$pid" -gt 0 ]]
 	kill -9 "$pid"
 

--- a/test/drop_infra.bats
+++ b/test/drop_infra.bats
@@ -17,6 +17,9 @@ function teardown() {
 }
 
 @test "test infra ctr dropped" {
+	if [ "$RUNTIME_TYPE" == "vm" ]; then
+		skip "infra ctr is not expected to drop with runtime type VM"
+	fi
 	jq '.linux.security_context.namespace_options.pid = 1' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_no_infra.json
 	pod_id=$(crictl runp "$TESTDIR"/sandbox_no_infra.json)
@@ -26,8 +29,13 @@ function teardown() {
 }
 
 @test "test infra ctr not dropped" {
-	jq '.linux.security_context.namespace_options.pid = 0' \
-		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_no_infra.json
+	if [ "$RUNTIME_TYPE" == "vm" ]; then
+		# with runtime type VM, the infra ctr is supposed to be kept always
+		cp "$TESTDATA"/sandbox_config.json "$TESTDIR"/sandbox_no_infra.json
+	else
+		jq '.linux.security_context.namespace_options.pid = 0' \
+			"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_no_infra.json
+	fi
 	pod_id=$(crictl runp "$TESTDIR"/sandbox_no_infra.json)
 
 	output=$(runtime list)

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -94,6 +94,15 @@ function runtime() {
     fi
 }
 
+# Uses the runtime() wrapper to retrieve the PID of the given container
+function runtime_pid() {
+    if [ "$RUNTIME_TYPE" == "vm" ]; then
+        runtime list | grep "$1" | awk '{ print $1 }'
+    else
+        runtime list -f json | jq ".[] | select(.id==\"$1\") | .pid"
+    fi
+}
+
 # Communicate with Docker on the host machine.
 # Should rarely use this.
 function docker_host() {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -86,7 +86,12 @@ function crioctl() {
 
 # Run the runtime binary with the specified RUNTIME_ROOT
 function runtime() {
-    "$RUNTIME_BINARY_PATH" --root "$RUNTIME_ROOT" "$@"
+    if [ "$RUNTIME_TYPE" == "vm" ]; then
+        # A specific tool should be used for runtime calls
+        ./kata_cmdline_tool.bash "$@"
+    else
+        "$RUNTIME_BINARY_PATH" --root "$RUNTIME_ROOT" "$@"
+    fi
 }
 
 # Communicate with Docker on the host machine.

--- a/test/kata_cmdline_tool.bash
+++ b/test/kata_cmdline_tool.bash
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# In helpers.bats, the "runtime()" wrapper is used to call the runtime
+# binary directly. It is used for 4 commands across the test files:
+#
+# list:
+#   Provides the list of containers running under the runtime.
+#   In this implementation, the output comes from a call to "ps" and contains
+#   the PID and command line used to run the kata process.
+#   with the "-q" parameter, the list is limited to the container ID of running
+#   containers.
+#
+# kill:
+# delete:
+# state:
+#
+# As there is no cmdline tool for kata, we have to find a different way of
+# retrieving the same information.
+# This script is used to mimic this behaviour and return meaningful information
+# in the kata use case.
+#
+
+case $1 in
+"list")
+    LIST=$(ps -o pid= -o args= -C containerd-shim)
+    if [ "$2" == "-q" ]; then
+        # list only the container IDs
+        echo "$LIST" | grep -oP '(?<=-id )[^ ]*'
+    else
+        echo "$LIST"
+    fi
+    ;;
+
+"kill" | "delete" | "state")
+    echo "runtime $1 - not implemented in test script"
+    exit 1
+    ;;
+
+*)
+    echo "Not supported command: $1"
+    exit 1
+    ;;
+
+esac


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

This PR starts an implementation of the missing features in the runtime() wrapper function in helpers.bats, when dealing with kata containers.

It modifies the wrapper to call a separate script, rather than the actual runtime, when using a container with RUNTIME_TYPE=vm. This new script will implement the various use cases of the runtime() wrapper for kata containers.

In this PR, we only implement the "runtime list" use case. Additional use cases will be added with more PRs.

The "runtime list" call is implemented, and another one "runtime_pid" is added to address a very specific need.
Several of the tests have been adapted accordingly.

These test will be enabled in the kata CI job when this PR is merged.

See #5896 for more information


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Not marking #5896 as fixed here, as this is just part of the full implementation needed to fix it.


#### Does this PR introduce a user-facing change?

```release-note
None
```
