### PR TITLE
test: limit number of parallel jobs

### DIFF
--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -30,7 +30,7 @@ function execute() {
 TESTS=("${@:-.}")
 
 # The number of parallel jobs to execute tests
-export JOBS=${JOBS:-$(($(nproc --all) * 4))}
+export JOBS=${JOBS:-$(nproc --all)}
 
 # Run the tests.
 execute bats --jobs "$JOBS" --tap "${TESTS[@]}"


### PR DESCRIPTION
Each parallel job eats lots of disk space in /tmp (mostly due to container images, I guess). Usually, /tmp resides on a tmpfs, which is limited to half the RAM.

As a result, when I run integration tests on my laptop (16 GB RAM, quad-core with hyperthreading), JOBS is 32, my /tmp quickly becomes full, and everything breaks. Manual cleanup after this takes time thanks to overlayfs mounts in /tmp (a separate issue).

This is the second time I came across this unfortunate behavior, and every single time I forget to set JOBS manually.

Let's be more conservative and run `nproc --all` jobs.

PS I believe this won't affect CI since we always set JOBS explicitly.
/kind other
```release-note
NONE
```
