### PR TITLE
test: use kata 3.6.0 for testing

### DIFF
--- a/contrib/test/ci/build/kata.yml
+++ b/contrib/test/ci/build/kata.yml
@@ -61,7 +61,7 @@
   block:
     - name: Get and extract kata tarball from upstream release
       unarchive:
-        src: "https://github.com/kata-containers/kata-containers/releases/download/{{ kata_version }}/kata-static-{{ kata_version }}-x86_64.tar.xz"
+        src: "https://github.com/kata-containers/kata-containers/releases/download/{{ kata_version }}/kata-static-{{ kata_version }}-amd64.tar.xz"
         dest: "/"
         remote_src: yes
 

--- a/contrib/test/ci/build/kata.yml
+++ b/contrib/test/ci/build/kata.yml
@@ -64,3 +64,11 @@
         src: "https://github.com/kata-containers/kata-containers/releases/download/{{ kata_version }}/kata-static-{{ kata_version }}-x86_64.tar.xz"
         dest: "/"
         remote_src: yes
+
+- name: Set debugging logs
+  block:
+    - name: Edit Kata Containers config to enable debug log level
+      replace:
+        path: "/opt/kata/share/defaults/kata-containers/configuration.toml"
+        regexp: '^#enable_debug = true'
+        replace: 'enable_debug = true'

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -89,6 +89,7 @@ kata_int_test_env:
     PRIVILEGED_WITHOUT_HOST_DEVICES: true
     RUNTIME_CONFIG_PATH: "/opt/kata/share/defaults/kata-containers/configuration.toml"
     PATH: "/opt/kata/bin:{{ ansible_env.PATH }}"
+    CONTAINER_STORAGE_OPT: "overlay.skip_mount_home=true"
 
 kata_skip_cgroups_tests:
   - 'test "pids limit"'

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -57,7 +57,6 @@ kata_skip_files:
   - "ctr_seccomp.bats"  # see https://github.com/kata-containers/tests/issues/4587
   - "ctr_userns.bats"
   - "drop_infra.bats"   # infra ctr is not dropped on purpose with kata
-  - "hooks.bats"        # hook test is being dropped while we wait for https://github.com/kata-containers/kata-containers/issues/9523
   - "infra_ctr_cpuset.bats"
   - "imagefsinfo.bats"  # image and container filesystems is not in kata at the moment
   - "inspect.bats"

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -44,7 +44,7 @@ ssh_user: "{{ lookup('env','USER') }}"
 ssh_location: "{{ lookup('env','HOME') }}/.ssh/id_rsa"
 
 # variables for testing with the kata-containers runtime
-kata_version: "3.1.3"
+kata_version: "3.6.0"
 
 kata_skip_files:
   - "apparmor.bats"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -376,6 +376,11 @@ function cleanup_test() {
         cleanup_pods
         stop_crio
         cleanup_testdir
+        if [ "$RUNTIME_TYPE" == "vm" ]; then
+            # cleanup left over kata processes
+            # don't fail if there is none
+            run killall containerd-shim-kata-v2
+        fi
     else
         echo >&3 "* Failed \"$BATS_TEST_DESCRIPTION\", TESTDIR=$TESTDIR, LVM_DEVICE=${LVM_DEVICE:-}"
     fi

--- a/test/kata.bats
+++ b/test/kata.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+# vim: set syntax=sh:
+
+# this is a canary test for the CI job for kata: if this one fails, all the others
+# are dubious, as it means they probably run without kata
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "container run with kata should have containerd-shim-kata-v2 process running" {
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip Not running with kata
+	fi
+	start_crio
+
+	# make sure no kata process is running before we start a container
+	output="$(ps --no-headers -C containerd-shim-kata-v2 | wc -l)"
+	echo "$output"
+	[[ "$output" == "0" ]]
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	# verify that the shim is running
+	[ "$(ps --no-headers -C containerd-shim-kata-v2 | wc -l)" == "1" ]
+
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+
+	# verify that the shim goes away with the pod
+	[ "$(ps --no-headers -C containerd-shim-kata-v2 | wc -l)" == "0" ]
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Update the version of kata to test with - using the latest 3.6.0 version. 
Also make kata test specific changes (affecting only the fedora-kata job).

Details:
- move to kata 3.6.0
- enable hooks tests, as the fix for it was released with 3.5.0
- make sure the storage.overlay.skip_mount_home flag is set to true (problem introduced with kata 3.3.0)
- enable debug logs for kata
- cleanup lingering kata processes on teardown
- add an integration test specific to kata, testing we're actually using the kata runtime. Useful to validate config/script changes in the CI

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
