### PR TITLE
WIP: Generate `/etc/shadow` together with `/etc/passwd`

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/containers/podman/v4/pkg/lookup"
+	"github.com/cri-o/cri-o/internal/log"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/sirupsen/logrus"
@@ -196,41 +198,41 @@ func GetUserInfo(rootfs, userName string) (uid, gid uint32, additionalGids []uin
 
 // GeneratePasswd generates a container specific passwd file,
 // iff uid is not defined in the containers /etc/passwd
-func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir string) (string, error) {
+func GeneratePasswd(ctx context.Context, username string, uid, gid uint32, homedir, rootfs, rundir string) (passwdFile, shadowFile string, err error) {
 	// if UID exists inside of container rootfs /etc/passwd then
 	// don't generate passwd
 	if _, err := lookup.GetUser(rootfs, strconv.Itoa(int(uid))); err == nil {
-		return "", nil
+		return "", "", nil
 	}
-	passwdFile := filepath.Join(rundir, "passwd")
+	passwdFile = filepath.Join(rundir, "passwd")
 	originPasswdFile, err := securejoin.SecureJoin(rootfs, "/etc/passwd")
 	if err != nil {
-		return "", fmt.Errorf("unable to follow symlinks to passwd file: %w", err)
+		return "", "", fmt.Errorf("unable to follow symlinks to passwd file: %w", err)
 	}
 	var st unix.Stat_t
 	err = unix.Stat(originPasswdFile, &st)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", nil
+			return "", "", nil
 		}
-		return "", fmt.Errorf("unable to stat passwd file %s: %w", originPasswdFile, err)
+		return "", "", fmt.Errorf("unable to stat passwd file %s: %w", originPasswdFile, err)
 	}
 	// Check if passwd file is world writable.
 	if st.Mode&0o022 != 0 {
-		return "", nil
+		return "", "", nil
 	}
 
 	if uid == st.Uid && st.Mode&0o200 != 0 {
-		return "", nil
+		return "", "", nil
 	}
 
 	orig, err := os.ReadFile(originPasswdFile)
 	if err != nil {
 		// If no /etc/passwd in container ignore and return
 		if os.IsNotExist(err) {
-			return "", nil
+			return "", "", nil
 		}
-		return "", fmt.Errorf("read passwd file: %w", err)
+		return "", "", fmt.Errorf("read passwd file: %w", err)
 	}
 	if username == "" {
 		username = "default"
@@ -240,13 +242,49 @@ func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir st
 	}
 	pwd := fmt.Sprintf("%s%s:x:%d:%d:%s user:%s:/sbin/nologin\n", orig, username, uid, gid, username, homedir)
 	if err := os.WriteFile(passwdFile, []byte(pwd), os.FileMode(st.Mode)&os.ModePerm); err != nil {
-		return "", fmt.Errorf("failed to create temporary passwd file: %w", err)
+		return "", "", fmt.Errorf("failed to create temporary passwd file: %w", err)
 	}
 	if err := os.Chown(passwdFile, int(st.Uid), int(st.Gid)); err != nil {
-		return "", fmt.Errorf("failed to chown temporary passwd file: %w", err)
+		return "", "", fmt.Errorf("failed to chown temporary passwd file: %w", err)
 	}
 
