### PR TITLE
Update `README.md` version table

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,10 @@ applies to features which are independent from Kubernetes.
 For more information visit the [Kubernetes Version Skew
 Policy](https://kubernetes.io/releases/version-skew-policy/).
 
-| Version - Branch            | Kubernetes branch/version       | Maintenance status |
-| --------------------------- | ------------------------------- | ------------------ |
-| CRI-O HEAD - main           | Kubernetes master branch        | ✓                  |
-| CRI-O 1.24.x - release-1.24 | Kubernetes 1.24 branch, v1.24.x | =                  |
-| CRI-O 1.23.x - release-1.23 | Kubernetes 1.23 branch, v1.23.x | =                  |
-| CRI-O 1.22.x - release-1.22 | Kubernetes 1.22 branch, v1.22.x | =                  |
-| CRI-O 1.21.x - release-1.21 | Kubernetes 1.21 branch, v1.21.x | =                  |
-
-Key:
-
-- `✓` Changes in the main Kubernetes repo about CRI are actively implemented in CRI-O
-- `=` Maintenance is manual, only bugs will be patched.
+| CRI-O                           | Kubernetes                      | Maintenance status                                                    |
+| ------------------------------- | ------------------------------- | --------------------------------------------------------------------- |
+| `main` branch                   | `master` branch                 | Features from the main Kubernetes repository are actively implemented |
+| `release-1.x` branch (`v1.x.y`) | `release-1.x` branch (`v1.x.z`) | Maintenance is manual, only bugfixes will be backported.              |
 
 The release notes for CRI-O are hand-crafted and can be continuously retrieved
 from [our GitHub pages website](https://cri-o.github.io/cri-o).


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation

#### What this PR does / why we need it:
We always forget to add the new release, which is now not required any more considering a new format. We also outline that the patch release of CRI-O (`.y`) does not have to match with them from Kubernetes (`.z`).

Since we only have two data rows within the table, we also can avoid the key mapping and add their description directly to it.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
