### PR TITLE
Add support for linking pods logs

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -59,6 +59,10 @@ const (
 
 	// PodLinuxResources indicates the sum of container resources for this pod
 	PodLinuxResources = "io.kubernetes.cri-o.PodLinuxResources"
+
+	// LinkLogsAnnotations indicates that CRI-O should link the pod containers logs into the specified
+	// emptyDir volume
+	LinkLogsAnnotation = "io.kubernetes.cri-o.LinkLogs"
 )
 
 var AllAllowedAnnotations = []string{
@@ -79,4 +83,5 @@ var AllAllowedAnnotations = []string{
 	UmaskAnnotation,
 	PodLinuxOverhead,
 	PodLinuxResources,
+	LinkLogsAnnotation,
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -198,6 +198,7 @@ type RuntimeHandler struct {
 	// "io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
 	// "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
 	// "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
+	// "io.kubernetes.cri-o.LinkLogs" for linking logs into the pod.
 	AllowedAnnotations []string `toml:"allowed_annotations,omitempty"`
 
 	// DisallowedAnnotations is the slice of experimental annotations that are not allowed for this handler.

--- a/server/sandbox_link_logs.go
+++ b/server/sandbox_link_logs.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/opencontainers/selinux/go-selinux/label"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	kubeletPodsRootDir    = "/var/lib/kubelet/pods"
+	kubeletPodLogsRootDir = "/var/log/pods"
+	kubeletEmptyDirLogDir = "kubernetes.io~empty-dir"
+)
+
+// linkLogs bind mounts the kubelet pod log directory under the specified empty dir volume
+func linkLogs(kubePodUID, emptyDirVolName, namespace, kubeName, mountLabel string) error {
+	// Validate the empty dir volume name
+	// This uses the same validation as the one in kubernetes
+	// It can be alphanumeric with dashes allowed in between
+	if errs := validation.IsDNS1123Label(emptyDirVolName); len(errs) != 0 {
+		return fmt.Errorf("empty dir vol name is invalid")
+	}
+	emptyDirLoggingVolumePath := podEmptyDirPath(kubePodUID, emptyDirVolName)
+	if _, err := os.Stat(emptyDirLoggingVolumePath); err != nil {
+		return fmt.Errorf("failed to find %v: %v", emptyDirLoggingVolumePath, err)
+	}
+	logDirMountPath := filepath.Join(emptyDirLoggingVolumePath, "logs")
+	if err := os.Mkdir(logDirMountPath, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+	podLogsDirectory := namespace + "_" + kubeName + "_" + kubePodUID
+	podLogsPath := filepath.Join(kubeletPodLogsRootDir, podLogsDirectory)
+	if err := unix.Mount(podLogsPath, logDirMountPath, "bind", unix.MS_BIND|unix.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("failed to mount %v to %v: %v", podLogsPath, logDirMountPath, err)
+	}
+	if err := label.SetFileLabel(logDirMountPath, mountLabel); err != nil {
+		return fmt.Errorf("failed to set selinux label: %v", err)
+	}
+	return nil
+}
+
+// unlinkLogs unmounts the pod log directory from the specified empty dir volume
+func unlinkLogs(sb *sandbox.Sandbox, emptyDirVolName string) error {
+	sbLabels := sb.Labels()
+	kubePodUID := sbLabels["io.kubernetes.pod.uid"]
+	emptyDirLoggingVolumePath := podEmptyDirPath(kubePodUID, emptyDirVolName)
+	logFileMountPath := filepath.Join(emptyDirLoggingVolumePath, "logs")
+	if _, err := os.Stat(logFileMountPath); !os.IsNotExist(err) {
+		if err := unix.Unmount(logFileMountPath, unix.MNT_DETACH); err != nil {
+			return fmt.Errorf("failed to unmounts logs: %v", err)
+		}
+	}
+	return nil
+}
+
+func podEmptyDirPath(podUID, emptyDirVolName string) string {
+	return filepath.Join(kubeletPodsRootDir, podUID, "volumes", kubeletEmptyDirLogDir, emptyDirVolName)
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -154,7 +154,7 @@ function setup_test() {
     CRIO_CONFIG_DIR="$TESTDIR/crio.conf.d"
     mkdir "$CRIO_CONFIG_DIR"
     CRIO_CONFIG="$TESTDIR/crio.conf"
-    CRIO_CUSTOM_CONFIG="$CRIO_CONFIG_DIR/crio-custom.conf"
+    CRIO_CUSTOM_CONFIG="$CRIO_CONFIG_DIR/00-crio-custom.conf"
     CRIO_CNI_CONFIG="$TESTDIR/cni/net.d/"
     CRIO_LOG="$TESTDIR/crio.log"
 

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -33,7 +33,8 @@ TESTS=("${@:-.}")
 export JOBS=${JOBS:-$(($(nproc --all) * 4))}
 
 # Run the tests.
-execute bats --jobs "$JOBS" --tap "${TESTS[@]}"
+# execute bats --jobs "$JOBS" --tap "${TESTS[@]}"
 # Set this var to run irqbalance tests
-export TEST_SERIAL="Yes"
-execute bats --tap ./irqbalance.bats
+#export TEST_SERIAL="Yes"
+#execute bats --tap ./irqbalance.bats
+execute bats -f "ctr log linking" ctr.bats


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
It adds support for linking logs in a pod using an annotation.
Example:
```
[mrunalp@fedora kubernetes]$ cat ~/specs/httpd.yaml
apiVersion: v1
kind: Pod
metadata:
  name: httpd
  annotations:
    io.kubernetes.cri-o.LinkLogs: "logging-volume"
spec:
  containers:
  - name: httpd
    image: httpd:2.4-alpine
    volumeMounts:
    - name: logging-volume
      mountPath: /acme-logs
  restartPolicy: Always
  volumes:
  - name: logging-volume
    emptyDir: {}
[mrunalp@fedora kubernetes]$
[mrunalp@fedora kubernetes]$ kubectl apply -f ~/specs/httpd.yaml
pod/httpd created
[mrunalp@fedora kubernetes]$ kubectl get pods -o wide
NAME    READY   STATUS    RESTARTS   AGE   IP          NODE        NOMINATED NODE   READINESS GATES
httpd   1/1     Running   0          4s    10.85.0.7   127.0.0.1   <none>           <none>
[mrunalp@fedora kubernetes]$ kubectl exec -it httpd  -- sh
/usr/local/apache2 # cd /acme-logs/logs/httpd/
/acme-logs/logs/httpd # ls
0.log
/acme-logs/logs/httpd # cat 0.log
2023-05-10T16:35:42.635693829-07:00 stderr F AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.85.0.7. Set the 'ServerName' directive globally to suppress this message
2023-05-10T16:35:42.637330584-07:00 stderr F AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.85.0.7. Set the 'ServerName' directive globally to suppress this message
2023-05-10T16:35:42.638926400-07:00 stderr F [Wed May 10 23:35:42.638887 2023] [mpm_event:notice] [pid 1:tid 140274418502472] AH00489: Apache/2.4.57 (Unix) configured -- resuming normal operations
2023-05-10T16:35:42.638926400-07:00 stderr F [Wed May 10 23:35:42.638919 2023] [core:notice] [pid 1:tid 140274418502472] AH00094: Command line: 'httpd -D FOREGROUND'
/acme-logs/logs/httpd # exit
[mrunalp@fedora kubernetes]$ curl 10.85.0.7
<html><body><h1>It works!</h1></body></html>
[mrunalp@fedora kubernetes]$ curl 10.85.0.7
<html><body><h1>It works!</h1></body></html>
[mrunalp@fedora kubernetes]$ curl 10.85.0.7
<html><body><h1>It works!</h1></body></html>
[mrunalp@fedora kubernetes]$ kubectl exec -it httpd  -- sh
/usr/local/apache2 # cat /acme-logs/logs/httpd/0.log
2023-05-10T16:35:42.635693829-07:00 stderr F AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.85.0.7. Set the 'ServerName' directive globally to suppress this message
2023-05-10T16:35:42.637330584-07:00 stderr F AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.85.0.7. Set the 'ServerName' directive globally to suppress this message
2023-05-10T16:35:42.638926400-07:00 stderr F [Wed May 10 23:35:42.638887 2023] [mpm_event:notice] [pid 1:tid 140274418502472] AH00489: Apache/2.4.57 (Unix) configured -- resuming normal operations
2023-05-10T16:35:42.638926400-07:00 stderr F [Wed May 10 23:35:42.638919 2023] [core:notice] [pid 1:tid 140274418502472] AH00094: Command line: 'httpd -D FOREGROUND'
2023-05-10T16:36:11.287927348-07:00 stdout F 10.85.0.1 - - [10/May/2023:23:36:11 +0000] "GET / HTTP/1.1" 200 45
2023-05-10T16:36:12.054634376-07:00 stdout F 10.85.0.1 - - [10/May/2023:23:36:12 +0000] "GET / HTTP/1.1" 200 45
2023-05-10T16:36:12.575269465-07:00 stdout F 10.85.0.1 - - [10/May/2023:23:36:12 +0000] "GET / HTTP/1.1" 200 45
```

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change

```release-note
Add support for linking logs inside a pod using an annotation
```
