### PR TITLE
Validate pod uid

### DIFF
--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -305,7 +305,7 @@ func (c *container) SetConfig(cfg *types.ContainerConfig, sboxConfig *types.PodS
 	}
 
 	if cfg.Metadata.Name == "" {
-		return errors.New("name is nil")
+		return errors.New("name is empty")
 	}
 
 	if sboxConfig == nil {

--- a/internal/factory/sandbox/sandbox.go
+++ b/internal/factory/sandbox/sandbox.go
@@ -72,7 +72,7 @@ func (s *sandbox) SetConfig(config *types.PodSandboxConfig) error {
 	}
 
 	if config.Metadata.Name == "" {
-		return errors.New("PodSandboxConfig.Metadata.Name should not be empty")
+		return errors.New("metadata.Name should not be empty")
 	}
 
 	if config.Linux == nil {
@@ -106,6 +106,10 @@ func (s *sandbox) SetNameAndID() error {
 
 	if s.config.Metadata.Name == "" {
 		return errors.New("cannot generate pod name without name in metadata")
+	}
+
+	if s.config.Metadata.Uid == "" {
+		return errors.New("cannot generate pod name without uid in metadata")
 	}
 
 	s.id = stringid.GenerateNonCryptoID()

--- a/internal/factory/sandbox/sandbox_setnameandid_test.go
+++ b/internal/factory/sandbox/sandbox_setnameandid_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Sandbox:SetNameAndID", func() {
 			Expect(sut.ID()).To(Equal(""))
 			Expect(sut.Name()).To(Equal(""))
 		})
+
 		It("should fail with empty namespace in metadata", func() {
 			// Given
 			config := &types.PodSandboxConfig{
@@ -77,7 +78,8 @@ var _ = Describe("Sandbox:SetNameAndID", func() {
 			Expect(sut.ID()).To(Equal(""))
 			Expect(sut.Name()).To(Equal(""))
 		})
-		It("should succeed with empty uid in metadata", func() {
+
+		It("should fail with empty uid in metadata", func() {
 			// Given
 			config := &types.PodSandboxConfig{
 				Metadata: &types.PodSandboxMetadata{
@@ -91,9 +93,9 @@ var _ = Describe("Sandbox:SetNameAndID", func() {
 			err := sut.SetNameAndID()
 
 			// Then
-			Expect(err).To(BeNil())
-			Expect(sut.ID()).NotTo(Equal(""))
-			Expect(sut.Name()).NotTo(Equal(""))
+			Expect(err).NotTo(BeNil())
+			Expect(sut.ID()).To(Equal(""))
+			Expect(sut.Name()).To(Equal(""))
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Pre-validate sandbox uid values before creation in the same way it's already done for the container name.


#### Which issue(s) this PR fixes:
Fixes https://github.com/cri-o/cri-o/issues/7351

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
**_This is a revert of https://github.com/cri-o/cri-o/pull/3774_**
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Validate pod namespace and uid before creation.
```
