### PR TITLE
[release-1.26] update NRI.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containerd/containerd v1.7.0-beta.0
 	github.com/containerd/cri-containerd v1.19.0
 	github.com/containerd/fifo v1.0.0
-	github.com/containerd/nri v0.3.0
+	github.com/containerd/nri v0.3.1-0.20230504231226-94185418e253
 	github.com/containerd/ttrpc v1.1.1-0.20220420014843-944ef4a40df3
 	github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67
 	github.com/containernetworking/cni v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -554,8 +554,8 @@ github.com/containerd/imgcrypt v1.1.1/go.mod h1:xpLnwiQmEUJPvQoAapeb2SNCxz7Xr6PJ
 github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFYfE5+So4M5syatU0N0f0LbWpuqyMi4/BE8c=
 github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
-github.com/containerd/nri v0.3.0 h1:2ZM4WImye1ypSnE7COjOvPAiLv84kaPILBDvb1tbDK8=
-github.com/containerd/nri v0.3.0/go.mod h1:Zw9q2lP16sdg0zYybemZ9yTDy8g7fPCIB3KXOGlggXI=
+github.com/containerd/nri v0.3.1-0.20230504231226-94185418e253 h1:cUfRSE/vMuzRREn61rJcDavM4e7V0sZwxLSQywvJop8=
+github.com/containerd/nri v0.3.1-0.20230504231226-94185418e253/go.mod h1:Zw9q2lP16sdg0zYybemZ9yTDy8g7fPCIB3KXOGlggXI=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/containerd/stargz-snapshotter/estargz v0.9.0/go.mod h1:aE5PCyhFMwR8sbrErO5eM2GcvkyXTTJremG883D4qF0=
 github.com/containerd/stargz-snapshotter/estargz v0.12.0/go.mod h1:AIQ59TewBFJ4GOPEQXujcrJ/EKxh5xXZegW1rkR1P/M=

--- a/vendor/github.com/containerd/nri/pkg/api/resources.go
+++ b/vendor/github.com/containerd/nri/pkg/api/resources.go
@@ -100,7 +100,10 @@ func (r *LinuxResources) ToOCI() *rspec.LinuxResources {
 	if r == nil {
 		return nil
 	}
-	o := &rspec.LinuxResources{}
+	o := &rspec.LinuxResources{
+		CPU:    &rspec.LinuxCPU{},
+		Memory: &rspec.LinuxMemory{},
+	}
 	if r.Memory != nil {
 		o.Memory = &rspec.LinuxMemory{
 			Limit:            r.Memory.Limit.Get(),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -568,7 +568,7 @@ github.com/containerd/fifo
 # github.com/containerd/go-runc v1.0.0
 ## explicit; go 1.13
 github.com/containerd/go-runc
-# github.com/containerd/nri v0.3.0
+# github.com/containerd/nri v0.3.1-0.20230504231226-94185418e253
 ## explicit; go 1.19
 github.com/containerd/nri/pkg/adaptation
 github.com/containerd/nri/pkg/api


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Update `github.com/containerd/nri` dependency to latest. Current code assumes that any resource update has a non-nil runtime-spec.LinuxMemory field. Tries to blindly dereference it in `internal/lib/container_server.go` without a nil-check. This is not a problem for internally generated `LinuxResources`, because the implicit assumption there is true. NRI used to violate this assumption and the latest commit fixes that. Without that fix an NRI plugin updating a container without touching memory resources/cgroupfs parametrization triggers a nil-pointer dereference/SIGSEGV panic and a crash in CRI-O. 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is effectively a backport of #6880 to 1.26.

#### Does this PR introduce a user-facing change?


```release-note
none
```
