### PR TITLE
[1.25] cgmgr: create cgroups for systemd cgroup driver for dropped infra pods

### DIFF
--- a/internal/config/cgmgr/cgmgr.go
+++ b/internal/config/cgmgr/cgmgr.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/cri-o/cri-o/internal/config/node"
 	libctr "github.com/opencontainers/runc/libcontainer/cgroups"
+	libctrCgMgr "github.com/opencontainers/runc/libcontainer/cgroups/manager"
+	cgcfgs "github.com/opencontainers/runc/libcontainer/configs"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -72,6 +74,9 @@ type CgroupManager interface {
 	// CreateSandboxCgroup takes the sandbox parent, and sandbox ID.
 	// It creates a new cgroup for that sandbox, which is useful when spoofing an infra container.
 	CreateSandboxCgroup(sbParent, containerID string) error
+	// RemoveSandboxCgroup takes the sandbox parent, and sandbox ID.
+	// It removes the cgroup for that sandbox, which is useful when spoofing an infra container.
+	RemoveSandboxCgroup(sbParent, containerID string) error
 }
 
 // New creates a new CgroupManager with defaults
@@ -158,4 +163,42 @@ func MoveProcessToContainerCgroup(containerPid, commandPid int) error {
 		}
 	}
 	return nil
+}
+
+// createSandboxCgroup takes the path of the sandbox parent and the desired containerCgroup
+// It creates a cgroup through cgroupfs (as opposed to systemd) at the location cgroupRoot/sbParent/containerCgroup.
+func createSandboxCgroup(sbParent, containerCgroup string) error {
+	cg := &cgcfgs.Cgroup{
+		Name:   containerCgroup,
+		Parent: sbParent,
+		Resources: &cgcfgs.Resources{
+			SkipDevices: true,
+		},
+	}
+	mgr, err := libctrCgMgr.New(cg)
+	if err != nil {
+		return err
+	}
+
+	return mgr.Apply(-1)
+}
+
+func removeSandboxCgroup(sbParent, containerCgroup string) error {
+	cg := &cgcfgs.Cgroup{
+		Name:   containerCgroup,
+		Parent: sbParent,
+		Resources: &cgcfgs.Resources{
+			SkipDevices: true,
+		},
+	}
+	mgr, err := libctrCgMgr.New(cg)
+	if err != nil {
+		return err
+	}
+
+	return mgr.Destroy()
+}
+
+func containerCgroupPath(id string) string {
+	return crioPrefix + "-" + id
 }

--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -155,18 +155,18 @@ func setWorkloadSettings(cgPath string, resources *rspec.LinuxResources) (err er
 	return mgr.Set(cg.Resources)
 }
 
-// createSandboxCgroup takes the sandbox parent, and sandbox ID.
-// It creates a new cgroup for that sandbox, which is useful when spoofing an infra container.
-func createSandboxCgroup(sbParent, containerID string, mgr CgroupManager) error {
-	cgroupAbsolutePath, err := mgr.ContainerCgroupAbsolutePath(sbParent, containerID)
-	if err != nil {
-		return err
-	}
-	_, err = cgroups.New(cgroupAbsolutePath, &cgcfgs.Resources{})
-	return err
-}
-
 // CreateSandboxCgroup calls the helper function createSandboxCgroup for this manager.
 func (m *CgroupfsManager) CreateSandboxCgroup(sbParent, containerID string) error {
-	return createSandboxCgroup(sbParent, containerID, m)
+	// prepend "/" to sbParent so the fs driver interprets it as an absolute path
+	// and the cgroup isn't created as a relative path to the cgroups of the CRI-O process.
+	// https://github.com/opencontainers/runc/blob/fd5debf3aa/libcontainer/cgroups/fs/paths.go#L156
+	return createSandboxCgroup(filepath.Join("/", sbParent), containerCgroupPath(containerID))
+}
+
+// RemoveSandboxCgroup calls the helper function removeSandboxCgroup for this manager.
+func (m *CgroupfsManager) RemoveSandboxCgroup(sbParent, containerID string) error {
+	// prepend "/" to sbParent so the fs driver interprets it as an absolute path
+	// and the cgroup isn't created as a relative path to the cgroups of the CRI-O process.
+	// https://github.com/opencontainers/runc/blob/fd5debf3aa/libcontainer/cgroups/fs/paths.go#L156
+	return removeSandboxCgroup(filepath.Join("/", sbParent), containerCgroupPath(containerID))
 }

--- a/internal/config/cgmgr/systemd.go
+++ b/internal/config/cgmgr/systemd.go
@@ -88,7 +88,7 @@ func (m *SystemdManager) ContainerCgroupAbsolutePath(sbParent, containerID strin
 		return "", fmt.Errorf("expanding systemd slice to get container %s stats: %w", containerID, err)
 	}
 
-	return filepath.Join(cgroup, crioPrefix+"-"+containerID+".scope"), nil
+	return filepath.Join(cgroup, containerCgroupPath(containerID)+".scope"), nil
 }
 
 // MoveConmonToCgroup takes the container ID, cgroup parent, conmon's cgroup (from the config) and conmon's PID
