### PR TITLE
Makefile: Remove GOPATH references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,21 +93,11 @@ CROSS_BUILD_TARGETS := \
 	bin/crio.cross.darwin.amd64 \
 	bin/crio.cross.linux.amd64
 
-# If GOPATH not specified, use one in the local directory
-ifeq ($(GOPATH),)
-export GOPATH := $(CURDIR)/_output
-unexport GOBIN
-endif
-GOPKGDIR := $(GOPATH)/src/$(PROJECT)
-GOPKGBASEDIR := $(shell dirname "$(GOPKGDIR)")
 GO_FILES := $(shell find . -type f -name '*.go' -not -name '*_test.go')
 
 # Some of the packages use the golang testing infra in end-to-end tests.
 # These can't be run as unit tests so ginkgo should skip them.
 GINKGO_SKIP_PACKAGES = test/nri
-
-# Update VPATH so make finds .gopathok
-VPATH := $(VPATH):$(GOPATH)
 
 # Set DEBUG=1 to enable debug symbols in binaries
 DEBUG ?= 0
@@ -151,16 +141,8 @@ help:
 # Dummy target for marking pattern rules phony
 .explicit_phony:
 
-.gopathok:
-ifeq ("$(wildcard $(GOPKGDIR))","")
-	mkdir -p "$(GOPKGBASEDIR)"
-	ln -s "$(CURDIR)" "$(GOPKGDIR)"
-endif
-	if [ ! -d "$(GOPATH)" ]; then mkdir -p $(GOPATH); fi
-	touch "$(GOPATH)/.gopathok"
-
 # See also: .github/workflows/verify.yml.
-lint: .gopathok ${GOLANGCI_LINT}
+lint:  ${GOLANGCI_LINT}
 	${GOLANGCI_LINT} version
 	${GOLANGCI_LINT} linters
 	GL_DEBUG=gocritic ${GOLANGCI_LINT} run
@@ -193,22 +175,22 @@ check-nri-bats-tests: test/nri/nri.test
 bin/pinns:
 	$(MAKE) -C pinns
 
-test/copyimg/copyimg: $(GO_FILES) .gopathok
+test/copyimg/copyimg: $(GO_FILES)
 	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/copyimg
 
-test/checkseccomp/checkseccomp: $(GO_FILES) .gopathok
+test/checkseccomp/checkseccomp: $(GO_FILES)
 	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkseccomp
 
-test/checkcriu/checkcriu: $(GO_FILES) .gopathok
+test/checkcriu/checkcriu: $(GO_FILES)
 	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkcriu
 
-test/nri/nri.test: $(wildcard test/nri/*.go) .gopathok
+test/nri/nri.test: $(wildcard test/nri/*.go)
 	$(GO) test --tags "test $(BUILDTAGS)" -c $(PROJECT)/test/nri -o $@
 
-bin/crio: $(GO_FILES) .gopathok
+bin/crio: $(GO_FILES)
 	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/crio
 
-bin/crio-status: $(GO_FILES) .gopathok
+bin/crio-status: $(GO_FILES)
 	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/crio-status
 
 build-static:
@@ -236,9 +218,6 @@ dependencies: ${GO_MOD_OUTDATED}
 		--output-path ${BUILD_PATH}/dependencies
 
 clean:
-ifneq ($(GOPATH),)
-	rm -f "$(GOPATH)/.gopathok"
-endif
 	rm -rf _output
 	rm -f docs/*.5 docs/*.8
 	rm -fr test/testdata/redis-image
@@ -258,7 +237,7 @@ endif
 local-cross:
 	@$(MAKE) --keep-going $(CROSS_BUILD_TARGETS)
 
-bin/crio.cross.%: .gopathok .explicit_phony
+bin/crio.cross.%:  .explicit_phony
 	@echo "==> make $@"; \
 	TARGET="$*"; \
 	GOOS="$${TARGET%%.*}" \
@@ -431,11 +410,11 @@ test-binaries: test/copyimg/copyimg test/checkseccomp/checkseccomp test/checkcri
 MANPAGES_MD := $(wildcard docs/*.md)
 MANPAGES    := $(MANPAGES_MD:%.md=%)
 
-docs/%.5: docs/%.5.md .gopathok ${GO_MD2MAN}
+docs/%.5: docs/%.5.md  ${GO_MD2MAN}
 	(${GO_MD2MAN} -in $< -out $@.tmp && touch $@.tmp && mv $@.tmp $@) || \
 		(${GO_MD2MAN} -in $< -out $@.tmp && touch $@.tmp && mv $@.tmp $@)
 
-docs/%.8: docs/%.8.md .gopathok ${GO_MD2MAN}
+docs/%.8: docs/%.8.md  ${GO_MD2MAN}
 	(${GO_MD2MAN} -in $< -out $@.tmp && touch $@.tmp && mv $@.tmp $@) || \
 		(${GO_MD2MAN} -in $< -out $@.tmp && touch $@.tmp && mv $@.tmp $@)
 
@@ -485,7 +464,7 @@ verify-gosec: ${GOSEC}
 verify-govulncheck:
 	./hack/govulncheck.sh
 
-install: .gopathok install.bin install.man install.completions install.systemd install.config
+install: install.bin install.man install.completions install.systemd install.config
 
 install.bin-nobuild:
 	install ${SELINUXOPT} -D -m 755 bin/crio $(BINDIR)/crio


### PR DESCRIPTION
We don't need GOPATH anymore with go modules

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>
Co-authored-by: Sohan Kunkerkar <sohank2602@gmail.com>



#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
Removes GOPATH setup logic from the Makefile.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
None
```
