### PR TITLE
Bump bats in ci jobs to latest release

### DIFF
--- a/contrib/test/ci/build/bats.yml
+++ b/contrib/test/ci/build/bats.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/bats-core/bats-core.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/bats-core/bats-core"
-    version: v1.6.0
+    version: v1.9.0
 
 - name: install bats
   command: "./install.sh /usr/local"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -73,6 +73,8 @@ dependencies:
       match: bats
     - path: contrib/test/integration/build/bats.yml
       match: version
+    - path: contrib/test/ci/build/bats.yml
+      match: version
 
   - name: zeitgeist
     version: 0.4.1


### PR DESCRIPTION


#### What type of PR is this?


/kind ci

#### What this PR does / why we need it:
The `pull-ci-cri-o-cri-o-main-ci-fedora-integration` test is complaining about the wrong bats version:

```
/usr/go/src/github.com/cri-o/cri-o/test/./helpers.bash: line 4: bats_require_minimum_version: command not found
```

We should keep them in sync which is now enforced via `dependencies.yaml`.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
