### PR TITLE
[release-1.27] OCPBUGS-31926: Cherry-pick changes from containers/image/pull#2363

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/containers/common v0.53.1-0.20240105071334-6b57a0d02d83
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.5.0
-	github.com/containers/image/v5 v5.25.0
+	github.com/containers/image/v5 v5.25.1-0.20240409053420-67ee9a088e82
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.1.8
 	github.com/containers/podman/v4 v4.5.2-0.20230706090613-813f1b53bf39

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6J
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.5.0 h1:WN24G4Pv1VOoUBmXt2W5RflpIO0bFSIUUD8OvJ7Am+M=
 github.com/containers/conmon-rs v0.5.0/go.mod h1:U3C8gOq+K191KGwWg8pXLEOSa2ryN/DDMk1ikIh4JdQ=
-github.com/containers/image/v5 v5.25.0 h1:TJ0unmalbU+scd0i3Txap2wjGsAnv06MSCwgn6bsizk=
-github.com/containers/image/v5 v5.25.0/go.mod h1:EKvys0WVlRFkDw26R8y52TuhV9Tfn0yq2luLX6W52Ls=
+github.com/containers/image/v5 v5.25.1-0.20240409053420-67ee9a088e82 h1:92h6Z1u98ijEBmi/W+C5n2/YZILsrOqV7Ao+bJYM8J0=
+github.com/containers/image/v5 v5.25.1-0.20240409053420-67ee9a088e82/go.mod h1:EKvys0WVlRFkDw26R8y52TuhV9Tfn0yq2luLX6W52Ls=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=
 github.com/containers/kubensmnt v1.2.0/go.mod h1:1/HG09N/a1+WSD3zkurzeWtqlKRSfUUnlIF/08zloqk=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -302,7 +302,7 @@ github.com/containers/conmon/runner/config
 ## explicit; go 1.18
 github.com/containers/conmon-rs/internal/proto
 github.com/containers/conmon-rs/pkg/client
-# github.com/containers/image/v5 v5.25.0
+# github.com/containers/image/v5 v5.25.1-0.20240409053420-67ee9a088e82
 ## explicit; go 1.18
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from https://github.com/containers/image/pull/2363 as these changes contain a fix that needs to be backported to CRI-O release 1.27, part of OpenShift 4.14 release.

Related:

- https://github.com/containers/image/pull/2363

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```