### PR TITLE
OCPBUGS-27963: highperfhooks: add precreate hook for injecting envs

### DIFF
--- a/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_linux.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/opencontainers/runtime-tools/generate"
 )
 
 // DefaultCPULoadBalanceHooks is used to run additional hooks that will configure containers for CPU load balancing.
@@ -15,6 +16,11 @@ import (
 // thus causing their `cpuset.sched_load_balance=1` to prevent the kernel from disabling load balancing.
 // This is the only case it seeks to fix, and thus does not define any other members of the RuntimeHandlerHooks functions.
 type DefaultCPULoadBalanceHooks struct{}
+
+// No-op
+func (*DefaultCPULoadBalanceHooks) PreCreate(context.Context, *generate.Generator, *sandbox.Sandbox, *oci.Container) error {
+	return nil
+}
 
 // No-op
 func (*DefaultCPULoadBalanceHooks) PreStart(context.Context, *oci.Container, *sandbox.Sandbox) error {

--- a/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_unsupported.go
+++ b/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_unsupported.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/opencontainers/runtime-tools/generate"
 )
 
 // DefaultCPULoadBalanceHooks is used to run additional hooks that will configure containers for CPU load balancing.
@@ -17,6 +18,11 @@ import (
 // thus causing their `cpuset.sched_load_balance=1` to prevent the kernel from disabling load balancing.
 // This is the only case it seeks to fix, and thus does not define any other members of the RuntimeHandlerHooks functions.
 type DefaultCPULoadBalanceHooks struct{}
+
+// No-op
+func (*DefaultCPULoadBalanceHooks) PreCreate(context.Context, *generate.Generator, *sandbox.Sandbox, *oci.Container) error {
+	return nil
+}
 
 // No-op
 func (*DefaultCPULoadBalanceHooks) PreStart(context.Context, *oci.Container, *sandbox.Sandbox) error {

--- a/internal/runtimehandlerhooks/runtime_handler_hooks.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/opencontainers/runtime-tools/generate"
 )
 
 var (
@@ -14,6 +15,7 @@ var (
 )
 
 type RuntimeHandlerHooks interface {
+	PreCreate(ctx context.Context, specgen *generate.Generator, s *sandbox.Sandbox, c *oci.Container) error
 	PreStart(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error
 	PreStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error
 	PostStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When the prestart hook gets called the config.json files is already created. This means the process exist but it's not contating the mixed CPUS environment variables.

In order to fix that we should implement a new hook point - precreate hook that runs before the container create stage and inject the environment variables if needed.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
