### PR TITLE
Move reload watcher into `Server`

### DIFF
--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -4,34 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/signal"
 
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/cri-o/cri-o/internal/log"
-	"github.com/cri-o/cri-o/internal/signals"
 	"github.com/sirupsen/logrus"
 )
-
-// StartWatcher starts a new SIGHUP go routine for the current config.
-func (c *Config) StartWatcher() {
-	// Setup the signal notifier
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, signals.Hup)
-
-	go func() {
-		for {
-			// Block until the signal is received
-			<-ch
-			if err := c.Reload(); err != nil {
-				logrus.Errorf("Unable to reload configuration: %v", err)
-				continue
-			}
-		}
-	}()
-
-	logrus.Debugf("Registered SIGHUP watcher for config")
-}
 
 // Reload reloads the configuration for the single crio.conf and the drop-in
 // configuration directory.


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
We need to be able to watch other instances/caches than the configuration later on, so we now move the config scoped watcher into the server instance.

From https://github.com/cri-o/cri-o/pull/7046

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
