### PR TITLE
[release-1.29] OCPNODE-2247: Implement configurable container minimum memory limit per OCI runtime.

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -143,7 +143,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l read-only -d 'Setup all un
 complete -c crio -n '__fish_crio_no_subcommand' -f -l registry -r -d 'Registry to be prepended when pulling unqualified images. Can be specified multiple times.'
 complete -c crio -n '__fish_crio_no_subcommand' -l root -s r -r -d 'The CRI-O root directory.'
 complete -c crio -n '__fish_crio_no_subcommand' -l runroot -r -d 'The CRI-O state directory.'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l runtimes -r -d 'OCI runtimes, format is \'runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path\'.'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l runtimes -r -d 'OCI runtimes, format is \'runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path:container_min_memory\'.'
 complete -c crio -n '__fish_crio_no_subcommand' -l seccomp-profile -r -d 'Path to the seccomp.json profile to be used as the runtime\'s default. If not specified, then the internal default seccomp profile will be used.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l seccomp-use-default-when-empty -d 'Use the default seccomp profile when an empty one is specified. This option is currently deprecated, and will be replaced by the SeccompDefault FeatureGate in Kubernetes.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l selinux -d 'Enable selinux support. This option is deprecated, and be interpreted from whether SELinux is enabled on the host in the future.'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -384,7 +384,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--runroot**="": The CRI-O state directory. (default: "/run/containers/storage")
 
-**--runtimes**="": OCI runtimes, format is 'runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path'.
+**--runtimes**="": OCI runtimes, format is 'runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path:container_min_memory'.
 
 **--seccomp-profile**="": Path to the seccomp.json profile to be used as the runtime's default. If not specified, then the internal default seccomp profile will be used.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -353,6 +353,9 @@ The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.  Th
   "io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
   "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
 
+**container_min_memory**=""
+  The minimum memory that must be set for a container. This value can be used to override the currently set global value for a specific runtime. If not set, a global default value of "12 MiB" will be used.
+
 **platform_runtime_paths**={}
   A mapping of platforms to the corresponding runtime executable paths for the runtime handler.
 

