### PR TITLE
test: fix potential flake in timezone tests.

### DIFF
--- a/test/image.bats
+++ b/test/image.bats
@@ -348,8 +348,9 @@ EOF
 		"$TESTDATA"/container_config.json > "$TESTDIR/timezone.json"
 
 	ctr_id=$(crictl run "$TESTDIR/timezone.json" "$TESTDATA/sandbox_config.json")
-	output=$(crictl exec "$ctr_id" date +"%a %b %e %H:%M:%S %Z %Y")
-	expected_output=$(TZ="Asia/Singapore" date +"%a %b %e %H:%M:%S %Z %Y")
+	datestr=$(date +%s)
+	output=$(crictl exec "$ctr_id" date -d "@$datestr" +"%a %b %e %H:%M:%S %Z %Y")
+	expected_output=$(TZ="Asia/Singapore" date -d "@$datestr" +"%a %b %e %H:%M:%S %Z %Y")
 	[[ "$output" == *"$expected_output"* ]]
 }
 
@@ -361,7 +362,8 @@ EOF
 		"$TESTDATA"/container_config.json > "$TESTDIR/empty_timezone.json"
 
 	ctr_id=$(crictl run "$TESTDIR/empty_timezone.json" "$TESTDATA/sandbox_config.json")
-	output=$(crictl exec "$ctr_id" date +"%a %b %e %H:%M:%S %Z %Y")
-	expected_output=$(date +"%a %b %e %H:%M:%S %Z %Y")
+	datestr=$(date +%s)
+	output=$(crictl exec "$ctr_id" date -d "@$datestr" +"%a %b %e %H:%M:%S %Z %Y")
+	expected_output=$(date -d "@$datestr" +"%a %b %e %H:%M:%S %Z %Y")
 	[[ "$output" == *"$expected_output"* ]]
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

I've seen occasional failures of the `run container in pod with local timezone` test in `images.bats`. Looking at he test case I think the reason for the failures is in the assumption that running `date` twice with second-level accuracy would always result in the same timestamp. This is not necessarily true when the initial invocation happens close enough to the 'edge' of a second. This PR removes that assumption by passing an explicit timestamp for formatting to both invocations of `date`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
