### PR TITLE
config: mark seccomp-use-default-when-empty as deprecated

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -139,7 +139,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -l root -s r -r -d 'The CRI-O ro
 complete -c crio -n '__fish_crio_no_subcommand' -l runroot -r -d 'The CRI-O state directory.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l runtimes -r -d 'OCI runtimes, format is \'runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path\'.'
 complete -c crio -n '__fish_crio_no_subcommand' -l seccomp-profile -r -d 'Path to the seccomp.json profile to be used as the runtime\'s default. If not specified, then the internal default seccomp profile will be used.'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l seccomp-use-default-when-empty -d 'Use the default seccomp profile when an empty one is specified.'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l seccomp-use-default-when-empty -d 'Use the default seccomp profile when an empty one is specified. This option is currently deprecated, and will be replaced by the SeccompDefault FeatureGate in Kubernetes.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l selinux -d 'Enable selinux support.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l separate-pull-cgroup -r -d '[EXPERIMENTAL] Pull in new cgroup.'
 complete -c crio -n '__fish_crio_no_subcommand' -l signature-policy -r -d 'Path to signature policy JSON file.'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -368,7 +368,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--seccomp-profile**="": Path to the seccomp.json profile to be used as the runtime's default. If not specified, then the internal default seccomp profile will be used.
 
-**--seccomp-use-default-when-empty**: Use the default seccomp profile when an empty one is specified.
+**--seccomp-use-default-when-empty**: Use the default seccomp profile when an empty one is specified. This option is currently deprecated, and will be replaced by the SeccompDefault FeatureGate in Kubernetes.
 
 **--selinux**: Enable selinux support.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -133,6 +133,7 @@ the container runtime configuration.
 
 **seccomp_profile**=""
   Path to the seccomp.json profile which is used as the default seccomp profile for the runtime. If not specified, then the internal default seccomp profile will be used.
+  This option is currently deprecated, and will be replaced by the SeccompDefault FeatureGate in Kubernetes.
 
 **seccomp_use_default_when_empty**=true
   Changes the meaning of an empty seccomp profile.  By default (and according to CRI spec), an empty profile means unconfined.

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -624,7 +624,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:    "seccomp-use-default-when-empty",
-			Usage:   "Use the default seccomp profile when an empty one is specified.",
+			Usage:   "Use the default seccomp profile when an empty one is specified. This option is currently deprecated, and will be replaced by the SeccompDefault FeatureGate in Kubernetes.",
 			EnvVars: []string{"CONTAINER_SECCOMP_USE_DEFAULT_WHEN_EMPTY"},
 			Value:   defConf.Seccomp().UseDefaultWhenEmpty(),
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -222,6 +222,7 @@ type Runtimes map[string]*RuntimeHandler
 type RuntimeConfig struct {
 	// SeccompUseDefaultWhenEmpty specifies whether the default profile
 	// should be used when an empty one is specified.
+	// This option is currently deprecated, and will be replaced by the SeccompDefault FeatureGate in Kubernetes.
 	SeccompUseDefaultWhenEmpty bool `toml:"seccomp_use_default_when_empty"`
 
 	// NoPivot instructs the runtime to not use `pivot_root`, but instead use `MS_MOVE`

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -881,6 +881,8 @@ const templateStringCrioRuntimeSeccompUseDefaultWhenEmpty = `# Changes the meani
 # (and according to CRI spec), an empty profile means unconfined.
 # This option tells CRI-O to treat an empty profile as the default profile,
 # which might increase security.
+# This option is currently deprecated,
+# and will be replaced by the SeccompDefault FeatureGate in Kubernetes.
 {{ $.Comment }}seccomp_use_default_when_empty = {{ .SeccompUseDefaultWhenEmpty }}
 
 `


### PR DESCRIPTION
as SeccompDefault FeatureGate has gone GA in upstream Kubernetes

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind deprecation
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Mark `seccomp-use-default-when-empty` option as deprecated, as it is replaced by the SeccompDefault FeatureGate
```
