### PR TITLE
packit: Update config and sync to Fedora

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,32 +1,162 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-specfile_path: cri-o.spec
-
 # name in upstream package repository or registry (e.g. in PyPI)
 upstream_package_name: cri-o
 upstream_tag_template: v{version}
 # downstream (Fedora) RPM package name
 downstream_package_name: cri-o
-actions:
-  post-upstream-clone: "wget https://src.fedoraproject.org/rpms/cri-o/raw/rawhide/f/cri-o.spec -O cri-o.spec"
-srpm_build_deps: ["wget"]
+
+packages:
+  fedora-rawhide:
+    specfile_path: .packit_rpm/cri-o.spec
+    files_to_sync:
+      - .packit.yaml
+      - src: .packit_rpm/cri-o.spec
+        dest: cri-o.spec
+    actions:
+      get-current-version: "bash -ec 'grep \"^const Version\" internal/version/version.go | cut -d\\\" -f2'"
+      post-upstream-clone:
+        # Use the Fedora Rawhide specfile
+        - "git clone https://src.fedoraproject.org/rpms/cri-o .packit_rpm --depth=1"
+        # Drop the "sources" file
+        - "rm -fv .packit_rpm/sources"
+        # Update %global commit0 <sha> in specfile
+        - "sed -i \"s/^%global commit0.*/%global commit0 $(git rev-parse HEAD)/\" .packit_rpm/cri-o.spec"
+        # Remove downstream patches (if any)
+        - "sed -ri '/^Patch[0-9].*/d' .packit_rpm/cri-o.spec"
+  fedora-40:
+    # v1.28.x
+    # Propose minor and patch releases downstream
+    # TODO: Use mask '\d+\.\d+\' after f40 switches to v1.29.x
+    version_update_mask: '\d+\'
+    specfile_path: .packit_rpm/cri-o.spec
+    files_to_sync:
+      - .packit.yaml
+      - src: .packit_rpm/cri-o.spec
+        dest: cri-o.spec
+    actions:
+      post-upstream-clone:
+        # Use the Fedora 40 specfile
+        - "git clone https://src.fedoraproject.org/rpms/cri-o .packit_rpm --branch=f40 --depth=1"
+        # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
+        - "rm -fv .packit_rpm/sources"
+        # Update %global commit0 <sha> in specfile
+        - "sed -i \"s/^%global commit0.*/%global commit0 $(git rev-parse HEAD)/\" .packit_rpm/cri-o.spec"
+  fedora-39:
+    # v1.27.x
+    # Only propose patch releases downstream
+    version_update_mask: '\d+\.\d+\'
+    specfile_path: .packit_rpm/cri-o.spec
+    files_to_sync:
+      - .packit.yaml
+      - src: .packit_rpm/cri-o.spec
+        dest: cri-o.spec
+    actions:
+      post-upstream-clone:
+        # Use the Fedora 39 specfile
+        - "git clone https://src.fedoraproject.org/rpms/cri-o .packit_rpm --branch=f39 --depth=1"
+        # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
+        - "rm -fv .packit_rpm/sources"
+        # Update %global commit0 <sha> in specfile
+        - "sed -i \"s/^%global commit0.*/%global commit0 $(git rev-parse HEAD)/\" .packit_rpm/cri-o.spec"
+
 jobs:
 - job: copr_build
-  trigger: commit
-  owner: "@OKD"
-  project: okd
+  trigger: pull_request
+  branch: main
   targets:
     - centos-stream-9-aarch64
     - centos-stream-9-x86_64
-    - fedora-all-aarch64
-    - fedora-all-x86_64
+    - fedora-development-aarch64
+    - fedora-development-x86_64
+    - fedora-latest-stable-aarch64
+    - fedora-latest-stable-x86_64
+  packages:
+    - fedora-rawhide
+
 - job: copr_build
-  trigger: release
-  owner: "@OKD"
-  project: okd
+  trigger: pull_request
+  branch: release-1.30
   targets:
     - centos-stream-9-aarch64
     - centos-stream-9-x86_64
-    - fedora-all-aarch64
-    - fedora-all-x86_64
+    - fedora-development-aarch64
+    - fedora-development-x86_64
+    - fedora-latest-stable-aarch64
+    - fedora-latest-stable-x86_64
+  packages:
+    - fedora-rawhide
+
+- job: copr_build
+  trigger: pull_request
+  branch: release-1.29
+  targets:
+    - centos-stream-9-aarch64
+    - centos-stream-9-x86_64
+    - fedora-rawhide-aarch64
+    - fedora-rawhide-x86_64
+    - fedora-40-aarch64
+    - fedora-40-x86_64
+  packages:
+    - fedora-40
+
+- job: copr_build
+  trigger: pull_request
+  branch: release-1.28
+  targets:
+    - centos-stream-9-aarch64
+    - centos-stream-9-x86_64
+    - fedora-rawhide-aarch64
+    - fedora-rawhide-x86_64
+    - fedora-40-aarch64
+    - fedora-40-x86_64
+  packages:
+    - fedora-40
+
+- job: copr_build
+  trigger: pull_request
+  branch: release-1.27
+  targets:
+    - centos-stream-9-aarch64
+    - centos-stream-9-x86_64
+    - fedora-rawhide-aarch64
+    - fedora-rawhide-x86_64
+    - fedora-39-aarch64
+    - fedora-39-x86_64
+  packages:
+    - fedora-39
+
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - rawhide
+  packages:
+    - fedora-rawhide
+
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - f40
+  packages:
+    - fedora-40
+
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - f39
+  packages:
+    - fedora-39
+
+# downstream automation:
+- job: koji_build
+  trigger: commit
+  allowed_pr_authors: ["packit-stg", "packit", "haircommander", "lorbus"]
+  dist_git_branches:
+    - fedora-all
+
+- job: bodhi_update
+  trigger: commit
+  allowed_pr_authors: ["packit-stg", "packit", "haircommander", "lorbus"]
+  dist_git_branches:
+    - fedora-branched


### PR DESCRIPTION
With this change:
- COPR builds are now run per-PR
- Packit will open PRs to the Fedora dist-git repo when a new release is created
- the `%global commit0` value is updated in the specfile for each build

cc @haircommander 

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind ci

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
packit: Update config and sync to Fedora
```
