### PR TITLE
Add debug log to expose details of an exec PID lifecycle

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -807,6 +807,8 @@ func (c *Container) KillExecPIDs() {
 			if shouldKill {
 				sig = syscall.SIGKILL
 			}
+
+			logrus.Debugf("Stopping exec PID %d for container %s with signal %s ...", pid, c.ID(), unix.SignalName(sig))
 			if err := syscall.Kill(pid, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
 				unkilled[pid] = shouldKill
 			}

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -773,6 +773,8 @@ func (c *Container) RuntimePathForPlatform(r *runtimeOCI) string {
 func (c *Container) AddExecPID(pid int, shouldKill bool) error {
 	c.stopLock.Lock()
 	defer c.stopLock.Unlock()
+
+	logrus.Debugf("Starting to track exec PID %d for container %s (should kill = %t) ...", pid, c.ID(), shouldKill)
 	if c.stopping {
 		return errors.New("cannot register an exec PID: container is stopping")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The following Pull Request introduced the concept of internally tracking the PID of the process created using the exec (whether synchronous or not) calls. This is very useful and immediately stops CRI-O from losing track of the processes created as part of the exec invocation.

However, aside from a debug log line added for each exec request, nothing else can be used to track a particular exec invocation and termination.

Thus, add a debug log line to expose details of an exec PID being newly started and to be killed, which can aid with troubleshooting.

Related:

- https://github.com/cri-o/cri-o/pull/7937

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
