### PR TITLE
[release-1.28] Cherry-pick changes from containers/common/pull#1689

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           mkdir -p ~/.cache/go-build ~/go/pkg/mod
           sudo podman run \
+            -e CGO_CFLAGS='-D_LARGEFILE64_SOURCE' \
             -v ~/go/pkg/mod:/go/pkg/mod \
             -v ~/.cache/go-build:/root/.cache/go-build \
             -v $PWD:/build \

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
 	github.com/containers/buildah v1.31.2
-	github.com/containers/common v0.55.5-0.20231119144331-165b7a4dd43c
+	github.com/containers/common v0.55.5-0.20240105071436-8fedf2e32c8a
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.5.1
 	github.com/containers/image/v5 v5.27.0
@@ -251,7 +251,6 @@ require (
 )
 
 replace (
-	// Kubernetes overrides
 	k8s.io/api => k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20230815101549-855e7c48de73
 	k8s.io/apiextensions-apiserver => k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20230815101549-855e7c48de73
 	k8s.io/apimachinery => k8s.io/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20230815101549-855e7c48de73

--- a/go.sum
+++ b/go.sum
@@ -900,8 +900,8 @@ github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
 github.com/containers/buildah v1.31.2 h1:Pfbuzq5dtbLYtj95zDu1rLbVo9bnboknv18ZmlfXVA4=
 github.com/containers/buildah v1.31.2/go.mod h1:EnrujxgRtUi0+2DrxXAzyQ/GybLliqT0+06PMLSTlvw=
-github.com/containers/common v0.55.5-0.20231119144331-165b7a4dd43c h1:FIXrw2efrUdbEYZqdrD8u3FhKf8S/A1Ftj8fDW98f7Q=
-github.com/containers/common v0.55.5-0.20231119144331-165b7a4dd43c/go.mod h1:5mVCpfMBWyO+zaD7Fw+DBHFa42YFKROwle1qpEKcX3U=
+github.com/containers/common v0.55.5-0.20240105071436-8fedf2e32c8a h1:4ib0EL6D+cP+OrSH0SvUVtxm0WSqZ+krILDfE3Z+Ubw=
+github.com/containers/common v0.55.5-0.20240105071436-8fedf2e32c8a/go.mod h1:5mVCpfMBWyO+zaD7Fw+DBHFa42YFKROwle1qpEKcX3U=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.5.1 h1:Qquw9pE0KOeJkb3MhuUIFTvUzI08m9f4SpkuSY0kVSs=

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.55.5-dev"
+const Version = "0.55.4"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.55.5-0.20231119144331-165b7a4dd43c
+# github.com/containers/common v0.55.5-0.20240105071436-8fedf2e32c8a
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from https://github.com/containers/common/pull/1689 as these changes contain a fixe that needs to be backported to CRI-O release 1.28, part of OpenShift 4.15 release.

Related:

- https://github.com/containers/common/pull/1689
- https://github.com/containers/common/issues/1746
- https://github.com/cri-o/cri-o/pull/7496
- https://github.com/cri-o/cri-o/pull/7498

Closes:

- https://github.com/cri-o/cri-o/issues/7490

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```