### PR TITLE
[1.24] cgmgr: create cgroups for systemd cgroup driver for dropped infra pods

### DIFF
--- a/internal/config/cgmgr/cgmgr.go
+++ b/internal/config/cgmgr/cgmgr.go
@@ -11,9 +11,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v3/pkg/rootless"
 	"github.com/cri-o/cri-o/internal/config/node"
 	libctr "github.com/opencontainers/runc/libcontainer/cgroups"
-	libctrCgMgr "github.com/opencontainers/runc/libcontainer/cgroups/manager"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 	cgcfgs "github.com/opencontainers/runc/libcontainer/configs"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -170,22 +172,22 @@ func MoveProcessToContainerCgroup(containerPid, commandPid int) error {
 // createSandboxCgroup takes the path of the sandbox parent and the desired containerCgroup
 // It creates a cgroup through cgroupfs (as opposed to systemd) at the location cgroupRoot/sbParent/containerCgroup.
 func createSandboxCgroup(sbParent, containerCgroup string) error {
-	cg := &cgcfgs.Cgroup{
-		Name:   containerCgroup,
-		Parent: sbParent,
-		Resources: &cgcfgs.Resources{
-			SkipDevices: true,
-		},
-	}
-	mgr, err := libctrCgMgr.New(cg)
+	mgr, err := libctrCgroupManager(sbParent, containerCgroup)
 	if err != nil {
 		return err
 	}
-
 	return mgr.Apply(-1)
 }
 
 func removeSandboxCgroup(sbParent, containerCgroup string) error {
+	mgr, err := libctrCgroupManager(sbParent, containerCgroup)
+	if err != nil {
+		return err
+	}
+	return mgr.Destroy()
+}
+
+func libctrCgroupManager(sbParent, containerCgroup string) (libctr.Manager, error) {
 	cg := &cgcfgs.Cgroup{
 		Name:   containerCgroup,
 		Parent: sbParent,
@@ -193,12 +195,10 @@ func removeSandboxCgroup(sbParent, containerCgroup string) error {
 			SkipDevices: true,
 		},
 	}
-	mgr, err := libctrCgMgr.New(cg)
-	if err != nil {
-		return err
+	if node.CgroupIsV2() {
+		return fs2.NewManager(cg, "", rootless.IsRootless())
 	}
-
-	return mgr.Destroy()
+	return fs.NewManager(cg, nil, rootless.IsRootless()), nil
 }
 
 func containerCgroupPath(id string) string {

--- a/internal/config/cgmgr/cgmgr.go
+++ b/internal/config/cgmgr/cgmgr.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/cri-o/cri-o/internal/config/node"
 	libctr "github.com/opencontainers/runc/libcontainer/cgroups"
+	libctrCgMgr "github.com/opencontainers/runc/libcontainer/cgroups/manager"
+	cgcfgs "github.com/opencontainers/runc/libcontainer/configs"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -74,6 +76,9 @@ type CgroupManager interface {
 	// CreateSandboxCgroup takes the sandbox parent, and sandbox ID.
 	// It creates a new cgroup for that sandbox, which is useful when spoofing an infra container.
 	CreateSandboxCgroup(sbParent, containerID string) error
+	// RemoveSandboxCgroup takes the sandbox parent, and sandbox ID.
+	// It removes the cgroup for that sandbox, which is useful when spoofing an infra container.
+	RemoveSandboxCgroup(sbParent, containerID string) error
 }
 
 // New creates a new CgroupManager with defaults
@@ -160,4 +165,42 @@ func MoveProcessToContainerCgroup(containerPid, commandPid int) error {
 		}
 	}
 	return nil
+}
+
+// createSandboxCgroup takes the path of the sandbox parent and the desired containerCgroup
+// It creates a cgroup through cgroupfs (as opposed to systemd) at the location cgroupRoot/sbParent/containerCgroup.
+func createSandboxCgroup(sbParent, containerCgroup string) error {
+	cg := &cgcfgs.Cgroup{
+		Name:   containerCgroup,
+		Parent: sbParent,
+		Resources: &cgcfgs.Resources{
+			SkipDevices: true,
+		},
+	}
+	mgr, err := libctrCgMgr.New(cg)
+	if err != nil {
+		return err
+	}
+
+	return mgr.Apply(-1)
+}
+
+func removeSandboxCgroup(sbParent, containerCgroup string) error {
+	cg := &cgcfgs.Cgroup{
+		Name:   containerCgroup,
+		Parent: sbParent,
+		Resources: &cgcfgs.Resources{
+			SkipDevices: true,
+		},
+	}
+	mgr, err := libctrCgMgr.New(cg)
+	if err != nil {
+		return err
+	}
+
+	return mgr.Destroy()
+}
+
+func containerCgroupPath(id string) string {
+	return crioPrefix + "-" + id
 }

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -52,6 +52,11 @@ func (s *Server) removePodSandbox(ctx context.Context, sb *sandbox.Sandbox) erro
 	if err := s.removeContainerInPod(ctx, sb, sb.InfraContainer()); err != nil {
 		return err
 	}
+	if sb.InfraContainer().Spoofed() {
+		if err := s.config.CgroupManager().RemoveSandboxCgroup(sb.CgroupParent(), sb.ID()); err != nil {
+			return err
+		}
+	}
 
 	// Cleanup network resources for this pod
 	if err := s.networkStop(ctx, sb); err != nil {


### PR DESCRIPTION
     The history here is a bit convoluted. Originally, runc created the cgroup for the infra container.
    cAdvisor was built to assume the cgroup for the infra container would be created, and it uses
    this to find the network metrics for the pod. When we dropped the infra container, cri-o needed to make this
    cgroup so cAdvisor could still find the network metrics.
    
    However, systemd didn't like the way we did it, and would remove the cgroup mid pod creation, which was fixed in
    https://github.com/cri-o/cri-o/pull/6196. This actually caused the cgroup to not be created at all, which then caused
    the networking metrics to not be gathered at all.
    
    Thus, we do need to create a cgroup underneath the systemd cgroup. Attempt to use a slice for this, as systemd won't require a
    process be underneath it.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
reverts https://github.com/cri-o/cri-o/pull/6196 
fixes https://github.com/cri-o/cri-o/issues/6657 
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
partial cherry-pick of https://github.com/cri-o/cri-o/pull/6856, ignoring the last commit because it's not relevant for 1.24
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where network metrics collection is broken with systemd cgroup driver and dropped infra containers.
```
