### PR TITLE
Fix nix `dirty` build

### DIFF
--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -32,9 +32,9 @@ with pkgs; buildGo121Module {
     export BUILDTAGS='static netgo osusergo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper seccomp apparmor selinux'
     export CGO_ENABLED=1
     export CGO_LDFLAGS='-lgpgme -lassuan -lgpg-error'
+    export SOURCE_DATE_EPOCH=0
   '';
   buildPhase = ''
-    patchShebangs .
     make bin/crio
     make bin/crio-status
     make bin/pinns


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
We do not need to patch the shebangs because all of those scripts are not required during build. This results in a `clearn` instead of `dirty` output when running `crio version`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
