### PR TITLE
Stop using BytesSize when merging the config

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -150,6 +150,11 @@ kata_skip_image_tests:
   - 'test "image pull and list by manifest list tag"'
   - 'test "image pull and list by manifest list and individual digest"'
   - 'test "image pull and list by individual and manifest list digest"'
+  - 'test "run container with memory_limit_in_bytes -1"'
+  - 'test "run container with memory_limit_in_bytes 12.5MiB"'
+  - 'test "run container with container_min_memory 17.5MiB"'
+  - 'test "run container with container_min_memory 5.5MiB"'
+  - 'test "run container with empty container_min_memory"'
 kata_skip_namespaces_tests:
   - 'test "pid namespace mode target test"'
 kata_skip_network_tests:

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -130,15 +130,16 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 			privilegedWithoutHostDevices := false
 			runtimeConfigPath := ""
 			var (
-				containerMinMemory int64
+				containerMinMemory string
 				err                error
 			)
 
 			switch len(fields) {
 			case 7:
-				containerMinMemory, err = units.RAMInBytes(fields[6])
+				containerMinMemory = fields[6]
+				_, err = units.RAMInBytes(containerMinMemory)
 				if err != nil {
-					return fmt.Errorf("invalid value %q for --runtimes:container_min_memory: %w", fields[6], err)
+					return fmt.Errorf("invalid value %q for --runtimes:container_min_memory: %w", containerMinMemory, err)
 				}
 				fallthrough
 			case 6:
@@ -159,7 +160,7 @@ func mergeConfig(config *libconfig.Config, ctx *cli.Context) error {
 					RuntimeType:                  runtimeType,
 					PrivilegedWithoutHostDevices: privilegedWithoutHostDevices,
 					RuntimeConfigPath:            runtimeConfigPath,
-					ContainerMinMemory:           units.BytesSize(float64(containerMinMemory)),
+					ContainerMinMemory:           containerMinMemory,
 				}
 			default:
 				return fmt.Errorf("invalid format for --runtimes: %q", r)

--- a/test/image.bats
+++ b/test/image.bats
@@ -380,12 +380,12 @@ runtime_path = "$RUNTIME_BINARY_PATH"
 EOF
 	start_crio
 
-	case $(go env GOARCH) in
-	amd64)
+	case $ARCH in
+	x86_64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		;;
-	arm64)
+	aarch64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		;;
@@ -410,12 +410,12 @@ container_min_memory = "7.5MiB"
 EOF
 	start_crio
 
-	case $(go env GOARCH) in
-	amd64)
+	case $ARCH in
+	x86_64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		;;
-	arm64)
+	aarch64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		;;
@@ -427,7 +427,7 @@ EOF
 		| .image.image = $image' \
 		"$TESTDATA"/container_config.json > "$TESTDIR"/memory.json
 
-	run crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
+	crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
 }
 
 @test "run container with container_min_memory 17.5MiB" {
@@ -440,12 +440,12 @@ container_min_memory = "17.5MiB"
 EOF
 	start_crio
 
-	case $(go env GOARCH) in
-	amd64)
+	case $ARCH in
+	x86_64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		;;
-	arm64)
+	aarch64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		;;
@@ -457,7 +457,7 @@ EOF
 		| .image.image = $image' \
 		"$TESTDATA"/container_config.json > "$TESTDIR"/memory.json
 
-	run crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
+	run ! crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
 }
 
 @test "run container with container_min_memory 5.5MiB" {
@@ -470,12 +470,12 @@ container_min_memory = "5.5MiB"
 EOF
 	start_crio
 
-	case $(go env GOARCH) in
-	amd64)
+	case $ARCH in
+	x86_64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		;;
-	arm64)
+	aarch64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		;;
@@ -486,7 +486,7 @@ EOF
 		| .image.image = $image' \
 		"$TESTDATA"/container_config.json > "$TESTDIR"/memory.json
 
-	run crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
+	crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
 }
 
 @test "run container with empty container_min_memory" {
@@ -498,12 +498,12 @@ runtime_path = "$RUNTIME_BINARY_PATH"
 EOF
 	start_crio
 
-	case $(go env GOARCH) in
-	amd64)
+	case $ARCH in
+	x86_64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_AMD64}
 		;;
-	arm64)
+	aarch64)
 		crictl pull ${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		IMAGE=${IMAGE_LIST_DIGEST_FOR_TAG_ARM64}
 		;;
@@ -514,5 +514,7 @@ EOF
 		| .image.image = $image' \
 		"$TESTDATA"/container_config.json > "$TESTDIR"/memory.json
 
-	run crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
+	wait_for_log 'Runtime handler \\"runc\\" container minimum memory set to 12582912 bytes'
+	wait_for_log 'Runtime handler \\"mem\\" container minimum memory set to 12582912 bytes'
+	crictl run "$TESTDIR"/memory.json "$TESTDATA"/sandbox_config.json
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

When you provide `--runtime` option (or `CONTAINER_RUNTIMES` variable) with no `container_min_memory`, it doesn't respect the default container_min_memory (12MiB) and it will be 0B. 

```
sudo crio --log-level=debug --runtimes=runc:/usr/local/sbin/runc:

...
INFO[2024-04-22 12:17:08.039694857Z] Using runtime handler runc version 1.1.12, commit: v1.1.12-0-g51d5e946, spec: 1.0.2-dev, go: go1.20.13, libseccomp: 2.5.4  file="config/config.go:1291"
DEBU[2024-04-22 12:17:08.039769758Z] Runtime handler "runc" container minimum memory set to 0 bytes  file="config/config.go:1300"
...
```

It should be 12 MiB.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
