### PR TITLE
Lower verbosity of `Allowed annotations are specified for workload` message

### DIFF
--- a/pkg/config/workloads.go
+++ b/pkg/config/workloads.go
@@ -117,7 +117,7 @@ func (w Workloads) FilterDisallowedAnnotations(allowed []string, toFilter map[st
 	if err != nil {
 		return err
 	}
-	logrus.Warnf("Allowed annotations are specified for workload %v", allowed)
+	logrus.Infof("Allowed annotations are specified for workload %v", allowed)
 
 	for ann := range toFilter {
 		for _, d := range disallowed {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

It's a bit annoying to have that a generic warning because the configuration is set intentionally. Having it still as an `Info` log should preserve it's major visibility.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
cc @haircommander 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Set the verbosity of the `Allowed annotations are specified for workload` message to `info` (instead of `warn`).
```
