### PR TITLE
[release-1.25] When crio restarts, restore the infraContainer

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -281,6 +281,9 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 		return sb, err
 	}
 
+	// We should restore the infraContainer to the container state store
+	c.AddInfraContainer(scontainer)
+
 	sb.RestoreStopped()
 	// We add an NS only if we can load a permanent one.
 	// Otherwise, the sandbox will live in the host namespace.

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -156,6 +156,19 @@ var _ = t.Describe("ContainerServer", func() {
 			Expect(err).To(BeNil())
 		})
 
+		It("should succeed load infraContainer", func() {
+			// Given
+			createDummyState()
+			mockDirs(testManifest)
+
+			// When
+			_, err := sut.LoadSandbox(context.Background(), "id")
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(sut.GetInfraContainer(sandboxID)).NotTo(BeNil())
+		})
+
 		It("should succeed with invalid network namespace", func() {
 			// Given
 			createDummyState()


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/cri-o/cri-o/pull/7726

/kind bug
/assign kwilczynski

```release-note
Restore infra containers state on CRI-O restart. Without this, the infra containers will be accounted as missing, leading to a spurious error message.
```
