### PR TITLE
Bump version to 1.29.3

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version is the version of the build.
-const Version = "1.29.2"
+const Version = "1.29.3"
 
 // Variables injected during build-time
 var (


### PR DESCRIPTION
Automated version bump to version `1.29.3`

/release-note-none