### PR TITLE
PoC: Add OCI artifact pull helper

### DIFF
--- a/internal/storage/artifact.go
+++ b/internal/storage/artifact.go
@@ -1,0 +1,88 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/containers/image/v5/types"
+	"github.com/cri-o/cri-o/internal/log"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// PullArtifact can be used to pull an OCI artifact from the specified ref to
+// the destPath.
+func PullArtifact(ctx context.Context, sctx *types.SystemContext, ref, destPath string) error {
+	log.Debugf(ctx, "Pulling artifact from %q to %q", ref, destPath)
+
+	tmpDir, err := os.MkdirTemp("", "cri-o-artifact-pull-")
+	if err != nil {
+		return fmt.Errorf("create temp artifact dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	srcRef, err := alltransports.ParseImageName("docker://" + ref)
+	if err != nil {
+		return fmt.Errorf("parse source reference: %w", err)
+	}
+
+	destRef, err := alltransports.ParseImageName("dir:" + tmpDir)
+	if err != nil {
+		return fmt.Errorf("parse destination reference: %w", err)
+	}
+
+	policy, err := signature.DefaultPolicy(sctx)
+	if err != nil {
+		return fmt.Errorf("get default policy: %w", err)
+	}
+	policyContext, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		return fmt.Errorf("create new policy context: %w", err)
+	}
+
+	manifestBlob, err := copy.Image(ctx, policyContext, destRef, srcRef, &copy.Options{
+		SourceCtx:      sctx,
+		DestinationCtx: sctx,
+	})
+	if err != nil {
+		return fmt.Errorf("copy OCI artifact image: %w", err)
+	}
+
+	mfest, err := manifest.FromBlob(manifestBlob, v1.MediaTypeImageManifest)
+	if err != nil {
+		return fmt.Errorf("get manifest from blob: %w", err)
+	}
+
+	for _, layerInfo := range mfest.LayerInfos() {
+		title, ok := layerInfo.Annotations[v1.AnnotationTitle]
+		if !ok {
+			log.Debugf(ctx, "No title for layer with digest: %s", layerInfo.Digest)
+			continue
+		}
+
+		log.Debugf(ctx, "Found artifact %s for digest: %s", title, layerInfo.Digest.Encoded())
+		fromPath := filepath.Join(tmpDir, layerInfo.Digest.Encoded())
+		toPath := filepath.Join(destPath, title)
+
+		artifactBytes, err := os.ReadFile(fromPath)
+		if err != nil {
+			return fmt.Errorf("read artifact content: %w", err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(toPath), 0o755); err != nil {
+			return fmt.Errorf("ensure destination path exists: %w", err)
+		}
+
+		log.Debugf(ctx, "Write artifact content to: %s", toPath)
+		if err := os.WriteFile(toPath, artifactBytes, 0o644); err != nil {
+			return fmt.Errorf("write artifact content: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -28,6 +28,20 @@ var localRegistryHostname = "localhost"
 
 // PullImage pulls a image with authentication config.
 func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*types.PullImageResponse, error) {
+	// TODO: this is for demoing purposes, it could be any other location
+	// The call below will pull the OCI artifact `profile-linux-amd64.yaml`
+	// into the system temp directory.
+	if err := storage.PullArtifact(
+		ctx,
+		s.config.SystemContext,
+		"ghcr.io/security-profiles/crun:v1.11.1",
+		os.TempDir(),
+	); err != nil {
+		return nil, fmt.Errorf("pull artifact: %w", err)
+	}
+
+	return &types.PullImageResponse{ImageRef: "test"}, nil
+
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 	// TODO: what else do we need here? (Signatures when the story isn't just pulling from docker://)


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
Intention is to have a helper function to pull OCI artifacts into a specified destination directory. Could be used for seccomp profiles, WASM workloads or anything where we need a set of files within CRI-O.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
/hold

Just a PoC for demo purposes.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
