### PR TITLE
Remove open-coded goroutines stacks printer

### DIFF
--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -155,39 +155,6 @@ var _ = t.Describe("Utils", func() {
 		})
 	})
 
-	t.Describe("WriteGoroutineStacks", func() {
-		It("should succeed", func() {
-			// Given
-			writer := &bytes.Buffer{}
-
-			// When
-			err := utils.WriteGoroutineStacks(writer)
-
-			// Then
-			Expect(err).To(BeNil())
-		})
-
-		It("should fail on invalid writer", func() {
-			// Given
-			writer := &errorReaderWriter{}
-
-			// When
-			err := utils.WriteGoroutineStacks(writer)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
-		It("should fail with nil reader/writer", func() {
-			// Given
-			// When
-			err := utils.WriteGoroutineStacks(nil)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-	})
-
 	t.Describe("RunUnderSystemdScope", func() {
 		It("should fail unauthenticated", func() {
 			// Given


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/assign kwilczynski

#### What this PR does / why we need it:

Replaces the `WriteGoroutineStacks()` function, which is an open-coded version of the same goroutines stacks printer routine that is available in the built-in **runtime/pprof** package, per:

- [runtime/pprof/pprof.go;l=697-716](https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/runtime/pprof/pprof.go;l=697-716) (Go version **1.21.0**)

The built-in function also provides a larger default internal buffer size to fit the results (64 MiB by default).

Generally, we don't need to carry this code ourselves; as such, it's safe to remove it.

Related to:

- https://github.com/cri-o/cri-o/pull/1813
- https://github.com/cri-o/cri-o/pull/2373

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
