### PR TITLE
Disambiguate image identification in container creation

### DIFF
--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -69,9 +69,8 @@ type RuntimeServer interface {
 	// same pod ID in its metadata that the pod's other members do, and
 	// with the pod's infrastructure container having the same value for
 	// both its pod's ID and its container ID.
-	// Pointer arguments can be nil.  Either the image name or ID can be
-	// omitted, but not both.  All other arguments are required.
-	CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error)
+	// Pointer arguments can be nil.  All other arguments are required.
+	CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageAuthFile, containerName, metadataName, uid, namespace string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error)
 
 	// GetContainerMetadata returns the metadata we've stored for a container.
 	GetContainerMetadata(idOrName string) (RuntimeContainerMetadata, error)
@@ -348,8 +347,8 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 	}, nil
 }
 
-func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {
-	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, podID, metadataName, uid, namespace, attempt, idMappingsOptions, labelOptions, true, privileged)
+func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageAuthFile, containerName, metadataName, uid, namespace string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {
+	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageAuthFile, "", containerName, podID, metadataName, uid, namespace, attempt, idMappingsOptions, labelOptions, true, privileged)
 }
 
 func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {

--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -299,7 +299,7 @@ func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, po
 		// Maybe it's some other transport's copy of the image?
 		otherRef, err2 := alltransports.ParseImageName(imageName)
 		if err2 == nil && otherRef.DockerReference() != nil {
-			ref, err = istorage.Transport.ParseStoreReference(r.storageImageServer.GetStore(), otherRef.DockerReference().String())
+			ref, err = istorage.Transport.NewStoreReference(r.storageImageServer.GetStore(), otherRef.DockerReference(), "")
 		}
 		if err != nil {
 			return ContainerInfo{}, err

--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -348,10 +348,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 }
 
 func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageAuthFile, containerName, metadataName, uid, namespace string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {
-	isPauseImage := true
-	imageID := ""
-
-	if imageName == "" && imageID == "" {
+	if imageName == "" {
 		return ContainerInfo{}, ErrInvalidImageName
 	}
 
@@ -365,23 +362,12 @@ func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, po
 			ref, err = istorage.Transport.ParseStoreReference(r.storageImageServer.GetStore(), otherRef.DockerReference().String())
 		}
 		if err != nil {
-			// Maybe the image ID is sufficient?
-			ref, err = istorage.Transport.ParseStoreReference(r.storageImageServer.GetStore(), "@"+imageID)
-			if err != nil {
-				return ContainerInfo{}, err
-			}
+			return ContainerInfo{}, err
 		}
 	}
 	img, err := istorage.Transport.GetStoreImage(r.storageImageServer.GetStore(), ref)
-	if err != nil && errors.Is(err, storage.ErrImageUnknown) && isPauseImage {
-		image := imageID
-		if imageName != "" {
-			image = imageName
-		}
-		if image == "" {
-			return ContainerInfo{}, ErrInvalidImageName
-		}
-		logrus.Debugf("Couldn't find image %q, retrieving it", image)
+	if err != nil && errors.Is(err, storage.ErrImageUnknown) {
+		logrus.Debugf("Couldn't find image %q, retrieving it", imageName)
 		sourceCtx := types.SystemContext{}
 		if systemContext != nil {
 			sourceCtx = *systemContext // A shallow copy
@@ -389,7 +375,7 @@ func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, po
 		if imageAuthFile != "" {
 			sourceCtx.AuthFilePath = imageAuthFile
 		}
-		ref, err = r.storageImageServer.PullImage(systemContext, image, &ImageCopyOptions{
+		ref, err = r.storageImageServer.PullImage(systemContext, imageName, &ImageCopyOptions{
 			SourceCtx:      &sourceCtx,
 			DestinationCtx: systemContext,
 		})
@@ -400,29 +386,19 @@ func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, po
 		if err != nil {
 			return ContainerInfo{}, err
 		}
-		logrus.Debugf("Successfully pulled image %q", image)
+		logrus.Debugf("Successfully pulled image %q", imageName)
 	}
 	if err != nil {
 		if errors.Is(err, storage.ErrImageUnknown) {
-			if imageID == "" {
-				return ContainerInfo{}, fmt.Errorf("image %q not present in image store", imageName)
-			}
-			if imageName == "" {
-				return ContainerInfo{}, fmt.Errorf("image with ID %q not present in image store", imageID)
-			}
-			return ContainerInfo{}, fmt.Errorf("image %q with ID %q not present in image store", imageName, imageID)
+			return ContainerInfo{}, fmt.Errorf("image %q not present in image store", imageName)
 		}
 		return ContainerInfo{}, err
 	}
 
-	// Update the image name and ID.
-	if imageName == "" && len(img.Names) > 0 {
-		imageName = img.Names[0]
-	}
-	imageID = img.ID
-	_ = imageID
+	// Resolve the image ID.
+	imageID := img.ID
 
-	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageAuthFile, "", containerName, podID, metadataName, uid, namespace, attempt, idMappingsOptions, labelOptions, true, privileged)
+	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, podID, metadataName, uid, namespace, attempt, idMappingsOptions, labelOptions, true, privileged)
 }
 
 func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {

--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -143,7 +143,7 @@ func (metadata *RuntimeContainerMetadata) SetMountLabel(mountLabel string) {
 
 // imageID must be provided and should refer to an image which existed at before calling this function (but that can change at any time).
 // The caller is also responsible for setting imageName (or "" if unknown)
-func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, containerID, metadataName, uid, namespace string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, isPauseImage, privileged bool) (ci ContainerInfo, retErr error) {
+func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, uid, namespace string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ci ContainerInfo, retErr error) {
 	if podName == "" || podID == "" {
 		return ContainerInfo{}, ErrInvalidPodName
 	}
@@ -338,7 +338,7 @@ func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, po
 	// Resolve the image ID.
 	imageID := img.ID
 
-	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageAuthFile, imageID, containerName, podID, metadataName, uid, namespace, attempt, idMappingsOptions, labelOptions, true, privileged)
+	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, podID, metadataName, uid, namespace, attempt, idMappingsOptions, labelOptions, privileged)
 }
 
 func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {
@@ -366,7 +366,7 @@ func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, pod
 		imageName = img.Names[0]
 	}
 
-	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, "", imageID, containerName, containerID, metadataName, "", "", attempt, idMappingsOptions, labelOptions, false, privileged)
+	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, "", "", attempt, idMappingsOptions, labelOptions, privileged)
 }
 
 func (r *runtimeService) deleteLayerIfMapped(imageID, layerID string) {

--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -244,12 +244,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 	// Add a name to the container's layer so that it's easier to follow
 	// what's going on if we're just looking at the storage-eye view of things.
 	layerName := metadata.ContainerName + "-layer"
-	names, err = r.storageImageServer.GetStore().Names(container.LayerID)
-	if err != nil {
-		return ContainerInfo{}, err
-	}
-	names = append(names, layerName)
-	err = r.storageImageServer.GetStore().SetNames(container.LayerID, names)
+	err = r.storageImageServer.GetStore().AddNames(container.LayerID, []string{layerName})
 	if err != nil {
 		return ContainerInfo{}, err
 	}

--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -51,6 +51,11 @@ var _ = t.Describe("Runtime", func() {
 			mockParseStoreReference(storeMock, "imagename"),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
+
+			imageServerMock.EXPECT().GetStore().Return(storeMock),
+			mockParseStoreReference(storeMock, "imagename"),
+			imageServerMock.EXPECT().GetStore().Return(storeMock),
+			mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
 			mockNewImage(storeMock, "docker.io/library/imagename:latest", "123"),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 		)
@@ -529,6 +534,13 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on invalid pod ID", func() {
 			// Given
+			inOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockParseStoreReference(storeMock, "imagename"),
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
+			)
+
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "", "imagename",
@@ -544,6 +556,13 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on invalid pod name", func() {
 			// Given
+			inOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockParseStoreReference(storeMock, "imagename"),
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
+			)
+
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"", "podID", "imagename",
@@ -573,6 +592,13 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on invalid container name", func() {
 			// Given
