### PR TITLE
ci: add version-bump workflow

### DIFF
--- a/.github/workflows/version_bump.yaml
+++ b/.github/workflows/version_bump.yaml
@@ -1,0 +1,32 @@
+name: Manual Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Type of version bump (major, minor, patch)'
+        required: true
+
+jobs:
+  version_bump:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.21
+
+    - name: Run Version Bump Script
+      run: go run scripts/version_bump.go -bump ${{ github.event.inputs.bump_type }} -f ./internal/version/version.go
+
+    - name: Commit and Push Changes
+      run: |
+        git config --global user.email "actions@github.com"
+        git config --global user.name "GitHub Actions"
+        git add .
+        git commit -m "Bump version: ${{ github.event.inputs.bump_type }}"
+        git push origin HEAD


### PR DESCRIPTION
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
This PR adds a Manual Trigger Workflow that would allow the maintainers to bump the version inside `internal/version/version.go` on the go by just running the workflow.

With this PR, the maintainers would not need to bump version in `internal/version/version.go` locally, and also doesn't require PRs to be created for the change.

Now simply run the workflow from the `Actions` tab on GitHub, and voila its all done for the version_bump side.

![image](https://github.com/cri-o/cri-o/assets/105716028/283a7793-be09-494f-8615-6fc7adaa1646)

**What's next?**
This workflow will be used to trigger the automated release pipeline as described in issue https://github.com/cri-o/cri-o/issues/4003

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
part of: https://github.com/cri-o/cri-o/issues/4003

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
