### PR TITLE
utils: make this package build on non-linux platforms

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,21 +3,17 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"time"
 
 	"github.com/containers/podman/v4/pkg/lookup"
-	"github.com/cri-o/cri-o/internal/dbusmgr"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
 	"k8s.io/client-go/tools/remotecommand"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -29,53 +25,6 @@ import (
 // StatusToExitCode converts wait status code to an exit code
 func StatusToExitCode(status int) int {
 	return ((status) & 0xff00) >> 8
-}
-
-// RunUnderSystemdScope adds the specified pid to a systemd scope
-func RunUnderSystemdScope(mgr *dbusmgr.DbusConnManager, pid int, slice, unitName string, properties ...systemdDbus.Property) (err error) {
-	ctx := context.Background()
-	// sanity check
-	if mgr == nil {
-		return errors.New("dbus manager is nil")
-	}
-	defaultProperties := []systemdDbus.Property{
-		newProp("PIDs", []uint32{uint32(pid)}),
-		newProp("Delegate", true),
-		newProp("DefaultDependencies", false),
-	}
-	properties = append(defaultProperties, properties...)
-	if slice != "" {
-		properties = append(properties, systemdDbus.PropSlice(slice))
-	}
-	// Make a buffered channel so that the sender (go-systemd's jobComplete)
-	// won't be blocked on channel send while holding the jobListener lock
-	// (RHBZ#2082344).
-	ch := make(chan string, 1)
-	if err := mgr.RetryOnDisconnect(func(c *systemdDbus.Conn) error {
-		_, err = c.StartTransientUnitContext(ctx, unitName, "replace", properties, ch)
-		return err
-	}); err != nil {
-		return fmt.Errorf("start transient unit %q: %w", unitName, err)
-	}
-
-	// Wait for the job status.
-	select {
-	case s := <-ch:
-		close(ch)
-		if s != "done" {
-			return fmt.Errorf("error moving conmon with pid %d to systemd unit %s: got %s", pid, unitName, s)
-		}
-	case <-time.After(time.Minute * 6):
-		// This case is a work around to catch situations where the dbus library sends the
-		// request but it unexpectedly disappears. We set the timeout very high to make sure
-		// we wait as long as possible to catch situations where dbus is overwhelmed.
-		// We also don't use the native context cancelling behavior of the dbus library,
-		// because experience has shown that it does not help.
-		// TODO: Find cause of the request being dropped in the dbus library and fix it.
-		return fmt.Errorf("timed out moving conmon with pid %d to systemd unit %s", pid, unitName)
-	}
-
-	return nil
 }
 
 func newProp(name string, units interface{}) systemdDbus.Property {
@@ -361,20 +310,6 @@ func Sync(path string) error {
 	defer f.Close()
 
 	if err := f.Sync(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Syncfs ensures the file system at path is synced to disk
-func Syncfs(path string) error {
-	f, err := os.OpenFile(path, os.O_RDONLY, 0o755)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	if err := unix.Syncfs(int(f.Fd())); err != nil {
 		return err
 	}
 	return nil

--- a/utils/utils_linux.go
+++ b/utils/utils_linux.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cri-o/cri-o/internal/dbusmgr"
+	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
+
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+)
+
+// RunUnderSystemdScope adds the specified pid to a systemd scope
+func RunUnderSystemdScope(mgr *dbusmgr.DbusConnManager, pid int, slice, unitName string, properties ...systemdDbus.Property) (err error) {
+	ctx := context.Background()
+	// sanity check
+	if mgr == nil {
+		return errors.New("dbus manager is nil")
+	}
+	defaultProperties := []systemdDbus.Property{
+		newProp("PIDs", []uint32{uint32(pid)}),
+		newProp("Delegate", true),
+		newProp("DefaultDependencies", false),
+	}
+	properties = append(defaultProperties, properties...)
+	if slice != "" {
+		properties = append(properties, systemdDbus.PropSlice(slice))
+	}
+	// Make a buffered channel so that the sender (go-systemd's jobComplete)
+	// won't be blocked on channel send while holding the jobListener lock
+	// (RHBZ#2082344).
+	ch := make(chan string, 1)
+	if err := mgr.RetryOnDisconnect(func(c *systemdDbus.Conn) error {
+		_, err = c.StartTransientUnitContext(ctx, unitName, "replace", properties, ch)
+		return err
+	}); err != nil {
+		return fmt.Errorf("start transient unit %q: %w", unitName, err)
+	}
+
+	// Wait for the job status.
+	select {
+	case s := <-ch:
+		close(ch)
+		if s != "done" {
+			return fmt.Errorf("error moving conmon with pid %d to systemd unit %s: got %s", pid, unitName, s)
+		}
+	case <-time.After(time.Minute * 6):
+		// This case is a work around to catch situations where the dbus library sends the
+		// request but it unexpectedly disappears. We set the timeout very high to make sure
+		// we wait as long as possible to catch situations where dbus is overwhelmed.
+		// We also don't use the native context cancelling behavior of the dbus library,
+		// because experience has shown that it does not help.
+		// TODO: Find cause of the request being dropped in the dbus library and fix it.
+		return fmt.Errorf("timed out moving conmon with pid %d to systemd unit %s", pid, unitName)
+	}
+
+	return nil
+}
+
+// Syncfs ensures the file system at path is synced to disk
+func Syncfs(path string) error {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0o755)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := unix.Syncfs(int(f.Fd())); err != nil {
+		return err
+	}
+	return nil
+}

--- a/utils/utils_unix.go
+++ b/utils/utils_unix.go
@@ -1,0 +1,14 @@
+//go:build !linux
+// +build !linux
+
+package utils
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Syncfs ensures the file system at path is synced to disk. This seems to be a
+// linux-specific syscall - for non-linux we have to sync all filesystems.
+func Syncfs(path string) error {
+	return unix.Sync()
+}


### PR DESCRIPTION
Thie moves RunUnderSystemdScope and Syncfs to utils_linux and adds an approximation of Syncfs on non-linux platforms. Part of #6492.

#### What type of PR is this?

/kind cleanup

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
