### PR TITLE
Add image removal lock to image server

### DIFF
--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -539,7 +539,7 @@ var _ = t.Describe("Runtime", func() {
 				info, err = sut.CreatePodSandbox(&types.SystemContext{},
 					"podName", "podID", pauseImage, "",
 					"containerName", "metadataName",
-					"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
+					"uid", "namespace", 0, nil, []string{"mountLabel"}, false, nil,
 				)
 			})
 
@@ -675,7 +675,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err = sut.CreatePodSandbox(&types.SystemContext{},
 				"podName", "podID", pauseImage, "",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
+				"uid", "namespace", 0, nil, []string{"mountLabel"}, false, nil,
 			)
 
 			// Then
@@ -697,7 +697,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err = sut.CreatePodSandbox(&types.SystemContext{},
 				"podName", "podID", pauseImage, "",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
+				"uid", "namespace", 0, nil, []string{"mountLabel"}, false, nil,
 			)
 
 			// Then
@@ -801,7 +801,7 @@ var _ = t.Describe("Runtime", func() {
 			info, err = sut.CreatePodSandbox(&types.SystemContext{},
 				"podName", "podID", pauseImage, "",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
+				"uid", "namespace", 0, nil, []string{"mountLabel"}, false, nil,
 			)
 		})
 
@@ -820,7 +820,7 @@ var _ = t.Describe("Runtime", func() {
 			info, err = sut.CreatePodSandbox(&types.SystemContext{},
 				"podName", "podID", pauseImage, "/var/non-default/credentials.json",
 				"containerName", "metadataName",
-				"uid", "namespace", 0, nil, []string{"mountLabel"}, false,
+				"uid", "namespace", 0, nil, []string{"mountLabel"}, false, nil,
 			)
 		})
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -223,6 +223,12 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 
 	imageName := imgResult.SomeNameOfThisImage
 	imageID := imgResult.ID
+
+	// Avoid image removal during container creation
+	imageRemovalLock := s.StorageImageServer().ImageRemovalLock(imageID)
+	imageRemovalLock.RLock()
+	defer imageRemovalLock.RUnlock()
+
 	someRepoDigest := ""
 	if len(imgResult.RepoDigests) > 0 {
 		someRepoDigest = imgResult.RepoDigests[0]

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	criu "github.com/checkpoint-restore/go-criu/v7/utils"
 	"github.com/containers/storage/pkg/archive"
@@ -547,6 +548,7 @@ var _ = t.Describe("ContainerRestore", func() {
 				mockutils.InOrder(
 					imageLookup,
 
+					imageServerMock.EXPECT().ImageRemovalLock(gomock.Any()).Return(&sync.RWMutex{}),
 					runtimeServerMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), imageID, gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -156,6 +156,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		nil,
 		labelOptions,
 		privileged,
+		s.ContainerServer.StorageImageServer(),
 	)
 	if errors.Is(err, storage.ErrDuplicateName) {
 		return nil, fmt.Errorf("pod sandbox with name %q already exists", sbox.Name())

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -472,6 +472,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		idMappingsOptions,
 		labelOptions,
 		privileged,
+		s.ContainerServer.StorageImageServer(),
 	)
 	if errors.Is(err, storage.ErrDuplicateName) {
 		return nil, fmt.Errorf("pod sandbox with name %q already exists", sbox.Name())

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -30,7 +30,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 				runtimeServerMock.EXPECT().CreatePodSandbox(gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).
 					Return(storage.ContainerInfo{
 						RunDir: "/tmp",
 						Config: &v1.Image{Config: v1.ImageConfig{}},
@@ -111,7 +112,8 @@ var _ = t.Describe("RunPodSandbox", func() {
 				runtimeServerMock.EXPECT().CreatePodSandbox(gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).
 					Return(storage.ContainerInfo{}, nil),
 				runtimeServerMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).
 					Return(nil),

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -7,6 +7,7 @@ package criostoragemock
 import (
 	context "context"
 	reflect "reflect"
+	sync "sync"
 
 	types "github.com/containers/image/v5/types"
 	storage "github.com/containers/storage"
@@ -94,6 +95,20 @@ func (m *MockImageServer) HeuristicallyTryResolvingStringAsIDPrefix(arg0 string)
 func (mr *MockImageServerMockRecorder) HeuristicallyTryResolvingStringAsIDPrefix(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeuristicallyTryResolvingStringAsIDPrefix", reflect.TypeOf((*MockImageServer)(nil).HeuristicallyTryResolvingStringAsIDPrefix), arg0)
+}
+
+// ImageRemovalLock mocks base method.
+func (m *MockImageServer) ImageRemovalLock(arg0 storage0.StorageImageID) *sync.RWMutex {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImageRemovalLock", arg0)
+	ret0, _ := ret[0].(*sync.RWMutex)
+	return ret0
+}
+
+// ImageRemovalLock indicates an expected call of ImageRemovalLock.
+func (mr *MockImageServerMockRecorder) ImageRemovalLock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageRemovalLock", reflect.TypeOf((*MockImageServer)(nil).ImageRemovalLock), arg0)
 }
 
 // ImageStatusByID mocks base method.
@@ -236,18 +251,18 @@ func (mr *MockRuntimeServerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3,
 }
 
 // CreatePodSandbox mocks base method.
-func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2 string, arg3 references.RegistryImageReference, arg4, arg5, arg6, arg7, arg8 string, arg9 uint32, arg10 *types0.IDMappingOptions, arg11 []string, arg12 bool) (storage0.ContainerInfo, error) {
+func (m *MockRuntimeServer) CreatePodSandbox(arg0 *types.SystemContext, arg1, arg2 string, arg3 references.RegistryImageReference, arg4, arg5, arg6, arg7, arg8 string, arg9 uint32, arg10 *types0.IDMappingOptions, arg11 []string, arg12 bool, arg13 storage0.ImageServer) (storage0.ContainerInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePodSandbox", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
+	ret := m.ctrl.Call(m, "CreatePodSandbox", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
 	ret0, _ := ret[0].(storage0.ContainerInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePodSandbox indicates an expected call of CreatePodSandbox.
-func (mr *MockRuntimeServerMockRecorder) CreatePodSandbox(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12 interface{}) *gomock.Call {
+func (mr *MockRuntimeServerMockRecorder) CreatePodSandbox(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePodSandbox", reflect.TypeOf((*MockRuntimeServer)(nil).CreatePodSandbox), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePodSandbox", reflect.TypeOf((*MockRuntimeServer)(nil).CreatePodSandbox), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
 }
 
 // DeleteContainer mocks base method.


### PR DESCRIPTION



#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We now avoid removing images when a sandbox or container creation is in progress. This should close the gap in the outlined corner case in:

https://github.com/kubernetes/kubernetes/issues/123631

Refers to https://github.com/kubernetes/kubernetes/pull/123711 as well.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where images can be removed during sandbox or container creation.
```
