### PR TITLE
In-memory OCI artifact pull

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -163,5 +163,6 @@ kata_skip_seccomp_oci_artifacts_tests:
   - 'test "seccomp OCI artifact with image annotation for pod"'
   - 'test "seccomp OCI artifact with image annotation for container"'
   - 'test "seccomp OCI artifact with image annotation and profile set to unconfined"'
+  - 'test "seccomp OCI artifact with missing artifact"'
 
 runc_git_version: main

--- a/test/mocks/ociartifact/ociartifact.go
+++ b/test/mocks/ociartifact/ociartifact.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	types "github.com/containers/image/v5/types"
 	ociartifact "github.com/cri-o/cri-o/internal/config/ociartifact"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -37,7 +36,7 @@ func (m *MockImpl) EXPECT() *MockImplMockRecorder {
 }
 
 // Pull mocks base method.
-func (m *MockImpl) Pull(arg0 context.Context, arg1 *types.SystemContext, arg2 string) (*ociartifact.Artifact, error) {
+func (m *MockImpl) Pull(arg0 context.Context, arg1 string, arg2 *ociartifact.PullOptions) (*ociartifact.Artifact, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Pull", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*ociartifact.Artifact)


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
CRI-O now pulls OCI artifacts directly in-memory after the discussions in https://github.com/containers/image/pull/2306 and https://github.com/kubernetes/website/pull/45121.

CRI-O also enforces the config media type
`application/vnd.cncf.seccomp-profile.config.v1+json` for seccomp profiles.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
