### PR TITLE
add version_bump.go script to automate the release pipeline

### DIFF
--- a/scripts/version_bump.go
+++ b/scripts/version_bump.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	var bumpType string
+	var versionFile string
+
+	// Define command-line flags for bump type and version file
+	flag.StringVar(&bumpType, "bump", "", "Version bump type: major, minor, or patch")
+	flag.StringVar(&versionFile, "f", "../internal/version/version.go", "Path to the version file")
+	flag.Parse()
+
+	// Read the current version from the version.go file
+	currentVersion, err := getCurrentVersion(versionFile)
+	if err != nil {
+		fmt.Printf("Error reading current version: %q\n", err)
+		os.Exit(1)
+	}
+
+	// Bump the version based on the specified type (major, minor, or patch)
+	newVersion := bumpVersion(currentVersion, bumpType)
+
+	// Update the version in the version.go file
+	if err := updateVersion(versionFile, newVersion); err != nil {
+		fmt.Printf("Error updating version: %q\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Version bumped from %q to %q\n", currentVersion, newVersion)
+}
+
+func getCurrentVersion(versionFile string) (string, error) {
+	versionPattern := `const\s+Version\s+=\s+"(.+)"`
+
+	// Read the content of the version file
+	content, err := os.ReadFile(versionFile)
+	if err != nil {
+		return "", err
+	}
+
+	// Find the version string using regex
+	re := regexp.MustCompile(versionPattern)
+	matches := re.FindStringSubmatch(string(content))
+	if len(matches) < 2 {
+		return "", fmt.Errorf("unable to find version in %q", versionFile)
+	}
+
+	return matches[1], nil
+}
+
+func bumpVersion(version, bumpType string) string {
+	parts := strings.Split(version, ".")
+
+	switch bumpType {
+	case "major":
+		parts[0] = incrementVersionPart(parts[0])
+		parts[1] = "0"
+		parts[2] = "0"
+	case "minor":
+		parts[1] = incrementVersionPart(parts[1])
+		parts[2] = "0"
+	case "patch":
+		parts[2] = incrementVersionPart(parts[2])
+	default:
+		parts[2] = incrementVersionPart(parts[2])
+	}
+
+	return strings.Join(parts, ".")
+}
+
+func incrementVersionPart(part string) string {
+	// Convert the part to an integer, increment it, and convert back to string
+	num, err := strconv.Atoi(part)
+	if err != nil {
+		return "0"
+	}
+	num++
+	return strconv.Itoa(num)
+}
+
+func updateVersion(versionFile, newVersion string) error {
+	versionPattern := `const\s+Version\s+=\s+".+"`
+
+	// Read the content of the version file
+	content, err := os.ReadFile(versionFile)
+	if err != nil {
+		return err
+	}
+
+	// Replace the version string with the new version using regex
+	re := regexp.MustCompile(versionPattern)
+	newContent := re.ReplaceAll(content, []byte(fmt.Sprintf(`const Version = %q`, newVersion)))
+
+	// Write the updated content back to the version file
+	if err := os.WriteFile(versionFile, newContent, 0o644); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
This PR adds the ```version_bump.go``` script to automatically bump the version in internal/version/version.go file.
/kind feature

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
We needed this feature to automate the version bumping using GitHub actions. This script has little use as of now, but as per issue https://github.com/cri-o/cri-o/issues/4003 this script would be used in the CI environment of GitHub actions to change the version and create pull requests.

#### Which issue(s) this PR fixes:
fixes #7169 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
This script is designed to work as below:

- run the command ```go run scripts/version_bump.go```
- The version inside the internal/version/version.go would be changed. For example: 1.2.3 to 1.2.4

It also supports additional arguments like:
- ```go run scripts/version_bump.go patch``` for patch bump. Example: 1.2.3 to 1.2.4
- ```go run scripts/version_bump.go minor``` for minor bump. Example: 1.2.3 to 1.3.0
- ```go run scripts/version_bump.go major``` for major bump. Example: 1.2.3 to 2.0.0

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add version bump automation script
```
