### PR TITLE
Use typed and explicitly named names for image fields in containers

### DIFF
--- a/internal/config/nsmgr/test/utils.go
+++ b/internal/config/nsmgr/test/utils.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -50,10 +51,14 @@ var AllSpoofedNamespaces = []nsmgr.Namespace{
 }
 
 func ContainerWithPid(pid int) (*oci.Container, error) {
+	imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+	if err != nil {
+		return nil, err
+	}
 	testContainer, err := oci.NewContainer("testid", "testname", "",
 		"/container/logs", map[string]string{},
 		map[string]string{}, map[string]string{}, "image",
-		"imageName", "imageRef", &types.ContainerMetadata{},
+		"imageName", &imageID, &types.ContainerMetadata{},
 		"testsandboxid", false, false, false, "",
 		"/root/for/container", time.Now(), "SIGKILL")
 	if err != nil {

--- a/internal/config/nsmgr/test/utils.go
+++ b/internal/config/nsmgr/test/utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -51,6 +52,10 @@ var AllSpoofedNamespaces = []nsmgr.Namespace{
 }
 
 func ContainerWithPid(pid int) (*oci.Container, error) {
+	imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("example.com/some-image:latest")
+	if err != nil {
+		return nil, err
+	}
 	imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
 	if err != nil {
 		return nil, err
@@ -58,7 +63,7 @@ func ContainerWithPid(pid int) (*oci.Container, error) {
 	testContainer, err := oci.NewContainer("testid", "testname", "",
 		"/container/logs", map[string]string{},
 		map[string]string{}, map[string]string{}, "image",
-		"imageName", &imageID, &types.ContainerMetadata{},
+		&imageName, &imageID, &types.ContainerMetadata{},
 		"testsandboxid", false, false, false, "",
 		"/root/for/container", time.Now(), "SIGKILL")
 	if err != nil {

--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -73,8 +73,8 @@ type Container interface {
 	// DisableFips returns whether the container should disable fips mode
 	DisableFips() bool
 
-	// Image returns the image specified in the container spec, or an error
-	Image() (string, error)
+	// UserRequestedImage returns the image specified in the container spec, or an error
+	UserRequestedImage() (string, error)
 
 	// ReadOnly returns whether the rootfs should be readonly
 	// it takes a bool as to whether crio was configured to
@@ -172,7 +172,7 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 	created := time.Now()
 	labels := c.Config().Labels
 
-	image, err := c.Image()
+	userRequestedImage, err := c.UserRequestedImage()
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 		}
 	}
 
-	c.spec.AddAnnotation(annotations.Image, image)
+	c.spec.AddAnnotation(annotations.Image, userRequestedImage)
 	imageName := ""
 	if imageResult.SomeNameOfThisImage != nil {
 		imageName = imageResult.SomeNameOfThisImage.StringForOutOfProcessConsumptionOnly()
@@ -464,8 +464,8 @@ func (c *container) DisableFips() bool {
 	return false
 }
 
-// Image returns the image specified in the container spec, or an error
-func (c *container) Image() (string, error) {
+// UserRequestedImage returns the image specified in the container spec, or an error
+func (c *container) UserRequestedImage() (string, error) {
 	imageSpec := c.config.Image
 	if imageSpec == nil {
 		return "", errors.New("CreateContainerRequest.ContainerConfig.Image is nil")

--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -213,7 +213,7 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 
 	c.spec.AddAnnotation(annotations.Image, image)
 	c.spec.AddAnnotation(annotations.ImageName, imageResult.Name)
-	c.spec.AddAnnotation(annotations.ImageRef, imageResult.ID)
+	c.spec.AddAnnotation(annotations.ImageRef, imageResult.ID.IDStringForOutOfProcessConsumptionOnly())
 	c.spec.AddAnnotation(annotations.Name, c.Name())
 	c.spec.AddAnnotation(annotations.ContainerID, c.ID())
 	c.spec.AddAnnotation(annotations.SandboxID, sb.ID())

--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -212,7 +212,11 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 	}
 
 	c.spec.AddAnnotation(annotations.Image, image)
-	c.spec.AddAnnotation(annotations.ImageName, imageResult.Name)
+	imageName := ""
+	if imageResult.SomeNameOfThisImage != nil {
+		imageName = imageResult.SomeNameOfThisImage.StringForOutOfProcessConsumptionOnly()
+	}
+	c.spec.AddAnnotation(annotations.ImageName, imageName)
 	c.spec.AddAnnotation(annotations.ImageRef, imageResult.ID.IDStringForOutOfProcessConsumptionOnly())
 	c.spec.AddAnnotation(annotations.Name, c.Name())
 	c.spec.AddAnnotation(annotations.ContainerID, c.ID())

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -86,7 +86,11 @@ var _ = t.Describe("Container", func() {
 			Expect(err).To(BeNil())
 			currentTime := time.Now()
 			volumes := []oci.ContainerVolume{}
-			imageResult := storage.ImageResult{}
+			imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b")
+			Expect(err).To(BeNil())
+			imageResult := storage.ImageResult{
+				ID: imageID,
+			}
 			mountPoint := "test"
 			configStopSignal := "test"
 
@@ -122,7 +126,7 @@ var _ = t.Describe("Container", func() {
 
 			Expect(sut.Spec().Config.Annotations[annotations.Image]).To(Equal(image))
 			Expect(sut.Spec().Config.Annotations[annotations.ImageName]).To(Equal(imageResult.Name))
-			Expect(sut.Spec().Config.Annotations[annotations.ImageRef]).To(Equal(imageResult.ID))
+			Expect(sut.Spec().Config.Annotations[annotations.ImageRef]).To(Equal(imageResult.ID.IDStringForOutOfProcessConsumptionOnly()))
 			Expect(sut.Spec().Config.Annotations[annotations.Name]).To(Equal(sut.Name()))
 			Expect(sut.Spec().Config.Annotations[annotations.ContainerID]).To(Equal(sut.ID()))
 			Expect(sut.Spec().Config.Annotations[annotations.SandboxID]).To(Equal(sb.ID()))

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	crioann "github.com/cri-o/cri-o/pkg/annotations"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -88,8 +89,11 @@ var _ = t.Describe("Container", func() {
 			volumes := []oci.ContainerVolume{}
 			imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b")
 			Expect(err).To(BeNil())
+			imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("example.com/repo/image:tag")
+			Expect(err).To(BeNil())
 			imageResult := storage.ImageResult{
-				ID: imageID,
+				ID:                  imageID,
+				SomeNameOfThisImage: &imageName,
 			}
 			mountPoint := "test"
 			configStopSignal := "test"
@@ -125,7 +129,7 @@ var _ = t.Describe("Container", func() {
 			Expect(err).To(BeNil())
 
 			Expect(sut.Spec().Config.Annotations[annotations.Image]).To(Equal(image))
-			Expect(sut.Spec().Config.Annotations[annotations.ImageName]).To(Equal(imageResult.Name))
+			Expect(sut.Spec().Config.Annotations[annotations.ImageName]).To(Equal(imageResult.SomeNameOfThisImage.StringForOutOfProcessConsumptionOnly()))
 			Expect(sut.Spec().Config.Annotations[annotations.ImageRef]).To(Equal(imageResult.ID.IDStringForOutOfProcessConsumptionOnly()))
 			Expect(sut.Spec().Config.Annotations[annotations.Name]).To(Equal(sut.Name()))
 			Expect(sut.Spec().Config.Annotations[annotations.ContainerID]).To(Equal(sut.ID()))

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -104,7 +104,7 @@ var _ = t.Describe("Container", func() {
 				[]*hostport.PortMapping{}, false, currentTime, "", nil, nil)
 			Expect(err).To(BeNil())
 
-			image, err := sut.Image()
+			image, err := sut.UserRequestedImage()
 			Expect(err).To(BeNil())
 
 			logpath, err := sut.LogPath(sb.LogDir())
@@ -186,7 +186,7 @@ var _ = t.Describe("Container", func() {
 			Expect(sut.DisableFips()).To(Equal(false))
 		})
 	})
-	t.Describe("Image", func() {
+	t.Describe("UserRequestedImage", func() {
 		It("should fail when spec not set", func() {
 			// Given
 
@@ -194,7 +194,7 @@ var _ = t.Describe("Container", func() {
 			Expect(sut.SetConfig(config, sboxConfig)).To(BeNil())
 
 			// Then
-			img, err := sut.Image()
+			img, err := sut.UserRequestedImage()
 			Expect(err).NotTo(BeNil())
 			Expect(img).To(BeEmpty())
 		})
@@ -206,7 +206,7 @@ var _ = t.Describe("Container", func() {
 			Expect(sut.SetConfig(config, sboxConfig)).To(BeNil())
 
 			// Then
-			img, err := sut.Image()
+			img, err := sut.UserRequestedImage()
 			Expect(err).NotTo(BeNil())
 			Expect(img).To(BeEmpty())
 		})
@@ -221,7 +221,7 @@ var _ = t.Describe("Container", func() {
 			Expect(sut.SetConfig(config, sboxConfig)).To(BeNil())
 
 			// Then
-			img, err := sut.Image()
+			img, err := sut.UserRequestedImage()
 			Expect(err).To(BeNil())
 			Expect(img).To(Equal(testImage))
 		})

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -182,12 +182,16 @@ func (c *ContainerServer) prepareCheckpointExport(ctr *oci.Container) error {
 	if id := ctr.ImageID(); id != nil {
 		rootFSImageRef = id.IDStringForOutOfProcessConsumptionOnly()
 	}
+	rootFSImageName := ""
+	if imageName := ctr.ImageName(); imageName != nil {
+		rootFSImageName = imageName.StringForOutOfProcessConsumptionOnly()
+	}
 	config := &metadata.ContainerConfig{
 		ID:              ctr.ID(),
 		Name:            ctr.Name(),
 		RootfsImage:     ctr.Image(),
 		RootfsImageRef:  rootFSImageRef,
-		RootfsImageName: ctr.ImageName(),
+		RootfsImageName: rootFSImageName,
 		CreatedTime:     ctr.CreatedAt(),
 		OCIRuntime: func() string {
 			runtimeHandler := c.GetSandbox(ctr.Sandbox()).RuntimeHandler()

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -178,11 +178,15 @@ func (c *ContainerServer) prepareCheckpointExport(ctr *oci.Container) error {
 		return fmt.Errorf("generating spec for container %q failed: %w", ctr.ID(), err)
 	}
 
+	rootFSImageRef := ""
+	if id := ctr.ImageID(); id != nil {
+		rootFSImageRef = id.IDStringForOutOfProcessConsumptionOnly()
+	}
 	config := &metadata.ContainerConfig{
 		ID:              ctr.ID(),
 		Name:            ctr.Name(),
 		RootfsImage:     ctr.Image(),
-		RootfsImageRef:  ctr.ImageRef(),
+		RootfsImageRef:  rootFSImageRef,
 		RootfsImageName: ctr.ImageName(),
 		CreatedTime:     ctr.CreatedAt(),
 		OCIRuntime: func() string {

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -189,7 +189,7 @@ func (c *ContainerServer) prepareCheckpointExport(ctr *oci.Container) error {
 	config := &metadata.ContainerConfig{
 		ID:              ctr.ID(),
 		Name:            ctr.Name(),
-		RootfsImage:     ctr.Image(),
+		RootfsImage:     ctr.UserRequestedImage(),
 		RootfsImageRef:  rootFSImageRef,
 		RootfsImageName: rootFSImageName,
 		CreatedTime:     ctr.CreatedAt(),

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -294,7 +294,7 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 	}
 
 	if !wasSpoofed {
-		scontainer, err = oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, m.Annotations[annotations.Image], "", "", nil, id, false, false, false, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+		scontainer, err = oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, m.Annotations[annotations.Image], "", nil, nil, id, false, false, false, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 		if err != nil {
 			return sb, err
 		}
@@ -455,9 +455,13 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 		imgName = ""
 	}
 
-	imgRef, ok := m.Annotations[annotations.ImageRef]
-	if !ok {
-		imgRef = ""
+	var imageID *storage.StorageImageID
+	if s, ok := m.Annotations[annotations.ImageRef]; ok {
+		id, err := storage.ParseStorageImageIDFromOutOfProcessData(s)
+		if err != nil {
+			return fmt.Errorf("invalid %s annotation %q: %w", annotations.ImageRef, s, err)
+		}
+		imageID = &id
 	}
 
 	platformRuntimePath, ok := m.Annotations[crioann.PlatformRuntimePath]
@@ -475,7 +479,7 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, img, imgName, imgRef, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, img, imgName, imageID, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -446,9 +446,9 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 		return err
 	}
 
-	img, ok := m.Annotations[annotations.Image]
+	userRequestedImage, ok := m.Annotations[annotations.Image]
 	if !ok {
-		img = ""
+		userRequestedImage = ""
 	}
 
 	var imgName *references.RegistryImageReference
@@ -484,7 +484,7 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, img, imgName, imageID, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, userRequestedImage, imgName, imageID, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -626,7 +626,7 @@ var _ = t.Describe("ContainerServer", func() {
 			// Given
 			container, err := oci.NewContainer(containerID, "", "", "",
 				make(map[string]string), make(map[string]string),
-				make(map[string]string), "", "", nil,
+				make(map[string]string), "", nil, nil,
 				&types.ContainerMetadata{}, sandboxID, false,
 				false, false, "", "/invalid", time.Now(), "")
 			Expect(err).To(BeNil())

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -626,7 +626,7 @@ var _ = t.Describe("ContainerServer", func() {
 			// Given
 			container, err := oci.NewContainer(containerID, "", "", "",
 				make(map[string]string), make(map[string]string),
-				make(map[string]string), "", "", "",
+				make(map[string]string), "", "", nil,
 				&types.ContainerMetadata{}, sandboxID, false,
 				false, false, "", "/invalid", time.Now(), "")
 			Expect(err).To(BeNil())

--- a/internal/lib/restore_test.go
+++ b/internal/lib/restore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/podman/v4/pkg/criu"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -327,10 +328,12 @@ var _ = t.Describe("ContainerRestore", func() {
 })
 
 func setupInfraContainerWithPid(pid int, bundle string) {
+	imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+	Expect(err).To(BeNil())
 	testContainer, err := oci.NewContainer("testid", "testname", bundle,
 		"/container/logs", map[string]string{},
 		map[string]string{}, map[string]string{}, "image",
-		"imageName", "imageRef", &types.ContainerMetadata{},
+		"imageName", &imageID, &types.ContainerMetadata{},
 		"testsandboxid", false, false, false, "",
 		"/root/for/container", time.Now(), "SIGKILL")
 	Expect(err).To(BeNil())

--- a/internal/lib/restore_test.go
+++ b/internal/lib/restore_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -328,12 +329,14 @@ var _ = t.Describe("ContainerRestore", func() {
 })
 
 func setupInfraContainerWithPid(pid int, bundle string) {
+	imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("example.com/some-image:latest")
+	Expect(err).To(BeNil())
 	imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
 	Expect(err).To(BeNil())
 	testContainer, err := oci.NewContainer("testid", "testname", bundle,
 		"/container/logs", map[string]string{},
 		map[string]string{}, map[string]string{}, "image",
-		"imageName", &imageID, &types.ContainerMetadata{},
+		&imageName, &imageID, &types.ContainerMetadata{},
 		"testsandboxid", false, false, false, "",
 		"/root/for/container", time.Now(), "SIGKILL")
 	Expect(err).To(BeNil())

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/internal/storage"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -201,11 +202,12 @@ var _ = t.Describe("Sandbox", func() {
 		var testContainer *oci.Container
 
 		BeforeEach(func() {
-			var err error
+			imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+			Expect(err).To(BeNil())
 			testContainer, err = oci.NewContainer("testid", "testname", "",
 				"/container/logs", map[string]string{},
 				map[string]string{}, map[string]string{}, "image",
-				"imageName", "imageRef", &types.ContainerMetadata{},
+				"imageName", &imageID, &types.ContainerMetadata{},
 				"testsandboxid", false, false, false, "",
 				"/root/for/container", time.Now(), "SIGKILL")
 			Expect(err).To(BeNil())

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -202,12 +203,14 @@ var _ = t.Describe("Sandbox", func() {
 		var testContainer *oci.Container
 
 		BeforeEach(func() {
+			imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("example.com/some-image:latest")
+			Expect(err).To(BeNil())
 			imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
 			Expect(err).To(BeNil())
 			testContainer, err = oci.NewContainer("testid", "testname", "",
 				"/container/logs", map[string]string{},
 				map[string]string{}, map[string]string{}, "image",
-				"imageName", &imageID, &types.ContainerMetadata{},
+				&imageName, &imageID, &types.ContainerMetadata{},
 				"testsandboxid", false, false, false, "",
 				"/root/for/container", time.Now(), "SIGKILL")
 			Expect(err).To(BeNil())

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 			"io.kubernetes.cri-o.SeccompProfilePath": "{}",
 			"io.kubernetes.cri-o.Image": "{}",
 			"io.kubernetes.cri-o.ImageName": "{}",
-			"io.kubernetes.cri-o.ImageRef": "{}",
+			"io.kubernetes.cri-o.ImageRef": "1111111111111111111111111111111111111111111111111111111111111111",
 			"io.kubernetes.cri-o.KubeName": "{}",
 			"io.kubernetes.cri-o.PortMappings": "[]",
 			"io.kubernetes.cri-o.Labels": "{}",
@@ -160,7 +160,7 @@ func beforeEach() {
 
 	myContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "", "", "",
+		make(map[string]string), "", "", nil,
 		&types.ContainerMetadata{}, sandboxID, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -66,7 +66,7 @@ var _ = BeforeSuite(func() {
 			"io.kubernetes.cri-o.NamespaceOptions": "{}",
 			"io.kubernetes.cri-o.SeccompProfilePath": "{}",
 			"io.kubernetes.cri-o.Image": "{}",
-			"io.kubernetes.cri-o.ImageName": "{}",
+			"io.kubernetes.cri-o.ImageName": "example.com/some-other/deduplicated-name:notlatest",
 			"io.kubernetes.cri-o.ImageRef": "1111111111111111111111111111111111111111111111111111111111111111",
 			"io.kubernetes.cri-o.KubeName": "{}",
 			"io.kubernetes.cri-o.PortMappings": "[]",
@@ -160,7 +160,7 @@ func beforeEach() {
 
 	myContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "", "", nil,
+		make(map[string]string), "", nil, nil,
 		&types.ContainerMetadata{}, sandboxID, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func() {
 			"io.kubernetes.cri-o.IP": "{}",
 			"io.kubernetes.cri-o.NamespaceOptions": "{}",
 			"io.kubernetes.cri-o.SeccompProfilePath": "{}",
-			"io.kubernetes.cri-o.Image": "{}",
+			"io.kubernetes.cri-o.Image": "quay.io/image",
 			"io.kubernetes.cri-o.ImageName": "example.com/some-other/deduplicated-name:notlatest",
 			"io.kubernetes.cri-o.ImageRef": "1111111111111111111111111111111111111111111111111111111111111111",
 			"io.kubernetes.cri-o.KubeName": "{}",

--- a/internal/mockutils/mockutils.go
+++ b/internal/mockutils/mockutils.go
@@ -1,0 +1,40 @@
+package mockutils
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	"github.com/onsi/ginkgo/v2"
+)
+
+type MockSequence struct {
+	first, last *gomock.Call // may be both nil (= the default value of mockSequence) to mean empty sequence
+}
+
+// like gomock.InOrder, but can be nested
+func InOrder(calls ...interface{}) MockSequence {
+	var first, last *gomock.Call
+	// This implementation does a few more assignments and checks than strictly necessary, but it is O(N) and reasonably easy to read, so, whatever.
+	for i := 0; i < len(calls); i++ {
+		var elem MockSequence
+		switch e := calls[i].(type) {
+		case MockSequence:
+			elem = e
+		case *gomock.Call:
+			elem = MockSequence{e, e}
+		default:
+			ginkgo.Fail(fmt.Sprintf("Invalid inOrder parameter %#v", e))
+		}
+
+		if elem.first == nil {
+			continue
+		}
+		if first == nil {
+			first = elem.first
+		} else if last != nil {
+			elem.first.After(last)
+		}
+		last = elem.last
+	}
+	return MockSequence{first, last}
+}

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -124,9 +124,11 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
+// userRequestedImage is the users' input originally used to find imageID; it might evaluate to a different image (or to a different kind of reference!)
+// at any future time.
 // imageName, if set, is _some_ name of the image imageID; it may have NO RELATIONSHIP to the users’ requested image name.
 // imageID is nil for infra containers.
-func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, image string, imageName *references.RegistryImageReference, imageID *storage.StorageImageID, md *types.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
+func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, userRequestedImage string, imageName *references.RegistryImageReference, imageID *storage.StorageImageID, md *types.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
 	externalImageRef := ""
@@ -142,7 +144,7 @@ func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations,
 			Metadata:     md,
 			Annotations:  annotations,
 			Image: &types.ImageSpec{
-				Image: image,
+				Image: userRequestedImage,
 			},
 			ImageRef: externalImageRef,
 		},
@@ -387,8 +389,9 @@ func (c *Container) CrioAnnotations() map[string]string {
 	return c.crioAnnotations
 }
 
-// Image returns the image of the container.
-func (c *Container) Image() string {
+// UserRequestedImage returns the users' input originally used to find imageID; it might evaluate to a different image
+// (or to a different kind of reference!) at any future time.
+func (c *Container) UserRequestedImage() string {
 	return c.criContainer.Image.Image
 }
 

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -42,7 +42,7 @@ var _ = t.Describe("Container", func() {
 		Expect(len(sut.Labels())).To(BeEquivalentTo(1))
 		Expect(len(sut.Annotations())).To(BeEquivalentTo(1))
 		Expect(len(sut.CrioAnnotations())).To(BeEquivalentTo(1))
-		Expect(sut.Image()).To(Equal("image"))
+		Expect(sut.UserRequestedImage()).To(Equal("image"))
 		Expect(sut.ImageName().StringForOutOfProcessConsumptionOnly()).To(Equal("docker.io/library/image-name:latest"))
 		Expect(sut.ImageID().IDStringForOutOfProcessConsumptionOnly()).To(Equal("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"))
 		Expect(sut.Sandbox()).To(Equal("sandbox"))

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -44,7 +44,7 @@ var _ = t.Describe("Container", func() {
 		Expect(len(sut.CrioAnnotations())).To(BeEquivalentTo(1))
 		Expect(sut.Image()).To(Equal("image"))
 		Expect(sut.ImageName()).To(Equal("imageName"))
-		Expect(sut.ImageRef()).To(Equal("imageRef"))
+		Expect(sut.ImageID().IDStringForOutOfProcessConsumptionOnly()).To(Equal("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"))
 		Expect(sut.Sandbox()).To(Equal("sandbox"))
 		Expect(sut.Dir()).To(Equal("dir"))
 		Expect(sut.CheckpointPath()).To(Equal("dir/checkpoint"))
@@ -184,7 +184,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", "", "", &types.ContainerMetadata{}, "",
+			"", "", nil, &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGNO")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
@@ -200,7 +200,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", "", "", &types.ContainerMetadata{}, "",
+			"", "", nil, &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "RTMIN+1")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
@@ -216,7 +216,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", "", "", &types.ContainerMetadata{}, "",
+			"", "", nil, &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGTRAP")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -43,7 +43,7 @@ var _ = t.Describe("Container", func() {
 		Expect(len(sut.Annotations())).To(BeEquivalentTo(1))
 		Expect(len(sut.CrioAnnotations())).To(BeEquivalentTo(1))
 		Expect(sut.Image()).To(Equal("image"))
-		Expect(sut.ImageName()).To(Equal("imageName"))
+		Expect(sut.ImageName().StringForOutOfProcessConsumptionOnly()).To(Equal("docker.io/library/image-name:latest"))
 		Expect(sut.ImageID().IDStringForOutOfProcessConsumptionOnly()).To(Equal("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"))
 		Expect(sut.Sandbox()).To(Equal("sandbox"))
 		Expect(sut.Dir()).To(Equal("dir"))
@@ -184,7 +184,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", "", nil, &types.ContainerMetadata{}, "",
+			"", nil, nil, &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGNO")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
@@ -200,7 +200,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", "", nil, &types.ContainerMetadata{}, "",
+			"", nil, nil, &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "RTMIN+1")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
@@ -216,7 +216,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", "", nil, &types.ContainerMetadata{}, "",
+			"", nil, nil, &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGTRAP")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())

--- a/internal/oci/suite_test.go
+++ b/internal/oci/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/internal/storage"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	. "github.com/cri-o/cri-o/test/framework"
 	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
@@ -37,7 +38,7 @@ func beforeEach() {
 	var err error
 	myContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "", "", "",
+		make(map[string]string), "", "", nil,
 		&types.ContainerMetadata{}, sandboxID, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
@@ -53,11 +54,13 @@ var _ = BeforeSuite(func() {
 })
 
 func getTestContainer() *oci.Container {
+	imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+	Expect(err).To(BeNil())
 	container, err := oci.NewContainer("id", "name", "bundlePath", "logPath",
 		map[string]string{"key": "label"},
 		map[string]string{"key": "crioAnnotation"},
 		map[string]string{"key": "annotation"},
-		"image", "imageName", "imageRef", &types.ContainerMetadata{}, "sandbox",
+		"image", "imageName", &imageID, &types.ContainerMetadata{}, "sandbox",
 		false, false, false, "", "dir", time.Now(), "")
 	Expect(err).To(BeNil())
 	Expect(container).NotTo(BeNil())

--- a/internal/oci/suite_test.go
+++ b/internal/oci/suite_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	. "github.com/cri-o/cri-o/test/framework"
 	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
@@ -38,7 +39,7 @@ func beforeEach() {
 	var err error
 	myContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "", "", nil,
+		make(map[string]string), "", nil, nil,
 		&types.ContainerMetadata{}, sandboxID, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
@@ -54,13 +55,15 @@ var _ = BeforeSuite(func() {
 })
 
 func getTestContainer() *oci.Container {
+	imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("docker.io/library/image-name:latest")
+	Expect(err).To(BeNil())
 	imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
 	Expect(err).To(BeNil())
 	container, err := oci.NewContainer("id", "name", "bundlePath", "logPath",
 		map[string]string{"key": "label"},
 		map[string]string{"key": "crioAnnotation"},
 		map[string]string{"key": "annotation"},
-		"image", "imageName", &imageID, &types.ContainerMetadata{}, "sandbox",
+		"image", &imageName, &imageID, &types.ContainerMetadata{}, "sandbox",
 		false, false, false, "", "dir", time.Now(), "")
 	Expect(err).To(BeNil())
 	Expect(container).NotTo(BeNil())

--- a/internal/runtimehandlerhooks/high_performance_hooks_test.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_test.go
@@ -23,7 +23,7 @@ const (
 var _ = Describe("high_performance_hooks", func() {
 	container, err := oci.NewContainer("containerID", "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "pauseImage", "", "",
+		make(map[string]string), "pauseImage", "", nil,
 		&types.ContainerMetadata{}, "sandboxID", false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/internal/runtimehandlerhooks/high_performance_hooks_test.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_test.go
@@ -23,7 +23,7 @@ const (
 var _ = Describe("high_performance_hooks", func() {
 	container, err := oci.NewContainer("containerID", "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "pauseImage", "", nil,
+		make(map[string]string), "pauseImage", nil, nil,
 		&types.ContainerMetadata{}, "sandboxID", false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -149,24 +149,36 @@ type ImageServer interface {
 	CandidatesForPotentiallyShortImageName(systemContext *types.SystemContext, imageName string) ([]RegistryImageReference, error)
 }
 
-func sortNamesByType(names []string) (bestName string, tags, digests []string) {
-	for _, name := range names {
-		if len(name) > 72 && name[len(name)-72:len(name)-64] == "@sha256:" {
+func parseImageNames(image *storage.Image) (someName *RegistryImageReference, tags []reference.NamedTagged, digests []reference.Canonical, err error) {
+	for _, nameString := range image.Names {
+		name, err := reference.ParseNormalizedNamed(nameString)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("invalid name %q in image %q: %w", nameString, image.ID, err)
+		}
+		if reference.IsNameOnly(name) {
+			return nil, nil, nil, fmt.Errorf("invalid name %q in image %q, it has neither a tag nor a digest", nameString, image.ID)
+		}
+		switch name := name.(type) {
+		case reference.Canonical:
 			digests = append(digests, name)
-		} else {
+		case reference.NamedTagged:
 			tags = append(tags, name)
+		default:
+			return nil, nil, nil, fmt.Errorf("internal error, invalid name %q in image %q is !IsNameOnly but neither Canonical nor NamedTagged", nameString, image.ID)
 		}
 	}
 	if len(digests) > 0 {
-		bestName = digests[0]
+		best := references.RegistryImageReferenceFromRaw(digests[0])
+		someName = &best
 	}
 	if len(tags) > 0 {
-		bestName = tags[0]
+		best := references.RegistryImageReferenceFromRaw(tags[0])
+		someName = &best
 	}
-	return bestName, tags, digests
+	return someName, tags, digests, nil
 }
 
-func (svc *imageService) makeRepoDigests(knownRepoDigests, tags []string, img *storage.Image) (imageDigest digest.Digest, repoDigests []string) {
+func (svc *imageService) makeRepoDigests(knownRepoDigests []reference.Canonical, tags []reference.NamedTagged, img *storage.Image) (imageDigest digest.Digest, repoDigests []reference.Canonical) {
 	// Look up the image's digests.
 	imageDigest = img.Digest
 	if imageDigest == "" {
@@ -187,19 +199,24 @@ func (svc *imageService) makeRepoDigests(knownRepoDigests, tags []string, img *s
 	digestMap := make(map[string]struct{})
 	repoDigests = knownRepoDigests
 	for _, repoDigest := range knownRepoDigests {
-		digestMap[repoDigest] = struct{}{}
+		digestMap[repoDigest.String()] = struct{}{}
 	}
-	// For each tagged name, parse the name, and if we can extract a named reference, convert
-	// it into a canonical reference using the digest and add it to the list.
-	for _, name := range append(tags, knownRepoDigests...) {
-		if ref, err2 := reference.ParseNormalizedNamed(name); err2 == nil {
-			trimmed := reference.TrimNamed(ref)
-			for _, imageDigest := range imageDigests {
-				if imageRef, err3 := reference.WithDigest(trimmed, imageDigest); err3 == nil {
-					if _, ok := digestMap[imageRef.String()]; !ok {
-						repoDigests = append(repoDigests, imageRef.String())
-						digestMap[imageRef.String()] = struct{}{}
-					}
+	// Collect all known repos...
+	repos := []reference.Named{}
+	for _, tagged := range tags {
+		repos = append(repos, reference.TrimNamed(tagged))
+	}
+	for _, digested := range knownRepoDigests {
+		repos = append(repos, reference.TrimNamed(digested))
+	}
+	// ... and combine each repo with each digest.
+	// Note that this may create digested references that never existed on those registries.
+	for _, repo := range repos {
+		for _, imageDigest := range imageDigests {
+			if imageRef, err3 := reference.WithDigest(repo, imageDigest); err3 == nil {
+				if _, ok := digestMap[imageRef.String()]; !ok {
+					repoDigests = append(repoDigests, imageRef)
+					digestMap[imageRef.String()] = struct{}{}
 				}
 			}
 		}
@@ -251,11 +268,28 @@ func (svc *imageService) buildImageCacheItem(systemContext *types.SystemContext,
 	}, nil
 }
 
-func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageCacheItem) ImageResult {
-	name, tags, digests := sortNamesByType(image.Names)
+func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageCacheItem) (ImageResult, error) {
+	someName, tags, digests, err := parseImageNames(image)
+	if err != nil {
+		return ImageResult{}, err
+	}
 	imageDigest, repoDigests := svc.makeRepoDigests(digests, tags, image)
-	sort.Strings(tags)
-	sort.Strings(repoDigests)
+
+	someNameString := ""
+	if someName != nil {
+		someNameString = someName.Raw().String()
+	}
+	repoTagStrings := make([]string, 0, len(tags))
+	for _, t := range tags {
+		repoTagStrings = append(repoTagStrings, t.String())
+	}
+	sort.Strings(repoTagStrings)
+	repoDigestStrings := make([]string, 0, len(repoDigests))
+	for _, d := range repoDigests {
+		repoDigestStrings = append(repoDigestStrings, d.String())
+	}
+	sort.Strings(repoDigestStrings)
+
 	previousName := ""
 	if len(image.NamesHistory) > 0 {
 		// Remove the tag because we can only keep the name as indicator
@@ -274,9 +308,9 @@ func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageC
 	}
 	return ImageResult{
 		ID:           storageImageIDFromImage(image),
-		Name:         name,
-		RepoTags:     tags,
-		RepoDigests:  repoDigests,
+		Name:         someNameString,
+		RepoTags:     repoTagStrings,
+		RepoDigests:  repoDigestStrings,
 		Size:         cacheItem.size,
 		Digest:       imageDigest,
 		ConfigDigest: cacheItem.configDigest,
@@ -286,7 +320,7 @@ func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageC
 		OCIConfig:    cacheItem.config,
 		Annotations:  cacheItem.annotations,
 		Pinned:       imagePinned,
-	}
+	}, nil
 }
 
 func (svc *imageService) ListImages(systemContext *types.SystemContext) ([]ImageResult, error) {
@@ -316,7 +350,11 @@ func (svc *imageService) ListImages(systemContext *types.SystemContext) ([]Image
 		}
 
 		newImageCache[image.ID] = cacheItem
-		results = append(results, svc.buildImageResult(image, cacheItem))
+		res, err := svc.buildImageResult(image, cacheItem)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, res)
 	}
 	// replace image cache with cache we just built
 	// this invalidates all stale entries in cache
@@ -376,7 +414,10 @@ func (svc *imageService) imageStatus(systemContext *types.SystemContext, ref typ
 		}
 	}
 
-	result := svc.buildImageResult(image, cacheItem)
+	result, err := svc.buildImageResult(image, cacheItem)
+	if err != nil {
+		return nil, err
+	}
 	return &result, nil
 }
 

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -43,19 +43,21 @@ const (
 // ImageResult wraps a subset of information about an image: its ID, its names,
 // and the size, if known, or nil if it isn't.
 type ImageResult struct {
-	ID           StorageImageID
-	Name         string
-	RepoTags     []string
-	RepoDigests  []string
-	Size         *uint64
-	Digest       digest.Digest
-	ConfigDigest digest.Digest
-	User         string
-	PreviousName string
-	Labels       map[string]string
-	OCIConfig    *specs.Image
-	Annotations  map[string]string
-	Pinned       bool // pinned image to prevent it from garbage collection
+	ID StorageImageID
+	// May be nil if the image was referenced by ID and has no names.
+	// It also has NO RELATIONSHIP to user input when returned by ImageStatusByName.
+	SomeNameOfThisImage *RegistryImageReference
+	RepoTags            []string
+	RepoDigests         []string
+	Size                *uint64
+	Digest              digest.Digest
+	ConfigDigest        digest.Digest
+	User                string
+	PreviousName        string
+	Labels              map[string]string
+	OCIConfig           *specs.Image
+	Annotations         map[string]string
+	Pinned              bool // pinned image to prevent it from garbage collection
 }
 
 type indexInfo struct {
@@ -275,10 +277,6 @@ func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageC
 	}
 	imageDigest, repoDigests := svc.makeRepoDigests(digests, tags, image)
 
-	someNameString := ""
-	if someName != nil {
-		someNameString = someName.Raw().String()
-	}
 	repoTagStrings := make([]string, 0, len(tags))
 	for _, t := range tags {
 		repoTagStrings = append(repoTagStrings, t.String())
@@ -307,19 +305,19 @@ func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageC
 		}
 	}
 	return ImageResult{
-		ID:           storageImageIDFromImage(image),
-		Name:         someNameString,
-		RepoTags:     repoTagStrings,
-		RepoDigests:  repoDigestStrings,
-		Size:         cacheItem.size,
-		Digest:       imageDigest,
-		ConfigDigest: cacheItem.configDigest,
-		User:         cacheItem.config.Config.User,
-		PreviousName: previousName,
-		Labels:       cacheItem.info.Labels,
-		OCIConfig:    cacheItem.config,
-		Annotations:  cacheItem.annotations,
-		Pinned:       imagePinned,
+		ID:                  storageImageIDFromImage(image),
+		SomeNameOfThisImage: someName,
+		RepoTags:            repoTagStrings,
+		RepoDigests:         repoDigestStrings,
+		Size:                cacheItem.size,
+		Digest:              imageDigest,
+		ConfigDigest:        cacheItem.configDigest,
+		User:                cacheItem.config.Config.User,
+		PreviousName:        previousName,
+		Labels:              cacheItem.info.Labels,
+		OCIConfig:           cacheItem.config,
+		Annotations:         cacheItem.annotations,
+		Pinned:              imagePinned,
 	}, nil
 }
 

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -43,7 +43,7 @@ const (
 // ImageResult wraps a subset of information about an image: its ID, its names,
 // and the size, if known, or nil if it isn't.
 type ImageResult struct {
-	ID           string
+	ID           StorageImageID
 	Name         string
 	RepoTags     []string
 	RepoDigests  []string
@@ -273,7 +273,7 @@ func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageC
 		}
 	}
 	return ImageResult{
-		ID:           image.ID,
+		ID:           storageImageIDFromImage(image),
 		Name:         name,
 		RepoTags:     tags,
 		RepoDigests:  repoDigests,

--- a/internal/storage/image_id.go
+++ b/internal/storage/image_id.go
@@ -17,6 +17,7 @@ import (
 // to an image in the first place).
 //
 // This is intended to be a value type; if a value exists, it is a correctly-formatted ID.
+// The values can be compared for equality, or used as map keys.
 type StorageImageID struct {
 	// privateID is INTENTIONALLY ENCAPSULATED to provide strong type safety and strong syntax/semantics guarantees.
 	// Use typed values, not strings, everywhere it is even remotely possible.

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/image/v5/types"
 	cs "github.com/containers/storage"
+	"github.com/cri-o/cri-o/internal/mockutils"
 	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/internal/storage/references"
 	"github.com/cri-o/cri-o/pkg/config"
@@ -304,7 +305,7 @@ var _ = t.Describe("Image", func() {
 	t.Describe("UntagImage", func() {
 		It("should succeed to untag an image", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				mockGetStoreImage(storeMock, testNormalizedImageName, testSHA256),
 				storeMock.EXPECT().Image(testSHA256).
 					Return(&cs.Image{ID: testSHA256}, nil),
@@ -323,7 +324,7 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to untag an image that can't be found", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				mockGetStoreImage(storeMock, testNormalizedImageName, ""),
 			)
 			ref, err := references.ParseRegistryImageReferenceFromOutOfProcessData(testImageName)
@@ -338,7 +339,7 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to untag an image with multiple names", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				// storage.Transport.GetStoreImage:
 				storeMock.EXPECT().Image(testNormalizedImageName).
 					Return(&cs.Image{
@@ -363,7 +364,7 @@ var _ = t.Describe("Image", func() {
 	t.Describe("ImageStatusByName", func() {
 		It("should succeed to get the image status with digest", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				// storage.Transport.GetStoreImage:
 				storeMock.EXPECT().Image(testNormalizedImageName).
 					Return(&cs.Image{
@@ -406,7 +407,7 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to get on missing store image", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				mockGetStoreImage(storeMock, testNormalizedImageName, ""),
 			)
 			ref, err := references.ParseRegistryImageReferenceFromOutOfProcessData(testImageName)
@@ -422,7 +423,7 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to get on corrupt image", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				mockGetStoreImage(storeMock, testNormalizedImageName, testSHA256),
 				// In buildImageCacheItem, storageReference.NewImage fails reading the manifest:
 				mockResolveImage(storeMock, testNormalizedImageName, testSHA256),
@@ -458,8 +459,8 @@ var _ = t.Describe("Image", func() {
 
 		It("should succeed to list multiple images without filter", func() {
 			// Given
-			mockLoop := func() mockSequence {
-				return inOrder(
+			mockLoop := func() mockutils.MockSequence {
+				return mockutils.InOrder(
 					// buildImageCacheItem:
 					mockNewImage(storeMock, testSHA256, testSHA256),
 					storeMock.EXPECT().Image(gomock.Any()).
@@ -476,7 +477,7 @@ var _ = t.Describe("Image", func() {
 						Return(digest.Digest(""), nil),
 				)
 			}
-			inOrder(
+			mockutils.InOrder(
 				storeMock.EXPECT().Images().Return(
 					[]cs.Image{
 						{ID: testSHA256, Names: []string{"a", "b", "c@sha256:" + testSHA256}},
@@ -526,7 +527,7 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail to list multiple images without filter on append", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				storeMock.EXPECT().Images().Return(
 					[]cs.Image{{ID: testSHA256}}, nil),
 				storeMock.EXPECT().Image(gomock.Any()).

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -480,7 +480,7 @@ var _ = t.Describe("Image", func() {
 			mockutils.InOrder(
 				storeMock.EXPECT().Images().Return(
 					[]cs.Image{
-						{ID: testSHA256, Names: []string{"a", "b", "c@sha256:" + testSHA256}},
+						{ID: testSHA256, Names: []string{"a:latest", "b:notlatest", "c@sha256:" + testSHA256}},
 						{ID: testSHA256},
 					},
 					nil),

--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	istorage "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/types"
 	cs "github.com/containers/storage"
+	"github.com/cri-o/cri-o/internal/mockutils"
 	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/internal/storage/references"
 	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
@@ -49,8 +50,8 @@ var _ = t.Describe("Runtime", func() {
 	})
 
 	// The part of runtimeService.CreateContainer before a CreateContainer call, if the image already exists locally.
-	mockCreateContainerImageExists := func() mockSequence {
-		return inOrder(
+	mockCreateContainerImageExists := func() mockutils.MockSequence {
+		return mockutils.InOrder(
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
@@ -61,8 +62,8 @@ var _ = t.Describe("Runtime", func() {
 	}
 
 	// The part of CreatePodSandbox before a CreateContainer call, if the image already exists locally.
-	mockCreatePodSandboxImageExists := func() mockSequence {
-		return inOrder(
+	mockCreatePodSandboxImageExists := func() mockutils.MockSequence {
+		return mockutils.InOrder(
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			mockGetStoreImage(storeMock, "docker.io/library/imagename:latest", imageID.IDStringForOutOfProcessConsumptionOnly()),
@@ -494,8 +495,8 @@ var _ = t.Describe("Runtime", func() {
 				err  error
 			)
 
-			mockUnderlyingCreateContainerSuccess := func() mockSequence {
-				return inOrder(
+			mockUnderlyingCreateContainerSuccess := func() mockutils.MockSequence {
+				return mockutils.InOrder(
 					storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(&cs.Container{ID: "id"}, nil),
@@ -512,7 +513,7 @@ var _ = t.Describe("Runtime", func() {
 
 			It("should succeed to create a container", func() {
 				// Given
-				inOrder(
+				mockutils.InOrder(
 					mockCreateContainerImageExists(),
 					mockUnderlyingCreateContainerSuccess(),
 				)
@@ -529,7 +530,7 @@ var _ = t.Describe("Runtime", func() {
 				// Given
 				pauseImage, err2 := references.ParseRegistryImageReferenceFromOutOfProcessData("imagename:latest")
 				Expect(err2).To(BeNil())
-				inOrder(
+				mockutils.InOrder(
 					mockCreatePodSandboxImageExists(),
 					mockUnderlyingCreateContainerSuccess(),
 				)
@@ -554,7 +555,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on invalid pod ID", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
@@ -574,7 +575,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on invalid pod name", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
@@ -594,7 +595,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on invalid container name", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
@@ -614,7 +615,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on run dir error", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				mockCreateContainerImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -644,7 +645,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on container dir error", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				mockCreateContainerImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -673,7 +674,7 @@ var _ = t.Describe("Runtime", func() {
 			// Given
 			pauseImage, err := references.ParseRegistryImageReferenceFromOutOfProcessData("imagename:latest")
 			Expect(err).To(BeNil())
-			inOrder(
+			mockutils.InOrder(
 				mockCreatePodSandboxImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -700,7 +701,7 @@ var _ = t.Describe("Runtime", func() {
 			// Given
 			pauseImage, err := references.ParseRegistryImageReferenceFromOutOfProcessData("imagename:latest")
 			Expect(err).To(BeNil())
-			inOrder(
+			mockutils.InOrder(
 				mockCreatePodSandboxImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -720,7 +721,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on main creation error", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				mockCreateContainerImageExists(),
 				storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -740,7 +741,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on error accessing local image", func() {
 			// Given
-			inOrder(
+			mockutils.InOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
@@ -778,7 +779,7 @@ var _ = t.Describe("Runtime", func() {
 			Expect(err).To(BeNil())
 			pulledRef, err := istorage.Transport.NewStoreReference(storeMock, pauseImageRef.Raw(), "")
 			Expect(err).To(BeNil())
-			inOrder(
+			mockutils.InOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", ""),

--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -53,9 +53,6 @@ var _ = t.Describe("Runtime", func() {
 	mockCreateContainerImageExists := func() mockutils.MockSequence {
 		return mockutils.InOrder(
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
-			imageServerMock.EXPECT().GetStore().Return(storeMock),
-			mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
-			imageServerMock.EXPECT().GetStore().Return(storeMock),
 			mockNewImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
 		)
@@ -555,11 +552,6 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on invalid pod ID", func() {
 			// Given
-			mockutils.InOrder(
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
-			)
 
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
@@ -575,11 +567,6 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on invalid pod name", func() {
 			// Given
-			mockutils.InOrder(
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
-			)
 
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
@@ -595,11 +582,6 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to create a container on invalid container name", func() {
 			// Given
-			mockutils.InOrder(
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
-			)
 
 			// When
 			_, err := sut.CreateContainer(&types.SystemContext{},
@@ -742,9 +724,6 @@ var _ = t.Describe("Runtime", func() {
 		It("should fail to create a container on error accessing local image", func() {
 			// Given
 			mockutils.InOrder(
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				mockGetStoreImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				// storageReference.newImage:
 				mockResolveImage(storeMock, imageID.IDStringForOutOfProcessConsumptionOnly(), imageID.IDStringForOutOfProcessConsumptionOnly()),

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,7 +9,7 @@ type ContainerInfo struct {
 	Name            string            `json:"name"`
 	Pid             int               `json:"pid"`
 	Image           string            `json:"image"`
-	ImageRef        string            `json:"image_ref"`
+	ImageRef        string            `json:"image_ref"` // In the format of StorageImageID.StringForOutOfProcessConsumptionOnly(), or "".
 	CreatedTime     int64             `json:"created_time"`
 	Labels          map[string]string `json:"labels"`
 	Annotations     map[string]string `json:"annotations"`

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -8,7 +8,7 @@ import (
 type ContainerInfo struct {
 	Name            string            `json:"name"`
 	Pid             int               `json:"pid"`
-	Image           string            `json:"image"`
+	Image           string            `json:"image"`     // If set, _some_ name of the image imageID; it may have NO RELATIONSHIP to the users’ requested image name.
 	ImageRef        string            `json:"image_ref"` // In the format of StorageImageID.StringForOutOfProcessConsumptionOnly(), or "".
 	CreatedTime     int64             `json:"created_time"`
 	Labels          map[string]string `json:"labels"`

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -235,7 +235,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		}
 	}
 
-	imageName := imgResult.Name
+	imageName := imgResult.SomeNameOfThisImage
 	imageID := imgResult.ID
 
 	labelOptions, err := ctr.SelinuxLabel(sb.ProcessLabel())

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -258,7 +258,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage creation")
 	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.config.SystemContext,
 		sb.Name(), sb.ID(),
-		image, imageRef,
+		image, imageRef.IDStringForOutOfProcessConsumptionOnly(), // This violates API rules, and will be fixed shortly.
 		containerName, containerID,
 		metadata.Name,
 		metadata.Attempt,
@@ -777,7 +777,8 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		Name:    metadata.Name,
 		Attempt: metadata.Attempt,
 	}
-	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, image, imageName, imageRef, criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	// The imageRef.IDStringForOutOfProcessConsumptionOnly() use violates API rules, and will be fixed shortly.
+	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, image, imageName, imageRef.IDStringForOutOfProcessConsumptionOnly(), criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -258,7 +258,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage creation")
 	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.config.SystemContext,
 		sb.Name(), sb.ID(),
-		image, imageRef.IDStringForOutOfProcessConsumptionOnly(), // This violates API rules, and will be fixed shortly.
+		image, imageRef,
 		containerName, containerID,
 		metadata.Name,
 		metadata.Attempt,

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -211,7 +211,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	if err != nil {
 		return nil, err
 	}
-	// Get imageName and imageRef that are later requested in container status
+	// Get imageName and imageID that are later requested in container status
 	var imgResult *storage.ImageResult
 	if id := s.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(image); id != nil {
 		imgResult, err = s.StorageImageServer().ImageStatusByID(s.config.SystemContext, *id)
@@ -236,7 +236,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	}
 
 	imageName := imgResult.Name
-	imageRef := imgResult.ID
+	imageID := imgResult.ID
 
 	labelOptions, err := ctr.SelinuxLabel(sb.ProcessLabel())
 	if err != nil {
@@ -258,7 +258,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage creation")
 	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.config.SystemContext,
 		sb.Name(), sb.ID(),
-		image, imageRef,
+		image, imageID,
 		containerName, containerID,
 		metadata.Name,
 		metadata.Attempt,
@@ -777,8 +777,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		Name:    metadata.Name,
 		Attempt: metadata.Attempt,
 	}
-	// The imageRef.IDStringForOutOfProcessConsumptionOnly() use violates API rules, and will be fixed shortly.
-	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, image, imageName, imageRef.IDStringForOutOfProcessConsumptionOnly(), criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, image, imageName, &imageID, criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -233,6 +234,11 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		if imgResultErr != nil {
 			return nil, imgResultErr
 		}
+	}
+	// At this point we know image is not empty; "" is accepted by neither HeuristicallyTryResolvingStringAsIDPrefix
+	// nor CandidatesForPotentiallyShortImageName. Just to be sure:
+	if image == "" {
+		return nil, errors.New("internal error: successfully found an image, but image is empty")
 	}
 
 	imageName := imgResult.SomeNameOfThisImage

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -208,19 +208,19 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		}
 	}
 
-	image, err := ctr.Image()
+	userRequestedImage, err := ctr.UserRequestedImage()
 	if err != nil {
 		return nil, err
 	}
 	// Get imageName and imageID that are later requested in container status
 	var imgResult *storage.ImageResult
-	if id := s.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(image); id != nil {
+	if id := s.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
 		imgResult, err = s.StorageImageServer().ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		potentialMatches, err := s.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, image)
+		potentialMatches, err := s.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, userRequestedImage)
 		if err != nil {
 			return nil, err
 		}
@@ -235,10 +235,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 			return nil, imgResultErr
 		}
 	}
-	// At this point we know image is not empty; "" is accepted by neither HeuristicallyTryResolvingStringAsIDPrefix
+	// At this point we know userRequestedImage is not empty; "" is accepted by neither HeuristicallyTryResolvingStringAsIDPrefix
 	// nor CandidatesForPotentiallyShortImageName. Just to be sure:
-	if image == "" {
-		return nil, errors.New("internal error: successfully found an image, but image is empty")
+	if userRequestedImage == "" {
+		return nil, errors.New("internal error: successfully found an image, but userRequestedImage is empty")
 	}
 
 	imageName := imgResult.SomeNameOfThisImage
@@ -264,7 +264,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage creation")
 	containerInfo, err := s.StorageRuntimeServer().CreateContainer(s.config.SystemContext,
 		sb.Name(), sb.ID(),
-		image, imageID,
+		userRequestedImage, imageID,
 		containerName, containerID,
 		metadata.Name,
 		metadata.Attempt,
@@ -551,7 +551,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 
 	containerImageConfig := containerInfo.Config
 	if containerImageConfig == nil {
-		err = fmt.Errorf("empty image config for %s", image)
+		err = fmt.Errorf("empty image config for %s", userRequestedImage)
 		return nil, err
 	}
 
@@ -783,7 +783,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		Name:    metadata.Name,
 		Attempt: metadata.Attempt,
 	}
-	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, image, imageName, &imageID, criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, userRequestedImage, imageName, &imageID, criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -525,7 +525,7 @@ var _ = t.Describe("ContainerRestore", func() {
 						}, nil),
 
 					runtimeServerMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
-						gomock.Any(), gomock.Any(), imageID.IDStringForOutOfProcessConsumptionOnly(), gomock.Any(),
+						gomock.Any(), gomock.Any(), imageID, gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any()).
 						Return(storage.ContainerInfo{

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -35,9 +35,7 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 			&metadata.ContainerConfig{
 				ID: c.ID(),
 			},
-			&libpod.ContainerCheckpointOptions{
-				TargetFile: c.ImageName(),
-			},
+			&libpod.ContainerCheckpointOptions{},
 		)
 		if err != nil {
 			ociContainer, err1 := s.GetContainerFromShortID(ctx, c.ID())

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -36,6 +36,10 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 	if id := c.ImageID(); id != nil {
 		imageRef = id.IDStringForOutOfProcessConsumptionOnly()
 	}
+	imageNameInSpec := ""
+	if imageName := c.ImageName(); imageName != nil {
+		imageNameInSpec = imageName.StringForOutOfProcessConsumptionOnly()
+	}
 	resp := &types.ContainerStatusResponse{
 		Status: &types.ContainerStatus{
 			Id:          containerID,
@@ -44,7 +48,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 			Annotations: c.Annotations(),
 			ImageRef:    imageRef,
 			Image: &types.ImageSpec{
-				Image: c.ImageName(),
+				Image: imageNameInSpec,
 			},
 		},
 	}

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -32,13 +32,17 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 	}
 
 	containerID := c.ID()
+	imageRef := ""
+	if id := c.ImageID(); id != nil {
+		imageRef = id.IDStringForOutOfProcessConsumptionOnly()
+	}
 	resp := &types.ContainerStatusResponse{
 		Status: &types.ContainerStatus{
 			Id:          containerID,
 			Metadata:    c.Metadata(),
 			Labels:      c.Labels(),
 			Annotations: c.Annotations(),
-			ImageRef:    c.ImageRef(),
+			ImageRef:    imageRef,
 			Image: &types.ImageSpec{
 				Image: c.ImageName(),
 			},

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -64,7 +64,7 @@ func ConvertImage(from *storage.ImageResult) *types.Image {
 	}
 
 	to := &types.Image{
-		Id:          from.ID,
+		Id:          from.ID.IDStringForOutOfProcessConsumptionOnly(),
 		RepoTags:    repoTags,
 		RepoDigests: repoDigests,
 		Pinned:      from.Pinned,

--- a/server/image_list_test.go
+++ b/server/image_list_test.go
@@ -17,6 +17,8 @@ import (
 var _ = t.Describe("ImageList", func() {
 	imageCandidate, err := references.ParseRegistryImageReferenceFromOutOfProcessData("docker.io/library/image:latest")
 	Expect(err).To(BeNil())
+	imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+	Expect(err).To(BeNil())
 
 	// Prepare the sut
 	BeforeEach(func() {
@@ -24,8 +26,6 @@ var _ = t.Describe("ImageList", func() {
 		setupSUT()
 	})
 	AfterEach(afterEach)
-
-	const imageID = "imageID"
 
 	t.Describe("ImageList", func() {
 		It("should succeed", func() {
@@ -46,7 +46,7 @@ var _ = t.Describe("ImageList", func() {
 			Expect(err).To(BeNil())
 			Expect(response).NotTo(BeNil())
 			Expect(len(response.Images)).To(BeEquivalentTo(1))
-			Expect(response.Images[0].Id).To(Equal(imageID))
+			Expect(response.Images[0].Id).To(Equal(imageID.IDStringForOutOfProcessConsumptionOnly()))
 		})
 
 		It("should succeed with filter", func() {
@@ -61,7 +61,7 @@ var _ = t.Describe("ImageList", func() {
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
 					Return(&storage.ImageResult{
-						ID:   "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812",
+						ID:   imageID,
 						User: "10", Size: &size,
 					}, nil),
 			)
@@ -121,7 +121,7 @@ var _ = t.Describe("ImageList", func() {
 	t.Describe("ConvertImage", func() {
 		It("should succeed with empty repo tags and digests", func() {
 			// Given
-			image := &storage.ImageResult{}
+			image := &storage.ImageResult{ID: imageID}
 
 			// When
 			result := server.ConvertImage(image)
@@ -136,6 +136,7 @@ var _ = t.Describe("ImageList", func() {
 			// Given
 			size := uint64(100)
 			image := &storage.ImageResult{
+				ID:          imageID,
 				RepoTags:    []string{"1", "2"},
 				RepoDigests: []string{"3", "4"},
 				Size:        &size,
@@ -158,6 +159,7 @@ var _ = t.Describe("ImageList", func() {
 		It("should succeed with previous tag but no current", func() {
 			// Given
 			image := &storage.ImageResult{
+				ID:           imageID,
 				PreviousName: "1",
 				Digest:       digest.Digest("2"),
 			}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -299,7 +299,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 	if err != nil {
 		return "", err
 	}
-	imageRef := status.ID
+	imageRef := status.ID.IDStringForOutOfProcessConsumptionOnly()
 	if len(status.RepoDigests) > 0 {
 		imageRef = status.RepoDigests[0]
 	}

--- a/server/image_pull_test.go
+++ b/server/image_pull_test.go
@@ -17,6 +17,10 @@ import (
 var _ = t.Describe("ImagePull", func() {
 	imageCandidate, err := references.ParseRegistryImageReferenceFromOutOfProcessData("docker.io/library/image:latest")
 	Expect(err).To(BeNil())
+	imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+	Expect(err).To(BeNil())
+	otherImageID, err := storage.ParseStorageImageIDFromOutOfProcessData("3a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+	Expect(err).To(BeNil())
 
 	// Prepare the sut
 	BeforeEach(func() {
@@ -36,7 +40,7 @@ var _ = t.Describe("ImagePull", func() {
 					imageCandidate).Return(imageCloserMock, nil),
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
-					Return(&storage.ImageResult{ID: "id"}, nil),
+					Return(&storage.ImageResult{ID: otherImageID}, nil),
 				imageCloserMock.EXPECT().ConfigInfo().
 					Return(imageTypes.BlobInfo{Digest: digest.Digest("")}),
 				imageServerMock.EXPECT().PullImage(
@@ -45,7 +49,7 @@ var _ = t.Describe("ImagePull", func() {
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
 					Return(&storage.ImageResult{
-						ID:          "image",
+						ID:          imageID,
 						RepoDigests: []string{"digest"},
 					}, nil),
 				imageCloserMock.EXPECT().Close().Return(nil),
@@ -73,7 +77,7 @@ var _ = t.Describe("ImagePull", func() {
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
 					Return(&storage.ImageResult{
-						ID:           "id",
+						ID:           imageID,
 						ConfigDigest: digest.Digest("digest"),
 					}, nil),
 				imageCloserMock.EXPECT().ConfigInfo().
@@ -81,7 +85,7 @@ var _ = t.Describe("ImagePull", func() {
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
 					Return(&storage.ImageResult{
-						ID:          "image",
+						ID:          imageID,
 						RepoDigests: []string{"digest"},
 					}, nil),
 				imageCloserMock.EXPECT().Close().Return(nil),
@@ -113,7 +117,7 @@ var _ = t.Describe("ImagePull", func() {
 					imageCandidate).Return(imageCloserMock, nil),
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
-					Return(&storage.ImageResult{ID: "id"}, nil),
+					Return(&storage.ImageResult{ID: otherImageID}, nil),
 				imageCloserMock.EXPECT().ConfigInfo().
 					Return(imageTypes.BlobInfo{Digest: digest.Digest("")}),
 				imageServerMock.EXPECT().PullImage(
@@ -167,7 +171,7 @@ var _ = t.Describe("ImagePull", func() {
 					imageCandidate).Return(imageCloserMock, nil),
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
-					Return(&storage.ImageResult{ID: "id"}, nil),
+					Return(&storage.ImageResult{ID: otherImageID}, nil),
 				imageCloserMock.EXPECT().ConfigInfo().
 					Return(imageTypes.BlobInfo{Digest: digest.Digest("")}),
 				imageServerMock.EXPECT().PullImage(

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -44,7 +44,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 
 	resp := &types.ImageStatusResponse{
 		Image: &types.Image{
-			Id:          status.ID,
+			Id:          status.ID.IDStringForOutOfProcessConsumptionOnly(),
 			RepoTags:    status.RepoTags,
 			RepoDigests: status.RepoDigests,
 			Size_:       size,

--- a/server/image_status_test.go
+++ b/server/image_status_test.go
@@ -17,6 +17,8 @@ import (
 var _ = t.Describe("ImageStatus", func() {
 	imageCandidate, err := references.ParseRegistryImageReferenceFromOutOfProcessData("docker.io/library/image:latest")
 	Expect(err).To(BeNil())
+	imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+	Expect(err).To(BeNil())
 
 	// Prepare the sut
 	BeforeEach(func() {
@@ -38,7 +40,7 @@ var _ = t.Describe("ImageStatus", func() {
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
 					Return(&storage.ImageResult{
-						ID:   "image",
+						ID:   imageID,
 						User: "10", Size: &size,
 					}, nil),
 			)
@@ -65,7 +67,7 @@ var _ = t.Describe("ImageStatus", func() {
 					gomock.Any(), imageCandidate,
 				).Return(
 					&storage.ImageResult{
-						ID:   "image",
+						ID:   imageID,
 						User: "10",
 						Size: &size,
 						OCIConfig: &specs.Image{
@@ -105,7 +107,7 @@ var _ = t.Describe("ImageStatus", func() {
 					Return(&parsedTestSHA256),
 				imageServerMock.EXPECT().ImageStatusByID(
 					gomock.Any(), parsedTestSHA256).
-					Return(&storage.ImageResult{ID: testSHA256, User: "me"}, nil),
+					Return(&storage.ImageResult{ID: parsedTestSHA256, User: "me"}, nil),
 			)
 
 			// When

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -95,11 +95,15 @@ func (s *Server) getContainerInfo(ctx context.Context, id string, getContainerFu
 			}
 		}
 	}
+	imageRef := ""
+	if id := ctr.ImageID(); id != nil {
+		imageRef = id.IDStringForOutOfProcessConsumptionOnly()
+	}
 	return types.ContainerInfo{
 		Name:            ctr.Name(),
 		Pid:             pidToReturn,
 		Image:           ctr.ImageName(),
-		ImageRef:        ctr.ImageRef(),
+		ImageRef:        imageRef,
 		CreatedTime:     ctrState.Created.UnixNano(),
 		Labels:          ctr.Labels(),
 		Annotations:     ctr.Annotations(),

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -95,6 +95,10 @@ func (s *Server) getContainerInfo(ctx context.Context, id string, getContainerFu
 			}
 		}
 	}
+	image := ""
+	if imageName := ctr.ImageName(); imageName != nil {
+		image = imageName.StringForOutOfProcessConsumptionOnly()
+	}
 	imageRef := ""
 	if id := ctr.ImageID(); id != nil {
 		imageRef = id.IDStringForOutOfProcessConsumptionOnly()
@@ -102,7 +106,7 @@ func (s *Server) getContainerInfo(ctx context.Context, id string, getContainerFu
 	return types.ContainerInfo{
 		Name:            ctr.Name(),
 		Pid:             pidToReturn,
-		Image:           ctr.ImageName(),
+		Image:           image,
 		ImageRef:        imageRef,
 		CreatedTime:     ctrState.Created.UnixNano(),
 		Labels:          ctr.Labels(),

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/pkg/config"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -50,7 +51,11 @@ func TestGetContainerInfo(t *testing.T) {
 		"io.kubernetes.test1": "value1",
 	}
 	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", "imageName", "imageRef", &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+		if err != nil {
+			t.Fatal(err)
+		}
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", "imageName", &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -85,8 +90,8 @@ func TestGetContainerInfo(t *testing.T) {
 	if ci.Image != "imageName" {
 		t.Fatalf("expected image name imageName, got %s", ci.Image)
 	}
-	if ci.ImageRef != "imageRef" {
-		t.Fatalf("expected image ref imageRef, got %s", ci.ImageRef)
+	if ci.ImageRef != "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812" {
+		t.Fatalf("expected image ref 2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812, got %s", ci.ImageRef)
 	}
 	if ci.Root != "/var/foo/container" {
 		t.Fatalf("expected root to be /var/foo/container, got %s", ci.Root)
@@ -167,7 +172,11 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+		if err != nil {
+			t.Fatal(err)
+		}
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -199,7 +208,11 @@ func TestGetContainerInfoSandboxNotFound(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", "imageRef", &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+		if err != nil {
+			t.Fatal(err)
+		}
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	"github.com/cri-o/cri-o/pkg/config"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -51,11 +52,15 @@ func TestGetContainerInfo(t *testing.T) {
 		"io.kubernetes.test1": "value1",
 	}
 	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
+		imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("example.com/some-image:latest")
+		if err != nil {
+			t.Fatal(err)
+		}
 		imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
 		if err != nil {
 			t.Fatal(err)
 		}
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", "imageName", &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", &imageName, &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -87,8 +92,8 @@ func TestGetContainerInfo(t *testing.T) {
 	if ci.Name != "testname" {
 		t.Fatalf("expected name testname, got %s", ci.Name)
 	}
-	if ci.Image != "imageName" {
-		t.Fatalf("expected image name imageName, got %s", ci.Image)
+	if ci.Image != "example.com/some-image:latest" {
+		t.Fatalf("expected image name example.com/some-image:latest, got %s", ci.Image)
 	}
 	if ci.ImageRef != "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812" {
 		t.Fatalf("expected image ref 2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812, got %s", ci.ImageRef)
@@ -172,11 +177,15 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
+		imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("example.com/some-image:latest")
+		if err != nil {
+			t.Fatal(err)
+		}
 		imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
 		if err != nil {
 			t.Fatal(err)
 		}
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -208,11 +217,15 @@ func TestGetContainerInfoSandboxNotFound(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
+		imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("example.com/some-image:latest")
+		if err != nil {
+			t.Fatal(err)
+		}
 		imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
 		if err != nil {
 			t.Fatal(err)
 		}
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", "imageName", &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -912,6 +912,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	// In the case of kernel separated containers, we need the infra container to create the VM for the pod
 	if sb.NeedsInfra(s.config.DropInfraCtr) || podIsKernelSeparated {
 		log.Debugf(ctx, "Keeping infra container for pod %s", sbox.ID())
+		// pauseImage, as the userRequestedImage parameter, only shows up in CRI values we return.
 		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 		if err != nil {
 			return nil, err

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -912,7 +912,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	// In the case of kernel separated containers, we need the infra container to create the VM for the pod
 	if sb.NeedsInfra(s.config.DropInfraCtr) || podIsKernelSeparated {
 		log.Debugf(ctx, "Keeping infra container for pod %s", sbox.ID())
-		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), "", "", nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), "", nil, nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 		if err != nil {
 			return nil, err
 		}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -912,7 +912,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	// In the case of kernel separated containers, we need the infra container to create the VM for the pod
 	if sb.NeedsInfra(s.config.DropInfraCtr) || podIsKernelSeparated {
 		log.Debugf(ctx, "Keeping infra container for pod %s", sbox.ID())
-		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), "", nil, nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 		if err != nil {
 			return nil, err
 		}

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -102,7 +102,7 @@ func createSandboxInfo(c *oci.Container) (map[string]string, error) {
 			Pid         int       `json:"pid"`
 			RuntimeSpec spec.Spec `json:"runtimeSpec,omitempty"`
 		}{
-			c.Image(),
+			c.UserRequestedImage(),
 			c.State().Pid,
 			c.Spec(),
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -651,7 +651,10 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []string)
 		// Best-effort append to imageMapToDelete
 		if ctrs, err := s.ContainerServer.ListContainers(); err == nil {
 			for _, ctr := range ctrs {
-				imageMapToDelete[ctr.ImageRef()] = struct{}{}
+				if id := ctr.ImageID(); id != nil {
+					// This violates API rules, and will be fixed shortly.
+					imageMapToDelete[id.IDStringForOutOfProcessConsumptionOnly()] = struct{}{}
+				}
 			}
 		}
 		for _, sb := range s.ContainerServer.ListSandboxes() {

--- a/server/server.go
+++ b/server/server.go
@@ -185,10 +185,10 @@ func (s *Server) getPortForward(req *types.PortForwardRequest) (*types.PortForwa
 // For every sandbox it fails to restore, it starts a cleanup routine attempting to call CNI DEL
 // For every container it fails to restore, it returns that containers image, so that
 // it can be cleaned up (if we're using internal_wipe).
-func (s *Server) restore(ctx context.Context) []string {
+func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
-	containersAndTheirImages := map[string]string{}
+	containersAndTheirImages := map[string]storage.StorageImageID{}
 	containers, err := s.Store().Containers()
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Warnf(ctx, "Could not read containers and sandboxes: %v", err)
@@ -212,7 +212,12 @@ func (s *Server) restore(ctx context.Context) []string {
 			pods[containers[i].ID] = &metadata
 		} else {
 			podContainers[containers[i].ID] = &metadata
-			containersAndTheirImages[containers[i].ID] = containers[i].ImageID
+			imageID, err := storage.ParseStorageImageIDFromOutOfProcessData(containers[i].ImageID)
+			if err != nil {
+				log.Warnf(ctx, "Error parsing image ID %q of container %q: %v, ignoring", containers[i].ImageID, containers[i].ID, err)
+				continue
+			}
+			containersAndTheirImages[containers[i].ID] = imageID
 		}
 	}
 
@@ -310,7 +315,7 @@ func (s *Server) restore(ctx context.Context) []string {
 	}
 
 	// Return a slice of images to remove, if internal_wipe is set.
-	imagesOfDeletedContainers := []string{}
+	imagesOfDeletedContainers := []storage.StorageImageID{}
 	for _, image := range containersAndTheirImages {
 		imagesOfDeletedContainers = append(imagesOfDeletedContainers, image)
 	}
@@ -610,7 +615,7 @@ func useDefaultUmask() {
 // wipeIfAppropriate takes a list of images. If the config's VersionFilePersist
 // indicates an upgrade has happened, it attempts to wipe that list of images.
 // This attempt is best-effort.
-func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []string) {
+func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []storage.StorageImageID) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 	if !s.config.InternalWipe {
@@ -641,7 +646,7 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []string)
 	}
 
 	// Translate to a map so the images are only attempted to be deleted once.
-	imageMapToDelete := make(map[string]struct{})
+	imageMapToDelete := make(map[storage.StorageImageID]struct{})
 	for _, img := range imagesToDelete {
 		imageMapToDelete[img] = struct{}{}
 	}
@@ -652,8 +657,7 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []string)
 		if ctrs, err := s.ContainerServer.ListContainers(); err == nil {
 			for _, ctr := range ctrs {
 				if id := ctr.ImageID(); id != nil {
-					// This violates API rules, and will be fixed shortly.
-					imageMapToDelete[id.IDStringForOutOfProcessConsumptionOnly()] = struct{}{}
+					imageMapToDelete[*id] = struct{}{}
 				}
 			}
 		}
@@ -669,7 +673,7 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []string)
 	// disk usage gets too high.
 	if shouldWipeImages {
 		for img := range imageMapToDelete {
-			if err := s.removeImage(ctx, img); err != nil {
+			if err := s.StorageImageServer().DeleteImage(s.config.SystemContext, img); err != nil {
 				log.Warnf(ctx, "Failed to remove image %s: %v", img, err)
 			}
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,8 +2,6 @@ package server_test
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"os"
 
 	cstorage "github.com/containers/storage"
@@ -83,17 +81,25 @@ var _ = t.Describe("Server", func() {
 
 		It("should succeed with container restore", func() {
 			// Given
-			testError := fmt.Errorf("error: %w", errors.New("/dev/null"))
 			gomock.InOrder(
 				libMock.EXPECT().GetData().Times(2).Return(serverConfig),
 				libMock.EXPECT().GetStore().Return(storeMock, nil),
 				libMock.EXPECT().GetData().Return(serverConfig),
 				storeMock.EXPECT().Containers().
 					Return([]cstorage.Container{
-						{},
-						{},
-						{},
-					}, testError),
+						{
+							ID:      "1111111111111111111111111111111111111111111111111111111111111111",
+							ImageID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						},
+						{
+							ID:      "2222222222222222222222222222222222222222222222222222222222222222",
+							ImageID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						},
+						{
+							ID:      "3333333333333333333333333333333333333333333333333333333333333333",
+							ImageID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+						},
+					}, nil),
 				storeMock.EXPECT().Metadata(gomock.Any()).
 					Return(`{"Pod": false, "pod-name": "name", "pod-id": "id" }`, nil),
 				storeMock.EXPECT().Metadata(gomock.Any()).

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -102,7 +102,7 @@ var beforeEach = func() {
 			"io.kubernetes.cri-o.NamespaceOptions": "{}",
 			"io.kubernetes.cri-o.SeccompProfilePath": "{}",
 			"io.kubernetes.cri-o.Image": "{}",
-			"io.kubernetes.cri-o.ImageName": "{}",
+			"io.kubernetes.cri-o.ImageName": "example.com/some-other/deduplicated-name:notlatest",
 			"io.kubernetes.cri-o.ImageRef": "1111111111111111111111111111111111111111111111111111111111111111",
 			"io.kubernetes.cri-o.KubeName": "{}",
 			"io.kubernetes.cri-o.PortMappings": "[]",
@@ -161,7 +161,7 @@ var beforeEach = func() {
 
 	testContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "pauseImage", "", nil,
+		make(map[string]string), "pauseImage", nil, nil,
 		&types.ContainerMetadata{}, sandboxID, false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -103,7 +103,7 @@ var beforeEach = func() {
 			"io.kubernetes.cri-o.SeccompProfilePath": "{}",
 			"io.kubernetes.cri-o.Image": "{}",
 			"io.kubernetes.cri-o.ImageName": "{}",
-			"io.kubernetes.cri-o.ImageRef": "{}",
+			"io.kubernetes.cri-o.ImageRef": "1111111111111111111111111111111111111111111111111111111111111111",
 			"io.kubernetes.cri-o.KubeName": "{}",
 			"io.kubernetes.cri-o.PortMappings": "[]",
 			"io.kubernetes.cri-o.Labels": "{}",
@@ -161,7 +161,7 @@ var beforeEach = func() {
 
 	testContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "pauseImage", "", "",
+		make(map[string]string), "pauseImage", "", nil,
 		&types.ContainerMetadata{}, sandboxID, false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -101,7 +101,7 @@ var beforeEach = func() {
 			"io.kubernetes.cri-o.IP": "{}",
 			"io.kubernetes.cri-o.NamespaceOptions": "{}",
 			"io.kubernetes.cri-o.SeccompProfilePath": "{}",
-			"io.kubernetes.cri-o.Image": "{}",
+			"io.kubernetes.cri-o.Image": "quay.io/image",
 			"io.kubernetes.cri-o.ImageName": "example.com/some-other/deduplicated-name:notlatest",
 			"io.kubernetes.cri-o.ImageRef": "1111111111111111111111111111111111111111111111111111111111111111",
 			"io.kubernetes.cri-o.KubeName": "{}",

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -209,7 +209,7 @@ func (m *MockRuntimeServer) EXPECT() *MockRuntimeServerMockRecorder {
 }
 
 // CreateContainer mocks base method.
-func (m *MockRuntimeServer) CreateContainer(arg0 *types.SystemContext, arg1, arg2, arg3, arg4, arg5, arg6, arg7 string, arg8 uint32, arg9 *types0.IDMappingOptions, arg10 []string, arg11 bool) (storage0.ContainerInfo, error) {
+func (m *MockRuntimeServer) CreateContainer(arg0 *types.SystemContext, arg1, arg2, arg3 string, arg4 storage0.StorageImageID, arg5, arg6, arg7 string, arg8 uint32, arg9 *types0.IDMappingOptions, arg10 []string, arg11 bool) (storage0.ContainerInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
 	ret0, _ := ret[0].(storage0.ContainerInfo)


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As a ~side-effect of an audit of how image-related data is produced, stored on disk, and used, rename the fields typically named (`image`, `imageName` and `imageRef`) to (`userRequestedHeuristicImage`, `someNameOfTheContainersImage` and `imageID`), and use strong types for the latter two, throughout the codebase.

As a side effect of this analysis, this allows us to remove one on-disk image lookup on the container creation path.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

See individual commit messages for details; notably this introduces new failure cases on invalid image names in storage, that might not be the best choice.

I’m stopping (after all those changes…) at the point where I’m confident that once we have an `imageID`, it is the only value that matters for running containers (assuming the checkpoint creation was created with a version that sets `RootfsImageRef`); and where it is ~explicit whether various APIs return the `userRequestedHeuristicImage` or the `someNameOfTheContainersImage` value.

AFAICT Kubelet never uses the image name values (only `ImageRef` = image ID), they “only”, show up in Pod statuses, so that’s where relevance to image signing goes.

Arguably the PR should do _something_ about the `userRequestedHeuristicImage` / `someNameOfTheContainersImage` values: maybe only ever use one of them, quite possibly make some effort to make `someNameOfTheContainersImage` more related to users’ input. If you think that’s required, please say so (and preferably choose a design).

Cc: @saschagrunert 

#### Does this PR introduce a user-facing change?

```release-note
None
```
