### PR TITLE
[1.24] Update c/common to fix umask bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containernetworking/cni v1.1.1
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/buildah v1.23.1
-	github.com/containers/common v0.46.1-0.20211001143714-161e078e4c7f
+	github.com/containers/common v0.46.1-0.20230510135603-1fce5055c6ee
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.0.0-20220505150146-7d0ae00b625c
 	github.com/containers/image/v5 v5.17.0

--- a/go.sum
+++ b/go.sum
@@ -359,8 +359,9 @@ github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19
 github.com/containers/buildah v1.23.1 h1:Tpc9DsRuU+0Oofewpxb6OJVNQjCu7yloN/obUqzfDTY=
 github.com/containers/buildah v1.23.1/go.mod h1:4WnrN0yrA7ab0ppgunixu2WM1rlD2rG8QLJAKbEkZlQ=
 github.com/containers/common v0.44.2/go.mod h1:7sdP4vmI5Bm6FPFxb3lvAh1Iktb6tiO1MzjUzhxdoGo=
-github.com/containers/common v0.46.1-0.20211001143714-161e078e4c7f h1:vVmx51AzWvB4/ao2zyR6s053a1leLTOh+zsOPVWQRgA=
 github.com/containers/common v0.46.1-0.20211001143714-161e078e4c7f/go.mod h1:aml/OO4FmYfPbfT87rvWiCgkLzTdqO6PuZ/xXq6bPbk=
+github.com/containers/common v0.46.1-0.20230510135603-1fce5055c6ee h1:eXuM7TTDhxh5uvYttJIL9Vqj4MtEPivmvJCwQj0Yv1A=
+github.com/containers/common v0.46.1-0.20230510135603-1fce5055c6ee/go.mod h1:aml/OO4FmYfPbfT87rvWiCgkLzTdqO6PuZ/xXq6bPbk=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.0.0-20220505150146-7d0ae00b625c h1:x6gYpFEXrLN+4+NgGg8QkmkGrtujHKgdUgoGY9oUtjU=

