### PR TITLE
Add support for setting CPU limits for workloads

### DIFF
--- a/internal/config/cgmgr/cgroupfs_linux.go
+++ b/internal/config/cgmgr/cgroupfs_linux.go
@@ -232,6 +232,12 @@ func setWorkloadSettings(cgPath string, resources *rspec.LinuxResources) (err er
 	if resources.CPU.Shares != nil {
 		cg.Resources.CpuShares = *resources.CPU.Shares
 	}
+	if resources.CPU.Quota != nil {
+		cg.Resources.CpuQuota = *resources.CPU.Quota
+	}
+	if resources.CPU.Period != nil {
+		cg.Resources.CpuPeriod = *resources.CPU.Period
+	}
 
 	mgr, err := libctrCgMgr.New(cg)
 	if err != nil {

--- a/internal/config/cgmgr/systemd_linux.go
+++ b/internal/config/cgmgr/systemd_linux.go
@@ -185,6 +185,18 @@ func (m *SystemdManager) MoveConmonToCgroup(cid, cgroupParent, conmonCgroup stri
 				Value: dbus.MakeVariant(resources.CPU.Shares),
 			})
 		}
+		if resources.CPU.Quota != nil {
+			props = append(props, systemdDbus.Property{
+				Name:  "CPUQuota",
+				Value: dbus.MakeVariant(resources.CPU.Quota),
+			})
+		}
+		if resources.CPU.Period != nil {
+			props = append(props, systemdDbus.Property{
+				Name:  "CPUQuotaPeriodSec",
+				Value: dbus.MakeVariant(resources.CPU.Period),
+			})
+		}
 	}
 
 	logrus.Debugf("Running conmon under slice %s and unitName %s", cgroupParent, conmonUnitName)

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1334,7 +1334,7 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 # that work based on annotations, rather than the CRI.
 # Note, the behavior of this table is EXPERIMENTAL and may change at any time.
 # Each workload, has a name, activation_annotation, annotation_prefix and set of resources it supports mutating.
-# The currently supported resources are "cpuperiod" "cpuquota", "cpushares" and "cpuset" to configure the cpuset.
+# The currently supported resources are "cpuperiod" "cpuquota", "cpushares" and "cpuset". The values for "cpuperiod" and "cpuquota" are denoted in microseconds.
 # Each resource can have a default value specified, or be empty.
 # For a container to opt-into this workload, the pod should be configured with the annotation $activation_annotation (key only, value is ignored).
 # To customize per-container, an annotation of the form $annotation_prefix.$resource/$ctrName = "value" can be specified
@@ -1347,7 +1347,7 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 # [crio.runtime.workloads.workload-type.resources]
 # cpuset = "0-1"
 # cpushares = "5"
-# cpuquota = "5"
+# cpuquota = "1000"
 # cpuperiod = "100000"
 # Where:
 # The workload name is workload-type.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1334,7 +1334,7 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 # that work based on annotations, rather than the CRI.
 # Note, the behavior of this table is EXPERIMENTAL and may change at any time.
 # Each workload, has a name, activation_annotation, annotation_prefix and set of resources it supports mutating.
-# The currently supported resources are "cpu" (to configure the cpu shares) and "cpuset" to configure the cpuset.
+# The currently supported resources are "cpuperiod" "cpuquota", "cpushares" and "cpuset" to configure the cpuset.
 # Each resource can have a default value specified, or be empty.
 # For a container to opt-into this workload, the pod should be configured with the annotation $activation_annotation (key only, value is ignored).
 # To customize per-container, an annotation of the form $annotation_prefix.$resource/$ctrName = "value" can be specified
@@ -1345,8 +1345,10 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 # activation_annotation = "io.crio/workload"
 # annotation_prefix = "io.crio.workload-type"
 # [crio.runtime.workloads.workload-type.resources]
-# cpuset = 0
-# cpushares = "0-1"
+# cpuset = "0-1"
+# cpushares = "5"
+# cpuquota = "5"
+# cpuperiod = "100000"
 # Where:
 # The workload name is workload-type.
 # To specify, the pod must have the "io.crio.workload" annotation (this is a precise string match).
