### PR TITLE
Remove `GH_TOKEN` usage from repo

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -8,17 +8,15 @@ env:
 jobs:
   patch-release:
     permissions:
-      contents: none
+      contents: write
+      pull-requests: write
     if: github.ref == 'refs/heads/main' && github.repository == 'cri-o/cri-o'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: make release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-branch-forward.yml
+++ b/.github/workflows/release-branch-forward.yml
@@ -8,18 +8,16 @@ env:
 jobs:
   release-branch-forward:
     permissions:
-      contents: none
+      contents: write
     if: github.ref == 'refs/heads/main' && github.repository == 'cri-o/cri-o'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: make release-branch-forward
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           DRY_RUN: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,6 +221,8 @@ jobs:
 
   create-release:
     if: contains(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs:
       - release-notes
@@ -236,7 +238,6 @@ jobs:
         with:
           allowUpdates: true
           bodyFile: build/release-notes/${{ env.RELEASE_VERSION }}.md
-          token: ${{ secrets.GH_TOKEN }}
 
   unit:
     strategy:
@@ -296,14 +297,13 @@ jobs:
 
   release-notes:
     permissions:
-      contents: none
+      contents: write
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -313,8 +313,6 @@ jobs:
           branch=${raw##*/}
           echo "CURRENT_BRANCH=$branch" >> $GITHUB_ENV
       - run: make release-notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: release-notes
@@ -323,7 +321,7 @@ jobs:
 
   dependencies:
     permissions:
-      contents: none
+      contents: write
     if: github.ref == 'refs/heads/main'
     needs: release-notes
     runs-on: ubuntu-latest
@@ -331,13 +329,10 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: make dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: dependencies


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
We should use GitHub action native tokens and not personal ones from an ancient time.

#### Which issue(s) this PR fixes:

/cherry-pick release-1.29
/cherry-pick release-1.28
/cherry-pick release-1.27

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
