### PR TITLE
Keep versions file simple to source only

### DIFF
--- a/scripts/versions
+++ b/scripts/versions
@@ -1,7 +1,4 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Versions to be used
+# Software versions to be used.
 declare -A VERSIONS=(
     ["cni-plugins"]=v1.4.0
     ["conmon"]=v2.1.10
@@ -11,4 +8,3 @@ declare -A VERSIONS=(
     ["bats"]=v1.10.0
     ["buildah"]=v1.34.0
 )
-export VERSIONS


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Files sourced in a shell script (often used as configuration files) should not set new settings for the shell instance itself or explicitly export any variables. This way, shell scripts that include it wouldn't be affected/changed following sourcing the file.

#### Does this PR introduce a user-facing change?

```release-note
None
```