### PR TITLE
OCPBUGS-13980,OCPBUGS-14018: Fix bugs with high performance hooks

### DIFF
--- a/internal/config/cgmgr/cgmgr.go
+++ b/internal/config/cgmgr/cgmgr.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	crioPrefix = "crio"
+	CrioPrefix = "crio"
 	// minMemoryLimit is the minimum memory that must be set for a container.
 	// A lower value would result in the container failing to start.
 	// this value has been arrived at for runc on x86_64 hardware
@@ -216,5 +216,5 @@ func removeSandboxCgroup(sbParent, containerCgroup string) error {
 }
 
 func containerCgroupPath(id string) string {
-	return crioPrefix + "-" + id
+	return CrioPrefix + "-" + id
 }

--- a/internal/config/cgmgr/cgroupfs.go
+++ b/internal/config/cgmgr/cgroupfs.go
@@ -46,7 +46,7 @@ func (*CgroupfsManager) ContainerCgroupPath(sbParent, containerID string) string
 	if sbParent != "" {
 		parent = sbParent
 	}
-	return filepath.Join("/", parent, crioPrefix+"-"+containerID)
+	return filepath.Join("/", parent, containerCgroupPath(containerID))
 }
 
 // PopulateContainerCgroupStats takes arguments sandbox parent cgroup, container ID, and
@@ -77,7 +77,7 @@ func (m *CgroupfsManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cg
 		return "", "", err
 	}
 
-	return sbParent, filepath.Join(sbParent, crioPrefix+"-"+sbID), nil
+	return sbParent, filepath.Join(sbParent, containerCgroupPath(sbID)), nil
 }
 
 // PopulateSandboxCgroupStats takes arguments sandbox parent cgroup and sandbox stats object

--- a/internal/config/cgmgr/systemd.go
+++ b/internal/config/cgmgr/systemd.go
@@ -63,7 +63,7 @@ func (*SystemdManager) ContainerCgroupPath(sbParent, containerID string) string 
 	if sbParent != "" {
 		parent = sbParent
 	}
-	return parent + ":" + crioPrefix + ":" + containerID
+	return parent + ":" + CrioPrefix + ":" + containerID
 }
 
 // PopulateContainerCgroupStats takes arguments sandbox parent cgroup, container ID, and
@@ -161,7 +161,7 @@ func (m *SystemdManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgP
 		return "", "", err
 	}
 
-	cgPath = cgParent + ":" + crioPrefix + ":" + sbID
+	cgPath = cgParent + ":" + CrioPrefix + ":" + sbID
 
 	return cgParent, cgPath, nil
 }

--- a/internal/runtimehandlerhooks/default_cpu_load_balance_hooks.go
+++ b/internal/runtimehandlerhooks/default_cpu_load_balance_hooks.go
@@ -1,0 +1,50 @@
+package runtimehandlerhooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cri-o/cri-o/internal/config/node"
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+// DefaultCPULoadBalanceHooks is used to run additional hooks that will configure containers for CPU load balancing.
+// Specifically, it will define a PostStop that disables `cpuset.sched_load_balance` for a recently stopped container.
+// This must be done because guaranteed pods with exclusive cpu access may be created after other containers are terminated,
+// but before their cgroup is cleaned up. In this case, cpumanager will not load balancing the exclusive CPUs away from those pods,
+// thus causing their `cpuset.sched_load_balance=1` to prevent the kernel from disabling load balancing.
+// This is the only case it seeks to fix, and thus does not define any other members of the RuntimeHandlerHooks functions.
+type DefaultCPULoadBalanceHooks struct{}
+
+// No-op
+func (*DefaultCPULoadBalanceHooks) PreStart(context.Context, *oci.Container, *sandbox.Sandbox) error {
+	return nil
+}
+
+// No-op
+func (*DefaultCPULoadBalanceHooks) PreStop(context.Context, *oci.Container, *sandbox.Sandbox) error {
+	return nil
+}
+
+func (*DefaultCPULoadBalanceHooks) PostStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error {
+	// Disable cpuset.sched_load_balance for all stale cgroups.
+	// This way, cpumanager can ignore stopped containers, but the running ones will still have exclusive access.
+	if node.CgroupIsV2() || c.Spoofed() {
+		return nil
+	}
+	containerCgroup, containerCgroupParent, systemd, err := containerCgroupAndParent(s.CgroupParent(), c)
+	if err != nil {
+		return err
+	}
+	mgr, err := libctrManager(containerCgroup, containerCgroupParent, systemd)
+	if err != nil {
+		return err
+	}
+	path := mgr.Path("cpuset")
+	if path == "" {
+		return fmt.Errorf("failed to find cpuset for newly created cgroup")
+	}
+	return cgroups.WriteFile(path, "cpuset.sched_load_balance", "0")
+}

