### PR TITLE
Remove golang-go from debian installation

### DIFF
--- a/install.md
+++ b/install.md
@@ -337,7 +337,6 @@ apt install -y  \
   btrfs-tools \
   containers-common \
   git \
-  golang-go \
   libassuan-dev \
   libdevmapper-dev \
   libglib2.0-dev \
@@ -364,7 +363,6 @@ apt-get update -qq && apt-get install -y \
   libbtrfs-dev \
   containers-common \
   git \
-  golang-go \
   libassuan-dev \
   libdevmapper-dev \
   libglib2.0-dev \


### PR DESCRIPTION
Using `apt-get install golang-go` on Debian/Ubuntu will end up with an older golang version, which will result in multiple errors while installing `cri-o`. 
If Go is already installed, it will shadow the installed version and change the env variables to point to the `apt-get` installed version ( an older version of Go) 
See: https://stackoverflow.com/questions/17480044/how-to-install-the-current-version-of-go-in-ubuntu-precise#comment38681257_17566846

#### What type of PR is this?

/kind documentation

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md

```release-note
None
```

