### PR TITLE
Fix AppArmor profile Apply() function to correctly handle an "Unconfined" mode

### DIFF
--- a/internal/config/apparmor/apparmor_linux.go
+++ b/internal/config/apparmor/apparmor_linux.go
@@ -109,6 +109,7 @@ func (c *Config) Apply(p *runtimeapi.LinuxContainerSecurityContext) (string, err
 	if p.Apparmor == nil && p.ApparmorProfile == "" || p.ApparmorProfile == v1.DeprecatedAppArmorBetaProfileRuntimeDefault {
 		return c.defaultProfile, nil
 	}
+
 	securityProfile := ""
 	if p.Apparmor == nil && p.ApparmorProfile != "" {
 		securityProfile = p.ApparmorProfile
@@ -116,6 +117,14 @@ func (c *Config) Apply(p *runtimeapi.LinuxContainerSecurityContext) (string, err
 
 	if p.Apparmor != nil && p.Apparmor.LocalhostRef != "" {
 		securityProfile = p.Apparmor.LocalhostRef
+	}
+
+	if p.Apparmor == nil && strings.EqualFold(p.ApparmorProfile, v1.DeprecatedAppArmorBetaProfileNameUnconfined) {
+		securityProfile = v1.DeprecatedAppArmorBetaProfileNameUnconfined
+	}
+
+	if p.Apparmor != nil && strings.EqualFold(p.Apparmor.ProfileType.String(), v1.DeprecatedAppArmorBetaProfileNameUnconfined) {
+		securityProfile = v1.DeprecatedAppArmorBetaProfileNameUnconfined
 	}
 
 	securityProfile = strings.TrimPrefix(securityProfile, v1.DeprecatedAppArmorBetaProfileNamePrefix)

--- a/internal/config/apparmor/apparmor_test.go
+++ b/internal/config/apparmor/apparmor_test.go
@@ -103,6 +103,30 @@ var _ = t.Describe("Config", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(profile).To(Equal("some-profile"))
 		})
+
+		It("should not return error if Apparmor is unconfined", func() {
+			// When
+			profile, err := sut.Apply(&runtimeapi.LinuxContainerSecurityContext{
+				Apparmor: &runtimeapi.SecurityProfile{
+					ProfileType: runtimeapi.SecurityProfile_Unconfined,
+				},
+			})
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(profile).To(Equal("unconfined"))
+		})
+
+		It("should not return error if ApparmorProfile is unconfined", func() {
+			// When
+			profile, err := sut.Apply(&runtimeapi.LinuxContainerSecurityContext{
+				ApparmorProfile: "unconfined",
+			})
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(profile).To(Equal("unconfined"))
+		})
 	})
 
 	t.Describe("IsEnabled", func() {

--- a/test/apparmor.bats
+++ b/test/apparmor.bats
@@ -20,6 +20,7 @@ function teardown() {
 	run_a_container_after_unloading_default_apparmor_profile_new_field
 	run_a_container_after_unloading_default_apparmor_profile
 	run_a_container_with_invalid_localhost_apparmor_profile_name
+	run_a_container_with_unconfined_apparmor_profile_name
 }
 
 # 1. test running with loading the default apparmor profile.
@@ -171,6 +172,29 @@ run_a_container_with_invalid_localhost_apparmor_profile_name() {
 	pod_id=$(crictl runp "$TESTDIR"/apparmor4.json)
 
 	run ! crictl create "$pod_id" "$TESTDIR"/apparmor_container4.json "$TESTDIR"/apparmor4.json
+
+	cleanup_test
+}
+
+# 8. test running with unconfined profile name. unconfined means no apparmor enforcement.
+run_a_container_with_unconfined_apparmor_profile_name() {
+	local output status
+
+	setup_test
+	start_crio
+
+	# Disable the feature for the sandbox or the container
+	# appArmorProfile.type="unconfined"
+	jq '.linux.security_context.apparmor.profile_type = 1' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/apparmor4.json
+
+	# appArmorProfile.type="unconfined"
+	jq '.linux.security_context.apparmor.profile_type = 1' \
+		"$TESTDATA"/container_redis.json > "$TESTDIR"/apparmor_container4.json
+
+	pod_id=$(crictl runp "$TESTDIR"/apparmor4.json)
+
+	crictl create "$pod_id" "$TESTDIR"/apparmor_container4.json "$TESTDIR"/apparmor4.json
 
 	cleanup_test
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When applying a given AppArmor profile, the `Apply()` function should correctly handle the "Unconfined" profile type for both fields, the `Apparmor` (which is a `SecurityProfile` type) and `ApparmorProfile` (a bare string), of the `LinuxContainerSecurityContext` type.

#### Which issue(s) this PR fixes:

Fixes #8080.

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None

```release-note
Fix AppArmour profile Apply() function to correctly handle an "Unconfined" mode.
```
