### PR TITLE
Change CRIU support from default off to default on

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -309,8 +309,8 @@ the container runtime configuration.
 **device_ownership_from_security_context**=false
   Changes the default behavior of setting container devices uid/gid from CRI's SecurityContext (RunAsUser/RunAsGroup) instead of taking host's uid/gid.
 
-**enable_criu_support**=false
-  Enable CRIU integration, requires that the criu binary is available in $PATH. (default: false)
+**enable_criu_support**=true
+  Enable CRIU integration, requires that the criu binary is available in $PATH. (default: true)
 
 **enable_pod_events**=false
 Enable CRI-O to generate the container pod-level events in order to optimize the performance of the Pod Lifecycle Event Generator (PLEG) module in Kubelet.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -890,6 +890,7 @@ func DefaultConfig() (*Config, error) {
 			ulimitsConfig:               ulimits.New(),
 			HostNetworkDisableSELinux:   true,
 			DisableHostPortMapping:      false,
+			EnableCriuSupport:           true,
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport:   "docker://",

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -24,6 +24,9 @@ import (
 // checkIfCheckpointOCIImage returns checks if the input refers to a checkpoint image.
 // It returns the StorageImageID of the image the input resolves to, nil otherwise.
 func (s *Server) checkIfCheckpointOCIImage(ctx context.Context, input string) (*storage.StorageImageID, error) {
+	if input == "" {
+		return nil, nil
+	}
 	if _, err := os.Stat(input); err == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

With the graduation of "Forensic Container Checkpointing" from Alpha to Beta the Kubernetes checkpoint feature defaults to on.

One of the arguments when introducing checkpoint/restore in CRI-O to default to off was to have the same behaviour as Kubernetes.

With this commit the behaviour of CRI-O is adapted to Kubernetes to default checkpoint/restore to on with the option to disable it explicitly.

CRI-O will also disable the feature if the CRIU binary is not found during initial CRI-O startup.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
CRI-O's checkpoint/restore support defaults to on mirroring the changes in Kubernetes.
```
