### PR TITLE
OCPBUGS-28586: higeperfhooks: mixedcpus: set only exclusive cpus in child cgroup

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -366,7 +366,7 @@ func (h *HighPerformanceHooks) setCPULoadBalancingV2(c *oci.Container, podManage
 		})
 	}
 	if childState != nil {
-		managers = append(managers, childState)
+		managers[len(managers)-1] = childState
 	}
 
 	if len(managers) == 0 {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When shared cpus are configured for the container, the child state object that represents that cpuset under the container's child cgroup is already exists under the managers slice.

This means, we should override last element instead of append a new one, because the child state is already there.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