@@ -197,8 +197,37 @@ func convertCgroupFsNameToSystemd(cgroupfsName string) string {
 }
 
 // CreateSandboxCgroup calls the helper function createSandboxCgroup for this manager.
+// Note: createSandboxCgroup will create a cgroupfs cgroup for the infra container underneath the pod slice.
+// It will not use dbus to create this cgroup, but instead call libcontainer's cgroupfs manager directly.
+// This is because a scope created here will not have a process within it (as it's usually for a dropped infra container),
+// and a slice cannot have the required `crio` prefix (while still being within the pod slice).
+// Ultimately, this cgroup is required for cAdvisor to be able to register the pod and collect network metrics for it.
+// This work will not be relevant when CRI-O is responsible for gathering pod metrics (KEP-2371), but is required until that's done.
 func (m *SystemdManager) CreateSandboxCgroup(sbParent, containerID string) error {
-	// If we are running systemd as cgroup driver then we would rely on
-	// systemd to create cgroups for us, there's nothing to do here in this case
-	return nil
+	// sbParent should always be specified by kubelet, but sometimes not by critest/crictl.
+	// Skip creation in this case.
+	if sbParent == "" {
+		logrus.Infof("Not creating sandbox cgroup: sbParent is empty")
+		return nil
+	}
+	expandedParent, err := systemd.ExpandSlice(sbParent)
+	if err != nil {
+		return err
+	}
+	return createSandboxCgroup(expandedParent, containerCgroupPath(containerID))
+}
+
+// RemoveSandboxCgroup calls the helper function removeSandboxCgroup for this manager.
+func (m *SystemdManager) RemoveSandboxCgroup(sbParent, containerID string) error {
+	// sbParent should always be specified by kubelet, but sometimes not by critest/crictl.
+	// Skip creation in this case.
+	if sbParent == "" {
+		logrus.Infof("Not creating sandbox cgroup: sbParent is empty")
+		return nil
+	}
+	expandedParent, err := systemd.ExpandSlice(sbParent)
+	if err != nil {
+		return err
+	}
+	return removeSandboxCgroup(expandedParent, containerCgroupPath(containerID))
 }

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -49,6 +49,11 @@ func (s *Server) removePodSandbox(ctx context.Context, sb *sandbox.Sandbox) erro
 	if err := s.removeContainerInPod(ctx, sb, sb.InfraContainer()); err != nil {
 		return err
 	}
+	if sb.InfraContainer().Spoofed() {
+		if err := s.config.CgroupManager().RemoveSandboxCgroup(sb.CgroupParent(), sb.ID()); err != nil {
+			return err
+		}
+	}
 
 	// Cleanup network resources for this pod
 	if err := s.networkStop(ctx, sb); err != nil {

--- a/test/cgroups.bats
+++ b/test/cgroups.bats
@@ -42,6 +42,28 @@ function teardown() {
 	[[ "$output" == *"customcrioconmon.slice"* ]]
 }
 
+@test "conmon custom cgroup with no infra container" {
+	parent="Burstablecriotest123"
+	if [ "$CONTAINER_CGROUP_MANAGER" == "systemd" ]; then
+		parent="$parent".slice
+	fi
+	cgroup_base="/sys/fs/cgroup"
+	if ! is_cgroup_v2; then
+		cgroup_base="$cgroup_base"/memory
+	fi
+
+	CONTAINER_DROP_INFRA_CTR=true start_crio
+
+	jq --arg cg "$parent" '	  .linux.cgroup_parent = $cg' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_config_slice.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_config_slice.json)
+	ls "$cgroup_base"/"$parent"/crio-"$pod_id"*
+
+	crictl rmp -fa
+	! ls "$cgroup_base"/"$parent"/crio-"$pod_id"*
+}
+
 @test "ctr with swap should be configured" {
 	if ! grep -v Filename < /proc/swaps; then
 		skip "swap not enabled"


### PR DESCRIPTION
     The history here is a bit convoluted. Originally, runc created the cgroup for the infra container.
    cAdvisor was built to assume the cgroup for the infra container would be created, and it uses
    this to find the network metrics for the pod. When we dropped the infra container, cri-o needed to make this
    cgroup so cAdvisor could still find the network metrics.
    
    However, systemd didn't like the way we did it, and would remove the cgroup mid pod creation, which was fixed in
    https://github.com/cri-o/cri-o/pull/6196. This actually caused the cgroup to not be created at all, which then caused
    the networking metrics to not be gathered at all.
    
    Thus, we do need to create a cgroup underneath the systemd cgroup. Attempt to use a slice for this, as systemd won't require a
    process be underneath it.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
reverts https://github.com/cri-o/cri-o/pull/6196 
fixes https://github.com/cri-o/cri-o/issues/6657 
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
partial cherry-pick of https://github.com/cri-o/cri-o/pull/6856, ignoring the last commit because it's not relevant for 1.25
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where network metrics collection is broken with systemd cgroup driver and dropped infra containers.
```
