### PR TITLE
sandbox: Handle PodLinuxOverhead and PodLinuxResources CRI fields

### DIFF
--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -93,7 +93,7 @@ var _ = t.Describe("Container", func() {
 			sb, err := sandbox.New("sandboxID", "", "", "", "test",
 				make(map[string]string), make(map[string]string), "", "",
 				&types.PodSandboxMetadata{}, "", "", false, "", "", "",
-				[]*hostport.PortMapping{}, false, currentTime, "")
+				[]*hostport.PortMapping{}, false, currentTime, "", nil, nil)
 			Expect(err).To(BeNil())
 
 			image, err := sut.Image()

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -408,6 +408,46 @@ var _ = t.Describe("ContainerServer", func() {
 			Expect(sb).To(BeNil())
 			Expect(err).NotTo(BeNil())
 		})
+
+		It("should fail with wrong PodLinuxOverhead", func() {
+			// Given
+			manifest := bytes.Replace(testManifest,
+				[]byte(`"io.kubernetes.cri-o.PodLinuxOverhead": "{}",`),
+				[]byte(`"io.kubernetes.cri-o.PodLinuxOverhead": "wrong",`), 1,
+			)
+			gomock.InOrder(
+				storeMock.EXPECT().
+					FromContainerDirectory(gomock.Any(), gomock.Any()).
+					Return(manifest, nil),
+			)
+
+			// When
+			sb, err := sut.LoadSandbox(context.Background(), "id")
+
+			// Then
+			Expect(sb).To(BeNil())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should fail with wrong PodLinuxResources", func() {
+			// Given
+			manifest := bytes.Replace(testManifest,
+				[]byte(`"io.kubernetes.cri-o.PodLinuxResources": "{}",`),
+				[]byte(`"io.kubernetes.cri-o.PodLinuxResources": "wrong",`), 1,
+			)
+			gomock.InOrder(
+				storeMock.EXPECT().
+					FromContainerDirectory(gomock.Any(), gomock.Any()).
+					Return(manifest, nil),
+			)
+
+			// When
+			sb, err := sut.LoadSandbox(context.Background(), "id")
+
+			// Then
+			Expect(sb).To(BeNil())
+			Expect(err).NotTo(BeNil())
+		})
 	})
 
 	t.Describe("LoadContainer", func() {

--- a/internal/lib/sandbox/history_test.go
+++ b/internal/lib/sandbox/history_test.go
@@ -20,7 +20,7 @@ var _ = t.Describe("History", func() {
 		otherTestSandbox, err := sandbox.New("sandboxID", "", "", "", "",
 			make(map[string]string), make(map[string]string), "", "",
 			&types.PodSandboxMetadata{}, "", "", false, "", "", "",
-			[]*hostport.PortMapping{}, false, time.Now(), "")
+			[]*hostport.PortMapping{}, false, time.Now(), "", nil, nil)
 		Expect(err).To(BeNil())
 		Expect(testSandbox).NotTo(BeNil())
 		sut = &sandbox.History{testSandbox, otherTestSandbox}

--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -64,6 +64,8 @@ type Sandbox struct {
 	hostNetwork        bool
 	usernsMode         string
 	containerEnvPath   string
+	podLinuxOverhead   *types.LinuxContainerResources
+	podLinuxResources  *types.LinuxContainerResources
 }
 
 // DefaultShmSize is the default shm size
@@ -75,7 +77,7 @@ var ErrIDEmpty = errors.New("PodSandboxId should not be empty")
 // New creates and populates a new pod sandbox
 // New sandboxes have no containers, no infra container, and no network namespaces associated with them
 // An infra container must be attached before the sandbox is added to the state
-func New(id, namespace, name, kubeName, logDir string, labels, annotations map[string]string, processLabel, mountLabel string, metadata *types.PodSandboxMetadata, shmPath, cgroupParent string, privileged bool, runtimeHandler, resolvPath, hostname string, portMappings []*hostport.PortMapping, hostNetwork bool, createdAt time.Time, usernsMode string) (*Sandbox, error) {
+func New(id, namespace, name, kubeName, logDir string, labels, annotations map[string]string, processLabel, mountLabel string, metadata *types.PodSandboxMetadata, shmPath, cgroupParent string, privileged bool, runtimeHandler, resolvPath, hostname string, portMappings []*hostport.PortMapping, hostNetwork bool, createdAt time.Time, usernsMode string, overhead, resources *types.LinuxContainerResources) (*Sandbox, error) {
 	sb := new(Sandbox)
 
 	sb.criSandbox = &types.PodSandbox{
@@ -101,6 +103,8 @@ func New(id, namespace, name, kubeName, logDir string, labels, annotations map[s
 	sb.portMappings = portMappings
 	sb.hostNetwork = hostNetwork
 	sb.usernsMode = usernsMode
+	sb.podLinuxOverhead = overhead
+	sb.podLinuxResources = resources
 
 	return sb, nil
 }
@@ -284,6 +288,16 @@ func (s *Sandbox) Hostname() string {
 // PortMappings returns a list of port mappings between the host and the sandbox
 func (s *Sandbox) PortMappings() []*hostport.PortMapping {
 	return s.portMappings
+}
+
+// PodLinuxOverhead returns the overheads associated with this sandbox
+func (s *Sandbox) PodLinuxOverhead() *types.LinuxContainerResources {
+	return s.podLinuxOverhead
+}
+
+// PodLinuxResources returns the sum of container resources for this sandbox
+func (s *Sandbox) PodLinuxResources() *types.LinuxContainerResources {
+	return s.podLinuxResources
 }
 
 // AddContainer adds a container to the sandbox

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -44,7 +44,7 @@ var _ = t.Describe("Sandbox", func() {
 			sandbox, err := sandbox.New(id, namespace, name, kubeName, logDir,
 				labels, annotations, processLabel, mountLabel, &metadata,
 				shmPath, cgroupParent, privileged, runtimeHandler,
-				resolvPath, hostname, portMappings, hostNetwork, createdAt, "")
+				resolvPath, hostname, portMappings, hostNetwork, createdAt, "", nil, nil)
 
 			// Then
 			Expect(err).To(BeNil())

--- a/internal/lib/sandbox/suite_test.go
+++ b/internal/lib/sandbox/suite_test.go
@@ -41,7 +41,7 @@ func beforeEach() {
 	testSandbox, err = sandbox.New("sandboxID", "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
 		&types.PodSandboxMetadata{}, "", "", false, "", "", "",
-		[]*hostport.PortMapping{}, false, time.Now(), "")
+		[]*hostport.PortMapping{}, false, time.Now(), "", nil, nil)
 	Expect(err).To(BeNil())
 	Expect(testSandbox).NotTo(BeNil())
 }

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -86,6 +86,8 @@ var _ = BeforeSuite(func() {
 			"io.kubernetes.cri-o.StdinOnce": "{}",
 			"io.kubernetes.cri-o.Volumes": "[{}]",
 			"io.kubernetes.cri-o.HostNetwork": "{}",
+			"io.kubernetes.cri-o.PodLinuxOverhead": "{}",
+			"io.kubernetes.cri-o.PodLinuxResources": "{}",
 			"io.kubernetes.cri-o.CNIResult": "{}"
 		},
 		"linux": {
@@ -153,7 +155,7 @@ func beforeEach() {
 	mySandbox, err = sandbox.New(sandboxID, "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
 		&types.PodSandboxMetadata{}, "", "", false, "", "", "",
-		[]*hostport.PortMapping{}, false, time.Now(), "")
+		[]*hostport.PortMapping{}, false, time.Now(), "", nil, nil)
 	Expect(err).To(BeNil())
 
 	myContainer, err = oci.NewContainer(containerID, "", "", "",

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -53,6 +53,12 @@ const (
 
 	// SeccompNotifierActionStop indicates that a container should be stopped if used via the SeccompNotifierActionAnnotation key.
 	SeccompNotifierActionStop = "stop"
+
+	// PodLinuxOverhead indicates the overheads associated with the pod
+	PodLinuxOverhead = "io.kubernetes.cri-o.PodLinuxOverhead"
+
+	// PodLinuxResources indicates the sum of container resources for this pod
+	PodLinuxResources = "io.kubernetes.cri-o.PodLinuxResources"
 )
 
 var AllAllowedAnnotations = []string{
@@ -71,4 +77,6 @@ var AllAllowedAnnotations = []string{
 	CPUFreqGovernorAnnotation,
 	SeccompNotifierActionAnnotation,
 	UmaskAnnotation,
+	PodLinuxOverhead,
+	PodLinuxResources,
 }

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -529,20 +529,16 @@ func (p *criPodSandbox) GetPodLinuxOverhead() *api.LinuxResources {
 	if p.Sandbox == nil {
 		return nil
 	}
-	// TODO(klihub): AFAICT, CRI PodSandboxConfig is not stored, so we can only
-	// get our hands on it during RunPodSandbox() request processing...
-	// return api.FromCRILinuxResources(p.Sandbox.GetConfig().GetLinux().GetOverhead())
-	return nil
+
+	return api.FromCRILinuxResources(p.Sandbox.PodLinuxOverhead())
 }
 
 func (p *criPodSandbox) GetPodLinuxResources() *api.LinuxResources {
 	if p.Sandbox == nil {
 		return nil
 	}
-	// TODO(klihub): AFAICT, CRI PodSandboxConfig is not stored, so we can only
-	// get our hands on it during RunPodSandbox() request processing...
-	// return api.FromCRILinuxResources(p.Sandbox.GetConfig().GetLinux().GetResources())
-	return nil
+
+	return api.FromCRILinuxResources(p.Sandbox.PodLinuxResources())
 }
 
 func (p *criPodSandbox) GetLinuxResources() *api.LinuxResources {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -674,7 +674,21 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		}
 	}
 
-	sb, err := libsandbox.New(sbox.ID(), namespace, sbox.Name(), kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, runtimeHandler, sbox.ResolvPath(), hostname, portMappings, hostNetwork, created, usernsMode)
+	overhead := sbox.Config().GetLinux().GetOverhead()
+	overheadJSON, err := json.Marshal(overhead)
+	if err != nil {
+		return nil, err
+	}
+	g.AddAnnotation(ann.PodLinuxOverhead, string(overheadJSON))
+
+	resources := sbox.Config().GetLinux().GetResources()
+	resourcesJSON, err := json.Marshal(resources)
+	if err != nil {
+		return nil, err
+	}
+	g.AddAnnotation(ann.PodLinuxResources, string(resourcesJSON))
+
+	sb, err := libsandbox.New(sbox.ID(), namespace, sbox.Name(), kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, runtimeHandler, sbox.ResolvPath(), hostname, portMappings, hostNetwork, created, usernsMode, overhead, resources)
 	if err != nil {
 		return nil, err
 	}

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -156,7 +156,7 @@ var beforeEach = func() {
 	testSandbox, err = sandbox.New(sandboxID, "", "", "", ".",
 		make(map[string]string), make(map[string]string), "", "",
 		&types.PodSandboxMetadata{}, "", "", false, "", "", "",
-		[]*hostport.PortMapping{}, false, time.Now(), "")
+		[]*hostport.PortMapping{}, false, time.Now(), "", nil, nil)
 	Expect(err).To(BeNil())
 
 	testContainer, err = oci.NewContainer(containerID, "", "", "",


### PR DESCRIPTION
The CRI PodLinuxOverhead and PodLinuxResources fields were not saved which meant that NRI plugins would need to cache the data in order not to miss them if cri-o is restarted. These two fields are already passed to NRI plugins by containerd. Solve this issue by caching those two fields and restoring them if cri-o is restarted.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This change allows cri-o to store PodLinuxOverhead and PodLinuxResource CRI resource fields and then later send them to NRI plugins. The issue is seen when cri-o is restarted in which case it has lost the value of these two fields and cannot forward them to NRI plugins. With this change, NRI plugins do not need to cache the fields as it is able to receive them when the plugin is started. The containerd already passes these fields to NRI plugins.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Store PodLinuxOverhead and PodLinuxResources CRI fields received in RunPodSandbox() and then later pass them to NRI plugins so that the plugins do not need to cache the values.
```
