### PR TITLE
Add dependabot group for OTEL deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
   labels:
     - "release-note-none"
   open-pull-requests-limit: 10
+  groups:
+    opentelemetry:
+      patterns:
+        - "go.opentelemetry.io/*"
+        - "github.com/uptrace/opentelemetry-go-extra/*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
This allows updating the opentelemetry dependencies in a single PR.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/pull/7259, https://github.com/cri-o/cri-o/pull/7258, https://github.com/cri-o/cri-o/pull/7260, https://github.com/cri-o/cri-o/pull/7261
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
