### PR TITLE
docs: install `libseccomp-devel` instead of `libseccomp`

### DIFF
--- a/install.md
+++ b/install.md
@@ -322,7 +322,7 @@ yum install -y \
   libassuan \
   libassuan-devel \
   libgpg-error \
-  libseccomp \
+  libseccomp-devel \
   libselinux \
   pkgconf-pkg-config \
   gpgme-devel \


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
For compiling crio  the `libseccomp` development version is needed otherwise `pkg-config` failed to find the library
and failed with
```
go build github.com/seccomp/libseccomp-golang:
# pkg-config --cflags  -- libseccomp
Package libseccomp was not found in the pkg-config search path.
Perhaps you should add the directory containing `libseccomp.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libseccomp', required by 'virtual:world', not found
pkg-config: exit status 1
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
none
```