### PR TITLE
Pause container during checkpointing

### DIFF
--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -42,6 +42,35 @@ func (c *ContainerServer) ContainerCheckpoint(
 		return "", fmt.Errorf("container %s is not running", ctr.ID())
 	}
 
+	// At this point the container needs to be paused. As we first checkpoint
+	// the processes in the container and the container will continue to run
+	// after checkpointing, there is a chance that the changed files we include
+	// in the checkpoint archive might change by the now again running processes
+	// in the container.
+	// Assuming this uses runc/crun (the OCI runtime is currently the only one
+	// supporting checkpointing), PauseContainer() will use the cgroup freezer
+	// to freeze the processes. CRIU will also use the cgroup freezer to freeze
+	// the processes if possible. If the cgroup is already frozen by runc/crun
+	// CRIU will not change the freezer status.
+	if err = c.runtime.PauseContainer(ctx, ctr); err != nil {
+		return "", fmt.Errorf("failed to pause container %q before checkpointing: %w", ctr.ID(), err)
+	}
+	defer func() {
+		if err := c.runtime.UpdateContainerStatus(ctx, ctr); err != nil {
+			log.Errorf(ctx, "Failed to update container status: %q: %v", ctr.ID(), err)
+		}
+		if ctr.State().Status == oci.ContainerStatePaused {
+			err := c.runtime.UnpauseContainer(ctx, ctr)
+			if err != nil {
+				log.Errorf(ctx, "Failed to unpause container: %q: %v", ctr.ID(), err)
+			}
+		}
+		// container state needs to be written _after_ unpausing
+		if err = c.ContainerStateToDisk(ctx, ctr); err != nil {
+			log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
+		}
+	}()
+
 	if opts.TargetFile != "" {
 		if err := c.prepareCheckpointExport(ctr); err != nil {
 			return "", fmt.Errorf("failed to write config dumps for container %s: %w", ctr.ID(), err)
@@ -56,11 +85,10 @@ func (c *ContainerServer) ContainerCheckpoint(
 			return "", fmt.Errorf("failed to write file system changes of container %s: %w", ctr.ID(), err)
 		}
 	}
-	if err := c.storageRuntimeServer.StopContainer(ctx, ctr.ID()); err != nil {
-		return "", fmt.Errorf("failed to unmount container %s: %w", ctr.ID(), err)
-	}
-	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
-		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
+	if !opts.KeepRunning {
+		if err := c.storageRuntimeServer.StopContainer(ctx, ctr.ID()); err != nil {
+			return "", fmt.Errorf("failed to unmount container %s: %w", ctr.ID(), err)
+		}
 	}
 
 	if !opts.Keep {

--- a/internal/lib/checkpoint_test.go
+++ b/internal/lib/checkpoint_test.go
@@ -110,7 +110,7 @@ var _ = t.Describe("ContainerCheckpoint", func() {
 
 			// Then
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring(`failed to checkpoint container containerID`))
+			Expect(err.Error()).To(ContainSubstring(`failed to pause container "containerID" before checkpointing`))
 		})
 	})
 	t.Describe("ContainerCheckpoint", func() {

--- a/server/container_checkpoint_test.go
+++ b/server/container_checkpoint_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containers/podman/v4/pkg/criu"
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -43,11 +42,6 @@ var _ = t.Describe("ContainerCheckpoint", func() {
 				State: specs.State{Status: oci.ContainerStateRunning},
 			})
 			testContainer.SetSpec(&specs.Spec{Version: "1.0.0"})
-
-			gomock.InOrder(
-				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).
-					Return(nil),
-			)
 
 			// When
 			_, err := sut.CheckpointContainer(


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The initial implementation of checkpointing in CRI-O was based on Podman and initially the default workflow would have been that the container is stopped after checkpointing. CRIU will just kill all processes in the container.

As the initial Kubernetes checkpointing feature is based on the Forensic Container Checkpointing KEP, the container keeps on running after checkpointing.

If the container keeps on running after checkpointing it can happen that the files in the container are changed once we put the into the checkpoint archive. This means that the files are different during restore than they were during checkpointing.

CRIU aborts restoring if the file size of any open file has changed as restoring will put the FD pointer at the same location as during checkpointing. If the file, however, is different this can lead to data loss or crashes.

To solve this, this commit pauses the container before checkpointing and unpauses it after the checkpoint archive has been written to disk.

As checkpointing only works with the OCI runtimes currently, we do not have to handle the pause during restore.

The OCI runtime (runc/crun) uses the cgroup freezer to pause the process. CRIU also uses the cgroup freezer to pause all processes in the container. CRIU does not change the state of the cgroup freezer if the cgroup is already frozen. So the cgroup was already always frozen during checkpointing. With this change the frozen time is now controlled by CRI-O and not CRIU, but we still do not have to handle it during restore.


#### Which issue(s) this PR fixes:

Fixes #6972 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```