### PR TITLE
[release-1.29] OCPBUGS-30240: deps: update otelttrpc to get rid of 'custom import path checks'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containerd/cri-containerd v1.19.0
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/nri v0.6.0
-	github.com/containerd/otelttrpc v0.0.0-20240115065405-5909713624e1
+	github.com/containerd/otelttrpc v0.0.0-20240305015340-ea5083fda723
 	github.com/containerd/ttrpc v1.2.3
 	github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67
 	github.com/containernetworking/cni v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -846,8 +846,8 @@ github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oM
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/nri v0.6.0 h1:hdztxwL0gCS1CrCa9bvD1SoJiFN4jBuRQhplCvCPMj8=
 github.com/containerd/nri v0.6.0/go.mod h1:F7OZfO4QTPqw5r87aq+syZJwiVvRYLIlHZiZDBV1W3A=
-github.com/containerd/otelttrpc v0.0.0-20240115065405-5909713624e1 h1:DzBGiha+Gvc0INnf4Z2WztM2VSATX7PAJpSdsFEVd6o=
-github.com/containerd/otelttrpc v0.0.0-20240115065405-5909713624e1/go.mod h1:ZKzztepTSz/LKtbUSzfBNVwgqBEPABVZV9PQF/l53+Q=
+github.com/containerd/otelttrpc v0.0.0-20240305015340-ea5083fda723 h1:swk9KxrmARZjSMrHc1Lzb39XhcDwAhYpqkBhinCFLCQ=
+github.com/containerd/otelttrpc v0.0.0-20240305015340-ea5083fda723/go.mod h1:ZKzztepTSz/LKtbUSzfBNVwgqBEPABVZV9PQF/l53+Q=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/containerd/stargz-snapshotter/estargz v0.12.0/go.mod h1:AIQ59TewBFJ4GOPEQXujcrJ/EKxh5xXZegW1rkR1P/M=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU=

--- a/vendor/github.com/containerd/otelttrpc/config.go
+++ b/vendor/github.com/containerd/otelttrpc/config.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 import (
 	"go.opentelemetry.io/otel"

--- a/vendor/github.com/containerd/otelttrpc/interceptor.go
+++ b/vendor/github.com/containerd/otelttrpc/interceptor.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 import (
 	"context"

--- a/vendor/github.com/containerd/otelttrpc/internal/parse.go
+++ b/vendor/github.com/containerd/otelttrpc/internal/parse.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package internal // import "github.com/containerd/ttrpc/otelttrpc"
+package internal
 
 import (
 	"strings"

--- a/vendor/github.com/containerd/otelttrpc/metadata_supplier.go
+++ b/vendor/github.com/containerd/otelttrpc/metadata_supplier.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 import (
 	"context"

--- a/vendor/github.com/containerd/otelttrpc/semconv.go
+++ b/vendor/github.com/containerd/otelttrpc/semconv.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 import (
 	"go.opentelemetry.io/otel/attribute"

--- a/vendor/github.com/containerd/otelttrpc/version.go
+++ b/vendor/github.com/containerd/otelttrpc/version.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 // Version is the current release version of the ttRPC instrumentation.
 func Version() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,7 +212,7 @@ github.com/containerd/nri/pkg/net
 github.com/containerd/nri/pkg/net/multiplex
 github.com/containerd/nri/pkg/runtime-tools/generate
 github.com/containerd/nri/pkg/stub
-# github.com/containerd/otelttrpc v0.0.0-20240115065405-5909713624e1
+# github.com/containerd/otelttrpc v0.0.0-20240305015340-ea5083fda723
 ## explicit; go 1.13
 github.com/containerd/otelttrpc
 github.com/containerd/otelttrpc/internal


### PR DESCRIPTION
Update otelttrpc to latest HEAD to get rid of custom import path checks which reportedly break RPM package builds.

#### What type of PR is this?


/kind dependency-change

#### What this PR does / why we need it:

Without this change the otelttrpc version we use has 'custom import path check' annotating comments in place, which reportedly break RPM package building. The updated otelttrpc version has eliminated those annotations.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
