### PR TITLE
Fix ctr log max test on arm64

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -295,7 +295,8 @@ function check_oci_annotation() {
 	logpath="$DEFAULT_LOG_PATH/$pod_id/$ctr_id.log"
 	[ -f "$logpath" ]
 	echo "$logpath :: $(cat "$logpath")"
-	len=$(wc -l "$logpath" | awk '{print $1}')
+	# Filter out https://github.com/opencontainers/runc/blob/02120488a4c0fc487d1ed2867e901eeed7ce8ecf/libcontainer/specconv/spec_linux.go#L1017-L1030
+	len=$(grep -cv config.json "$logpath")
 	[ "$len" -eq 250 ]
 }
 


### PR DESCRIPTION

#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:


We have to omit the runc warning introduced by:
https://github.com/opencontainers/runc/blob/02120488a4c0fc487d1ed2867e901eeed7ce8ecf/libcontainer/specconv/spec_linux.go#L1017-L1030

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
