### PR TITLE
[1.28] config/server: add functions to check IDMap support in runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc4
 	github.com/opencontainers/runc v1.1.9
-	github.com/opencontainers/runtime-spec v1.1.0
+	github.com/opencontainers/runtime-spec v1.1.1-0.20230823135140-4fec88fd00a4
 	github.com/opencontainers/runtime-tools v0.9.1-0.20230317050512-e931285f4b69
 	github.com/opencontainers/selinux v1.11.0
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1648,8 +1648,8 @@ github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bll4AjJ9odEGpg=
-github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.1.1-0.20230823135140-4fec88fd00a4 h1:EctkgBjZ1y4q+sibyuuIgiKpa0QSd2elFtSSdNvBVow=
+github.com/opencontainers/runtime-spec v1.1.1-0.20230823135140-4fec88fd00a4/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/runtime-tools v0.9.1-0.20230317050512-e931285f4b69 h1:NL4xDvl68WWqQ+8WPMM3l5PsZTxaT7Z4K3VSKDRuAGs=
 github.com/opencontainers/runtime-tools v0.9.1-0.20230317050512-e931285f4b69/go.mod h1:bNpfuSHA3DZRtD0TPWO8LzgtLpFPTVA/3jDkzD/OPyk=

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -181,6 +181,17 @@ func (r *Runtime) RuntimeType(runtimeHandler string) (string, error) {
 	return rh.RuntimeType, nil
 }
 
