### PR TITLE
Deflake seccomp notifier bats tests

### DIFF
--- a/test/seccomp_notifier.bats
+++ b/test/seccomp_notifier.bats
@@ -41,10 +41,11 @@ function teardown() {
 	done
 
 	sleep 6 # wait until the notifier stop the workload
-	EXPECTED_EXIT_STATUS=137 wait_until_exit "$CTR"
 
 	# Assert
 	grep -q "Got seccomp notifier message for container ID: $CTR (syscall = swapoff)" "$CRIO_LOG"
+	# Check if container exited
+	crictl inspect "$CTR" | jq -e '.status.state == "CONTAINER_EXITED"'
 	crictl inspect "$CTR" | jq -e '.status.reason == "seccomp killed"'
 	crictl inspect "$CTR" | jq -e '.status.message == "Used forbidden syscalls: swapoff (3x)"'
 	curl -sf "http://localhost:$PORT/metrics" | grep 'container_runtime_crio_containers_seccomp_notifier_count_total{name="k8s_podsandbox1-redis_podsandbox1_redhat.test.crio_redhat-test-crio_0",syscall="swapoff"} 3'
@@ -102,10 +103,11 @@ function teardown() {
 	done
 
 	sleep 6 # wait until the notifier stop the workload
-	EXPECTED_EXIT_STATUS=137 wait_until_exit "$CTR"
 
 	# Assert
 	grep -q "Got seccomp notifier message for container ID: $CTR (syscall = swapoff)" "$CRIO_LOG"
+	# Check if container exited
+	crictl inspect "$CTR" | jq -e '.status.state == "CONTAINER_EXITED"'
 	crictl inspect "$CTR" | jq -e '.status.reason == "seccomp killed"'
 	crictl inspect "$CTR" | jq -e '.status.message == "Used forbidden syscalls: swapoff (5x)"'
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind ci
/kind failing-test

#### What this PR does / why we need it:

In some cases the notifier does not have time to stop the workload, in that cases 
exit code is `0`.

This PR increase a bit the timers and sleep interval.

#### Which issue(s) this PR fixes:

Fixes #7932

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

```release-note
None
```