@@ -1360,6 +1362,8 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 {{ $.Comment }}annotation_prefix = "{{ $workload_config.AnnotationPrefix }}"
 {{ if $workload_config.Resources }}{{ $.Comment }}[crio.runtime.workloads.{{ $workload_type }}.resources]
 {{ $.Comment }}cpuset = "{{ $workload_config.Resources.CPUSet }}"
+{{ $.Comment }}cpuquota = {{ $workload_config.Resources.CPUQuota }}
+{{ $.Comment }}cpuperiod = {{ $workload_config.Resources.CPUPeriod }}
 {{ $.Comment }}cpushares = {{ $workload_config.Resources.CPUShares }}{{ end }}
 {{ end }}
 `

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1334,7 +1334,9 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 # that work based on annotations, rather than the CRI.
 # Note, the behavior of this table is EXPERIMENTAL and may change at any time.
 # Each workload, has a name, activation_annotation, annotation_prefix and set of resources it supports mutating.
-# The currently supported resources are "cpuperiod" "cpuquota", "cpushares" and "cpuset". The values for "cpuperiod" and "cpuquota" are denoted in microseconds.
+# The currently supported resources are "cpuperiod" "cpuquota", "cpushares", "cpulimit" and "cpuset". The values for "cpuperiod" and "cpuquota" are denoted in microseconds.
+# The value for "cpulimit" is denoted in millicores, this value is used to calculate the "cpuquota" with the supplied "cpuperiod" or the default "cpuperiod".
+# Note that the "cpulimit" field overrides the "cpuquota" value supplied in this configuration.
 # Each resource can have a default value specified, or be empty.
 # For a container to opt-into this workload, the pod should be configured with the annotation $activation_annotation (key only, value is ignored).
 # To customize per-container, an annotation of the form $annotation_prefix.$resource/$ctrName = "value" can be specified
@@ -1349,6 +1351,7 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 # cpushares = "5"
 # cpuquota = "1000"
 # cpuperiod = "100000"
+# cpulimit = "35"
 # Where:
 # The workload name is workload-type.
 # To specify, the pod must have the "io.crio.workload" annotation (this is a precise string match).
@@ -1364,7 +1367,8 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 {{ $.Comment }}cpuset = "{{ $workload_config.Resources.CPUSet }}"
 {{ $.Comment }}cpuquota = {{ $workload_config.Resources.CPUQuota }}
 {{ $.Comment }}cpuperiod = {{ $workload_config.Resources.CPUPeriod }}
-{{ $.Comment }}cpushares = {{ $workload_config.Resources.CPUShares }}{{ end }}
+{{ $.Comment }}cpushares = {{ $workload_config.Resources.CPUShares }}
+{{ $.Comment }}cpulimit = {{ $workload_config.Resources.CPULimit }}{{ end }}
 {{ end }}
 `
 

