### PR TITLE
Fix filemode for device

### DIFF
--- a/internal/factory/container/device.go
+++ b/internal/factory/container/device.go
@@ -115,12 +115,13 @@ func (c *container) specAddContainerConfigDevices(enableDeviceOwnershipFromSecur
 		// if there was no error, return the device
 		if err == nil {
 			rd := rspec.LinuxDevice{
-				Path:  device.ContainerPath,
-				Type:  string(dev.Type),
-				Major: dev.Major,
-				Minor: dev.Minor,
-				UID:   getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsUser, dev.Uid, enableDeviceOwnershipFromSecurityContext),
-				GID:   getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsGroup, dev.Gid, enableDeviceOwnershipFromSecurityContext),
+				Path:     device.ContainerPath,
+				Type:     string(dev.Type),
+				Major:    dev.Major,
+				Minor:    dev.Minor,
+				FileMode: &dev.FileMode,
+				UID:      getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsUser, dev.Uid, enableDeviceOwnershipFromSecurityContext),
+				GID:      getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsGroup, dev.Gid, enableDeviceOwnershipFromSecurityContext),
 			}
 			c.Spec().AddDevice(rd)
 			sp.Linux.Resources.Devices = append(sp.Linux.Resources.Devices, rspec.LinuxDeviceCgroup{
@@ -151,12 +152,13 @@ func (c *container) specAddContainerConfigDevices(enableDeviceOwnershipFromSecur
 					}
 					cPath := strings.Replace(dpath, path, device.ContainerPath, 1)
 					rd := rspec.LinuxDevice{
-						Path:  cPath,
-						Type:  string(childDevice.Type),
-						Major: childDevice.Major,
-						Minor: childDevice.Minor,
-						UID:   &childDevice.Uid,
-						GID:   &childDevice.Gid,
+						Path:     cPath,
+						Type:     string(childDevice.Type),
+						Major:    childDevice.Major,
+						Minor:    childDevice.Minor,
+						FileMode: &childDevice.FileMode,
+						UID:      &childDevice.Uid,
+						GID:      &childDevice.Gid,
 					}
 					c.Spec().AddDevice(rd)
 					sp.Linux.Resources.Devices = append(sp.Linux.Resources.Devices, rspec.LinuxDeviceCgroup{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When running a container with the kata runtime and setting up a block device, the device appears in the container with permissions set to 0.
The kata agent, creating this device in the VM, is applying the file mode provided in the spec file by cri-o - this field is not filled by cri-o, and defaults to 0.

This PR makes sure that the device's permission is provided in the spec, so that the agent can apply them appropriately.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue preventing the use of block devices with kata containers
```
