### PR TITLE
test/cgroup: fix for cgroupfs

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -631,7 +631,7 @@ function set_container_pod_cgroup_root() {
 
     export POD_CGROUP="$CGROUP_ROOT"/"$controller"/pod_123.slice/pod_123-456.slice
     export CTR_CGROUP="$POD_CGROUP"/crio-"$ctr_id".scope
-    if "$CONTAINER_CGROUP_MANAGER" != "systemd"; then
+    if [ "$CONTAINER_CGROUP_MANAGER" != "systemd" ]; then
         export POD_CGROUP="$CGROUP_ROOT"/"$controller"/pod_123-456
         export CTR_CGROUP="$POD_CGROUP"/crio-"$ctr_id"
     fi


### PR DESCRIPTION
This fixes 

```
not ok 19 cpu-quota.crio.io can disable quota
# (in test file ./cgroups.bats, line 220)
#   `[[ $(cat "$CTR_CGROUP"/"$cgroup_file") == "-1" ]]' failed
```
in integration/test-cgroupfs.

Fixes: a875ef486e3640bb1b3c6a21bf0c6e8bb3f5804d

/kind bug
/kind ci

```release-note
NONE
```
