### PR TITLE
OCPNODE-1286: Add a CI job to run cri-o e2e tests by enabling the evented pleg feature

### DIFF
--- a/contrib/test/ci/build/cri-o.yml
+++ b/contrib/test/ci/build/cri-o.yml
@@ -87,6 +87,14 @@
       runtime_root = "/run/crun"
   when: "use_conmonrs | default(False) | bool"
 
+- name: use evented-pleg
+  copy:
+    dest: /etc/crio/crio.conf.d/99-evented-pleg.conf
+    content: |
+      [crio.runtime]
+      enable_pod_events = true
+  when: "evented_pleg_fg | default(False) | bool"
+
 - name: use kata
   copy:
     dest: /etc/crio/crio.conf.d/50-kata.conf

--- a/contrib/test/ci/e2e-base.yml
+++ b/contrib/test/ci/e2e-base.yml
@@ -34,6 +34,17 @@
     enabled: yes
     daemon_reload: yes
 
+- name: update the evented pleg feature gate for the custom cluster
+  become: yes
+  lineinfile:
+    dest: /usr/local/bin/createcluster.sh
+    line: |
+        # Added by Ansible from e2e.yml
+        export FEATURE_GATES="EventedPLEG=true"
+    regexp: "^export FEATURE_GATES="
+    state: present
+  when: "evented_pleg_fg | default(False) | bool"
+
 - name: update the server address for the custom cluster
   become: yes
   lineinfile:

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -11,6 +11,7 @@ build_crun: False
 build_kata: False
 cgroupv2: False
 use_conmonrs: '{{ USE_CONMONRS | default(False) | bool }}'
+evented_pleg_fg: '{{ EVENTED_PLEG | default(False) | bool }}'
 
 critest_mirror_repo: quay.io/crio
 cri_tools_git_version: "v1.27.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind ci
#### What this PR does / why we need it:
This PR enables a new ci job to run e2e tests with the evented pleg feature enabled both in the kubelet and the cri-o configurations
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Linked PR in the `openshift/release` repository
https://github.com/openshift/release/pull/39629 
#### Does this PR introduce a user-facing change?
No
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`None`
```
