### PR TITLE
docs: Update the containers/image branch name

### DIFF
--- a/install.md
+++ b/install.md
@@ -582,7 +582,7 @@ registries = []
 ```
 <!-- markdownlint-enable MD013 -->
 
-For more information about this file see [registries.conf(5)](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md).
+For more information about this file see [registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md).
 
 ### Optional - Modify verbosity of logs
 

--- a/tutorials/kubeadm.md
+++ b/tutorials/kubeadm.md
@@ -48,7 +48,7 @@ user.private.repo/etcd:3.4.3-0
 user.private.repo/coredns:1.6.7
 ```
 
-The user needs to configure the [registries.conf](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md)
+The user needs to configure the [registries.conf](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)
 file.
 
 Sample of configurations:


### PR DESCRIPTION
Branch master was renamed to main, update it directly without the help of github page redirection.

/kind documentation

```release-note
None
```
