### PR TITLE
Deprecate device mapper

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -964,6 +964,10 @@ func (c *RootConfig) Validate(onExecution bool) error {
 		if err := os.MkdirAll(c.LogDir, 0o700); err != nil {
 			return fmt.Errorf("invalid log_dir: %w", err)
 		}
+		if c.Storage == "devicemapper" {
+			// TODO: return error.
+			logrus.Warn("devicemapper storage driver is deprecated and will be removed in cri-o v1.28")
+		}
 		store, err := c.GetStore()
 		if err != nil {
 			return fmt.Errorf("failed to get store to set defaults: %w", err)

--- a/test/command.bats
+++ b/test/command.bats
@@ -54,3 +54,8 @@ load helpers
 	run ! "$CRIO_BINARY_PATH" --log-size-max 18446744073709551616
 	[[ "$output" == *"value out of range"* ]]
 }
+
+@test "devicemapper is deprecated" {
+	run "$CRIO_BINARY_PATH" -s devicemapper
+	[[ "$output" == *"devicemapper storage driver is deprecated"* ]]
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Devicemapper storage driver is now deprecated and will be removed in cri-o v1.28.
```
