### PR TITLE
OCPBUGS-13542: high perf hooks: disable CPU quota with libcontainer as a pre start hook

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/cri-o/cri-o/internal/config/cgmgr"
 	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
@@ -17,7 +19,9 @@ import (
 	crioannotations "github.com/cri-o/cri-o/pkg/annotations"
 	"github.com/cri-o/cri-o/utils/cmdrunner"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runtime-spec/specs-go"
+	libCtrMgr "github.com/opencontainers/runc/libcontainer/cgroups/manager"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
@@ -53,6 +57,7 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 	if !shouldRunHooks(ctx, c.ID(), &cSpec, s) {
 		return nil
 	}
+
 	// disable the CPU load balancing for the container CPUs
 	if shouldCPULoadBalancingBeDisabled(s.Annotations()) {
 		if err := disableCPULoadBalancing(c); err != nil {
@@ -65,6 +70,14 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 		log.Infof(ctx, "Disable irq smp balancing for container %q", c.ID())
 		if err := setIRQLoadBalancing(ctx, c, false, IrqSmpAffinityProcFile, h.irqBalanceConfigFile); err != nil {
 			return fmt.Errorf("set IRQ load balancing: %w", err)
+		}
+	}
+
+	// disable the CFS quota for the container CPUs
+	if shouldCPUQuotaBeDisabled(s.Annotations()) {
+		log.Infof(ctx, "Disable cpu cfs quota for container %q", c.ID())
+		if err := setCPUQuota(s.CgroupParent(), c); err != nil {
+			return fmt.Errorf("set CPU CFS quota: %w", err)
 		}
 	}
 
@@ -142,6 +155,15 @@ func shouldCPULoadBalancingBeDisabled(annotations fields.Set) bool {
 
 	return annotations[crioannotations.CPULoadBalancingAnnotation] == annotationTrue ||
 		annotations[crioannotations.CPULoadBalancingAnnotation] == annotationDisable
+}
+
+func shouldCPUQuotaBeDisabled(annotations fields.Set) bool {
+	if annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue {
+		log.Warnf(context.TODO(), annotationValueDeprecationWarning(crioannotations.CPUQuotaAnnotation))
+	}
+
+	return annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue ||
+		annotations[crioannotations.CPUQuotaAnnotation] == annotationDisable
 }
 
 func shouldIRQLoadBalancingBeDisabled(annotations fields.Set) bool {
@@ -250,6 +272,54 @@ func setIRQLoadBalancing(ctx context.Context, c *oci.Container, enable bool, irq
 		log.Warnf(ctx, "Irqbalance service restart failed: %v", err)
 	}
 	return nil
+}
+
+func setCPUQuota(parentDir string, c *oci.Container) error {
+	var (
+		cgroupManager cgmgr.CgroupManager
+		err           error
+	)
+
+	if strings.HasSuffix(parentDir, ".slice") {
+		if cgroupManager, err = cgmgr.SetCgroupManager("systemd"); err != nil {
+			// Programming error, this is only possible if the manager string is invalid.
+			panic(err)
+		}
+	} else if cgroupManager, err = cgmgr.SetCgroupManager("cgroupfs"); err != nil {
+		// Programming error, this is only possible if the manager string is invalid.
+		panic(err)
+	}
+	cgroupPath, err := cgroupManager.ContainerCgroupAbsolutePath(parentDir, c.ID())
+	if err != nil {
+		return err
+	}
+	containerCgroup := filepath.Base(cgroupPath)
+	containerCgroupParent := filepath.Dir(cgroupPath)
+	podCgroup := filepath.Base(containerCgroupParent)
+	podCgroupParent := filepath.Dir(containerCgroupParent)
+
+	if err := disableCPUQuotaForCgroup(podCgroup, podCgroupParent, cgroupManager.IsSystemd()); err != nil {
+		return err
+	}
+	return disableCPUQuotaForCgroup(containerCgroup, containerCgroupParent, cgroupManager.IsSystemd())
+}
+
+func disableCPUQuotaForCgroup(cgroup, parent string, systemd bool) error {
+	cg := &configs.Cgroup{
+		Name:   cgroup,
+		Parent: parent,
+		Resources: &configs.Resources{
+			SkipDevices: true,
+			CpuQuota:    -1,
+		},
+		Systemd: systemd,
+	}
+	mgr, err := libCtrMgr.New(cg)
+	if err != nil {
+		return err
+	}
+
+	return mgr.Set(cg.Resources)
 }
 
 // setCPUPMQOSResumeLatency sets the pm_qos_resume_latency_us for a cpu and stores the original

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
-	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
 	"github.com/cri-o/cri-o/internal/storage"
 	crioann "github.com/cri-o/cri-o/pkg/annotations"
 	securejoin "github.com/cyphar/filepath-securejoin"
@@ -407,12 +406,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	if linux != nil {
 		resources := linux.Resources
 		if resources != nil {
-			specgen.SetLinuxResourcesCPUShares(uint64(resources.CpuShares))
 			specgen.SetLinuxResourcesCPUPeriod(uint64(resources.CpuPeriod))
 			specgen.SetLinuxResourcesCPUQuota(resources.CpuQuota)
-			if runtimehandlerhooks.ShouldCPUQuotaBeDisabled(ctx, containerID, specgen.Config, sb, sb.Annotations()) {
-				specgen.SetLinuxResourcesCPUQuota(-1)
-			}
+			specgen.SetLinuxResourcesCPUShares(uint64(resources.CpuShares))
 
 			memoryLimit := resources.MemoryLimitInBytes
 			if memoryLimit != 0 {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -621,6 +621,22 @@ function set_swap_fields_given_cgroup_version() {
     fi
 }
 
+function set_container_pod_cgroup_root() {
+    controller="$1"
+    ctr_id="$2"
+    CGROUP_ROOT="/sys/fs/cgroup"
+    if is_cgroup_v2; then
+        controller=""
+    fi
+
+    export POD_CGROUP="$CGROUP_ROOT"/"$controller"/pod_123.slice/pod_123-456.slice
+    export CTR_CGROUP="$POD_CGROUP"/crio-"$ctr_id".scope
+    if "$CONTAINER_CGROUP_MANAGER" != "systemd"; then
+        export POD_CGROUP="$CGROUP_ROOT"/"$controller"/pod_123-456
+        export CTR_CGROUP="$POD_CGROUP"/crio-"$ctr_id"
+    fi
+}
+
 function check_conmon_cpuset() {
     local ctr_id="$1"
     local cpuset="$2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
    if cpu quota is disabled as part of container creation, then the pod
    cgroup does not have it disabled, which causes the cgroup to continue to
    have cpu quota. Instead, partially revert efaea10606ce6c7012 and use
    libcontainer to fix the issue it was originally trying to (an issue
    where newer systemd reverts the disabling of cpu quota because it was
    only applied on the cgroupfs)
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where the `cpu-quota.crio.io` annotation was not propagated to the pod cgroup, meaning cpu quota was not disabled for the container
```
