### PR TITLE
Allow plain annotation `seccomp-profile.kubernetes.cri-o.io` for images

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -159,6 +159,7 @@ kata_skip_pod_tests:
 kata_skip_seccomp_oci_artifacts_tests:
   - 'test "seccomp OCI artifact with pod annotation"'
   - 'test "seccomp OCI artifact with container annotation"'
+  - 'test "seccomp OCI artifact with image annotation without suffix"'
   - 'test "seccomp OCI artifact with image annotation for pod"'
   - 'test "seccomp OCI artifact with image annotation for container"'
   - 'test "seccomp OCI artifact with image annotation and profile set to unconfined"'

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -359,6 +359,8 @@ The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  Th
     - a specific container by using: "seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>"
     - a whole pod by using: "seccomp-profile.kubernetes.cri-o.io/POD"
     Note that the annotation works on containers as well as on images.
+    For images, the plain annotation `seccomp-profile.kubernetes.cri-o.io`
+    can be used without the required `/POD` suffix or a container name.
 
 **platform_runtime_paths**={}
   A mapping of platforms to the corresponding runtime executable paths for the runtime handler.

--- a/internal/config/seccomp/seccompociartifact/seccompociartifact.go
+++ b/internal/config/seccomp/seccompociartifact/seccompociartifact.go
@@ -49,6 +49,9 @@ func (s *SeccompOCIArtifact) TryPull(
 	} else if val, ok := podAnnotations[SeccompProfilePodAnnotation]; ok {
 		log.Infof(ctx, "Found pod specific seccomp profile annotation: %s=%s", annotations.SeccompProfileAnnotation, val)
 		profileRef = val
+	} else if val, ok := imageAnnotations[annotations.SeccompProfileAnnotation]; ok {
+		log.Infof(ctx, "Found image specific seccomp profile annotation: %s=%s", annotations.SeccompProfileAnnotation, val)
+		profileRef = val
 	} else if val, ok := imageAnnotations[containerKey]; ok {
 		log.Infof(ctx, "Found image specific seccomp profile annotation for container %s: %s=%s", containerName, annotations.SeccompProfileAnnotation, val)
 		profileRef = val

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -77,6 +77,8 @@ const (
 	// - a specific container by using: `seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>`
 	// - a whole pod by using: `seccomp-profile.kubernetes.cri-o.io/POD`
 	// Note that the annotation works on containers as well as on images.
+	// For images, the plain annotation `seccomp-profile.kubernetes.cri-o.io`
+	// can be used without the required `/POD` suffix or a container name.
 	SeccompProfileAnnotation = "seccomp-profile.kubernetes.cri-o.io"
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -210,6 +210,8 @@ type RuntimeHandler struct {
 	//   - a specific container by using: `seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>`
 	//   - a whole pod by using: `seccomp-profile.kubernetes.cri-o.io/POD`
 	//   Note that the annotation works on containers as well as on images.
+	//   For images, the plain annotation `seccomp-profile.kubernetes.cri-o.io`
+	//   can be used without the required `/POD` suffix or a container name.
 	AllowedAnnotations []string `toml:"allowed_annotations,omitempty"`
 
 	// DisallowedAnnotations is the slice of experimental annotations that are not allowed for this handler.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1269,6 +1269,8 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 #     - a specific container by using: "seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>"
 #     - a whole pod by using: "seccomp-profile.kubernetes.cri-o.io/POD"
 #     Note that the annotation works on containers as well as on images.
+#     For images, the plain annotation "seccomp-profile.kubernetes.cri-o.io"
+#     can be used without the required "/POD" suffix or a container name.
 # - monitor_path (optional, string): The path of the monitor binary. Replaces
 #   deprecated option "conmon".
 # - monitor_cgroup (optional, string): The cgroup the container monitor process will be put in.


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now additionally allow the plain
`seccomp-profile.kubernetes.cri-o.io` annotation for container images, to not require users to suffix the annotation using `/POD` or a container name.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
