### PR TITLE
crio: deprecate config migrate support

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -178,6 +178,9 @@ by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.'
 complete -c crio -n '__fish_seen_subcommand_from config' -f -l default -d 'Output the default configuration (without taking into account any configuration options).'
 complete -c crio -n '__fish_seen_subcommand_from config' -f -l migrate-defaults -s m -r -d 'Migrate the default config from a specified version.
+
+    The migrate-defaults command has been deprecated and will be removed in the future.
+
     To run a config migration, just select the input config via the global
     \'--config,-c\' command line argument, for example:
     ```

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -441,6 +441,9 @@ it later with **--config**. Global options will modify the output.
 **--default**: Output the default configuration (without taking into account any configuration options).
 
 **--migrate-defaults, -m**="": Migrate the default config from a specified version.
+
+    The migrate-defaults command has been deprecated and will be removed in the future.
+
     To run a config migration, just select the input config via the global
     '--config,-c' command line argument, for example:
     ```

--- a/internal/criocli/config.go
+++ b/internal/criocli/config.go
@@ -27,6 +27,9 @@ it later with **--config**. Global options will modify the output.`,
 			Aliases:     []string{"m"},
 			Destination: &from,
 			Usage: fmt.Sprintf(`Migrate the default config from a specified version.
+
+    The migrate-defaults command has been deprecated and will be removed in the future.
+
     To run a config migration, just select the input config via the global
     '--config,-c' command line argument, for example:
     `+"```"+`
@@ -61,6 +64,7 @@ it later with **--config**. Global options will modify the output.`,
 
 		if c.IsSet("migrate-defaults") {
 			logrus.Infof("Migrating config from %s", from)
+			logrus.Warn("Config migration has been deprecated and will be removed in the future.")
 			if err := migrate.Config(conf, from); err != nil {
 				return fmt.Errorf("migrate config: %w", err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

<!--
/kind api-change
/kind bug
/kind ci
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Deprecate config migration support which will be removed in v1.29.0

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #6884

<!--
or
None
-->

#### Special notes for your reviewer:

:)

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Deprecate config migration support (will be removed in v1.29.0)
```
