### PR TITLE
GitHub actions: Don't fail-fast matrix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   test-binaries:
     strategy:
+      fail-fast: false
       matrix:
         run:
           - runner: ubuntu-latest
@@ -59,6 +60,7 @@ jobs:
   integration:
     needs: test-binaries
     strategy:
+      fail-fast: false
       matrix:
         run:
           - name: critest / conmon

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,6 +214,7 @@ jobs:
 
   unit:
     strategy:
+      fail-fast: false
       matrix:
         run:
           - runner: ubuntu-latest


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
The integration tests seems to be a bit flaky these days. We now set `fail-fast` to `false` to not abort ongoing jobs which may succeed.

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
