### PR TITLE
checkpoint: clean-up checkpoint dir after export

### DIFF
--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -84,6 +84,12 @@ func (c *ContainerServer) ContainerCheckpoint(
 		if err := c.exportCheckpoint(ctx, ctr, specgen.Config, opts.TargetFile); err != nil {
 			return "", fmt.Errorf("failed to write file system changes of container %s: %w", ctr.ID(), err)
 		}
+		defer func() {
+			// clean up checkpoint directory
+			if err := os.RemoveAll(ctr.CheckpointPath()); err != nil {
+				log.Warnf(ctx, "Unable to remove checkpoint directory %s: %v", ctr.CheckpointPath(), err)
+			}
+		}()
 	}
 	if !opts.KeepRunning {
 		if err := c.storageRuntimeServer.StopContainer(ctx, ctr.ID()); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

The CRI-O implementation for container checkpointing is based on Podman. One of the differences between CRI-O and Podman is that with CRI-O, containers continue to run after checkpointing, and the checkpoint is exported as a tar archive file. However, after the checkpoint has been created, all checkpoint files remain in the userdata directory of the container. As a result, subsequent checkpoints include files from previous checkpoints. To fix this problem, this patch ensures that we clean up the checkpoint directory after the checkpoint files have been exported.

#### Special notes for your reviewer:

The original pull request introducing container checkpoint (https://github.com/cri-o/cri-o/pull/4199) contains more information about exporting of checkpoints.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Clean up container checkpoint directory after export
```