--- a/internal/config/cgmgr/cgmgr_linux.go
+++ b/internal/config/cgmgr/cgmgr_linux.go
@@ -21,10 +21,6 @@ import (
 
 const (
 	CrioPrefix = "crio"
-	// minMemoryLimit is the minimum memory that must be set for a container.
-	// A lower value would result in the container failing to start.
-	// this value has been arrived at for runc on x86_64 hardware
-	minMemoryLimit = 12 * 1024 * 1024
 	// CgroupfsCgroupManager represents cgroupfs native cgroup manager
 	cgroupfsCgroupManager = "cgroupfs"
 	// SystemdCgroupManager represents systemd native cgroup manager
@@ -64,10 +60,10 @@ type CgroupManager interface {
 	ContainerCgroupManager(sbParent, containerID string) (libctr.Manager, error)
 	// RemoveContainerCgManager removes the cgroup manager for the container
 	RemoveContainerCgManager(containerID string)
-	// SandboxCgroupPath takes the sandbox parent, and sandbox ID. It
+	// SandboxCgroupPath takes the sandbox parent, and sandbox ID, and container minimum memory. It
 	// returns the cgroup parent, cgroup path, and error. For systemd cgroups,
 	// it also checks there is enough memory in the given cgroup
-	SandboxCgroupPath(string, string) (string, string, error)
+	SandboxCgroupPath(string, string, int64) (string, string, error)
 	// PopulateContainerCgroupStats takes arguments sandbox parent cgroup, and sandbox stats object.
 	// It fills the object with information from the cgroup found given that parent.
 	PopulateSandboxCgroupStats(sbParent string, stats *types.PodSandboxStats) error
@@ -122,7 +118,7 @@ func SetCgroupManager(cgroupManager string) (CgroupManager, error) {
 	}
 }
 
-func verifyCgroupHasEnoughMemory(slicePath, memorySubsystemPath, memoryMaxFilename string) error {
+func verifyCgroupHasEnoughMemory(slicePath, memorySubsystemPath, memoryMaxFilename string, containerMinMemory int64) error {
 	// read in the memory limit from memory max file
 	fileData, err := os.ReadFile(filepath.Join(memorySubsystemPath, slicePath, memoryMaxFilename))
 	if err != nil {
@@ -141,7 +137,7 @@ func verifyCgroupHasEnoughMemory(slicePath, memorySubsystemPath, memoryMaxFilena
 			return fmt.Errorf("error converting cgroup memory value from string to int %q: %w", strMemory, err)
 		}
 		// Compare with the minimum allowed memory limit
-		if err := VerifyMemoryIsEnough(memoryLimit); err != nil {
+		if err := VerifyMemoryIsEnough(memoryLimit, containerMinMemory); err != nil {
 			return fmt.Errorf("pod %w", err)
 		}
 	}
@@ -149,9 +145,9 @@ func verifyCgroupHasEnoughMemory(slicePath, memorySubsystemPath, memoryMaxFilena
 }
 
 // VerifyMemoryIsEnough verifies that the cgroup memory limit is above a specified minimum memory limit.
-func VerifyMemoryIsEnough(memoryLimit int64) error {
-	if memoryLimit != 0 && memoryLimit < minMemoryLimit {
-		return fmt.Errorf("set memory limit %d too low; should be at least %d", memoryLimit, minMemoryLimit)
+func VerifyMemoryIsEnough(memoryLimit, minMemory int64) error {
+	if memoryLimit != 0 && memoryLimit < minMemory {
+		return fmt.Errorf("set memory limit %d too low; should be at least %d bytes", memoryLimit, minMemory)
 	}
 	return nil
 }

--- a/internal/config/cgmgr/cgmgr_test.go
+++ b/internal/config/cgmgr/cgmgr_test.go
@@ -136,7 +136,7 @@ var _ = t.Describe("Cgmgr", func() {
 				// Given
 				sbParent := "sandbox-parent.slice"
 				// When
-				cgParent, cgPath, err := sut.SandboxCgroupPath(sbParent, sbID)
+				cgParent, cgPath, err := sut.SandboxCgroupPath(sbParent, sbID, int64(0))
 
 				// Then
 				Expect(cgParent).To(BeEmpty())
@@ -146,7 +146,7 @@ var _ = t.Describe("Cgmgr", func() {
 			It("can override sandbox parent", func() {
 				// Given
 				// When
-				cgParent, cgPath, err := sut.SandboxCgroupPath(genericSandboxParent, sbID)
+				cgParent, cgPath, err := sut.SandboxCgroupPath(genericSandboxParent, sbID, int64(0))
 
 				// Then
 				Expect(cgParent).To(Equal(genericSandboxParent))
@@ -221,7 +221,7 @@ var _ = t.Describe("Cgmgr", func() {
 				// Given
 				sbParent := "slice"
 				// When
-				cgParent, cgPath, err := sut.SandboxCgroupPath(sbParent, sbID)
+				cgParent, cgPath, err := sut.SandboxCgroupPath(sbParent, sbID, int64(0))
 
 				// Then
 				Expect(cgParent).To(BeEmpty())
@@ -232,12 +232,26 @@ var _ = t.Describe("Cgmgr", func() {
 				// Given
 				sbParent := "systemd.invalid"
 				// When
-				cgParent, cgPath, err := sut.SandboxCgroupPath(sbParent, sbID)
+				cgParent, cgPath, err := sut.SandboxCgroupPath(sbParent, sbID, int64(0))
 
 				// Then
 				Expect(cgParent).To(BeEmpty())
 				Expect(cgPath).To(BeEmpty())
 				Expect(err).To(Not(BeNil()))
+			})
+			It("should fail container minimum memory limit check", func() {
+				// When
+				err := cgmgr.VerifyMemoryIsEnough(100, 200)
+
+				// Then
+				Expect(err).To(HaveOccurred())
+			})
+			It("should not fail container minimum memory limit check", func() {
+				// When
+				err := cgmgr.VerifyMemoryIsEnough(151, 150)
+
+				// Then
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 		t.Describe("MoveConmonToCgroup", func() {

--- a/internal/config/cgmgr/cgmgr_unsupported.go
+++ b/internal/config/cgmgr/cgmgr_unsupported.go
@@ -16,15 +16,14 @@ type CgroupManager interface {
 	// the cgroup path for that containerID. If parentCgroup is empty, it
 	// uses the default parent for that particular manager
 	ContainerCgroupPath(string, string) string
-	// cgroup parent, cgroup path, error
-	SandboxCgroupPath(string, string) string
+	// cgroup parent, cgroup path, minimum container memory, error
+	SandboxCgroupPath(string, string, int64) string
 	// RemoveSandboxCgroup takes the sandbox parent, and sandbox ID.
 	// It removes the cgroup for that sandbox, which is useful when spoofing an infra container
 	RemoveSandboxCgroup(sbParent, containerID string) error
 }
 
-type NullCgroupManager struct {
-}
+type NullCgroupManager struct{}
 
 func InitializeCgroupManager(cgroupManager string) (CgroupManager, error) {
 	return nil, errors.New("not implemented yet")
@@ -45,7 +44,7 @@ func MoveProcessToContainerCgroup(containerPid, commandPid int) error {
 }
 
 // VerifyMemoryIsEnough verifies that the cgroup memory limit is above a specified minimum memory limit.
-func VerifyMemoryIsEnough(memoryLimit int64) error {
+func VerifyMemoryIsEnough(memoryLimit, containerMinMemory int64) error {
 	return nil
 }
 
@@ -61,7 +60,7 @@ func (*NullCgroupManager) ContainerCgroupPath(string, string) string {
 	return ""
 }
 
-func (*NullCgroupManager) SandboxCgroupPath(string, string) string {
+func (*NullCgroupManager) SandboxCgroupPath(string, string, int64) string {
 	return ""
 }
 

--- a/internal/config/cgmgr/cgroupfs_linux.go
+++ b/internal/config/cgmgr/cgroupfs_linux.go
@@ -110,14 +110,15 @@ func (m *CgroupfsManager) RemoveContainerCgManager(containerID string) {
 	}
 }
 
-// SandboxCgroupPath takes the sandbox parent, and sandbox ID. It
-// returns the cgroup parent, cgroup path, and error.
-func (m *CgroupfsManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgPath string, _ error) {
+// SandboxCgroupPath takes the sandbox parent, sandbox ID, and container minimum memory.
+// It returns the cgroup parent, cgroup path, and error.
+// It also checks if enough memory is available in the given cgroup.
+func (m *CgroupfsManager) SandboxCgroupPath(sbParent, sbID string, containerMinMemory int64) (cgParent, cgPath string, _ error) {
 	if strings.HasSuffix(path.Base(sbParent), ".slice") {
 		return "", "", fmt.Errorf("cri-o configured with cgroupfs cgroup manager, but received systemd slice as parent: %s", sbParent)
 	}
 
-	if err := verifyCgroupHasEnoughMemory(sbParent, m.memoryPath, m.memoryMaxFile); err != nil {
+	if err := verifyCgroupHasEnoughMemory(sbParent, m.memoryPath, m.memoryMaxFile, containerMinMemory); err != nil {
 		return "", "", err
 	}
 

--- a/internal/config/cgmgr/systemd_linux.go
+++ b/internal/config/cgmgr/systemd_linux.go
@@ -204,10 +204,10 @@ func (m *SystemdManager) MoveConmonToCgroup(cid, cgroupParent, conmonCgroup stri
 	return "", nil
 }
 
-// SandboxCgroupPath takes the sandbox parent, and sandbox ID. It
-// returns the cgroup parent, cgroup path, and error.
-// It also checks there is enough memory in the given cgroup
-func (m *SystemdManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgPath string, _ error) {
+// SandboxCgroupPath takes the sandbox parent, sandbox ID, and container minimum memory.
+// It returns the cgroup parent, cgroup path, and error.
+// It also checks if enough memory is available in the given cgroup.
+func (m *SystemdManager) SandboxCgroupPath(sbParent, sbID string, containerMinMemory int64) (cgParent, cgPath string, _ error) {
 	if sbParent == "" {
 		return "", "", nil
 	}
@@ -217,7 +217,7 @@ func (m *SystemdManager) SandboxCgroupPath(sbParent, sbID string) (cgParent, cgP
 	}
 
 	cgParent = convertCgroupFsNameToSystemd(sbParent)
-	if err := verifyCgroupHasEnoughMemory(sbParent, m.memoryPath, m.memoryMaxFile); err != nil {
+	if err := verifyCgroupHasEnoughMemory(sbParent, m.memoryPath, m.memoryMaxFile, containerMinMemory); err != nil {
 		return "", "", err
 	}
 

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -7,6 +7,7 @@ import (
 
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/server/otel-collector/collectors"
+	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -127,8 +128,18 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 			runtimeType := libconfig.DefaultRuntimeType
 			privilegedWithoutHostDevices := false
 			runtimeConfigPath := ""
+			var (
+				containerMinMemory int64
+				err                error
+			)
 
 			switch len(fields) {
+			case 7:
+				containerMinMemory, err = units.RAMInBytes(fields[6])
+				if err != nil {
+					return fmt.Errorf("invalid value %q for --runtimes:container_min_memory: %w", fields[6], err)
+				}
+				fallthrough
 			case 6:
 				runtimeConfigPath = fields[5]
 				fallthrough
@@ -147,9 +158,10 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 					RuntimeType:                  runtimeType,
 					PrivilegedWithoutHostDevices: privilegedWithoutHostDevices,
 					RuntimeConfigPath:            runtimeConfigPath,
+					ContainerMinMemory:           units.BytesSize(float64(containerMinMemory)),
 				}
 			default:
-				return fmt.Errorf("wrong format for --runtimes: %q", r)
+				return fmt.Errorf("invalid format for --runtimes: %q", r)
 			}
 		}
 	}
@@ -637,7 +649,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:    "runtimes",
-			Usage:   "OCI runtimes, format is 'runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path'.",
+			Usage:   "OCI runtimes, format is 'runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path:container_min_memory'.",
 			EnvVars: []string{"CONTAINER_RUNTIMES"},
 		},
 		&cli.StringFlag{

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/pkg/config"
+	"github.com/docker/go-units"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/tools/remotecommand"
@@ -179,6 +180,20 @@ func (r *Runtime) RuntimeType(runtimeHandler string) (string, error) {
 	}
 
 	return rh.RuntimeType, nil
+}
+
+// GetContainerMinMemory returns the minimum memory for a container
+// for a given runtime handler.
+func (r *Runtime) GetContainerMinMemory(runtimeHandler string) (int64, error) {
+	rh, err := r.getRuntimeHandler(runtimeHandler)
+	if err != nil {
+		return int64(0), err
+	}
+	// We can skip error checking since the value was checked
+	// at the time of initializing the runtime handlers features.
+	value, _ := units.RAMInBytes(rh.ContainerMinMemory) //nolint: errcheck
+
+	return value, nil
 }
 
 // RuntimeSupportsIDMap returns whether the runtime of runtimeHandler supports the "runtime features"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cri-o/cri-o/utils"
 	"github.com/cri-o/cri-o/utils/cmdrunner"
 	"github.com/cri-o/ocicni/pkg/ocicni"
+	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go/features"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
@@ -49,6 +50,7 @@ import (
 // Defaults if none are specified
 const (
 	defaultGRPCMaxMsgSize      = 80 * 1024 * 1024
+	defaultContainerMinMemory  = 12 * 1024 * 1024 // 12 MiB
 	OCIBufSize                 = 8192
 	RuntimeTypeVM              = "vm"
 	RuntimeTypePod             = "pod"
@@ -227,6 +229,9 @@ type RuntimeHandler struct {
 	// Marks the runtime as performing image pulling on its own, and doesn't
 	// require crio to do it.
 	RuntimePullImage bool `toml:"runtime_pull_image,omitempty"`
+
+	// ContainerMinMemory is the minimum memory that must be set for a container.
+	ContainerMinMemory string `toml:"container_min_memory,omitempty"`
 
 	// Output of the "features" subcommand.
 	// This is populated dynamically and not read from config.
@@ -1224,7 +1229,8 @@ func defaultRuntimeHandler() *RuntimeHandler {
 		MonitorEnv: []string{
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		},
-		MonitorCgroup: defaultMonitorCgroup,
+		ContainerMinMemory: units.BytesSize(defaultContainerMinMemory),
+		MonitorCgroup:      defaultMonitorCgroup,
 	}
 }
 
@@ -1253,7 +1259,16 @@ func (c *RuntimeConfig) ValidateRuntimes() error {
 }
 
 func (c *RuntimeConfig) initializeRuntimeFeatures() {
-	for _, handler := range c.Runtimes {
+	for name, handler := range c.Runtimes {
+		memoryBytes, err := handler.SetContainerMinMemory()
+		if err != nil {
+			logrus.Errorf(
+				"Unable to set minimum container memory for runtime handler %q: %v; default value of %q will be used",
+				name, err, units.BytesSize(float64(memoryBytes)),
+			)
+		}
+		logrus.Debugf("Runtime handler %q container minimum memory set to %d bytes", name, memoryBytes)
+
 		// If this returns an error, we just ignore it and assume the features sub-command is
 		// not supported by the runtime.
 		output, err := cmdrunner.Command(handler.RuntimePath, "features").CombinedOutput()
@@ -1571,6 +1586,24 @@ func (r *RuntimeHandler) ValidateRuntimeAllowedAnnotations() error {
 	)
 	r.DisallowedAnnotations = disallowed
 	return nil
+}
+
+// SetContainerMinMemory sets the minimum container memory for a given runtime.
+// assigns defaultContainerMinMemory if no container_min_memory provided.
+func (r *RuntimeHandler) SetContainerMinMemory() (int64, error) {
+	if r.ContainerMinMemory == "" {
+		r.ContainerMinMemory = units.BytesSize(defaultContainerMinMemory)
+	}
+
+	memoryBytes, err := units.RAMInBytes(r.ContainerMinMemory)
+	if err != nil {
+		err = fmt.Errorf("unable to set runtime memory to %q: %w", r.ContainerMinMemory, err)
+		// Fallback to default value if something is wrong with the configured value.
+		r.ContainerMinMemory = units.BytesSize(defaultContainerMinMemory)
+		return int64(defaultContainerMinMemory), err
+	}
+
+	return memoryBytes, nil
 }
 
 // RuntimeSupportsIDMap returns whether this runtime supports the "runtime features"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,7 +26,7 @@ var _ = t.Describe("Config", func() {
 
 	runtimeValidConfig := func() *config.Config {
 		sut.Runtimes["runc"] = &config.RuntimeHandler{
-			RuntimePath: validFilePath, RuntimeType: config.DefaultRuntimeType,
+			RuntimePath: validFilePath, RuntimeType: config.DefaultRuntimeType, ContainerMinMemory: "12MiB",
 		}
 		sut.PinnsPath = validFilePath
 		sut.NamespacesDir = os.TempDir()
@@ -294,6 +294,17 @@ var _ = t.Describe("Config", func() {
 
 			// Then
 			Expect(err).NotTo(BeNil())
+		})
+
+		It("should inherit default value if invalid runtime container minimum memory limit is set", func() {
+			// Given
+			sut.Runtimes["runc"].ContainerMinMemory = "123invalid"
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should fail on wrong invalid device specification", func() {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1270,6 +1270,9 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 #   Replaces deprecated option "conmon_env".
 # - platform_runtime_paths (optional, map): A mapping of platforms to the corresponding
 #   runtime executable paths for the runtime handler.
+# - container_min_memory (optional, string): The minimum memory that must be set for a container.
+#   This value can be used to override the currently set global value for a specific runtime. If not set,
+#   a global default value of "12 MiB" will be used.
 #
 # Using the seccomp notifier feature:
 #
@@ -1304,6 +1307,7 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 {{ $.Comment }}runtime_type = "{{ $runtime_handler.RuntimeType }}"
 {{ $.Comment }}runtime_root = "{{ $runtime_handler.RuntimeRoot }}"
 {{ $.Comment }}runtime_config_path = "{{ $runtime_handler.RuntimeConfigPath }}"
+{{ $.Comment }}container_min_memory = "{{ $runtime_handler.ContainerMinMemory }}"
 {{ $.Comment }}monitor_path = "{{ $runtime_handler.MonitorPath }}"
 {{ $.Comment }}monitor_cgroup = "{{ $runtime_handler.MonitorCgroup }}"
 {{ $.Comment }}monitor_exec_cgroup = "{{ $runtime_handler.MonitorExecCgroup }}"

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -428,7 +428,11 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 
 			memoryLimit := resources.MemoryLimitInBytes
 			if memoryLimit != 0 {
-				if err := cgmgr.VerifyMemoryIsEnough(memoryLimit); err != nil {
+				containerMinMemory, err := s.Runtime().GetContainerMinMemory(sb.RuntimeHandler())
+				if err != nil {
+					return nil, err
+				}
+				if err := cgmgr.VerifyMemoryIsEnough(memoryLimit, containerMinMemory); err != nil {
 					return nil, err
 				}
 				specgen.SetLinuxResourcesMemoryLimit(memoryLimit)

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -122,7 +122,11 @@ func (a *nriAPI) createContainer(ctx context.Context, specgen *generate.Generato
 				}
 				if mem := r.Memory; mem != nil {
 					if mem.Limit != nil {
-						if err := cgmgr.VerifyMemoryIsEnough(*mem.Limit); err != nil {
+						containerMinMemory, err := a.cri.Runtime().GetContainerMinMemory(criPod.RuntimeHandler())
+						if err != nil {
+							return err
+						}
+						if err := cgmgr.VerifyMemoryIsEnough(*mem.Limit, containerMinMemory); err != nil {
 							return err
 						}
 					}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -665,8 +665,11 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 	g.AddAnnotation(annotations.PortMappings, string(portMappingsJSON))
-
-	cgroupParent, cgroupPath, err := s.config.CgroupManager().SandboxCgroupPath(sbox.Config().Linux.CgroupParent, sbox.ID())
+	containerMinMemory, err := s.Runtime().GetContainerMinMemory(runtimeHandler)
+	if err != nil {
+		return nil, err
+	}
+	cgroupParent, cgroupPath, err := s.config.CgroupManager().SandboxCgroupPath(sbox.Config().Linux.CgroupParent, sbox.ID(), containerMinMemory)
 	if err != nil {
 		return nil, err
 	}

--- a/test/image.bats
+++ b/test/image.bats
@@ -9,6 +9,7 @@ SIGNED_IMAGE=registry.access.redhat.com/rhel7-atomic:latest
 IMAGE_LIST_TAG=quay.io/crio/alpine:3.9
 IMAGE_LIST_DIGEST_FOR_TAG=quay.io/crio/alpine@sha256:414e0518bb9228d35e4cd5165567fb91d26c6a214e9c95899e1e056fcd349011
 IMAGE_LIST_DIGEST_FOR_TAG_AMD64=quay.io/crio/alpine@sha256:65b3a80ebe7471beecbc090c5b2cdd0aafeaefa0715f8f12e40dc918a3a70e32
+IMAGE_LIST_DIGEST_FOR_TAG_ARM64=quay.io/crio/alpine@sha256:f920ccc826134587fffcf1ddc6b2a554947e0f1a5ae5264bbf3435da5b2e8e61
 
 IMAGE_LIST_DIGEST_AMD64=quay.io/crio/alpine@sha256:65b3a80ebe7471beecbc090c5b2cdd0aafeaefa0715f8f12e40dc918a3a70e32
 IMAGE_LIST_DIGEST=quay.io/crio/alpine@sha256:414e0518bb9228d35e4cd5165567fb91d26c6a214e9c95899e1e056fcd349011
@@ -338,4 +339,150 @@ EOF
 	crictl pull quay.io/crio/hello-wasm:latest
 	output=$(crictl images -o json | jq '.images[] | select(.repoTags[] == "quay.io/crio/hello-wasm:latest") | .pinned')
 	[ "$output" == "true" ]
+}
+
+@test "run container with memory_limit_in_bytes -1" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-mem.conf"
+[crio.runtime]
+default_runtime = "mem"
+[crio.runtime.runtimes.mem]
+runtime_path = "$RUNTIME_BINARY_PATH"
+EOF
+	start_crio
+
+	case $(go env GOARCH) in
+	amd64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		;;
+	arm64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		;;
+	esac
+
+	jq --arg image "$IMAGE" '.metadata.name = "memory"
+		| .command = ["/bin/sh", "-c", "sleep 600"]
+		| .linux.resources.memory_limit_in_bytes = -1
+		| .image.image = $image' \
+		"$TESTDATA"/container_config.json > "$TESTDIR"/memory.json
+
+	run ! crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
+}
+
+@test "run container with memory_limit_in_bytes 12.5MiB" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-mem.conf"
+[crio.runtime]
+default_runtime = "mem"
+[crio.runtime.runtimes.mem]
+runtime_path = "$RUNTIME_BINARY_PATH"
+container_min_memory = "7.5MiB"
+EOF
+	start_crio
+
+	case $(go env GOARCH) in
+	amd64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		;;
+	arm64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		;;
+	esac
+
+	jq --arg image "$IMAGE" '.metadata.name = "memory"
+		| .command = ["/bin/sh", "-c", "sleep 600"]
+		| .linux.resources.memory_limit_in_bytes = 12582912
+		| .image.image = $image' \
+		"$TESTDATA"/container_config.json > "$TESTDIR"/memory.json
+
+	run crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
+}
+
+@test "run container with container_min_memory 17.5MiB" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-mem.conf"
+[crio.runtime]
+default_runtime = "mem"
+[crio.runtime.runtimes.mem]
+runtime_path = "$RUNTIME_BINARY_PATH"
+container_min_memory = "17.5MiB"
+EOF
+	start_crio
+
+	case $(go env GOARCH) in
+	amd64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		;;
+	arm64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		;;
+	esac
+
+	jq --arg image "$IMAGE" '.metadata.name = "memory"
+		| .command = ["/bin/sh", "-c", "sleep 600"]
+		| .linux.resources.memory_limit_in_bytes = 12582912
+		| .image.image = $image' \
+		"$TESTDATA"/container_config.json > "$TESTDIR"/memory.json
+
+	run crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
+}
+
+@test "run container with container_min_memory 5.5MiB" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-mem.conf"
+[crio.runtime]
+default_runtime = "mem"
+[crio.runtime.runtimes.mem]
+runtime_path = "$RUNTIME_BINARY_PATH"
+container_min_memory = "5.5MiB"
+EOF
+	start_crio
+
+	case $(go env GOARCH) in
+	amd64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		;;
+	arm64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		;;
+	esac
+
+	jq --arg image "$IMAGE" '.metadata.name = "memory"
+		| .command = ["/bin/sh", "-c", "sleep 600"]
+		| .image.image = $image' \
+		"$TESTDATA"/container_config.json > "$TESTDIR"/memory.json
+
+	run crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
+}
+
+@test "run container with empty container_min_memory" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-mem.conf"
+[crio.runtime]
+default_runtime = "mem"
+[crio.runtime.runtimes.mem]
+runtime_path = "$RUNTIME_BINARY_PATH"
+EOF
+	start_crio
+
+	case $(go env GOARCH) in
+	amd64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
+		;;
+	arm64)
+		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
+		;;
+	esac
+
+	jq --arg image "$IMAGE" '.metadata.name = "memory"
+		| .command = ["/bin/sh", "-c", "sleep 600"]
+		| .image.image = $image' \
+		"$TESTDATA"/container_config.json > "$TESTDIR"/memory.json
+
+	run crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/cri-o/cri-o/pull/7832

/assign kwilczynski

```release-note
None
```