### PR TITLE
ci/gha: fix double caching

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,17 +16,10 @@ jobs:
   critest:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-integration-v1-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-integration-v1-
       - run: scripts/github-actions-packages
       - run: scripts/github-actions-setup
       - run: make all test-binaries
@@ -38,17 +31,10 @@ jobs:
   critest-conmonrs:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-integration-v1-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-integration-v1-
       - uses: sigstore/cosign-installer@v3
       - run: scripts/github-actions-packages
       - run: scripts/github-actions-setup
@@ -62,17 +48,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-integration-v1-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-integration-v1-
       - run: scripts/github-actions-packages
       - run: scripts/github-actions-setup
       - run: make all test-binaries
@@ -83,17 +62,10 @@ jobs:
   test-cgroupfs:
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-integration-v1-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-integration-v1-
       - run: scripts/github-actions-packages
       - run: scripts/github-actions-setup
       - run: make all test-binaries
@@ -107,17 +79,10 @@ jobs:
   test-userns:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-integration-v1-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-integration-v1-
       - run: scripts/github-actions-packages
       - run: scripts/github-actions-setup
       - run: make all test-binaries
@@ -129,17 +94,10 @@ jobs:
   test-conmonrs:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-integration-v1-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-integration-v1-
       - uses: sigstore/cosign-installer@v3
       - run: scripts/github-actions-packages
       - run: scripts/github-actions-setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,17 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-build-
       - run: scripts/github-actions-packages
       - run: make
       - run: bin/crio version
@@ -197,14 +190,9 @@ jobs:
       - build-static-ppc64le
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/setup-go@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            /tmp/spdx # default bom cache directory
-          key: go-bundles-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-bundles-
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/download-artifact@v3
         with:
           name: build-static-amd64
@@ -224,9 +212,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: config
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
       - run: chmod -R +x bin
       - run: make bundles
       - uses: actions/upload-artifact@v3
@@ -346,17 +331,10 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-unit-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-unit-
       - run: scripts/github-actions-packages
       - run: |
           make mockgen -j $(nproc)
@@ -386,20 +364,13 @@ jobs:
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v3
+      - uses: actions/setup-go@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-build-
+          go-version: ${{ env.GO_VERSION }}
       - name: Set current branch
         run: |
           raw=$(git branch -r --contains ${{ github.ref }})
@@ -421,20 +392,13 @@ jobs:
     needs: release-notes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v3
+      - uses: actions/setup-go@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-build-
+          go-version: ${{ env.GO_VERSION }}
       - run: make dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -449,20 +413,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v3
+      - uses: actions/setup-go@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-build-
+          go-version: ${{ env.GO_VERSION }}
       - run: make release-branch-forward
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -62,11 +62,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-
       - run: make check-vendor
 
   log-capitalization:
@@ -76,11 +71,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-
       - run: make check-log-lines
 
   verify-config-template:
@@ -90,11 +80,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-
       - run: make check-config-template
 
   get-script:
@@ -113,13 +98,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-get-script-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-get-script-
       - uses: sigstore/cosign-installer@v3
       - run: |
           make get-script
@@ -137,11 +115,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: go-verify-dependencies-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-verify-dependencies-
       - run: make verify-dependencies
 
   typos:


### PR DESCRIPTION
Since commit b34038f8f4b1bc / PR #6735, gha ci uses actions/setup-go v4. This version adds implicit caching, very similar to what we did, and so we don't have to use actions/cache explicitly anymore.

The only catch is, it needs go.mod, so make sure that actions/checkout is run before actions/setup-go.

Remove own caching, except for build-i386.

/kind ci

```release-note
NONE
```
