### PR TITLE
[release-1.29] Reload config update pinned_images

### DIFF
--- a/contrib/test/ci/integration.yml
+++ b/contrib/test/ci/integration.yml
@@ -54,6 +54,7 @@
         state: present
       loop: "{{ ['cgroups.bats'] | product(kata_skip_cgroups_tests) \
         + ['command.bats'] | product(kata_skip_command_tests) \
+        + ['reload_config.bats'] | product(kata_skip_reload_config_tests) \
         + ['config.bats'] | product(kata_skip_config_tests) \
         + ['config_migrate.bats'] | product(kata_skip_config_migrate_tests) \
         + ['crio-wipe.bats'] | product(kata_skip_crio_wipe_tests) \

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -96,6 +96,10 @@ kata_skip_cgroups_tests:
 kata_skip_command_tests:
   - 'test "crio commands"'
   - 'test "log max boundary testing"'
+kata_skip_reload_config_tests:
+  - "test \"reload config should update 'pinned_images'\""
+  - "test \"reload config should update 'pinned_images' and only 'pause_image' is pinned\""
+  - "test \"reload config should update 'pause_image' and it becomes 'pinned_images'\""
 kata_skip_config_tests:
   - 'test "choose different default runtime should succeed"'
   - 'test "runc not existing when default_runtime changed should succeed"'

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -151,6 +151,9 @@ type ImageServer interface {
 	// CandidatesForPotentiallyShortImageName resolves an image name into a set of fully-qualified image names (domain/repo/image:tag|@digest).
 	// It will only return an empty slice if err != nil.
 	CandidatesForPotentiallyShortImageName(systemContext *types.SystemContext, imageName string) ([]RegistryImageReference, error)
+
+	// UpdatePinnedImagesList updates pinned and pause images list in imageService.
+	UpdatePinnedImagesList(imageList []string)
 }
 
 func parseImageNames(image *storage.Image) (someName *RegistryImageReference, tags []reference.NamedTagged, digests []reference.Canonical, err error) {
@@ -895,6 +898,11 @@ type nativeStorageTransport struct{}
 
 func (st nativeStorageTransport) ResolveReference(ref types.ImageReference) (types.ImageReference, *storage.Image, error) {
 	return istorage.ResolveReference(ref)
+}
+
+// UpdatePinnedImagesList updates pinned images list in imageService.
+func (svc *imageService) UpdatePinnedImagesList(pinnedImages []string) {
+	svc.regexForPinnedImages = CompileRegexpsForPinnedImages(pinnedImages)
 }
 
 // FilterPinnedImage checks if the given image needs to be pinned

--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/cri-o/cri-o/internal/log"
@@ -20,7 +21,7 @@ func (c *Config) Reload() error {
 	// Reload the config
 	newConfig, err := DefaultConfig()
 	if err != nil {
-		return fmt.Errorf("unable to create default config")
+		return fmt.Errorf("unable to create default config: %w", err)
 	}
 
 	if _, err := os.Stat(c.singleConfigPath); !os.IsNotExist(err) {
@@ -143,17 +144,23 @@ func (c *Config) ReloadPauseImage(newConfig *Config) error {
 }
 
 // ReloadPinnedImages updates the PinnedImages with the provided `newConfig`.
+// The method print log in case of any updates.
 func (c *Config) ReloadPinnedImages(newConfig *Config) {
 	updatedPinnedImages := make([]string, len(newConfig.PinnedImages))
+	updatedPinnedImageList := false
+
 	for i, image := range newConfig.PinnedImages {
 		if i < len(c.PinnedImages) && image == c.PinnedImages[i] {
-			updatedPinnedImages[i] = c.PinnedImages[i]
-		} else {
-			updatedPinnedImages[i] = image
+			continue
 		}
+		updatedPinnedImages[i] = image
+		updatedPinnedImageList = true
 	}
-	logrus.Infof("Updated new pinned images: %+v", updatedPinnedImages)
-	c.PinnedImages = updatedPinnedImages
+
+	if updatedPinnedImageList {
+		logConfig("pinned_images", strings.Join(updatedPinnedImages, ", "))
+		c.PinnedImages = updatedPinnedImages
+	}
 }
 
 // ReloadRegistries reloads the registry configuration from the Configs

--- a/server/server.go
+++ b/server/server.go
@@ -596,6 +596,9 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 				logrus.Errorf("Unable to reload configuration: %v", err)
 				continue
 			}
+			// ImageServer compiles the list with regex for both
+			// pinned and sandbox/pause images, we need to update them
+			s.StorageImageServer().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
 		}
 	}()
 

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -185,6 +185,18 @@ func (mr *MockImageServerMockRecorder) UntagImage(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagImage", reflect.TypeOf((*MockImageServer)(nil).UntagImage), arg0, arg1)
 }
 
+// UpdatePinnedImagesList mocks base method.
+func (m *MockImageServer) UpdatePinnedImagesList(arg0 []string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatePinnedImagesList", arg0)
+}
+
+// UpdatePinnedImagesList indicates an expected call of UpdatePinnedImagesList.
+func (mr *MockImageServerMockRecorder) UpdatePinnedImagesList(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePinnedImagesList", reflect.TypeOf((*MockImageServer)(nil).UpdatePinnedImagesList), arg0)
+}
+
 // MockRuntimeServer is a mock of RuntimeServer interface.
 type MockRuntimeServer struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
This is a manual [cherry-pick of https://github.com/cri-o/cri-o/pull/7937](https://github.com/cri-o/cri-o/pull/7976)

/assign sohankunkerkar

```release-note
Updates pinned images list on config reload
```