### PR TITLE
[1.26] Update c/common to fix umask bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6
-	github.com/containers/common v0.50.2-0.20221104122933-582fadb8228b
+	github.com/containers/common v0.50.2-0.20230510115104-2ba2fd3a37fe
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.4.0
 	github.com/containers/image/v5 v5.24.2

--- a/go.sum
+++ b/go.sum
@@ -591,8 +591,8 @@ github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNG
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
 github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6 h1:6bFoF3QIUzza8NWAsHS1ZGDDEr+r5do46dXEbzkZb3Y=
 github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6/go.mod h1:skMuWv4FIebpsAFT7fBv2Ll0e0w2j71IUWCIrw9iTV0=
-github.com/containers/common v0.50.2-0.20221104122933-582fadb8228b h1:/WN9Tlng1xWqr56U2sOSLM5b1Q8DF2gr87jI+fjEA04=
-github.com/containers/common v0.50.2-0.20221104122933-582fadb8228b/go.mod h1:XLXycBIzTc4yNU6VzqCwgjPt9mtibATtOeXKjlCAsCY=
+github.com/containers/common v0.50.2-0.20230510115104-2ba2fd3a37fe h1:nCuh1iDeHvPEIMsJe6UOSieFjYwMVL5vmlmpQGH73iQ=
+github.com/containers/common v0.50.2-0.20230510115104-2ba2fd3a37fe/go.mod h1:XLXycBIzTc4yNU6VzqCwgjPt9mtibATtOeXKjlCAsCY=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.4.0 h1:Nl8/xFsc2/dlQUdYi2GTZ+aPCqcedeqnOUld09eiZHc=

--- a/vendor/github.com/containers/common/pkg/umask/umask.go
+++ b/vendor/github.com/containers/common/pkg/umask/umask.go
@@ -1,0 +1,58 @@
+package umask
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MkdirAllIgnoreUmask creates a directory by ignoring the currently set umask.
+func MkdirAllIgnoreUmask(dir string, mode os.FileMode) error {
+	parent := dir
+	dirs := []string{}
+
+	// Find all parent directories which would have been created by MkdirAll
+	for {
+		if _, err := os.Stat(parent); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("cannot stat %s: %w", dir, err)
+		}
+
+		dirs = append(dirs, parent)
+		newParent := filepath.Dir(parent)
+
+		// Only possible if the root paths are not existing, which would be odd
+		if parent == newParent {
+			break
+		}
+
+		parent = newParent
+	}
+
+	if err := os.MkdirAll(dir, mode); err != nil {
+		return fmt.Errorf("create directory %s: %w", dir, err)
+	}
+
+	for _, d := range dirs {
+		if err := os.Chmod(d, mode); err != nil {
+			return fmt.Errorf("chmod directory %s: %w", d, err)
+		}
+	}
+
+	return nil
+}
+
+// WriteFileIgnoreUmask write the provided data to the path by ignoring the
+// currently set umask.
+func WriteFileIgnoreUmask(path string, data []byte, mode os.FileMode) error {
+	if err := os.WriteFile(path, data, mode); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("chmod file: %w", err)
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -623,7 +623,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.50.2-0.20221104122933-582fadb8228b
+# github.com/containers/common v0.50.2-0.20230510115104-2ba2fd3a37fe
 ## explicit; go 1.17
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
This fixes the umask `0` bug because it contains: https://github.com/containers/common/pull/1421

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Manual pick of https://github.com/cri-o/cri-o/pull/6843

Refers to https://issues.redhat.com/browse/OCPBUGS-13280
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where CRI-O runs with umask of `0`.
```
