### PR TITLE
RFC: Turn ListImages(filter) into ImageStatus

### DIFF
--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -303,7 +303,7 @@ func (svc *imageService) ListImages(systemContext *types.SystemContext) ([]Image
 	newImageCache := make(imageCache, len(images))
 	for i := range images {
 		image := &images[i]
-		ref, err := istorage.Transport.ParseStoreReference(svc.store, "@"+image.ID)
+		ref, err := istorage.Transport.NewStoreReference(svc.store, nil, image.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -295,25 +295,17 @@ func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageC
 }
 
 func (svc *imageService) appendCachedResult(systemContext *types.SystemContext, ref types.ImageReference, image *storage.Image, results []ImageResult, newImageCache imageCache) ([]ImageResult, error) {
-	var err error
 	svc.imageCacheLock.Lock()
 	cacheItem, ok := svc.imageCache[image.ID]
 	svc.imageCacheLock.Unlock()
 	if !ok {
+		var err error
 		cacheItem, err = svc.buildImageCacheItem(systemContext, ref)
 		if err != nil {
 			return results, err
 		}
-		if newImageCache == nil {
-			svc.imageCacheLock.Lock()
-			svc.imageCache[image.ID] = cacheItem
-			svc.imageCacheLock.Unlock()
-		} else {
-			newImageCache[image.ID] = cacheItem
-		}
-	} else if newImageCache != nil {
-		newImageCache[image.ID] = cacheItem
 	}
+	newImageCache[image.ID] = cacheItem
 
 	return append(results, svc.buildImageResult(image, cacheItem)), nil
 }

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -542,9 +542,7 @@ var _ = t.Describe("Image", func() {
 						{ID: testSHA256},
 					},
 					nil),
-				mockParseStoreReference(storeMock, "@"+testSHA256),
 				mockLoop(),
-				mockParseStoreReference(storeMock, "@"+testSHA256),
 				mockLoop(),
 			)
 
@@ -590,7 +588,6 @@ var _ = t.Describe("Image", func() {
 			inOrder(
 				storeMock.EXPECT().Images().Return(
 					[]cs.Image{{ID: testSHA256}}, nil),
-				mockParseStoreReference(storeMock, "@"+testSHA256),
 				storeMock.EXPECT().Image(gomock.Any()).
 					Return(nil, t.TestError),
 			)

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -508,7 +508,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			res, err := sut.ListImages(&types.SystemContext{}, "")
+			res, err := sut.ListImages(&types.SystemContext{})
 
 			// Then
 			Expect(err).To(BeNil())
@@ -549,91 +549,11 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			res, err := sut.ListImages(&types.SystemContext{}, "")
+			res, err := sut.ListImages(&types.SystemContext{})
 
 			// Then
 			Expect(err).To(BeNil())
 			Expect(len(res)).To(Equal(2))
-		})
-
-		It("should succeed to list images with filter", func() {
-			// Given
-			inOrder(
-				mockGetRef(),
-				mockGetStoreImage(storeMock, testNormalizedImageName, testSHA256),
-				// buildImageCacheItem:
-				mockNewImage(storeMock, testNormalizedImageName, testSHA256),
-
-				storeMock.EXPECT().Image(gomock.Any()).
-					Return(&cs.Image{
-						ID: testSHA256,
-						Names: []string{
-							testNormalizedImageName,
-						},
-					}, nil),
-				storeMock.EXPECT().ImageBigData(testSHA256, gomock.Any()).
-					Return(nil, nil),
-
-				// makeRepoDigests:
-				storeMock.EXPECT().ImageBigDataDigest(testSHA256, gomock.Any()).
-					Return(digest.Digest(""), nil),
-			)
-
-			// When
-			res, err := sut.ListImages(&types.SystemContext{}, testImageName)
-
-			// Then
-			Expect(err).To(BeNil())
-			Expect(len(res)).To(Equal(1))
-			Expect(res[0].ID).To(Equal(testSHA256))
-		})
-
-		It("should succeed to list images on failure to access an image", func() {
-			// Given
-			inOrder(
-				mockGetRef(),
-				mockGetStoreImage(storeMock, testNormalizedImageName, ""),
-			)
-
-			// When
-			res, err := sut.ListImages(&types.SystemContext{}, testImageName)
-
-			// Then
-			Expect(err).To(BeNil())
-			Expect(len(res)).To(Equal(0))
-		})
-
-		It("should fail to list images with filter an invalid reference", func() {
-			// Given
-			gomock.InOrder(
-				// parseStoreReference("@wrong://image") tries this before failing in parseNormalizedNamed:
-				storeMock.EXPECT().Image("wrong://image").Return(nil, cs.ErrImageUnknown),
-			)
-			// When
-			res, err := sut.ListImages(&types.SystemContext{}, "wrong://image")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(res).To(BeNil())
-		})
-
-		It("should fail to list images with filter on failing appendCachedResult", func() {
-			// Given
-			inOrder(
-				mockGetRef(),
-				mockGetStoreImage(storeMock, testNormalizedImageName, testSHA256),
-				// in buildImageCacheItem, NewImage is failing:
-				mockResolveImage(storeMock, testNormalizedImageName, testSHA256),
-				storeMock.EXPECT().ImageBigData(testSHA256, gomock.Any()).
-					Return(nil, t.TestError),
-			)
-
-			// When
-			res, err := sut.ListImages(&types.SystemContext{}, testImageName)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-			Expect(res).To(BeNil())
 		})
 
 		It("should fail to list images without a filter on failing store", func() {
@@ -643,7 +563,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			res, err := sut.ListImages(&types.SystemContext{}, "")
+			res, err := sut.ListImages(&types.SystemContext{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -658,7 +578,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			res, err := sut.ListImages(&types.SystemContext{}, "")
+			res, err := sut.ListImages(&types.SystemContext{})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -676,7 +596,7 @@ var _ = t.Describe("Image", func() {
 			)
 
 			// When
-			res, err := sut.ListImages(&types.SystemContext{}, "")
+			res, err := sut.ListImages(&types.SystemContext{})
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -11,15 +11,26 @@ import (
 func (s *Server) ListImages(ctx context.Context, req *types.ListImagesRequest) (*types.ListImagesResponse, error) {
 	_, span := log.StartSpan(ctx)
 	defer span.End()
-	filter := ""
-	reqFilter := req.Filter
-	if reqFilter != nil {
-		filterImage := reqFilter.Image
-		if filterImage != nil {
-			filter = filterImage.Image
+
+	if reqFilter := req.Filter; reqFilter != nil {
+		if filterImage := reqFilter.Image; filterImage != nil && filterImage.Image != "" {
+			// Historically CRI-O has interpreted the “filter” as a single image to look up.
+			// Also, the type of the value is types.ImageSpec, the value used to refer to a single image.
+			// And, ultimately, Kubelet never uses the filter.
+			// So, fall back to existing code instead of having an extra code path doing some kind of filtering.
+			status, err := s.storageImageStatus(ctx, *filterImage)
+			if err != nil {
+				return nil, err
+			}
+			resp := &types.ListImagesResponse{}
+			if status != nil {
+				resp.Images = append(resp.Images, ConvertImage(status))
+			}
+			return resp, nil
 		}
 	}
-	results, err := s.StorageImageServer().ListImages(s.config.SystemContext, filter)
+
+	results, err := s.StorageImageServer().ListImages(s.config.SystemContext, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -30,7 +30,7 @@ func (s *Server) ListImages(ctx context.Context, req *types.ListImagesRequest) (
 		}
 	}
 
-	results, err := s.StorageImageServer().ListImages(s.config.SystemContext, "")
+	results, err := s.StorageImageServer().ListImages(s.config.SystemContext)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_list_test.go
+++ b/server/image_list_test.go
@@ -48,12 +48,18 @@ var _ = t.Describe("ImageList", func() {
 
 		It("should succeed with filter", func() {
 			// Given
+			size := uint64(100)
 			gomock.InOrder(
-				imageServerMock.EXPECT().ListImages(
-					gomock.Any(), gomock.Any()).
-					Return([]storage.ImageResult{{ID: imageID}}, nil),
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), "image").
+					Return([]string{"docker.io/library/image"}, nil),
+				imageServerMock.EXPECT().ImageStatus(
+					gomock.Any(), "docker.io/library/image").
+					Return(&storage.ImageResult{
+						ID:   "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812",
+						User: "10", Size: &size,
+					}, nil),
 			)
-
 			// When
 			response, err := sut.ListImages(context.Background(),
 				&types.ListImagesRequest{Filter: &types.ImageFilter{
@@ -76,6 +82,28 @@ var _ = t.Describe("ImageList", func() {
 			// When
 			response, err := sut.ListImages(context.Background(),
 				&types.ListImagesRequest{})
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(response).To(BeNil())
+		})
+
+		It("should fail with filter status error", func() {
+			// Given
+			gomock.InOrder(
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), "image").
+					Return([]string{"docker.io/library/image"}, nil),
+				imageServerMock.EXPECT().ImageStatus(
+					gomock.Any(), "docker.io/library/image").
+					Return(nil, t.TestError),
+			)
+
+			// When
+			response, err := sut.ListImages(context.Background(),
+				&types.ListImagesRequest{Filter: &types.ImageFilter{
+					Image: &types.ImageSpec{Image: "image"},
+				}})
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/server/image_list_test.go
+++ b/server/image_list_test.go
@@ -28,8 +28,7 @@ var _ = t.Describe("ImageList", func() {
 			// Given
 			size := uint64(100)
 			gomock.InOrder(
-				imageServerMock.EXPECT().ListImages(
-					gomock.Any(), gomock.Any()).
+				imageServerMock.EXPECT().ListImages(gomock.Any()).
 					Return([]storage.ImageResult{
 						{ID: imageID, Size: &size, User: "10"},
 					}, nil),
@@ -75,8 +74,8 @@ var _ = t.Describe("ImageList", func() {
 		It("should fail when image listing errors", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ListImages(gomock.Any(),
-					gomock.Any()).Return(nil, t.TestError),
+				imageServerMock.EXPECT().ListImages(gomock.Any()).
+					Return(nil, t.TestError),
 			)
 
 			// When

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -29,34 +29,11 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 	}
 
 	log.Infof(ctx, "Checking image status: %s", image)
-	images, err := s.StorageImageServer().ResolveNames(s.config.SystemContext, image)
-	if err != nil {
-		return nil, err
-	}
-	var (
-		status  *pkgstorage.ImageResult
-		lastErr error
-	)
-	for _, image := range images {
-		status_, err := s.StorageImageServer().ImageStatus(s.config.SystemContext, image)
-		if err != nil {
-			if errors.Is(err, storage.ErrImageUnknown) {
-				log.Debugf(ctx, "Can't find %s", image)
-				continue
-			}
-			log.Warnf(ctx, "Error getting status from %s: %v", image, err)
-			lastErr = err
-			continue
-		}
-		status = status_
-		break
-	}
+	status, err := s.storageImageStatus(ctx, *img)
 	if status == nil {
-		if lastErr != nil {
-			return nil, lastErr
+		if err != nil {
+			return nil, err
 		}
-		// ResolveNames returns at least one value if it doesn't fail.
-		// So, if we got here, there was at least one ErrImageUnknown, and no other errors.
 		log.Infof(ctx, "Image %s not found", image)
 		return &types.ImageStatusResponse{}, nil
 	}
@@ -94,6 +71,43 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 	resp.Image.Username = username
 	log.Infof(ctx, "Image status: %v", resp)
 	return resp, nil
+}
+
+// storageImageStatus calls ImageStatus for a k8s ImageSpec.
+// Returns (nil, nil) if image was not found.
+func (s *Server) storageImageStatus(ctx context.Context, spec types.ImageSpec) (*pkgstorage.ImageResult, error) {
+	images, err := s.StorageImageServer().ResolveNames(s.config.SystemContext, spec.Image)
+	if err != nil {
+		return nil, err
+	}
+	var (
+		status  *pkgstorage.ImageResult
+		lastErr error
+	)
+	for _, image := range images {
+		status_, err := s.StorageImageServer().ImageStatus(s.config.SystemContext, image)
+		if err != nil {
+			if errors.Is(err, storage.ErrImageUnknown) {
+				log.Debugf(ctx, "Can't find %s", image)
+				continue
+			}
+			log.Warnf(ctx, "Error getting status from %s: %v", image, err)
+			lastErr = err
+			continue
+		}
+		status = status_
+		break
+	}
+	if status == nil {
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		// ResolveNames returns at least one value if it doesn't fail.
+		// So, if we got here, there was at least one ErrImageUnknown, and no other errors.
+		log.Infof(ctx, "Image %s not found", spec.Image)
+		return nil, nil
+	}
+	return status, nil
 }
 
 // getUserFromImage gets uid or user name of the image user.

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -19,22 +19,18 @@ import (
 func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest) (*types.ImageStatusResponse, error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
-	image := ""
 	img := req.Image
-	if img != nil {
-		image = img.Image
-	}
-	if image == "" {
+	if img == nil || img.Image == "" {
 		return nil, fmt.Errorf("no image specified")
 	}
 
-	log.Infof(ctx, "Checking image status: %s", image)
+	log.Infof(ctx, "Checking image status: %s", img.Image)
 	status, err := s.storageImageStatus(ctx, *img)
+	if err != nil {
+		return nil, err
+	}
 	if status == nil {
-		if err != nil {
-			return nil, err
-		}
-		log.Infof(ctx, "Image %s not found", image)
+		log.Infof(ctx, "Image %s not found", img.Image)
 		return &types.ImageStatusResponse{}, nil
 	}
 

--- a/test/image.bats
+++ b/test/image.bats
@@ -88,7 +88,7 @@ function teardown() {
 	imageid=$(crictl images --quiet "$IMAGE")
 	[ "$imageid" != "" ]
 
-	output=$(crictl images @"$imageid")
+	output=$(crictl images "$imageid")
 	[[ "$output" == *"$IMAGE"* ]]
 
 	output=$(crictl images --quiet "$imageid")
@@ -106,7 +106,7 @@ function teardown() {
 	imageid=$(crictl images --quiet "$FEDORA")
 	[ "$imageid" != "" ]
 
-	output=$(crictl images @"$imageid")
+	output=$(crictl images "$imageid")
 	[[ "$output" == *"$FEDORA"* ]]
 
 	output=$(crictl images --quiet "$imageid")
@@ -136,9 +136,6 @@ function teardown() {
 	imageid=$(crictl images --quiet "$IMAGE:go")
 	[ "$imageid" != "" ]
 
-	output=$(crictl images --quiet @"$imageid")
-	[ "$output" != "" ]
-
 	output=$(crictl images --quiet "$imageid")
 	[ "$output" != "" ]
 
@@ -152,8 +149,6 @@ function teardown() {
 
 	imageid=$(crictl images --quiet "$NGINX_IMAGE")
 	[ "$imageid" != "" ]
-	output=$(crictl images --quiet @"$imageid")
-	[ "$output" != "" ]
 
 	output=$(crictl images --quiet "$imageid")
 	[ "$output" != "" ]
@@ -180,9 +175,6 @@ function teardown() {
 		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_AMD64}"* ]]
 		;;
 	esac
-
-	output=$(crictl images --quiet @"$imageid")
-	[ "$output" != "" ]
 
 	output=$(crictl images --quiet "$imageid")
 	[ "$output" != "" ]
@@ -213,9 +205,6 @@ function teardown() {
 		;;
 	esac
 
-	output=$(crictl images --quiet @"$imageid")
-	[ "$output" != "" ]
-
 	output=$(crictl images --quiet "$imageid")
 	[ "$output" != "" ]
 
@@ -239,9 +228,6 @@ function teardown() {
 
 	output=$(crictl images -v ${IMAGE_LIST_DIGEST})
 	[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST}"* ]]
-
-	output=$(crictl images --quiet @"$imageid")
-	[ "$output" != "" ]
 
 	output=$(crictl images --quiet "$imageid")
 	[ "$output" != "" ]
@@ -267,9 +253,6 @@ function teardown() {
 
 	output=$(crictl images -v ${IMAGE_LIST_DIGEST})
 	[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST}"* ]]
-
-	output=$(crictl images --quiet @"$imageid")
-	[ "$output" != "" ]
 
 	output=$(crictl images --quiet "$imageid")
 	[ "$output" != "" ]

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -68,18 +68,18 @@ func (mr *MockImageServerMockRecorder) ImageStatus(arg0, arg1 interface{}) *gomo
 }
 
 // ListImages mocks base method.
-func (m *MockImageServer) ListImages(arg0 *types.SystemContext, arg1 string) ([]storage0.ImageResult, error) {
+func (m *MockImageServer) ListImages(arg0 *types.SystemContext) ([]storage0.ImageResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListImages", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListImages", arg0)
 	ret0, _ := ret[0].([]storage0.ImageResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListImages indicates an expected call of ListImages.
-func (mr *MockImageServerMockRecorder) ListImages(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockImageServerMockRecorder) ListImages(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockImageServer)(nil).ListImages), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockImageServer)(nil).ListImages), arg0)
 }
 
 // PrepareImage mocks base method.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Turn `ListImages(filter)` into `ImageStatus`. That "filter" was never really much of a filter, we always only got one image.
    
The current logic is, effectively, the only user which accepts that specific form of heuristically-interpreted syntax (because all other non-`PauseImage` users of internal/storage use `ResolveNames`), so removing that syntax would consolidate and clarify the semantics of internal/storage names.
    
Kubelet never calls `ListImages` with a filter AFAIK, so this should make no difference in practice - and it means we get to remove a chunk of code and tests.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Do note that this changes how `ListImagesRequest.Filter.Image.Image` is interpreted (to be the same as the same field in of the same struct in `ImageStatusRequest.Image.Image`), and that might be an incompatible change.

It’s quite possible that there are other non-Kubelet users of this API I’m unaware of.

I don’t _really_ need this change to happen for signing — it clarifies how CRI-O interprets names on input, and I think that’s a bit valuable in itself, as well as the code simplification it would eventually allow (ultimately removing `getRef` entirely). But this PR is mostly a side-effect of me clarifying my thinking about which values matter and how they are parsed

#### Does this PR introduce a user-facing change?

```release-note
If a filter is specified in the `ListImages` CRI method, it is now interpreted the same way image names in the `ImageStatus` methods are.
```
