### PR TITLE
Add parameter validation checkpoint CRI call

### DIFF
--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -142,3 +142,11 @@ function teardown() {
 	[[ "$container_name" == "restored-sleep-container" ]]
 	[[ "$pod_name" == "restoresandbox2" ]]
 }
+
+@test "checkpoint one container into non-existing directory" {
+	CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	run ! crictl checkpoint --export=/does/not/exist/cp.tar "$ctr_id"
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

As Kubernetes always uses the checkpoint CRI call with the 'Location' parameter set, there was never a problem not checking if the parameter is set or not. It was, however, possible to use the checkpoint CRI call via crictl without specifying the 'Location' parameter. Latest crictl has a check to ensure 'Location' is set, but to avoid unexpected and undefined behaviour, this changes CRI-O to early check if 'Location' is set and if not CRI-O will return an error.

#### Which issue(s) this PR fixes:

This is another way to fix https://github.com/kubernetes-sigs/cri-tools/issues/1235

Now the existence of the required parameter is fixed in `crictl` and CRI-O

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```