### PR TITLE
Save CRIU restore.log

### DIFF
--- a/internal/lib/restore_test.go
+++ b/internal/lib/restore_test.go
@@ -92,6 +92,8 @@ var _ = t.Describe("ContainerRestore", func() {
 			config := &metadata.ContainerConfig{
 				ID: containerID,
 			}
+			Expect(os.WriteFile("restore.log", []byte(``), 0o600)).To(Succeed())
+			defer os.RemoveAll("restore.log")
 
 			// When
 			res, err := sut.ContainerRestore(
@@ -216,6 +218,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			Expect(err).ToNot(HaveOccurred())
 			setupInfraContainerWithPid(42, "bundle")
 			defer os.RemoveAll("bundle")
+			defer os.RemoveAll("restore.log")
 
 			// When
 			res, err := sut.ContainerRestore(
@@ -309,6 +312,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			err = os.WriteFile("bind.mounts", []byte(bindMounts), 0o644)
 			Expect(err).ToNot(HaveOccurred())
 			defer os.RemoveAll("bind.mounts")
+			defer os.RemoveAll("restore.log")
 
 			err = os.Mkdir("bundle", 0o700)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

If there is an error restoring a container then there is usually an error message pointing to the log file created by CRIU. Unfortunately this log file is created in the bundle directory which is remove after container restore. The user gets told to look at a file which is automatically deleted.

In the case of an error the log file is now copied to a temporary directory:

  `os.CreateTemp("", fmt.Sprintf("restore-%s-*.log", ctr.ID()))`

The resulting error message is also adapted to point to this copy of the log file.

This change comes with a test that tries to trigger a restore error by creating a container with an established TCP connection and telling CRIU to handle established TCP connection while not telling CRIU to handle established TCP connection during restore. The restore will fail and the test can verify that the reported log file copy exists.

The main reason for this change is that one of most asked questions about checkpoint/restore in Kubernetes/CRI-O is that the log file is not readable.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
The CRIU log file (restore.log) is no longer deleted if the restore of the container fails. It will be copied to a temporary location.
```
