### PR TITLE
[1.23] cgmgr: create cgroups for systemd cgroup driver for dropped infra pods

### DIFF
--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -52,6 +52,11 @@ func (s *Server) removePodSandbox(ctx context.Context, sb *sandbox.Sandbox) erro
 	if err := s.removeContainerInPod(ctx, sb, sb.InfraContainer()); err != nil {
 		return err
 	}
+	if sb.InfraContainer().Spoofed() {
+		if err := s.config.CgroupManager().RemoveSandboxCgroup(sb.CgroupParent(), sb.ID()); err != nil {
+			return err
+		}
+	}
 
 	// Cleanup network resources for this pod
 	if err := s.networkStop(ctx, sb); err != nil {

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -277,22 +277,17 @@ function teardown() {
 }
 
 @test "kubernetes pod terminationGracePeriod passthru" {
-	[ -v CIRCLECI ] && skip "runc v1.0.0-rc11 required" # TODO remove this
-	# Make sure there is no XDG_RUNTIME_DIR set, otherwise the test might end up using the user instance.
 	# There is an assumption in the test to use the system instance of systemd (systemctl show).
-	CONTAINER_CGROUP_MANAGER="systemd" DBUS_SESSION_BUS_ADDRESS="" XDG_RUNTIME_DIR="" start_crio
-
-	# for systemd, cgroup_parent should not be set
-	jq '	  del(.linux.cgroup_parent)' \
-		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
+	if [[ "$CONTAINER_CGROUP_MANAGER" != "systemd" ]]; then
+		skip "need systemd cgroup manager"
+	fi
+	# Make sure there is no XDG_RUNTIME_DIR set, otherwise the test might end up using the user instance.
+	DBUS_SESSION_BUS_ADDRESS="" XDG_RUNTIME_DIR="" start_crio
 
 	jq '	  .annotations += { "io.kubernetes.pod.terminationGracePeriod": "88" }' \
 		"$TESTDATA"/container_sleep.json > "$TESTDIR"/ctr.json
 
-	pod_id=$(crictl runp "$TESTDIR"/sandbox.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDIR"/ctr.json "$TESTDIR"/sandbox.json)
-
-	crictl start "$ctr_id"
+	ctr_id=$(crictl run "$TESTDIR"/ctr.json "$TESTDATA"/sandbox_config.json)
 
 	output=$(systemctl show "crio-${ctr_id}.scope")
 	echo "$output" | grep 'TimeoutStopUSec=' || true      # show


### PR DESCRIPTION
     The history here is a bit convoluted. Originally, runc created the cgroup for the infra container.
    cAdvisor was built to assume the cgroup for the infra container would be created, and it uses
    this to find the network metrics for the pod. When we dropped the infra container, cri-o needed to make this
    cgroup so cAdvisor could still find the network metrics.
    
    However, systemd didn't like the way we did it, and would remove the cgroup mid pod creation, which was fixed in
    https://github.com/cri-o/cri-o/pull/6196. This actually caused the cgroup to not be created at all, which then caused
    the networking metrics to not be gathered at all.
    
    Thus, we do need to create a cgroup underneath the systemd cgroup. Attempt to use a slice for this, as systemd won't require a
    process be underneath it.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
reverts https://github.com/cri-o/cri-o/pull/6196 
fixes https://github.com/cri-o/cri-o/issues/6657 
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
cherry-pick of https://github.com/cri-o/cri-o/pull/6949

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where network metrics collection is broken with systemd cgroup driver and dropped infra containers.
```
