### PR TITLE
[release-1.26] OCPBUGS-30896: Cherry-pick changes from containers/common/pull#1437

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.2.0
 	github.com/containers/buildah v1.30.0
-	github.com/containers/common v0.52.1-0.20240214131428-852b056f0855
+	github.com/containers/common v0.52.1-0.20240315151407-84399ba6f723
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.4.0
 	github.com/containers/image/v5 v5.25.0

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ github.com/containernetworking/plugins v1.2.0 h1:SWgg3dQG1yzUo4d9iD8cwSVh1VqI+bP
 github.com/containernetworking/plugins v1.2.0/go.mod h1:/VjX4uHecW5vVimFa1wkG4s+r/s9qIfPdqlLF4TW8c4=
 github.com/containers/buildah v1.30.0 h1:mdp2COGKFFEZNEGP8VZ5ITuUFVNPFoH+iK2sSesNfTA=
 github.com/containers/buildah v1.30.0/go.mod h1:lyMLZIevpAa6zSzjRl7z4lFJMCMQLFjfo56YIefaB/U=
-github.com/containers/common v0.52.1-0.20240214131428-852b056f0855 h1:Doze84TH/0wlWFNzNIhpf1xpz06G9AUM4pZUr1/L8tY=
-github.com/containers/common v0.52.1-0.20240214131428-852b056f0855/go.mod h1:dNJJVNBu1wJtAH+vFIMXV+fQHBdEVNmNP3ImjbKper4=
+github.com/containers/common v0.52.1-0.20240315151407-84399ba6f723 h1:Sk0ghiLjpancOIBUfgIWgOsW6oVLAShPytWLSruqL2E=
+github.com/containers/common v0.52.1-0.20240315151407-84399ba6f723/go.mod h1:dNJJVNBu1wJtAH+vFIMXV+fQHBdEVNmNP3ImjbKper4=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.4.0 h1:Nl8/xFsc2/dlQUdYi2GTZ+aPCqcedeqnOUld09eiZHc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -616,7 +616,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.52.1-0.20240214131428-852b056f0855
+# github.com/containers/common v0.52.1-0.20240315151407-84399ba6f723
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from https://github.com/containers/common/pull/1437 as these changes contain a fix that needs to be backported to CRI-O release 1.25, part of OpenShift 4.12 release.

Related:

- https://github.com/containers/common/pull/1421
- https://github.com/containers/common/pull/1437
- https://github.com/containers/common/pull/1908

Closes:

- https://github.com/cri-o/cri-o/issues/7880

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```