### PR TITLE
Add OCI artifact layer cache

### DIFF
--- a/internal/config/ociartifact/impl.go
+++ b/internal/config/ociartifact/impl.go
@@ -3,6 +3,7 @@ package ociartifact
 import (
 	"context"
 	"io"
+	"os"
 
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
@@ -21,6 +22,11 @@ type Impl interface {
 	LayerInfos(manifest.Manifest) []manifest.LayerInfo
 	GetBlob(context.Context, types.ImageSource, types.BlobInfo, types.BlobInfoCache) (io.ReadCloser, int64, error)
 	ReadAll(io.Reader) ([]byte, error)
+	MkdirAll(string, os.FileMode) error
+	ReadDir(string) ([]os.DirEntry, error)
+	ReadFile(string) ([]byte, error)
+	RemoveAll(string) error
+	WriteFile(string, []byte, os.FileMode) error
 }
 
 // defaultImpl is the default implementation for the OCI artifact handling.
@@ -61,4 +67,24 @@ func (*defaultImpl) GetBlob(ctx context.Context, src types.ImageSource, bi types
 
 func (*defaultImpl) ReadAll(r io.Reader) ([]byte, error) {
 	return io.ReadAll(r)
+}
+
+func (*defaultImpl) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (*defaultImpl) ReadDir(name string) ([]os.DirEntry, error) {
+	return os.ReadDir(name)
+}
+
+func (*defaultImpl) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name)
+}
+
+func (*defaultImpl) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (*defaultImpl) WriteFile(name string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(name, data, perm)
 }

