### PR TITLE
[1.28] Add registries.conf to CRI-O bundle

### DIFF
--- a/contrib/bundle/build
+++ b/contrib/bundle/build
@@ -37,6 +37,7 @@ FILES_ETC=(
     "$GIT_ROOT/contrib/bundle/10-crun.conf"
 )
 FILES_CONTRIB=(
+    "$GIT_ROOT/contrib/bundle/registries.conf"
     "$GIT_ROOT/contrib/cni/11-crio-ipv4-bridge.conflist"
     "$GIT_ROOT/contrib/policy.json"
     "$GIT_ROOT/contrib/systemd/crio.service"
@@ -182,7 +183,7 @@ $BOM validate -e "$SPDX_PATH" -d "$CRIODIR"
 pushd "$TMPDIR"
 export DESTDIR=test/
 ./install
-EXP_CNT=66
+EXP_CNT=67
 if ! command -v runc; then
     EXP_CNT=$((EXP_CNT + 1))
 fi

--- a/contrib/bundle/install
+++ b/contrib/bundle/install
@@ -21,10 +21,17 @@ install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man8" man/crio.8
 install $SELINUX -D -m 644 -t "$DESTDIR$BASHINSTALLDIR" completions/bash/crio
 install $SELINUX -D -m 644 -t "$DESTDIR$FISHINSTALLDIR" completions/fish/crio.fish
 install $SELINUX -D -m 644 -t "$DESTDIR$ZSHINSTALLDIR" completions/zsh/_crio
-install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/policy.json
 install $SELINUX -D -m 644 -t "$DESTDIR$SYSTEMDDIR" contrib/crio.service
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/pinns
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crun
+
+if [ ! -f "$DESTDIR$CONTAINERS_DIR/policy.json" ]; then
+    install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/policy.json
+fi
+
+if [ ! -f "$DESTDIR$CONTAINERS_DIR/registries.conf" ]; then
+    install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/registries.conf
+fi
 
 # only install runc if it's not already in the path
 if ! command -v runc; then

--- a/contrib/bundle/registries.conf
+++ b/contrib/bundle/registries.conf
@@ -1,0 +1,9 @@
+[registries]
+[registries.block]
+registries = []
+
+[registries.insecure]
+registries = []
+
+[registries.search]
+registries = ["docker.io", "quay.io"]

--- a/contrib/bundle/test
+++ b/contrib/bundle/test
@@ -25,7 +25,7 @@ pushd cri-o
 
 # Start CRI-O
 systemctl daemon-reload
-systemctl start crio
+systemctl start crio || (journalctl -xeu crio.service && exit 1)
 systemctl is-active --quiet crio && echo CRI-O is running
 
 # Run a workload

--- a/contrib/bundle/test-e2e
+++ b/contrib/bundle/test-e2e
@@ -58,8 +58,8 @@ ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 apt-get remove \
     conmon \
     containernetworking-plugins \
-    crun \
-    moby-runc
+    crun
+rm -rf "$(command -v runc)"
 ufw disable
 ip6tables --list >/dev/null
 iptables -F
@@ -114,7 +114,7 @@ crio config --default
 
 # Start CRI-O
 systemctl daemon-reload
-systemctl start crio
+systemctl start crio || (journalctl -xeu crio.service && exit 1)
 systemctl is-active --quiet crio && echo CRI-O is running
 journalctl --no-pager -u crio
 

--- a/scripts/get
+++ b/scripts/get
@@ -243,10 +243,17 @@ install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man8" man/crio.8
 install $SELINUX -D -m 644 -t "$DESTDIR$BASHINSTALLDIR" completions/bash/crio
 install $SELINUX -D -m 644 -t "$DESTDIR$FISHINSTALLDIR" completions/fish/crio.fish
 install $SELINUX -D -m 644 -t "$DESTDIR$ZSHINSTALLDIR" completions/zsh/_crio
-install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/policy.json
 install $SELINUX -D -m 644 -t "$DESTDIR$SYSTEMDDIR" contrib/crio.service
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/pinns
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crun
+
+if [ ! -f "$DESTDIR$CONTAINERS_DIR/policy.json" ]; then
+    install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/policy.json
+fi
+
+if [ ! -f "$DESTDIR$CONTAINERS_DIR/registries.conf" ]; then
+    install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_DIR" contrib/registries.conf
+fi
 
 # only install runc if it's not already in the path
 if ! command -v runc; then


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
To make the build in OBS work with the latest spec.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/7280 and https://github.com/kubernetes/release/issues/3214
 
#### Special notes for your reviewer:
Inherited from https://github.com/cri-o/cri-o/pull/7243 and https://github.com/cri-o/cri-o/pull/7232
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added registries.conf to CRI-O bundle
```
