### PR TITLE
Reuse nixpkgs branch for scheduled CI job

### DIFF
--- a/.github/workflows/nixpkgs.yml
+++ b/.github/workflows/nixpkgs.yml
@@ -31,7 +31,6 @@ jobs:
           title: 'Update nixpkgs'
           body: Update nixpkgs to the latest HEAD commit.
           labels: kind/ci, release-note-none, ok-to-test
-          branch-suffix: timestamp
-          branch: update-nixpkgs
+          branch: nixpkgs
           delete-branch: true
           signoff: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
       - release-*
-      - update-nixpkgs-*
+      - nixpkgs
   pull_request:
 env:
   GO_VERSION: '1.21'


### PR DESCRIPTION


#### What type of PR is this?


/kind ci

#### What this PR does / why we need it:
We reuse the branch if we don't merge the PR within one week to avoid creating stale branches.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
