### PR TITLE
Add missing kernel version check to the RRO mounts integration tests

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1084,6 +1084,8 @@ function create_test_rro_mounts() {
 }
 
 @test "ctr that fails to mount container storage as recursively read-only without readonly option" {
+	requires_kernel "5.12"
+
 	# Check for the minimum cri-tools version that supports RRO mounts.
 	requires_crictl "1.30"
 
@@ -1110,6 +1112,8 @@ function create_test_rro_mounts() {
 }
 
 @test "ctr that fails to mount container storage as recursively read-only without private propagation" {
+	requires_kernel "5.12"
+
 	# Check for the minimum cri-tools version that supports RRO mounts.
 	requires_crictl "1.30"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Following the release of both Kubernetes 1.30 and crictl 1.30, we no longer skip the Recursive Read-only (RRO) mounts tests. However, on some platforms (such as Arm64), the support for the new feature is not present—not because of the hardware platform in itself, but because of the runtime environment, where the kernel version can be too old to provide the necessary support per:

```console
# time="2024-04-18 09:01:35.155875800Z" level=debug msg="Runtime handler \"runc\" supports Recursive Read-only (RRO) mounts" file="config/config.go:1326"
# time="2024-04-18 09:01:35.156253360Z" level=warning msg="Runtime handler \"runc\" supports Recursive Read-only (RRO) mounts, but kernel does not: kernel version \"5.10.201\" does not support recursive read-only mounts: unable to set recursive read-only mount attribute: function not implemented" file="config/config.go:1331"
```

Thus, we should skip RRO mounts-related tests when the kernel does not include the required support.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
