### PR TITLE
drop inactive-or-failed property

### DIFF
--- a/internal/config/node/node_linux.go
+++ b/internal/config/node/node_linux.go
@@ -52,13 +52,6 @@ func ValidateConfig() error {
 			fatal:     false,
 		},
 		{
-			name:      "systemd CollectMode",
-			init:      SystemdHasCollectMode,
-			err:       &systemdHasCollectModeErr,
-			activated: &systemdHasCollectMode,
-			fatal:     false,
-		},
-		{
 			name:      "systemd AllowedCPUs",
 			init:      SystemdHasAllowedCPUs,
 			err:       &systemdHasAllowedCPUsErr,

--- a/internal/config/node/systemd_linux.go
+++ b/internal/config/node/systemd_linux.go
@@ -11,21 +11,10 @@ import (
 )
 
 var (
-	systemdHasCollectModeOnce sync.Once
-	systemdHasCollectMode     bool
-	systemdHasCollectModeErr  error
-
 	systemdHasAllowedCPUsOnce sync.Once
 	systemdHasAllowedCPUs     bool
 	systemdHasAllowedCPUsErr  error
 )
-
-func SystemdHasCollectMode() bool {
-	systemdHasCollectModeOnce.Do(func() {
-		systemdHasCollectMode, systemdHasCollectModeErr = systemdSupportsProperty("CollectMode")
-	})
-	return systemdHasCollectMode
-}
 
 func SystemdHasAllowedCPUs() bool {
 	systemdHasAllowedCPUsOnce.Do(func() {

--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -104,7 +104,7 @@ type Container interface {
 	SpecAddMount(rspec.Mount)
 
 	// SpecAddAnnotations adds annotations to the spec.
-	SpecAddAnnotations(ctx context.Context, sandbox *sandbox.Sandbox, containerVolume []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool, seccompRef, platformRuntimePath string) error
+	SpecAddAnnotations(ctx context.Context, sandbox *sandbox.Sandbox, containerVolume []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd bool, seccompRef, platformRuntimePath string) error
 
 	// SpecAddDevices adds devices from the server config, and container CRI config
 	SpecAddDevices([]device.Device, []device.Device, bool, bool) error
@@ -162,7 +162,7 @@ func (c *container) SpecAddMount(r rspec.Mount) {
 }
 
 // SpecAddAnnotation adds all annotations to the spec
-func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox, containerVolumes []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd, systemdHasCollectMode bool, seccompRef, platformRuntimePath string) (err error) {
+func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox, containerVolumes []oci.ContainerVolume, mountPoint, configStopSignal string, imageResult *storage.ImageResult, isSystemd bool, seccompRef, platformRuntimePath string) (err error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 	// Copied from k8s.io/kubernetes/pkg/kubelet/kuberuntime/labels.go

--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -271,9 +271,6 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 			// https://github.com/opencontainers/runc/pull/2224
 			c.spec.AddAnnotation("org.systemd.property.TimeoutStopUSec", "uint64 "+t+"000000") // sec to usec
 		}
-		if systemdHasCollectMode {
-			c.spec.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
-		}
 		c.spec.AddAnnotation("org.systemd.property.DefaultDependencies", "true")
 		c.spec.AddAnnotation("org.systemd.property.After", "['crio.service']")
 	}

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -117,7 +117,7 @@ var _ = t.Describe("Container", func() {
 			Expect(currentTime).ToNot(BeNil())
 			Expect(sb).ToNot(BeNil())
 
-			err = sut.SpecAddAnnotations(context.Background(), sb, volumes, mountPoint, configStopSignal, &imageResult, false, false, "foo", "")
+			err = sut.SpecAddAnnotations(context.Background(), sb, volumes, mountPoint, configStopSignal, &imageResult, false, "foo", "")
 			Expect(err).To(BeNil())
 
 			Expect(sut.Spec().Config.Annotations[annotations.Image]).To(Equal(image))

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cri-o/cri-o/internal/storage/references"
 	"github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/utils"
-	"github.com/godbus/dbus/v5"
 	json "github.com/json-iterator/go"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -460,16 +459,7 @@ func moveSelfToCgroup(cgroup string, hasCollectMode bool) error {
 
 	unitName := fmt.Sprintf("crio-pull-image-%d.scope", os.Getpid())
 
-	systemdProperties := []systemdDbus.Property{}
-	if hasCollectMode {
-		systemdProperties = append(systemdProperties,
-			systemdDbus.Property{
-				Name:  "CollectMode",
-				Value: dbus.MakeVariant("inactive-or-failed"),
-			})
-	}
-
-	return utils.RunUnderSystemdScope(dbusmgr.NewDbusConnManager(rootless.IsRootless()), os.Getpid(), slice, unitName, systemdProperties...)
+	return utils.RunUnderSystemdScope(dbusmgr.NewDbusConnManager(rootless.IsRootless()), os.Getpid(), slice, unitName, []systemdDbus.Property{})
 }
 
 func copyImageChild() {

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -26,8 +26,6 @@ import (
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/reexec"
-	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
-	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/dbusmgr"
 	"github.com/cri-o/cri-o/internal/storage/references"
 	"github.com/cri-o/cri-o/pkg/config"
@@ -433,18 +431,17 @@ func init() {
 }
 
 type copyImageArgs struct {
-	Lookup         *imageLookupService
-	ImageName      string // In the format of RegistryImageReference.StringForOutOfProcessConsumptionOnly()
-	ParentCgroup   string
-	SystemContext  *types.SystemContext
-	Options        *ImageCopyOptions
-	HasCollectMode bool
+	Lookup        *imageLookupService
+	ImageName     string // In the format of RegistryImageReference.StringForOutOfProcessConsumptionOnly()
+	ParentCgroup  string
+	SystemContext *types.SystemContext
+	Options       *ImageCopyOptions
 
 	StoreOptions storage.StoreOptions
 }
 
 // moveSelfToCgroup moves the current process to a new transient cgroup.
-func moveSelfToCgroup(cgroup string, hasCollectMode bool) error {
+func moveSelfToCgroup(cgroup string) error {
 	slice := "system.slice"
 	if rootless.IsRootless() {
 		slice = "user.slice"
@@ -459,7 +456,7 @@ func moveSelfToCgroup(cgroup string, hasCollectMode bool) error {
 
 	unitName := fmt.Sprintf("crio-pull-image-%d.scope", os.Getpid())
 
-	return utils.RunUnderSystemdScope(dbusmgr.NewDbusConnManager(rootless.IsRootless()), os.Getpid(), slice, unitName, []systemdDbus.Property{})
+	return utils.RunUnderSystemdScope(dbusmgr.NewDbusConnManager(rootless.IsRootless()), os.Getpid(), slice, unitName)
 }
 
 func copyImageChild() {
@@ -470,7 +467,7 @@ func copyImageChild() {
 		os.Exit(1)
 	}
 
-	if err := moveSelfToCgroup(args.ParentCgroup, args.HasCollectMode); err != nil {
+	if err := moveSelfToCgroup(args.ParentCgroup); err != nil {
 		fmt.Fprintf(os.Stderr, "%v", err)
 		os.Exit(1)
 	}
@@ -572,7 +569,6 @@ func (svc *imageService) copyImage(systemContext *types.SystemContext, imageName
 			UIDMap:             svc.store.UIDMap(),
 			GIDMap:             svc.store.GIDMap(),
 		},
-		HasCollectMode: node.SystemdHasCollectMode(),
 	}
 
 	stdinArguments.Options.Progress = nil

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -661,7 +661,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	if err != nil {
 		return nil, err
 	}
-	err = ctr.SpecAddAnnotations(ctx, sb, containerVolumes, mountPoint, containerImageConfig.Config.StopSignal, imgResult, s.config.CgroupManager().IsSystemd(), node.SystemdHasCollectMode(), seccompRef, runtimePath)
+	err = ctr.SpecAddAnnotations(ctx, sb, containerVolumes, mountPoint, containerImageConfig.Config.StopSignal, imgResult, s.config.CgroupManager().IsSystemd(), seccompRef, runtimePath)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -16,7 +16,6 @@ import (
 	selinux "github.com/containers/podman/v4/pkg/selinux"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
-	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	ctrfactory "github.com/cri-o/cri-o/internal/factory/container"
 	sboxfactory "github.com/cri-o/cri-o/internal/factory/sandbox"
@@ -652,10 +651,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	if podContainer.Config.Config.StopSignal != "" {
 		// this key is defined in image-spec conversion document at https://github.com/opencontainers/image-spec/pull/492/files#diff-8aafbe2c3690162540381b8cdb157112R57
 		g.AddAnnotation("org.opencontainers.image.stopSignal", podContainer.Config.Config.StopSignal)
-	}
-
-	if s.config.CgroupManager().IsSystemd() && node.SystemdHasCollectMode() {
-		g.AddAnnotation("org.systemd.property.CollectMode", "'inactive-or-failed'")
 	}
 
 	created := time.Now()


### PR DESCRIPTION
it was originally added because failed scopes weren't being cleaned up. This is the incorrect solution. Instead, the oci runtime should reset a failed unit after the container is done.

With inactive-or-failed property, systemd races with conmon reading the oom file of a container.

Note: this means that CRI-O should run with crun 1.9 and runc 1.1.8 or later. This should be enforced in the package.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind deprecation
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
fixes https://github.com/cri-o/cri-o/issues/7035
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
No longer set inactive-or-failed collect mode property, which fixes a race with container that OOM kill. As a result, users should upgrade to runc 1.1.8 or crun 1.9
```
