### PR TITLE
oci: AttachContainer: always read attach socket

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1185,12 +1185,10 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 	defer conn.Close()
 
 	receiveStdout := make(chan error)
-	if outputStream != nil || errorStream != nil {
-		go func() {
-			receiveStdout <- redirectResponseToOutputStreams(outputStream, errorStream, conn)
-			close(receiveStdout)
-		}()
-	}
+	go func() {
+		receiveStdout <- redirectResponseToOutputStreams(outputStream, errorStream, conn)
+		close(receiveStdout)
+	}()
 
 	stdinDone := make(chan error)
 	go func() {
@@ -1226,12 +1224,8 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 		if _, ok := err.(utils.DetachError); ok {
 			return nil
 		}
-		if outputStream != nil || errorStream != nil {
-			return <-receiveStdout
-		}
+		return <-receiveStdout
 	}
-
-	return nil
 }
 
 // ReopenContainerLog reopens the log file of a container.


### PR DESCRIPTION
conmon uses blocking writes on attach socket, if we do not read at all, conmon will be stuck.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind bug

#### What this PR does / why we need it:

On an attach request with both stdout and stderr disabled, when there are output, since we never read from conmon attach socket in this case, conmon will be stuck at writing, and as a result, stdio of the container will be frozen.

It can be reproduced with a container that runs `cat` and an attach request with large enough data (above 1MB seems to be enough) for stdin, and disabled stdout, stderr.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
