### PR TITLE
Remove 386 build test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,39 +51,6 @@ jobs:
       - run: scripts/github-actions-packages
       - run: make bin/crio.cross.freebsd.amd64
 
-  build-386:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-build-386-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-build-386-
-      - name: Build 386 binary in container
-        run: |
-          mkdir -p ~/.cache/go-build ~/go/pkg/mod
-          sudo podman run \
-            -v ~/go/pkg/mod:/go/pkg/mod \
-            -v ~/.cache/go-build:/root/.cache/go-build \
-            -v $PWD:/build \
-            -w /build \
-            -it i386/golang:${{ env.GO_VERSION }}-alpine \
-            sh -c \
-              "apk --no-cache add \
-                bash \
-                build-base \
-                git \
-                gpgme-dev \
-                libseccomp-dev \
-                libselinux-dev \
-                linux-headers \
-                tzdata && \
-              make bin/crio && \
-              bin/crio version"
-
   validate-docs:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
I think we can remove the test since it inherits from old CircleCI times. 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/7570

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
