### PR TITLE
Fix buildah setup for critest on arm64

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -58,7 +58,7 @@ dependencies:
       match: cri_tools_git_version
 
   - name: buildah
-    version: v1.33.2
+    version: v1.34.0
     refPaths:
     - path: scripts/versions
       match: buildah

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -139,8 +139,8 @@ install_buildah() {
     git clone $URL
     pushd buildah
     git checkout "${VERSIONS["buildah"]}"
-    make
-    sudo -E PATH="$PATH" make BINDIR=/usr/bin install
+    make bin/buildah
+    sudo install -m 755 bin/buildah /usr/bin/buildah
     popd
     sudo rm -rf buildah
     sudo buildah --version

--- a/scripts/versions
+++ b/scripts/versions
@@ -10,6 +10,6 @@ declare -A VERSIONS=(
     ["runc"]=v1.1.9
     ["crun"]=1.9.2
     ["bats"]=v1.10.0
-    ["buildah"]=v1.33.2
+    ["buildah"]=v1.34.0
 )
 export VERSIONS


### PR DESCRIPTION

#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
Buildah doesn't install well on arm64, which is now fixed. We also update the version to the latest release.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
