### PR TITLE
Build s390x binaries using musl libc

### DIFF
--- a/nix/default-s390x.nix
+++ b/nix/default-s390x.nix
@@ -1,6 +1,9 @@
 (import ./nixpkgs.nix {
   crossSystem = {
-    config = "s390x-unknown-linux-gnu";
+    # TODO: Switch back to glibc when
+    # https://github.com/NixOS/nixpkgs/issues/306473
+    # is resolved.
+    config = "s390x-unknown-linux-musl";
   };
   overlays = [ (import ./overlay.nix) ];
 }).callPackage ./derivation.nix

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,4 +1,6 @@
-{ pkgs }:
+{ stdenv
+, pkgs
+}:
 with pkgs; buildGo122Module {
   name = "cri-o";
   src = ./..;
@@ -15,9 +17,10 @@ with pkgs; buildGo122Module {
     pkg-config
     which
   ];
-  buildInputs = [
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isMusl) [
     glibc
     glibc.static
+  ] ++ [
     gpgme
     libassuan
     libgpgerror


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Building using musl until https://github.com/NixOS/nixpkgs/issues/306473 is resolved.

#### Which issue(s) this PR fixes:

Refers to https://github.com/cri-o/cri-o/issues/7911
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Using musl libc for s390x until the static glibc issue is resolved.
```
