### PR TITLE
Remove devicemapper storage driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,13 @@ BUILDTAGS ?= containers_image_ostree_stub \
 			 $(shell hack/apparmor_tag.sh) \
 			 $(shell hack/btrfs_installed_tag.sh) \
 			 $(shell hack/btrfs_tag.sh) \
-			 $(shell hack/libdm_installed.sh) \
-			 $(shell hack/libdm_no_deferred_remove_tag.sh) \
 			 $(shell hack/openpgp_tag.sh) \
 			 $(shell hack/seccomp_tag.sh) \
 			 $(shell hack/selinux_tag.sh) \
 			 $(shell hack/libsubid_tag.sh)
+# Device mapper is deprecated; keep this tag until the dm code
+# is removed from the c/storage vendored here.
+BUILDTAGS += exclude_graphdriver_devicemapper
 CRICTL_CONFIG_DIR=${DESTDIR}/etc
 CONTAINER_RUNTIME ?= podman
 BUILD_PATH := $(shell pwd)/build
@@ -224,7 +225,7 @@ bin/crio.cross.%:  .explicit_phony
 	TARGET="$*"; \
 	GOOS="$${TARGET%%.*}" \
 	GOARCH="$${TARGET##*.}" \
-	$(GO_BUILD) $(GO_LDFLAGS) -tags "containers_image_openpgp btrfs_noversion" -o "$@" ./cmd/crio
+	$(GO_BUILD) $(GO_LDFLAGS) -tags "containers_image_openpgp btrfs_noversion exclude_graphdriver_devicemapper" -o "$@" ./cmd/crio
 
 nixpkgs:
 	@nix run -f channel:nixpkgs-unstable nix-prefetch-git -- \

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,7 @@ export GOPROXY=https://proxy.golang.org
 export GOSUMDB=https://sum.golang.org
 
 TRIMPATH ?= -trimpath
-GO_ARCH=$(shell $(GO) env GOARCH)
-GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
-GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
-GO_GT_1_17 := $(shell [ $(GO_MAJOR_VERSION) -ge 1 -a $(GO_MINOR_VERSION) -ge 17 ] && echo true)
-GO_FLAGS ?=
-ifeq ($(GO_GT_1_17),true)
-ifeq ($(GO_ARCH),386)
-GO_FLAGS += -buildvcs=false
-endif
-endif
-
-GO_BUILD ?= $(GO) build $(GO_FLAGS) $(TRIMPATH)
+GO_BUILD ?= $(GO) build $(TRIMPATH)
 GO_RUN ?= $(GO) run
 NIX_IMAGE ?= nixos/nix:2.3.16
 

--- a/Makefile
+++ b/Makefile
@@ -159,19 +159,19 @@ bin/pinns:
 	$(MAKE) -C pinns
 
 test/copyimg/copyimg: $(GO_FILES)
-	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/copyimg
+	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ ./test/copyimg
 
 test/checkseccomp/checkseccomp: $(GO_FILES)
-	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkseccomp
+	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ ./test/checkseccomp
 
 test/checkcriu/checkcriu: $(GO_FILES)
