### PR TITLE
Filter image annotations before used

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -159,5 +159,7 @@ kata_skip_pod_tests:
 kata_skip_seccomp_oci_artifacts_tests:
   - 'test "seccomp OCI artifact with pod annotation"'
   - 'test "seccomp OCI artifact with container annotation"'
+  - 'test "seccomp OCI artifact with image annotation"'
+  - 'test "seccomp OCI artifact with image annotation and profile set to unconfined"'
 
 runc_git_version: main

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -649,6 +649,11 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 
 	created := time.Now()
 	seccompRef := types.SecurityProfile_Unconfined.String()
+
+	if err := s.FilterDisallowedAnnotations(sb.Annotations(), imgResult.Annotations, sb.RuntimeHandler()); err != nil {
+		return nil, fmt.Errorf("filter image annotations: %w", err)
+	}
+
 	if !ctr.Privileged() {
 		notifier, ref, err := s.config.Seccomp().Setup(
 			ctx,

--- a/test/seccomp_oci_artifacts.bats
+++ b/test/seccomp_oci_artifacts.bats
@@ -38,6 +38,21 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	crictl inspect "$CTR" | jq -e .info.runtimeSpec.linux.seccomp | grep -q $TEST_SYSCALL
 }
 
+@test "seccomp OCI artifact with image annotation but not allowed annotation on runtime config" {
+	start_crio
+
+	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_ANNOTATION'"' \
+		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
+
+	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
+	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+
+	# Assert
+	grep -vq "Found image specific seccomp profile annotation: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
+	grep -vq "Retrieved OCI artifact seccomp profile" "$CRIO_LOG"
+	crictl inspect "$CTR" | jq -e '.info.runtimeSpec.linux.seccomp == null'
+}
+
 @test "seccomp OCI artifact with image annotation and profile set to unconfined" {
 	# Run with enabled feature set
 	create_runtime_with_allowed_annotation seccomp $ANNOTATION


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We should filter the image annotations in the same way as for the sandbox/container annotations to avoid misusage. The seccomp OCI artifact feature relies on image annotations which will only be considered when allowed by the runtime now.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
