### PR TITLE
OCPBUGS-28981: fix busyloop when killing container

### DIFF
--- a/internal/oci/container_freebsd.go
+++ b/internal/oci/container_freebsd.go
@@ -29,3 +29,12 @@ func getPidStartTime(pid int) (string, error) {
 	kp := (*C.struct_kinfo_proc)(unsafe.Pointer(&data[0]))
 	return fmt.Sprintf("%d,%d", kp.ki_start.tv_sec, kp.ki_start.tv_usec), nil
 }
+
+// getPidData reads the kernel's /proc entry for various data.
+func getPidData(pid int) (*StatData, error) {
+	startData := getPidStartTime(pid)
+	return &StatData{
+		StartTime: startTime,
+		State:     "not implemented",
+	}, nil
+}

--- a/internal/oci/container_freebsd_nocgo.go
+++ b/internal/oci/container_freebsd_nocgo.go
@@ -18,3 +18,15 @@ func getPidStartTime(pid int) (string, error) {
 	fields := strings.Fields(string(data))
 	return fields[7], nil
 }
+
+// getPidData reads the kernel's /proc entry for various data.
+func getPidData(pid int) (*StatData, error) {
+	startTime, err := getPidStartTime(pid)
+	if err != nil {
+		return nil, err
+	}
+	return &StatData{
+		StartTime: startTime,
+		State:     "not implemented",
+	}, nil
+}

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -871,15 +871,14 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container) {
 			log.Warnf(ctx, "Stopping container %v with stop signal timed out. Killing", c.ID())
 			if _, err := r.runtimeCmd("kill", c.ID(), "KILL"); err != nil {
 				log.Errorf(ctx, "Killing container %v failed: %v", c.ID(), err)
+				targetTime = time.Now().Add(10 * time.Millisecond)
 			}
 			if err := c.Living(); err != nil {
 				finished = true
-				break
 			}
 
 		case <-done:
 			finished = true
-			break
 		}
 	}
 


### PR DESCRIPTION
This fixes the busy loop on a failed kill (D-state process) and reschedules the timer to sometime in the future. Since targetTime has expired, the loop re-enters the kill case statement without waiting. The pod is terminal at this point, so a 10ms pause seems ok.

#### Does this PR introduce a user-facing change?
```release-note
Fix busy loop on killing a D-state container
```