### PR TITLE
Use strongly encapsulated types with strict semantics for RemoveImage

### DIFF
--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -705,14 +705,14 @@ func (svc *imageService) UntagImage(systemContext *types.SystemContext, nameOrID
 			name = namedRef.DockerReference().String()
 		}
 
-		prunedNames := 0
+		remainingNames := 0
 		for _, imgName := range img.Names {
 			if imgName != name && imgName != nameOrID {
-				prunedNames += 1
+				remainingNames += 1
 			}
 		}
 
-		if prunedNames > 0 {
+		if remainingNames > 0 {
 			return svc.store.RemoveNames(img.ID, []string{name, nameOrID})
 		}
 	}

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -127,9 +127,13 @@ type ImageServer interface {
 	PrepareImage(systemContext *types.SystemContext, imageName string) (types.ImageCloser, error)
 	// PullImage imports an image from the specified location.
 	PullImage(systemContext *types.SystemContext, imageName string, options *ImageCopyOptions) (types.ImageReference, error)
+
+	// DeleteImage deletes a storage image (impacting all its tags)
+	DeleteImage(systemContext *types.SystemContext, id StorageImageID) error
 	// UntagImage removes a name from the specified image, and if it was
 	// the only name the image had, removes the image.
 	UntagImage(systemContext *types.SystemContext, imageName string) error
+
 	// GetStore returns the reference to the storage library Store which
 	// the image server uses to hold images, and is the destination used
 	// when it's asked to pull an image.
@@ -711,6 +715,16 @@ func (svc *imageService) UntagImage(systemContext *types.SystemContext, nameOrID
 		if prunedNames > 0 {
 			return svc.store.RemoveNames(img.ID, []string{name, nameOrID})
 		}
+	}
+
+	return ref.DeleteImage(svc.ctx, systemContext)
+}
+
+// DeleteImage deletes a storage image (impacting all its tags)
+func (svc *imageService) DeleteImage(systemContext *types.SystemContext, id StorageImageID) error {
+	ref, err := id.imageRef(svc)
+	if err != nil {
+		return err
 	}
 
 	return ref.DeleteImage(svc.ctx, systemContext)

--- a/internal/storage/image_id.go
+++ b/internal/storage/image_id.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/storage"
 )
 
 // StorageImageID is a stable identifier for a (deduplicated) image in a local storage.
@@ -44,6 +45,11 @@ func parseStorageImageID(input string) (StorageImageID, error) {
 		return StorageImageID{}, fmt.Errorf("%q is not a valid image ID", input)
 	}
 	return newExactStorageImageID(input), nil
+}
+
+// storageImageIDFromImage is an internal constructor of a StorageImageID.
+func storageImageIDFromImage(image *storage.Image) StorageImageID {
+	return newExactStorageImageID(image.ID)
 }
 
 func (id StorageImageID) ensureInitialized() {

--- a/internal/storage/image_id.go
+++ b/internal/storage/image_id.go
@@ -1,0 +1,70 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/containers/image/v5/docker/reference"
+)
+
+// StorageImageID is a stable identifier for a (deduplicated) image in a local storage.
+// The image referenced by the ID is _mostly_ immutable, notably the layers and config
+// will never change; the names and some other metadata may change (as images are deduplicated).
+//
+// An ID might not refer to an image (e.g. if the image was deleted, or if the ID never referred
+// to an image in the first place).
+//
+// This is intended to be a value type; if a value exists, it is a correctly-formatted ID.
+type StorageImageID struct {
+	// privateID is INTENTIONALLY ENCAPSULATED to provide strong type safety and strong syntax/semantics guarantees.
+	// Use typed values, not strings, everywhere it is even remotely possible.
+	privateID string // Always a full *storage.Image.ID value (not a prefix); but there might not be any image with this ID
+}
+
+// newExactStorageImageID is a private constructor of a StorageImageID.
+func newExactStorageImageID(rawImageID string) StorageImageID {
+	if !reference.IsFullIdentifier(rawImageID) {
+		panic(fmt.Sprintf("internal error, invalid input %q to newExactStorageImageID", rawImageID))
+	}
+	return StorageImageID{privateID: rawImageID}
+}
+
+// ParseStorageImageIDFromOutOfProcessData constructs a StorageImageID from a string.
+// It is only intended for communication with OUT-OF-PROCESS APIs,
+// like image IDs provided by CRI by Kubelet (who got it from CRI-O’s
+// StorageImageID.IDStringForOutOfProcessConsumptionOnly() in the first place).
+func ParseStorageImageIDFromOutOfProcessData(input string) (StorageImageID, error) {
+	return parseStorageImageID(input)
+}
+
+// parseStorageImageID is an private constructor of a StorageImageID.
+// Most callers should use ParseStorageImageIDFromOutOfProcessData ,
+// or preferably not parse strings in the first place.
+func parseStorageImageID(input string) (StorageImageID, error) {
+	if !reference.IsFullIdentifier(input) {
+		return StorageImageID{}, fmt.Errorf("%q is not a valid image ID", input)
+	}
+	return newExactStorageImageID(input), nil
+}
+
+func (id StorageImageID) ensureInitialized() {
+	// It’s deeply disappointing that we need to check this at runtime, instead of just
+	// requiring a constructor to be called.
+	if id.privateID == "" {
+		panic("internal error, use of an uninitialized StorageImageID")
+	}
+}
+
+// IDStringForOutOfProcessConsumptionOnly is only intended for communication with OUT-OF-PROCESS APIs,
+// like image IDs in CRI to provide stable identifiers to Kubelet.
+//
+// StorageImageID intentionally does not implement String(). Use typed values wherever possible.
+func (id StorageImageID) IDStringForOutOfProcessConsumptionOnly() string {
+	id.ensureInitialized()
+	return id.privateID
+}
+
+// Format() is implemented so that log entries can be written, without providing a convenient String() method.
+func (id StorageImageID) Format(f fmt.State, verb rune) {
+	id.ensureInitialized()
+	fmt.Fprintf(f, fmt.FormatString(f, verb), id.privateID)
+}

