### PR TITLE
Drop support for path based seccomp profiles

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -14,7 +14,7 @@ use_conmonrs: '{{ USE_CONMONRS | default(False) | bool }}'
 evented_pleg_fg: '{{ EVENTED_PLEG | default(False) | bool }}'
 
 critest_mirror_repo: quay.io/crio
-cri_tools_git_version: "v1.27.0"
+cri_tools_git_version: master
 golang_version: "1.20"
 
 # For results.yml Paths use rsync 'source' conventions

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -12,7 +12,7 @@ build_kata: False
 cgroupv2: False
 
 critest_mirror_repo: quay.io/crio
-cri_tools_git_version: "v1.27.0"
+cri_tools_git_version: master
 golang_version: "1.20"
 
 # For results.yml Paths use rsync 'source' conventions

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -48,10 +48,11 @@ dependencies:
     refPaths:
     - path: scripts/versions
       match: cri-tools
-    - path: contrib/test/integration/vars.yml
-      match: cri_tools_git_version
-    - path: contrib/test/ci/vars.yml
-      match: cri_tools_git_version
+    # Uncomment and pin once we have cri-tools v1.28.0
+    # - path: contrib/test/integration/vars.yml
+    #   match: cri_tools_git_version
+    # - path: contrib/test/ci/vars.yml
+    #   match: cri_tools_git_version
 
   - name: runc
     version: v1.1.7

