### PR TITLE
Confidential Containers - Skip pullimage for runtimes that are handling it

### DIFF
--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -127,7 +127,7 @@ var _ = t.Describe("Container", func() {
 			Expect(currentTime).ToNot(BeNil())
 			Expect(sb).ToNot(BeNil())
 
-			err = sut.SpecAddAnnotations(context.Background(), sb, volumes, mountPoint, configStopSignal, &imageResult, false, "foo", "")
+			err = sut.SpecAddAnnotations(context.Background(), sb, volumes, mountPoint, configStopSignal, &someNameOfThisImage, &imageID, false, "foo", "")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(sut.Spec().Config.Annotations[annotations.UserRequestedImage]).To(Equal(image))

--- a/internal/storage/runtime_test.go
+++ b/internal/storage/runtime_test.go
@@ -520,7 +520,7 @@ var _ = t.Describe("Runtime", func() {
 				info, err = sut.CreateContainer(&types.SystemContext{},
 					"podName", "podID", "imagename", imageID,
 					"containerName", "containerID", "",
-					0, nil, []string{"mountLabel"}, false,
+					0, nil, []string{"mountLabel"}, false, false,
 				)
 			})
 
@@ -558,7 +558,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "", "imagename", imageID,
 				"containerName", "containerID", "metadataName",
-				0, nil, []string{"mountLabel"}, false,
+				0, nil, []string{"mountLabel"}, false, false,
 			)
 
 			// Then
@@ -573,7 +573,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"", "podID", "imagename", imageID,
 				"containerName", "containerID", "metadataName",
-				0, nil, []string{"mountLabel"}, false,
+				0, nil, []string{"mountLabel"}, false, false,
 			)
 
 			// Then
@@ -588,7 +588,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "imagename", imageID,
 				"", "containerID", "metadataName",
-				0, nil, []string{"mountLabel"}, false,
+				0, nil, []string{"mountLabel"}, false, false,
 			)
 
 			// Then
@@ -619,7 +619,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "imagename", imageID,
 				"containerName", "containerID", "metadataName",
-				0, nil, []string{"mountLabel"}, false,
+				0, nil, []string{"mountLabel"}, false, false,
 			)
 
 			// Then
@@ -646,7 +646,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "imagename", imageID,
 				"containerName", "containerID", "metadataName",
-				0, nil, []string{"mountLabel"}, false,
+				0, nil, []string{"mountLabel"}, false, false,
 			)
 
 			// Then
@@ -715,7 +715,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "imagename", imageID,
 				"containerName", "containerID", "metadataName",
-				0, nil, []string{"mountLabel"}, false,
+				0, nil, []string{"mountLabel"}, false, false,
 			)
 
 			// Then
@@ -740,7 +740,7 @@ var _ = t.Describe("Runtime", func() {
 			_, err := sut.CreateContainer(&types.SystemContext{},
 				"podName", "podID", "imagename", imageID,
 				"containerName", "containerID", "metadataName",
-				0, nil, []string{"mountLabel"}, false,
+				0, nil, []string{"mountLabel"}, false, false,
 			)
 
 			// Then

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -253,6 +253,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		idMappingOptions,
 		labelOptions,
 		ctr.Privileged(),
+		isRuntimePullImage,
 	)
 	if err != nil {
 		return nil, err

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -503,7 +503,7 @@ var _ = t.Describe("ContainerRestore", func() {
 					runtimeServerMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), imageID, gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-						gomock.Any(), gomock.Any()).
+						gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(storage.ContainerInfo{
 							Config: &v1.Image{
 								Config: v1.ImageConfig{

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -227,18 +227,18 @@ func (m *MockRuntimeServer) EXPECT() *MockRuntimeServerMockRecorder {
 }
 
 // CreateContainer mocks base method.
-func (m *MockRuntimeServer) CreateContainer(systemContext *types.SystemContext, podName, podID, userRequestedImage string, imageID storage0.StorageImageID, containerName, containerID, metadataName string, attempt uint32, idMappingsOptions *types0.IDMappingOptions, labelOptions []string, privileged bool) (storage0.ContainerInfo, error) {
+func (m *MockRuntimeServer) CreateContainer(systemContext *types.SystemContext, podName, podID, userRequestedImage string, imageID storage0.StorageImageID, containerName, containerID, metadataName string, attempt uint32, idMappingsOptions *types0.IDMappingOptions, labelOptions []string, privileged, isRuntimePullImage bool) (storage0.ContainerInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateContainer", systemContext, podName, podID, userRequestedImage, imageID, containerName, containerID, metadataName, attempt, idMappingsOptions, labelOptions, privileged)
+	ret := m.ctrl.Call(m, "CreateContainer", systemContext, podName, podID, userRequestedImage, imageID, containerName, containerID, metadataName, attempt, idMappingsOptions, labelOptions, privileged, isRuntimePullImage)
 	ret0, _ := ret[0].(storage0.ContainerInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateContainer indicates an expected call of CreateContainer.
-func (mr *MockRuntimeServerMockRecorder) CreateContainer(systemContext, podName, podID, userRequestedImage, imageID, containerName, containerID, metadataName, attempt, idMappingsOptions, labelOptions, privileged any) *gomock.Call {
+func (mr *MockRuntimeServerMockRecorder) CreateContainer(systemContext, podName, podID, userRequestedImage, imageID, containerName, containerID, metadataName, attempt, idMappingsOptions, labelOptions, privileged, isRuntimePullImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockRuntimeServer)(nil).CreateContainer), systemContext, podName, podID, userRequestedImage, imageID, containerName, containerID, metadataName, attempt, idMappingsOptions, labelOptions, privileged)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockRuntimeServer)(nil).CreateContainer), systemContext, podName, podID, userRequestedImage, imageID, containerName, containerID, metadataName, attempt, idMappingsOptions, labelOptions, privileged, isRuntimePullImage)
 }
 
 // CreatePodSandbox mocks base method.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
With https://github.com/cri-o/cri-o/pull/7471 we introduced a way to support Confidential Container's feature of pulling the image in the guest VM.
When this happens, cri-o is still pulling the image on the host, because kubernetes keeps sending the "PullImageRequest", and cri-o has no reason to not process it.

This has two drawbacks:
1) it is a waste of time and resources, as the image that crio will pull and prepare will not be used anyway
2) it can block the actual execution of the container in the Confidential Container use case: if the image is encrypted, and the key is not shared with crio, then crio will fail to prepare the image because it can't read it.
   This failure will block the container creation, as kubernetes will not proceed with CreateContainer if PullImage failed.

This PR is meant to make crio skip the pull image phase when the runtime is configured with the "runtime_pull_image" flag introduced in #7471 

#### Which issue(s) this PR fixes:

Fixes: #8261 

#### Special notes for your reviewer:
I have modified the code in crio to skip the pull image processing when the runtime is configured with the "runtime_pull_image" flag.
Crio then just reports a success status to kubernetes, which is happy with that, even when subsequent ImageList or ImageStatus report the image is missing.

Now without an image in the local store, cri-o will fail to create the container. This required further changes in create_sandbox_container and runtimeService, to get information from the remote repository, without pulling the image.

I kept those changes in separate commits for easier review, but I suspect it would make sense to squash them, and get a single, functional commit.

#### Does this PR introduce a user-facing change?

```release-note
Allow the runtime to be configured to skip the pull image phase, and make sure that cri-o can still run the container with it. This allows the use of the Confidential Containers runtime, that pulls the container image separately.
```