--- a/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go
+++ b/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go
@@ -2,6 +2,7 @@ package subscriptions
 
 import (
 	"bufio"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -27,9 +28,10 @@ var (
 	UserOverrideMountsFile = filepath.Join(os.Getenv("HOME"), ".config/containers/mounts.conf")
 )
 
-// subscriptionData stores the name of the file and the content read from it
+// subscriptionData stores the relative name of the file and the content read from it
 type subscriptionData struct {
-	name    string
+	// relPath is the relative path to the file
+	relPath string
 	data    []byte
 	mode    os.FileMode
 	dirMode os.FileMode
@@ -37,11 +39,16 @@ type subscriptionData struct {
 
 // saveTo saves subscription data to given directory
 func (s subscriptionData) saveTo(dir string) error {
-	path := filepath.Join(dir, s.name)
-	if err := os.MkdirAll(filepath.Dir(path), s.dirMode); err != nil {
-		return err
+	// We need to join the path here and create all parent directories, only
+	// creating dir is not good enough as relPath could also contain directories.
+	path := filepath.Join(dir, s.relPath)
+	if err := umask.MkdirAllIgnoreUmask(filepath.Dir(path), s.dirMode); err != nil {
+		return fmt.Errorf("create subscription directory: %w", err)
 	}
-	return ioutil.WriteFile(path, s.data, s.mode)
+	if err := umask.WriteFileIgnoreUmask(path, s.data, s.mode); err != nil {
+		return fmt.Errorf("write subscription data: %w", err)
+	}
+	return nil
 }
 
 func readAll(root, prefix string, parentMode os.FileMode) ([]subscriptionData, error) {
@@ -94,7 +101,7 @@ func readFileOrDir(root, name string, parentMode os.FileMode) ([]subscriptionDat
 		return nil, err
 	}
 	return []subscriptionData{{
-		name:    name,
+		relPath: name,
 		data:    bytes,
 		mode:    s.Mode(),
 		dirMode: parentMode,
@@ -239,14 +246,10 @@ func addSubscriptionsFromMountsFile(filePath, mountLabel, containerWorkingDir st
 				return nil, err
 			}
 
-			// Don't let the umask have any influence on the file and directory creation
-			oldUmask := umask.Set(0)
-			defer umask.Set(oldUmask)
-
 			switch mode := fileInfo.Mode(); {
 			case mode.IsDir():
-				if err = os.MkdirAll(ctrDirOrFileOnHost, mode.Perm()); err != nil {
-					return nil, errors.Wrap(err, "making container directory")
+				if err = umask.MkdirAllIgnoreUmask(ctrDirOrFileOnHost, mode.Perm()); err != nil {
+					return nil, fmt.Errorf("making container directory: %w", err)
 				}
 				data, err := getHostSubscriptionData(hostDirOrFile, mode.Perm())
 				if err != nil {
@@ -264,11 +267,12 @@ func addSubscriptionsFromMountsFile(filePath, mountLabel, containerWorkingDir st
 
 				}
 				for _, s := range data {
-					if err := os.MkdirAll(filepath.Dir(ctrDirOrFileOnHost), s.dirMode); err != nil {
-						return nil, err
+					dir := filepath.Dir(ctrDirOrFileOnHost)
+					if err := umask.MkdirAllIgnoreUmask(dir, s.dirMode); err != nil {
+						return nil, fmt.Errorf("create container dir: %w", err)
 					}
-					if err := ioutil.WriteFile(ctrDirOrFileOnHost, s.data, s.mode); err != nil {
-						return nil, errors.Wrap(err, "saving data to container filesystem")
+					if err := umask.WriteFileIgnoreUmask(ctrDirOrFileOnHost, s.data, s.mode); err != nil {
+						return nil, fmt.Errorf("saving data to container filesystem: %w", err)
 					}
 				}
 			default:

--- a/vendor/github.com/containers/common/pkg/umask/umask.go
+++ b/vendor/github.com/containers/common/pkg/umask/umask.go
@@ -1,0 +1,58 @@
+package umask
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MkdirAllIgnoreUmask creates a directory by ignoring the currently set umask.
+func MkdirAllIgnoreUmask(dir string, mode os.FileMode) error {
+	parent := dir
+	dirs := []string{}
+
+	// Find all parent directories which would have been created by MkdirAll
+	for {
+		if _, err := os.Stat(parent); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("cannot stat %s: %w", dir, err)
+		}
+
+		dirs = append(dirs, parent)
+		newParent := filepath.Dir(parent)
+
+		// Only possible if the root paths are not existing, which would be odd
+		if parent == newParent {
+			break
+		}
+
+		parent = newParent
+	}
+
+	if err := os.MkdirAll(dir, mode); err != nil {
+		return fmt.Errorf("create directory %s: %w", dir, err)
+	}
+
+	for _, d := range dirs {
+		if err := os.Chmod(d, mode); err != nil {
+			return fmt.Errorf("chmod directory %s: %w", d, err)
+		}
+	}
+
+	return nil
+}
+
+// WriteFileIgnoreUmask write the provided data to the path by ignoring the
+// currently set umask.
+func WriteFileIgnoreUmask(path string, data []byte, mode os.FileMode) error {
+	if err := os.WriteFile(path, data, mode); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("chmod file: %w", err)
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -230,7 +230,7 @@ github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/util
-# github.com/containers/common v0.46.1-0.20211001143714-161e078e4c7f
+# github.com/containers/common v0.46.1-0.20230510135603-1fce5055c6ee
 ## explicit; go 1.15
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
This fixes the umask `0` bug because it contains: https://github.com/containers/common/pull/1421

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Manual pick of https://github.com/cri-o/cri-o/pull/6843

Refers to https://issues.redhat.com/browse/OCPBUGS-13281
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where CRI-O runs with umask of `0`.
```
