### PR TITLE
Prepare image pulling for per-namespace signature enforcement

### DIFF
--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -531,16 +531,6 @@ func pullImageChild() {
 	os.Exit(0)
 }
 
-func toCopyOptions(options *ImageCopyOptions, progress chan types.ProgressProperties) *copy.Options {
-	return &copy.Options{
-		SourceCtx:        options.SourceCtx,
-		DestinationCtx:   options.DestinationCtx,
-		OciDecryptConfig: options.OciDecryptConfig,
-		ProgressInterval: options.ProgressInterval,
-		Progress:         progress,
-	}
-}
-
 func (svc *imageService) pullImageParent(imageName RegistryImageReference, parentCgroup string, options *ImageCopyOptions) error {
 	progress := options.Progress
 	// the first argument imageName is not used by the re-execed command but it is useful for debugging as it
@@ -650,9 +640,13 @@ func pullImageImplementation(ctx context.Context, destRef, srcRef types.ImageRef
 		return err
 	}
 
-	copyOptions := toCopyOptions(options, options.Progress)
-
-	if _, err := copy.Image(ctx, policyContext, destRef, srcRef, copyOptions); err != nil {
+	if _, err := copy.Image(ctx, policyContext, destRef, srcRef, &copy.Options{
+		SourceCtx:        options.SourceCtx,
+		DestinationCtx:   options.DestinationCtx,
+		OciDecryptConfig: options.OciDecryptConfig,
+		ProgressInterval: options.ProgressInterval,
+		Progress:         options.Progress,
+	}); err != nil {
 		return err
 	}
 	return nil

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -651,21 +651,11 @@ func (svc *imageService) pullImageParent(imageName RegistryImageReference, paren
 }
 
 func (svc *imageService) PullImage(imageName RegistryImageReference, options *ImageCopyOptions) (types.ImageReference, error) {
-	var destRef types.ImageReference
 	if options.CgroupPull.UseNewCgroup {
-		dr, err := svc.pullImageParent(imageName, options.CgroupPull.ParentCgroup, options)
-		if err != nil {
-			return nil, err
-		}
-		destRef = dr
+		return svc.pullImageParent(imageName, options.CgroupPull.ParentCgroup, options)
 	} else {
-		dr, err := pullImageImplementation(svc.ctx, svc.lookup, svc.store, imageName, options)
-		if err != nil {
-			return nil, err
-		}
-		destRef = dr
+		return pullImageImplementation(svc.ctx, svc.lookup, svc.store, imageName, options)
 	}
-	return destRef, nil
 }
 
 // pullImageImplementation is called in PullImage, both directly and inside pullImageChild.

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -550,7 +550,7 @@ var _ = t.Describe("Image", func() {
 			Expect(err).To(BeNil())
 
 			// When
-			res, err := sut.PullImage(nil, imageRef, &storage.ImageCopyOptions{
+			res, err := sut.PullImage(imageRef, &storage.ImageCopyOptions{
 				SourceCtx: &types.SystemContext{SignaturePolicyPath: "/not-existing"},
 			})
 
@@ -565,7 +565,7 @@ var _ = t.Describe("Image", func() {
 			Expect(err).To(BeNil())
 
 			// When
-			res, err := sut.PullImage(nil, imageRef, &storage.ImageCopyOptions{
+			res, err := sut.PullImage(imageRef, &storage.ImageCopyOptions{
 				SourceCtx: &types.SystemContext{SignaturePolicyPath: "../../test/policy.json"},
 			})
 
@@ -580,7 +580,7 @@ var _ = t.Describe("Image", func() {
 			Expect(err).To(BeNil())
 
 			// When
-			res, err := sut.PullImage(nil, imageRef, &storage.ImageCopyOptions{
+			res, err := sut.PullImage(imageRef, &storage.ImageCopyOptions{
 				SourceCtx: &types.SystemContext{SignaturePolicyPath: "../../test/policy.json"},
 			})
 

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -550,9 +550,9 @@ var _ = t.Describe("Image", func() {
 			Expect(err).To(BeNil())
 
 			// When
-			res, err := sut.PullImage(&types.SystemContext{
-				SignaturePolicyPath: "/not-existing",
-			}, imageRef, &storage.ImageCopyOptions{})
+			res, err := sut.PullImage(nil, imageRef, &storage.ImageCopyOptions{
+				SourceCtx: &types.SystemContext{SignaturePolicyPath: "/not-existing"},
+			})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -565,9 +565,9 @@ var _ = t.Describe("Image", func() {
 			Expect(err).To(BeNil())
 
 			// When
-			res, err := sut.PullImage(&types.SystemContext{
-				SignaturePolicyPath: "../../test/policy.json",
-			}, imageRef, &storage.ImageCopyOptions{})
+			res, err := sut.PullImage(nil, imageRef, &storage.ImageCopyOptions{
+				SourceCtx: &types.SystemContext{SignaturePolicyPath: "../../test/policy.json"},
+			})
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -580,9 +580,9 @@ var _ = t.Describe("Image", func() {
 			Expect(err).To(BeNil())
 
 			// When
-			res, err := sut.PullImage(&types.SystemContext{
-				SignaturePolicyPath: "../../test/policy.json",
-			}, imageRef, &storage.ImageCopyOptions{})
+			res, err := sut.PullImage(nil, imageRef, &storage.ImageCopyOptions{
+				SourceCtx: &types.SystemContext{SignaturePolicyPath: "../../test/policy.json"},
+			})
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/internal/storage/runtime.go
+++ b/internal/storage/runtime.go
@@ -314,7 +314,7 @@ func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, po
 		if imageAuthFile != "" {
 			sourceCtx.AuthFilePath = imageAuthFile
 		}
-		ref, err = r.storageImageServer.PullImage(systemContext, pauseImage, &ImageCopyOptions{
+		ref, err = r.storageImageServer.PullImage(pauseImage, &ImageCopyOptions{
 			SourceCtx:      &sourceCtx,
 			DestinationCtx: systemContext,
 		})

--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -762,7 +762,7 @@ var _ = t.Describe("Runtime", func() {
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", ""),
-				imageServerMock.EXPECT().PullImage(gomock.Any(), pauseImageRef, expectedCopyOptions).Return(pulledRef, nil),
+				imageServerMock.EXPECT().PullImage(pauseImageRef, expectedCopyOptions).Return(pulledRef, nil),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				mockGetStoreImage(storeMock, "docker.io/library/pauseimagename:latest", imageID.IDStringForOutOfProcessConsumptionOnly()),
 				imageServerMock.EXPECT().GetStore().Return(storeMock),

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -246,7 +246,7 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 	defer close(progress) // nolint:gocritic
 	go metricsFromProgressGoroutine(ctx, progress, remoteCandidateName, tmpImg)
 
-	_, err = s.StorageImageServer().PullImage(s.config.SystemContext, remoteCandidateName, &storage.ImageCopyOptions{
+	_, err = s.StorageImageServer().PullImage(remoteCandidateName, &storage.ImageCopyOptions{
 		SourceCtx:        sourceCtx,
 		DestinationCtx:   s.config.SystemContext,
 		OciDecryptConfig: decryptConfig,

--- a/server/image_pull_test.go
+++ b/server/image_pull_test.go
@@ -43,8 +43,7 @@ var _ = t.Describe("ImagePull", func() {
 					Return(&storage.ImageResult{ID: otherImageID}, nil),
 				imageCloserMock.EXPECT().ConfigInfo().
 					Return(imageTypes.BlobInfo{Digest: digest.Digest("")}),
-				imageServerMock.EXPECT().PullImage(
-					gomock.Any(), imageCandidate, gomock.Any()).
+				imageServerMock.EXPECT().PullImage(imageCandidate, gomock.Any()).
 					Return(nil, nil),
 				imageCloserMock.EXPECT().Close().Return(nil),
 				imageServerMock.EXPECT().ImageStatusByName(
@@ -120,8 +119,7 @@ var _ = t.Describe("ImagePull", func() {
 					Return(&storage.ImageResult{ID: otherImageID}, nil),
 				imageCloserMock.EXPECT().ConfigInfo().
 					Return(imageTypes.BlobInfo{Digest: digest.Digest("")}),
-				imageServerMock.EXPECT().PullImage(
-					gomock.Any(), imageCandidate, gomock.Any()).
+				imageServerMock.EXPECT().PullImage(imageCandidate, gomock.Any()).
 					Return(nil, nil),
 				imageCloserMock.EXPECT().Close().Return(nil),
 				imageServerMock.EXPECT().ImageStatusByName(
@@ -174,8 +172,7 @@ var _ = t.Describe("ImagePull", func() {
 					Return(&storage.ImageResult{ID: otherImageID}, nil),
 				imageCloserMock.EXPECT().ConfigInfo().
 					Return(imageTypes.BlobInfo{Digest: digest.Digest("")}),
-				imageServerMock.EXPECT().PullImage(
-					gomock.Any(), imageCandidate, gomock.Any()).
+				imageServerMock.EXPECT().PullImage(imageCandidate, gomock.Any()).
 					Return(nil, t.TestError),
 				imageCloserMock.EXPECT().Close().Return(nil),
 			)

--- a/server/image_pull_test.go
+++ b/server/image_pull_test.go
@@ -46,13 +46,13 @@ var _ = t.Describe("ImagePull", func() {
 				imageServerMock.EXPECT().PullImage(
 					gomock.Any(), imageCandidate, gomock.Any()).
 					Return(nil, nil),
+				imageCloserMock.EXPECT().Close().Return(nil),
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
 					Return(&storage.ImageResult{
 						ID:          imageID,
 						RepoDigests: []string{"digest"},
 					}, nil),
-				imageCloserMock.EXPECT().Close().Return(nil),
 			)
 
 			// When
@@ -82,13 +82,13 @@ var _ = t.Describe("ImagePull", func() {
 					}, nil),
 				imageCloserMock.EXPECT().ConfigInfo().
 					Return(imageTypes.BlobInfo{Digest: digest.Digest("digest")}),
+				imageCloserMock.EXPECT().Close().Return(nil),
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
 					Return(&storage.ImageResult{
 						ID:          imageID,
 						RepoDigests: []string{"digest"},
 					}, nil),
-				imageCloserMock.EXPECT().Close().Return(nil),
 			)
 
 			// When
@@ -123,10 +123,10 @@ var _ = t.Describe("ImagePull", func() {
 				imageServerMock.EXPECT().PullImage(
 					gomock.Any(), imageCandidate, gomock.Any()).
 					Return(nil, nil),
+				imageCloserMock.EXPECT().Close().Return(nil),
 				imageServerMock.EXPECT().ImageStatusByName(
 					gomock.Any(), imageCandidate).
 					Return(nil, t.TestError),
-				imageCloserMock.EXPECT().Close().Return(nil),
 			)
 
 			// When

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -157,18 +157,18 @@ func (mr *MockImageServerMockRecorder) PrepareImage(arg0, arg1 interface{}) *gom
 }
 
 // PullImage mocks base method.
-func (m *MockImageServer) PullImage(arg0 *types.SystemContext, arg1 references.RegistryImageReference, arg2 *storage0.ImageCopyOptions) (types.ImageReference, error) {
+func (m *MockImageServer) PullImage(arg0 references.RegistryImageReference, arg1 *storage0.ImageCopyOptions) (types.ImageReference, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PullImage", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PullImage", arg0, arg1)
 	ret0, _ := ret[0].(types.ImageReference)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PullImage indicates an expected call of PullImage.
-func (mr *MockImageServerMockRecorder) PullImage(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockImageServerMockRecorder) PullImage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockImageServer)(nil).PullImage), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockImageServer)(nil).PullImage), arg0, arg1)
 }
 
 // UntagImage mocks base method.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is mostly refactoring:
- Split the 180-line `Server.pullImage` function into 3 major components, making it more manageable and simplifying the control flow
- Modify the `copyImageChild` subprocess interface to be able to return values. This will be necessary to return the correct resolved image reference after pulling an image.
- Then share _everything_ in the implementation of `PullImage` between the in-process and `copyImageChild` variants, so that we can consistently enforce signature policies in the future without duplicating it in two implementations (which have _already_ diverged by now).

+ some smaller cleanups and bug fixes along the way.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

See individual commit messages for details.

I didn’t even smoke-test the “experimental” `copyImageChild` code path.

Cc: @saschagrunert . Almost there now.

#### Does this PR introduce a user-facing change?

```release-note
None
```
