### PR TITLE
Use conmon-rs as default monitor in static binary bundle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,7 +232,7 @@ jobs:
           path: build/bundle
       - run: make bundle-test
 
-  bundle-test-e2e:
+  bundle-test-e2e-conmon:
     runs-on: ubuntu-latest
     needs: bundles
     steps:
@@ -244,7 +244,7 @@ jobs:
         with:
           name: bundle
           path: build/bundle
-      - run: make bundle-test-e2e
+      - run: make bundle-test-e2e-conmon
 
   bundle-test-e2e-conmonrs:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -437,11 +437,11 @@ bundle: ${BOM}
 bundle-test:
 	sudo contrib/bundle/test
 
-bundle-test-e2e:
-	sudo contrib/bundle/test-e2e
+bundle-test-e2e-conmon:
+	sudo contrib/bundle/test-e2e --use-conmon
 
 bundle-test-e2e-conmonrs:
-	sudo contrib/bundle/test-e2e --use-conmonrs
+	sudo contrib/bundle/test-e2e
 
 bundle-test-kubernetes:
 	cd contrib/bundle && vagrant up

--- a/contrib/bundle/10-crun.conf
+++ b/contrib/bundle/10-crun.conf
@@ -2,6 +2,7 @@
 default_runtime = "crun"
 
 [crio.runtime.runtimes.crun]
+runtime_type = "pod"
 allowed_annotations = [
     "io.containers.trace-syscall",
 ]

--- a/contrib/bundle/test-e2e
+++ b/contrib/bundle/test-e2e
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-USE_CONMONRS=0
+USE_CONMON=0
 
 usage() {
     printf "Usage: %s [ --use-conmonrs ] [ -h ]\n\n" "$(basename "$0")"
     echo "Possible arguments:"
-    printf "  --use-conmonrs\tUse conmonrs instead of conmon\n"
+    printf "  --use-conmon\tUse conmon instead of conmon-rs\n"
     printf "  -h\t\t\tShow this help message\n"
 }
 
@@ -14,7 +14,7 @@ parse_args() {
     for arg in "$@"; do
         shift
         case "$arg" in
-        '--use-conmonrs') set -- "$@" '-c' ;;
+        '--use-conmon') set -- "$@" '-c' ;;
         '--help') set -- "$@" '-h' ;;
         *) set -- "$@" "$arg" ;;
         esac
@@ -23,7 +23,7 @@ parse_args() {
     while getopts 'ch' OPTION; do
         case "$OPTION" in
         c)
-            USE_CONMONRS=1
+            USE_CONMON=1
             ;;
         h)
             usage
@@ -86,26 +86,20 @@ pushd cri-o
 ./install
 
 # Set runtime type based on selection
-RUNTIME_TYPE=oci
-if [[ $USE_CONMONRS -eq 1 ]]; then
-    echo "Using conmonrs instead of conmon"
-    RUNTIME_TYPE=pod
-else
+if [[ $USE_CONMON -eq 1 ]]; then
+    echo "Using conmon instead of conmon-rs"
+    sed 's;pod;oci;g' /etc/crio/crio.conf.d/10-crun.conf
     conmon --version
+else
+    conmonrs --version
 fi
 
-# Use runc as default runtime
-rm /etc/crio/crio.conf.d/10-crun.conf
-cat <<EOT >>/etc/crio/crio.conf.d/10-config.conf
+cat <<EOT >>/etc/crio/crio.conf.d/10-log-level.conf
 [crio.runtime]
 log_level = "debug"
-
-[crio.runtime.runtimes.runc]
-runtime_path = "/usr/local/bin/runc"
-runtime_type = "$RUNTIME_TYPE"
 EOT
 
-runc --version
+crun --version
 
 crio config
 crio config --default
@@ -188,6 +182,6 @@ _output/bin/e2e.test --provider=local --host="https://$IP:6443" \
     --ginkgo.skip='\[Flaky|Slow|Serial|sig-network|NodeFeature:RuntimeHandler\]|exec hook properly'
 
 # Validate that we were using conmonrs
-if [[ $USE_CONMONRS -eq 1 ]]; then
+if [[ $USE_CONMON -eq 0 ]]; then
     journalctl --no-pager -u crio | grep -qm1 "Using conmonrs version:"
 fi


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
Switching to conmon-rs over conmon after adding it to the bundle. Adapting the tests as needed.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Using conmon-rs as default container monitor in static binary bundles.
```
