### PR TITLE
Support image policy verification error

### DIFF
--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containers/image/v5/signature"
 	imageTypes "github.com/containers/image/v5/types"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/storage"
@@ -98,6 +99,12 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 		if errors.Is(pullOp.err, syscall.ECONNREFUSED) {
 			return nil, crierrors.ErrRegistryUnavailable
 		}
+
+		var policyErr signature.PolicyRequirementError
+		if errors.As(pullOp.err, &policyErr) {
+			return nil, crierrors.ErrSignatureValidationFailed
+		}
+
 		return nil, pullOp.err
 	}
 


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now check for c/image policy errors and convert them to the CRI equivalent if necessary.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support image policy verification error through the CRI.
```
