### PR TITLE
OCPBUGS-29398: [release-1.26] Fix wrong umask by updating c/common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.2.0
 	github.com/containers/buildah v1.30.0
-	github.com/containers/common v0.52.1-0.20240105071109-142ede1e7506
+	github.com/containers/common v0.52.1-0.20240214131428-852b056f0855
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.4.0
 	github.com/containers/image/v5 v5.25.0

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ github.com/containernetworking/plugins v1.2.0 h1:SWgg3dQG1yzUo4d9iD8cwSVh1VqI+bP
 github.com/containernetworking/plugins v1.2.0/go.mod h1:/VjX4uHecW5vVimFa1wkG4s+r/s9qIfPdqlLF4TW8c4=
 github.com/containers/buildah v1.30.0 h1:mdp2COGKFFEZNEGP8VZ5ITuUFVNPFoH+iK2sSesNfTA=
 github.com/containers/buildah v1.30.0/go.mod h1:lyMLZIevpAa6zSzjRl7z4lFJMCMQLFjfo56YIefaB/U=
-github.com/containers/common v0.52.1-0.20240105071109-142ede1e7506 h1:CCYmGnfT32yZUHQgYHUHNkNLFZE1FKqwUrrWiZk4wXs=
-github.com/containers/common v0.52.1-0.20240105071109-142ede1e7506/go.mod h1:dNJJVNBu1wJtAH+vFIMXV+fQHBdEVNmNP3ImjbKper4=
+github.com/containers/common v0.52.1-0.20240214131428-852b056f0855 h1:Doze84TH/0wlWFNzNIhpf1xpz06G9AUM4pZUr1/L8tY=
+github.com/containers/common v0.52.1-0.20240214131428-852b056f0855/go.mod h1:dNJJVNBu1wJtAH+vFIMXV+fQHBdEVNmNP3ImjbKper4=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.4.0 h1:Nl8/xFsc2/dlQUdYi2GTZ+aPCqcedeqnOUld09eiZHc=

--- a/vendor/github.com/containers/common/pkg/umask/umask.go
+++ b/vendor/github.com/containers/common/pkg/umask/umask.go
@@ -1,0 +1,58 @@
+package umask
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MkdirAllIgnoreUmask creates a directory by ignoring the currently set umask.
+func MkdirAllIgnoreUmask(dir string, mode os.FileMode) error {
+	parent := dir
+	dirs := []string{}
+
+	// Find all parent directories which would have been created by MkdirAll
+	for {
+		if _, err := os.Stat(parent); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("cannot stat %s: %w", dir, err)
+		}
+
+		dirs = append(dirs, parent)
+		newParent := filepath.Dir(parent)
+
+		// Only possible if the root paths are not existing, which would be odd
+		if parent == newParent {
+			break
+		}
+
+		parent = newParent
+	}
+
+	if err := os.MkdirAll(dir, mode); err != nil {
+		return fmt.Errorf("create directory %s: %w", dir, err)
+	}
+
+	for _, d := range dirs {
+		if err := os.Chmod(d, mode); err != nil {
+			return fmt.Errorf("chmod directory %s: %w", d, err)
+		}
+	}
+
+	return nil
+}
+
+// WriteFileIgnoreUmask write the provided data to the path by ignoring the
+// currently set umask.
+func WriteFileIgnoreUmask(path string, data []byte, mode os.FileMode) error {
+	if err := os.WriteFile(path, data, mode); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("chmod file: %w", err)
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -616,7 +616,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.52.1-0.20240105071109-142ede1e7506
+# github.com/containers/common v0.52.1-0.20240214131428-852b056f0855
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Refers to https://issues.redhat.com/browse/OCPBUGS-29398
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed wrong umask of `0000`.
```
