### PR TITLE
Add all update types to dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
   groups:
     gomod:
       update-types:
+        - "major"
+        - "minor"
         - "patch"
 - package-ecosystem: "github-actions"
   directory: "/"
@@ -21,5 +23,6 @@ updates:
   groups:
     actions:
       update-types:
+        - "major"
         - "minor"
         - "patch"


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
We now group all types of updates together and don't focus on a subset of them.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
