### PR TITLE
Print runtime version info on CRI-O startup

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1273,6 +1273,15 @@ func (c *RuntimeConfig) ValidateRuntimes() error {
 
 func (c *RuntimeConfig) initializeRuntimeFeatures() {
 	for name, handler := range c.Runtimes {
+		versionOutput, err := cmdrunner.CombinedOutput(handler.RuntimePath, "--version")
+		if err != nil {
+			logrus.Errorf("Unable to determine version of runtime handler %s: %v", name, err)
+			continue
+		}
+
+		versionString := strings.ReplaceAll(strings.TrimSpace(string(versionOutput)), "\n", ", ")
+		logrus.Infof("Using runtime %s", versionString)
+
 		memoryBytes, err := handler.SetContainerMinMemory()
 		if err != nil {
 			logrus.Errorf(
@@ -1284,7 +1293,7 @@ func (c *RuntimeConfig) initializeRuntimeFeatures() {
 
 		// If this returns an error, we just ignore it and assume the features sub-command is
 		// not supported by the runtime.
-		output, err := cmdrunner.Command(handler.RuntimePath, "features").CombinedOutput()
+		output, err := cmdrunner.CombinedOutput(handler.RuntimePath, "features")
 		if err != nil {
 			logrus.Errorf("Getting %s OCI runtime features failed: %s: %v", handler.RuntimePath, output, err)
 			continue


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now print a full runtime version execution on startup for each found runtime. If the runtime does not support `--version`, then we just emit a warning.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/pull/7998#issuecomment-2056410698
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Print runtime version info on CRI-O startup.
```
