### PR TITLE
[1.26] Add support for linking pod logs

### DIFF
--- a/internal/linklogs/link_logs.go
+++ b/internal/linklogs/link_logs.go
@@ -1,0 +1,64 @@
+package linklogs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/opencontainers/selinux/go-selinux/label"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	kubeletPodsRootDir    = "/var/lib/kubelet/pods"
+	kubeletPodLogsRootDir = "/var/log/pods"
+	kubeletEmptyDirLogDir = "kubernetes.io~empty-dir"
+)
+
+// MountPodLogs bind mounts the kubelet pod log directory under the specified empty dir volume
+func MountPodLogs(ctx context.Context, kubePodUID, emptyDirVolName, namespace, kubeName, mountLabel string) error {
+	// Validate the empty dir volume name
+	// This uses the same validation as the one in kubernetes
+	// It can be alphanumeric with dashes allowed in between
+	if errs := validation.IsDNS1123Label(emptyDirVolName); len(errs) != 0 {
+		return fmt.Errorf("empty dir vol name is invalid")
+	}
+	emptyDirLoggingVolumePath := podEmptyDirPath(kubePodUID, emptyDirVolName)
+	if _, err := os.Stat(emptyDirLoggingVolumePath); err != nil {
+		return fmt.Errorf("failed to find %v: %w", emptyDirLoggingVolumePath, err)
+	}
+	logDirMountPath := filepath.Join(emptyDirLoggingVolumePath, "logs")
+	if err := os.Mkdir(logDirMountPath, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+	podLogsDirectory := namespace + "_" + kubeName + "_" + kubePodUID
+	podLogsPath := filepath.Join(kubeletPodLogsRootDir, podLogsDirectory)
+	log.Infof(ctx, "Mounting from %s to %s for linked logs", podLogsPath, logDirMountPath)
+	if err := unix.Mount(podLogsPath, logDirMountPath, "bind", unix.MS_BIND|unix.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("failed to mount %v to %v: %w", podLogsPath, logDirMountPath, err)
+	}
+	if err := label.SetFileLabel(logDirMountPath, mountLabel); err != nil {
+		return fmt.Errorf("failed to set selinux label: %w", err)
+	}
+	return nil
+}
+
+// UnmountPodLogs unmounts the pod log directory from the specified empty dir volume
+func UnmountPodLogs(ctx context.Context, kubePodUID, emptyDirVolName string) error {
+	emptyDirLoggingVolumePath := podEmptyDirPath(kubePodUID, emptyDirVolName)
+	logDirMountPath := filepath.Join(emptyDirLoggingVolumePath, "logs")
+	log.Infof(ctx, "Unmounting %s for linked logs", logDirMountPath)
+	if _, err := os.Stat(logDirMountPath); !os.IsNotExist(err) {
+		if err := unix.Unmount(logDirMountPath, unix.MNT_DETACH); err != nil {
+			return fmt.Errorf("failed to unmounts logs: %w", err)
+		}
+	}
+	return nil
+}
+
+func podEmptyDirPath(podUID, emptyDirVolName string) string {
+	return filepath.Join(kubeletPodsRootDir, podUID, "volumes", kubeletEmptyDirLogDir, emptyDirVolName)
+}

--- a/internal/runtimehandlerhooks/high_performance_hooks.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks.go
@@ -19,10 +19,10 @@ import (
 	crioannotations "github.com/cri-o/cri-o/pkg/annotations"
 	"github.com/cri-o/cri-o/utils/cmdrunner"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/sirupsen/logrus"
 	libCtrMgr "github.com/opencontainers/runc/libcontainer/cgroups/manager"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -50,6 +50,10 @@ const (
 
 	// SeccompNotifierActionStop indicates that a container should be stopped if used via the SeccompNotifierActionAnnotation key.
 	SeccompNotifierActionStop = "stop"
+
+	// LinkLogsAnnotations indicates that CRI-O should link the pod containers logs into the specified
+	// emptyDir volume
+	LinkLogsAnnotation = "io.kubernetes.cri-o.LinkLogs"
 )
 
 var AllAllowedAnnotations = []string{
@@ -67,4 +71,5 @@ var AllAllowedAnnotations = []string{
 	CPUCStatesAnnotation,
 	CPUFreqGovernorAnnotation,
 	SeccompNotifierActionAnnotation,
+	LinkLogsAnnotation,
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -197,6 +197,7 @@ type RuntimeHandler struct {
 	// "io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
 	// "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
 	// "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
+	// "io.kubernetes.cri-o.LinkLogs" for linking logs into the pod.
 	AllowedAnnotations []string `toml:"allowed_annotations,omitempty"`
 
 	// DisallowedAnnotations is the slice of experimental annotations that are not allowed for this handler.

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -22,6 +22,7 @@ import (
 	sboxfactory "github.com/cri-o/cri-o/internal/factory/sandbox"
 	"github.com/cri-o/cri-o/internal/lib"
 	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/linklogs"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/resourcestore"
@@ -346,6 +347,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	pathsToChown := []string{}
 
 	kubeName := sbox.Config().Metadata.Name
+	kubePodUID := sbox.Config().Metadata.Uid
 	namespace := sbox.Config().Metadata.Namespace
 	attempt := sbox.Config().Metadata.Attempt
 
@@ -572,6 +574,13 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 			}
 			return nil
 		})
+	}
+
+	// Link logs if requested
+	if emptyDirVolName, ok := kubeAnnotations[ann.LinkLogsAnnotation]; ok {
+		if err = linklogs.MountPodLogs(ctx, kubePodUID, emptyDirVolName, namespace, kubeName, mountLabel); err != nil {
+			log.Warnf(ctx, "Failed to link logs: %v", err)
+		}
 	}
 
 	s.resourceStore.SetStageForResource(ctx, sbox.Name(), "sandbox spec configuration")

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -345,12 +345,14 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 
 	pathsToChown := []string{}
 
-	// we need to fill in the container name, as it is not present in the request. Luckily, it is a constant.
-	log.Infof(ctx, "Running pod sandbox: %s%s", translateLabelsToDescription(sbox.Config().Labels), oci.InfraContainerName)
-
 	kubeName := sbox.Config().Metadata.Name
 	namespace := sbox.Config().Metadata.Namespace
 	attempt := sbox.Config().Metadata.Attempt
+
+	// These fields are populated by the Kubelet, but not crictl. Populate if needed.
+	sbox.Config().Labels = populateSandboxLabels(sbox.Config().Labels, kubeName, kubePodUID, namespace)
+	// we need to fill in the container name, as it is not present in the request. Luckily, it is a constant.
+	log.Infof(ctx, "Running pod sandbox: %s%s", translateLabelsToDescription(sbox.Config().Labels), oci.InfraContainerName)
 
 	if err := sbox.SetNameAndID(); err != nil {
 		return nil, fmt.Errorf("setting pod sandbox name and id: %w", err)
@@ -1003,6 +1005,25 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	log.Infof(ctx, "Ran pod sandbox %s with infra container: %s", container.ID(), container.Description())
 	resp = &types.RunPodSandboxResponse{PodSandboxId: sbox.ID()}
 	return resp, nil
+}
+
+// populateSandboxLabels adds some fields that Kubelet specifies by default, but other clients (crictl) does not.
+// While CRI-O typically only cares about the kubelet, the cost here is low. Adding this code prevents issues
+// with the LogLink feature, as the unmounting relies on the existence of the UID in the sandbox labels.
+func populateSandboxLabels(labels map[string]string, kubeName, kubePodUID, namespace string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if _, ok := labels[kubeletTypes.KubernetesPodNameLabel]; !ok {
+		labels[kubeletTypes.KubernetesPodNameLabel] = kubeName
+	}
+	if _, ok := labels[kubeletTypes.KubernetesPodNamespaceLabel]; !ok {
+		labels[kubeletTypes.KubernetesPodNamespaceLabel] = namespace
+	}
+	if _, ok := labels[kubeletTypes.KubernetesPodUIDLabel]; !ok {
+		labels[kubeletTypes.KubernetesPodUIDLabel] = kubePodUID
+	}
+	return labels
 }
 
 func setupShm(ctx context.Context, podSandboxRunDir, mountLabel string, shmSize int64) (shmPath string, _ error) {

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/containers/storage"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/linklogs"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
+	ann "github.com/cri-o/cri-o/pkg/annotations"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error {
@@ -20,6 +23,14 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 	stopMutex := sb.StopMutex()
 	stopMutex.Lock()
 	defer stopMutex.Unlock()
+
+	// Unlink logs if they were linked
+	sbAnnotations := sb.Annotations()
+	if emptyDirVolName, ok := sbAnnotations[ann.LinkLogsAnnotation]; ok {
+		if err := linklogs.UnmountPodLogs(ctx, sb.Labels()[kubeletTypes.KubernetesPodUIDLabel], emptyDirVolName); err != nil {
+			log.Warnf(ctx, "Failed to unlink logs: %v", err)
+		}
+	}
 
 	// Clean up sandbox networking and close its network namespace.
 	if err := s.networkStop(ctx, sb); err != nil {

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1069,3 +1069,67 @@ function check_oci_annotation() {
 
 	! crictl run "$newconfig" "$TESTDATA"/sandbox_config.json
 }
+
+@test "ctr log linking" {
+	if [[ $RUNTIME_TYPE == vm ]]; then
+		skip "not applicable to vm runtime type"
+	fi
+	create_runtime_with_allowed_annotation logs io.kubernetes.cri-o.LinkLogs
+	start_crio
+
+	# Create directories created by the kubelet needed for log linking to work
+	pod_uid=$(head -c 32 /proc/sys/kernel/random/uuid)
+	pod_name=$(jq -r '.metadata.name' "$TESTDATA/sandbox_config.json")
+	pod_namespace=$(jq -r '.metadata.namespace' "$TESTDATA/sandbox_config.json")
+	pod_log_dir="/var/log/pods/${pod_namespace}_${pod_name}_${pod_uid}"
+	mkdir -p "$pod_log_dir"
+	pod_empty_dir_volume_path="/var/lib/kubelet/pods/$pod_uid/volumes/kubernetes.io~empty-dir/logging-volume"
+	mkdir -p "$pod_empty_dir_volume_path"
+	ctr_path="/mnt/logging-volume"
+
+	ctr_name=$(jq -r '.metadata.name' "$TESTDATA/container_config.json")
+	ctr_attempt=$(jq -r '.metadata.attempt' "$TESTDATA/container_config.json")
+
+	# Add annotation for log linking in the pod
+	jq --arg pod_log_dir "$pod_log_dir" --arg pod_uid "$pod_uid" '.annotations["io.kubernetes.cri-o.LinkLogs"] = "logging-volume"
+	| .log_directory = $pod_log_dir | .metadata.uid = $pod_uid' \
+		"$TESTDATA/sandbox_config.json" > "$TESTDIR/sandbox_config.json"
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_config.json)
+
+	# Touch the log file
+	mkdir -p "$pod_log_dir/$ctr_name"
+	touch "$pod_log_dir/$ctr_name/$ctr_attempt.log"
+
+	# Create a new container
+	jq --arg host_path "$pod_empty_dir_volume_path" --arg ctr_path "$ctr_path" --arg log_path "$ctr_name/$ctr_attempt.log" \
+		'	  .command = ["sh", "-c", "echo Hello log linking && sleep 1000"]
+		| .log_path = $log_path
+		| .mounts = [ {
+				host_path: $host_path,
+				container_path: $ctr_path
+			} ]' \
+		"$TESTDATA"/container_config.json > "$TESTDIR/container_config.json"
+	ctr_id=$(crictl create "$pod_id" "$TESTDIR/container_config.json" "$TESTDIR/sandbox_config.json")
+
+	# Check that the log is linked
+	ctr_log_path="$pod_log_dir/$ctr_name/$ctr_attempt.log"
+	[ -f "$ctr_log_path" ]
+	mounted_log_path="$pod_empty_dir_volume_path/logs/$ctr_name/$ctr_attempt.log"
+	[ -f "$mounted_log_path" ]
+	linked_log_path="$pod_empty_dir_volume_path/logs/$ctr_id"
+	[ -f "$linked_log_path" ]
+
+	crictl start "$ctr_id"
+
+	# Check expected file contents
+	grep -E "Hello log linking" "$mounted_log_path"
+	grep -E "Hello log linking" "$ctr_log_path"
+	grep -E "Hello log linking" "$linked_log_path"
+
+	crictl exec --sync "$ctr_id" grep -E "Hello log linking" "$ctr_path"/logs/"$ctr_id"
+
+	# Check linked logs were cleaned up
+	crictl rmp -fa
+	[ ! -f "$mounted_log_path" ]
+	[ ! -f "$linked_log_path" ]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -163,7 +163,7 @@ function setup_test() {
     CRIO_CONFIG_DIR="$TESTDIR/crio.conf.d"
     mkdir "$CRIO_CONFIG_DIR"
     CRIO_CONFIG="$TESTDIR/crio.conf"
-    CRIO_CUSTOM_CONFIG="$CRIO_CONFIG_DIR/crio-custom.conf"
+    CRIO_CUSTOM_CONFIG="$CRIO_CONFIG_DIR/00-crio-custom.conf"
     CRIO_CNI_CONFIG="$TESTDIR/cni/net.d/"
     CRIO_LOG="$TESTDIR/crio.log"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature
#### What this PR does / why we need it:
follow up of https://github.com/cri-o/cri-o/pull/6911, changing a couple of things:
- reverting a wip test change
- moving the log linking code to a separate package
- updating the test to include cleanup
- adding a feature where the directory of container logs is symlinked to the container ID to aid in log processing
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
cherry-pick of https://github.com/cri-o/cri-o/pull/6990
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add support for `io.kubernetes.cri-o.LinkLogs` annotation, which allows a pod's logs to be mounted into a specified empty-dir for inspection by a log aggregator
```
