### PR TITLE
Use release-note block instead of label

### DIFF
--- a/scripts/patch-release/patch-release.go
+++ b/scripts/patch-release/patch-release.go
@@ -177,8 +177,8 @@ func updateVersionAndCreatePR(
 	headBranchName := fmt.Sprintf("%s:%s", org, newBranch)
 	title := "Bump version to " + newVersion
 	body := fmt.Sprintf(
-		"Automated version bump to version `%s`\n\n%s",
-		newVersion, "/release-note-none",
+		"Automated version bump to version `%s`\n\n```release-note\nNone\n```",
+		newVersion,
 	)
 
 	pr, err := gh.CreatePullRequest(org, crioOrgRepo, baseBranchName,


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
The label will not be considered when opening the PR, means we stick to the release notes block for now.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
