### PR TITLE
Fix ImageRef field for containers to default to an image ID

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -237,9 +237,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 
 	imageName := imgResult.Name
 	imageRef := imgResult.ID
-	if len(imgResult.RepoDigests) > 0 {
-		imageRef = imgResult.RepoDigests[0]
-	}
 
 	labelOptions, err := ctr.SelinuxLabel(sb.ProcessLabel())
 	if err != nil {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -211,7 +211,7 @@ function check_images() {
     eval "$(jq -r '.images[] |
         select(.repoTags[0] == "quay.io/crio/fedora-crio-ci:latest") |
         "REDIS_IMAGEID=" + .id + "\n" +
-	"REDIS_IMAGEREF=" + .repoDigests[0]' <<<"$json")"
+	"REDIS_IMAGEREF=" + .id' <<<"$json")"
 }
 
 function start_crio_no_setup() {

--- a/test/image.bats
+++ b/test/image.bats
@@ -79,7 +79,6 @@ function teardown() {
 
 	output=$(crictl inspect -o yaml "$ctr_id")
 	[[ "$output" == *"image: $IMAGE_LIST_DIGEST"* ]]
-	[[ "$output" == *"imageRef: $IMAGE_LIST_DIGEST"* ]]
 }
 
 @test "image pull and list" {


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
When restoring containers, then we always restore an image ID based on the annotation. When creating containers, then we use the first digest with a higher priority than the image ID. We now streamline this behavior by always using an image ID.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes https://github.com/cri-o/cri-o/issues/7143
Refers to https://github.com/kubernetes-incubator/cri-o/issues/531
#### Special notes for your reviewer:
cc @QiWang19 @mtrmac @nalind 

The change got introduced in https://github.com/cri-o/cri-o/pull/1116/commits/f3b7065bd80a53e4c48e8c45c36dcb86717e1578#diff-1ec6bb9cf833fd4ded46ce1feb6440f1d7532294e0445623f2f2e0bb2726ea63L976-R975


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where `ImageRef` refers to a digest rather than an image ID, which negatively impacted kubelets garbage collection.
```
