### PR TITLE
Deflake `pod annotations capability for chained cni plugins` test

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -608,6 +608,7 @@ function wait_until_exit() {
 # Helpers for pod annotations tests
 function prepare_cni_plugin() {
     # name the config with prefix 001 to ensure the corresponding cni plugin will be invoked when pod is created
+    mkdir -p "$CRIO_CNI_CONFIG"
     cat >"$CRIO_CNI_CONFIG"/001-"$CNI_PLUGIN_NAME".conf <<-EOF
 {
   "cniVersion": "0.3.1",
@@ -628,6 +629,7 @@ EOF
 
 function prepare_chained_cni_plugins() {
     # create a chained cni plugin configuration file
+    mkdir -p "$CRIO_CNI_CONFIG"
     cat >"$CRIO_CNI_CONFIG"/001-"$CNI_PLUGIN_NAME".conflist <<-EOF
 {
   "cniVersion": "0.3.1",

--- a/test/pod_annotations_capability.bats
+++ b/test/pod_annotations_capability.bats
@@ -24,8 +24,8 @@ function delete_pod() {
 	enable_capability=true
 	cni_plugin_log_path="$TESTDIR/cni.log"
 
-	start_crio
 	prepare_cni_plugin "$cni_plugin_log_path" $enable_capability
+	start_crio
 	run_pod
 	delete_pod
 
@@ -39,8 +39,8 @@ function delete_pod() {
 	enable_capability=false
 	cni_plugin_log_path="$TESTDIR/cni.log"
 
-	start_crio
 	prepare_cni_plugin "$cni_plugin_log_path" $enable_capability
+	start_crio
 	run_pod
 	delete_pod
 
@@ -56,8 +56,8 @@ function delete_pod() {
 	enable_capability_second=true
 	cni_plugin_log_path_second="$TESTDIR/cni-02.log"
 
-	start_crio
 	prepare_chained_cni_plugins "${cni_plugin_log_path_first}" $enable_capability_first "$cni_plugin_log_path_second" $enable_capability_second
+	start_crio
 	run_pod
 	delete_pod
 


### PR DESCRIPTION


#### What type of PR is this?


/kind flake


#### What this PR does / why we need it:
We hit the following error in CI:

```
time="2024-03-12 08:43:22.550384064Z" level=info msg="CNI monitoring event CREATE        \"/tmp/tmp.PiZMelzV6x/cni/net.d/001-log_cni_plugin.conflist\"" file="ocicni/ocicni.go:155"
time="2024-03-12 08:43:22.550557032Z" level=error msg="Error loading CNI config list file /tmp/tmp.PiZMelzV6x/cni/net.d/001-log_cni_plugin.conflist: error parsing configuration list: unexpected end of JSON input" file="ocicni/ocicni.go:298"
```

Assuming that CRI-O reads the config while the test still writes to it causes invalid JSON. This can be mitigated by writing the config before starting CRI-O.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/7802
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
