### PR TITLE
Do not overwrite stored latency/governor on container restart

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks_test.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_test.go
@@ -248,6 +248,17 @@ var _ = Describe("high_performance_hooks", func() {
 			})
 		})
 
+		Context("with n/a latency and latency already saved", func() {
+			BeforeEach(func() {
+				pmQosResumeLatencyUs = "n/a"
+				pmQosResumeLatencyUsOriginal = "0"
+			})
+
+			It("should not change the saved CPU PM QOS latency", func() {
+				verifySetCPUPMQOSResumeLatency("n/a", "n/a", "0", false)
+			})
+		})
+
 		Context("with 0 latency", func() {
 			BeforeEach(func() {
 				pmQosResumeLatencyUs = "n/a"
@@ -392,6 +403,18 @@ var _ = Describe("high_performance_hooks", func() {
 			})
 		})
 
+		Context("with available governor and governor already saved", func() {
+			BeforeEach(func() {
+				scalingGovernor = "performance"
+				scalingAvailableGovernors = "conservative ondemand userspace powersave performance schedutil"
+				scalingGovernorOriginal = "schedutil"
+			})
+
+			It("should not change the saved CPU scaling governor", func() {
+				verifySetCPUScalingGovernor("performance", "performance", "schedutil", false)
+			})
+		})
+
 		Context("with unknown governor", func() {
 			BeforeEach(func() {
 				scalingGovernor = "schedutil"
@@ -420,6 +443,18 @@ var _ = Describe("high_performance_hooks", func() {
 			BeforeEach(func() {
 				scalingGovernor = "conservative"
 				scalingAvailableGovernors = ""
+				scalingGovernorOriginal = ""
+			})
+
+			It("should fail", func() {
+				verifySetCPUScalingGovernor("performance", "", "", true)
+			})
+		})
+
+		Context("with no configured scaling governor", func() {
+			BeforeEach(func() {
+				scalingGovernor = ""
+				scalingAvailableGovernors = "conservative ondemand userspace powersave performance"
 				scalingGovernorOriginal = ""
 			})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a container in a pod with the cpu-c-states.crio.io or cpu-freq-governor.crio.io annotations is restarted, the high performance pre-start hook is called again. The current code will overwrite the stored pm_qos_resume_latency and/or scaling_governor with those that were written to /sys/devices/system/cpu/cpuX the first time the pre-start hook was called. Then when the pod is deleted, the pre-stop hook will restore the incorrect pm_qos_resume_latency and/or scaling_governor values.

The fix is to only store the pm_qos_resume_latency and/or scaling_governor the first time the pre-start hook is run. If the stored values already exist the pre-start hook will not overwrite them.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
