### PR TITLE
[1.27] Revert "Fix filemode for device"

### DIFF
--- a/internal/factory/container/device.go
+++ b/internal/factory/container/device.go
@@ -115,13 +115,12 @@ func (c *container) specAddContainerConfigDevices(enableDeviceOwnershipFromSecur
 		// if there was no error, return the device
 		if err == nil {
 			rd := rspec.LinuxDevice{
-				Path:     device.ContainerPath,
-				Type:     string(dev.Type),
-				Major:    dev.Major,
-				Minor:    dev.Minor,
-				FileMode: &dev.FileMode,
-				UID:      getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsUser, dev.Uid, enableDeviceOwnershipFromSecurityContext),
-				GID:      getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsGroup, dev.Gid, enableDeviceOwnershipFromSecurityContext),
+				Path:  device.ContainerPath,
+				Type:  string(dev.Type),
+				Major: dev.Major,
+				Minor: dev.Minor,
+				UID:   getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsUser, dev.Uid, enableDeviceOwnershipFromSecurityContext),
+				GID:   getDeviceUserGroupID(c.Config().Linux.SecurityContext.RunAsGroup, dev.Gid, enableDeviceOwnershipFromSecurityContext),
 			}
 			c.Spec().AddDevice(rd)
 			sp.Linux.Resources.Devices = append(sp.Linux.Resources.Devices, rspec.LinuxDeviceCgroup{
@@ -152,13 +151,12 @@ func (c *container) specAddContainerConfigDevices(enableDeviceOwnershipFromSecur
 					}
 					cPath := strings.Replace(dpath, path, device.ContainerPath, 1)
 					rd := rspec.LinuxDevice{
-						Path:     cPath,
-						Type:     string(childDevice.Type),
-						Major:    childDevice.Major,
-						Minor:    childDevice.Minor,
-						FileMode: &childDevice.FileMode,
-						UID:      &childDevice.Uid,
-						GID:      &childDevice.Gid,
+						Path:  cPath,
+						Type:  string(childDevice.Type),
+						Major: childDevice.Major,
+						Minor: childDevice.Minor,
+						UID:   &childDevice.Uid,
+						GID:   &childDevice.Gid,
 					}
 					c.Spec().AddDevice(rd)
 					sp.Linux.Resources.Devices = append(sp.Linux.Resources.Devices, rspec.LinuxDeviceCgroup{


### PR DESCRIPTION
This commit caused issue for non-root access to block devices

```release-note
Revert kata containers block devices fix because it prevents non-root users from accessing block devices (where they were previously able to)
```