-	return passwdFile, nil
+	// Update /etc/shadow accordingly if present
+	originShadowFile, err := securejoin.SecureJoin(rootfs, "/etc/shadow")
+	if err != nil {
+		log.Debugf(ctx, "Unable to follow symlink to shadow file: %v", err)
+		return passwdFile, "", nil
+	}
+	var sts unix.Stat_t
+	if err := unix.Stat(originShadowFile, &sts); err != nil {
+		if os.IsNotExist(err) {
+			log.Debugf(ctx, "Shadow file does not exist")
+			return passwdFile, "", nil
+		}
+		log.Debugf(ctx, "Unable to stat shadow file: %v", err)
+		return passwdFile, "", nil
+	}
+
+	origShadowFileContent, err := os.ReadFile(originShadowFile)
+	if err != nil {
+		// If no /etc/shadow in container ignore and return
+		if os.IsNotExist(err) {
+			log.Debugf(ctx, "No shadow file in container, ignoring")
+			return passwdFile, "", nil
+		}
+		log.Debugf(ctx, "Unable to read shadow file: %v", err)
+		return passwdFile, "", nil
+	}
+	newShadowFileContent := fmt.Sprintf("%s%s:!::0:::::\n", origShadowFileContent, username)
+	shadowFile = filepath.Join(rundir, "shadow")
+	if err := os.WriteFile(shadowFile, []byte(newShadowFileContent), os.FileMode(sts.Mode)&os.ModePerm); err != nil {
+		log.Debugf(ctx, "Unable to write shadow file: %v", err)
+		return passwdFile, "", nil
+	}
+	if err := os.Chown(shadowFile, int(sts.Uid), int(sts.Gid)); err != nil {
+		return passwdFile, "", nil
+	}
+
+	return passwdFile, shadowFile, nil
 }
 
 // Int32Ptr is a utility function to assign to integer pointer variables

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -207,9 +208,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file isn't created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd(context.Background(), "", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "root")
@@ -226,9 +228,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file isn't created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd(context.Background(), "", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon")
@@ -245,9 +248,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file isn't created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd(context.Background(), "", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "25")
@@ -264,9 +268,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should not be empty because an updated /etc/passwd file is created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd(context.Background(), "", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).ToNot(BeEmpty())
+			Expect(shadowFile).ToNot(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300")
@@ -290,9 +295,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file is not created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd(context.Background(), "", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon:mail")
@@ -309,9 +315,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file is not created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd(context.Background(), "", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "2:22")
@@ -328,9 +335,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should be empty because an updated /etc/passwd file is not created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd(context.Background(), "", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+			Expect(shadowFile).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon:250")
@@ -347,9 +355,14 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should not be empty because an updated /etc/passwd file is created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd(context.Background(), "", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).ToNot(BeEmpty())
+			Expect(shadowFile).ToNot(BeEmpty())
+
+			shadowContent, err := os.ReadFile(shadowFile)
+			Expect(err).To(BeNil())
+			Expect(shadowContent).To(ContainSubstring("default:!::0:::::"))
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:250")
@@ -366,9 +379,10 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 
 			// passwdFile should not be empty because an updated /etc/passwd file is created.
-			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
+			passwdFile, shadowFile, err := utils.GeneratePasswd(context.Background(), "", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).ToNot(BeEmpty())
+			Expect(shadowFile).ToNot(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:mail")
@@ -413,6 +427,35 @@ ntp:x:123:123:NTP:/var/empty:/sbin/nologin
 smmsp:x:209:209:smmsp:/var/spool/mqueue:/sbin/nologin
 guest:x:405:100:guest:/dev/null:/sbin/nologin
 nobody:x:65534:65534:nobody:/:/sbin/nologin`
+
+	alpineShadowFile := `root:*::0:::::
+bin:!::0:::::
+daemon:!::0:::::
+adm:!::0:::::
+lp:!::0:::::
+sync:!::0:::::
+shutdown:!::0:::::
+halt:!::0:::::
+mail:!::0:::::
+news:!::0:::::
+uucp:!::0:::::
+operator:!::0:::::
+man:!::0:::::
+postmaster:!::0:::::
+cron:!::0:::::
+ftp:!::0:::::
+sshd:!::0:::::
+at:!::0:::::
+squid:!::0:::::
+xfs:!::0:::::
+games:!::0:::::
+cyrus:!::0:::::
+vpopmail:!::0:::::
+ntp:!::0:::::
+smmsp:!::0:::::
+guest:!::0:::::
+nobody:!::0:::::
+`
 
 	alpineGroupFile := `root:x:0:root
 bin:x:1:root,bin,daemon
@@ -468,6 +511,8 @@ nobody:x:65534:`
 	err = os.Mkdir(filepath.Join(dir, "etc"), 0o755)
 	Expect(err).To(BeNil())
 	err = os.WriteFile(filepath.Join(dir, "etc", "passwd"), []byte(alpinePasswdFile), 0o755)
+	Expect(err).To(BeNil())
+	err = os.WriteFile(filepath.Join(dir, "etc", "shadow"), []byte(alpineShadowFile), 0o640)
 	Expect(err).To(BeNil())
 	err = os.WriteFile(filepath.Join(dir, "etc", "group"), []byte(alpineGroupFile), 0o755)
 	Expect(err).To(BeNil())


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:

This synchronizes the modifications done to `/etc/passwd` to the containers `/etc/shadow` file.

#### Which issue(s) this PR fixes:

Refers to: https://issues.redhat.com/browse/OCPBUGS-17421, https://github.com/cri-o/cri-o/pull/7239
#### Special notes for your reviewer:

/hold

For feedback.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Generate `/etc/shadow` together with `/etc/passwd` within the container if required.
```
