### PR TITLE
Warn users when trying to use `noNewPrivileges` on privileged or `CAP_SYS_ADMIN`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -233,7 +233,7 @@ linters-settings:
       # - filepathJoin
       # - whyNoLint
   gocyclo:
-    min-complexity: 154
+    min-complexity: 160
   nakedret:
     max-func-lines: 15
   goconst:

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -477,6 +477,20 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 				return nil, err
 			}
 		}
+
+		if securityContext.NoNewPrivs {
+			const sysAdminCap = "CAP_SYS_ADMIN"
+			for _, cap := range specgen.Config.Process.Capabilities.Bounding {
+				if cap == sysAdminCap {
+					log.Warnf(ctx, "Setting `noNewPrivileges` flag has no effect because container has %s capability", sysAdminCap)
+				}
+			}
+
+			if ctr.Privileged() {
+				log.Warnf(ctx, "Setting `noNewPrivileges` flag has no effect because container is privileged")
+			}
+		}
+
 		specgen.SetProcessNoNewPrivileges(securityContext.NoNewPrivs)
 
 		if !ctr.Privileged() {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

Combining both settings does not make much sense because the option `noNewPrivileges` will do nothing for containers using privileged or `CAPCAP_SYS_ADMIN`. We now warn users if that's the case.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Warn users on container creation when trying to use `noNewPrivileges` on privileged or `CAP_SYS_ADMIN`.
```
