### PR TITLE
[release-1.28] Revert "Fix ImageRef field for containers to default to an image ID"

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -237,6 +237,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 
 	imageName := imgResult.Name
 	imageRef := imgResult.ID
+	if len(imgResult.RepoDigests) > 0 {
+		imageRef = imgResult.RepoDigests[0]
+	}
 
 	labelOptions, err := ctr.SelinuxLabel(sb.ProcessLabel())
 	if err != nil {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -211,7 +211,7 @@ function check_images() {
     eval "$(jq -r '.images[] |
         select(.repoTags[0] == "quay.io/crio/fedora-crio-ci:latest") |
         "REDIS_IMAGEID=" + .id + "\n" +
-	"REDIS_IMAGEREF=" + .id' <<<"$json")"
+	"REDIS_IMAGEREF=" + .repoDigests[0]' <<<"$json")"
 }
 
 function start_crio_no_setup() {

--- a/test/image.bats
+++ b/test/image.bats
@@ -80,6 +80,7 @@ function teardown() {
 
 	output=$(crictl inspect -o yaml "$ctr_id")
 	[[ "$output" == *"image: $IMAGE_LIST_DIGEST"* ]]
+	[[ "$output" == *"imageRef: $IMAGE_LIST_DIGEST"* ]]
 }
 
 @test "image pull and list" {


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
This reverts commit 41b13e28dd75828ab9cc24806ad4d2d3b4a605b9 and therefore https://github.com/cri-o/cri-o/pull/7149.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reverted image ID field change in the container status.
```
