### PR TITLE
skip setting the process args when restoring a container checkpoint

### DIFF
--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -564,6 +564,11 @@ func (c *container) AddUnifiedResourcesFromAnnotations(annotationsMap map[string
 // SpecSetProcessArgs sets the process args in the spec,
 // given the image information and passed-in container config
 func (c *container) SpecSetProcessArgs(imageOCIConfig *v1.Image) error {
+	// When restoring a container checkpoint, skip setting the process args
+	if c.Restore() {
+		return nil
+	}
+
 	kubeCommands := c.config.Command
 	kubeArgs := c.config.Args
 

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/podman/v4/pkg/annotations"
 	"github.com/cri-o/cri-o/internal/config/capabilities"
+	"github.com/cri-o/cri-o/internal/factory/container"
 	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
@@ -483,6 +484,22 @@ var _ = t.Describe("Container", func() {
 			// Then
 			Expect(sut.SpecSetProcessArgs(img)).To(BeNil())
 			Expect(sut.Spec().Config.Process.Args).To(Equal(append(img.Config.Entrypoint, img.Config.Cmd...)))
+		})
+		It("should set nothing if container is checkpoint", func() {
+			// Given
+			config.Command = nil
+			config.Args = nil
+			img := &v1.Image{}
+			emptyContainer, err := container.New()
+
+			// When
+			Expect(err).To(BeNil())
+			Expect(sut.SetConfig(config, sboxConfig)).To(BeNil())
+			sut.SetRestore(true)
+
+			// Then
+			Expect(sut.SpecSetProcessArgs(img)).To(BeNil())
+			Expect(sut.Spec().Config.Process.Args).To(Equal(emptyContainer.Spec().Config.Process.Args))
 		})
 	})
 	t.Describe("WillRunSystemd", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug

#### What this PR does / why we need it:
When restoring a container checkpoint, and there is no command/arg setting both in image spec and kubernetes manifest, it will cause failure. But actually, restoring a checkpoint won't used the command/arg.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
