### PR TITLE
Do not abort startup if CRIU binary not found

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1160,11 +1160,12 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 		if c.EnableCriuSupport {
 			if err := validateCriuInPath(); err != nil {
 				c.EnableCriuSupport = false
-				return errors.New("cannot enable checkpoint/restore support without the criu binary in $PATH")
+				logrus.Infof("Checkpoint/restore support disabled: CRIU binary not found int $PATH")
+			} else {
+				logrus.Infof("Checkpoint/restore support enabled")
 			}
-			logrus.Infof("Checkpoint/restore support enabled")
 		} else {
-			logrus.Infof("Checkpoint/restore support disabled")
+			logrus.Infof("Checkpoint/restore support disabled via configuration")
 		}
 
 		if err := c.seccompConfig.LoadProfile(c.SeccompProfile); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Now that checkpoint/restore is turned on by default, CRI-O no longer starts up if the CRIU binary is missing. This changes the error if the CRIU binary is not found to an information message. Checkpoint/Restore support is turned of but CRI-O still starts.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I would have preferred a way to detect if the option has been explicitly set by the user, but that seems hard to detect (if possible at all). If the user explicitly requests `--enable-criu-support=true` then it would make sense to fail if the CRIU binary is not found. If the user is just using the default setting then it  should not be fatal if the CRIU binary is missing.

In Kubernetes I have seen something like this in combination with `*int` and if the value is `!=nil` something was selected by the user and if it is `nil` the default value is used. I have not seen something like this in CRI-O.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```