### PR TITLE
oci: handle early exited container faster in stop loop

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -594,6 +594,17 @@ func (c *Container) WaitOnStopTimeout(ctx context.Context, timeout int64) {
 	}
 }
 
+func (c *Container) SetAsDoneStopping() {
+	c.stopLock.Lock()
+	for _, watcher := range c.stopWatchers {
+		close(watcher)
+	}
+	c.stopWatchers = make([]chan struct{}, 0)
+	c.stopping = false
+	close(c.stopTimeoutChan)
+	c.stopLock.Unlock()
+}
+
 func (c *Container) AddManagedPIDNamespace(ns nsmgr.Namespace) {
 	c.pidns = ns
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -830,6 +830,7 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container) {
 			// Set state accordingly.
 			c.state.Finished = time.Now()
 			c.opLock.Unlock()
+			c.SetAsDoneStopping()
 			return
 		}
 	}
@@ -884,14 +885,7 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container) {
 
 	c.state.Finished = time.Now()
 	c.opLock.Unlock()
-
-	c.stopLock.Lock()
-	for _, watcher := range c.stopWatchers {
-		close(watcher)
-	}
-	c.stopping = false
-	close(c.stopTimeoutChan)
-	c.stopLock.Unlock()
+	c.SetAsDoneStopping()
 }
 
 // DeleteContainer deletes a container.

--- a/internal/oci/runtime_oci_test.go
+++ b/internal/oci/runtime_oci_test.go
@@ -89,7 +89,9 @@ var _ = t.Describe("Oci", func() {
 
 			// When
 			sut.SetAsStopping()
-			runtime.StopLoopForContainer(sut)
+			go runtime.StopLoopForContainer(sut)
+			stoppedChan := stopTimeoutWithChannel(context.Background(), sut, shortTimeout)
+			<-stoppedChan
 
 			// Then
 			Expect(sut.State().Finished).NotTo(BeZero())


### PR DESCRIPTION
if we hit a TOCTOU race with c.Living() and StopLoopForContainer, then we will be forced to wait until the kubelet re-requests. instead, update watchers immediately so this doesn't happen

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a bug where a container that exits soon after a StopContainer request is issued will be paused in termination for longer than the grace period
```
