### PR TITLE
Add an annotation for asking for a RW sysfs mount

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -344,6 +344,7 @@ The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  Th
   "io.kubernetes.cri-o.userns-mode" for configuring a user namespace for the pod.
   "io.kubernetes.cri-o.Devices" for configuring devices for the pod.
   "io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
+  "io.kubernetes.cri-o.sysfs-mount-rw" to mount sysfs writable when set to "true" (only safe combined with userns-mode).
   "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
   "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
 

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -72,6 +72,9 @@ const (
 
 	// PlatformRuntimePath indicates the runtime path that CRI-O should use for a specific platform.
 	PlatformRuntimePath = "io.kubernetes.cri-o.PlatformRuntimePath"
+
+	// SysfsRWAnnotation specifies mounting sysfs as an rw filesystem.
+	SysfsRWAnnotation = "io.kubernetes.cri-o.sysfs-mount-rw"
 )
 
 var AllAllowedAnnotations = []string{
@@ -94,4 +97,5 @@ var AllAllowedAnnotations = []string{
 	PodLinuxResources,
 	LinkLogsAnnotation,
 	CPUSharedAnnotation,
+	SysfsRWAnnotation,
 }

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1245,6 +1245,7 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 #   "io.kubernetes.cri-o.cgroup2-mount-hierarchy-rw" for mounting cgroups writably when set to "true".
 #   "io.kubernetes.cri-o.Devices" for configuring devices for the pod.
 #   "io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
+#   "io.kubernetes.cri-o.sysfs-mount-rw" to mount sysfs writable when set to "true" (only safe combined with userns-mode).
 #   "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
 #   "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
 #   "io.kubernetes.cri.rdt-class" for setting the RDT class of a container

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -31,7 +31,7 @@ func TestAddOCIBindsForDev(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, binds, err := addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, "")
+	_, binds, err := addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, false, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -75,7 +75,7 @@ func TestAddOCIBindsForSys(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, binds, err := addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, "")
+	_, binds, err := addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, false, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -107,7 +107,7 @@ func TestAddOCIBindsCGroupRW(t *testing.T) {
 	}); err != nil {
 		t.Error(err)
 	}
-	_, _, err = addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, true, false, "")
+	_, _, err = addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, true, false, false, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -141,7 +141,7 @@ func TestAddOCIBindsCGroupRW(t *testing.T) {
 		t.Error(err)
 	}
 	var hasCgroupRO bool
-	_, _, err = addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, "")
+	_, _, err = addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, false, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -189,12 +189,12 @@ func TestAddOCIBindsErrorWithoutIDMap(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, "")
+	_, _, err = addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, false, "")
 	if err == nil {
 		t.Errorf("Should have failed to create id mapped mount with no id map support")
 	}
 
-	_, _, err = addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, true, "")
+	_, _, err = addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, true, "")
 	if err != nil {
 		t.Errorf("%v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind feature

#### What this PR does / why we need it:

This allows some additional use-cases for user namespaces, in particular when running systemd + docker within a container, it allows using `docker run --privileged`.

Even with `procMountType: Unmasked` because of how masked mounts work, a container cannot mount sysfs read-write, because /sys is already mounted read-only. Mounting sysfs read-write *within* a user namespace is something that a standard user on Linux can do:

```
$ unshare -Urnm bash
root@dev4:~# mkdir /tmp/sys
root@dev4:~# mount -t sysfs none /tmp/sys
root@dev4:~# mount | grep /tmp/sys
none on /tmp/sys type sysfs (rw,relatime)
```

So therefore this isn't as scary as it may seem. It is obviously not safe if the container is not within a user namespace.

Note this does go against the [systemd container interface spec](https://systemd.io/CONTAINER_INTERFACE/) which specifies sysfs should be mounted read-only. I have tested this with systemd and docker and haven't yet noticed any unexpected behaviour as a result, potentially this should be investigated more, but this seems fine for an experimental feature for now. (We could potentially consider mounting a read-write sysfs elsewhere to keep the systemd interface correct.)

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or

-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add an experimental `io.kubernetes.cri-o.sysfs-mount-rw` annotation to request `/sys` is mounted read-write.
```
