### PR TITLE
Re-add `GITHUB_TOKEN` for GitHub actions jobs

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -20,3 +20,5 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-branch-forward.yml
+++ b/.github/workflows/release-branch-forward.yml
@@ -20,4 +20,5 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - run: make release-branch-forward
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,6 +313,8 @@ jobs:
           branch=${raw##*/}
           echo "CURRENT_BRANCH=$branch" >> $GITHUB_ENV
       - run: make release-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: release-notes
@@ -333,6 +335,8 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: make dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: dependencies


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
We need to set the env variable because it will not get exposed automatically.

#### Which issue(s) this PR fixes:

Follow-up on https://github.com/cri-o/cri-o/pull/8107
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
