### PR TITLE
Rename seccomp profile annotation to `seccomp-profile.kubernetes.cri-o.io`

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -159,7 +159,8 @@ kata_skip_pod_tests:
 kata_skip_seccomp_oci_artifacts_tests:
   - 'test "seccomp OCI artifact with pod annotation"'
   - 'test "seccomp OCI artifact with container annotation"'
-  - 'test "seccomp OCI artifact with image annotation"'
+  - 'test "seccomp OCI artifact with image annotation for pod"'
+  - 'test "seccomp OCI artifact with image annotation for container"'
   - 'test "seccomp OCI artifact with image annotation and profile set to unconfined"'
 
 runc_git_version: main

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -355,7 +355,10 @@ The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  Th
   "io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
   "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
   "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
-  "io.kubernetes.cri-o.seccompProfile" for setting the seccomp profile for a specific container, pod or whole image.
+  "seccomp-profile.kubernetes.cri-o.io" for setting the seccomp profile for:
+    - a specific container by using: "seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>"
+    - a whole pod by using: "seccomp-profile.kubernetes.cri-o.io/POD"
+    Note that the annotation works on containers as well as on images.
 
 **platform_runtime_paths**={}
   A mapping of platforms to the corresponding runtime executable paths for the runtime handler.
@@ -383,7 +386,10 @@ A workload is chosen for a pod based on whether the workload's **activation_anno
   "io.kubernetes.cri-o.seccompNotifierAction" for enabling the seccomp notifier feature.
   "io.kubernetes.cri-o.umask" for setting the umask for container init process.
   "io.kubernetes.cri.rdt-class" for setting the RDT class of a container
-  "io.kubernetes.cri-o.seccompProfile" for setting the seccomp profile for a specific container, pod or whole image.
+  "seccomp-profile.kubernetes.cri-o.io" for setting the seccomp profile for:
+    - a specific container by using: "seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>"
+    - a whole pod by using: "seccomp-profile.kubernetes.cri-o.io/POD"
+    Note that the annotation works on containers as well as on images.
 
 #### Using the seccomp notifier feature:
 

--- a/internal/config/seccomp/seccompociartifact/seccompociartifact.go
+++ b/internal/config/seccomp/seccompociartifact/seccompociartifact.go
@@ -27,6 +27,10 @@ func New() *SeccompOCIArtifact {
 	}
 }
 
