### PR TITLE
Fix inconsistency in restore image name resolution

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -56,31 +56,31 @@ type Container struct {
 	dir        string
 	stopSignal string
 	// If set, _some_ name of the image imageID; it may have NO RELATIONSHIP to the users’ requested image name.
-	imageName          *references.RegistryImageReference
-	imageID            *storage.StorageImageID // nil for infra containers.
-	mountPoint         string
-	seccompProfilePath string
-	conmonCgroupfsPath string
-	crioAnnotations    fields.Set
-	state              *ContainerState
-	opLock             sync.RWMutex
-	spec               *specs.Spec
-	idMappings         *idtools.IDMappings
-	terminal           bool
-	stdin              bool
-	stdinOnce          bool
-	created            bool
-	spoofed            bool
-	stopping           bool
-	stopLock           sync.Mutex
-	stopTimeoutChan    chan int64
-	stopWatchers       []chan struct{}
-	pidns              nsmgr.Namespace
-	restore            bool
-	restoreArchive     string
-	restoreIsOCIImage  bool
-	resources          *types.ContainerResources
-	runtimePath        string // runtime path for a given platform
+	imageName             *references.RegistryImageReference
+	imageID               *storage.StorageImageID // nil for infra containers.
+	mountPoint            string
+	seccompProfilePath    string
+	conmonCgroupfsPath    string
+	crioAnnotations       fields.Set
+	state                 *ContainerState
+	opLock                sync.RWMutex
+	spec                  *specs.Spec
+	idMappings            *idtools.IDMappings
+	terminal              bool
+	stdin                 bool
+	stdinOnce             bool
+	created               bool
+	spoofed               bool
+	stopping              bool
+	stopLock              sync.Mutex
+	stopTimeoutChan       chan int64
+	stopWatchers          []chan struct{}
+	pidns                 nsmgr.Namespace
+	restore               bool
+	restoreArchivePath    string
+	restoreStorageImageID *storage.StorageImageID
+	resources             *types.ContainerResources
+	runtimePath           string // runtime path for a given platform
 }
 
 func (c *Container) CRIAttributes() *types.ContainerAttributes {
@@ -635,20 +635,22 @@ func (c *Container) SetRestore(restore bool) {
 	c.restore = restore
 }
 
-func (c *Container) RestoreArchive() string {
-	return c.restoreArchive
+// If Restore(), and the container is being restored from a local path, RestoreArchivePath returns that path.
+func (c *Container) RestoreArchivePath() string {
+	return c.restoreArchivePath
 }
 
-func (c *Container) SetRestoreArchive(restoreArchive string) {
-	c.restoreArchive = restoreArchive
+func (c *Container) SetRestoreArchivePath(restoreArchivePath string) {
+	c.restoreArchivePath = restoreArchivePath
 }
 
-func (c *Container) RestoreIsOCIImage() bool {
-	return c.restoreIsOCIImage
+// If Restore(), and the container is being restored from a container image, restoreStorageImageID returns the ID of that image.
+func (c *Container) RestoreStorageImageID() *storage.StorageImageID {
+	return c.restoreStorageImageID
 }
 
-func (c *Container) SetRestoreIsOCIImage(restoreIsOCIImage bool) {
-	c.restoreIsOCIImage = restoreIsOCIImage
+func (c *Container) SetRestoreStorageImageID(restoreStorageImageID *storage.StorageImageID) {
+	c.restoreStorageImageID = restoreStorageImageID
 }
 
 // SetResources loads the OCI Spec.Linux.Resources in the container struct

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/internal/storage"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -56,8 +57,8 @@ var _ = t.Describe("Container", func() {
 			To(BeNumerically("<", time.Now().UnixNano()))
 		Expect(sut.Spoofed()).To(Equal(false))
 		Expect(sut.Restore()).To(Equal(false))
-		Expect(sut.RestoreArchive()).To(Equal(""))
-		Expect(sut.RestoreIsOCIImage()).To(Equal(false))
+		Expect(sut.RestoreArchivePath()).To(Equal(""))
+		Expect(sut.RestoreStorageImageID()).To(BeNil())
 	})
 
 	It("should succeed to set the spec", func() {
@@ -151,13 +152,14 @@ var _ = t.Describe("Container", func() {
 
 	It("should succeed to set restore is oci image", func() {
 		// Given
-		restore := true
+		storageImageID, err := storage.ParseStorageImageIDFromOutOfProcessData("1111111111111111111111111111111111111111111111111111111111111111")
+		Expect(err).To(BeNil())
 
 		// When
-		sut.SetRestoreIsOCIImage(restore)
+		sut.SetRestoreStorageImageID(&storageImageID)
 
 		// Then
-		Expect(sut.RestoreIsOCIImage()).To(Equal(restore))
+		Expect(sut.RestoreStorageImageID()).To(Equal(&storageImageID))
 	})
 
 	It("should succeed to set restore archive", func() {
@@ -165,10 +167,10 @@ var _ = t.Describe("Container", func() {
 		restoreArchive := "image-name"
 
 		// When
-		sut.SetRestoreArchive(restoreArchive)
+		sut.SetRestoreArchivePath(restoreArchive)
 
 		// Then
-		Expect(sut.RestoreArchive()).To(Equal(restoreArchive))
+		Expect(sut.RestoreArchivePath()).To(Equal(restoreArchive))
 	})
 
 	It("should succeed to set start failed with nil error", func() {

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -329,12 +329,12 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 			return true, nil
 		}
 		// Check if this is an OCI checkpoint image
-		ok, err := s.checkIfCheckpointOCIImage(ctx, req.Config.Image.Image)
+		imageID, err := s.checkIfCheckpointOCIImage(ctx, req.Config.Image.Image)
 		if err != nil {
 			return false, fmt.Errorf("failed to check if this is a checkpoint image: %w", err)
 		}
 
-		return ok, nil
+		return imageID != nil, nil
 	}()
 	if err != nil {
 		return nil, err

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -26,26 +26,18 @@ func (s *Server) checkIfCheckpointOCIImage(ctx context.Context, input string) (b
 	if _, err := os.Stat(input); err == nil {
 		return false, nil
 	}
-	imageStatusResponse, err := s.ImageStatus(
-		ctx,
-		&types.ImageStatusRequest{
-			Image: &types.ImageSpec{
-				Image: input,
-			},
-		},
-	)
+	status, err := s.storageImageStatus(ctx, types.ImageSpec{
+		Image: input,
+	})
 	if err != nil {
 		return false, err
 	}
 
-	if imageStatusResponse == nil ||
-		imageStatusResponse.Image == nil ||
-		imageStatusResponse.Image.Spec == nil ||
-		imageStatusResponse.Image.Spec.Annotations == nil {
+	if status == nil || status.Annotations == nil {
 		return false, nil
 	}
 
-	ann, ok := imageStatusResponse.Image.Spec.Annotations[crioann.CheckpointAnnotationName]
+	ann, ok := status.Annotations[crioann.CheckpointAnnotationName]
 	if !ok {
 		return false, nil
 	}

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/containers/podman/v4/pkg/criu"
-	cs "github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/cri-o/cri-o/internal/mockutils"
 	"github.com/cri-o/cri-o/internal/oci"
@@ -600,19 +599,6 @@ var _ = t.Describe("ContainerRestore", func() {
 						User: "10", Size: &size,
 						Annotations: map[string]string{
 							crioann.CheckpointAnnotationName: "foo",
-						},
-					}, nil),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().GraphOptions().Return([]string{}),
-				storeMock.EXPECT().GraphDriverName().Return(""),
-				storeMock.EXPECT().GraphRoot().Return(""),
-				storeMock.EXPECT().RunRoot().Return(""),
-				imageServerMock.EXPECT().GetStore().Return(storeMock),
-				storeMock.EXPECT().Image("localhost/checkpoint-image:tag1").
-					Return(&cs.Image{
-						ID: imageID.IDStringForOutOfProcessConsumptionOnly(),
-						Names: []string{
-							"localhost/checkpoint-image:tag1",
 						},
 					}, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The code was calling `checkIfCheckpointOCIImage`, which resolves short names into all candidates, and then using `ParseStoreReference`, which interprets short names as `docker.io/[library]`.
    
Instead, have `checkIfCheckpointOCIImage` return the resolved storage ID, use that, and avoid the redundant lookup entirely.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Initially, fixing this bug seemed easier than building the test mocks to work with the previous version of the code in #7302. Other than that, this has no relationship to signature verification.

Alternatively, the input → image ID resolution could use some other rules; either not resolving short names and hard-coding `docker.io`, or maybe even conceivably requiring an image ID as input. I don’t know what’s the right thing to do here; using the same rules as for regular `CreateContainer` paths seems reasonable to me as an outsider.

`checkIfCheckpointOCIImage` is still being called twice in quick succession from `CreateContainer` (and if the input were tagged, it could potentially resolve to different images?); that could be cleaned up further, but I’ll leave that to others.

Cc: @saschagrunert 

#### Does this PR introduce a user-facing change?

```release-note
None
```

(This could possibly advertise that short-name restore images work, but I have no idea how restore is used and whether that could ever happen. Even if it could, it shouldn’t…)