### PR TITLE
[release-1.25] OCPBUGS-31928: Cherry-pick changes from containers/image/pull#2363

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containers/common v0.52.1-0.20240315151432-b891c56aeab5
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.4.0
-	github.com/containers/image/v5 v5.25.0
+	github.com/containers/image/v5 v5.25.1-0.20240409053442-438a5d8f18a2
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.1.8
 	github.com/containers/podman/v4 v4.4.1
@@ -406,10 +406,10 @@ require (
 )
 
 replace (
-	// TODO: Remove me when Podman uses a pinned runc version:
-	// https://github.com/containers/podman/blob/74aa681e59352257eb5f25f089dffa66d6345a3a/go.mod#L78
 	github.com/checkpoint-restore/checkpointctl => github.com/checkpoint-restore/checkpointctl v0.0.0-20220321135231-33f4a66335f0
 	github.com/container-orchestrated-devices/container-device-interface => github.com/container-orchestrated-devices/container-device-interface v0.5.3
+	// TODO: Remove me when Podman uses a pinned runc version:
+	// https://github.com/containers/podman/blob/74aa681e59352257eb5f25f089dffa66d6345a3a/go.mod#L78
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
 	github.com/u-root/u-root => github.com/u-root/u-root v0.8.1-0.20220307150114-d511ded1d944
 	k8s.io/api => k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20220823173643-a866cbe2e5bb

--- a/go.sum
+++ b/go.sum
@@ -502,8 +502,8 @@ github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6J
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.4.0 h1:Nl8/xFsc2/dlQUdYi2GTZ+aPCqcedeqnOUld09eiZHc=
 github.com/containers/conmon-rs v0.4.0/go.mod h1:S/TkClMzr+70voUEFUu4wG03McTgyuvC2nGA5rXHJ08=
-github.com/containers/image/v5 v5.25.0 h1:TJ0unmalbU+scd0i3Txap2wjGsAnv06MSCwgn6bsizk=
-github.com/containers/image/v5 v5.25.0/go.mod h1:EKvys0WVlRFkDw26R8y52TuhV9Tfn0yq2luLX6W52Ls=
+github.com/containers/image/v5 v5.25.1-0.20240409053442-438a5d8f18a2 h1:KYfCOojUH2Xpbe2wBmswsDB09LmpW/mXqpvJEDMU2rk=
+github.com/containers/image/v5 v5.25.1-0.20240409053442-438a5d8f18a2/go.mod h1:EKvys0WVlRFkDw26R8y52TuhV9Tfn0yq2luLX6W52Ls=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=
 github.com/containers/kubensmnt v1.2.0/go.mod h1:1/HG09N/a1+WSD3zkurzeWtqlKRSfUUnlIF/08zloqk=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -652,7 +652,7 @@ github.com/containers/conmon/runner/config
 ## explicit; go 1.18
 github.com/containers/conmon-rs/internal/proto
 github.com/containers/conmon-rs/pkg/client
-# github.com/containers/image/v5 v5.25.0
+# github.com/containers/image/v5 v5.25.1-0.20240409053442-438a5d8f18a2
 ## explicit; go 1.18
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from https://github.com/containers/image/pull/2363 as these changes contain a fix that needs to be backported to CRI-O release 1.25, part of OpenShift 4.12 release.

Related:

- https://github.com/containers/image/pull/2363

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```