### PR TITLE
Add OBS package build jobs

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -1,0 +1,44 @@
+name: obs
+on:
+  schedule:
+    - cron: "0 0 * * *"
+env:
+  GO_VERSION: '1.21'
+jobs:
+  obs-test-ubuntu:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.vagrant.d/boxes
+          key: obs-test-${{ hashFiles('test/obs/ubuntu/Vagrantfile') }}
+      - run: cd test/obs/ubuntu && vagrant up
+
+  obs-test-fedora:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.vagrant.d/boxes
+          key: obs-test-${{ hashFiles('test/obs/fedora/Vagrantfile') }}
+      - run: cd test/obs/fedora && vagrant up
+
+  obs-release:
+    runs-on: ubuntu-latest
+    needs:
+      - obs-test-fedora
+      - obs-test-ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Release OBS package
+        run: scripts/obs
+        env:
+          RELEASE: 1
+          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,6 +441,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           DRY_RUN: false
+
   codeql-build:
     runs-on: ubuntu-latest
     permissions:
@@ -466,3 +467,19 @@ jobs:
         run: make verify-govulncheck
       - name: Run Gosec
         run: make verify-gosec
+
+  obs-build:
+    if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    needs: upload-artifacts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Get release version
+        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Build OBS package
+        run: scripts/obs
+        env:
+          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -136,3 +136,19 @@ dependencies:
     refPaths:
       - path: contrib/bundle/Vagrantfile
         match: KUBERNETES_VERSION
+      - path: test/obs/fedora/Vagrantfile
+        match: KUBERNETES_VERSION
+      - path: test/obs/ubuntu/Vagrantfile
+        match: KUBERNETES_VERSION
+
+  - name: OSC
+    version: 1.3.1
+    refPaths:
+      - path: scripts/obs
+        match: OSC_VERSION
+
+  - name: Development package version
+    version: 1.29.0-dev
+    refPaths:
+      - path: scripts/obs
+        match: DEV_PACKAGE_VERSION

