### PR TITLE
OCPNODE-2213: Add support for Recursive Read-only (RRO) mounts

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -130,6 +130,10 @@ kata_skip_ctr_tests:
   - 'test "ctr with default_env set in configuration"'
   - 'test "ctr with absent mount that should be rejected"'
   - 'test "ctr stop loop kill retry attempts"'
+  - 'test "ctr that mounts container storage as read-only option but not recursively"'
+  - 'test "ctr that mounts container storage as recursively read-only"'
+  - 'test "ctr that fails to mount container storage as recursively read-only without readonly option"'
+  - 'test "ctr that fails to mount container storage as recursively read-only without private propagation"'
 kata_skip_devices_tests:
   - 'test "additional devices permissions"'
   - 'test "annotation devices support"'

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -87,11 +87,12 @@ func (c *Container) CRIAttributes() *types.ContainerAttributes {
 
 // ContainerVolume is a bind mount for the container.
 type ContainerVolume struct {
-	ContainerPath  string                 `json:"container_path"`
-	HostPath       string                 `json:"host_path"`
-	Readonly       bool                   `json:"readonly"`
-	Propagation    types.MountPropagation `json:"propagation"`
-	SelinuxRelabel bool                   `json:"selinux_relabel"`
+	ContainerPath     string                 `json:"container_path"`
+	HostPath          string                 `json:"host_path"`
+	Readonly          bool                   `json:"readonly"`
+	RecursiveReadOnly bool                   `json:"recursive_read_only"`
+	Propagation       types.MountPropagation `json:"propagation"`
+	SelinuxRelabel    bool                   `json:"selinux_relabel"`
 }
 
 // ContainerState represents the status of a container.

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -214,6 +214,18 @@ func (r *Runtime) RuntimeSupportsIDMap(runtimeHandler string) bool {
 	return rh.RuntimeSupportsIDMap()
 }
 
+// RuntimeSupportsRROMounts returns whether the runtime of runtimeHandler supports
+// the "runtime features" command and that the output advertises support for the
+// Recursive Read-only (RRO) mount as an option.
+func (r *Runtime) RuntimeSupportsRROMounts(runtimeHandler string) bool {
+	rh, err := r.getRuntimeHandler(runtimeHandler)
+	if err != nil {
+		return false
+	}
+
+	return rh.RuntimeSupportsRROMounts()
+}
+
 func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
 	rh, err := r.getRuntimeHandler(c.runtimeHandler)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,6 +190,12 @@ func (c *RootConfig) GetStore() (storage.Store, error) {
 	})
 }
 
+// runtimeHandlerFeatures represents the supported features of the runtime.
+type runtimeHandlerFeatures struct {
+	RecursiveReadOnlyMounts bool `json:"-"` // Internal use only.
+	features.Features
+}
+
 // RuntimeHandler represents each item of the "crio.runtime.runtimes" TOML
 // config table.
 type RuntimeHandler struct {
@@ -243,7 +249,7 @@ type RuntimeHandler struct {
 
 	// Output of the "features" subcommand.
 	// This is populated dynamically and not read from config.
-	features features.Features
+	features runtimeHandlerFeatures
 }
 
 // Multiple runtime Handlers in a map
@@ -1258,7 +1264,7 @@ func (c *RuntimeConfig) ValidateRuntimes() error {
 				return err
 			}
 
-			logrus.Warnf("'%s is being ignored due to: %q", name, err)
+			logrus.Warnf("Runtime handler %q is being ignored due to: %v", name, err)
 			failedValidation = append(failedValidation, name)
 		}
 	}