--- a/internal/runtimehandlerhooks/high_performance_hooks.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks.go
@@ -148,6 +148,15 @@ func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s 
 	return nil
 }
 
+// If CPU load balancing is enabled, then *all* containers must run this PostStop hook.
+func (*HighPerformanceHooks) PostStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error {
+	// We could check if `!cpuLoadBalancingAllowed()` here, but it requires access to the config, which would be
+	// odd to plumb. Instead, always assume if they're using a HighPerformanceHook, they have CPULoadBalanceDisabled
+	// annotation allowed.
+	h := &DefaultCPULoadBalanceHooks{}
+	return h.PostStop(ctx, c, s)
+}
+
 func shouldCPULoadBalancingBeDisabled(annotations fields.Set) bool {
 	if annotations[crioannotations.CPULoadBalancingAnnotation] == annotationTrue {
 		log.Warnf(context.TODO(), annotationValueDeprecationWarning(crioannotations.CPULoadBalancingAnnotation))
@@ -275,6 +284,20 @@ func setIRQLoadBalancing(ctx context.Context, c *oci.Container, enable bool, irq
 }
 
 func setCPUQuota(parentDir string, c *oci.Container) error {
+	containerCgroup, containerCgroupParent, systemd, err := containerCgroupAndParent(parentDir, c)
+	if err != nil {
+		return err
+	}
+	podCgroup := filepath.Base(containerCgroupParent)
+	podCgroupParent := filepath.Dir(containerCgroupParent)
+
+	if err := disableCPUQuotaForCgroup(podCgroup, podCgroupParent, systemd); err != nil {
+		return err
+	}
+	return disableCPUQuotaForCgroup(containerCgroup, containerCgroupParent, systemd)
+}
+
+func containerCgroupAndParent(parentDir string, c *oci.Container) (ctrCgroup, parentCgroup string, systemd bool, _ error) {
 	var (
 		cgroupManager cgmgr.CgroupManager
 		err           error
@@ -291,7 +314,7 @@ func setCPUQuota(parentDir string, c *oci.Container) error {
 	}
 	cgroupPath, err := cgroupManager.ContainerCgroupAbsolutePath(parentDir, c.ID())
 	if err != nil {
-		return err
+		return "", "", false, err
 	}
 	containerCgroup := filepath.Base(cgroupPath)
 	// A quirk of libcontainer's cgroup driver.
@@ -299,17 +322,22 @@ func setCPUQuota(parentDir string, c *oci.Container) error {
 	if cgroupManager.IsSystemd() {
 		containerCgroup = c.ID()
 	}
-	containerCgroupParent := filepath.Dir(cgroupPath)
-	podCgroup := filepath.Base(containerCgroupParent)
-	podCgroupParent := filepath.Dir(containerCgroupParent)
-
-	if err := disableCPUQuotaForCgroup(podCgroup, podCgroupParent, cgroupManager.IsSystemd()); err != nil {
-		return err
-	}
-	return disableCPUQuotaForCgroup(containerCgroup, containerCgroupParent, cgroupManager.IsSystemd())
+	return containerCgroup, filepath.Dir(cgroupPath), cgroupManager.IsSystemd(), nil
 }
 
 func disableCPUQuotaForCgroup(cgroup, parent string, systemd bool) error {
+	mgr, err := libctrManager(cgroup, parent, systemd)
+	if err != nil {
+		return err
+	}
+
+	return mgr.Set(&configs.Resources{
+		SkipDevices: true,
+		CpuQuota:    -1,
+	})
+}
+
+func libctrManager(cgroup, parent string, systemd bool) (cgroups.Manager, error) {
 	if systemd {
 		parent = filepath.Base(parent)
 	}
@@ -318,7 +346,6 @@ func disableCPUQuotaForCgroup(cgroup, parent string, systemd bool) error {
 		Parent: parent,
 		Resources: &configs.Resources{
 			SkipDevices: true,
-			CpuQuota:    -1,
 		},
 		Systemd: systemd,
 		// If the cgroup manager is systemd, then libcontainer
@@ -328,12 +355,7 @@ func disableCPUQuotaForCgroup(cgroup, parent string, systemd bool) error {
 		// See: https://github.com/opencontainers/runc/tree/main/libcontainer/cgroups/systemd/common.go:getUnitName
 		ScopePrefix: cgmgr.CrioPrefix,
 	}
-	mgr, err := libCtrMgr.New(cg)
-	if err != nil {
-		return err
-	}
-
-	return mgr.Set(cg.Resources)
+	return libCtrMgr.New(cg)
 }
 
 // setCPUPMQOSResumeLatency sets the pm_qos_resume_latency_us for a cpu and stores the original

--- a/internal/runtimehandlerhooks/high_performance_hooks.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks.go
@@ -294,6 +294,11 @@ func setCPUQuota(parentDir string, c *oci.Container) error {
 		return err
 	}
 	containerCgroup := filepath.Base(cgroupPath)
+	// A quirk of libcontainer's cgroup driver.
+	// See explanation in disableCPUQuotaForCgroup function.
+	if cgroupManager.IsSystemd() {
+		containerCgroup = c.ID()
+	}
 	containerCgroupParent := filepath.Dir(cgroupPath)
 	podCgroup := filepath.Base(containerCgroupParent)
 	podCgroupParent := filepath.Dir(containerCgroupParent)
@@ -305,6 +310,9 @@ func setCPUQuota(parentDir string, c *oci.Container) error {
 }
 
 func disableCPUQuotaForCgroup(cgroup, parent string, systemd bool) error {
+	if systemd {
+		parent = filepath.Base(parent)
+	}
 	cg := &configs.Cgroup{
 		Name:   cgroup,
 		Parent: parent,
@@ -313,6 +321,12 @@ func disableCPUQuotaForCgroup(cgroup, parent string, systemd bool) error {
 			CpuQuota:    -1,
 		},
 		Systemd: systemd,
+		// If the cgroup manager is systemd, then libcontainer
+		// will construct the cgroup path (for scopes) as:
+		// ScopePrefix-Name.scope. For slices, and for cgroupfs manager,
+		// this will be ignored.
+		// See: https://github.com/opencontainers/runc/tree/main/libcontainer/cgroups/systemd/common.go:getUnitName
+		ScopePrefix: cgmgr.CrioPrefix,
 	}
 	mgr, err := libCtrMgr.New(cg)
 	if err != nil {

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -55,11 +55,6 @@ func (s *Server) removeContainerInPod(ctx context.Context, sb *sandbox.Sandbox, 
 		if err := s.stopContainer(ctx, c, int64(10)); err != nil {
 			return fmt.Errorf("failed to stop container for removal")
 		}
-
-		if err := s.nri.stopContainer(ctx, sb, c); err != nil {
-			log.Warnf(ctx, "NRI container stop failed for container %s of pod %s: %v",
-				c.ID(), sb.ID(), err)
-		}
 	}
 
 	if err := s.nri.removeContainer(ctx, sb, c); err != nil {

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -79,6 +79,12 @@ func (s *Server) stopContainer(ctx context.Context, ctr *oci.Container, timeout 
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
 
+	if hooks != nil {
+		if err := hooks.PostStop(ctx, ctr, sb); err != nil {
+			return fmt.Errorf("failed to run post-stop hook for container %q: %w", ctr.ID(), err)
+		}
+	}
+
 	if err := s.nri.stopContainer(ctx, sb, ctr); err != nil {
 		return err
 	}

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -22,24 +22,8 @@ func (s *Server) StopContainer(ctx context.Context, req *types.StopContainerRequ
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 
-	sandbox := s.getSandbox(ctx, c.Sandbox())
-	hooks, err := runtimehandlerhooks.GetRuntimeHandlerHooks(ctx, &s.config, sandbox.RuntimeHandler(), sandbox.Annotations())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get runtime handler %q hooks", sandbox.RuntimeHandler())
-	}
-
-	if hooks != nil {
-		if err := hooks.PreStop(ctx, c, sandbox); err != nil {
-			return nil, fmt.Errorf("failed to run pre-stop hook for container %q: %w", c.ID(), err)
-		}
-	}
-
 	if err := s.stopContainer(ctx, c, req.Timeout); err != nil {
 		return nil, err
-	}
-
-	if err := s.nri.stopContainer(ctx, sandbox, c); err != nil {
-		log.Warnf(ctx, "NRI stop failed for container %q: %v", c.ID(), err)
 	}
 
 	log.Infof(ctx, "Stopped container %s: %s", c.ID(), c.Description())
@@ -50,6 +34,20 @@ func (s *Server) StopContainer(ctx context.Context, req *types.StopContainerRequ
 func (s *Server) stopContainer(ctx context.Context, ctr *oci.Container, timeout int64) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
+
+	sb := s.getSandbox(ctx, ctr.Sandbox())
+
+	hooks, err := runtimehandlerhooks.GetRuntimeHandlerHooks(ctx, &s.config, sb.RuntimeHandler(), sb.Annotations())
+	if err != nil {
+		return fmt.Errorf("failed to get runtime handler %q hooks", sb.RuntimeHandler())
+	}
+
+	if hooks != nil {
+		if err := hooks.PreStop(ctx, ctr, sb); err != nil {
+			return fmt.Errorf("failed to run pre-stop hook for container %q: %w", ctr.ID(), err)
+		}
+	}
+
 	if ctr.StateNoLock().Status == oci.ContainerStatePaused {
 		if err := s.Runtime().UnpauseContainer(ctx, ctr); err != nil {
 			return fmt.Errorf("failed to stop container %s: %v", ctr.Name(), err)
@@ -79,6 +77,10 @@ func (s *Server) stopContainer(ctx context.Context, ctr *oci.Container, timeout 
 
 	if err := s.ContainerStateToDisk(ctx, ctr); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
+	}
+
+	if err := s.nri.stopContainer(ctx, sb, ctr); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
This PR fixes two separate bugs with high performance hooks, and does some code reorganization while it's at it.
It's kept in one PR to simplify backporting.
- Fix a bug where the wrong cgroup path was chosen by libcontainer when disabling cpu quota
- Reoganize hooks and NRI plugins so they're called in all cases containers are stopped
- Fix a bug where stale containers (ones that have stopped but not been cleaned up) break cpu load balancing by disabling load balancing after they're stopped.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug with cpu quota annotation that manifests like:
`pod with cpu-quota.crio.io: disable fails with error: set CPU CFS quota: invalid slice name: /kubepods.slice`
Fix a bug where stopped containers break cpu load balancing being disabled
```
