### PR TITLE
tests/timeout: skip for conmon-rs

### DIFF
--- a/test/timeout.bats
+++ b/test/timeout.bats
@@ -3,6 +3,9 @@
 load helpers
 
 function setup() {
+	if [[ $RUNTIME_TYPE == pod ]]; then
+		skip "test needs conmon, not conmon-rs"
+	fi
 	# do not use the crictl() wrapper function here: we need to test the crictl
 	# features with no additional arg.
 	if ! "$CRICTL_BINARY" runp -h | grep -q "cancel-timeout"; then


### PR DESCRIPTION
These tests are not compatible with conmon-rs, and are failing. It seems it does not make sense to test both conmon and conmon-rs.

/kind ci

```release-note
NONE
```
