### PR TITLE
Simplify, and optimize, ImageServer.ResolveNames

### DIFF
--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -793,7 +793,7 @@ func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageN
 		}
 	}
 
-	// Disable short name alias mode. Will enable it once we settle on a shortname alias table.
+	// Always resolve unqualified names to all candidates. We should use a more secure mode once we settle on a shortname alias table.
 	disabled := types.ShortNameModeDisabled
 	systemContext.ShortNameMode = &disabled
 	resolved, err := shortnames.Resolve(systemContext, imageName)

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -792,11 +792,6 @@ func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageN
 			return []string{img.ID}, nil
 		}
 	}
-	// This to prevent any image ID to go through this routine
-	_, err := reference.ParseNormalizedNamed(imageName)
-	if err != nil {
-		return nil, err
-	}
 
 	// Disable short name alias mode. Will enable it once we settle on a shortname alias table.
 	disabled := types.ShortNameModeDisabled

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -794,9 +794,13 @@ func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageN
 	}
 
 	// Always resolve unqualified names to all candidates. We should use a more secure mode once we settle on a shortname alias table.
+	sc := types.SystemContext{}
+	if systemContext != nil {
+		sc = *systemContext // A shallow copy
+	}
 	disabled := types.ShortNameModeDisabled
-	systemContext.ShortNameMode = &disabled
-	resolved, err := shortnames.Resolve(systemContext, imageName)
+	sc.ShortNameMode = &disabled
+	resolved, err := shortnames.Resolve(&sc, imageName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -786,7 +786,7 @@ func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageN
 		return []string{imageName}, nil // If it is already a full image ID, there’s nothing to do.
 	}
 	if len(imageName) >= minimumTruncatedIDLength {
-		if img, err := svc.store.Image(imageName); err == nil && img != nil && strings.HasPrefix(img.ID, imageName) {
+		if img, err := svc.store.Image(imageName); err == nil && strings.HasPrefix(img.ID, imageName) {
 			// It's a truncated version of the ID of an image that's present in local storage;
 			// we need to expand it.
 			return []string{img.ID}, nil

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -786,7 +786,7 @@ func (svc *imageLookupService) isSecureIndex(indexName string) bool {
 // ResolveNames resolves an image name into a storage image ID or a fully-qualified image name (domain/repo/image:tag).
 // Will only return an empty slice if err != nil.
 func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageName string) ([]string, error) {
-	// _Maybe_ it's a truncated image ID.  Don't prepend a registry name, then.
+	// _Maybe_ it's a truncated image ID, or an image ID that refers to a locally-present image.  Don't prepend a registry name, then.
 	if len(imageName) >= minimumTruncatedIDLength && svc.store != nil {
 		if img, err := svc.store.Image(imageName); err == nil && img != nil && strings.HasPrefix(img.ID, imageName) {
 			// It's a truncated version of the ID of an image that's present in local storage;

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -42,12 +42,8 @@ const (
 	minimumTruncatedIDLength = 3
 )
 
-var (
-	// ErrCannotParseImageID is returned when we try to ResolveNames for an image ID
-	ErrCannotParseImageID = errors.New("cannot parse an image ID")
-	// ErrImageMultiplyTagged is returned when we try to remove an image that still has multiple names
-	ErrImageMultiplyTagged = errors.New("image still has multiple names applied")
-)
+// ErrCannotParseImageID is returned when we try to ResolveNames for an image ID
+var ErrCannotParseImageID = errors.New("cannot parse an image ID")
 
 // ImageResult wraps a subset of information about an image: its ID, its names,
 // and the size, if known, or nil if it isn't.

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -41,9 +40,6 @@ import (
 const (
 	minimumTruncatedIDLength = 3
 )
-
-// ErrCannotParseImageID is returned when we try to ResolveNames for an image ID
-var ErrCannotParseImageID = errors.New("cannot parse an image ID")
 
 // ImageResult wraps a subset of information about an image: its ID, its names,
 // and the size, if known, or nil if it isn't.
@@ -797,8 +793,8 @@ func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageN
 	// This to prevent any image ID to go through this routine
 	_, err := reference.ParseNormalizedNamed(imageName)
 	if err != nil {
-		if strings.Contains(err.Error(), "cannot specify 64-byte hexadecimal strings") {
-			return nil, ErrCannotParseImageID
+		if reference.IsFullIdentifier(imageName) {
+			return []string{imageName}, nil
 		}
 		return nil, err
 	}

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -785,7 +785,7 @@ func (svc *imageService) ResolveNames(systemContext *types.SystemContext, imageN
 	if reference.IsFullIdentifier(imageName) {
 		return []string{imageName}, nil // If it is already a full image ID, there’s nothing to do.
 	}
-	if len(imageName) >= minimumTruncatedIDLength && svc.store != nil {
+	if len(imageName) >= minimumTruncatedIDLength {
 		if img, err := svc.store.Image(imageName); err == nil && img != nil && strings.HasPrefix(img.ID, imageName) {
 			// It's a truncated version of the ID of an image that's present in local storage;
 			// we need to expand it.

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -259,20 +259,19 @@ var _ = t.Describe("Image", func() {
 			Expect(names[0]).To(Equal(testImageName))
 		})
 
-		It("should fail to resolve with invalid image id", func() {
+		It("should succeed to resolve with a locally-not-matching image id", func() {
 			// Given
 			gomock.InOrder(
-				storeMock.EXPECT().Image(gomock.Any()).
-					Return(&cs.Image{ID: testImageName}, nil),
+				storeMock.EXPECT().Image(testSHA256).
+					Return(nil, cs.ErrImageUnknown),
 			)
 
 			// When
 			names, err := sut.ResolveNames(ctx, testSHA256)
 
 			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(err).To(Equal(storage.ErrCannotParseImageID))
-			Expect(names).To(BeNil())
+			Expect(err).To(BeNil())
+			Expect(names[0]).To(Equal(testSHA256))
 		})
 
 		It("should fail to resolve with invalid registry name", func() {

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -261,10 +261,7 @@ var _ = t.Describe("Image", func() {
 
 		It("should succeed to resolve with a locally-not-matching image id", func() {
 			// Given
-			gomock.InOrder(
-				storeMock.EXPECT().Image(testSHA256).
-					Return(nil, cs.ErrImageUnknown),
-			)
+			gomock.InOrder()
 
 			// When
 			names, err := sut.ResolveNames(ctx, testSHA256)

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -213,11 +213,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	}
 	images, err := s.StorageImageServer().ResolveNames(s.config.SystemContext, image)
 	if err != nil {
-		if err == storage.ErrCannotParseImageID {
-			images = append(images, image)
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	// Get imageName and imageRef that are later requested in container status

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/signature"
 	imageTypes "github.com/containers/image/v5/types"
 	"github.com/cri-o/cri-o/internal/log"
@@ -155,6 +156,9 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 		images []string
 		pulled string
 	)
+	if reference.IsFullIdentifier(pullArgs.image) {
+		return "", errors.New("cannot parse an image ID")
+	}
 	images, err = s.StorageImageServer().ResolveNames(s.config.SystemContext, pullArgs.image)
 	if err != nil {
 		return "", err

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/signature"
 	imageTypes "github.com/containers/image/v5/types"
 	"github.com/cri-o/cri-o/internal/log"
@@ -156,9 +155,6 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 		images []string
 		pulled string
 	)
-	if reference.IsFullIdentifier(pullArgs.image) {
-		return "", errors.New("cannot parse an image ID")
-	}
 	images, err = s.StorageImageServer().ResolveNames(s.config.SystemContext, pullArgs.image)
 	if err != nil {
 		return "", err

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/cri-o/cri-o/internal/log"
-	"github.com/cri-o/cri-o/internal/storage"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -34,11 +33,7 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) error {
 
 	images, err := s.StorageImageServer().ResolveNames(s.config.SystemContext, imageRef)
 	if err != nil {
-		if err == storage.ErrCannotParseImageID {
-			images = append(images, imageRef)
-		} else {
-			return err
-		}
+		return err
 	}
 	for _, img := range images {
 		err = s.StorageImageServer().UntagImage(s.config.SystemContext, img)

--- a/server/image_remove_test.go
+++ b/server/image_remove_test.go
@@ -3,7 +3,6 @@ package server_test
 import (
 	"context"
 
-	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,18 +36,20 @@ var _ = t.Describe("ImageRemove", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should succeed when image id cannot be parsed", func() {
-			// Given
+		// Given
+		It("should succeed with a full image id", func() {
+			const testSHA256 = "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"
 			gomock.InOrder(
 				imageServerMock.EXPECT().ResolveNames(
-					gomock.Any(), gomock.Any()).
-					Return(nil, storage.ErrCannotParseImageID),
-				imageServerMock.EXPECT().UntagImage(gomock.Any(),
-					gomock.Any()).Return(nil),
+					gomock.Any(), testSHA256).
+					Return([]string{testSHA256}, nil),
+				imageServerMock.EXPECT().UntagImage(
+					gomock.Any(), testSHA256).
+					Return(nil),
 			)
 			// When
 			_, err := sut.RemoveImage(context.Background(),
-				&types.RemoveImageRequest{Image: &types.ImageSpec{Image: "image"}})
+				&types.RemoveImageRequest{Image: &types.ImageSpec{Image: testSHA256}})
 
 			// Then
 			Expect(err).To(BeNil())

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -32,11 +32,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 	log.Infof(ctx, "Checking image status: %s", image)
 	images, err := s.StorageImageServer().ResolveNames(s.config.SystemContext, image)
 	if err != nil {
-		if err == pkgstorage.ErrCannotParseImageID {
-			images = append(images, image)
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	var (
 		notfound bool

--- a/server/image_status_test.go
+++ b/server/image_status_test.go
@@ -89,20 +89,20 @@ var _ = t.Describe("ImageStatus", func() {
 			))
 		})
 
-		It("should succeed with wrong image id", func() {
+		It("should succeed with a full image ID", func() {
+			const testSHA256 = "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(
-					gomock.Any(), gomock.Any()).
-					Return(nil, storage.ErrCannotParseImageID),
+				imageServerMock.EXPECT().ResolveNames(gomock.Any(), testSHA256).
+					Return([]string{testSHA256}, nil),
 				imageServerMock.EXPECT().ImageStatus(
-					gomock.Any(), gomock.Any()).
-					Return(&storage.ImageResult{ID: "image", User: "me"}, nil),
+					gomock.Any(), testSHA256).
+					Return(&storage.ImageResult{ID: testSHA256, User: "me"}, nil),
 			)
 
 			// When
 			response, err := sut.ImageStatus(context.Background(),
-				&types.ImageStatusRequest{Image: &types.ImageSpec{Image: "image"}})
+				&types.ImageStatusRequest{Image: &types.ImageSpec{Image: testSHA256}})
 
 			// Then
 			Expect(err).To(BeNil())


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As a prerequisite of work on sigstore signature signing (earlier #7046), I need to tighten how CRI-O refers to images, to use types and values with strict semantics. That significantly revolves around the values consumed and returned by `ResolveNames`; I will want to completely replace that with code more explicit about the semantics/heuristics.

Let’s start with some baby steps:
- Eliminate the `ErrCannotParseImageID` special error, which almost all callers special-case exactly the same way. Instead, have `ResolveNames` do what the callers need.
- This allows optimizing out one c/storage lookup (= 2 FS lock hits), when starting a container from an already-pulled image or when deleting an image by Kubelet’s GC
- Also fix some other smaller bugs and remove unnecessary code.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

See individual commit messages for details.

#### Does this PR introduce a user-facing change?

```release-note
None
```