+			inOrder(
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockParseStoreReference(storeMock, "imagename"),
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
+			)
+
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "imagename", "imageID",
@@ -748,6 +774,11 @@ var _ = t.Describe("Runtime", func() {
 				mockParseStoreReference(storeMock, "imagename"),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
+
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockParseStoreReference(storeMock, "imagename"),
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
 				// storageReference.newImage:
 				mockResolveImage(storeMock, "docker.io/library/imagename:latest", "123"),
 				storeMock.EXPECT().ImageBigData(gomock.Any(), gomock.Any()).
@@ -785,6 +816,11 @@ var _ = t.Describe("Runtime", func() {
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", ""),
 				imageServerMock.EXPECT().PullImage(gomock.Any(), "pauseimagename", expectedCopyOptions).Return(pulledRef, nil),
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", "123"),
+
+				imageServerMock.EXPECT().GetStore().Return(storeMock),
+				mockParseStoreReference(storeMock, "pauseimagename"),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", "123"),
 				mockNewImage(storeMock, "docker.io/library/pauseimagename:latest", "nonempty"),

--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -50,12 +50,8 @@ var _ = t.Describe("Runtime", func() {
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			mockGetStoreImage(storeMock, "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
-
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
-			mockParseStoreReference(storeMock, "imagename"),
-			imageServerMock.EXPECT().GetStore().Return(storeMock),
-			mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
-			mockNewImage(storeMock, "docker.io/library/imagename:latest", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
+			mockNewImage(storeMock, "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 		)
 	}
@@ -66,13 +62,9 @@ var _ = t.Describe("Runtime", func() {
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			mockParseStoreReference(storeMock, "imagename"),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
-			mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
-
+			mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
-			mockParseStoreReference(storeMock, "imagename"),
-			imageServerMock.EXPECT().GetStore().Return(storeMock),
-			mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
-			mockNewImage(storeMock, "docker.io/library/imagename:latest", "123"),
+			mockNewImage(storeMock, "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 		)
 	}
@@ -796,13 +788,9 @@ var _ = t.Describe("Runtime", func() {
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
-
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				mockParseStoreReference(storeMock, "imagename"),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", "123"),
 				// storageReference.newImage:
-				mockResolveImage(storeMock, "docker.io/library/imagename:latest", "123"),
+				mockResolveImage(storeMock, "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
 				storeMock.EXPECT().ImageBigData(gomock.Any(), gomock.Any()).
 					Return(testManifest, nil),
 				storeMock.EXPECT().ListImageBigData(gomock.Any()).
@@ -839,13 +827,9 @@ var _ = t.Describe("Runtime", func() {
 				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", ""),
 				imageServerMock.EXPECT().PullImage(gomock.Any(), "pauseimagename", expectedCopyOptions).Return(pulledRef, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", "123"),
-
+				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				mockParseStoreReference(storeMock, "pauseimagename"),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", "123"),
-				mockNewImage(storeMock, "docker.io/library/pauseimagename:latest", "nonempty"),
+				mockNewImage(storeMock, "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b", "8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b"),
 
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),

--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -497,9 +497,7 @@ var _ = t.Describe("Runtime", func() {
 						gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(&cs.Container{ID: "id"}, nil),
 					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().Names(gomock.Any()).Return([]string{}, nil),
-					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().SetNames(gomock.Any(), gomock.Any()).Return(nil),
+					storeMock.EXPECT().AddNames(gomock.Any(), gomock.Any()).Return(nil),
 					imageServerMock.EXPECT().GetStore().Return(storeMock),
 					storeMock.EXPECT().ContainerDirectory(gomock.Any()).
 						Return("dir", nil),
@@ -634,9 +632,7 @@ var _ = t.Describe("Runtime", func() {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&cs.Container{ID: "id"}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().Names(gomock.Any()).Return([]string{}, nil),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().SetNames(gomock.Any(), gomock.Any()).Return(nil),
+				storeMock.EXPECT().AddNames(gomock.Any(), gomock.Any()).Return(nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().ContainerDirectory(gomock.Any()).
 					Return("dir", nil),
@@ -667,9 +663,7 @@ var _ = t.Describe("Runtime", func() {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&cs.Container{ID: "id"}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().Names(gomock.Any()).Return([]string{}, nil),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().SetNames(gomock.Any(), gomock.Any()).Return(nil),
+				storeMock.EXPECT().AddNames(gomock.Any(), gomock.Any()).Return(nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().ContainerDirectory(gomock.Any()).
 					Return("", t.TestError),
@@ -697,35 +691,8 @@ var _ = t.Describe("Runtime", func() {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&cs.Container{ID: "id"}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().Names(gomock.Any()).Return([]string{}, nil),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().SetNames(gomock.Any(), gomock.Any()).
+				storeMock.EXPECT().AddNames(gomock.Any(), gomock.Any()).
 					Return(t.TestError),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().DeleteContainer(gomock.Any()).Return(t.TestError),
-			)
-
-			// When
-			_, err := sut.CreatePodSandbox(&types.SystemContext{},
-				"podName", "podID", "imagename", "",
-				"containerName", "metadataName",
-				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
-			)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
-		It("should fail to create a pod sandbox on names retrieval error", func() {
-			// Given
-			inOrder(
-				mockCreatePodSandboxImageExists(),
-				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&cs.Container{ID: "id"}, nil),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().Names(gomock.Any()).
-					Return([]string{}, t.TestError),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().DeleteContainer(gomock.Any()).Return(t.TestError),
 			)
@@ -836,9 +803,7 @@ var _ = t.Describe("Runtime", func() {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&cs.Container{ID: "id"}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().Names(gomock.Any()).Return([]string{}, nil),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().SetNames(gomock.Any(), gomock.Any()).Return(nil),
+				storeMock.EXPECT().AddNames(gomock.Any(), gomock.Any()).Return(nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().ContainerDirectory(gomock.Any()).
 					Return("dir", nil),

--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -512,7 +512,6 @@ var _ = t.Describe("Runtime", func() {
 				// When
 				info, err = sut.CreatePodSandbox(&types.SystemContext{},
 					"podName", "podID", "imagename", "",
-					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 					"containerName", "metadataName",
 					"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
 				)
@@ -668,7 +667,6 @@ var _ = t.Describe("Runtime", func() {
 			// When
 			_, err := sut.CreatePodSandbox(&types.SystemContext{},
 				"podName", "podID", "imagename", "",
-				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
 			)
@@ -694,7 +692,6 @@ var _ = t.Describe("Runtime", func() {
 			// When
 			_, err := sut.CreatePodSandbox(&types.SystemContext{},
 				"podName", "podID", "imagename", "",
-				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
 			)
@@ -715,7 +712,6 @@ var _ = t.Describe("Runtime", func() {
 			// When
 			_, err := sut.CreatePodSandbox(&types.SystemContext{},
 				"podName", "podID", "imagename", "",
-				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
 			)
@@ -824,7 +820,6 @@ var _ = t.Describe("Runtime", func() {
 			// When
 			info, err = sut.CreatePodSandbox(&types.SystemContext{},
 				"podName", "podID", "pauseimagename", "",
-				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
 			)
@@ -844,7 +839,6 @@ var _ = t.Describe("Runtime", func() {
 			// When
 			info, err = sut.CreatePodSandbox(&types.SystemContext{},
 				"podName", "podID", "pauseimagename", "/var/non-default/credentials.json",
-				"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 				"containerName", "metadataName",
 				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
 			)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -455,7 +455,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		sbox.Name(), sbox.ID(),
 		s.config.PauseImage,
 		s.config.PauseImageAuthFile,
-		"",
 		containerName,
 		kubeName,
 		sbox.Config().Metadata.Uid,

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -30,8 +30,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 				runtimeServerMock.EXPECT().CreatePodSandbox(gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any()).
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(storage.ContainerInfo{
 						RunDir: "/tmp",
 						Config: &v1.Image{Config: v1.ImageConfig{}},
@@ -112,8 +111,7 @@ var _ = t.Describe("RunPodSandbox", func() {
 				runtimeServerMock.EXPECT().CreatePodSandbox(gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any()).
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(storage.ContainerInfo{}, nil),
 				runtimeServerMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).
 					Return(nil),

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -180,18 +180,18 @@ func (mr *MockRuntimeServerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3,
 }
 
 // CreatePodSandbox mocks base method.
-func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 string, arg10 uint32, arg11 *types0.IDMappingOptions, arg12 []string, arg13 bool) (storage0.ContainerInfo, error) {
+func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 string, arg9 uint32, arg10 *types0.IDMappingOptions, arg11 []string, arg12 bool) (storage0.ContainerInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePodSandbox", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
+	ret := m.ctrl.Call(m, "CreatePodSandbox", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
 	ret0, _ := ret[0].(storage0.ContainerInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePodSandbox indicates an expected call of CreatePodSandbox.
-func (mr *MockRuntimeServerMockRecorder) CreatePodSandbox(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13 interface{}) *gomock.Call {
+func (mr *MockRuntimeServerMockRecorder) CreatePodSandbox(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePodSandbox", reflect.TypeOf((*MockRuntimeServer)(nil).CreatePodSandbox), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePodSandbox", reflect.TypeOf((*MockRuntimeServer)(nil).CreatePodSandbox), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
 }
 
 // DeleteContainer mocks base method.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As one of prerequisites of per-namespace signature enforcement (the effort of #7046 ), it is _strictly necessary_ that exactly the image ID for which we have verified a signature is used to eventually create the container. This is a part of that, one of the necessary steps, starting fairly deep in the call stack. (With possibly more to come, as I actually come to understand the relevant parts of the full container lifecycle).

I also want to more strictly limit the semantics of values passed to `PullImage`, to make the problem space more manageable. This does not change anything about the value itself, but the simplification makes analysis a tiny bit more tractable.

Currently, `runtimeService.createContainerOrPodSandbox` handles both non-infra containers and the pause=infra container, with quite flexible code paths with somewhat unclear assumptions. Looking at the (single) callers, the non-infra containers and the pause=infra container paths, are, in fact, almost entirely distinct. So, pull the image lookup code into the callers of `createContainerOrPodSandbox`:
- When dealing with the pause image, we only have a name (with unclear format assumptions); use it to potentially pull, and to look up an image ID by name
- When dealing with non-infra containers, we already must have a resolved image ID; make sure to use only that value, and only potentially look up an image name.

This is not an end-to-end cleanup (notably the caller of runtimeService.CreateContainer` is _also_ providing a fallback name, so one of those can probably be eliminated); that can come over time. I’m trying to file smaller, more manageable, PRs.

---

The net effect of this is:
- Relevant to me: It is clearer, and better-documented how images are identified on these code paths. (I don't think this ends up providing a user-relevant image ID promise, yet; I need to extend the analysis into the callers etc.
- Relevant to most others: Some slight optimizations, because we do more lookups by IDs instead parsing and resolving names.
- Some only tangentially-related error handling bug fixes and optimizations.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

See individual commit messages for details.

#### Does this PR introduce a user-facing change?

```release-note
None
```
