### PR TITLE
config, docs, completions: enable NRI by default.

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -54,7 +54,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l disable-hostport-mapping -
 complete -c crio -n '__fish_crio_no_subcommand' -f -l drop-infra-ctr -d 'Determines whether pods are created without an infra container, when the pod is not using a pod level PID namespace.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-criu-support -d 'Enable CRIU integration, requires that the criu binary is available in $PATH.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-metrics -d 'Enable metrics endpoint for the server.'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-nri -d 'Enable NRI (Node Resource Interface) support. (default: false)'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-nri -d 'Enable NRI (Node Resource Interface) support. (default: true)'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-pod-events -d 'If true, CRI-O starts sending the container events to the kubelet'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-profile-unix-socket -d 'Enable pprof profiler on crio unix domain socket.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-tracing -d 'Enable OpenTelemetry trace data exporting.'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -237,7 +237,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--enable-metrics**: Enable metrics endpoint for the server.
 
-**--enable-nri**: Enable NRI (Node Resource Interface) support. (default: false)
+**--enable-nri**: Enable NRI (Node Resource Interface) support. (default: true)
 
 **--enable-pod-events**: If true, CRI-O starts sending the container events to the kubelet
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -530,7 +530,7 @@ The `crio.stats` table specifies all necessary configuration for reporting conta
 
 ## CRIO.NRI TABLE
 The `crio.nri` table contains settings for controlling NRI (Node Resource Interface) support in CRI-O.
-**enable_nri**=false
+**enable_nri**=true
   Enable CRI-O NRI support.
 
 **nri_plugin_dir**="/opt/nri/plugins"

--- a/internal/config/nri/nri.go
+++ b/internal/config/nri/nri.go
@@ -23,6 +23,7 @@ type Config struct {
 // New returns the default CRI-O NRI configuration.
 func New() *Config {
 	return &Config{
+		Enabled:                   true,
 		SocketPath:                nri.DefaultSocketPath,
 		PluginPath:                nri.DefaultPluginPath,
 		PluginConfigPath:          nri.DefaultPluginConfigPath,

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -41,6 +41,14 @@ function setup_test() {
     CRIO_CNI_CONFIG="$TESTDIR/cni/net.d/"
     CRIO_LOG="$TESTDIR/crio.log"
 
+    # Override NRI socket to a testcase-specific location.
+    CRIO_NRI_CONFIG="$CRIO_CONFIG_DIR/10-crio-nri.conf"
+    NRI_SOCKET="$TESTDIR/nri.sock"
+    cat <<EOF >"$CRIO_NRI_CONFIG"
+[crio.nri]
+nri_listen = "$NRI_SOCKET"
+EOF
+
     # Copy all the CNI dependencies around to ensure encapsulated tests
     CRIO_CNI_PLUGIN="$TESTDIR/cni-bin"
     mkdir "$CRIO_CNI_PLUGIN"

--- a/test/nri.bats
+++ b/test/nri.bats
@@ -13,16 +13,6 @@ function setup() {
 	setup_test
 	NRITEST_BINARY=${NRITEST_BINARY:-${CRIO_ROOT}/test/nri/nri.test}
 	NRITEST_LOG="$TESTDIR/nri.test.log"
-	NRI_SOCKET="$TESTDIR/nri.sock"
-	enable_nri
-}
-
-function enable_nri() {
-	cat << EOF > "$CRIO_CONFIG_DIR/zz-nri.conf"
-[crio.nri]
-enable_nri = true
-nri_listen = "$NRI_SOCKET"
-EOF
 }
 
 function teardown() {


### PR DESCRIPTION

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Flip NRI on in the default configuration.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

As discussed in the last community meeting, this PR flips NRI on in the default configuration.

For maintaining command line backward compatibility this PR leaves the original `--enable-nri` command line option intact, only changing its default to `true` from `false` (as opposed to flipping it to `--disable-nri=[false]`). Hence, NRI can now be disabled on the command line using the `--enable-nri=false` option.

#### Does this PR introduce a user-facing change?

```release-note
Flip NRI on by default.
To revert to a configuration with NRI disabled, either either pass the `--enable-nri=false` option to crio
on the command line, or set the `enable_nri = false` in the `[crio.nri]` section of the configuration.
```
