### PR TITLE
crio: remove DefaultsPath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,6 @@ else
 GCFLAGS = -gcflags '-N -l'
 endif
 
-DEFAULTS_PATH := ""
-
 DATE_FMT = +'%Y-%m-%dT%H:%M:%SZ'
 ifdef SOURCE_DATE_EPOCH
     BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
@@ -117,7 +115,6 @@ else
 endif
 
 BASE_LDFLAGS = ${SHRINKFLAGS} \
-	-X ${PROJECT}/internal/pkg/criocli.DefaultsPath=${DEFAULTS_PATH} \
 	-X ${PROJECT}/internal/version.buildDate=${BUILD_DATE}
 
 GO_LDFLAGS = -ldflags '${BASE_LDFLAGS} ${EXTRA_LDFLAGS}'

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -3,7 +3,6 @@ package criocli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	libconfig "github.com/cri-o/cri-o/pkg/config"
@@ -11,9 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
-
-// DefaultsPath is the path to default configuration files set at build time
-var DefaultsPath string
 
 // DefaultCommands are the flags commands can be added to every binary
 var DefaultCommands = []*cli.Command{
@@ -48,16 +44,6 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 		if err := config.UpdateFromFile(path); err != nil {
 			if ctx.IsSet("config") || !os.IsNotExist(err) {
 				return err
-			}
-
-			// Use the build-time-defined defaults path
-			if DefaultsPath != "" && os.IsNotExist(err) {
-				path = filepath.Join(DefaultsPath, "/crio.conf")
-				if err := config.UpdateFromFile(path); err != nil {
-					if ctx.IsSet("config") || !os.IsNotExist(err) {
-						return err
-					}
-				}
 			}
 		}
 	}


### PR DESCRIPTION
Commit 1e54cdd362e6ff8e (PR #1740) added support for setting build-time DefaultsPath.

Commit 97b9587f160583d6 (PR #3321) added setting DefaultsPath from the Makefile.

Commit eb9cc161cb0f47b8 (PR #3298) renamed internal/criocli to internal/pkg/criocli.

The last two commits/PRs were merged the same day (5 March 2020).
This means the feature never worked (it could have worked in backports but they
never happened).

Since it never worked for 3+ years, it probably have no users.
    
Remove it.

Essentially, this reverts commits 1e54cdd362e6ff8e and 97b9587f160583d6.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
