### PR TITLE
RFC: [1.28] server: treat image Digest as ID

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -236,7 +236,11 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	}
 
 	imageName := imgResult.Name
-	imageRef := imgResult.ID
+	// Instead of using the image ID, which is generated on the pull, use the digest of the image.
+	// This allows us to construct a pull reference of the image by stripping the tag from imageName
+	// and appending the digest at the end.
+	// One limitation of this is a user needs to figure out the algorithm...
+	imageRef := imgResult.Digest.Encoded()
 
 	labelOptions, err := ctr.SelinuxLabel(sb.ProcessLabel())
 	if err != nil {

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -53,7 +53,9 @@ func ConvertImage(from *storage.ImageResult) *types.Image {
 	}
 
 	to := &types.Image{
-		Id:          from.ID,
+		// TODO: KEEP ID in sync with that which we store in the imageRef field in the container in container_create_linux.go
+		// This allows the kubelet to detect when an image is present, and garbage collect correctly.
+		Id:          from.Digest.Encoded(),
 		RepoTags:    repoTags,
 		RepoDigests: repoDigests,
 		Pinned:      from.Pinned,

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -65,7 +65,9 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 
 		resp = &types.ImageStatusResponse{
 			Image: &types.Image{
-				Id:          status.ID,
+				// TODO: KEEP ID in sync with that which we store in the imageRef field in the container in container_create_linux.go
+				// This allows the kubelet to detect when an image is present, and garbage collect correctly.
+				Id:          status.Digest.Encoded(),
 				RepoTags:    status.RepoTags,
 				RepoDigests: status.RepoDigests,
 				Size_:       size,


### PR DESCRIPTION
It turns out, many users were relying on ImageRef as a reference to the resolved image. Even though this breaks the Kubelet garbage collection (see cri-o/cri-o#7149).

Try to get the best of both worlds by using the Digest of the image as the ID. It shouldn't make a difference to the kubelet as long as we do it consistently, and end-users can use the `$image + ':$assumedAlgorithm' + $imageID` to construct a name of the resolved image.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use the Digest of the image instead of the generated storage ID, which allows an end user to construct the resolved image by using a combination of the image name and image ID
```