+// SeccompProfilePodAnnotation is the annotation used for matching a whole pod
+// rather than a specific container.
+const SeccompProfilePodAnnotation = annotations.SeccompProfileAnnotation + "/POD"
+
 // TryPull tries to pull the OCI artifact seccomp profile while evaluating
 // the provided annotations.
 func (s *SeccompOCIArtifact) TryPull(
@@ -42,11 +46,14 @@ func (s *SeccompOCIArtifact) TryPull(
 	if val, ok := podAnnotations[containerKey]; ok {
 		log.Infof(ctx, "Found container specific seccomp profile annotation: %s=%s", containerKey, val)
 		profileRef = val
-	} else if val, ok := podAnnotations[annotations.SeccompProfileAnnotation]; ok {
+	} else if val, ok := podAnnotations[SeccompProfilePodAnnotation]; ok {
 		log.Infof(ctx, "Found pod specific seccomp profile annotation: %s=%s", annotations.SeccompProfileAnnotation, val)
 		profileRef = val
-	} else if val, ok := imageAnnotations[annotations.SeccompProfileAnnotation]; ok {
-		log.Infof(ctx, "Found image specific seccomp profile annotation: %s=%s", annotations.SeccompProfileAnnotation, val)
+	} else if val, ok := imageAnnotations[containerKey]; ok {
+		log.Infof(ctx, "Found image specific seccomp profile annotation for container %s: %s=%s", containerName, annotations.SeccompProfileAnnotation, val)
+		profileRef = val
+	} else if val, ok := imageAnnotations[SeccompProfilePodAnnotation]; ok {
+		log.Infof(ctx, "Found image specific seccomp profile annotation for pod: %s=%s", annotations.SeccompProfileAnnotation, val)
 		profileRef = val
 	}
 

--- a/internal/config/seccomp/seccompociartifact/seccompociartifact_test.go
+++ b/internal/config/seccomp/seccompociartifact/seccompociartifact_test.go
@@ -68,7 +68,7 @@ var _ = t.Describe("SeccompOCIArtifact", func() {
 			Expect(res).To(BeNil())
 		})
 
-		It("should match image specific annotation", func() {
+		It("should match image specific annotation for whole pod", func() {
 			// Given
 			gomock.InOrder(
 				ociArtifactImplMock.EXPECT().Pull(gomock.Any(), gomock.Any(), gomock.Any()).Return(testArtifact, nil),
@@ -77,7 +77,24 @@ var _ = t.Describe("SeccompOCIArtifact", func() {
 			// When
 			res, err := sut.TryPull(context.Background(), nil, "", nil,
 				map[string]string{
-					annotations.SeccompProfileAnnotation: "test",
+					seccompociartifact.SeccompProfilePodAnnotation: "test",
+				})
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(BeEquivalentTo(testProfileContent))
+		})
+
+		It("should match image specific annotation for container", func() {
+			// Given
+			gomock.InOrder(
+				ociArtifactImplMock.EXPECT().Pull(gomock.Any(), gomock.Any(), gomock.Any()).Return(testArtifact, nil),
+			)
+
+			// When
+			res, err := sut.TryPull(context.Background(), nil, "container", nil,
+				map[string]string{
+					annotations.SeccompProfileAnnotation + "/container": "test",
 				})
 
 			// Then
@@ -94,7 +111,7 @@ var _ = t.Describe("SeccompOCIArtifact", func() {
 			// When
 			res, err := sut.TryPull(context.Background(), nil, "",
 				map[string]string{
-					annotations.SeccompProfileAnnotation: "test",
+					seccompociartifact.SeccompProfilePodAnnotation: "test",
 				}, nil)
 
 			// Then
@@ -141,7 +158,7 @@ var _ = t.Describe("SeccompOCIArtifact", func() {
 			// When
 			res, err := sut.TryPull(context.Background(), nil, "", nil,
 				map[string]string{
-					annotations.SeccompProfileAnnotation: "test",
+					seccompociartifact.SeccompProfilePodAnnotation: "test",
 				})
 
 			// Then
@@ -159,7 +176,7 @@ var _ = t.Describe("SeccompOCIArtifact", func() {
 			// When
 			res, err := sut.TryPull(context.Background(), nil, "", nil,
 				map[string]string{
-					annotations.SeccompProfileAnnotation: "test",
+					seccompociartifact.SeccompProfilePodAnnotation: "test",
 				})
 
 			// Then

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -73,8 +73,11 @@ const (
 	// PlatformRuntimePath indicates the runtime path that CRI-O should use for a specific platform.
 	PlatformRuntimePath = "io.kubernetes.cri-o.PlatformRuntimePath"
 
-	// SeccompProfileAnnotation can be used to set the seccomp profile for a specific container, pod or whole image.
-	SeccompProfileAnnotation = "io.kubernetes.cri-o.seccompProfile"
+	// SeccompProfileAnnotation can be used to set the seccomp profile for:
+	// - a specific container by using: `seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>`
+	// - a whole pod by using: `seccomp-profile.kubernetes.cri-o.io/POD`
+	// Note that the annotation works on containers as well as on images.
+	SeccompProfileAnnotation = "seccomp-profile.kubernetes.cri-o.io"
 )
 
 var AllAllowedAnnotations = []string{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -206,7 +206,10 @@ type RuntimeHandler struct {
 	// "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
 	// "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
 	// "io.kubernetes.cri-o.LinkLogs" for linking logs into the pod.
-	// "io.kubernetes.cri-o.seccompProfile" for setting the seccomp profile for a specific container, pod or whole image.
+	// "seccomp-profile.kubernetes.cri-o.io" for setting the seccomp profile for:
+	//   - a specific container by using: `seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>`
+	//   - a whole pod by using: `seccomp-profile.kubernetes.cri-o.io/POD`
+	//   Note that the annotation works on containers as well as on images.
 	AllowedAnnotations []string `toml:"allowed_annotations,omitempty"`
 
 	// DisallowedAnnotations is the slice of experimental annotations that are not allowed for this handler.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1265,7 +1265,10 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 #   "io.kubernetes.cri-o.seccompNotifierAction" for enabling the seccomp notifier feature.
 #   "io.kubernetes.cri-o.umask" for setting the umask for container init process.
 #   "io.kubernetes.cri.rdt-class" for setting the RDT class of a container
-#   "io.kubernetes.cri-o.seccompProfile" for setting the seccomp profile for a specific container, pod or whole image.
+#   "seccomp-profile.kubernetes.cri-o.io" for setting the seccomp profile for:
+#     - a specific container by using: "seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>"
+#     - a whole pod by using: "seccomp-profile.kubernetes.cri-o.io/POD"
+#     Note that the annotation works on containers as well as on images.
 # - monitor_path (optional, string): The path of the monitor binary. Replaces
 #   deprecated option "conmon".
 # - monitor_cgroup (optional, string): The cgroup the container monitor process will be put in.

--- a/pkg/config/workloads.go
+++ b/pkg/config/workloads.go
@@ -25,7 +25,7 @@ type WorkloadConfig struct {
 	// "io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
 	// "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
 	// "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
-	// "io.kubernetes.cri-o.seccompProfile" for setting the seccomp profile for a specific container, pod or whole image.
+	// "seccomp-profile.kubernetes.cri-o.io" for setting the seccomp profile for a specific container, pod or whole image.
 	AllowedAnnotations []string `toml:"allowed_annotations,omitempty"`
 	// DisallowedAnnotations is the slice of experimental annotations that are not allowed for this workload.
 	DisallowedAnnotations []string

--- a/test/seccomp_oci_artifacts.bats
+++ b/test/seccomp_oci_artifacts.bats
@@ -16,24 +16,44 @@ function teardown() {
 	cleanup_test
 }
 
-ARTIFACT_IMAGE_WITH_ANNOTATION=quay.io/crio/nginx-seccomp
+ARTIFACT_IMAGE_WITH_POD_ANNOTATION=quay.io/crio/nginx-seccomp:pod
+ARTIFACT_IMAGE_WITH_CONTAINER_ANNOTATION=quay.io/crio/nginx-seccomp:container
 ARTIFACT_IMAGE=quay.io/crio/seccomp:v1
-ANNOTATION=io.kubernetes.cri-o.seccompProfile
+CONTAINER_NAME=container1
+ANNOTATION=seccomp-profile.kubernetes.cri-o.io
+POD_ANNOTATION=seccomp-profile.kubernetes.cri-o.io/POD
 TEST_SYSCALL=OCI_ARTIFACT_TEST
 
-@test "seccomp OCI artifact with image annotation" {
+@test "seccomp OCI artifact with image annotation for pod" {
 	# Run with enabled feature set
 	create_runtime_with_allowed_annotation seccomp $ANNOTATION
 	start_crio
 
-	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_ANNOTATION'"' \
+	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_POD_ANNOTATION'"' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
+	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
-	grep -q "Found image specific seccomp profile annotation: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
+	grep -q "Found image specific seccomp profile annotation for pod: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
+	grep -q "Retrieved OCI artifact seccomp profile" "$CRIO_LOG"
+	crictl inspect "$CTR" | jq -e .info.runtimeSpec.linux.seccomp | grep -q $TEST_SYSCALL
+}
+
+@test "seccomp OCI artifact with image annotation for container" {
+	# Run with enabled feature set
+	create_runtime_with_allowed_annotation seccomp $ANNOTATION
+	start_crio
+
+	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_CONTAINER_ANNOTATION'"' \
+		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
+
+	crictl pull $ARTIFACT_IMAGE_WITH_CONTAINER_ANNOTATION
+	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+
+	# Assert
+	grep -q "Found image specific seccomp profile annotation for container $CONTAINER_NAME: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
 	grep -q "Retrieved OCI artifact seccomp profile" "$CRIO_LOG"
 	crictl inspect "$CTR" | jq -e .info.runtimeSpec.linux.seccomp | grep -q $TEST_SYSCALL
 }
@@ -41,10 +61,10 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 @test "seccomp OCI artifact with image annotation but not allowed annotation on runtime config" {
 	start_crio
 
-	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_ANNOTATION'"' \
+	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_POD_ANNOTATION'"' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
+	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
@@ -58,15 +78,15 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	create_runtime_with_allowed_annotation seccomp $ANNOTATION
 	start_crio
 
-	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_ANNOTATION'"
+	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_POD_ANNOTATION'"
         | .linux.security_context.seccomp.profile_type = 1' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
+	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
-	grep -q "Found image specific seccomp profile annotation: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
+	grep -q "Found image specific seccomp profile annotation for pod: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
 	grep -q "Retrieved OCI artifact seccomp profile" "$CRIO_LOG"
 	crictl inspect "$CTR" | jq -e .info.runtimeSpec.linux.seccomp | grep -q $TEST_SYSCALL
 }
@@ -76,15 +96,15 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	create_runtime_with_allowed_annotation seccomp $ANNOTATION
 	start_crio
 
-	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_ANNOTATION'"
+	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_POD_ANNOTATION'"
         | .linux.security_context.seccomp.profile_type = 0' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
+	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
-	grep -vq "Found image specific seccomp profile annotation: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
+	grep -vq "Found image specific seccomp profile annotation for pod: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
 	grep -vq "Retrieved OCI artifact seccomp profile" "$CRIO_LOG"
 	crictl inspect "$CTR" | jq -e .info.runtimeSpec.linux.seccomp | grep -vq $TEST_SYSCALL
 }
@@ -97,16 +117,16 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	sed -e 's/"chmod",//' -e 's/"fchmod",//' -e 's/"fchmodat",//g' \
 		"$CONTAINER_SECCOMP_PROFILE" > "$TESTDIR"/profile.json
 
-	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_ANNOTATION'"
+	jq '.image.image = "'$ARTIFACT_IMAGE_WITH_POD_ANNOTATION'"
         | .linux.security_context.seccomp.profile_type = 2
         | .linux.security_context.seccomp.localhost_ref = "'"$TESTDIR"'/profile.json"' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
+	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
-	grep -vq "Found image specific seccomp profile annotation: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
+	grep -vq "Found image specific seccomp profile annotation for pod: $ANNOTATION=$ARTIFACT_IMAGE" "$CRIO_LOG"
 	grep -vq "Retrieved OCI artifact seccomp profile" "$CRIO_LOG"
 	crictl inspect "$CTR" | jq -e .info.runtimeSpec.linux.seccomp | grep -vq $TEST_SYSCALL
 }
@@ -116,10 +136,9 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	create_runtime_with_allowed_annotation seccomp $ANNOTATION
 	start_crio
 
-	jq '.annotations += { "'$ANNOTATION'": "'$ARTIFACT_IMAGE'" }' \
+	jq '.annotations += { "'$POD_ANNOTATION'": "'$ARTIFACT_IMAGE'" }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
-	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
 	CTR=$(crictl run "$TESTDATA/container_config.json" "$TESTDIR/sandbox.json")
 
 	# Assert
@@ -133,14 +152,13 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	create_runtime_with_allowed_annotation seccomp $ANNOTATION
 	start_crio
 
-	jq '.annotations += { "'$ANNOTATION'/container1": "'$ARTIFACT_IMAGE'" }' \
+	jq '.annotations += { "'$ANNOTATION'/'$CONTAINER_NAME'": "'$ARTIFACT_IMAGE'" }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
-	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
 	CTR=$(crictl run "$TESTDATA/container_config.json" "$TESTDIR/sandbox.json")
 
 	# Assert
-	grep -q "Found container specific seccomp profile annotation: $ANNOTATION/container1=$ARTIFACT_IMAGE" "$CRIO_LOG"
+	grep -q "Found container specific seccomp profile annotation: $ANNOTATION/$CONTAINER_NAME=$ARTIFACT_IMAGE" "$CRIO_LOG"
 	grep -q "Retrieved OCI artifact seccomp profile" "$CRIO_LOG"
 	crictl inspect "$CTR" | jq -e .info.runtimeSpec.linux.seccomp | grep -q $TEST_SYSCALL
 }
@@ -153,7 +171,6 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	jq '.annotations += { "'$ANNOTATION'/container2": "'$ARTIFACT_IMAGE'" }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
-	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
 	CTR=$(crictl run "$TESTDATA/container_config.json" "$TESTDIR/sandbox.json")
 
 	# Assert


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:

As part of the discussion in https://github.com/kubernetes/website/pull/45121#discussion_r1488130556


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
The feature has not been released, to a change of the annotation is still possible.

Follow-up on https://github.com/cri-o/cri-o/pull/7719
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
