### PR TITLE
[1.25] Generate `/etc/shadow` together with `/etc/passwd`

### DIFF
--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -207,9 +207,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file isn't created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "root")
@@ -226,9 +227,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file isn't created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon")
@@ -245,9 +247,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file isn't created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "25")
@@ -264,9 +267,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should not be empty because an updated /etc/passwd file is created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).ToNot(BeEmpty())
+			Expect(shadowFile).ToNot(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300")
@@ -290,9 +294,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file is not created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon:mail")
@@ -309,9 +314,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file is not created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "2:22")
@@ -328,9 +334,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file is not created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon:250")
@@ -347,9 +354,14 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should not be empty because an updated /etc/passwd file is created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).ToNot(BeEmpty())
+			Expect(shadowFile).ToNot(BeEmpty())
+
+			shadowContent, err := os.ReadFile(shadowFile)
+			Expect(err).To(BeNil())
+			Expect(shadowContent).To(ContainSubstring("default:!::0:::::"))
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:250")
@@ -366,9 +378,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should not be empty because an updated /etc/passwd file is created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).ToNot(BeEmpty())
+			Expect(shadowFile).ToNot(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:mail")
@@ -413,6 +426,35 @@ ntp:x:123:123:NTP:/var/empty:/sbin/nologin
 smmsp:x:209:209:smmsp:/var/spool/mqueue:/sbin/nologin
 guest:x:405:100:guest:/dev/null:/sbin/nologin
 nobody:x:65534:65534:nobody:/:/sbin/nologin`
+
+	alpineShadowFile := `root:*::0:::::
+bin:!::0:::::
+daemon:!::0:::::
+adm:!::0:::::
+lp:!::0:::::
+sync:!::0:::::
+shutdown:!::0:::::
+halt:!::0:::::
+mail:!::0:::::
+news:!::0:::::
+uucp:!::0:::::
+operator:!::0:::::
+man:!::0:::::
+postmaster:!::0:::::
+cron:!::0:::::
+ftp:!::0:::::
+sshd:!::0:::::
+at:!::0:::::
+squid:!::0:::::
+xfs:!::0:::::
+games:!::0:::::
+cyrus:!::0:::::
+vpopmail:!::0:::::
+ntp:!::0:::::
+smmsp:!::0:::::
+guest:!::0:::::
+nobody:!::0:::::
+`
 
 	alpineGroupFile := `root:x:0:root
 bin:x:1:root,bin,daemon
@@ -468,6 +510,8 @@ nobody:x:65534:`
 	err = os.Mkdir(filepath.Join(dir, "etc"), 0o755)
 	Expect(err).To(BeNil())
 	err = os.WriteFile(filepath.Join(dir, "etc", "passwd"), []byte(alpinePasswdFile), 0o755)
+	Expect(err).To(BeNil())
+	err = os.WriteFile(filepath.Join(dir, "etc", "shadow"), []byte(alpineShadowFile), 0o640)
 	Expect(err).To(BeNil())
 	err = os.WriteFile(filepath.Join(dir, "etc", "group"), []byte(alpineGroupFile), 0o755)
 	Expect(err).To(BeNil())


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:

This synchronizes the modifications done to `/etc/passwd` to the containers `/etc/shadow` file

#### Which issue(s) this PR fixes:

Refers to: https://issues.redhat.com/browse/OCPBUGS-17421

#### Special notes for your reviewer:

/hold

For feedback.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Generate `/etc/shadow` together with `/etc/passwd` within the container if required.
```
