### PR TITLE
[release-1.29] OCPBUGS-29439: Cherry-pick changes from containers/image/pull#2363

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containers/common v0.57.1
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.6.2-0.20230920142715-f5a362044a57
-	github.com/containers/image/v5 v5.29.0
+	github.com/containers/image/v5 v5.29.1-0.20240409053318-bccacc1bc526
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.1.9
 	github.com/containers/podman/v4 v4.8.2

--- a/go.sum
+++ b/go.sum
@@ -891,8 +891,8 @@ github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6J
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.6.2-0.20230920142715-f5a362044a57 h1:EHiHMe0cOPvBzi20g/f+NzhjhPFTxpyAkpRE4h1ZAzw=
 github.com/containers/conmon-rs v0.6.2-0.20230920142715-f5a362044a57/go.mod h1:rMhWT6H3demwJCFuT+Bc9b+T9oypfZ5SnPzOrt6QNkg=
-github.com/containers/image/v5 v5.29.0 h1:9+nhS/ZM7c4Kuzu5tJ0NMpxrgoryOJ2HAYTgG8Ny7j4=
-github.com/containers/image/v5 v5.29.0/go.mod h1:kQ7qcDsps424ZAz24thD+x7+dJw1vgur3A9tTDsj97E=
+github.com/containers/image/v5 v5.29.1-0.20240409053318-bccacc1bc526 h1:I8oeZBvwcsF4e77Uz3dQNVf4ozVySxc42YVyZFSefK8=
+github.com/containers/image/v5 v5.29.1-0.20240409053318-bccacc1bc526/go.mod h1:kQ7qcDsps424ZAz24thD+x7+dJw1vgur3A9tTDsj97E=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=
 github.com/containers/kubensmnt v1.2.0/go.mod h1:1/HG09N/a1+WSD3zkurzeWtqlKRSfUUnlIF/08zloqk=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -336,7 +336,7 @@ github.com/containers/conmon/runner/config
 ## explicit; go 1.20
 github.com/containers/conmon-rs/internal/proto
 github.com/containers/conmon-rs/pkg/client
-# github.com/containers/image/v5 v5.29.0
+# github.com/containers/image/v5 v5.29.1-0.20240409053318-bccacc1bc526
 ## explicit; go 1.19
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from https://github.com/containers/image/pull/2363 as these changes contain a fix that needs to be backported to CRI-O release 1.29, part of OpenShift 4.16 release.

Related:

- https://github.com/containers/image/pull/2363

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```