### PR TITLE
[release-1.24] Backport install_ginkgo() from CRI-O release 1.26

### DIFF
--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -101,9 +101,11 @@ install_runc() {
 
 install_ginkgo() {
     GOPATH="$(go env GOPATH)"
-    sudo chown -R "$(id -u):$(id -g)" "$GOPATH"
+    for i in $GOPATH "$(go env GOCACHE)"; do
+        sudo chown -R "$(id -u):$(id -g)" "$i"
+    done
     go install github.com/onsi/ginkgo/ginkgo@latest
-    sudo -E cp "$GOPATH/bin//ginkgo" /usr/bin
+    sudo -E cp "$GOPATH/bin/ginkgo" /usr/bin
     ginkgo version
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind ci
/kind failing-test
/assign kwilczynski

#### What this PR does / why we need it:

To fix the following failure related to Ginkgo setup step:

```
+ install_ginkgo
++ go env GOPATH
+ GOPATH=/home/runner/go
++ id -u
++ id -g
+ sudo chown -R 1001:127 /home/runner/go
+ go install github.com/onsi/ginkgo/ginkgo@latest
go: downloading github.com/onsi/ginkgo v1.16.5
go: github.com/onsi/ginkgo/ginkgo@latest: github.com/onsi/ginkgo/ginkgo: open /home/runner/.cache/go-build/7e/7ef034d25a873f232bad78599087e86cefc2feaa947b7b1a0bba5926e9eb2430-d: permission denied
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
