### PR TITLE
[release-1.24] Cherry-pick changes from containers/common/pull#1689

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containernetworking/cni v1.1.1
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/buildah v1.23.1
-	github.com/containers/common v0.46.1-0.20230510135603-1fce5055c6ee
+	github.com/containers/common v0.46.1-0.20240109075609-52aab2048c15
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.0.0-20220505150146-7d0ae00b625c
 	github.com/containers/image/v5 v5.17.0

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/containers/buildah v1.23.1 h1:Tpc9DsRuU+0Oofewpxb6OJVNQjCu7yloN/obUqz
 github.com/containers/buildah v1.23.1/go.mod h1:4WnrN0yrA7ab0ppgunixu2WM1rlD2rG8QLJAKbEkZlQ=
 github.com/containers/common v0.44.2/go.mod h1:7sdP4vmI5Bm6FPFxb3lvAh1Iktb6tiO1MzjUzhxdoGo=
 github.com/containers/common v0.46.1-0.20211001143714-161e078e4c7f/go.mod h1:aml/OO4FmYfPbfT87rvWiCgkLzTdqO6PuZ/xXq6bPbk=
-github.com/containers/common v0.46.1-0.20230510135603-1fce5055c6ee h1:eXuM7TTDhxh5uvYttJIL9Vqj4MtEPivmvJCwQj0Yv1A=
-github.com/containers/common v0.46.1-0.20230510135603-1fce5055c6ee/go.mod h1:aml/OO4FmYfPbfT87rvWiCgkLzTdqO6PuZ/xXq6bPbk=
+github.com/containers/common v0.46.1-0.20240109075609-52aab2048c15 h1:818BGzbFG6sQZi+LcWpCT2lHhOy2O2fEjsByRUNCix4=
+github.com/containers/common v0.46.1-0.20240109075609-52aab2048c15/go.mod h1:aml/OO4FmYfPbfT87rvWiCgkLzTdqO6PuZ/xXq6bPbk=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.0.0-20220505150146-7d0ae00b625c h1:x6gYpFEXrLN+4+NgGg8QkmkGrtujHKgdUgoGY9oUtjU=

--- a/vendor/github.com/Microsoft/hcsshim/.gitattributes
+++ b/vendor/github.com/Microsoft/hcsshim/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/vendor/github.com/containerd/fifo/.gitattributes
+++ b/vendor/github.com/containerd/fifo/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/vendor/github.com/containers/common/pkg/apparmor/apparmor_linux.go
+++ b/vendor/github.com/containers/common/pkg/apparmor/apparmor_linux.go
@@ -202,6 +202,11 @@ func parseAAParserVersion(output string) (int, error) {
 	words := strings.Split(lines[0], " ")
 	version := words[len(words)-1]
 
+	// trim "-beta1" suffix from version="3.0.0-beta1" if exists
+	version = strings.SplitN(version, "-", 2)[0]
+	// also trim "~..." suffix used historically (https://gitlab.com/apparmor/apparmor/-/commit/bca67d3d27d219d11ce8c9cc70612bd637f88c10)
+	version = strings.SplitN(version, "~", 2)[0]
+
 	// split by major minor version
 	v := strings.Split(version, ".")
 	if len(v) == 0 || len(v) > 3 {

--- a/vendor/github.com/fsnotify/fsnotify/.gitattributes
+++ b/vendor/github.com/fsnotify/fsnotify/.gitattributes
@@ -1,0 +1,1 @@
+go.sum linguist-generated

--- a/vendor/github.com/fsouza/go-dockerclient/.gitattributes
+++ b/vendor/github.com/fsouza/go-dockerclient/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/vendor/github.com/go-task/slim-sprig/.gitattributes
+++ b/vendor/github.com/go-task/slim-sprig/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/vendor/github.com/kevinburke/ssh_config/.gitattributes
+++ b/vendor/github.com/kevinburke/ssh_config/.gitattributes
@@ -1,0 +1,1 @@
+testdata/dos-lines eol=crlf

--- a/vendor/github.com/klauspost/compress/.gitattributes
+++ b/vendor/github.com/klauspost/compress/.gitattributes
@@ -1,0 +1,2 @@
+* -text
+*.bin -text -diff

--- a/vendor/go.opentelemetry.io/otel/.gitattributes
+++ b/vendor/go.opentelemetry.io/otel/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/vendor/k8s.io/client-go/pkg/version/.gitattributes
+++ b/vendor/k8s.io/client-go/pkg/version/.gitattributes
@@ -1,0 +1,1 @@
+base.go export-subst

--- a/vendor/k8s.io/component-base/version/.gitattributes
+++ b/vendor/k8s.io/component-base/version/.gitattributes
@@ -1,0 +1,1 @@
+base.go export-subst

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -230,7 +230,7 @@ github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/util
-# github.com/containers/common v0.46.1-0.20230510135603-1fce5055c6ee
+# github.com/containers/common v0.46.1-0.20240109075609-52aab2048c15
 ## explicit; go 1.15
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from https://github.com/containers/common/pull/1689 as these changes contain a fixe that needs to be backported to CRI-O release 1.24, part of OpenShift 4.11 release.

Related:

- https://github.com/containers/common/pull/1689
- https://github.com/containers/common/issues/1746
- https://github.com/cri-o/cri-o/pull/7496

Closes:

- https://github.com/cri-o/cri-o/issues/7490

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```