### PR TITLE
RFC: Explicitly define a much stricter format for pause_image

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -415,7 +415,9 @@ CRI-O reads its configured registries defaults from the system wide containers-r
   The path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.
 
 **pause_image**="registry.k8s.io/pause:3.9"
-  The image used to instantiate infra containers. This option supports live configuration reload.
+  The on-registry image used to instantiate infra containers.
+  The value should start with a registry host name.
+  This option supports live configuration reload.
 
 **pause_image_auth_file**=""
  The path to a file like /var/lib/kubelet/config.json holding credentials specific to pulling the pause_image from above. This option supports live configuration reload.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -717,6 +717,70 @@ var _ = t.Describe("Config", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 		})
+
+		It("should fail when PauseImage is invalid", func() {
+			// Given
+			sut.ImageConfig.PauseImage = "//NOT:a valid image reference!"
+
+			// When
+			err := sut.ImageConfig.Validate(false)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	t.Describe("ImageConfig.ParsePauseImage", func() {
+		It("should succeed with the default value", func() {
+			// Given
+			sut.ImageConfig.PauseImage = config.DefaultPauseImage
+
+			// When
+			ref, err := sut.ImageConfig.ParsePauseImage()
+
+			// Then
+			Expect(err).To(BeNil())
+			// DefaultPauseImage is using a canonical form where this comparison is expected to work.
+			Expect(ref.String()).To(Equal(config.DefaultPauseImage))
+		})
+
+		It("should succeed with a name-only value", func() {
+			// Given
+			sut.ImageConfig.PauseImage = "registry.k8s.io/pause"
+
+			// When
+			ref, err := sut.ImageConfig.ParsePauseImage()
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(ref.String()).To(Equal("registry.k8s.io/pause:latest"))
+		})
+
+		It("should succeed with a short name", func() {
+			// NOTE: This behavior is undocumented. Users are expected to provide a
+			// name with a registry
+
+			// Given
+			sut.ImageConfig.PauseImage = "short:notlatest"
+
+			// When
+			ref, err := sut.ImageConfig.ParsePauseImage()
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(ref.String()).To(Equal("docker.io/library/short:notlatest"))
+		})
+
+		It("should fail with an invalid value", func() {
+			// Given
+			sut.ImageConfig.PauseImage = "//THIS is:very!invalid="
+
+			// When
+			_, err := sut.ImageConfig.ParsePauseImage()
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
 	})
 
 	t.Describe("ValidateNetworkConfig", func() {

--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -119,6 +119,9 @@ func (c *Config) ReloadLogFilter(newConfig *Config) error {
 
 func (c *Config) ReloadPauseImage(newConfig *Config) error {
 	if c.PauseImage != newConfig.PauseImage {
+		if _, err := newConfig.ParsePauseImage(); err != nil {
+			return err
+		}
 		c.PauseImage = newConfig.PauseImage
 		logConfig("pause_image", c.PauseImage)
 	}

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -182,6 +182,19 @@ var _ = t.Describe("Config", func() {
 			Expect(sut.PauseImage).To(Equal(newPauseImage))
 		})
 
+		It("should fail with invalid pause_image change", func() {
+			// Given
+			const newPauseImage = "//THIS=is!invalid"
+			newConfig := defaultConfig()
+			newConfig.PauseImage = newPauseImage
+
+			// When
+			err := sut.ReloadPauseImage(newConfig)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+		})
+
 		It("should succeed with pause_command change", func() {
 			// Given
 			const newPauseCommand = "/new-pause"

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	reference "github.com/containers/image/v5/docker/reference"
 	types "github.com/containers/image/v5/types"
 	storage "github.com/containers/storage"
 	types0 "github.com/containers/storage/types"
@@ -180,7 +181,7 @@ func (mr *MockRuntimeServerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3,
 }
 
 // CreatePodSandbox mocks base method.
-func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 string, arg9 uint32, arg10 *types0.IDMappingOptions, arg11 []string, arg12 bool) (storage0.ContainerInfo, error) {
+func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2 string, arg3 reference.Named, arg4, arg5, arg6, arg7, arg8 string, arg9 uint32, arg10 *types0.IDMappingOptions, arg11 []string, arg12 bool) (storage0.ContainerInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePodSandbox", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
 	ret0, _ := ret[0].(storage0.ContainerInfo)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The handling of `pause_image` in `CreatePodSandbox` currently heuristically accepts many different values, and most would lead to very surprising behavior:

- Don't accept storage IDs (they work locally but can't be pulled)
- Don't accept prefixes of storage IDs either (if they ever match locally, that would be VERY surprising)
- Don't accept short names (`dir:foo` could locally search for `docker.io/library/dir:foo`, but then try to "pull" from local filesystem at `./foo`)
- Don't accept `transport:`_..._ values

Instead, just accept ordinary registry references, qualified with a host name (and, _undocumented_, use the traditional `docker.io/[library]` fallback semantics).

Also parse the `pause_image` option already at daemon start, and every reload.

I don’t expect this to affect production workloads — I think most of the accepted syntaxes are just not practical, but I am steeling myself to be surprised.

In theory, values starting with any of `docker://`, `docker-archive:`, `docker-daemon:`, `atomic:`, `containers-storage:` _might_ currently work; some in case where the referenced image is already available locally, some could also be pulled.

Note what is currently _not_ supported: short names (`CreatePodSandbox` does not do alias / search registry resolution), and `DefaultTransport` is not involved. Either way the values are currently very different from what e.g. `PullImage` accepts.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- I don’t _strictly_ need this for the signing work — it’s a byproduct of clarifying my thoughts; and it would allow (along with #7336 ) completely removing various code paths in `internal/storage`, ultimately removing _all_ heuristics from there. But I also think restricting the accepted values seems a bit valuable either way, just for reliability.
- It might make sense to completely reject short names (= names without a host name) instead of defaulting to `docker.io`. I am a bit worried that this could really break someone.
- It seems somewhat attractive to make `ImageConfig.PauseImage` itself a well-typed value, instead of a string and parsing the value later, but that seems like a bit more invasive change to me.

#### Does this PR introduce a user-facing change?

```release-note
The semantics of the `pause_image` config option has been clarified, and invalid values are rejected at daemon start and reload.
```
