### PR TITLE
OCPBUGS-28981: Add exponential backoff to the container stop loop

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -129,6 +129,7 @@ kata_skip_ctr_tests:
   - 'test "annotations passed through"'
   - 'test "ctr with default_env set in configuration"'
   - 'test "ctr with absent mount that should be rejected"'
+  - 'test "ctr stop loop kill retry attempts"'
 kata_skip_devices_tests:
   - 'test "additional devices permissions"'
   - 'test "annotation devices support"'

--- a/internal/oci/container_freebsd.go
+++ b/internal/oci/container_freebsd.go
@@ -14,18 +14,37 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Reads the process start time using sysctl. This is marginally more efficient
-// than /proc but more importantly, it works when /proc is not mounted which is
-// normal.
+const sysctlName = "kern.proc.pid"
+
+// getPidStartTime returns the process start time for a given PID.
 func getPidStartTime(pid int) (string, error) {
-	data, err := unix.SysctlRaw("kern.proc.pid", pid)
+	return getPidStatDataFromSysctl(pid)
+}
+
+// getPidStatData returns the process state and start time for a given PID.
+//
+// TODO: Return the process state using struct kinfo_proc.
+func getPidStatData(pid int) (string, string, error) { //nolint:gocritic // Ignore unnamedResult.
+	startTime, err := getPidStartTime(pid)
+	return "", startTime, err
+}
+
+// getPidStatDataFromSysctl reads the process start time using sysctl. This
+// is marginally more efficient than /proc but more importantly, it works
+// when /proc is not mounted, which not a requirement on FreeBSD.
+//
+// TODO: Add process state collection using struct kinfo_proc.
+func getPidStatDataFromSysctl(pid int) (string, error) {
+	data, err := unix.SysctlRaw(sysctlName, pid)
 	if err != nil {
 		return "", err
 	}
 
 	if len(data) != C.sizeof_struct_kinfo_proc {
-		return "", fmt.Errorf("unexpected size %d", len(data))
+		return "", fmt.Errorf("incorrect read of %d bytes from %s sysctl", len(data), sysctlName)
 	}
+
 	kp := (*C.struct_kinfo_proc)(unsafe.Pointer(&data[0]))
+
 	return fmt.Sprintf("%d,%d", kp.ki_start.tv_sec, kp.ki_start.tv_usec), nil
 }

--- a/internal/oci/container_freebsd_nocgo.go
+++ b/internal/oci/container_freebsd_nocgo.go
@@ -9,12 +9,41 @@ import (
 	"strings"
 )
 
-// Reads the process start time via /proc
+const (
+	procStatusFile = "/proc/%d/status"
+
+	// Fields from the /proc/<PID>/status file. see:
+	//   https://man.freebsd.org/cgi/man.cgi?query=procfs&sektion=5
+	//
+	// Field no. 7, the process start time in seconds and microseconds.
+	startTimeFieldIndex = 7
+)
+
+// getPidStartTime returns the process start time for a given PID.
 func getPidStartTime(pid int) (string, error) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	return getPidStatDataFromFile(fmt.Sprintf(procStatusFile, pid))
+}
+
+// getPidStatData returns the process start time for a given PID.
+func getPidStatData(pid int) (string, string, error) { //nolint:gocritic // Ignore unnamedResult.
+	startTime, err := getPidStartTime(pid)
+	return "", startTime, err
+}
+
+// getPidStatData parses the /proc/<PID>/status file, looking for the
+// process start time for a given PID. The procfs file system has to be
+// mounted, which is not a requirement on FreeBSD.
+//
+// Note: The process state is not available via the status file on FreeBSD.
+func getPidStatDataFromFile(file string) (string, error) {
+	data, err := os.ReadFile(file)
 	if err != nil {
-		return "", fmt.Errorf("%v: %w", err, ErrNotFound)
+		return "", fmt.Errorf("unable to read status file: %w", err)
 	}
+
 	fields := strings.Fields(string(data))
-	return fields[7], nil
+
+	// The /proc/<PID>/status file on FreeBSD does not currently
+	// include the process state.
+	return fields[startTimeFieldIndex], nil
 }

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -500,6 +500,47 @@ var _ = t.Describe("Container", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+	t.Describe("ProcessState", func() {
+		It("should be false if pid uninitialized", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Pid = 0
+			sut.SetState(state)
+			// When
+			processState, err := sut.ProcessState()
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(processState).To(BeEmpty())
+		})
+		It("should succeed if pid is running", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Pid = alwaysRunningPid
+			Expect(state.SetInitPid(state.Pid)).To(Succeed())
+			sut.SetState(state)
+			// When
+			processState, err := sut.ProcessState()
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(processState).To(Equal("S")) // A process will be sleeping most of the time.
+		})
+		It("should be false if pid is not running", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Pid = neverRunningPid
+			// SetInitPid will fail because the pid is not running
+			Expect(state.SetInitPid(state.Pid)).NotTo(Succeed())
+			sut.SetState(state)
+			// When
+			processState, err := sut.ProcessState()
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(processState).To(BeEmpty())
+		})
+	})
 	t.Describe("Pid", func() {
 		It("should fail if container state not set", func() {
 			// Given


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently, when CRI-O attempts to stop a container where the process within, especially an init process (the so-called "PID 1"), is in an uninterruptible blocking state (for example, it's sleeping and waiting for a disk I/O completion, etc.), CRI-O will enter a broken state where it tries to delivery termination signals to such a process as fast as possible.

Nonetheless, a blocked process might not promptly respond to the signals delivered, causing CRI-O to enter a "busy loop" while it repeatedly tries to signal delivery. This seemingly unbound loop can render CRI-O unresponsive and result in high CPU usage while it happens.

Thus, add exponential backoff support to the container stop loop to fix the possible busy loop issue irregardless of the current state of the process to be terminated. The exponential backoff will stagger termination signals delivery for as long as the process is still running, allowing it to eventually terminate on its own volition (or crash, whichever comes first).

Related to:

- https://github.com/cri-o/cri-o/pull/7736

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
- Add exponential backoff to the container stop loop to fix a busy loop issue when a process running with the container is in an uninterruptible blocking state and would become unresponsive to signals delivery during container termination.
- Add a new error log line to notify the user that a process (the container init) has been blocked in uninterruptible sleep for some time.```
