### PR TITLE
Add image digests to `crio status` API

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -210,6 +210,7 @@ complete -c crio -n '__fish_seen_subcommand_from wipe' -f -l force -s f -d 'forc
 complete -c crio -n '__fish_seen_subcommand_from status' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'status' -d 'Display status information'
 complete -c crio -n '__fish_seen_subcommand_from status' -l socket -s s -r -d 'absolute path to the unix socket'
+complete -c crio -n '__fish_seen_subcommand_from status' -f -l json -s j -d 'output JSON instead of plain text'
 complete -c crio -n '__fish_seen_subcommand_from config c' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_seen_subcommand_from status' -a 'config c' -d 'Show the configuration of CRI-O as a TOML string.'
 complete -c crio -n '__fish_seen_subcommand_from containers container cs s' -f -l help -s h -d 'show help'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -498,6 +498,8 @@ wipe CRI-O's container and image storage
 
 Display status information
 
+**--json, -j**: output JSON instead of plain text
+
 **--socket, -s**="": absolute path to the unix socket (default: "/var/run/crio/crio.sock")
 
 ### config, c

--- a/internal/config/nsmgr/test/utils.go
+++ b/internal/config/nsmgr/test/utils.go
@@ -63,7 +63,7 @@ func ContainerWithPid(pid int) (*oci.Container, error) {
 	testContainer, err := oci.NewContainer("testid", "testname", "",
 		"/container/logs", map[string]string{},
 		map[string]string{}, map[string]string{}, "image",
-		&imageName, &imageID, &types.ContainerMetadata{},
+		&imageName, &imageID, nil, &types.ContainerMetadata{},
 		"testsandboxid", false, false, false, "",
 		"/root/for/container", time.Now(), "SIGKILL")
 	if err != nil {

--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -218,8 +218,13 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb *sandbox.Sandbox,
 	if imageResult.SomeNameOfThisImage != nil {
 		imageName = imageResult.SomeNameOfThisImage.StringForOutOfProcessConsumptionOnly()
 	}
+	imageDigests, err := json.Marshal(imageResult.RepoDigests)
+	if err != nil {
+		return fmt.Errorf("marshal image repo digests: %w", err)
+	}
 	c.spec.AddAnnotation(annotations.ImageName, imageName)
 	c.spec.AddAnnotation(annotations.ImageRef, imageResult.ID.IDStringForOutOfProcessConsumptionOnly())
+	c.spec.AddAnnotation(annotations.ImageDigests, string(imageDigests))
 	c.spec.AddAnnotation(annotations.Name, c.Name())
 	c.spec.AddAnnotation(annotations.ContainerID, c.ID())
 	c.spec.AddAnnotation(annotations.SandboxID, sb.ID())

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -628,7 +628,7 @@ var _ = t.Describe("ContainerServer", func() {
 			// Given
 			container, err := oci.NewContainer(containerID, "", "", "",
 				make(map[string]string), make(map[string]string),
-				make(map[string]string), "", nil, nil,
+				make(map[string]string), "", nil, nil, nil,
 				&types.ContainerMetadata{}, sandboxID, false,
 				false, false, "", "/invalid", time.Now(), "")
 			Expect(err).To(BeNil())

--- a/internal/lib/restore_test.go
+++ b/internal/lib/restore_test.go
@@ -338,7 +338,7 @@ func setupInfraContainerWithPid(pid int, bundle string) {
 	testContainer, err := oci.NewContainer("testid", "testname", bundle,
 		"/container/logs", map[string]string{},
 		map[string]string{}, map[string]string{}, "image",
-		&imageName, &imageID, &types.ContainerMetadata{},
+		&imageName, &imageID, nil, &types.ContainerMetadata{},
 		"testsandboxid", false, false, false, "",
 		"/root/for/container", time.Now(), "SIGKILL")
 	Expect(err).To(BeNil())

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -210,7 +210,7 @@ var _ = t.Describe("Sandbox", func() {
 			testContainer, err = oci.NewContainer("testid", "testname", "",
 				"/container/logs", map[string]string{},
 				map[string]string{}, map[string]string{}, "image",
-				&imageName, &imageID, &types.ContainerMetadata{},
+				&imageName, &imageID, nil, &types.ContainerMetadata{},
 				"testsandboxid", false, false, false, "",
 				"/root/for/container", time.Now(), "SIGKILL")
 			Expect(err).To(BeNil())

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -160,7 +160,7 @@ func beforeEach() {
 
 	myContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "", nil, nil,
+		make(map[string]string), "", nil, nil, nil,
 		&types.ContainerMetadata{}, sandboxID, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -58,6 +58,7 @@ type Container struct {
 	// If set, _some_ name of the image imageID; it may have NO RELATIONSHIP to the users’ requested image name.
 	imageName             *references.RegistryImageReference
 	imageID               *storage.StorageImageID // nil for infra containers.
+	imageDigests          []string                // possible repo digests of the image.
 	mountPoint            string
 	seccompProfilePath    string
 	conmonCgroupfsPath    string
@@ -125,7 +126,7 @@ type ContainerState struct {
 // at any future time.
 // imageName, if set, is _some_ name of the image imageID; it may have NO RELATIONSHIP to the users’ requested image name.
 // imageID is nil for infra containers.
-func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, userRequestedImage string, imageName *references.RegistryImageReference, imageID *storage.StorageImageID, md *types.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
+func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, userRequestedImage string, imageName *references.RegistryImageReference, imageID *storage.StorageImageID, imageDigests []string, md *types.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
 	externalImageRef := ""
@@ -155,6 +156,7 @@ func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations,
 		crioAnnotations: crioAnnotations,
 		imageName:       imageName,
 		imageID:         imageID,
+		imageDigests:    imageDigests,
 		dir:             dir,
 		state:           state,
 		stopSignal:      stopSignal,
@@ -370,6 +372,11 @@ func (c *Container) ImageName() *references.RegistryImageReference {
 // ImageID returns the image ID of the container, or nil for infra containers.
 func (c *Container) ImageID() *storage.StorageImageID {
 	return c.imageID
+}
+
+// ImageDigests returns possible repo digests of the image used in the container.
+func (c *Container) ImageDigests() []string {
+	return c.imageDigests
 }
 
 // Sandbox returns the sandbox name of the container.

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -186,7 +186,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", nil, nil, &types.ContainerMetadata{}, "",
+			"", nil, nil, nil, &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGNO")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
@@ -202,7 +202,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", nil, nil, &types.ContainerMetadata{}, "",
+			"", nil, nil, nil, &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "RTMIN+1")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
@@ -218,7 +218,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", nil, nil, &types.ContainerMetadata{}, "",
+			"", nil, nil, nil, &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGTRAP")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())

--- a/internal/oci/suite_test.go
+++ b/internal/oci/suite_test.go
@@ -39,7 +39,7 @@ func beforeEach() {
 	var err error
 	myContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "", nil, nil,
+		make(map[string]string), "", nil, nil, nil,
 		&types.ContainerMetadata{}, sandboxID, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
@@ -63,7 +63,7 @@ func getTestContainer() *oci.Container {
 		map[string]string{"key": "label"},
 		map[string]string{"key": "crioAnnotation"},
 		map[string]string{"key": "annotation"},
-		"image", &imageName, &imageID, &types.ContainerMetadata{}, "sandbox",
+		"image", &imageName, &imageID, nil, &types.ContainerMetadata{}, "sandbox",
 		false, false, false, "", "dir", time.Now(), "")
 	Expect(err).To(BeNil())
 	Expect(container).NotTo(BeNil())

--- a/internal/runtimehandlerhooks/high_performance_hooks_test.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_test.go
@@ -26,7 +26,7 @@ const (
 var _ = Describe("high_performance_hooks", func() {
 	container, err := oci.NewContainer("containerID", "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "pauseImage", nil, nil,
+		make(map[string]string), "pauseImage", nil, nil, nil,
 		&types.ContainerMetadata{}, "sandboxID", false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
@@ -627,7 +627,7 @@ var _ = Describe("high_performance_hooks", func() {
 		}
 		c, err := oci.NewContainer("containerID", "", "", "",
 			make(map[string]string), make(map[string]string),
-			make(map[string]string), "pauseImage", nil, nil,
+			make(map[string]string), "pauseImage", nil, nil, nil,
 			&types.ContainerMetadata{Name: "cnt1"}, "sandboxID", false, false,
 			false, "", "", time.Now(), "")
 		Expect(err).To(BeNil())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -8,8 +8,9 @@ import (
 type ContainerInfo struct {
 	Name            string            `json:"name"`
 	Pid             int               `json:"pid"`
-	Image           string            `json:"image"`     // If set, _some_ name of the image imageID; it may have NO RELATIONSHIP to the users’ requested image name.
-	ImageRef        string            `json:"image_ref"` // In the format of StorageImageID.StringForOutOfProcessConsumptionOnly(), or "".
+	Image           string            `json:"image"`         // If set, _some_ name of the image imageID; it may have NO RELATIONSHIP to the users’ requested image name.
+	ImageRef        string            `json:"image_ref"`     // In the format of StorageImageID.StringForOutOfProcessConsumptionOnly(), or "".
+	ImageDigests    []string          `json:"image_digests"` // Possible repo digests of the used container image.
 	CreatedTime     int64             `json:"created_time"`
 	Labels          map[string]string `json:"labels"`
 	Annotations     map[string]string `json:"annotations"`

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -802,7 +802,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		Name:    metadata.Name,
 		Attempt: metadata.Attempt,
 	}
-	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, userRequestedImage, imageName, &imageID, criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, userRequestedImage, imageName, &imageID, imgResult.RepoDigests, criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -109,6 +109,7 @@ func (s *Server) getContainerInfo(ctx context.Context, id string, getContainerFu
 		Pid:             pidToReturn,
 		Image:           image,
 		ImageRef:        imageRef,
+		ImageDigests:    ctr.ImageDigests(),
 		CreatedTime:     ctrState.Created.UnixNano(),
 		Labels:          ctr.Labels(),
 		Annotations:     ctr.Annotations(),

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -60,7 +60,7 @@ func TestGetContainerInfo(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", &imageName, &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", &imageName, &imageID, nil, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -185,7 +185,7 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, nil, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,7 @@ func TestGetContainerInfoSandboxNotFound(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, nil, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -423,7 +423,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	// In the case of kernel separated containers, we need the infra container to create the VM for the pod
 	if sb.NeedsInfra(s.config.DropInfraCtr) || podIsKernelSeparated {
 		log.Debugf(ctx, "Keeping infra container for pod %s", sbox.ID())
-		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, nil, nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 		if err != nil {
 			return nil, err
 		}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -919,7 +919,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	if sb.NeedsInfra(s.config.DropInfraCtr) || podIsKernelSeparated {
 		log.Debugf(ctx, "Keeping infra container for pod %s", sbox.ID())
 		// pauseImage, as the userRequestedImage parameter, only shows up in CRI values we return.
-		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, nil, nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 		if err != nil {
 			return nil, err
 		}

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -161,7 +161,7 @@ var beforeEach = func() {
 
 	testContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "pauseImage", nil, nil,
+		make(map[string]string), "pauseImage", nil, nil, nil,
 		&types.ContainerMetadata{}, sandboxID, false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/test/status.bats
+++ b/test/status.bats
@@ -35,6 +35,14 @@ function teardown() {
 	[[ "$output" == *"storage driver"* ]]
 }
 
+@test "status should succeed to retrieve the info in JSON" {
+	# when
+	run -0 "${CRIO_BINARY_PATH}" status --json --socket="${CRIO_SOCKET}" info
+
+	# then
+	[[ "$output" == *"{\"storage_driver\":"* ]]
+}
+
 @test "status should fail to retrieve the info with invalid socket" {
 	run -1 "${CRIO_BINARY_PATH}" status --socket wrong.sock i
 }

--- a/vendor/github.com/containers/podman/v4/pkg/annotations/annotations.go
+++ b/vendor/github.com/containers/podman/v4/pkg/annotations/annotations.go
@@ -40,6 +40,9 @@ const (
 	// ImageRef is the container image ref annotation.
 	ImageRef = "io.kubernetes.cri-o.ImageRef"
 
+	// ImageDigests is the container image digests annotation.
+	ImageDigests = "io.kubernetes.cri-o.ImageDigests"
+
 	// KubeName is the kubernetes name annotation.
 	KubeName = "io.kubernetes.cri-o.KubeName"
 
@@ -125,7 +128,7 @@ const ContainerManagerLibpod = "libpod"
 // already reserved annotation that Podman sets during container creation.
 func IsReservedAnnotation(value string) bool {
 	switch value {
-	case Annotations, ContainerID, ContainerName, ContainerType, Created, HostName, CgroupParent, IP, NamespaceOptions, SeccompProfilePath, Image, ImageName, ImageRef, KubeName, PortMappings, Labels, LogPath, Metadata, Name, Namespace, PrivilegedRuntime, ResolvPath, HostnamePath, SandboxID, SandboxName, ShmPath, MountPoint, RuntimeHandler, TTY, Stdin, StdinOnce, Volumes, HostNetwork, CNIResult, ContainerManager:
+	case Annotations, ContainerID, ContainerName, ContainerType, Created, HostName, CgroupParent, IP, NamespaceOptions, SeccompProfilePath, Image, ImageName, ImageRef, ImageDigests, KubeName, PortMappings, Labels, LogPath, Metadata, Name, Namespace, PrivilegedRuntime, ResolvPath, HostnamePath, SandboxID, SandboxName, ShmPath, MountPoint, RuntimeHandler, TTY, Stdin, StdinOnce, Volumes, HostNetwork, CNIResult, ContainerManager:
 		return true
 
 	default:


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
We now feature a `-j/--json` output for `crio status`. Beside this, the output has been extended to contain the image digests for the used container image. This will be achieved by utilizing a new reserved annotation `io.kubernetes.cri-o.ImageDigests`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Follow-up on https://github.com/cri-o/cri-o/pull/7762

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added image digests to `crio status` API as well as `-j/--json` flag.
```