@@ -1275,12 +1281,12 @@ func (c *RuntimeConfig) initializeRuntimeFeatures() {
 	for name, handler := range c.Runtimes {
 		versionOutput, err := cmdrunner.CombinedOutput(handler.RuntimePath, "--version")
 		if err != nil {
-			logrus.Errorf("Unable to determine version of runtime handler %s: %v", name, err)
+			logrus.Errorf("Unable to determine version of runtime handler %q: %v", name, err)
 			continue
 		}
 
 		versionString := strings.ReplaceAll(strings.TrimSpace(string(versionOutput)), "\n", ", ")
-		logrus.Infof("Using runtime %s", versionString)
+		logrus.Infof("Using runtime handler %s", versionString)
 
 		memoryBytes, err := handler.SetContainerMinMemory()
 		if err != nil {
@@ -1298,10 +1304,33 @@ func (c *RuntimeConfig) initializeRuntimeFeatures() {
 			logrus.Errorf("Getting %s OCI runtime features failed: %s: %v", handler.RuntimePath, output, err)
 			continue
 		}
-		// Ignore errors to Unmarshal too, we can't populate it.
-		if err := json.Unmarshal(output, &handler.features); err != nil {
-			logrus.Errorf("Unmarshalling OCI features failed: %s", err)
+
+		// Ignore error if we can't load runtime features.
+		if err := handler.LoadRuntimeFeatures(output); err != nil {
+			logrus.Errorf("Unable to load OCI features for runtime handler %q: %v", name, err)
+			continue
 		}
+
+		if handler.RuntimeSupportsIDMap() {
+			logrus.Debugf("Runtime handler %q supports User and Group ID-mappings", name)
+		}
+
+		// Recursive Read-only (RRO) mounts require runtime handler support,
+		// such as runc v1.1 or crun v1.4. For Linux, the minimum kernel
+		// version 5.12 or a kernel with the necessary changes backported
+		// is required.
+		rro := handler.RuntimeSupportsMountFlag("rro")
+		if rro {
+			logrus.Debugf("Runtime handler %q supports Recursive Read-only (RRO) mounts", name)
+
+			// A given runtime might support Recursive Read-only (RRO) mounts,
+			// but the current kernel might not.
+			if err := checkKernelRROMountSupport(); err != nil {
+				logrus.Warnf("Runtime handler %q supports Recursive Read-only (RRO) mounts, but kernel does not: %v", name, err)
+				rro = false
+			}
+		}
+		handler.features.RecursiveReadOnlyMounts = rro
 	}
 }
 
@@ -1621,6 +1650,29 @@ func (r *RuntimeHandler) SetContainerMinMemory() (int64, error) {
 	return memoryBytes, nil
 }
 
+// LoadRuntimeFeatures loads features for a given runtime handler using the "features"
+// sub-command output, where said output contains a JSON document called "Features
+// Structure" that describes the runtime handler's supported features.
+func (r *RuntimeHandler) LoadRuntimeFeatures(input []byte) error {
+	if err := json.Unmarshal(input, &r.features); err != nil {
+		return fmt.Errorf("unable to unmarshal features structure: %w", err)
+	}
+
+	// All other properties of the Features Structure are optional and might be
+	// either absent, empty, or set to the null value, with the exception of
+	// OCIVersionMin and OCIVersionMax, which are required. Thus, the lack of
+	// them should indicate that the Features Structure document is potentially
+	// not valid.
+	//
+	// See the following for more details about the Features Structure:
+	//   https://github.com/opencontainers/runtime-spec/blob/main/features.md
+	if r.features.OCIVersionMin == "" || r.features.OCIVersionMax == "" {
+		return errors.New("runtime features structure is not valid")
+	}
+
+	return nil
+}
+
 // RuntimeSupportsIDMap returns whether this runtime supports the "runtime features"
 // command, and that the output of that command advertises IDMap mounts as an option
 func (r *RuntimeHandler) RuntimeSupportsIDMap() bool {
@@ -1631,6 +1683,11 @@ func (r *RuntimeHandler) RuntimeSupportsIDMap() bool {
 		return false
 	}
 	return true
+}
+
+// RuntimeSupportsRROMounts returns whether this runtime supports the Recursive Read-only mount as an option.
+func (r *RuntimeHandler) RuntimeSupportsRROMounts() bool {
+	return r.features.RecursiveReadOnlyMounts
 }
 
 // RuntimeSupportsMountFlag returns whether this runtime supports the specified mount option.

--- a/pkg/config/config_freebsd.go
+++ b/pkg/config/config_freebsd.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/cri-o/cri-o/utils/errdefs"
+
 // Defaults if none are specified
 // Defaults for linux/unix if none are specified
 const (
@@ -39,6 +41,11 @@ const (
 
 func selinuxEnabled() bool {
 	return false
+}
+
+// checkKernelRROMountSupport checks the kernel support for the Recursive Read-only (RRO) mounts.
+func checkKernelRROMountSupport() error {
+	return errdefs.ErrNotImplemented
 }
 
 func (c *RuntimeConfig) ValidatePinnsPath(executable string) error {

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,6 +1,16 @@
 package config
 
-import selinux "github.com/opencontainers/selinux/go-selinux"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/containers/storage/pkg/parsers/kernel"
+	selinux "github.com/opencontainers/selinux/go-selinux"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
 
 // Defaults if none are specified
 const (
@@ -14,6 +24,11 @@ const (
 	DefaultPauseImage string = "registry.k8s.io/pause:3.9"
 )
 
+var (
+	kernelRROSupportOnce  sync.Once
+	kernelRROSupportError error
+)
+
 func selinuxEnabled() bool {
 	return selinux.GetEnabled()
 }
@@ -23,4 +38,106 @@ func (c *RuntimeConfig) ValidatePinnsPath(executable string) error {
 	c.PinnsPath, err = validateExecutablePath(executable, c.PinnsPath)
 
 	return err
+}
+
+// checkKernelRROMountSupport checks the kernel support for the Recursive Read-only (RRO) mounts.
+func checkKernelRROMountSupport() error {
+	kernelRROSupportOnce.Do(func() {
+		kernelRROSupportError = (func() error {
+			// Check the current kernel version for RRO mounts support...
+			err := validateKernelRROVersion()
+			if err != nil {
+				versionErr := err
+				// ... and if the kernel version does not match the minimum required version,
+				// then verify whether the kernel supports RRO mounts regardless, as often
+				// Linux distributions provide heavily patched kernel releases, and the
+				// current kernel might include backported support.
+				err = validateKernelRROMount()
+				if err != nil {
+					err = fmt.Errorf("%w: %w", versionErr, err)
+				}
+			}
+			return err
+		})()
+	})
+
+	return kernelRROSupportError
+}
+
+// validateKernelRROVersion checks whether the current kernel version matches the release 5.12 or newer,
+// which is the minimum required kernel version that supports Recursive Read-only (RRO) mounts.
+func validateKernelRROVersion() error {
+	kv, err := kernel.GetKernelVersion()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve kernel version: %w", err)
+	}
+
+	result := kernel.CompareKernelVersion(*kv,
+		kernel.VersionInfo{
+			Kernel: 5,
+			Major:  12,
+			Minor:  0,
+		},
+	)
+	if result < 0 {
+		return fmt.Errorf("kernel version %q does not support recursive read-only mounts", kv)
+	}
+
+	return nil
+}
+
+// validateKernelRROMount checks whether the current kernel can support Recursive Read-only mounts.
+// It uses a test mount of tmpfs against which an attempt will be made to set the required attributes.
+// If there is no failure in doing so, then the kernel has the required support.
+func validateKernelRROMount() error {
+	path, err := os.MkdirTemp("", "crio-rro-*")
+	if err != nil {
+		return fmt.Errorf("unable to create directory: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(path); err != nil {
+			logrus.Errorf("Unable to remove directory: %v", err)
+		}
+	}()
+
+	for {
+		err = unix.Mount("", path, "tmpfs", 0, "")
+		if !errors.Is(err, unix.EINTR) {
+			break
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("unable to mount directory %q using tmpfs: %w", path, err)
+	}
+	defer func() {
+		var unmountErr error
+		for {
+			unmountErr = unix.Unmount(path, 0)
+			if !errors.Is(unmountErr, unix.EINTR) {
+				break
+			}
+		}
+		if unmountErr != nil {
+			logrus.Errorf("Unable to unmount directory %q: %v", path, unmountErr)
+		}
+	}()
+
+	for {
+		err = unix.MountSetattr(-1, path, unix.AT_RECURSIVE,
+			&unix.MountAttr{
+				Attr_set: unix.MOUNT_ATTR_RDONLY,
+			},
+		)
+		if !errors.Is(err, unix.EINTR) {
+			break
+		}
+	}
+	if err != nil {
+		if !errors.Is(err, unix.ENOSYS) {
+			return fmt.Errorf("unable to set mount attribute for directory %q: %w", path, err)
+		}
+		return fmt.Errorf("unable to set recursive read-only mount attribute: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/config/config_unsupported.go
+++ b/pkg/config/config_unsupported.go
@@ -1,6 +1,9 @@
-//go:build !linux && !freebsd
+//go:build !linux && !freebsd && !windows
+// +build !linux,!freebsd,!windows
 
 package config
+
+import "github.com/cri-o/cri-o/utils/errdefs"
 
 // Defaults if none are specified
 // This uses the Linux values, just to have something that compiles. They don’t even pass unit tests.
@@ -17,4 +20,9 @@ const (
 
 func selinuxEnabled() bool {
 	return false
+}
+
+// checkKernelRROMountSupport checks the kernel support for the Recursive Read-only (RRO) mounts.
+func checkKernelRROMountSupport() error {
+	return errdefs.ErrNotImplemented
 }

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/cri-o/cri-o/utils/errdefs"
+
 // Defaults for linux/unix if none are specified
 const (
 	cniConfigDir             = "C:\\cni\\etc\\net.d\\"
@@ -19,3 +21,8 @@ const (
 	// CrioVersionPath is where the CRI-O version file is located
 	CrioConfigPath = "C:\\crio\\etc\\version"
 )
+
+// checkKernelRROMountSupport checks the kernel support for the Recursive Read-only (RRO) mounts.
+func checkKernelRROMountSupport() error {
+	return errdefs.ErrNotImplemented
+}

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -322,6 +322,8 @@ func (s *Server) CRImportCheckpoint(
 			switch opt {
 			case "ro":
 				mount.Readonly = true
+			case "rro":
+				mount.RecursiveReadOnly = true
 			case "rprivate":
 				mount.Propagation = types.MountPropagation_PROPAGATION_PRIVATE
 			case "rshared":
@@ -329,6 +331,13 @@ func (s *Server) CRImportCheckpoint(
 			case "rslaved":
 				mount.Propagation = types.MountPropagation_PROPAGATION_HOST_TO_CONTAINER
 			}
+		}
+
+		// Recursive Read-only (RRO) support requires the mount to be
+		// read-only and the mount propagation set to private.
+		if mount.RecursiveReadOnly {
+			mount.Readonly = true
+			mount.Propagation = types.MountPropagation_PROPAGATION_PRIVATE
 		}
 
 		log.Debugf(ctx, "Adding mounts %#v", mount)

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -53,11 +53,12 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 	mounts := []*types.Mount{}
 	for _, cv := range c.Volumes() {
 		mounts = append(mounts, &types.Mount{
-			ContainerPath:  cv.ContainerPath,
-			HostPath:       cv.HostPath,
-			Readonly:       cv.Readonly,
-			Propagation:    cv.Propagation,
-			SelinuxRelabel: cv.SelinuxRelabel,
+			ContainerPath:     cv.ContainerPath,
+			HostPath:          cv.HostPath,
+			Readonly:          cv.Readonly,
+			RecursiveReadOnly: cv.RecursiveReadOnly,
+			Propagation:       cv.Propagation,
+			SelinuxRelabel:    cv.SelinuxRelabel,
 		})
 	}
 	resp.Status.Mounts = mounts

--- a/server/runtime_status.go
+++ b/server/runtime_status.go
@@ -48,10 +48,7 @@ func (s *Server) Status(ctx context.Context, req *types.StatusRequest) (*types.S
 			}
 		}
 
-		// TODO: enable when CRI-O implemented Recursive Read-only (RRO) mounts
-		// rro := runtime.RuntimeSupportsMountFlag("rro")
-		rro := false
-
+		rro := runtime.RuntimeSupportsRROMounts()
 		userns := runtime.RuntimeSupportsIDMap()
 		h := makeRuntimeHandler(name, rro, userns)
 		resp.RuntimeHandlers = append(resp.RuntimeHandlers, h)

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1032,6 +1032,11 @@ function check_oci_annotation() {
 }
 
 @test "ctr that mounts container storage as recursively read-only" {
+	requires_kernel "5.12"
+
+	# Check for the minimum cri-tools version that supports RRO mounts.
+	requires_crictl "1.30"
+
 	# See https://www.shellcheck.net/wiki/SC2154 for more details.
 	declare stderr
 
@@ -1069,6 +1074,9 @@ function check_oci_annotation() {
 }
 
 @test "ctr that fails to mount container storage as recursively read-only without readonly option" {
+	# Check for the minimum cri-tools version that supports RRO mounts.
+	requires_crictl "1.30"
+
 	# See https://www.shellcheck.net/wiki/SC2154 for more details.
 	declare stderr
 
@@ -1092,6 +1100,9 @@ function check_oci_annotation() {
 }
 
 @test "ctr that fails to mount container storage as recursively read-only without private propagation" {
+	# Check for the minimum cri-tools version that supports RRO mounts.
+	requires_crictl "1.30"
+
 	# See https://www.shellcheck.net/wiki/SC2154 for more details.
 	declare stderr
 

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -997,6 +997,14 @@ function check_oci_annotation() {
 }
 
 @test "ctr that mounts container storage as read-only option but not recursively" {
+	# When SELinux is enabled and set to Enforcing, then the read-only
+	# mounts within a container will stop sub-mounts access in a read-write
+	# manner, and this test will then fail, thus it's best to disable it.
+	# Note: This is not a problem on a systems without SELinux.
+	if is_selinux_enforcing; then
+		skip "SELinux is set to Enforcing"
+	fi
+
 	# See https://www.shellcheck.net/wiki/SC2154 for more details.
 	declare stderr
 

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -996,6 +996,125 @@ function check_oci_annotation() {
 	crictl exec --sync "$ctr_id" findmnt -no TARGET,PROPAGATION "$CTR_DIR" | grep -v private
 }
 
+@test "ctr that mounts container storage as read-only option but not recursively" {
+	# See https://www.shellcheck.net/wiki/SC2154 for more details.
+	declare stderr
+
+	# Parent of "--root", keep in sync with test/helpers.bash file.
+	TEST_VOLUME="$TESTDIR"/test-volume
+
+	mkdir -p "$TEST_VOLUME"
+	mount -t tmpfs none "$TEST_VOLUME"
+
+	mkdir -p "$TEST_VOLUME"/test-sub-volume
+	mount -t tmpfs none "$TEST_VOLUME"/test-sub-volume
+
+	PARENT_DIR="$TEST_VOLUME"
+	CTR_DIR="/host"
+
+	jq --arg path "$PARENT_DIR" --arg ctr_dir "$CTR_DIR" \
+		'  .mounts = [ {
+			host_path: $path,
+			container_path: $ctr_dir,
+			readonly: true,
+			propagation: 0
+		} ]' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR"/config
+
+	start_crio
+
+	ctr_id=$(crictl run "$TESTDIR"/config "$TESTDATA"/sandbox_config.json)
+
+	run ! --separate-stderr crictl exec --sync "$ctr_id" touch /host/test
+	[[ "$stderr" == *"Read-only file system"* ]]
+
+	crictl exec --sync "$ctr_id" touch /host/test-sub-volume/test
+}
+
+@test "ctr that mounts container storage as recursively read-only" {
+	# See https://www.shellcheck.net/wiki/SC2154 for more details.
+	declare stderr
+
+	# Parent of "--root", keep in sync with test/helpers.bash file.
+	TEST_VOLUME="$TESTDIR"/test-volume
+
+	mkdir -p "$TEST_VOLUME"
+	mount -t tmpfs none "$TEST_VOLUME"
+
+	mkdir -p "$TEST_VOLUME"/test-sub-volume
+	mount -t tmpfs none "$TEST_VOLUME"/test-sub-volume
+
+	PARENT_DIR="$TEST_VOLUME"
+	CTR_DIR="/host"
+
+	jq --arg path "$PARENT_DIR" --arg ctr_dir "$CTR_DIR" \
+		'  .mounts = [ {
+			host_path: $path,
+			container_path: $ctr_dir,
+			readonly: true,
+			recursive_read_only: true,
+			propagation: 0
+		} ]' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR"/config
+
+	start_crio
+
+	ctr_id=$(crictl run "$TESTDIR"/config "$TESTDATA"/sandbox_config.json)
+
+	run ! --separate-stderr crictl exec --sync "$ctr_id" touch /host/test
+	[[ "$stderr" == *"Read-only file system"* ]]
+
+	run ! --separate-stderr crictl exec --sync "$ctr_id" touch /host/test-sub-volume/test
+	[[ "$stderr" == *"Read-only file system"* ]]
+}
+
+@test "ctr that fails to mount container storage as recursively read-only without readonly option" {
+	# See https://www.shellcheck.net/wiki/SC2154 for more details.
+	declare stderr
+
+	# Parent of "--root", keep in sync with test/helpers.bash file.
+	PARENT_DIR="$TESTDIR"
+	CTR_DIR="/host"
+
+	jq --arg path "$PARENT_DIR" --arg ctr_dir "$CTR_DIR" \
+		'  .mounts = [ {
+			host_path: $path,
+			container_path: $ctr_dir,
+			readonly: false,
+			recursive_read_only: true,
+		} ]' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR"/config
+
+	start_crio
+
+	run ! --separate-stderr crictl run "$TESTDIR"/config "$TESTDATA"/sandbox_config.json
+	[[ "$stderr" == *"recursive read-only mount conflicts with read-write mount"* ]]
+}
+
+@test "ctr that fails to mount container storage as recursively read-only without private propagation" {
+	# See https://www.shellcheck.net/wiki/SC2154 for more details.
+	declare stderr
+
+	# Parent of "--root", keep in sync with test/helpers.bash file.
+	PARENT_DIR="$TESTDIR"
+	CTR_DIR="/host"
+
+	jq --arg path "$PARENT_DIR" --arg ctr_dir "$CTR_DIR" \
+		'  .mounts = [ {
+			host_path: $path,
+			container_path: $ctr_dir,
+			readonly: true,
+			recursive_read_only: true,
+			propagation: 2
+		} ]' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR"/config
+
+	start_crio
+
+	run ! --separate-stderr crictl run "$TESTDIR"/config "$TESTDATA"/sandbox_config.json
+	[[ "$stderr" == *"recursive read-only mount requires private propagation"* ]]
+}
+
 @test "ctr has containerenv" {
 	start_crio
 	ctr_id=$(crictl run "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -404,6 +404,16 @@ function is_apparmor_enabled() {
     grep -q Y "$APPARMOR_PARAMETERS_FILE_PATH" 2>/dev/null
 }
 
+function is_selinux_enabled() {
+    selinuxenabled 2>/dev/null || false
+}
+
+function is_selinux_enforcing() {
+    command -v getenforce 1>/dev/null || false
+
+    [[ $(getenforce) == "Enforcing" ]]
+}
+
 function prepare_network_conf() {
     mkdir -p "$CRIO_CNI_CONFIG"
     cat >"$CRIO_CNI_CONFIG/10-crio.conf" <<-EOF

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -264,6 +264,44 @@ function host_and_port_listens() {
     netstat -ln46 | grep -E -q "${host}:${port}\b"
 }
 
+function check_kernel_version() {
+    local version="$1"
+
+    required_major=${version%%.*}
+    required_minor=${version##*.}
+
+    [[ $(uname -r) =~ ([0-9]+)\.([0-9]+) ]]
+    major=${BASH_REMATCH[1]}
+    minor=${BASH_REMATCH[2]}
+
+    ((major > required_major)) || ((major == required_major && minor >= required_minor))
+}
+
+function check_crictl_version() {
+    local version="$1"
+
+    required_major=${version%%.*}
+    required_minor=${version##*.}
+
+    crictl_binary=${CRICTL_BINARY:-/usr/bin/crictl}
+
+    [[ $($crictl_binary --version) =~ ([0-9]+)\.([0-9]+) ]]
+    major=${BASH_REMATCH[1]}
+    minor=${BASH_REMATCH[2]}
+
+    ((major > required_major)) || ((major == required_major && minor >= required_minor))
+}
+
+function requires_kernel() {
+    check_kernel_version "$@" ||
+        skip "requires kernel version \"$1\" or newer"
+}
+
+function requires_crictl() {
+    check_crictl_version "$@" ||
+        skip "requires crictl version \"$1\" or newer"
+}
+
 function cleanup_ctrs() {
     crictl rm -a -f
     rm -f "$HOOKSCHECK"

--- a/test/selinux.bats
+++ b/test/selinux.bats
@@ -22,7 +22,7 @@ function teardown() {
 }
 
 @test "selinux skips relabeling if TrySkipVolumeSELinuxLabel annotation is present" {
-	if [[ $(getenforce) != "Enforcing" ]]; then
+	if ! is_selinux_enforcing; then
 		skip "not enforcing"
 	fi
 
@@ -86,7 +86,7 @@ function teardown() {
 }
 
 @test "selinux skips relabeling for super privileged container" {
-	if [[ $(getenforce) != "Enforcing" ]]; then
+	if ! is_selinux_enforcing; then
 		skip "not enforcing"
 	fi
 	VOLUME="$TESTDIR"/dir


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Currently, the read-only option set for the host mounts does not correctly propagate recursively from the top level of the given mount point. As such, any sub-mounts that happen to be part of the tree would retain their current options, and should it be a read/write type mount, then it could be modified without any restriction. This is often both unexpected and undesirable.

Thus, add support for so-called Recursive Read-only (RRO) mounts. This allows a mount point to propagate the read-only option through the tree, marking the entire mount point read-only.

Support for the RRO mounts has already been available in the runtimes, such as **crun** and **runc**, for some time now.

> [!NOTE] 
> Support of the Recursive Read-only (RRO) mounts requires:
>
> - For Linux, kernel version 5.12
> - Kubernetes v1.30🔹
> - cri-tools v1.30
> - crun v1.4
> - runc v1.1
>
> 🔹⚠️ Feature gate called **RecursiveReadOnlyMounts** needs to be enabled given the _Alpha_ status of the feature.

Related to:

- https://github.com/kubernetes/enhancements/issues/3857
- https://github.com/kubernetes/enhancements/pull/3858
- https://github.com/kubernetes/kubernetes/pull/123272
- https://github.com/kubernetes-sigs/cri-tools/pull/1344
- https://github.com/opencontainers/runc/pull/3272
- https://github.com/containers/crun/pull/778

#### Which issue(s) this PR fixes:

A temporary workaround:

- https://github.com/cri-o/cri-o/pull/7828

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Add support for the Recursive Read-only (RRO) mounts following runtimes and kernel support to enable read-only mounts to be recursively read-only.
```