-	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkcriu
+	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ ./test/checkcriu
 
 test/nri/nri.test: $(wildcard test/nri/*.go)
-	$(GO) test --tags "test $(BUILDTAGS)" -c $(PROJECT)/test/nri -o $@
+	$(GO) test --tags "test $(BUILDTAGS)" -c ./test/nri -o $@
 
 bin/crio: $(GO_FILES)
-	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/crio
+	$(GO_BUILD) $(GCFLAGS) $(GO_LDFLAGS) -tags "$(BUILDTAGS)" -o $@ ./cmd/crio
 
 build-static:
 	$(CONTAINER_RUNTIME) run --network=host --rm --privileged -ti -v /:/mnt \
@@ -224,7 +224,7 @@ bin/crio.cross.%:  .explicit_phony
 	TARGET="$*"; \
 	GOOS="$${TARGET%%.*}" \
 	GOARCH="$${TARGET##*.}" \
-	$(GO_BUILD) $(GO_LDFLAGS) -tags "containers_image_openpgp btrfs_noversion" -o "$@" $(PROJECT)/cmd/crio
+	$(GO_BUILD) $(GO_LDFLAGS) -tags "containers_image_openpgp btrfs_noversion" -o "$@" ./cmd/crio
 
 nixpkgs:
 	@nix run -f channel:nixpkgs-unstable nix-prefetch-git -- \
@@ -501,7 +501,7 @@ bin/metrics-exporter:
 	$(GO_BUILD) -o $@ \
 		-ldflags '-linkmode external -extldflags "-static -lm"' \
 		-tags netgo \
-		$(PROJECT)/contrib/metrics-exporter
+		./contrib/metrics-exporter
 
 metrics-exporter: bin/metrics-exporter
 	$(CONTAINER_RUNTIME) build . \

--- a/contrib/kube-local/kube-local.profile
+++ b/contrib/kube-local/kube-local.profile
@@ -281,7 +281,6 @@ MD2MAN_GOLANG_DIR="${GOLANG_PROJECT_HOME_SRC}/${MD2MAN_GOLANG_SRC_GITHUB}/${MD2M
 #
 # Fedora < 31 | RHEL < 7 | CentOS < 8
 CRIO_PACKAGES_FEDORA_RHEL_CENTOS="containers-common \
-device-mapper-devel \
 git \
 glib2-devel \
 glibc-devel \
@@ -298,7 +297,6 @@ runc"
 
 # Fedora >= 31 / RHEL >= 8 / CentOS >=8
 CRIO_PACKAGES_FEDORA_RHEL_CENTOS_LATEST="containers-common \
-device-mapper-devel \
 git \
 glib2-devel \
 glibc-devel \
@@ -320,7 +318,6 @@ CRIO_PACKAGES_UBUNTU="containers-common \
 git \
 golang-go \
 libassuan-dev \
-libdevmapper-dev \
 libglib2.0-dev \
 libc6-dev \
 libgpgme11-dev \

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -13,7 +13,6 @@ export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
 GOPATH_BIN=$(go env GOPATH)/bin
 export PATH="$PATH:$GOPATH_BIN"
 
-# Install gosec
 go install golang.org/x/vuln/cmd/govulncheck@latest
 
 # Generate report

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Install dependencies
 sudo apt-get update
-sudo apt-get install -y pkg-config libgpgme-dev libbtrfs-dev libseccomp-dev libdevmapper-dev btrfs-progs
+sudo apt-get install -y pkg-config libgpgme-dev libbtrfs-dev libseccomp-dev btrfs-progs
 
 # Set environment variables
 export GO111MODULE=on
@@ -18,7 +18,7 @@ go install golang.org/x/vuln/cmd/govulncheck@latest
 # Generate report
 report=$(mktemp)
 trap 'rm "$report"' EXIT
-"$GOPATH_BIN"/govulncheck -json -tags=test ./... >"$report"
+"$GOPATH_BIN"/govulncheck -json -tags=test,exclude_graphdriver_devicemapper ./... >"$report"
 
 # Parse vulnerabilities from report
 modvulns=$(jq -Sr '.vulnerability.modules[]? | select(.path != "stdlib") | [.path, "affected package(s): \(.packages[].path)", "found version: \(.found_version)", "fixed version: \(.fixed_version)"]' <"$report")

--- a/hack/libdm_installed.sh
+++ b/hack/libdm_installed.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-cc -E - >/dev/null 2>/dev/null <<EOF
-#include <libdevmapper.h>
+
+cat > /dev/stderr << EOF
+WARNING: device mapper is obsoleted and is not compiled in.
+
+If you see this from a build, please modify it to not use
+this ($0) file, as it will be removed from the sources soon!
 EOF
-if test $? -ne 0; then
-    echo exclude_graphdriver_devicemapper
-fi
+
+# TODO: remove this file once https://github.com/containers/storage/pull/1622
+# is merged and a new c/storage is vendored here, and all build systems stop
+# using this file.
+echo exclude_graphdriver_devicemapper

--- a/hack/libdm_no_deferred_remove_tag.sh
+++ b/hack/libdm_no_deferred_remove_tag.sh
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
-tmpdir="$PWD/tmp.$RANDOM"
-mkdir -p "$tmpdir"
-trap 'rm -fr "$tmpdir"' EXIT
-cc -o "$tmpdir"/libdm_tag -ldevmapper -x c - >/dev/null 2>/dev/null <<EOF
-#include <libdevmapper.h>
-int main() {
-	struct dm_task *task;
-	dm_task_deferred_remove(task);
-	return 0;
-}
+
+cat > /dev/stderr << EOF
+If you see this from a build, please modify it to not use
+this ($0) file, as it will be removed from the sources soon!
 EOF
-if test $? -ne 0; then
-    echo libdm_no_deferred_remove
-fi
+# Do nothing else here (see ./libdm_installed.sh).

--- a/install.md
+++ b/install.md
@@ -108,7 +108,6 @@ Fedora, RHEL 7, CentOS and related distributions:
 ```shell
 yum install -y \
   containers-common \
-  device-mapper-devel \
   git \
   glib2-devel \
   glibc-devel \
@@ -165,7 +164,6 @@ Install dependencies:
 ```shell
 yum install -y \
   containers-common \
-  device-mapper-devel \
   git \
   make \
   glib2-devel \
@@ -210,7 +208,6 @@ apt install -y  \
   containers-common \
   git \
   libassuan-dev \
-  libdevmapper-dev \
   libglib2.0-dev \
   libc6-dev \
   libgpgme11-dev \
@@ -236,7 +233,6 @@ apt-get update -qq && apt-get install -y \
   containers-common \
   git \
   libassuan-dev \
-  libdevmapper-dev \
   libglib2.0-dev \
   libc6-dev \
   libgpgme-dev \
@@ -339,8 +335,6 @@ which uses the following buildtags.
 | -------------------------------- | ----------------------------------------------- | ------------ |
 | exclude_graphdriver_btrfs        | exclude btrfs as a storage option               |              |
 | btrfs_noversion                  | for building btrfs version < 3.16.1             | btrfs        |
-| exclude_graphdriver_devicemapper | exclude devicemapper as a storage option        |              |
-| libdm_no_deferred_remove         | don't compile deferred remove with devicemapper | devicemapper |
 | exclude_graphdriver_overlay      | exclude overlay as a storage option             |              |
 | ostree                           | build storage using ostree                      | ostree       |
 <!-- markdownlint-enable MD013 -->
@@ -356,7 +350,6 @@ binaries are integration tested as well and support the following features:
 
 - apparmor
 - btrfs
-- device mapper
 - gpgme
 - seccomp
 - selinux

--- a/scripts/github-actions-packages
+++ b/scripts/github-actions-packages
@@ -15,7 +15,6 @@ sudo apt install -y \
     libapparmor-dev \
     libbtrfs-dev \
     libcap-dev \
-    libdevmapper-dev \
     libfuse-dev \
     libgpgme11-dev \
     libnet1-dev \

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -303,14 +303,6 @@ function restart_crio() {
     fi
 }
 
-function cleanup_lvm() {
-    if [ -n "${LVM_DEVICE+x}" ]; then
-        lvm lvremove -y storage/thinpool
-        lvm vgremove -y storage
-        lvm pvremove -y "$LVM_DEVICE"
-    fi
-}
-
 function cleanup_testdir() {
     # shellcheck disable=SC2013
     # Note: By using 'sort -r' we're ensuring longer paths go first, which
@@ -347,7 +339,6 @@ function cleanup_test() {
         cleanup_ctrs
         cleanup_pods
         stop_crio
-        cleanup_lvm
         cleanup_testdir
     else
         echo >&3 "* Failed \"$BATS_TEST_DESCRIPTION\", TESTDIR=$TESTDIR, LVM_DEVICE=${LVM_DEVICE:-}"


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation

#### What this PR does / why we need it:

Device mapper storage driver is hard to set up, slow, and obsoleted by overlayfs.
My best guess is nobody is using it nowadays.

Let's remove it.

#### Which issue(s) this PR fixes:

Fixes: #7002

#### Special notes for your reviewer:

* replaces #7003.
* related to https://github.com/containers/storage/pull/1622 and https://github.com/containers/storage/issues/1619.
* includes some Makefile cleanups (the first two commits).

#### Does this PR introduce a user-facing change?

```release-note
Remove device mapper storage driver.
```
