### PR TITLE
Removed UpdateContainerStatus function

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1016,7 +1016,7 @@ func (s *Server) generateCRIEvent(ctx context.Context, container *oci.Container,
 	if !s.config.EnablePodEvents {
 		return
 	}
-	
+
 	if !s.HasSandbox(container.Sandbox()) {
 		return
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1016,11 +1016,7 @@ func (s *Server) generateCRIEvent(ctx context.Context, container *oci.Container,
 	if !s.config.EnablePodEvents {
 		return
 	}
-	if err := s.Runtime().UpdateContainerStatus(ctx, container); err != nil {
-		log.Errorf(ctx, "GenerateCRIEvent: event type: %s, failed to update the container status %s: %v", eventType, container.ID(), err)
-		return
-	}
-
+	
 	if !s.HasSandbox(container.Sandbox()) {
 		return
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

Checking evented_pleg feature's functionality.

#### Which issue(s) this PR fixes:
Fixes #6465
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
