### PR TITLE
[1.26] OCPBUGS-13853: high perf hooks: disable CPU quota with libcontainer as a pre start hook

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/cri-o/cri-o/internal/config/cgmgr"
 	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
@@ -17,8 +19,10 @@ import (
 	crioannotations "github.com/cri-o/cri-o/pkg/annotations"
 	"github.com/cri-o/cri-o/utils/cmdrunner"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+	libCtrMgr "github.com/opencontainers/runc/libcontainer/cgroups/manager"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
@@ -56,6 +60,7 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 	if !shouldRunHooks(ctx, c.ID(), &cSpec, s) {
 		return nil
 	}
+
 	// disable the CPU load balancing for the container CPUs
 	if shouldCPULoadBalancingBeDisabled(s.Annotations()) {
 		if err := disableCPULoadBalancing(c); err != nil {
@@ -68,6 +73,14 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 		log.Infof(ctx, "Disable irq smp balancing for container %q", c.ID())
 		if err := setIRQLoadBalancing(c, false, IrqSmpAffinityProcFile, h.irqBalanceConfigFile); err != nil {
 			return fmt.Errorf("set IRQ load balancing: %w", err)
+		}
+	}
+
+	// disable the CFS quota for the container CPUs
+	if shouldCPUQuotaBeDisabled(s.Annotations()) {
+		log.Infof(ctx, "Disable cpu cfs quota for container %q", c.ID())
+		if err := setCPUQuota(s.CgroupParent(), c); err != nil {
+			return fmt.Errorf("set CPU CFS quota: %w", err)
 		}
 	}
 
@@ -149,6 +162,15 @@ func shouldCPULoadBalancingBeDisabled(annotations fields.Set) bool {
 
 	return annotations[crioannotations.CPULoadBalancingAnnotation] == annotationTrue ||
 		annotations[crioannotations.CPULoadBalancingAnnotation] == annotationDisable
+}
+
+func shouldCPUQuotaBeDisabled(annotations fields.Set) bool {
+	if annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue {
+		log.Warnf(context.TODO(), annotationValueDeprecationWarning(crioannotations.CPUQuotaAnnotation))
+	}
+
+	return annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue ||
+		annotations[crioannotations.CPUQuotaAnnotation] == annotationDisable
 }
 
 func shouldIRQLoadBalancingBeDisabled(annotations fields.Set) bool {
@@ -257,6 +279,54 @@ func setIRQLoadBalancing(c *oci.Container, enable bool, irqSmpAffinityFile, irqB
 		logrus.Warnf("Irqbalance service restart failed: %v", err)
 	}
 	return nil
+}
+
+func setCPUQuota(parentDir string, c *oci.Container) error {
+	var (
+		cgroupManager cgmgr.CgroupManager
+		err           error
+	)
+
+	if strings.HasSuffix(parentDir, ".slice") {
+		if cgroupManager, err = cgmgr.SetCgroupManager("systemd"); err != nil {
+			// Programming error, this is only possible if the manager string is invalid.
+			panic(err)
+		}
+	} else if cgroupManager, err = cgmgr.SetCgroupManager("cgroupfs"); err != nil {
+		// Programming error, this is only possible if the manager string is invalid.
+		panic(err)
+	}
+	cgroupPath, err := cgroupManager.ContainerCgroupAbsolutePath(parentDir, c.ID())
+	if err != nil {
+		return err
+	}
+	containerCgroup := filepath.Base(cgroupPath)
+	containerCgroupParent := filepath.Dir(cgroupPath)
+	podCgroup := filepath.Base(containerCgroupParent)
+	podCgroupParent := filepath.Dir(containerCgroupParent)
+
+	if err := disableCPUQuotaForCgroup(podCgroup, podCgroupParent, cgroupManager.IsSystemd()); err != nil {
+		return err
+	}
+	return disableCPUQuotaForCgroup(containerCgroup, containerCgroupParent, cgroupManager.IsSystemd())
+}
+
+func disableCPUQuotaForCgroup(cgroup, parent string, systemd bool) error {
+	cg := &configs.Cgroup{
+		Name:   cgroup,
+		Parent: parent,
+		Resources: &configs.Resources{
+			SkipDevices: true,
+			CpuQuota:    -1,
+		},
+		Systemd: systemd,
+	}
+	mgr, err := libCtrMgr.New(cg)
+	if err != nil {
+		return err
+	}
+
+	return mgr.Set(cg.Resources)
 }
 
 // setCPUPMQOSResumeLatency sets the pm_qos_resume_latency_us for a cpu and stores the original

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
-	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
 	"github.com/cri-o/cri-o/internal/storage"
 	crioann "github.com/cri-o/cri-o/pkg/annotations"
 	securejoin "github.com/cyphar/filepath-securejoin"
@@ -405,12 +404,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	if linux != nil {
 		resources := linux.Resources
 		if resources != nil {
-			specgen.SetLinuxResourcesCPUShares(uint64(resources.CpuShares))
 			specgen.SetLinuxResourcesCPUPeriod(uint64(resources.CpuPeriod))
 			specgen.SetLinuxResourcesCPUQuota(resources.CpuQuota)
-			if runtimehandlerhooks.ShouldCPUQuotaBeDisabled(ctx, containerID, specgen.Config, sb, sb.Annotations()) {
-				specgen.SetLinuxResourcesCPUQuota(-1)
-			}
+			specgen.SetLinuxResourcesCPUShares(uint64(resources.CpuShares))
 
 			memoryLimit := resources.MemoryLimitInBytes
 			if memoryLimit != 0 {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -630,6 +630,22 @@ function set_swap_fields_given_cgroup_version() {
     fi
 }
 
+function set_container_pod_cgroup_root() {
+    controller="$1"
+    ctr_id="$2"
+    CGROUP_ROOT="/sys/fs/cgroup"
+    if is_cgroup_v2; then
+        controller=""
+    fi
+
+    export POD_CGROUP="$CGROUP_ROOT"/"$controller"/pod_123.slice/pod_123-456.slice
+    export CTR_CGROUP="$POD_CGROUP"/crio-"$ctr_id".scope
+    if "$CONTAINER_CGROUP_MANAGER" != "systemd"; then
+        export POD_CGROUP="$CGROUP_ROOT"/"$controller"/pod_123-456
+        export CTR_CGROUP="$POD_CGROUP"/crio-"$ctr_id"
+    fi
+}
+
 function check_conmon_cpuset() {
     local ctr_id="$1"
     local cpuset="$2"


### PR DESCRIPTION
cherry-pick of #6917
/kind bug

```release-note
Fix a bug where the `cpu-quota.crio.io` annotation was not propagated to the pod cgroup, meaning cpu quota was not disabled for the container
```