--- a/pkg/config/workloads.go
+++ b/pkg/config/workloads.go
@@ -222,7 +222,7 @@ func (r *Resources) ValidateDefaults() error {
 	if _, err := cpuset.Parse(r.CPUSet); err != nil {
 		return fmt.Errorf("unable to parse cpuset %q: %w", r.CPUSet, err)
 	}
-	if r.CPUQuota < int64(r.CPUShares) {
+	if r.CPUQuota != 0 && r.CPUQuota < int64(r.CPUShares) {
 		return fmt.Errorf("cpuquota %d cannot be less than cpushares %d", r.CPUQuota, r.CPUShares)
 	}
 	if r.CPUPeriod != 0 && r.CPUPeriod < minQuotaPeriod {

--- a/pkg/config/workloads_test.go
+++ b/pkg/config/workloads_test.go
@@ -88,12 +88,42 @@ var _ = t.Describe("Workloads config", func() {
 	})
 
 	It("resources should validate defaults", func() {
-		// Given
-		resources := config.Resources{}
-		// When
-		err := resources.ValidateDefaults()
-		// Then
-		Expect(err).NotTo(HaveOccurred())
+		testCases := []struct {
+			description string
+			resources   config.Resources
+		}{
+			{
+				description: "when only cpushares are provided",
+				resources: config.Resources{
+					CPUShares: 37,
+				},
+			},
+			{
+				description: "when only cpuquota is provided",
+				resources: config.Resources{
+					CPUQuota: 3700,
+				},
+			},
+			{
+				description: "when only cpuperiod is provided",
+				resources: config.Resources{
+					CPUPeriod: 37000,
+				},
+			},
+			{
+				description: "when only cpuset is provided",
+				resources: config.Resources{
+					CPUSet: "0-1",
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			By(tc.description, func() {
+				err := tc.resources.ValidateDefaults()
+				Expect(err).NotTo(HaveOccurred())
+			})
+		}
 	})
 
 	It("resources should mutate the container spec", func() {

--- a/pkg/config/workloads_test.go
+++ b/pkg/config/workloads_test.go
@@ -4,16 +4,25 @@ import (
 	"github.com/cri-o/cri-o/pkg/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/generate"
 )
 
+// Helper function for pointer reference
+func pointer[A any](m A) *A {
+	return &m
+}
+
 // The actual test suite
-var _ = t.Describe("Workloads", func() {
+var _ = t.Describe("Workloads config", func() {
 	BeforeEach(beforeEach)
 
 	It("should fail on invalid cpuset", func() {
 		// Given
 		workloads := config.Workloads{
 			"management": &config.WorkloadConfig{
+				ActivationAnnotation: "target.workload.openshift.io/management",
+				AnnotationPrefix:     "resources.workload.openshift.io",
 				Resources: &config.Resources{
 					CPUSet: "-20",
 				},
@@ -23,13 +32,15 @@ var _ = t.Describe("Workloads", func() {
 		sut.Workloads = workloads
 		err := sut.Workloads.Validate()
 		// Then
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("should fail when cpuquota is less than cpushares", func() {
 		// Given
 		workloads := config.Workloads{
 			"management": &config.WorkloadConfig{
+				ActivationAnnotation: "target.workload.openshift.io/management",
+				AnnotationPrefix:     "resources.workload.openshift.io",
 				Resources: &config.Resources{
 					CPUShares: 2000,
 					CPUQuota:  1000,
@@ -40,13 +51,15 @@ var _ = t.Describe("Workloads", func() {
 		sut.Workloads = workloads
 		err := sut.Workloads.Validate()
 		// Then
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("should fail when cpuperiod is less than 1000 usecs", func() {
 		// Given
 		workloads := config.Workloads{
 			"management": &config.WorkloadConfig{
+				ActivationAnnotation: "target.workload.openshift.io/management",
+				AnnotationPrefix:     "resources.workload.openshift.io",
 				Resources: &config.Resources{
 					CPUPeriod: 999,
 				},
@@ -56,18 +69,168 @@ var _ = t.Describe("Workloads", func() {
 		sut.Workloads = workloads
 		err := sut.Workloads.Validate()
 		// Then
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("should contain default values for resources", func() {
 		// Given
 		workloads := config.Workloads{
-			"management": &config.WorkloadConfig{},
+			"management": &config.WorkloadConfig{
+				ActivationAnnotation: "target.workload.openshift.io/management",
+				AnnotationPrefix:     "resources.workload.openshift.io",
+				Resources:            &config.Resources{},
+			},
 		}
 		// When
-		sut.Workloads = workloads
-		err := sut.Workloads.Validate()
+		err := workloads.Validate()
 		// Then
-		Expect(err).NotTo(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("resources should validate defaults", func() {
+		// Given
+		resources := config.Resources{}
+		// When
+		err := resources.ValidateDefaults()
+		// Then
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("resources should mutate the container spec", func() {
+		testCases := []struct {
+			description       string
+			resources         config.Resources
+			expectedCPUSet    string
+			expectedCPUShare  *uint64
+			expectedCPUQuota  *int64
+			expectedCPUPeriod *uint64
+		}{
+			{
+				description: "when values are provided",
+				resources: config.Resources{
+					CPUShares: 15,
+					CPUSet:    "0-1",
+					CPUQuota:  20,
+					CPUPeriod: 50000,
+				},
+				expectedCPUSet:    "0-1",
+				expectedCPUQuota:  pointer(int64(20)),
+				expectedCPUShare:  pointer(uint64(15)),
+				expectedCPUPeriod: pointer(uint64(50000)),
+			},
+		}
+
+		for _, tc := range testCases {
+			By(tc.description, func() {
+				g := &generate.Generator{
+					Config: &rspec.Spec{
+						Linux: &rspec.Linux{
+							Resources: &rspec.LinuxResources{},
+						},
+					},
+				}
+				tc.resources.MutateSpec(g)
+				Expect(g.Config.Linux.Resources.CPU.Quota).To(Equal(tc.expectedCPUQuota))
+				Expect(g.Config.Linux.Resources.CPU.Shares).To(Equal(tc.expectedCPUShare))
+				Expect(g.Config.Linux.Resources.CPU.Period).To(Equal(tc.expectedCPUPeriod))
+				Expect(g.Config.Linux.Resources.CPU.Cpus).To(Equal(tc.expectedCPUSet))
+			})
+		}
+	})
+
+	It("should mutate container spec based on annotation", func() {
+		const (
+			workloadsKey                = "management"
+			containerName               = "limitbox"
+			resourceContainerPrefix     = "resources.workload.openshift.io"
+			resourceContainerAnnotation = resourceContainerPrefix + "/" + containerName
+			workloadTargetAnnotation    = "target.workload.openshift.io/" + workloadsKey
+		)
+
+		// CPUShare support was the first feature implemented for workloads.
+		// We always check 'cpushares' in every test case to insure its operation
+		// does not change for existing users.
+		testCases := []struct {
+			description       string
+			annotations       map[string]string
+			expectedCPUShare  *uint64
+			expectedCPUQuota  *int64
+			expectedCPUPeriod *uint64
+		}{
+			{
+				description: "when cpushares and cpulimit are present",
+				annotations: map[string]string{
+					resourceContainerAnnotation: "{\"cpushares\":15,\"cpulimit\":35}",
+					workloadTargetAnnotation:    "{\"effect\":\"PreferredDuringScheduling\"}",
+				},
+				expectedCPUQuota: pointer(int64(3500)),
+				expectedCPUShare: pointer(uint64(15)),
+			},
+			{
+				description: "when cpulimit is present it should override cpuquota",
+				annotations: map[string]string{
+					resourceContainerAnnotation: "{\"cpushares\":35,\"cpulimit\":105,\"cpuquota\":35}",
+					workloadTargetAnnotation:    "{\"effect\":\"PreferredDuringScheduling\"}",
+				},
+				expectedCPUQuota: pointer(int64(10500)),
+				expectedCPUShare: pointer(uint64(35)),
+			},
+			{
+				description: "when cpuquota is present",
+				annotations: map[string]string{
+					resourceContainerAnnotation: "{\"cpushares\":25,\"cpuquota\":35}",
+					workloadTargetAnnotation:    "{\"effect\":\"PreferredDuringScheduling\"}",
+				},
+				expectedCPUQuota: pointer(int64(35)),
+				expectedCPUShare: pointer(uint64(25)),
+			},
+			{
+				description: "when only cpuperiod is present",
+				annotations: map[string]string{
+					resourceContainerAnnotation: "{\"cpushares\":65,\"cpuperiod\":50000}",
+					workloadTargetAnnotation:    "{\"effect\":\"PreferredDuringScheduling\"}",
+				},
+				expectedCPUPeriod: pointer(uint64(50000)),
+				expectedCPUShare:  pointer(uint64(65)),
+			},
+			{
+				description: "when only cpushares is present",
+				annotations: map[string]string{
+					resourceContainerAnnotation: "{\"cpushares\":45}",
+					workloadTargetAnnotation:    "{\"effect\":\"PreferredDuringScheduling\"}",
+				},
+				expectedCPUShare: pointer(uint64(45)),
+			},
+		}
+
+		for _, tc := range testCases {
+			By(tc.description, func() {
+				// Given
+				workloads := config.Workloads{
+					workloadsKey: &config.WorkloadConfig{
+						AnnotationPrefix:     resourceContainerPrefix,
+						ActivationAnnotation: workloadTargetAnnotation,
+						Resources: &config.Resources{
+							CPUShares: 0,
+							CPUSet:    "",
+						},
+					},
+				}
+
+				g := &generate.Generator{
+					Config: &rspec.Spec{
+						Linux: &rspec.Linux{
+							Resources: &rspec.LinuxResources{},
+						},
+					},
+				}
+				err := workloads.MutateSpecGivenAnnotations(containerName, g, tc.annotations)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(g.Config.Linux.Resources.CPU.Quota).To(Equal(tc.expectedCPUQuota))
+				Expect(g.Config.Linux.Resources.CPU.Shares).To(Equal(tc.expectedCPUShare))
+				Expect(g.Config.Linux.Resources.CPU.Period).To(Equal(tc.expectedCPUPeriod))
+				Expect(g.Config.Linux.Resources.CPU.Cpus).To(Equal(""))
+			})
+		}
 	})
 })

--- a/pkg/config/workloads_test.go
+++ b/pkg/config/workloads_test.go
@@ -1,0 +1,73 @@
+package config_test
+
+import (
+	"github.com/cri-o/cri-o/pkg/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The actual test suite
+var _ = t.Describe("Workloads", func() {
+	BeforeEach(beforeEach)
+
+	It("should fail on invalid cpuset", func() {
+		// Given
+		workloads := config.Workloads{
+			"management": &config.WorkloadConfig{
+				Resources: &config.Resources{
+					CPUSet: "-20",
+				},
+			},
+		}
+		// When
+		sut.Workloads = workloads
+		err := sut.Workloads.Validate()
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+
+	It("should fail when cpuquota is less than cpushares", func() {
+		// Given
+		workloads := config.Workloads{
+			"management": &config.WorkloadConfig{
+				Resources: &config.Resources{
+					CPUShares: 2000,
+					CPUQuota:  1000,
+				},
+			},
+		}
+		// When
+		sut.Workloads = workloads
+		err := sut.Workloads.Validate()
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+
+	It("should fail when cpuperiod is less than 1000 usecs", func() {
+		// Given
+		workloads := config.Workloads{
+			"management": &config.WorkloadConfig{
+				Resources: &config.Resources{
+					CPUPeriod: 999,
+				},
+			},
+		}
+		// When
+		sut.Workloads = workloads
+		err := sut.Workloads.Validate()
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+
+	It("should contain default values for resources", func() {
+		// Given
+		workloads := config.Workloads{
+			"management": &config.WorkloadConfig{},
+		}
+		// When
+		sut.Workloads = workloads
+		err := sut.Workloads.Validate()
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+})


### PR DESCRIPTION
Added the ability to support cpuquota and cpuperiod for specific workloads, this allows more fine tune control for containers that are assigned to those workloads to be set to a specific CPU quota.

Added a wrapper struct for annotation object to be used for information such as cpu milli cores to be used in the calculation for cpu quota.

Design Info:
[Enhancement Proposal](https://github.com/openshift/enhancements/pull/1546)

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Currently the workloads feature does not take into account `cpuquota` for cpu limits. CPU limits just get ignored for the time as it currently stands, this feature adds support for cpu limits by exposing cpu quota configuration.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Extend `workloads` config option to support CPU limits for containers that use the workloads annotations. This will expose `cpuperiod` and `cpuquota` options for a desired default value outside the norm. This feature will primarily be utilized to ensure that containers with workload annotations are correctly limited, the average use cases will not need to alter the default values.
```