+// RuntimeSupportsIDMap returns whether the runtime of runtimeHandler supports the "runtime features"
+// command, and that the output of that command advertises IDMapped mounts as an option
+func (r *Runtime) RuntimeSupportsIDMap(runtimeHandler string) bool {
+	rh, err := r.getRuntimeHandler(runtimeHandler)
+	if err != nil {
+		return false
+	}
+
+	return rh.RuntimeSupportsIDMap()
+}
+
 func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
 	rh, err := r.getRuntimeHandler(c.runtimeHandler)
 	if err != nil {

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/features/features.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/features/features.go
@@ -1,0 +1,139 @@
+// Package features provides the Features struct.
+package features
+
+// Features represents the supported features of the runtime.
+type Features struct {
+	// OCIVersionMin is the minimum OCI Runtime Spec version recognized by the runtime, e.g., "1.0.0".
+	OCIVersionMin string `json:"ociVersionMin,omitempty"`
+
+	// OCIVersionMax is the maximum OCI Runtime Spec version recognized by the runtime, e.g., "1.0.2-dev".
+	OCIVersionMax string `json:"ociVersionMax,omitempty"`
+
+	// Hooks is the list of the recognized hook names, e.g., "createRuntime".
+	// Nil value means "unknown", not "no support for any hook".
+	Hooks []string `json:"hooks,omitempty"`
+
+	// MountOptions is the list of the recognized mount options, e.g., "ro".
+	// Nil value means "unknown", not "no support for any mount option".
+	// This list does not contain filesystem-specific options passed to mount(2) syscall as (const void *).
+	MountOptions []string `json:"mountOptions,omitempty"`
+
+	// Linux is specific to Linux.
+	Linux *Linux `json:"linux,omitempty"`
+
+	// Annotations contains implementation-specific annotation strings,
+	// such as the implementation version, and third-party extensions.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// Linux is specific to Linux.
+type Linux struct {
+	// Namespaces is the list of the recognized namespaces, e.g., "mount".
+	// Nil value means "unknown", not "no support for any namespace".
+	Namespaces []string `json:"namespaces,omitempty"`
+
+	// Capabilities is the list of the recognized capabilities , e.g., "CAP_SYS_ADMIN".
+	// Nil value means "unknown", not "no support for any capability".
+	Capabilities []string `json:"capabilities,omitempty"`
+
+	Cgroup          *Cgroup          `json:"cgroup,omitempty"`
+	Seccomp         *Seccomp         `json:"seccomp,omitempty"`
+	Apparmor        *Apparmor        `json:"apparmor,omitempty"`
+	Selinux         *Selinux         `json:"selinux,omitempty"`
+	IntelRdt        *IntelRdt        `json:"intelRdt,omitempty"`
+	MountExtensions *MountExtensions `json:"mountExtensions,omitempty"`
+}
+
+// Cgroup represents the "cgroup" field.
+type Cgroup struct {
+	// V1 represents whether Cgroup v1 support is compiled in.
+	// Unrelated to whether the host uses cgroup v1 or not.
+	// Nil value means "unknown", not "false".
+	V1 *bool `json:"v1,omitempty"`
+
+	// V2 represents whether Cgroup v2 support is compiled in.
+	// Unrelated to whether the host uses cgroup v2 or not.
+	// Nil value means "unknown", not "false".
+	V2 *bool `json:"v2,omitempty"`
+
+	// Systemd represents whether systemd-cgroup support is compiled in.
+	// Unrelated to whether the host uses systemd or not.
+	// Nil value means "unknown", not "false".
+	Systemd *bool `json:"systemd,omitempty"`
+
+	// SystemdUser represents whether user-scoped systemd-cgroup support is compiled in.
+	// Unrelated to whether the host uses systemd or not.
+	// Nil value means "unknown", not "false".
+	SystemdUser *bool `json:"systemdUser,omitempty"`
+
+	// Rdma represents whether RDMA cgroup support is compiled in.
+	// Unrelated to whether the host supports RDMA or not.
+	// Nil value means "unknown", not "false".
+	Rdma *bool `json:"rdma,omitempty"`
+}
+
+// Seccomp represents the "seccomp" field.
+type Seccomp struct {
+	// Enabled is true if seccomp support is compiled in.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Actions is the list of the recognized actions, e.g., "SCMP_ACT_NOTIFY".
+	// Nil value means "unknown", not "no support for any action".
+	Actions []string `json:"actions,omitempty"`
+
+	// Operators is the list of the recognized operators, e.g., "SCMP_CMP_NE".
+	// Nil value means "unknown", not "no support for any operator".
+	Operators []string `json:"operators,omitempty"`
+
+	// Archs is the list of the recognized archs, e.g., "SCMP_ARCH_X86_64".
+	// Nil value means "unknown", not "no support for any arch".
+	Archs []string `json:"archs,omitempty"`
+
+	// KnownFlags is the list of the recognized filter flags, e.g., "SECCOMP_FILTER_FLAG_LOG".
+	// Nil value means "unknown", not "no flags are recognized".
+	KnownFlags []string `json:"knownFlags,omitempty"`
+
+	// SupportedFlags is the list of the supported filter flags, e.g., "SECCOMP_FILTER_FLAG_LOG".
+	// This list may be a subset of KnownFlags due to some flags
+	// not supported by the current kernel and/or libseccomp.
+	// Nil value means "unknown", not "no flags are supported".
+	SupportedFlags []string `json:"supportedFlags,omitempty"`
+}
+
+// Apparmor represents the "apparmor" field.
+type Apparmor struct {
+	// Enabled is true if AppArmor support is compiled in.
+	// Unrelated to whether the host supports AppArmor or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// Selinux represents the "selinux" field.
+type Selinux struct {
+	// Enabled is true if SELinux support is compiled in.
+	// Unrelated to whether the host supports SELinux or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// IntelRdt represents the "intelRdt" field.
+type IntelRdt struct {
+	// Enabled is true if Intel RDT support is compiled in.
+	// Unrelated to whether the host supports Intel RDT or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// MountExtensions represents the "mountExtensions" field.
+type MountExtensions struct {
+	// IDMap represents the status of idmap mounts support.
+	IDMap *IDMap `json:"idmap,omitempty"`
+}
+
+type IDMap struct {
+	// Enabled represents whether idmap mounts supports is compiled in.
+	// Unrelated to whether the host supports it or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "+dev"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1015,9 +1015,10 @@ github.com/opencontainers/runc/libcontainer/devices
 github.com/opencontainers/runc/libcontainer/user
 github.com/opencontainers/runc/libcontainer/userns
 github.com/opencontainers/runc/libcontainer/utils
-# github.com/opencontainers/runtime-spec v1.1.0
+# github.com/opencontainers/runtime-spec v1.1.1-0.20230823135140-4fec88fd00a4
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
+github.com/opencontainers/runtime-spec/specs-go/features
 # github.com/opencontainers/runtime-tools v0.9.1-0.20230317050512-e931285f4b69
 ## explicit; go 1.19
 github.com/opencontainers/runtime-tools/generate


### PR DESCRIPTION
This is a backport of #7289 as the [automatic backport failed][link] due to changes in go.sum.

I don't know if the project uses manual backports, but doing it in case it helps, as time is pressing to get this in a new release. Feel free to close this if another solution is better :)

I've also tested this locally in this branch, all works fine.

cc @haircommander 

[link]: https://github.com/cri-o/cri-o/pull/7289#issuecomment-1714750921
---


if we don't, we risk container creation failures or security holes from the runtime not correctly setting up idmaps

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

For the 1.28 release branch it:
Fixes: #7262 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Check the runtime supports IDMap support before specifying it
```
