### PR TITLE
Add basic crictl info config with sandboxImage

### DIFF
--- a/server/runtime_status_test.go
+++ b/server/runtime_status_test.go
@@ -46,5 +46,16 @@ var _ = t.Describe("Status", func() {
 				Expect(condition.Status).To(BeTrue())
 			}
 		})
+
+		It("should return info as part of a verbose response", func() {
+			// When
+			response, err := sut.Status(context.Background(),
+				&types.StatusRequest{Verbose: true})
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(response).NotTo(BeNil())
+			Expect(response.Info).NotTo(BeNil())
+		})
 	})
 })


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds information about pause image to `crictl info`, as used by kubeadm in 1.27

#### Which issue(s) this PR fixes:

Fixes #6816

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
a new field "config" has been added to the verbose output of crictl info
```


`crictl info`
```json
{
  "status": {
    "conditions": [
      {
        "type": "RuntimeReady",
        "status": true,
        "reason": "",
        "message": ""
      },
      {
        "type": "NetworkReady",
        "status": false,
        "reason": "NetworkPluginNotReady",
        "message": "Network plugin returns error: No CNI configuration file in /etc/cni/net.d/. Has your network provider started?"
      }
    ]
  },
  "config": {
    "sandboxImage": "registry.k8s.io/pause:3.9"
  }
}

```