--- a/scripts/obs
+++ b/scripts/obs
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+# Setup a tmp work dir
+TMPDIR="$(mktemp -d)"
+trap 'sudo rm -rf -- "$TMPDIR"' EXIT
+pushd "$TMPDIR"
+
+# Package options
+TEMPLATE_DIR=cmd/krel/templates/latest
+PACKAGE=cri-o
+DEV_PACKAGE_VERSION="1.29.0-dev"
+PROJECT_ROOT=isv:kubernetes:addons:cri-o
+VERSION=${VERSION:-}
+RELEASE=${RELEASE:-0}
+COMMIT=
+
+curl_retry() {
+    curl -sSfL --retry 5 --retry-delay 3 "$@"
+}
+
+# Change the project based on the provided version
+if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    PROJECT_VERSION=$(echo "$VERSION" | cut -c1-5)
+    VERSION=${VERSION#v}
+    PROJECT=$PROJECT_ROOT:stable:$PROJECT_VERSION:build
+else
+    COMMIT=$(curl_retry https://storage.googleapis.com/cri-o/latest-main.txt)
+    VERSION=$DEV_PACKAGE_VERSION
+    PROJECT=$PROJECT_ROOT:prerelease:main:build
+fi
+
+export OBS_USERNAME=cri-o-release-bot
+
+krel() {
+    go run ./cmd/krel "$@"
+}
+
+setup_krel() {
+    git clone --depth 1 https://github.com/kubernetes/release
+    pushd release
+    krel version
+}
+
+install_osc() {
+    OSC_VERSION=1.3.1
+    curl_retry https://github.com/openSUSE/osc/archive/refs/tags/$OSC_VERSION.tar.gz -o- | tar xfz -
+    pushd osc-$OSC_VERSION
+    sudo ./setup.py build
+    sudo ./setup.py install
+    popd
+}
+
+obs_stage() {
+    if [[ "$COMMIT" != "" ]]; then
+        # Patch the package metadata to download the latest commit
+        sed -i 's;gs://cri-o/artifacts/cri-o.{{ .Architecture }}.v{{ .PackageVersion }}.tar.gz;gs://cri-o/artifacts/cri-o.{{ .Architecture }}.'"$COMMIT"'.tar.gz;g' $TEMPLATE_DIR/metadata.yaml
+    fi
+
+    # Push the sources
+    krel obs stage \
+        --workspace . \
+        --template-dir $TEMPLATE_DIR \
+        --packages $PACKAGE \
+        --project "$PROJECT" \
+        --version "$VERSION" \
+        --architectures amd64,arm64,ppc64le \
+        --submit=false \
+        --nomock
+}
+
+obs_release() {
+    krel obs release \
+        --workspace . \
+        --template-dir "$TEMPLATE_DIR" \
+        --packages $PACKAGE \
+        --project "$PROJECT" \
+        --submit=false \
+        --nomock
+}
+
+install_osc
+setup_krel
+
+if [[ $RELEASE == 0 ]]; then
+    obs_stage
+else
+    obs_release
+fi

--- a/test/obs/fedora/Vagrantfile
+++ b/test/obs/fedora/Vagrantfile
@@ -1,0 +1,89 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrant box for testing
+Vagrant.configure("2") do |config|
+  config.vm.box = "fedora/38-cloud-base"
+  memory = 8192
+  cpus = 4
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.provider :libvirt do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
+  config.vm.provision "install-dependencies", type: "shell", run: "once" do |sh|
+    sh.inline = <<~SHELL
+      set -euxo pipefail
+
+      # Use a non-localhost DNS to avoid cluster DNS lookup loops
+      echo "nameserver 8.8.8.8" > /etc/resolv.conf
+
+      KUBERNETES_VERSION=v1.28
+      cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/rpm/repodata/repomd.xml.key
+EOF
+
+      cat <<EOF | tee /etc/yum.repos.d/cri-o.repo
+[cri-o]
+name=CRI-O
+baseurl=https://pkgs.k8s.io/addons:/cri-o:/prerelease:/main:/build/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/addons:/cri-o:/prerelease:/main:/build/rpm/repodata/repomd.xml.key
+EOF
+
+      dnf install -y \
+        cri-o \
+        container-selinux \
+        kubeadm \
+        kubectl \
+        kubelet \
+        kubernetes-cni
+
+      systemctl enable --now crio.service
+
+      dnf remove -y \
+        zram-generator-defaults
+
+      hostnamectl set-hostname fedora
+
+      # Configure system to work seamlessly on single node clusters
+      modprobe br_netfilter
+      ip6tables --list >/dev/null
+      iptables -F
+      sysctl -w net.ipv4.conf.all.route_localnet=1
+      sysctl -w net.ipv4.ip_forward=1
+      sysctl -w net.bridge.bridge-nf-call-iptables=1
+      sysctl -w fs.inotify.max_user_watches=1048576
+      iptables -t nat -I POSTROUTING -s 127.0.0.0/8 ! -d 127.0.0.0/8 -j MASQUERADE
+      systemctl stop dev-zram0.swap
+      swapoff -a
+
+      # Cluster
+      IP=`ip route get 1.2.3.4 | cut -d ' ' -f7 | tr -d '[:space:]'`
+      NODENAME=$(hostname -s)
+      kubeadm init --apiserver-cert-extra-sans=$IP --node-name $NODENAME
+
+      # Check cluster
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+      kubectl wait -n kube-system --timeout=180s --for=condition=available deploy coredns
+      kubectl wait --timeout=180s --for=condition=ready pods --all -A
+      kubectl get pods -A
+      kubectl run -i --restart=Never --image debian --rm debian -- echo test | grep test
+    SHELL
+  end
+end

--- a/test/obs/ubuntu/Vagrantfile
+++ b/test/obs/ubuntu/Vagrantfile
@@ -1,0 +1,57 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2204"
+  memory = 6144
+  cpus = 4
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.provider :libvirt do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
+  config.vm.provision "install-dependencies", type: "shell", run: "once" do |sh|
+    sh.inline = <<~SHELL
+      set -euxo pipefail
+
+      # Use a non-localhost DNS to avoid cluster DNS lookup loops
+      echo "nameserver 8.8.8.8" > /etc/resolv.conf
+
+      # Package configs
+      KUBERNETES_VERSION=v1.28
+      curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
+      curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/prerelease:/main:/build/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://pkgs.k8s.io/addons:/cri-o:/prerelease:/main:/build/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
+      apt-get update
+
+      # Install dependencies
+      apt-get install -y cri-o kubelet kubeadm kubectl
+      systemctl enable --now crio.service
+
+      # Cluster
+      IP=`ip route get 1.2.3.4 | cut -d ' ' -f7 | tr -d '[:space:]'`
+      NODENAME=$(hostname -s)
+      swapoff -a
+      modprobe br_netfilter
+      sysctl -w net.ipv4.ip_forward=1
+      kubeadm init --apiserver-cert-extra-sans=$IP --node-name $NODENAME
+
+      # Check cluster
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+      kubectl wait -n kube-system --timeout=180s --for=condition=available deploy coredns
+      kubectl wait --timeout=180s --for=condition=ready pods --all -A
+      kubectl get pods -A
+      kubectl run -i --restart=Never --image debian --rm debian -- echo test | grep test
+    SHELL
+  end
+end


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

On every `main` commit we will now build packages within OBS:

- https://build.opensuse.org/project/show/isv:kubernetes:addons:cri-o:prerelease:main:build

This also happens for future tags, for example

- https://build.opensuse.org/project/show/isv:kubernetes:addons:cri-o:stable:v1.29:build

#### Which issue(s) this PR fixes:

Refers to https://github.com/cri-o/cri-o/issues/7280 and https://github.com/kubernetes/release/issues/3214

#### Special notes for your reviewer:

The cronjob for releasing the packages into the dedicated release repos is right now only working for `main` on a daily basis.

- https://build.opensuse.org/project/show/isv:kubernetes:addons:cri-o:prerelease:main

I'll blog about this at some later point and add documentation as follow-up if everything works as expected.

#### Does this PR introduce a user-facing change?


```release-note
None
```