--- a/internal/config/seccomp/seccomp_test.go
+++ b/internal/config/seccomp/seccomp_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/opencontainers/runtime-tools/generate"
-	k8sV1 "k8s.io/api/core/v1"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -91,67 +90,6 @@ var _ = t.Describe("Config", func() {
 	})
 
 	t.Describe("Setup", func() {
-		It("should succeed with profile from file", func() {
-			// Given
-			generator, err := generate.New("linux")
-			Expect(err).To(BeNil())
-			file := writeProfileFile()
-
-			// When
-			_, err = sut.Setup(
-				context.Background(),
-				nil,
-				"",
-				nil,
-				&generator,
-				nil,
-				k8sV1.SeccompLocalhostProfileNamePrefix+file,
-			)
-
-			// Then
-			Expect(err).To(BeNil())
-		})
-
-		It("should succeed with profile from file and runtime default", func() {
-			// Given
-			generator, err := generate.New("linux")
-			Expect(err).To(BeNil())
-
-			// When
-			_, err = sut.Setup(
-				context.Background(),
-				nil,
-				"",
-				nil,
-				&generator,
-				nil,
-				k8sV1.SeccompProfileRuntimeDefault,
-			)
-
-			// Then
-			Expect(err).To(BeNil())
-		})
-
-		It("should fail with profile from file if wrong filename", func() {
-			// Given
-			generator, err := generate.New("linux")
-			Expect(err).To(BeNil())
-
-			// When
-			_, err = sut.Setup(
-				context.Background(),
-				nil,
-				"",
-				nil,
-				&generator,
-				nil,
-				"not-existing",
-			)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
 		It("should succeed with custom profile from field", func() {
 			// Given
 			generator, err := generate.New("linux")
@@ -161,18 +99,18 @@ var _ = t.Describe("Config", func() {
 			}
 
 			// When
-			_, err = sut.Setup(
+			_, ref, err := sut.Setup(
 				context.Background(),
 				nil,
 				"",
 				nil,
 				&generator,
 				field,
-				"",
 			)
 
 			// Then
 			Expect(err).To(BeNil())
+			Expect(ref).To(Equal(types.SecurityProfile_RuntimeDefault.String()))
 		})
 
 		It("should succeed with custom profile from field", func() {
@@ -186,18 +124,18 @@ var _ = t.Describe("Config", func() {
 			}
 
 			// When
-			_, err = sut.Setup(
+			_, ref, err := sut.Setup(
 				context.Background(),
 				nil,
 				"",
 				nil,
 				&generator,
 				field,
-				"",
 			)
 
 			// Then
 			Expect(err).To(BeNil())
+			Expect(ref).To(Equal(file))
 		})
 
 		It("should fail with custom profile from field if not existing", func() {
@@ -210,14 +148,13 @@ var _ = t.Describe("Config", func() {
 			}
 
 			// When
-			_, err = sut.Setup(
+			_, _, err = sut.Setup(
 				context.Background(),
 				nil,
 				"",
 				nil,
 				&generator,
 				field,
-				"",
 			)
 
 			// Then

--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -104,7 +104,7 @@ type Container interface {
 	SpecAddMount(rspec.Mount)
 
 	// SpecAddAnnotations adds annotations to the spec.
-	SpecAddAnnotations(ctx context.Context, sandbox *sandbox.Sandbox, containerVolume []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool) error
+	SpecAddAnnotations(ctx context.Context, sandbox *sandbox.Sandbox, containerVolume []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool, seccompRef string) error
 
 	// SpecAddDevices adds devices from the server config, and container CRI config
 	SpecAddDevices([]device.Device, []device.Device, bool, bool) error
@@ -162,7 +162,7 @@ func (c *container) SpecAddMount(r rspec.Mount) {
 }
 
 // SpecAddAnnotation adds all annotations to the spec
-func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox, containerVolumes []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool) (err error) {
+func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox, containerVolumes []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool, seccompRef string) (err error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 	// Copied from k8s.io/kubernetes/pkg/kubelet/kuberuntime/labels.go
@@ -226,7 +226,7 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 	c.spec.AddAnnotation(annotations.ResolvPath, sb.ResolvPath())
 	c.spec.AddAnnotation(annotations.ContainerManager, lib.ContainerManagerCRIO)
 	c.spec.AddAnnotation(annotations.MountPoint, mountPoint)
-	c.spec.AddAnnotation(annotations.SeccompProfilePath, c.Config().Linux.SecurityContext.SeccompProfilePath)
+	c.spec.AddAnnotation(annotations.SeccompProfilePath, seccompRef)
 	c.spec.AddAnnotation(annotations.Created, created.Format(time.RFC3339Nano))
 
 	metadataJSON, err := json.Marshal(c.Config().Metadata)

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -117,7 +117,7 @@ var _ = t.Describe("Container", func() {
 			Expect(currentTime).ToNot(BeNil())
 			Expect(sb).ToNot(BeNil())
 
-			err = sut.SpecAddAnnotations(context.Background(), sb, volumes, mountPoint, configStopSignal, &imageResult, false, false)
+			err = sut.SpecAddAnnotations(context.Background(), sb, volumes, mountPoint, configStopSignal, &imageResult, false, false, "foo")
 			Expect(err).To(BeNil())
 
 			Expect(sut.Spec().Config.Annotations[annotations.Image]).To(Equal(image))
@@ -135,7 +135,7 @@ var _ = t.Describe("Container", func() {
 			Expect(sut.Spec().Config.Annotations[annotations.ResolvPath]).To(Equal(sb.ResolvPath()))
 			Expect(sut.Spec().Config.Annotations[annotations.ContainerManager]).To(Equal(lib.ContainerManagerCRIO))
 			Expect(sut.Spec().Config.Annotations[annotations.MountPoint]).To(Equal(mountPoint))
-			Expect(sut.Spec().Config.Annotations[annotations.SeccompProfilePath]).To(Equal(sut.Config().Linux.SecurityContext.SeccompProfilePath))
+			Expect(sut.Spec().Config.Annotations[annotations.SeccompProfilePath]).To(Equal("foo"))
 			Expect(sut.Spec().Config.Annotations[annotations.Created]).ToNot(BeNil())
 			Expect(sut.Spec().Config.Annotations[annotations.Metadata]).To(Equal(string(metadataJSON)))
 			Expect(sut.Spec().Config.Annotations[annotations.Labels]).To(Equal(string(labelsJSON)))

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -75,7 +75,8 @@ install_critools() {
 
     git clone $URL
     pushd cri-tools
-    git checkout "${VERSIONS["cri-tools"]}"
+    # TODO: uncomment once we released cri-tools v1.28.0
+    # git checkout "${VERSIONS["cri-tools"]}"
     sudo -E PATH="$PATH" make BINDIR=/usr/bin install
     popd
     sudo rm -rf cri-tools

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -621,15 +621,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	specgen.AddProcessEnv("HOSTNAME", sb.Hostname())
 
 	created := time.Now()
+	seccompRef := types.SecurityProfile_Unconfined.String()
 	if !ctr.Privileged() {
-		notifier, err := s.config.Seccomp().Setup(
+		notifier, ref, err := s.config.Seccomp().Setup(
 			ctx,
 			s.seccompNotifierChan,
 			containerID,
 			sb.Annotations(),
 			specgen,
 			securityContext.Seccomp,
-			containerConfig.Linux.SecurityContext.SeccompProfilePath,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("setup seccomp: %w", err)
@@ -637,6 +637,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		if notifier != nil {
 			s.seccompNotifiers.Store(containerID, notifier)
 		}
+		seccompRef = ref
 	}
 
 	// Get RDT class
@@ -650,7 +651,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		specgen.Config.Linux.IntelRdt = &rspec.LinuxIntelRdt{ClosID: rdt.ResctrlPrefix + rdtClass}
 	}
 
-	err = ctr.SpecAddAnnotations(ctx, sb, containerVolumes, mountPoint, containerImageConfig.Config.StopSignal, imgResult, s.config.CgroupManager().IsSystemd(), node.SystemdHasCollectMode())
+	err = ctr.SpecAddAnnotations(ctx, sb, containerVolumes, mountPoint, containerImageConfig.Config.StopSignal, imgResult, s.config.CgroupManager().IsSystemd(), node.SystemdHasCollectMode(), seccompRef)
 	if err != nil {
 		return nil, err
 	}
@@ -857,7 +858,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 
 	ociContainer.SetSpec(specgen.Config)
 	ociContainer.SetMountPoint(mountPoint)
-	ociContainer.SetSeccompProfilePath(containerConfig.Linux.SecurityContext.SeccompProfilePath)
+	ociContainer.SetSeccompProfilePath(seccompRef)
 
 	for _, cv := range containerVolumes {
 		ociContainer.AddVolume(cv)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -870,22 +870,23 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 
 	sb.SetNamespaceOptions(securityContext.NamespaceOptions)
 
-	seccompProfilePath := securityContext.SeccompProfilePath
-	g.AddAnnotation(annotations.SeccompProfilePath, seccompProfilePath)
-	sb.SetSeccompProfilePath(seccompProfilePath)
+	seccompRef := types.SecurityProfile_Unconfined.String()
 	if !privileged {
-		if _, err := s.config.Seccomp().Setup(
+		_, ref, err := s.config.Seccomp().Setup(
 			ctx,
 			nil,
 			"",
 			nil,
 			g,
 			securityContext.Seccomp,
-			seccompProfilePath,
-		); err != nil {
+		)
+		if err != nil {
 			return nil, fmt.Errorf("setup seccomp: %w", err)
 		}
+		seccompRef = ref
 	}
+	sb.SetSeccompProfilePath(seccompRef)
+	g.AddAnnotation(annotations.SeccompProfilePath, seccompRef)
 
 	runtimeType, err := s.Runtime().RuntimeType(runtimeHandler)
 	if err != nil {

--- a/test/seccomp_notifier.bats
+++ b/test/seccomp_notifier.bats
@@ -22,7 +22,7 @@ function teardown() {
 	CONTAINER_ENABLE_METRICS=true CONTAINER_METRICS_PORT=$PORT start_crio
 
 	# Run with runtime/default
-	jq '.linux.security_context.seccomp_profile_path = "runtime/default"' \
+	jq '.linux.security_context.seccomp.profile_type = 0' \
 		"$TESTDATA"/container_redis.json > "$TESTDIR"/container.json
 
 	# Enable the annotation in the sandbox
@@ -53,7 +53,7 @@ function teardown() {
 	CONTAINER_ENABLE_METRICS=true CONTAINER_METRICS_PORT=$PORT start_crio
 
 	# Run with runtime/default
-	jq '.linux.security_context.seccomp_profile_path = "runtime/default"' \
+	jq '.linux.security_context.seccomp.profile_type = 0' \
 		"$TESTDATA"/container_redis.json > "$TESTDIR"/container.json
 
 	# Enable the annotation in the sandbox
@@ -83,7 +83,7 @@ function teardown() {
 		"$CONTAINER_SECCOMP_PROFILE" > "$TESTDIR"/profile.json
 	sed -i 's;swapon;chmod;' "$TESTDIR"/profile.json
 
-	jq '.linux.security_context.seccomp_profile_path = "localhost/'"$TESTDIR"'/profile.json"' \
+	jq '.linux.security_context.seccomp.profile_type = 2 | .linux.security_context.seccomp.localhost_ref = "'"$TESTDIR"'/profile.json"' \
 		"$TESTDATA"/container_sleep.json > "$TESTDIR"/container.json
 
 	# Enable the annotation in the sandbox
@@ -115,7 +115,7 @@ function teardown() {
 		"$CONTAINER_SECCOMP_PROFILE" > "$TESTDIR"/profile.json
 	sed -i 's;swapoff;chmod;' "$TESTDIR"/profile.json
 
-	jq '.linux.security_context.seccomp_profile_path = "localhost/'"$TESTDIR"'/profile.json"' \
+	jq '.linux.security_context.seccomp.profile_type = 2 | .linux.security_context.seccomp.localhost_ref = "'"$TESTDIR"'/profile.json"' \
 		"$TESTDATA"/container_sleep.json > "$TESTDIR"/container.json
 
 	# Enable the annotation in the sandbox


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Field based profiles should be standard since many Kubernetes releases, means we can drop the path based logic and cleanup some code.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Dropped support for annotation based seccomp profiles, Kubernetes uses a native field since many releases.
```
