### PR TITLE
RFC: Add image ref test

### DIFF
--- a/test/image_ref.bats
+++ b/test/image_ref.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# vim:set ft=bash :
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+IMAGE_REF=quay.io/crio/alpine:3.9
+IMAGE_DIGEST=quay.io/crio/alpine@sha256:414e0518bb9228d35e4cd5165567fb91d26c6a214e9c95899e1e056fcd349011
+
+function run_using_digest() {
+	jq '.image.image = "'"$IMAGE_DIGEST"'"' "$TESTDATA/container_config.json" > "$TESTDIR/ctr.json"
+	CTR_ID=$(crictl run "$TESTDIR"/ctr.json "$TESTDATA"/sandbox_config.json)
+
+	IMAGE=$(crictl inspect "$CTR_ID" | jq -r .status.image.image)
+	[[ "$IMAGE" == "$IMAGE_DIGEST" ]]
+}
+
+@test "should reference image digest if specified" {
+	start_crio
+	crictl pull "$IMAGE_DIGEST"
+	run_using_digest
+}
+
+@test "should reference image digest if specified and tag is referencing digest" {
+	start_crio
+	crictl pull "$IMAGE_REF"
+	run_using_digest
+}


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:


_The tests added in this PR fails right now to outline the problem._

When running a container by referencing a repo digest as image, then the container status should not resolve into a tag when locally available. Is this the correct intention?


#### Which issue(s) this PR fixes:

Found in https://github.com/kubernetes/kubernetes/pull/121531

#### Special notes for your reviewer:
PTAL @mtrmac 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
TBD
```
