### PR TITLE
CRI: An empty DNSConfig != unspecified

### DIFF
--- a/internal/factory/sandbox/infra.go
+++ b/internal/factory/sandbox/infra.go
@@ -88,14 +88,16 @@ func PauseCommand(cfg *libconfig.Config, image *v1.Image) ([]string, error) {
 
 func (s *sandbox) createResolvConf(podContainer *storage.ContainerInfo) (retErr error) {
 	// set DNS options
+	s.resolvPath = fmt.Sprintf("%s/resolv.conf", podContainer.RunDir)
+
 	if s.config.DnsConfig == nil {
-		return nil
+		// Ref https://github.com/kubernetes/kubernetes/issues/120748#issuecomment-1922220911
+		s.config.DnsConfig = &types.DNSConfig{}
 	}
 
 	dnsServers := s.config.DnsConfig.Servers
 	dnsSearches := s.config.DnsConfig.Searches
 	dnsOptions := s.config.DnsConfig.Options
-	s.resolvPath = fmt.Sprintf("%s/resolv.conf", podContainer.RunDir)
 	err := ParseDNSOptions(dnsServers, dnsSearches, dnsOptions, s.resolvPath)
 	defer func() {
 		if retErr != nil {


### PR DESCRIPTION
if DnsConfig empty, it should copy the host's resolv.conf

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

This PR coordinates the behavior with the containerd. https://github.com/containerd/containerd/pull/9730

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Reference https://github.com/kubernetes/kubernetes/issues/120748

#### Does this PR introduce a user-facing change?

I guess some users will find this behavior a breaking change.


```release-note
In case of an empty struct of DSNConfig /etc/resolv.conf be copied.
```
