### PR TITLE
Filter namespace creation args to clone in default seccomp policy

### DIFF
--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -77,7 +77,7 @@ function teardown() {
 	crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 8. test running with ctr runtime/default don't allow unshare
+# 8. test running with ctr runtime/default doesn't allow unshare
 @test "ctr seccomp profiles runtime/default block unshare" {
 	unset CONTAINER_SECCOMP_PROFILE
 	restart_crio
@@ -87,4 +87,23 @@ function teardown() {
 
 	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 	run ! crictl exec --sync "$ctr_id" /bin/sh -c "unshare"
+}
+
+# 9. test running with ctr runtime/default don't allow clone with namespace flags
+@test "ctr seccomp profiles runtime/default blocks clone creating namespaces" {
+	unset CONTAINER_SECCOMP_PROFILE
+	restart_crio
+
+	jq --arg TESTDATA "$TESTDATA" '.linux.security_context.seccomp.profile_type = 0 |
+          .mounts = [{
+            host_path: $TESTDATA,
+            container_path: "/testdata",
+          }]' \
+		"$TESTDATA/container_sleep.json" > "$TESTDIR/container.json"
+
+	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
+	crictl exec --sync "$ctr_id" /usr/bin/make -C / clone-ns
+	run crictl exec --sync "$ctr_id" /clone-ns
+	[[ "$output" =~ "Operation not permitted" ]]
 }

--- a/test/testdata/clone-ns.c
+++ b/test/testdata/clone-ns.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sched.h>
+
+int entry() {
+        system("id");
+        return 0;
+}
+
+int main() {
+        void *stack = malloc(1024*1024);
+        if (clone(entry, (stack+1024*1024), CLONE_NEWUSER|CLONE_NEWNET, 0) == -1) {
+          perror("clone");
+        }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

The default seccomp policy used by cri-o did not previously block `clone()` with `CLONE_NEWNS` and other namespace creation flags. This PR blocks those flags. In addition it has to disable `clone3` as it is not currently possible to filter a struct argument with seccomp, this matches the approach taken by containerd.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

I can't actually get the bats test to pass in my environment, but then I don't see some of the existing seccomp tests pass, so not sure what's happening there.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The default seccomp policy now blocks clone system calls that create a Linux namespace, this provides defense-in-depth against Linux kernel vulnerabilities and matches the default seccomp policy provided by containerd.
```
