### PR TITLE
server: allow containers within a cluster to opt out of FIPS mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -200,7 +200,7 @@ linters-settings:
       # - filepathJoin
       # - whyNoLint
   gocyclo:
-    min-complexity: 165
+    min-complexity: 167
   nakedret:
     max-func-lines: 15
   goconst:

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -163,6 +163,7 @@ kata_skip_pod_tests:
   - 'test "restart crio and still get pod status"'
   - 'test "systemd cgroup_parent correctly set"'
   - 'test "kubernetes pod terminationGracePeriod passthru"'
+  - 'test "disable crypto.fips_enabled when FIPS_DISABLE is set"'
 kata_skip_seccomp_oci_artifacts_tests:
   - 'test "seccomp OCI artifact with pod annotation"'
   - 'test "seccomp OCI artifact with container annotation"'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -58,7 +58,7 @@ dependencies:
       match: buildah
 
   - name: runc
-    version: v1.1.12
+    version: main
     refPaths:
     - path: scripts/versions
       match: runc

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -391,6 +391,7 @@ A workload is chosen for a pod based on whether the workload's **activation_anno
     - a specific container by using: "seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>"
     - a whole pod by using: "seccomp-profile.kubernetes.cri-o.io/POD"
     Note that the annotation works on containers as well as on images.
+  "io.kubernetes.cri-o.DisableFIPS" for disabling FIPS mode for a pod within a FIPS-enabled Kubernetes cluster.
 
 #### Using the seccomp notifier feature:
 

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -80,6 +80,9 @@ const (
 	// For images, the plain annotation `seccomp-profile.kubernetes.cri-o.io`
 	// can be used without the required `/POD` suffix or a container name.
 	SeccompProfileAnnotation = "seccomp-profile.kubernetes.cri-o.io"
+
+	// DisableFIPSAnnotation is used to disable FIPS mode for a pod within a FIPS-enabled Kubernetes cluster.
+	DisableFIPSAnnotation = "io.kubernetes.cri-o.DisableFIPS"
 )
 
 var AllAllowedAnnotations = []string{
@@ -103,4 +106,5 @@ var AllAllowedAnnotations = []string{
 	LinkLogsAnnotation,
 	CPUSharedAnnotation,
 	SeccompProfileAnnotation,
+	DisableFIPSAnnotation,
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -221,6 +221,7 @@ type RuntimeHandler struct {
 	//   Note that the annotation works on containers as well as on images.
 	//   For images, the plain annotation `seccomp-profile.kubernetes.cri-o.io`
 	//   can be used without the required `/POD` suffix or a container name.
+	// "io.kubernetes.cri-o.DisableFIPS" for disabling FIPS mode for a pod within a FIPS-enabled Kubernetes cluster.
 	AllowedAnnotations []string `toml:"allowed_annotations,omitempty"`
 
 	// DisallowedAnnotations is the slice of experimental annotations that are not allowed for this handler.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1255,6 +1255,7 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 #     Note that the annotation works on containers as well as on images.
 #     For images, the plain annotation "seccomp-profile.kubernetes.cri-o.io"
 #     can be used without the required "/POD" suffix or a container name.
+#   "io.kubernetes.cri-o.DisableFIPS" for disabling FIPS mode in a Kubernetes pod within a FIPS-enabled cluster.
 # - monitor_path (optional, string): The path of the monitor binary. Replaces
 #   deprecated option "conmon".
 # - monitor_cgroup (optional, string): The cgroup the container monitor process will be put in.

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -106,17 +106,26 @@ install_cni_plugins() {
 }
 
 install_runc() {
-    URL=https://github.com/opencontainers/runc/releases/download/"${VERSIONS["runc"]}"
-    BINARY=/usr/sbin/runc
-    sudo wget -O "$BINARY" "$URL/runc.$GOARCH"
-    sudo chmod +x "$BINARY"
+    # Once https://github.com/opencontainers/runc/issues/4233 is fixed,
+    # we can delete go 1.21.9 and link the latest go toolchain.
+    GO_BINARY_URL="https://storage.googleapis.com/golang/go1.21.9.linux-$GOARCH.tar.gz"
+    GO_INSTALLATION_DIR="$(pwd)/go1.21.9"
+    RUNC_DIR="$(pwd)/runc"
 
-    # Verify the SHA256
-    SUMFILE=runc.sha256sum
-    wget "$URL"/$SUMFILE
-    grep -qw "$(sha256sum "$BINARY" | awk '{ print $1 }')" $SUMFILE
-    rm $SUMFILE
+    mkdir -p "$GO_INSTALLATION_DIR"
+    curl -L -o - "$GO_BINARY_URL" | tar -xz -C "$GO_INSTALLATION_DIR"
 
+    git clone https://github.com/opencontainers/runc.git "$RUNC_DIR"
+
+    pushd "$RUNC_DIR"
+    git checkout "${VERSIONS["runc"]}"
+    GOROOT="$GO_INSTALLATION_DIR/go"
+    make GO="$GOROOT/bin/go"
+    sudo install -D -m0755 runc /usr/sbin/runc
+    popd
+    # Remove the runc and go repositories.
+    rm -rf "$RUNC_DIR"
+    rm -rf "$GO_INSTALLATION_DIR"
     runc --version
 }
 

--- a/scripts/versions
+++ b/scripts/versions
@@ -3,7 +3,7 @@ declare -A VERSIONS=(
     ["cni-plugins"]=v1.4.1
     ["conmon"]=v2.1.10
     ["cri-tools"]=v1.30.0
-    ["runc"]=v1.1.12
+    ["runc"]=main
     ["bats"]=v1.11.0
     ["buildah"]=v1.34.0
 )

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -758,6 +758,12 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		ctr.DisableFips(),
 	)
 
+	if ctr.DisableFips() && sb.Annotations()[crioann.DisableFIPSAnnotation] == "true" {
+		if err := disableFipsForContainer(ctr, containerInfo.RunDir); err != nil {
+			return nil, fmt.Errorf("failed to disable FIPS for container %s: %w", containerID, err)
+		}
+	}
+
 	mounts := []rspec.Mount{}
 	mounts = append(mounts, ociMounts...)
 	mounts = append(mounts, volumeMounts...)
@@ -936,6 +942,25 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	}
 
 	return ociContainer, nil
+}
+
+func disableFipsForContainer(ctr ctrfactory.Container, containerDir string) error {
+	// Create a unique filename for the FIPS setting file.
+	fileName := filepath.Join(containerDir, "sysctl-fips")
+	content := []byte("0\n")
+
+	// Write the value '0' to disable FIPS directly to the file.
+	if err := os.WriteFile(fileName, content, 0o444); err != nil {
+		return fmt.Errorf("failed to write to file: %w", err)
+	}
+	ctr.SpecAddMount(rspec.Mount{
+		Destination: "/proc/sys/crypto/fips_enabled",
+		Source:      fileName,
+		Type:        "bind",
+		Options:     []string{"noexec", "nosuid", "nodev", "ro", "bind"},
+	})
+
+	return nil
 }
 
 func configureTimezone(tz, containerRunDir, mountPoint, mountLabel, etcPath, containerID string, options []string, ctr ctrfactory.Container) error {


### PR DESCRIPTION
With [this](https://github.com/opencontainers/runc/pull/4246) change, we can disable FIPS mode in containers for a cluster that is FIPS-enabled.
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

This isn't fully tested; I'm relying on our CI, which can build `runc` with Go 1.21

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow containers within a Kubernetes cluster to opt out of FIPS mode when required
```
