### PR TITLE
Implement sandbox and containers stats collection using `libcontainer`'s cgroup managers

### DIFF
--- a/internal/config/cgmgr/cgmgr_linux.go
+++ b/internal/config/cgmgr/cgmgr_linux.go
@@ -62,6 +62,9 @@ type CgroupManager interface {
 	// ContainerCgroupManager takes the cgroup parent, and container ID.
 	// It returns the raw libcontainer cgroup manager for that container.
 	ContainerCgroupManager(sbParent, containerID string) (libctr.Manager, error)
+	// ContainerCgroupStats returns a stats object with information from the cgroup found
+	// given a cgroup parent and container ID.
+	ContainerCgroupStats(sbParent, containerID string) (*CgroupStats, error)
 	// RemoveContainerCgManager removes the cgroup manager for the container
 	RemoveContainerCgManager(containerID string)
 	// SandboxCgroupPath takes the sandbox parent, and sandbox ID. It
@@ -74,6 +77,9 @@ type CgroupManager interface {
 	// SandboxCgroupManager takes the cgroup parent, and sandbox ID.
 	// It returns the raw libcontainer cgroup manager for that sandbox.
 	SandboxCgroupManager(sbParent, sbID string) (libctr.Manager, error)
+	// SandboxCgroupStats takes arguments sandbox parent cgroup, and sandbox stats object.
+	// It returns an object with information from the cgroup found given that parent.
+	SandboxCgroupStats(sbParent, sbID string) (*CgroupStats, error)
 	// RemoveSandboxCgroupManager removes the cgroup manager for the sandbox
 	RemoveSandboxCgManager(sbID string)
 	// MoveConmonToCgroup takes the container ID, cgroup parent, conmon's cgroup (from the config), conmon's PID, and some customized resources

--- a/internal/config/cgmgr/cgmgr_linux.go
+++ b/internal/config/cgmgr/cgmgr_linux.go
@@ -77,7 +77,7 @@ type CgroupManager interface {
 	// SandboxCgroupManager takes the cgroup parent, and sandbox ID.
 	// It returns the raw libcontainer cgroup manager for that sandbox.
 	SandboxCgroupManager(sbParent, sbID string) (libctr.Manager, error)
-	// SandboxCgroupStats returns a stats object with with data from the cgroup found
+	// SandboxCgroupStats returns a stats object with data from the cgroup found
 	// given a cgroup parent, and sandbox ID.
 	SandboxCgroupStats(sbParent, sbID string) (*CgroupStats, error)
 	// RemoveSandboxCgroupManager removes the cgroup manager for the sandbox

--- a/internal/config/cgmgr/cgmgr_linux.go
+++ b/internal/config/cgmgr/cgmgr_linux.go
@@ -62,7 +62,7 @@ type CgroupManager interface {
 	// ContainerCgroupManager takes the cgroup parent, and container ID.
 	// It returns the raw libcontainer cgroup manager for that container.
 	ContainerCgroupManager(sbParent, containerID string) (libctr.Manager, error)
-	// ContainerCgroupStats returns a stats object with information from the cgroup found
+	// ContainerCgroupStats returns a stats object with data from the cgroup found
 	// given a cgroup parent and container ID.
 	ContainerCgroupStats(sbParent, containerID string) (*CgroupStats, error)
 	// RemoveContainerCgManager removes the cgroup manager for the container
@@ -77,8 +77,8 @@ type CgroupManager interface {
 	// SandboxCgroupManager takes the cgroup parent, and sandbox ID.
 	// It returns the raw libcontainer cgroup manager for that sandbox.
 	SandboxCgroupManager(sbParent, sbID string) (libctr.Manager, error)
-	// SandboxCgroupStats takes arguments sandbox parent cgroup, and sandbox stats object.
-	// It returns an object with information from the cgroup found given that parent.
+	// SandboxCgroupStats returns a stats object with with data from the cgroup found
+	// given a cgroup parent, and sandbox ID.
 	SandboxCgroupStats(sbParent, sbID string) (*CgroupStats, error)
 	// RemoveSandboxCgroupManager removes the cgroup manager for the sandbox
 	RemoveSandboxCgManager(sbID string)

--- a/internal/config/cgmgr/cgroupfs_linux.go
+++ b/internal/config/cgmgr/cgroupfs_linux.go
@@ -170,7 +170,7 @@ func (m *CgroupfsManager) SandboxCgroupManager(sbParent, sbID string) (libctrCg.
 	return cgMgr, nil
 }
 
-// SandboxCgroupStats returns a stats object with with data from the cgroup found
+// SandboxCgroupStats returns a stats object with data from the cgroup found
 // given a cgroup parent, and sandbox ID.
 func (m *CgroupfsManager) SandboxCgroupStats(sbParent, sbID string) (*CgroupStats, error) {
 	cgMgr, err := m.SandboxCgroupManager(sbParent, sbID)

--- a/internal/config/cgmgr/stats_linux.go
+++ b/internal/config/cgmgr/stats_linux.go
@@ -19,6 +19,25 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
+// CgroupStats is a structure used to augment libctr.Stats object, because
+// it does not have all of the information required for all of the stats we're
+// interested in.
+type CgroupStats struct {
+	MostStats     *libctrcgroups.Stats
+	OtherMemStats *CgroupMemoryStats
+	SystemNano    int64
+}
+
+// CgroupMemoryStats is an object to hold the memory stats from the memory.stat file
+// of the given cgroup.
+type CgroupMemoryStats struct {
+	Rss            uint64
+	PgFault        uint64
+	PgMajFault     uint64
+	WorkingSet     uint64
+	AvailableBytes uint64
+}
+
 func populateSandboxCgroupStatsFromPath(cgroupPath string, stats *types.PodSandboxStats) error {
 	cgroupStats, err := cgroupStatsFromPath(cgroupPath)
 	if err != nil {

--- a/internal/config/cgmgr/systemd_linux.go
+++ b/internal/config/cgmgr/systemd_linux.go
@@ -262,7 +262,7 @@ func (m *SystemdManager) SandboxCgroupManager(sbParent, sbID string) (cgroups.Ma
 	return cgMgr, nil
 }
 
-// SandboxCgroupStats returns a stats object with with data from the cgroup found
+// SandboxCgroupStats returns a stats object with data from the cgroup found
 // given a cgroup parent, and sandbox ID.
 func (m *SystemdManager) SandboxCgroupStats(sbParent, sbID string) (*CgroupStats, error) {
 	cgMgr, err := m.SandboxCgroupManager(sbParent, sbID)


### PR DESCRIPTION


#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
As a step into `libcontainer`'s, based stats collection, this PR implements the sandbox/container stats for both `systemd` and `cgroupfs` cg managers. original work done by @sohankunkerkar here https://github.com/cri-o/cri-o/pull/7256 but this PR is based on libcontainer/cgroups instead of containers/common

After this being merged, should be follow be two PRs:
- Integrate this into the stats server
- Cleanup the deprecated `PopulateContainerCgroupStats` and `PopulateSandboxCgroupStats` and their dependencies since they will be no longer needed.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