--- a/internal/storage/image_id.go
+++ b/internal/storage/image_id.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/containers/image/v5/docker/reference"
+	istorage "github.com/containers/image/v5/storage"
+	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 )
 
@@ -73,4 +75,12 @@ func (id StorageImageID) IDStringForOutOfProcessConsumptionOnly() string {
 func (id StorageImageID) Format(f fmt.State, verb rune) {
 	id.ensureInitialized()
 	fmt.Fprintf(f, fmt.FormatString(f, verb), id.privateID)
+}
+
+// imageRef(svc) returns a types.ImageReference for id
+// This succeeds even if the image does not exist.
+func (id StorageImageID) imageRef(svc *imageService) (types.ImageReference, error) {
+	id.ensureInitialized()
+	// This is never expected to fail, we have validated privateID.
+	return istorage.Transport.NewStoreReference(svc.store, nil, id.privateID)
 }

--- a/internal/storage/image_id_test.go
+++ b/internal/storage/image_id_test.go
@@ -1,0 +1,51 @@
+package storage_test
+
+import (
+	"fmt"
+
+	"github.com/cri-o/cri-o/internal/storage"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const testSHA256 = "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"
+
+var _ = t.Describe("StorageImageID", func() {
+	It("Should parse valid IDs", func() {
+		id, err := storage.ParseStorageImageIDFromOutOfProcessData(testSHA256)
+		Expect(err).To(BeNil())
+		Expect(id.IDStringForOutOfProcessConsumptionOnly()).To(Equal(testSHA256))
+	})
+
+	It("Should reject invalid IDs", func() {
+		for _, input := range []string{
+			"",
+			"@",
+			testSHA256[:len(testSHA256)-1],
+		} {
+			_, err := storage.ParseStorageImageIDFromOutOfProcessData(input)
+			Expect(err).NotTo(BeNil())
+		}
+	})
+
+	It("Should reject use of uninitialized/empty values", func() {
+		id := storage.StorageImageID{}
+		Expect(func() { _ = id.IDStringForOutOfProcessConsumptionOnly() }).To(Panic())
+	})
+
+	It("Should be usable for logging, but not otherwise expose a string value", func() {
+		id, err := storage.ParseStorageImageIDFromOutOfProcessData(testSHA256)
+		Expect(err).To(BeNil())
+
+		var _ fmt.Formatter = id // A compile-time check that id implements Formatter
+
+		// We need an intermediate any() value, otherwise Go refuses to allow a compile-time-known check to be done at runtime.
+		_, isStringer := any(id).(fmt.Stringer)
+		Expect(isStringer).To(BeFalse())
+
+		res := fmt.Sprintf("%s", id)
+		Expect(res).To(Equal(testSHA256))
+		res = fmt.Sprintf("%q", id)
+		Expect(res).To(Equal(`"` + testSHA256 + `"`))
+	})
+})

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/image/v5/types"
 	cs "github.com/containers/storage"
 	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	"github.com/cri-o/cri-o/pkg/config"
 	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
 	"github.com/golang/mock/gomock"
@@ -308,75 +309,40 @@ var _ = t.Describe("Image", func() {
 		It("should succeed to untag an image", func() {
 			// Given
 			inOrder(
-				mockGetRef(),
 				mockGetStoreImage(storeMock, testNormalizedImageName, testSHA256),
-				mockResolveImage(storeMock, testNormalizedImageName, testSHA256),
+				storeMock.EXPECT().Image(testSHA256).
+					Return(&cs.Image{ID: testSHA256}, nil),
 				storeMock.EXPECT().DeleteImage(testSHA256, true).
 					Return(nil, nil),
 			)
+			ref, err := references.ParseRegistryImageReferenceFromOutOfProcessData(testImageName)
+			Expect(err).To(BeNil())
 
 			// When
-			err := sut.UntagImage(&types.SystemContext{}, testImageName)
+			err = sut.UntagImage(&types.SystemContext{}, ref)
 
 			// Then
 			Expect(err).To(BeNil())
 		})
 
-		It("should fail to untag an image with invalid name", func() {
-			// Given
-			// When
-			err := sut.UntagImage(&types.SystemContext{}, "")
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
 		It("should fail to untag an image that can't be found", func() {
 			// Given
 			inOrder(
-				mockGetRef(),
 				mockGetStoreImage(storeMock, testNormalizedImageName, ""),
 			)
+			ref, err := references.ParseRegistryImageReferenceFromOutOfProcessData(testImageName)
+			Expect(err).To(BeNil())
 
 			// When
-			err := sut.UntagImage(&types.SystemContext{}, testImageName)
+			err = sut.UntagImage(&types.SystemContext{}, ref)
 
 			// Then
 			Expect(err).NotTo(BeNil())
-		})
-
-		It("should fail to untag an image with a docker:// reference", func() {
-			// Given
-			const imageName = "docker://localhost/busybox:latest"
-			inOrder(
-				mockGetStoreImage(storeMock, "localhost/busybox:latest", testSHA256),
-			)
-
-			// When
-			err := sut.UntagImage(&types.SystemContext{}, imageName)
-
-			// Then
-			Expect(err).NotTo(BeNil()) // FIXME: this actually fails because it tries to untag the image at the docker://localhost registry!
-		})
-
-		It("should fail to untag an image with a docker:// digest reference", func() {
-			// Given
-			const imageName = "docker://localhost/busybox@sha256:" + testSHA256
-			inOrder(
-				mockGetStoreImage(storeMock, "localhost/busybox@sha256:"+testSHA256, testSHA256),
-			)
-
-			// When
-			err := sut.UntagImage(&types.SystemContext{}, imageName)
-
-			// Then
-			Expect(err).NotTo(BeNil()) // FIXME: this actually fails because it tries to untag the image at the docker://localhost registry!
 		})
 
 		It("should fail to untag an image with multiple names", func() {
 			// Given
 			inOrder(
-				mockGetRef(),
 				// storage.Transport.GetStoreImage:
 				storeMock.EXPECT().Image(testNormalizedImageName).
 					Return(&cs.Image{
@@ -384,12 +350,14 @@ var _ = t.Describe("Image", func() {
 						Names: []string{testNormalizedImageName, "localhost/b:latest", "localhost/c:latest"},
 					}, nil),
 
-				storeMock.EXPECT().RemoveNames(testSHA256, []string{"docker.io/library/image:latest", "image"}).
+				storeMock.EXPECT().RemoveNames(testSHA256, []string{"docker.io/library/image:latest"}).
 					Return(t.TestError),
 			)
+			ref, err := references.ParseRegistryImageReferenceFromOutOfProcessData(testImageName)
+			Expect(err).To(BeNil())
 
 			// When
-			err := sut.UntagImage(&types.SystemContext{}, testImageName)
+			err = sut.UntagImage(&types.SystemContext{}, ref)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -243,22 +243,6 @@ var _ = t.Describe("Image", func() {
 			}))
 		})
 
-		It("should succeed to resolve with a local copy", func() {
-			// Given
-			gomock.InOrder(
-				storeMock.EXPECT().Image(gomock.Any()).
-					Return(&cs.Image{ID: testImageName}, nil),
-			)
-
-			// When
-			names, err := sut.ResolveNames(nil, testImageName)
-
-			// Then
-			Expect(err).To(BeNil())
-			Expect(len(names)).To(Equal(1))
-			Expect(names[0]).To(Equal(testImageName))
-		})
-
 		It("should succeed to resolve with a locally-not-matching image id", func() {
 			// Given
 			gomock.InOrder()

--- a/internal/storage/references/registry_reference.go
+++ b/internal/storage/references/registry_reference.go
@@ -1,0 +1,86 @@
+package references
+
+import (
+	"fmt"
+
+	"github.com/containers/image/v5/docker/reference"
+)
+
+// RegistryImageReference is a name of a specific image location on a registry.
+// The image may or may not exist, and, in general, what image the name points to may change
+// over time.
+//
+// More specifically:
+// - The name always specifies a registry; it is not an alias nor a short name input to a search
+// - The name contains a tag or digest; it does not specify just a repo.
+//
+// This is intended to be a value type; if a value exists, it contains a valid reference.
+type RegistryImageReference struct {
+	// privateNamed is INTENTIONALLY ENCAPSULATED to provide strong type safety and strong syntax/semantics guarantees.
+	// Use typed values, not strings, everywhere it is even remotely possible.
+	privateNamed reference.Named // Satisfies !reference.IsNameOnly
+}
+
+// RegistryImageReferenceFromRaw is an internal constructor of a RegistryImageReference.
+//
+// This should only be called from internal/storage.
+// It’s the caller’s responsibility to provide a valid value (!IsNameOnly, and registry-qualified)
+func RegistryImageReferenceFromRaw(rawNamed reference.Named) RegistryImageReference {
+	// Ideally this would be better encapsulated, e.g. in internal/storage/internal, but
+	// that would require using a type defined with the internal package with a public alias,
+	// and as of 2023-10 mockgen creates code that refers to the internal target of the alias,
+	// which doesn’t compile.
+	if reference.IsNameOnly(rawNamed) {
+		panic(fmt.Sprintf("internal error, NewRegistryImageReference with a NameOnly %q", rawNamed.String()))
+	}
+	return RegistryImageReference{privateNamed: rawNamed}
+}
+
+// ParseRegistryImageReferenceFromOutOfProcessData constructs a RegistryImageReference from a string.
+//
+// It is only intended for communication with OUT-OF-PROCESS APIs,
+// like registry references provided by CRI by Kubelet.
+func ParseRegistryImageReferenceFromOutOfProcessData(input string) (RegistryImageReference, error) {
+	// Alternatively, should we provide two parsers, one with docker.io/library and :latest defaulting,
+	// and one only accepting fully-specified reference.Named.String() values?
+	ref, err := reference.ParseNormalizedNamed(input)
+	if err != nil {
+		return RegistryImageReference{}, err
+	}
+	ref = reference.TagNameOnly(ref)
+	return RegistryImageReferenceFromRaw(ref), nil
+}
+
+func (ref RegistryImageReference) ensureInitialized() {
+	// It’s deeply disappointing that we need to check this at runtime, instead of just
+	// requiring a constructor to be called.
+	if ref.privateNamed == nil {
+		panic("internal error, use of an uninitialized RegistryImageReference")
+	}
+}
+
+// StringForOutOfProcessConsumptionOnly is only intended for communication with OUT-OF-PROCESS APIs,
+// like image names in CRI status objects.
+//
+// RegistryImageReference intentionally does not implement String(). Use typed values wherever possible.
+func (ref RegistryImageReference) StringForOutOfProcessConsumptionOnly() string {
+	ref.ensureInitialized()
+	return ref.privateNamed.String()
+}
+
+// Format() is implemented so that log entries can be written, without providing a convenient String() method.
+func (ref RegistryImageReference) Format(f fmt.State, verb rune) {
+	ref.ensureInitialized()
+	fmt.Fprintf(f, fmt.FormatString(f, verb), ref.privateNamed.String())
+}
+
+// Raw returns the underlying reference.Named.
+//
+// The return value is !IsNameOnly, and the repo is registry-qualified.
+//
+// This should only be called from internal/storage.
+func (ref RegistryImageReference) Raw() reference.Named {
+	// See the comment in RegistryImageReferenceFromRaw about better encapsulation.
+	ref.ensureInitialized()
+	return ref.privateNamed
+}

--- a/internal/storage/references/registry_reference_test.go
+++ b/internal/storage/references/registry_reference_test.go
@@ -1,0 +1,74 @@
+package references_test
+
+import (
+	"fmt"
+
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/cri-o/cri-o/internal/storage/references"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = t.Describe("RegistryImageReference", func() {
+	It("Should parse valid references", func() {
+		ref, err := references.ParseRegistryImageReferenceFromOutOfProcessData("minimal")
+		Expect(err).To(BeNil())
+		Expect(ref.StringForOutOfProcessConsumptionOnly()).To(Equal("docker.io/library/minimal:latest"))
+
+		ref, err = references.ParseRegistryImageReferenceFromOutOfProcessData("quay.io/ns/repo:notlatest")
+		Expect(err).To(BeNil())
+		Expect(ref.StringForOutOfProcessConsumptionOnly()).To(Equal("quay.io/ns/repo:notlatest"))
+	})
+
+	It("Should reject invalid references", func() {
+		for _, input := range []string{
+			"",
+			"@",
+			"example.com/",
+		} {
+			_, err := references.ParseRegistryImageReferenceFromOutOfProcessData(input)
+			Expect(err).NotTo(BeNil())
+		}
+	})
+
+	It("Should reject construction of invalid values", func() {
+		Expect(func() { references.RegistryImageReferenceFromRaw(nil) }).To(Panic())
+
+		nameOnly, err := reference.ParseNormalizedNamed("example.com/ns/repo-only")
+		Expect(err).To(BeNil())
+		Expect(func() { references.RegistryImageReferenceFromRaw(nameOnly) }).To(Panic())
+	})
+
+	It("Should reject use of uninitialized/empty values", func() {
+		ref := references.RegistryImageReference{}
+		Expect(func() { _ = ref.StringForOutOfProcessConsumptionOnly() }).To(Panic())
+	})
+
+	It("Should be usable for logging, but not otherwise expose a string value", func() {
+		const testName = "quay.io/ns/repo:notlatest"
+
+		ref, err := references.ParseRegistryImageReferenceFromOutOfProcessData(testName)
+		Expect(err).To(BeNil())
+
+		var _ fmt.Formatter = ref // A compile-time check that ref implements Formatter
+
+		// We need an intermediate any() value, otherwise Go refuses to allow a compile-time-known check to be done at runtime.
+		_, isStringer := any(ref).(fmt.Stringer)
+		Expect(isStringer).To(BeFalse())
+
+		res := fmt.Sprintf("%s", ref)
+		Expect(res).To(Equal(testName))
+		res = fmt.Sprintf("%q", ref)
+		Expect(res).To(Equal(`"` + testName + `"`))
+	})
+
+	It("Should return a plausible raw value", func() {
+		const testName = "quay.io/ns/repo:notlatest"
+
+		ref, err := references.ParseRegistryImageReferenceFromOutOfProcessData(testName)
+		Expect(err).To(BeNil())
+
+		raw := ref.Raw()
+		Expect(raw.String()).To(Equal(testName))
+	})
+})

--- a/internal/storage/references/suite_test.go
+++ b/internal/storage/references/suite_test.go
@@ -1,0 +1,26 @@
+package references_test
+
+import (
+	"testing"
+
+	. "github.com/cri-o/cri-o/test/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// TestReferences runs the created specs
+func TestReferences(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "Storage/references")
+}
+
+var t *TestFramework
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})

--- a/internal/storage/registry_reference.go
+++ b/internal/storage/registry_reference.go
@@ -1,0 +1,17 @@
+package storage
+
+import "github.com/cri-o/cri-o/internal/storage/references"
+
+// RegistryImageReference is a name of a specific image location on a registry.
+// The image may or may not exist, and, in general, what image the name points to may change
+// over time.
+//
+// More specifically:
+// - The name always specifies a registry; it is not an alias nor a short name input to a search
+// - The name contains a tag or digest; it does not specify just a repo.
+//
+// This is intended to be a value type; if a value exists, it contains a valid reference.
+type RegistryImageReference = references.RegistryImageReference
+
+// ^^ is in a separate subpackage to break a dependency loop; but conceptually it should
+// be provided by the same package as StorageImageID.

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -31,20 +31,19 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
-	var images []string
 	if id := s.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
-		images = []string{id.IDStringForOutOfProcessConsumptionOnly()} // This violates rules of references.StorageImageID, but it will be removed soon.
-	} else {
-		potentialMatches, err := s.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, imageRef)
-		if err != nil {
-			return err
-		}
-		for _, ref := range potentialMatches {
-			images = append(images, ref.StringForOutOfProcessConsumptionOnly()) // This violates rules of references.StorageImageID, but it will be removed soon.
-		}
+		return s.StorageImageServer().DeleteImage(s.config.SystemContext, *id)
 	}
 
-	var err error
+	potentialMatches, err := s.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, imageRef)
+	if err != nil {
+		return err
+	}
+	images := make([]string, 0, len(potentialMatches))
+	for _, ref := range potentialMatches {
+		images = append(images, ref.StringForOutOfProcessConsumptionOnly()) // This violates rules of references.StorageImageID, but it will be removed soon.
+	}
+
 	for _, img := range images {
 		err = s.StorageImageServer().UntagImage(s.config.SystemContext, img)
 		if err != nil {

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -31,6 +31,15 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
+	// FIXME: The CRI API definition says
+	//      This call is idempotent, and must not return an error if the image has
+	//      already been removed.
+	// and this code doesn’t seem to conform to that.
+
+	// Actually Kubelet is only ever calling this with full image IDs.
+	// So we don't really need to accept ID prefixes nor short names;
+	// or is there another user?!
+
 	if id := s.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
 		return s.StorageImageServer().DeleteImage(s.config.SystemContext, *id)
 	}

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -39,15 +39,10 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) error {
 	if err != nil {
 		return err
 	}
-	images := make([]string, 0, len(potentialMatches))
-	for _, ref := range potentialMatches {
-		images = append(images, ref.StringForOutOfProcessConsumptionOnly()) // This violates rules of references.StorageImageID, but it will be removed soon.
-	}
-
-	for _, img := range images {
-		err = s.StorageImageServer().UntagImage(s.config.SystemContext, img)
+	for _, name := range potentialMatches {
+		err = s.StorageImageServer().UntagImage(s.config.SystemContext, name)
 		if err != nil {
-			log.Debugf(ctx, "Error deleting image %s: %v", img, err)
+			log.Debugf(ctx, "Error deleting image %s: %v", name, err)
 			continue
 		}
 		deleted = true

--- a/server/image_remove_test.go
+++ b/server/image_remove_test.go
@@ -33,7 +33,7 @@ var _ = t.Describe("ImageRemove", func() {
 					gomock.Any(), "image").
 					Return([]storage.RegistryImageReference{resolvedImageName}, nil),
 				imageServerMock.EXPECT().UntagImage(gomock.Any(),
-					resolvedImageName.StringForOutOfProcessConsumptionOnly()).Return(nil),
+					resolvedImageName).Return(nil),
 			)
 			// When
 			_, err := sut.RemoveImage(context.Background(),
@@ -72,7 +72,7 @@ var _ = t.Describe("ImageRemove", func() {
 					gomock.Any(), "image").
 					Return([]storage.RegistryImageReference{resolvedImageName}, nil),
 				imageServerMock.EXPECT().UntagImage(gomock.Any(),
-					resolvedImageName.StringForOutOfProcessConsumptionOnly()).Return(t.TestError),
+					resolvedImageName).Return(t.TestError),
 			)
 			// When
 			_, err := sut.RemoveImage(context.Background(),

--- a/server/image_remove_test.go
+++ b/server/image_remove_test.go
@@ -3,6 +3,8 @@ package server_test
 import (
 	"context"
 
+	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -11,6 +13,9 @@ import (
 
 // The actual test suite
 var _ = t.Describe("ImageRemove", func() {
+	resolvedImageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("docker.io/library/image:latest")
+	Expect(err).To(BeNil())
+
 	// Prepare the sut
 	BeforeEach(func() {
 		beforeEach()
@@ -22,11 +27,13 @@ var _ = t.Describe("ImageRemove", func() {
 		It("should succeed", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(
-					gomock.Any(), gomock.Any()).
-					Return([]string{"image"}, nil),
+				imageServerMock.EXPECT().HeuristicallyTryResolvingStringAsIDPrefix("image").
+					Return(nil),
+				imageServerMock.EXPECT().CandidatesForPotentiallyShortImageName(
+					gomock.Any(), "image").
+					Return([]storage.RegistryImageReference{resolvedImageName}, nil),
 				imageServerMock.EXPECT().UntagImage(gomock.Any(),
-					gomock.Any()).Return(nil),
+					resolvedImageName.StringForOutOfProcessConsumptionOnly()).Return(nil),
 			)
 			// When
 			_, err := sut.RemoveImage(context.Background(),
@@ -39,16 +46,17 @@ var _ = t.Describe("ImageRemove", func() {
 		// Given
 		It("should succeed with a full image id", func() {
 			const testSHA256 = "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"
+			parsedTestSHA256, err := storage.ParseStorageImageIDFromOutOfProcessData(testSHA256)
+			Expect(err).To(BeNil())
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(
-					gomock.Any(), testSHA256).
-					Return([]string{testSHA256}, nil),
+				imageServerMock.EXPECT().HeuristicallyTryResolvingStringAsIDPrefix(testSHA256).
+					Return(&parsedTestSHA256),
 				imageServerMock.EXPECT().UntagImage(
-					gomock.Any(), testSHA256).
+					gomock.Any(), gomock.Any()).
 					Return(nil),
 			)
 			// When
-			_, err := sut.RemoveImage(context.Background(),
+			_, err = sut.RemoveImage(context.Background(),
 				&types.RemoveImageRequest{Image: &types.ImageSpec{Image: testSHA256}})
 
 			// Then
@@ -58,11 +66,13 @@ var _ = t.Describe("ImageRemove", func() {
 		It("should fail when image untag errors", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(
-					gomock.Any(), gomock.Any()).
-					Return([]string{"image"}, nil),
+				imageServerMock.EXPECT().HeuristicallyTryResolvingStringAsIDPrefix("image").
+					Return(nil),
+				imageServerMock.EXPECT().CandidatesForPotentiallyShortImageName(
+					gomock.Any(), "image").
+					Return([]storage.RegistryImageReference{resolvedImageName}, nil),
 				imageServerMock.EXPECT().UntagImage(gomock.Any(),
-					gomock.Any()).Return(t.TestError),
+					resolvedImageName.StringForOutOfProcessConsumptionOnly()).Return(t.TestError),
 			)
 			// When
 			_, err := sut.RemoveImage(context.Background(),
@@ -75,8 +85,10 @@ var _ = t.Describe("ImageRemove", func() {
 		It("should fail when name resolving errors", func() {
 			// Given
 			gomock.InOrder(
-				imageServerMock.EXPECT().ResolveNames(
-					gomock.Any(), gomock.Any()).
+				imageServerMock.EXPECT().HeuristicallyTryResolvingStringAsIDPrefix("image").
+					Return(nil),
+				imageServerMock.EXPECT().CandidatesForPotentiallyShortImageName(
+					gomock.Any(), "image").
 					Return(nil, t.TestError),
 			)
 			// When

--- a/server/image_remove_test.go
+++ b/server/image_remove_test.go
@@ -51,8 +51,8 @@ var _ = t.Describe("ImageRemove", func() {
 			gomock.InOrder(
 				imageServerMock.EXPECT().HeuristicallyTryResolvingStringAsIDPrefix(testSHA256).
 					Return(&parsedTestSHA256),
-				imageServerMock.EXPECT().UntagImage(
-					gomock.Any(), gomock.Any()).
+				imageServerMock.EXPECT().DeleteImage(
+					gomock.Any(), parsedTestSHA256).
 					Return(nil),
 			)
 			// When

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -55,6 +55,20 @@ func (mr *MockImageServerMockRecorder) CandidatesForPotentiallyShortImageName(ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidatesForPotentiallyShortImageName", reflect.TypeOf((*MockImageServer)(nil).CandidatesForPotentiallyShortImageName), arg0, arg1)
 }
 
+// DeleteImage mocks base method.
+func (m *MockImageServer) DeleteImage(arg0 *types.SystemContext, arg1 storage0.StorageImageID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteImage", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteImage indicates an expected call of DeleteImage.
+func (mr *MockImageServerMockRecorder) DeleteImage(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteImage", reflect.TypeOf((*MockImageServer)(nil).DeleteImage), arg0, arg1)
+}
+
 // GetStore mocks base method.
 func (m *MockImageServer) GetStore() storage.Store {
 	m.ctrl.T.Helper()

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -13,6 +13,7 @@ import (
 	storage "github.com/containers/storage"
 	types0 "github.com/containers/storage/types"
 	storage0 "github.com/cri-o/cri-o/internal/storage"
+	references "github.com/cri-o/cri-o/internal/storage/references"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -39,6 +40,21 @@ func (m *MockImageServer) EXPECT() *MockImageServerMockRecorder {
 	return m.recorder
 }
 
+// CandidatesForPotentiallyShortImageName mocks base method.
+func (m *MockImageServer) CandidatesForPotentiallyShortImageName(arg0 *types.SystemContext, arg1 string) ([]references.RegistryImageReference, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CandidatesForPotentiallyShortImageName", arg0, arg1)
+	ret0, _ := ret[0].([]references.RegistryImageReference)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CandidatesForPotentiallyShortImageName indicates an expected call of CandidatesForPotentiallyShortImageName.
+func (mr *MockImageServerMockRecorder) CandidatesForPotentiallyShortImageName(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidatesForPotentiallyShortImageName", reflect.TypeOf((*MockImageServer)(nil).CandidatesForPotentiallyShortImageName), arg0, arg1)
+}
+
 // GetStore mocks base method.
 func (m *MockImageServer) GetStore() storage.Store {
 	m.ctrl.T.Helper()
@@ -51,6 +67,20 @@ func (m *MockImageServer) GetStore() storage.Store {
 func (mr *MockImageServerMockRecorder) GetStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStore", reflect.TypeOf((*MockImageServer)(nil).GetStore))
+}
+
+// HeuristicallyTryResolvingStringAsIDPrefix mocks base method.
+func (m *MockImageServer) HeuristicallyTryResolvingStringAsIDPrefix(arg0 string) *storage0.StorageImageID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HeuristicallyTryResolvingStringAsIDPrefix", arg0)
+	ret0, _ := ret[0].(*storage0.StorageImageID)
+	return ret0
+}
+
+// HeuristicallyTryResolvingStringAsIDPrefix indicates an expected call of HeuristicallyTryResolvingStringAsIDPrefix.
+func (mr *MockImageServerMockRecorder) HeuristicallyTryResolvingStringAsIDPrefix(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeuristicallyTryResolvingStringAsIDPrefix", reflect.TypeOf((*MockImageServer)(nil).HeuristicallyTryResolvingStringAsIDPrefix), arg0)
 }
 
 // ImageStatus mocks base method.

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -173,7 +173,7 @@ func (mr *MockImageServerMockRecorder) ResolveNames(arg0, arg1 interface{}) *gom
 }
 
 // UntagImage mocks base method.
-func (m *MockImageServer) UntagImage(arg0 *types.SystemContext, arg1 string) error {
+func (m *MockImageServer) UntagImage(arg0 *types.SystemContext, arg1 references.RegistryImageReference) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagImage", arg0, arg1)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Split `ImageServer.ResolveNames` into two well-typed parsers
    
We will push the heuristics to the callers to make the heuristics explicit, very loud to readers, and most importantly to give callers well-typed data instead of ambiguous strings.

This introduces `storage.StorageImageID` and `storage.RegistryImageReference` types, with the intent that users dealing with `internal/storage` should only use these strongly-typed values, not strings, for image identification/referencing.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

See individual commit messages for details. Overall, this should not actually change behavior of `RemoveImage`.

This is the beginning of the payoff of the recent API/semantics PRs. I have two similar directly related items queued to follow:
- Migrate `ImageServer.ImageStatus` to accept well-typed input (`StorageImageID` or `RegistryImageReference`)
- Migrate `PrepareImage`/`PullImage` to accept `RegistryImageReference`

and that will eliminate (or push to callers) all the heuristic “does it parse this way, that way, another way?” code paths in `internal/storage`, allowing the pull code to precisely reason about the names and to manipulate them with confidence.

This PR is filed separately (leaving the rules-violating `ResolveNames` in place) to get the review of the API types and general approach quickly, to surface concerns, if any, earlier.

Cc: @saschagrunert 

#### Does this PR introduce a user-facing change?

```release-note
None
```
