### PR TITLE
[1.25] server: do not take lock to populate pid in container status and inspect

### DIFF
--- a/server/container_status.go
+++ b/server/container_status.go
@@ -122,7 +122,7 @@ func (s *Server) createContainerInfo(container *oci.Container) (map[string]strin
 		Privileged  bool      `json:"privileged"`
 	}{
 		container.Sandbox(),
-		container.State().Pid,
+		container.StateNoLock().Pid,
 		container.Spec(),
 		metadata.Privileged,
 	}

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -65,7 +65,7 @@ func (s *Server) getContainerInfo(id string, getContainerFunc, getInfraContainer
 		isInfra = true
 	}
 	// TODO(mrunalp): should we call UpdateStatus()?
-	ctrState := ctr.State()
+	ctrState := ctr.StateNoLock()
 	if ctrState == nil {
 		return types.ContainerInfo{}, errCtrStateNil
 	}
@@ -75,7 +75,7 @@ func (s *Server) getContainerInfo(id string, getContainerFunc, getInfraContainer
 		return types.ContainerInfo{}, errSandboxNotFound
 	}
 
-	pidToReturn := ctrState.Pid
+	pidToReturn := ctrState.InitPid
 	if isInfra && pidToReturn == 0 {
 		// It is possible the infra container doesn't report a PID.
 		// That can either happen if we're using a vm based runtime,

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -54,11 +54,9 @@ func TestGetContainerInfo(t *testing.T) {
 		}
 		container.SetMountPoint("/var/foo/container")
 		cstate := &oci.ContainerState{}
-		cstate.State = specs.State{
-			Pid: 42,
-		}
+		cstate.State = specs.State{}
 		cstate.Created = created
-		container.SetState(cstate)
+		container.SetStateAndSpoofPid(cstate)
 		return container
 	}
 	getInfraContainerFunc := func(id string) *oci.Container {
@@ -76,8 +74,8 @@ func TestGetContainerInfo(t *testing.T) {
 	if ci.CreatedTime != created.UnixNano() {
 		t.Fatalf("expected same created time %d, got %d", created.UnixNano(), ci.CreatedTime)
 	}
-	if ci.Pid != 42 {
-		t.Fatalf("expected pid 42, got %v", ci.Pid)
+	if ci.Pid != 1 {
+		t.Fatalf("expected pid 1, got %v", ci.Pid)
 	}
 	if ci.Name != "testname" {
 		t.Fatalf("expected name testname, got %s", ci.Name)


### PR DESCRIPTION
This is a manual cherry-pick of #6925

/assign haircommander

```release-note
Fix a bug where sending information to cadvisor is stalled on taking the container's state lock
```