### PR TITLE
[release-1.29] Revert "Fix ImageRef field for containers to default to an image ID"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -233,7 +233,7 @@ linters-settings:
       # - filepathJoin
       # - whyNoLint
   gocyclo:
-    min-complexity: 160
+    min-complexity: 161
   nakedret:
     max-func-lines: 15
   goconst:

--- a/internal/config/nsmgr/test/utils.go
+++ b/internal/config/nsmgr/test/utils.go
@@ -63,7 +63,7 @@ func ContainerWithPid(pid int) (*oci.Container, error) {
 	testContainer, err := oci.NewContainer("testid", "testname", "",
 		"/container/logs", map[string]string{},
 		map[string]string{}, map[string]string{}, "image",
-		&imageName, &imageID, &types.ContainerMetadata{},
+		&imageName, &imageID, "", &types.ContainerMetadata{},
 		"testsandboxid", false, false, false, "",
 		"/root/for/container", time.Now(), "SIGKILL")
 	if err != nil {

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -295,7 +295,7 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 	}
 
 	if !wasSpoofed {
-		scontainer, err = oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, m.Annotations[annotations.Image], nil, nil, nil, id, false, false, false, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+		scontainer, err = oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, m.Annotations[annotations.Image], nil, nil, "", nil, id, false, false, false, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 		if err != nil {
 			return sb, err
 		}
@@ -487,7 +487,7 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, userRequestedImage, imgName, imageID, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, userRequestedImage, imgName, imageID, "", &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -628,7 +628,7 @@ var _ = t.Describe("ContainerServer", func() {
 			// Given
 			container, err := oci.NewContainer(containerID, "", "", "",
 				make(map[string]string), make(map[string]string),
-				make(map[string]string), "", nil, nil,
+				make(map[string]string), "", nil, nil, "",
 				&types.ContainerMetadata{}, sandboxID, false,
 				false, false, "", "/invalid", time.Now(), "")
 			Expect(err).To(BeNil())

--- a/internal/lib/restore_test.go
+++ b/internal/lib/restore_test.go
@@ -338,7 +338,7 @@ func setupInfraContainerWithPid(pid int, bundle string) {
 	testContainer, err := oci.NewContainer("testid", "testname", bundle,
 		"/container/logs", map[string]string{},
 		map[string]string{}, map[string]string{}, "image",
-		&imageName, &imageID, &types.ContainerMetadata{},
+		&imageName, &imageID, "", &types.ContainerMetadata{},
 		"testsandboxid", false, false, false, "",
 		"/root/for/container", time.Now(), "SIGKILL")
 	Expect(err).To(BeNil())

--- a/internal/lib/sandbox/sandbox_test.go
+++ b/internal/lib/sandbox/sandbox_test.go
@@ -210,7 +210,7 @@ var _ = t.Describe("Sandbox", func() {
 			testContainer, err = oci.NewContainer("testid", "testname", "",
 				"/container/logs", map[string]string{},
 				map[string]string{}, map[string]string{}, "image",
-				&imageName, &imageID, &types.ContainerMetadata{},
+				&imageName, &imageID, "", &types.ContainerMetadata{},
 				"testsandboxid", false, false, false, "",
 				"/root/for/container", time.Now(), "SIGKILL")
 			Expect(err).To(BeNil())

--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -160,7 +160,7 @@ func beforeEach() {
 
 	myContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "", nil, nil,
+		make(map[string]string), "", nil, nil, "",
 		&types.ContainerMetadata{}, sandboxID, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -125,11 +125,17 @@ type ContainerState struct {
 // at any future time.
 // imageName, if set, is _some_ name of the image imageID; it may have NO RELATIONSHIP to the users’ requested image name.
 // imageID is nil for infra containers.
-func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, userRequestedImage string, imageName *references.RegistryImageReference, imageID *storage.StorageImageID, md *types.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
+// someRepoDigest, if set, is some repo@some digest of the image imageID; it
+// may have NO RELATIONSHIP to the users’ requested image name (and, which
+// should be fixed eventually, may be a repo@digest combination which has never
+// existed on a registry).
+func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, userRequestedImage string, imageName *references.RegistryImageReference, imageID *storage.StorageImageID, someRepoDigest string, md *types.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
 	externalImageRef := ""
-	if imageID != nil {
+	if someRepoDigest != "" {
+		externalImageRef = someRepoDigest
+	} else if imageID != nil {
 		externalImageRef = imageID.IDStringForOutOfProcessConsumptionOnly()
 	}
 	c := &Container{

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -186,7 +186,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", nil, nil, &types.ContainerMetadata{}, "",
+			"", nil, nil, "", &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGNO")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
@@ -202,7 +202,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", nil, nil, &types.ContainerMetadata{}, "",
+			"", nil, nil, "", &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "RTMIN+1")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
@@ -218,7 +218,7 @@ var _ = t.Describe("Container", func() {
 		// Given
 		container, err := oci.NewContainer("", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
-			"", nil, nil, &types.ContainerMetadata{}, "",
+			"", nil, nil, "", &types.ContainerMetadata{}, "",
 			false, false, false, "", "", time.Now(), "SIGTRAP")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())

--- a/internal/oci/suite_test.go
+++ b/internal/oci/suite_test.go
@@ -39,7 +39,7 @@ func beforeEach() {
 	var err error
 	myContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "", nil, nil,
+		make(map[string]string), "", nil, nil, "",
 		&types.ContainerMetadata{}, sandboxID, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
@@ -63,7 +63,7 @@ func getTestContainer() *oci.Container {
 		map[string]string{"key": "label"},
 		map[string]string{"key": "crioAnnotation"},
 		map[string]string{"key": "annotation"},
-		"image", &imageName, &imageID, &types.ContainerMetadata{}, "sandbox",
+		"image", &imageName, &imageID, "", &types.ContainerMetadata{}, "sandbox",
 		false, false, false, "", "dir", time.Now(), "")
 	Expect(err).To(BeNil())
 	Expect(container).NotTo(BeNil())

--- a/internal/runtimehandlerhooks/high_performance_hooks_test.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_test.go
@@ -26,7 +26,7 @@ const (
 var _ = Describe("high_performance_hooks", func() {
 	container, err := oci.NewContainer("containerID", "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "pauseImage", nil, nil,
+		make(map[string]string), "pauseImage", nil, nil, "",
 		&types.ContainerMetadata{}, "sandboxID", false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
@@ -627,7 +627,7 @@ var _ = Describe("high_performance_hooks", func() {
 		}
 		c, err := oci.NewContainer("containerID", "", "", "",
 			make(map[string]string), make(map[string]string),
-			make(map[string]string), "pauseImage", nil, nil,
+			make(map[string]string), "pauseImage", nil, nil, "",
 			&types.ContainerMetadata{Name: "cnt1"}, "sandboxID", false, false,
 			false, "", "", time.Now(), "")
 		Expect(err).To(BeNil())

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -244,6 +244,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 
 	imageName := imgResult.SomeNameOfThisImage
 	imageID := imgResult.ID
+	someRepoDigest := ""
+	if len(imgResult.RepoDigests) > 0 {
+		someRepoDigest = imgResult.RepoDigests[0]
+	}
 
 	labelOptions, err := ctr.SelinuxLabel(sb.ProcessLabel())
 	if err != nil {
@@ -798,7 +802,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		Name:    metadata.Name,
 		Attempt: metadata.Attempt,
 	}
-	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, userRequestedImage, imageName, &imageID, criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().Annotations, userRequestedImage, imageName, &imageID, someRepoDigest, criMetadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -32,10 +32,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 	}
 
 	containerID := c.ID()
-	imageRef := ""
-	if id := c.ImageID(); id != nil {
-		imageRef = id.IDStringForOutOfProcessConsumptionOnly()
-	}
+	imageRef := c.CRIContainer().ImageRef
 	imageNameInSpec := ""
 	if imageName := c.ImageName(); imageName != nil {
 		imageNameInSpec = imageName.StringForOutOfProcessConsumptionOnly()

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -100,10 +100,7 @@ func (s *Server) getContainerInfo(ctx context.Context, id string, getContainerFu
 	if imageName := ctr.ImageName(); imageName != nil {
 		image = imageName.StringForOutOfProcessConsumptionOnly()
 	}
-	imageRef := ""
-	if id := ctr.ImageID(); id != nil {
-		imageRef = id.IDStringForOutOfProcessConsumptionOnly()
-	}
+	imageRef := ctr.CRIContainer().ImageRef
 	return types.ContainerInfo{
 		Name:            ctr.Name(),
 		Pid:             pidToReturn,

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -60,7 +60,7 @@ func TestGetContainerInfo(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", &imageName, &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "image", &imageName, &imageID, "", &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -185,7 +185,7 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, "", &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,7 @@ func TestGetContainerInfoSandboxNotFound(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", labels, annotations, annotations, "imageName", &imageName, &imageID, "", &types.ContainerMetadata{}, "testsandboxid", false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -916,7 +916,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	if sb.NeedsInfra(s.config.DropInfraCtr) || podIsKernelSeparated {
 		log.Debugf(ctx, "Keeping infra container for pod %s", sbox.ID())
 		// pauseImage, as the userRequestedImage parameter, only shows up in CRI values we return.
-		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+		container, err = oci.NewContainer(sbox.ID(), containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, "", nil, sbox.ID(), false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 		if err != nil {
 			return nil, err
 		}

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -161,7 +161,7 @@ var beforeEach = func() {
 
 	testContainer, err = oci.NewContainer(containerID, "", "", "",
 		make(map[string]string), make(map[string]string),
-		make(map[string]string), "pauseImage", nil, nil,
+		make(map[string]string), "pauseImage", nil, nil, "",
 		&types.ContainerMetadata{}, sandboxID, false, false,
 		false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -211,7 +211,7 @@ function check_images() {
     eval "$(jq -r '.images[] |
         select(.repoTags[0] == "quay.io/crio/fedora-crio-ci:latest") |
         "REDIS_IMAGEID=" + .id + "\n" +
-	"REDIS_IMAGEREF=" + .id' <<<"$json")"
+	"REDIS_IMAGEREF=" + .repoDigests[0]' <<<"$json")"
 }
 
 function start_crio_no_setup() {

--- a/test/image.bats
+++ b/test/image.bats
@@ -80,6 +80,7 @@ function teardown() {
 
 	output=$(crictl inspect -o yaml "$ctr_id")
 	[[ "$output" == *"image: $IMAGE_LIST_DIGEST"* ]]
+	[[ "$output" == *"imageRef: $IMAGE_LIST_DIGEST"* ]]
 }
 
 @test "image pull and list" {


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

This reverts commit 41b13e2.

Manual backport of https://github.com/cri-o/cri-o/pull/7762

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reverted image ID field change in the container status. While the change did fix an issue with Kubelet image GC, it caused an unintended change in the container status of the Kubernetes pod API, breaking an accidentally stable API.
```
