### PR TITLE
Fix patch release workflow restriction

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -9,7 +9,7 @@ jobs:
   patch-release:
     permissions:
       contents: none
-    if: startsWith(github.ref, 'refs/heads/release-')
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -10,6 +10,8 @@ dependencies:
       match: GO_VERSION
     - path: .github/workflows/cron.yml
       match: GO_VERSION
+    - path: .github/workflows/patch-release.yml
+      match: GO_VERSION
     - path: contrib/test/ci/vars.yml
       match: golang_version
 


### PR DESCRIPTION


#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:
We run the workflow always from `main`, means the release branch restriction will not allow to execute it.

Other than that, the golang version is now checked from `dependencies.yaml`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/4003
#### Special notes for your reviewer:
PTAL @cri-o/cri-o-maintainers 
cc @olad5 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
