### PR TITLE
feat(cmdrunner): add support for context

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -409,12 +409,13 @@ func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []stri
 
 	args := r.defaultRuntimeArgs()
 	args = append(args, "exec", "--process", processFile, c.ID())
-	execCmd := cmdrunner.Command(c.RuntimePathForPlatform(r), args...) // nolint: gosec
+	execCmd := cmdrunner.CommandContext(ctx, c.RuntimePathForPlatform(r), args...) // nolint: gosec
 	if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
 		execCmd.Env = append(execCmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", v))
 	}
 	var cmdErr, copyError error
 	if tty {
+		execCmd.WaitDelay = 30 * time.Second
 		cmdErr = ttyCmd(execCmd, stdin, stdout, resizeChan)
 	} else {
 		var r, w *os.File

--- a/test/mocks/cmdrunner/cmdrunner.go
+++ b/test/mocks/cmdrunner/cmdrunner.go
@@ -5,6 +5,7 @@
 package cmdrunnermock
 
 import (
+	context "context"
 	exec "os/exec"
 	reflect "reflect"
 
@@ -71,4 +72,23 @@ func (mr *MockCommandRunnerMockRecorder) Command(arg0 interface{}, arg1 ...inter
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommandRunner)(nil).Command), varargs...)
+}
+
+// CommandContext mocks base method.
+func (m *MockCommandRunner) CommandContext(arg0 context.Context, arg1 string, arg2 ...string) *exec.Cmd {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CommandContext", varargs...)
+	ret0, _ := ret[0].(*exec.Cmd)
+	return ret0
+}
+
+// CommandContext indicates an expected call of CommandContext.
+func (mr *MockCommandRunnerMockRecorder) CommandContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommandContext", reflect.TypeOf((*MockCommandRunner)(nil).CommandContext), varargs...)
 }

--- a/utils/cmdrunner/cmdrunner.go
+++ b/utils/cmdrunner/cmdrunner.go
@@ -1,6 +1,7 @@
 package cmdrunner
 
 import (
+	"context"
 	"os/exec"
 )
 
@@ -13,6 +14,7 @@ var commandRunner CommandRunner
 // It gives the option to change the way commands are run server-wide.
 type CommandRunner interface {
 	Command(string, ...string) *exec.Cmd
+	CommandContext(context.Context, string, ...string) *exec.Cmd
 	CombinedOutput(string, ...string) ([]byte, error)
 }
 
@@ -55,6 +57,16 @@ func Command(cmd string, args ...string) *exec.Cmd {
 	return commandRunner.Command(cmd, args...)
 }
 
+// CommandContext calls CommandContext on the defined commandRunner,
+// or the default implementation in the exec package if there's no commandRunner defined.
+func CommandContext(ctx context.Context, cmd string, args ...string) *exec.Cmd {
+	if commandRunner == nil {
+		return exec.CommandContext(ctx, cmd, args...)
+	}
+
+	return commandRunner.CommandContext(ctx, cmd, args...)
+}
+
 // Command creates an exec.Cmd object. If prependCmd is defined, the command will be prependCmd
 // and the args will be prependArgs + cmd + args.
 // Otherwise, cmd and args will be as inputted.
@@ -68,6 +80,21 @@ func (c *prependableCommandRunner) Command(cmd string, args ...string) *exec.Cmd
 		realArgs = append(realArgs, args...)
 	}
 	return exec.Command(realCmd, realArgs...)
+}
+
+// CommandContext creates an exec.Cmd object. If prependCmd is defined, the command will be prependCmd
+// and the args will be prependArgs + cmd + args.
+// Otherwise, cmd and args will be as inputted.
+func (c *prependableCommandRunner) CommandContext(ctx context.Context, cmd string, args ...string) *exec.Cmd {
+	realCmd := cmd
+	realArgs := args
+	if c.prependCmd != "" {
+		realCmd = c.prependCmd
+		realArgs = c.prependArgs
+		realArgs = append(realArgs, cmd)
+		realArgs = append(realArgs, args...)
+	}
+	return exec.CommandContext(ctx, realCmd, realArgs...)
 }
 
 // GetPrependedCmd returns the prepended command if one is configured, else the empty string


### PR DESCRIPTION
Support passing context through to *exec.Command by adding CommandContext to the CommandRunner interface. This allows context cancellation to terminate the running command.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Support creating an `*exec.Command` with a context, and link the lifetime of commands started by `ExecContainer` to that of the passed in context.

#### Which issue(s) this PR fixes:

#6699 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
