### PR TITLE
[release-1.26] OCPBUGS-30656: Add exponential backoff to the container stop loop

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -77,3 +77,4 @@ kata_skip_ctr_tests:
   - 'test "annotations passed through"'
   - 'test "ctr with default_env set in configuration"'
   - 'test "ctr with absent mount that should be rejected"'
+  - 'test "ctr stop loop kill retry attempts"'

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -387,6 +387,47 @@ var _ = t.Describe("Container", func() {
 			Expect(err).NotTo(BeNil())
 		})
 	})
+	t.Describe("ProcessState", func() {
+		It("should be false if pid uninitialized", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Pid = 0
+			sut.SetState(state)
+			// When
+			processState, err := sut.ProcessState()
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(processState).To(BeEmpty())
+		})
+		It("should succeed if pid is running", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Pid = alwaysRunningPid
+			Expect(state.SetInitPid(state.Pid)).To(Succeed())
+			sut.SetState(state)
+			// When
+			processState, err := sut.ProcessState()
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(processState).To(Equal("S")) // A process will be sleeping most of the time.
+		})
+		It("should be false if pid is not running", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Pid = neverRunningPid
+			// SetInitPid will fail because the pid is not running
+			Expect(state.SetInitPid(state.Pid)).NotTo(Succeed())
+			sut.SetState(state)
+			// When
+			processState, err := sut.ProcessState()
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(processState).To(BeEmpty())
+		})
+	})
 	t.Describe("Pid", func() {
 		It("should fail if container state not set", func() {
 			// Given

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	kclock "k8s.io/utils/clock"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -45,6 +47,24 @@ const (
 
 	// Command line flag used to specify the run root directory
 	rootFlag = "--root"
+
+	// Configuration for the stop loop exponential backoff manager.
+	stopInitialBackoff = 20 * time.Millisecond
+	stopMaximumBackoff = 2 * time.Minute
+	stopResetBackoff   = 5 * time.Minute
+	stopBackoffFactor  = 2.0
+	stopBackoffJitter  = 1.25
+
+	// When to start the blocked process reminder and
+	// how frequently the reminder should be shown.
+	stopProcessBlockedInterval = stopMaximumBackoff / 2
+
+	// Used to delay periodic process liveness check. Part of the
+	// container stop loop where a goroutine wakes up on a regular
+	// basis to check whether a given PID (process) continues to
+	// run. This allows to short-circuit stop logic if the process
+	// has already been terminated.
+	stopProcessWatchSleep = 100 * time.Millisecond
 )
 
 // runtimeOCI is the Runtime interface implementation relying on conmon to
@@ -631,7 +651,7 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 
 		if r.handler.MonitorExecCgroup == config.MonitorExecCgroupContainer && r.config.InfraCtrCPUSet != "" {
 			// Update the exec's cgroup
-			containerPid, err := c.pid()
+			containerPid, _, err := c.pid()
 			if err != nil {
 				return err
 			}
@@ -810,21 +830,38 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 	}
 
 	if c.SetAsStopping() {
-		go r.StopLoopForContainer(c)
+		// The API is due to be deprecated. However, the replacement is completely broken, see:
+		//   https://github.com/kubernetes/kubernetes/issues/118638
+		go r.StopLoopForContainer(c,
+			kwait.NewExponentialBackoffManager( //nolint:staticcheck // Ignore deprecated function warning.
+				stopInitialBackoff,
+				stopMaximumBackoff,
+				stopResetBackoff,
+				stopBackoffFactor,
+				stopBackoffJitter,
+				&kclock.RealClock{},
+			),
+		)
 	}
 
 	c.WaitOnStopTimeout(ctx, timeout)
 	return nil
 }
 
-func (r *runtimeOCI) StopLoopForContainer(c *Container) {
+func (r *runtimeOCI) StopLoopForContainer(c *Container, bm kwait.BackoffManager) {
 	ctx := context.Background()
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
+	startTime := time.Now()
+
+	// Allow for SIGINT to correctly interrupt the stop loop, especially
+	// when CRI-O is run directly in the foreground in the terminal.
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
+
 	c.opLock.Lock()
 
-	// Begin the actual kill
+	// Begin the actual kill.
 	if _, err := r.runtimeCmd("kill", c.ID(), c.GetStopSignal()); err != nil {
 		if err := c.Living(); err != nil {
 			// The initial container process either doesn't exist, or isn't ours.
@@ -847,42 +884,60 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container) {
 				close(done)
 				return
 			}
-			// the PID is still active and belongs to the container, continue to wait
-			time.Sleep(100 * time.Millisecond)
+
+			// The PID is still active and belongs to the container, continue to wait.
+			time.Sleep(stopProcessWatchSleep)
 		}
 	}()
 
 	// Operate in terms of targetTime, so that we can pause in the middle of the operation
 	// to catch a new timeout (and possibly ignore that new timeout if it's not correct to
 	// take a new one).
-	targetTime := time.Unix(1<<50-1, 0)
-	for finished := false; !finished; {
+	targetTime := time.Now().AddDate(+1, 0, 0) // A year from this one.
+
+	blockedTimer := time.AfterFunc(stopProcessBlockedInterval, func() {
+		if state, err := c.ProcessState(); err == nil && state == "D" {
+			log.Errorf(ctx,
+				"Detected process (%d) blocked in uninterruptible sleep for more than %d seconds for container %s",
+				c.state.InitPid, int(time.Since(startTime)/time.Second), c.ID(),
+			)
+		}
+	})
+	defer blockedTimer.Stop()
+
+	// Do not start the stuck process reminder immediately.
+	blockedTimer.Stop()
+
+	// We cannot use ExponentialBackoff() here as its stop conditions are not flexible enough.
+	kwait.BackoffUntil(func() {
 		select {
 		case newTimeout := <-c.stopTimeoutChan:
-			// If a new timeout comes in,
-			// interrupt the old one, and start a new one
+			// If a new timeout comes in, interrupt the old one, and start a new one.
 			newTargetTime := time.Now().Add(time.Duration(newTimeout) * time.Second)
 
-			// but only if it's earlier
+			// But, only if it's an earlier one.
 			if newTargetTime.Before(targetTime) {
 				targetTime = newTargetTime
 			}
 
 		case <-time.After(time.Until(targetTime)):
-			log.Warnf(ctx, "Stopping container %v with stop signal timed out. Killing", c.ID())
+			log.Warnf(ctx, "Stopping container %s with stop signal timed out. Killing...", c.ID())
+
 			if _, err := r.runtimeCmd("kill", c.ID(), "KILL"); err != nil {
 				log.Errorf(ctx, "Killing container %v failed: %v", c.ID(), err)
 			}
+
 			if err := c.Living(); err != nil {
-				finished = true
-				break
+				stop()
 			}
 
+			// Reschedule the timer so that the periodic reminder can continue.
+			blockedTimer.Reset(stopProcessBlockedInterval)
+
 		case <-done:
-			finished = true
-			break
+			stop()
 		}
-	}
+	}, bm, true, ctx.Done())
 
 	c.state.Finished = time.Now()
 	c.opLock.Unlock()

--- a/internal/oci/runtime_oci_test.go
+++ b/internal/oci/runtime_oci_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	kclock "k8s.io/utils/clock"
 )
 
 const (
@@ -30,6 +32,7 @@ var _ = t.Describe("Oci", func() {
 			sleepProcess *exec.Cmd
 			runner       *runnerMock.MockCommandRunner
 			runtime      oci.RuntimeOCI
+			bm           kwait.BackoffManager
 		)
 		BeforeEach(func() {
 			sleepProcess = exec.Command("sleep", "100000")
@@ -51,6 +54,14 @@ var _ = t.Describe("Oci", func() {
 			r, err := oci.New(cfg)
 			Expect(err).To(BeNil())
 			runtime = oci.NewRuntimeOCI(r, &libconfig.RuntimeHandler{})
+			bm = kwait.NewExponentialBackoffManager( //nolint:staticcheck
+				1.0, // Initial backoff.
+				10,  // Maximum backoff.
+				10,  // Reset backoff.
+				2.0, // Backoff factor.
+				0.0, // Backoff jitter.
+				kclock.RealClock{},
+			)
 		})
 		AfterEach(func() {
 			// nolint:errcheck
@@ -89,7 +100,7 @@ var _ = t.Describe("Oci", func() {
 
 			// When
 			sut.SetAsStopping()
-			go runtime.StopLoopForContainer(sut)
+			go runtime.StopLoopForContainer(sut, bm)
 			stoppedChan := stopTimeoutWithChannel(context.Background(), sut, shortTimeout)
 			<-stoppedChan
 
@@ -109,7 +120,7 @@ var _ = t.Describe("Oci", func() {
 				),
 			)
 			sut.SetAsStopping()
-			go runtime.StopLoopForContainer(sut)
+			go runtime.StopLoopForContainer(sut, bm)
 
 			// Then
 			waitOnContainerTimeout(sut, longTimeout, mediumTimeout, sleepProcess)
@@ -118,7 +129,7 @@ var _ = t.Describe("Oci", func() {
 			// Given
 			containerIgnoreSignalCmdrunnerMock(sleepProcess, runner)
 			sut.SetAsStopping()
-			go runtime.StopLoopForContainer(sut)
+			go runtime.StopLoopForContainer(sut, bm)
 
 			// Then
 			waitOnContainerTimeout(sut, shortTimeout, mediumTimeout, sleepProcess)
@@ -127,7 +138,7 @@ var _ = t.Describe("Oci", func() {
 			// Given
 			containerIgnoreSignalCmdrunnerMock(sleepProcess, runner)
 			sut.SetAsStopping()
-			go runtime.StopLoopForContainer(sut)
+			go runtime.StopLoopForContainer(sut, bm)
 			go sut.WaitOnStopTimeout(context.Background(), longTimeout)
 
 			// Then
@@ -138,7 +149,7 @@ var _ = t.Describe("Oci", func() {
 			// Given
 			containerIgnoreSignalCmdrunnerMock(sleepProcess, runner)
 			sut.SetAsStopping()
-			go runtime.StopLoopForContainer(sut)
+			go runtime.StopLoopForContainer(sut, bm)
 
 			// When
 			shortStopChan := stopTimeoutWithChannel(context.Background(), sut, shortTimeout)
@@ -151,7 +162,7 @@ var _ = t.Describe("Oci", func() {
 			// Given
 			containerIgnoreSignalCmdrunnerMock(sleepProcess, runner)
 			sut.SetAsStopping()
-			go runtime.StopLoopForContainer(sut)
+			go runtime.StopLoopForContainer(sut, bm)
 			// very long timeout
 			stoppedChan := stopTimeoutWithChannel(context.Background(), sut, longTimeout*10)
 

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1133,3 +1133,67 @@ function check_oci_annotation() {
 	[ ! -f "$mounted_log_path" ]
 	[ ! -f "$linked_log_path" ]
 }
+
+@test "ctr stop loop kill retry attempts" {
+	FAKE_RUNTIME_BINARY_PATH="$TESTDIR"/fake
+	FAKE_RUNTIME_ATTEMPTS_LOG="$TESTDIR"/fake.log
+
+	# Both values should be adjusted to match the current
+	# exponential backoff configuration of the container
+	# stop loop retry logic.
+	FAKE_RUNTIME_ATTEMPTS_LIMIT=10
+	FAKE_RUNTIME_ATTEMPTS_TIME_DURATION=30 # Seconds.
+
+	cat << EOF > "$FAKE_RUNTIME_BINARY_PATH"
+#!/usr/bin/env bash
+set -eo pipefail
+[[ \$* == *kill* ]] && {
+  attempts=\$(wc -l $FAKE_RUNTIME_ATTEMPTS_LOG || echo 0) ;
+  date +'%s' >> $FAKE_RUNTIME_ATTEMPTS_LOG ;
+  (( \${attempts%% *} > $FAKE_RUNTIME_ATTEMPTS_LIMIT )) || exit 0 ;
+}
+exec $RUNTIME_BINARY_PATH "\$@"
+EOF
+
+	cat << EOF > "$CRIO_CONFIG_DIR"/99-fake-runtime.conf
+[crio.runtime]
+default_runtime = "fake"
+[crio.runtime.runtimes.fake]
+runtime_path = "$FAKE_RUNTIME_BINARY_PATH"
+EOF
+	chmod 755 "$FAKE_RUNTIME_BINARY_PATH"
+
+	start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+
+	crictl start "$ctr_id"
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+
+	grep -q "Stopping container ${ctr_id} with stop signal timed out." "$CRIO_LOG"
+
+	readarray -t attempts < "$FAKE_RUNTIME_ATTEMPTS_LOG"
+
+	if ((${#attempts[@]} < FAKE_RUNTIME_ATTEMPTS_LIMIT)); then
+		echo "Container stop loop should have at least ${FAKE_RUNTIME_ATTEMPTS_LIMIT} kill attempts" >&3
+		return 1
+	fi
+
+	# The exponential backoff is not working if there are too many retry attempts.
+	if ((${#attempts[@]} > 100)); then
+		echo "Container stop loop has too many kill attempts" >&3
+		return 1
+	fi
+
+	# The test should run long enough to retry over 10 times, where the first
+	# and the last timestamp of when the kill command was invoked will be
+	# about a minute apart. As such, 30 seconds should be the minimum.
+	if ((${attempts[${#attempts[@]} - 1]} - attempts[0] < FAKE_RUNTIME_ATTEMPTS_TIME_DURATION)); then
+		echo "Container stop loop kill retry attempts should be at least 30 seconds apart" >&3
+		return 1
+	fi
+
+	run ! crictl inspect "$ctr_id"
+}


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/cri-o/cri-o/pull/7854

/assign kwilczynski

```release-note
None
```