### PR TITLE
server: move post stop container behavior to server.go:handleExit

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -790,7 +790,6 @@ func (s *Server) handleExit(ctx context.Context, event fsnotify.Event) {
 	containerID := filepath.Base(event.Name)
 	log.Debugf(ctx, "Container or sandbox exited: %v", containerID)
 	c := s.GetContainer(ctx, containerID)
-	nriCtr := c
 	resource := "container"
 	var sb *sandbox.Sandbox
 	if c == nil {
@@ -805,26 +804,15 @@ func (s *Server) handleExit(ctx context.Context, event fsnotify.Event) {
 	}
 	log.Debugf(ctx, "%s exited and found: %v", resource, containerID)
 
-	if err := s.ContainerStateToDisk(ctx, c); err != nil {
-		log.Warnf(ctx, "Unable to write %s %s state to disk: %v", resource, c.ID(), err)
-	}
-
-	if nriCtr != nil {
-		if err := s.nri.stopContainer(ctx, nil, nriCtr); err != nil {
-			log.Warnf(ctx, "NRI stop container request of %s failed: %v", nriCtr.ID(), err)
-		}
-	}
-
 	hooks, err := runtimehandlerhooks.GetRuntimeHandlerHooks(ctx, &s.config, sb.RuntimeHandler(), sb.Annotations())
 	if err != nil {
 		log.Warnf(ctx, "Failed to get runtime handler %q hooks", sb.RuntimeHandler())
-	} else if hooks != nil {
-		if err := hooks.PostStop(ctx, c, sb); err != nil {
-			log.Errorf(ctx, "Failed to run post-stop hook for container %s: %v", c.ID(), err)
-		}
 	}
 
-	s.generateCRIEvent(ctx, c, types.ContainerEventType_CONTAINER_STOPPED_EVENT)
+	if err := s.postStopContainer(ctx, c, sb, hooks); err != nil {
+		log.Warnf(ctx, "Failed to do post stop container tasks: %v", err)
+	}
+
 	if err := os.Remove(event.Name); err != nil {
 		log.Warnf(ctx, "Failed to remove exit file: %v", err)
 	}

--- a/test/nri/nri_test.go
+++ b/test/nri/nri_test.go
@@ -128,7 +128,7 @@ func TestContainerEvents(stdT *testing.T) {
 	require.NotNil(t, p.WaitEvent(PostStartContainerEvent(pod, ctr), timeout), "container post-start event")
 
 	t.stopContainer(ctr)
-	require.NotNil(t, p.WaitEvent(StopContainerEvent(pod, ctr), 0), "container stop event")
+	require.NotNil(t, p.WaitEvent(StopContainerEvent(pod, ctr), timeout), "container stop event")
 
 	t.removeContainer(ctr)
 	require.NotNil(t, p.WaitEvent(RemoveContainerEvent(pod, ctr), 0), "container removal event")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
Currently, we're duplicating a lot of the container stop operations. Whenever a container stops, conmon will write the exit file
and CRI-O should catch the exit, no matter whether it was triggered by CRI-O or happened naturally.

Not adding these will prevent duplicated work like UpdateContainerStatus, which calls `runc update` and is not negligible.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reduce duplicated work in container stops
```
