### PR TITLE
Make the release branch fast forward a cronjob

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,25 @@
+name: cron
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+env:
+  GO_VERSION: '1.21'
+jobs:
+  release-branch-forward:
+    permissions:
+      contents: none
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - run: make release-branch-forward
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          DRY_RUN: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -424,23 +424,6 @@ jobs:
           name: dependencies
           path: build/dependencies
 
-  release-branch-forward:
-    permissions:
-      contents: none
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - run: make release-branch-forward
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          DRY_RUN: false
   codeql-build:
     runs-on: ubuntu-latest
     permissions:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -10,6 +10,8 @@ dependencies:
       match: GO_VERSION
     - path: .github/workflows/test.yml
       match: GO_VERSION
+    - path: .github/workflows/cron.yml
+      match: GO_VERSION
     - path: contrib/test/integration/vars.yml
       match: golang_version
     - path: contrib/test/ci/vars.yml


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
This allows to decouple the racing CI between `main` and the latest release branch, which should make it more stable.

It's also possible to dispatch the forward manually, giving us more flexibility.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
