### PR TITLE
When crio restarts, restore the infraContainers

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -319,6 +319,9 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 		return sb, err
 	}
 
+	// We should restore the infraContainer to the container state store
+	c.AddInfraContainer(ctx, scontainer)
+
 	sb.RestoreStopped()
 	// We add an NS only if we can load a permanent one.
 	// Otherwise, the sandbox will live in the host namespace.

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -157,6 +157,19 @@ var _ = t.Describe("ContainerServer", func() {
 			Expect(err).To(BeNil())
 		})
 
+		It("should succeed load infraContainer", func() {
+			// Given
+			createDummyState()
+			mockDirs(testManifest)
+
+			// When
+			_, err := sut.LoadSandbox(context.Background(), "id")
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.GetInfraContainer(context.Background(), sandboxID)).NotTo(BeNil())
+		})
+
 		It("should succeed with invalid network namespace", func() {
 			// Given
 			createDummyState()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
Although there is a PR #6153 to fix issue #5490, but the problem still persists (see: https://github.com/cri-o/cri-o/issues/5490#issuecomment-1403716666). The root cause of the issue is that after crio restarts, the data for infraContainers is lost as  it is stored in memory(https://github.com/cri-o/cri-o/blob/main/internal/lib/container_server.go#L585). During the restore process, the sandbox and containers are reconstructed and restored through **LoadSandbox** and **LoadContainer** in restore funtion(https://github.com/cri-o/cri-o/blob/main/server/server.go#L222-L279), but the infraContainers are not restored during **LoadSandbox**.

 As a result, when kubelet cadvisor queries and retrieves infraContainer information, it returns an **errCtrNotFound** error(https://github.com/cri-o/cri-o/blob/main/server/inspect.go#L68), causing kubelet cadvisor to continuously log error messages.

If we rebuild and restore the infraContainers data when restarting crio, which is necessary, it won't cause cadvisor to fail to retrieve data and, consequently, won't lead to print error log

#### Which issue(s) this PR fixes:
fixes #5490
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Restore infra containers state on CRI-O restart. Without this, the infra containers will be accounted as missing, leading to a spurious error message.
```
