### PR TITLE
Add Kubernetes package test for static binary bundle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           pushFilter: cri-o
       - run: nix-build nix/default-arm64.nix
-      - run: file result/bin/crio
+      - run: file result/bin/crio | grep aarch64
       - uses: actions/upload-artifact@v3
         with:
           name: build-static-arm64
@@ -172,7 +172,7 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           pushFilter: cri-o
       - run: nix-build nix/default-ppc64le.nix
-      - run: file result/bin/crio
+      - run: file result/bin/crio | grep PowerPC
       - uses: actions/upload-artifact@v3
         with:
           name: build-static-ppc64le
@@ -257,6 +257,22 @@ jobs:
           name: bundle
           path: build/bundle
       - run: make bundle-test-e2e-conmonrs
+
+  bundle-test-kubernetes:
+    runs-on: macos-12
+    needs: bundles
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.vagrant.d/boxes
+          key: e2e-fedora-${{ hashFiles('hack/ci/Vagrantfile-fedora') }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: bundle
+          path: build/bundle
+      - run: make bundle-test-kubernetes
 
   sign-artifacts:
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')

--- a/Makefile
+++ b/Makefile
@@ -443,6 +443,9 @@ bundle-test-e2e:
 bundle-test-e2e-conmonrs:
 	sudo contrib/bundle/test-e2e --use-conmonrs
 
+bundle-test-kubernetes:
+	cd contrib/bundle && vagrant up
+
 bundles: ${BOM}
 	contrib/bundle/build amd64
 	contrib/bundle/build arm64

--- a/contrib/bundle/Vagrantfile
+++ b/contrib/bundle/Vagrantfile
@@ -1,0 +1,61 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2204"
+  memory = 6144
+  cpus = 4
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.provider :libvirt do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.synced_folder "../../", "/vagrant"
+
+  config.vm.provision "install-dependencies", type: "shell", run: "once" do |sh|
+    sh.inline = <<~SHELL
+      set -euxo pipefail
+
+      # Use a non-localhost DNS to avoid cluster DNS lookup loops
+      echo "nameserver 8.8.8.8" > /etc/resolv.conf
+
+      # CRI-O
+      pushd /vagrant
+      source contrib/bundle/vars
+      pushd "$ARCHIVE_PATH"
+      tar xfvz "$ARCHIVE"
+      pushd cri-o
+      ./install
+      systemctl enable --now crio.service
+
+      # Kubernetes
+      KUBERNETES_VERSION=v1.28
+      curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
+      apt-get update
+      apt-get install -y kubelet kubeadm kubectl
+
+      # Cluster
+      IP=`ip route get 1.2.3.4 | cut -d ' ' -f7 | tr -d '[:space:]'`
+      NODENAME=$(hostname -s)
+      swapoff -a
+      modprobe br_netfilter
+      sysctl -w net.ipv4.ip_forward=1
+      kubeadm init --apiserver-cert-extra-sans=$IP --node-name $NODENAME
+
+      # Check cluster
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+      kubectl wait -n kube-system --timeout=180s --for=condition=available deploy coredns
+      kubectl wait --timeout=180s --for=condition=ready pods --all -A
+      kubectl get pods -A
+      kubectl run -i --restart=Never --image debian --rm debian -- echo test | grep test
+    SHELL
+  end
+end

--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -37,6 +37,7 @@ FILES_ETC=(
     "$GIT_ROOT/contrib/bundle/10-crun.conf"
 )
 FILES_CONTRIB=(
+    "$GIT_ROOT/contrib/bundle/registries.conf"
     "$GIT_ROOT/contrib/cni/11-crio-ipv4-bridge.conflist"
     "$GIT_ROOT/contrib/policy.json"
     "$GIT_ROOT/contrib/systemd/crio.service"
@@ -185,7 +186,7 @@ $BOM validate -e "$SPDX_PATH" -d "$CRIODIR"
 pushd "$TMPDIR"
 export DESTDIR=test/
 ./install
-EXP_CNT=66
+EXP_CNT=67
 if ! command -v runc; then
     EXP_CNT=$((EXP_CNT + 1))
 fi

--- a/contrib/bundle/install
+++ b/contrib/bundle/install
@@ -21,10 +21,17 @@ install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man8" man/crio.8
 install $SELINUX -D -m 644 -t "$DESTDIR$BASHINSTALLDIR" completions/bash/crio
 install $SELINUX -D -m 644 -t "$DESTDIR$FISHINSTALLDIR" completions/fish/crio.fish
 install $SELINUX -D -m 644 -t "$DESTDIR$ZSHINSTALLDIR" completions/zsh/_crio
-install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/policy.json
 install $SELINUX -D -m 644 -t "$DESTDIR$SYSTEMDDIR" contrib/crio.service
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/pinns
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crun
+
+if [ ! -f "$DESTDIR$CONTAINERS_DIR/policy.json" ]; then
+    install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/policy.json
+fi
+
+if [ ! -f "$DESTDIR$CONTAINERS_DIR/registries.conf" ]; then
+    install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/registries.conf
+fi
 
 # only install runc if it's not already in the path
 if ! command -v runc; then

--- a/contrib/bundle/registries.conf
+++ b/contrib/bundle/registries.conf
@@ -1,0 +1,9 @@
+[registries]
+[registries.block]
+registries = []
+
+[registries.insecure]
+registries = []
+
+[registries.search]
+registries = ["docker.io", "quay.io"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -122,3 +122,9 @@ dependencies:
     refPaths:
       - path: Makefile
         match: GOSEC_VERSION
+
+  - name: Kubernetes
+    version: v1.28
+    refPaths:
+      - path: contrib/bundle/Vagrantfile
+        match: KUBERNETES_VERSION

--- a/scripts/get
+++ b/scripts/get
@@ -243,10 +243,17 @@ install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man8" man/crio.8
 install $SELINUX -D -m 644 -t "$DESTDIR$BASHINSTALLDIR" completions/bash/crio
 install $SELINUX -D -m 644 -t "$DESTDIR$FISHINSTALLDIR" completions/fish/crio.fish
 install $SELINUX -D -m 644 -t "$DESTDIR$ZSHINSTALLDIR" completions/zsh/_crio
-install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/policy.json
 install $SELINUX -D -m 644 -t "$DESTDIR$SYSTEMDDIR" contrib/crio.service
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/pinns
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crun
+
+if [ ! -f "$DESTDIR$CONTAINERS_DIR/policy.json" ]; then
+    install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/policy.json
+fi
+
+if [ ! -f "$DESTDIR$CONTAINERS_DIR/registries.conf" ]; then
+    install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/registries.conf
+fi
 
 # only install runc if it's not already in the path
 if ! command -v runc; then


### PR DESCRIPTION
#### What type of PR is this?


/kind ci

#### What this PR does / why we need it:
This test ensures a basic working setup for kubeadm bootstrapped clusters using the official packages.

We also have to add a default `registries.conf` to the bundle to make it work. As follow-up we will remove non-required binaries like the CNI plugins (no installed in parallel to the official packages).

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/7280
#### Special notes for your reviewer:
The tests `get-script` and `get-script-with-verification` should become green after merge.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added default `registries.conf` to static binary bundle, which gets installed if not existing.
Only install `policy.json` from bundle if not existing.
```
