### PR TITLE
[release-1.28] OCPBUGS-32481: oci: keep track of exec PIDs and stop them on container stop

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -844,6 +844,8 @@ func (c *Container) RuntimePathForPlatform(r *runtimeOCI) string {
 func (c *Container) AddExecPID(pid int, shouldKill bool) error {
 	c.stopLock.Lock()
 	defer c.stopLock.Unlock()
+
+	logrus.Debugf("Starting to track exec PID %d for container %s (should kill = %t) ...", pid, c.ID(), shouldKill)
 	if c.stopping {
 		return errors.New("cannot register an exec PID: container is stopping")
 	}

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -878,6 +878,8 @@ func (c *Container) KillExecPIDs() {
 			if shouldKill {
 				sig = syscall.SIGKILL
 			}
+
+			logrus.Debugf("Stopping exec PID %d for container %s with signal %s ...", pid, c.ID(), unix.SignalName(sig))
 			if err := syscall.Kill(pid, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
 				unkilled[pid] = shouldKill
 			}

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -89,6 +89,7 @@ type Container struct {
 	restoreIsOCIImage  bool
 	resources          *types.ContainerResources
 	runtimePath        string // runtime path for a given platform
+	execPIDs           map[int]bool
 }
 
 func (c *Container) CRIAttributes() *types.ContainerAttributes {
@@ -159,6 +160,7 @@ func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations,
 		stopSignal:      stopSignal,
 		stopTimeoutChan: make(chan int64, 10),
 		stopWatchers:    []chan struct{}{},
+		execPIDs:        map[int]bool{},
 	}
 	return c, nil
 }
@@ -832,4 +834,55 @@ func (c *Container) RuntimePathForPlatform(r *runtimeOCI) string {
 		return r.handler.RuntimePath
 	}
 	return c.runtimePath
+}
+
+// AddExecPID registers a PID associated with an exec session.
+// It is tracked so exec sessions can be cancelled when the container is being stopped.
+// If the PID is conmon, shouldKill should be false, as we should not call SIGKILL on conmon.
+// If it is an exec session, shouldKill should be true, as we can't guarantee the exec process
+// will have a SIGINT handler.
+func (c *Container) AddExecPID(pid int, shouldKill bool) error {
+	c.stopLock.Lock()
+	defer c.stopLock.Unlock()
+	if c.stopping {
+		return errors.New("cannot register an exec PID: container is stopping")
+	}
+	c.execPIDs[pid] = shouldKill
+	return nil
+}
+
+// DeleteExecPID is for deregistering a pid after it has exited.
+func (c *Container) DeleteExecPID(pid int) {
+	c.stopLock.Lock()
+	defer c.stopLock.Unlock()
+	delete(c.execPIDs, pid)
+}
+
+// KillExecPIDs loops through the saved execPIDs and sends a signal to them.
+// If shouldKill is true, the signal is SIGKILL. Otherwise, SIGINT.
+func (c *Container) KillExecPIDs() {
+	c.stopLock.Lock()
+	toKill := c.execPIDs
+	c.stopLock.Unlock()
+
+	for len(toKill) != 0 {
+		unkilled := map[int]bool{}
+		for pid, shouldKill := range toKill {
+			if pid == 0 {
+				// The caller may accidentally register `0` (for instance if the PID of the cmd has already exited)
+				// and killing 0 is the way to ask the kernel to kill the whole process group of the calling process.
+				// We definitely don't want to kill the CRI-O process group, so add this check just in case.
+				continue
+			}
+			sig := syscall.SIGINT
+			if shouldKill {
+				sig = syscall.SIGKILL
+			}
+			if err := syscall.Kill(pid, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
+				unkilled[pid] = shouldKill
+			}
+		}
+		toKill = unkilled
+		time.Sleep(stopProcessWatchSleep)
+	}
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -435,7 +435,7 @@ func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []stri
 	}
 	var cmdErr, copyError error
 	if tty {
-		cmdErr = ttyCmd(execCmd, stdin, stdout, resizeChan)
+		cmdErr = ttyCmd(execCmd, stdin, stdout, resizeChan, c)
 	} else {
 		var r, w *os.File
 		if stdin != nil {
@@ -472,6 +472,12 @@ func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []stri
 		if err := execCmd.Start(); err != nil {
 			return err
 		}
+
+		pid := execCmd.Process.Pid
+		if err := c.AddExecPID(pid, true); err != nil {
+			return err
+		}
+		defer c.DeleteExecPID(pid)
 
 		// The read side of the pipe should be closed after the container process has been started.
 		if r != nil {
@@ -648,6 +654,12 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 			}
 		}()
 
+		// A neat trick we can do is register the exec PID before we send info down the start pipe.
+		// Doing so guarantees we can short circuit the exec process if the container is stopping already.
+		if err := c.AddExecPID(cmd.Process.Pid, false); err != nil {
+			return err
+		}
+
 		if r.handler.MonitorExecCgroup == config.MonitorExecCgroupContainer && r.config.InfraCtrCPUSet != "" {
 			// Update the exec's cgroup
 			containerPid, _, err := c.pid()
@@ -678,8 +690,13 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 		}
 	}
 
+	// defer in case the Pid is changed after Wait()
+	pid := cmd.Process.Pid
+
 	// first, wait till the command is done
 	waitErr := cmd.Wait()
+
+	c.DeleteExecPID(pid)
 
 	// regardless of what is in waitErr
 	// we should attempt to decode the output of the parent pipe
@@ -853,6 +870,8 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container, bm kwait.BackoffManager)
 	defer span.End()
 
 	startTime := time.Now()
+
+	go c.KillExecPIDs()
 
 	// Allow for SIGINT to correctly interrupt the stop loop, especially
 	// when CRI-O is run directly in the foreground in the terminal.

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -536,6 +536,21 @@ function check_oci_annotation() {
 	[[ $(crictl exec --sync "$ctr_id" /bin/sh -c "for i in $(seq 1 50000000); do echo -n 'a'; done" | wc -c) -le 16777216 ]]
 }
 
+@test "ctr exec{,sync} should be cancelled when container is stopped" {
+	start_crio
+	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+
+	crictl exec --sync "$ctr_id" /bin/bash -c 'while true; do echo XXXXXXXXXXXXXXXXXXXXXXXX; done' &
+	pid1=$!
+	crictl exec "$ctr_id" /bin/bash -c 'while true; do echo XXXXXXXXXXXXXXXXXXXXXXXX; done' || true &
+	pid2=$!
+
+	sleep 1s
+
+	crictl stop "$ctr_id"
+	wait "$pid1" "$pid2"
+}
+
 @test "ctr device add" {
 	# In an user namespace we can only bind mount devices from the host, not mknod
 	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/cri-o/cri-o/pull/7937

/assign kwilczynski

Related:

- https://github.com/cri-o/cri-o/pull/8095

```release-note
Keep track of exec calls for a container, and make sure to kill them when a container is being stopped
```