--- a/internal/config/ociartifact/ociartifact.go
+++ b/internal/config/ociartifact/ociartifact.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/manifest"
@@ -31,12 +34,30 @@ func New() *OCIArtifact {
 type Artifact struct {
 	// Data is the actual artifact content.
 	Data []byte
+
+	// Path is the file representation of the artifact on disk. Can be empty if
+	// the cache is not used.
+	Path string
 }
 
 // PullOptions can be used to customize the pull behavior.
 type PullOptions struct {
 	// SystemContext is the context used for pull.
 	SystemContext *types.SystemContext
+
+	// CachePath is the path to the used artifact cache. The cache can be
+	// disabled if the value is an empty string.
+	CachePath string
+
+	// CacheEntryMaxAge is the maximum age cache entries can have before
+	// getting removed.
+	//
+	// Defaults to 3 days.
+	// Can be set to a negative value for disabling the removal.
+	//
+	// Note: Items only get removed on calling Pull(), which means they can be
+	// technically older on disk.
+	CacheEntryMaxAge time.Duration
 
 	// EnforceConfigMediaType can be set to enforce a specific manifest config media type.
 	EnforceConfigMediaType string
@@ -46,8 +67,13 @@ type PullOptions struct {
 	MaxSize int
 }
 
-// defaultMaxArtifactSize is the default maximum artifact size.
-const defaultMaxArtifactSize = 1024 * 1024 // 1 MiB
+const (
+	// defaultMaxArtifactSize is the default maximum artifact size.
+	defaultMaxArtifactSize = 1024 * 1024 // 1 MiB
+
+	// defaultCacheEntryMaxAge is the default max age for a cache entry item.
+	defaultCacheEntryMaxAge = 3 * 24 * time.Hour // 3 days
+)
 
 // Pull downloads the artifact content by using the provided image name and the specified options.
 func (o *OCIArtifact) Pull(ctx context.Context, img string, opts *PullOptions) (*Artifact, error) {
@@ -98,7 +124,12 @@ func (o *OCIArtifact) Pull(ctx context.Context, img string, opts *PullOptions) (
 
 	// Just supporting one layer here. This can be later enhanced by extending
 	// the PullOptions.
-	layer := layers[0]
+	layer := &layers[0]
+
+	useCache := o.prepareCache(ctx, opts)
+	if artifact := o.tryLookupCache(ctx, useCache, opts, layer); artifact != nil {
+		return artifact, nil
+	}
 
 	bic := blobinfocache.DefaultCache(opts.SystemContext)
 	rc, size, err := o.impl.GetBlob(ctx, src, layer.BlobInfo, bic)
@@ -121,13 +152,113 @@ func (o *OCIArtifact) Pull(ctx context.Context, img string, opts *PullOptions) (
 		return nil, fmt.Errorf("read with limit: %w", err)
 	}
 
-	if err := verifyDigest(&layer, layerBytes); err != nil {
+	if err := verifyDigest(layer, layerBytes); err != nil {
 		return nil, fmt.Errorf("verify digest of layer: %w", err)
 	}
 
+	keyPath := o.tryWriteCache(ctx, useCache, opts, layer, layerBytes)
+
 	return &Artifact{
 		Data: layerBytes,
+		Path: keyPath,
 	}, nil
+}
+
+func (o *OCIArtifact) prepareCache(ctx context.Context, opts *PullOptions) (useCache bool) {
+	if opts.CachePath == "" {
+		return false
+	}
+
+	if err := o.impl.MkdirAll(opts.CachePath, 0o700); err != nil {
+		log.Errorf(ctx, "Unable to create cache path: %v", err)
+		return false
+	}
+
+	entries, err := o.impl.ReadDir(opts.CachePath)
+	if err != nil {
+		log.Errorf(ctx, "Unable to read cache path: %v", err)
+		return false
+	}
+
+	maxAge := opts.CacheEntryMaxAge
+	if opts.CacheEntryMaxAge == 0 {
+		maxAge = defaultCacheEntryMaxAge
+	}
+
+	now := time.Now()
+	if maxAge > 0 {
+		for _, entry := range entries {
+			info, err := entry.Info()
+			if err != nil {
+				log.Errorf(ctx, "Unable to get artifact layer info for %q: %v", entry.Name(), err)
+				continue
+			}
+
+			if diff := now.Sub(info.ModTime()); diff > maxAge {
+				p := filepath.Join(opts.CachePath, info.Name())
+				log.Infof(ctx, "Removing old artifact layer %q (age: %v)", p, diff.Round(time.Second))
+				if err := o.impl.RemoveAll(p); err != nil {
+					log.Errorf(ctx, "Unable to remove artifact layer %q: %v", p, err)
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+func (o *OCIArtifact) tryLookupCache(ctx context.Context, useCache bool, opts *PullOptions, layer *manifest.LayerInfo) *Artifact {
+	if !useCache {
+		return nil
+	}
+
+	keyPath := getKeyPath(opts, layer)
+	tryRemoveKeyPath := false
+
+	if value, err := o.impl.ReadFile(keyPath); err == nil {
+		if err := verifyDigest(layer, value); err == nil {
+			log.Infof(ctx, "Using cached artifact layer for digest %q", layer.BlobInfo.Digest)
+			return &Artifact{
+				Data: value,
+				Path: keyPath,
+			}
+		}
+
+		log.Warnf(ctx, "Unable to verify cached artifact layer digest: %v", err)
+		tryRemoveKeyPath = true
+	} else if !os.IsNotExist(err) {
+		log.Warnf(ctx, "Unable to read cached artifact layer: %v", err)
+		tryRemoveKeyPath = true
+	}
+
+	if tryRemoveKeyPath {
+		log.Infof(ctx, "Removing cached artifact layer for digest %q", layer.BlobInfo.Digest)
+		if err := o.impl.RemoveAll(keyPath); err != nil {
+			log.Warnf(ctx, "Unable to remove artifact from cache: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (o *OCIArtifact) tryWriteCache(ctx context.Context, useCache bool, opts *PullOptions, layer *manifest.LayerInfo, layerBytes []byte) (keyPath string) {
+	if !useCache {
+		return ""
+	}
+
+	keyPath = getKeyPath(opts, layer)
+
+	if err := o.impl.WriteFile(keyPath, layerBytes, 0o600); err != nil {
+		log.Errorf(ctx, "Unable to write artifact layer to cache: %v", err)
+		return ""
+	}
+
+	return keyPath
+}
+
+func getKeyPath(opts *PullOptions, layer *manifest.LayerInfo) string {
+	key := string(layer.BlobInfo.Digest)
+	return filepath.Join(opts.CachePath, key)
 }
 
 func (o *OCIArtifact) readLimit(reader io.Reader, limit int) ([]byte, error) {

--- a/internal/config/seccomp/seccompociartifact/seccompociartifact.go
+++ b/internal/config/seccomp/seccompociartifact/seccompociartifact.go
@@ -69,6 +69,7 @@ func (s *SeccompOCIArtifact) TryPull(
 	pullOptions := &ociartifact.PullOptions{
 		SystemContext:          sys,
 		EnforceConfigMediaType: requiredConfigMediaType,
+		CachePath:              "/var/lib/crio/seccomp-oci-artifacts",
 	}
 	artifact, err := s.impl.Pull(ctx, profileRef, pullOptions)
 	if err != nil {

--- a/test/mocks/ociartifact/ociartifact.go
+++ b/test/mocks/ociartifact/ociartifact.go
@@ -7,6 +7,7 @@ package ociartifactmock
 import (
 	context "context"
 	io "io"
+	fs "io/fs"
 	reflect "reflect"
 
 	reference "github.com/containers/image/v5/docker/reference"
@@ -114,6 +115,20 @@ func (mr *MockImplMockRecorder) ManifestFromBlob(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManifestFromBlob", reflect.TypeOf((*MockImpl)(nil).ManifestFromBlob), arg0, arg1)
 }
 
+// MkdirAll mocks base method.
+func (m *MockImpl) MkdirAll(arg0 string, arg1 fs.FileMode) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MkdirAll", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MkdirAll indicates an expected call of MkdirAll.
+func (mr *MockImplMockRecorder) MkdirAll(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockImpl)(nil).MkdirAll), arg0, arg1)
+}
+
 // NewImageSource mocks base method.
 func (m *MockImpl) NewImageSource(arg0 context.Context, arg1 types.ImageReference, arg2 *types.SystemContext) (types.ImageSource, error) {
 	m.ctrl.T.Helper()
@@ -172,4 +187,62 @@ func (m *MockImpl) ReadAll(arg0 io.Reader) ([]byte, error) {
 func (mr *MockImplMockRecorder) ReadAll(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAll", reflect.TypeOf((*MockImpl)(nil).ReadAll), arg0)
+}
+
+// ReadDir mocks base method.
+func (m *MockImpl) ReadDir(arg0 string) ([]fs.DirEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadDir", arg0)
+	ret0, _ := ret[0].([]fs.DirEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadDir indicates an expected call of ReadDir.
+func (mr *MockImplMockRecorder) ReadDir(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDir", reflect.TypeOf((*MockImpl)(nil).ReadDir), arg0)
+}
+
+// ReadFile mocks base method.
+func (m *MockImpl) ReadFile(arg0 string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadFile", arg0)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadFile indicates an expected call of ReadFile.
+func (mr *MockImplMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockImpl)(nil).ReadFile), arg0)
+}
+
+// RemoveAll mocks base method.
+func (m *MockImpl) RemoveAll(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveAll", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveAll indicates an expected call of RemoveAll.
+func (mr *MockImplMockRecorder) RemoveAll(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockImpl)(nil).RemoveAll), arg0)
+}
+
+// WriteFile mocks base method.
+func (m *MockImpl) WriteFile(arg0 string, arg1 []byte, arg2 fs.FileMode) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteFile", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteFile indicates an expected call of WriteFile.
+func (mr *MockImplMockRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockImpl)(nil).WriteFile), arg0, arg1, arg2)
 }


### PR DESCRIPTION
#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
We now utilize an on-disk key/value cache for OCI artifacts. The digests will be used to identify if a layer has to be re-pulled or not. The artifact API now returns a path to the file on disk.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added OCI artifact layer cache to avoid repeatedly pulling the same container image.
```
