### PR TITLE
CRIO changes to support split filesystem 

### DIFF
--- a/server/image_fs_info_test.go
+++ b/server/image_fs_info_test.go
@@ -24,6 +24,7 @@ var _ = t.Describe("ImageFsInfo", func() {
 			gomock.InOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().GraphRoot().Return(""),
+				storeMock.EXPECT().ImageStore().Return(""),
 				storeMock.EXPECT().GraphDriverName().Return("test"),
 			)
 			testImageDir := "test-images"
@@ -37,6 +38,7 @@ var _ = t.Describe("ImageFsInfo", func() {
 			Expect(err).To(BeNil())
 			Expect(response).NotTo(BeNil())
 			Expect(len(response.ImageFilesystems)).To(BeEquivalentTo(1))
+			Expect(len(response.ContainerFilesystems)).To(BeEquivalentTo(1))
 		})
 
 		It("should fail on invalid image dir", func() {
@@ -44,6 +46,7 @@ var _ = t.Describe("ImageFsInfo", func() {
 			gomock.InOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().GraphRoot().Return(""),
+				storeMock.EXPECT().ImageStore().Return(""),
 				storeMock.EXPECT().GraphDriverName().Return(""),
 			)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind api-change
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
Implement Image_Fs_Info as part of the separate gc KEP.  We should not merge unless this KEP is approved.  TODO: Add a link.  

Opening this up now to gather feedback on feasibility of this implementation.

Note, since I had a few changes in other areas, I vendored these changes here.  I already opened up a PR into c/storage.  Kubernetes is based on KEP approval.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
We are having some problems with the integration tests picking up an older version of crictl. I moved the integration tests to https://github.com/cri-o/cri-o/pull/7269 just to move this PR through.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added more file system information in `ImageFsInfo` as part of the garbage collection KEP.
```
