### PR TITLE
[release-1.28] Remove `GH_TOKEN` usage from repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,6 +249,8 @@ jobs:
 
   create-release:
     if: contains(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs:
       - release-notes
@@ -264,7 +266,6 @@ jobs:
         with:
           allowUpdates: true
           bodyFile: build/release-notes/${{ env.RELEASE_VERSION }}.md
-          token: ${{ secrets.GH_TOKEN }}
 
   unit:
     runs-on: ubuntu-latest
@@ -298,14 +299,13 @@ jobs:
 
   release-notes:
     permissions:
-      contents: none
+      contents: write
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -316,7 +316,7 @@ jobs:
           echo "CURRENT_BRANCH=$branch" >> $GITHUB_ENV
       - run: make release-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v3
         with:
           name: release-notes
@@ -325,7 +325,7 @@ jobs:
 
   dependencies:
     permissions:
-      contents: none
+      contents: write
     if: github.ref == 'refs/heads/main'
     needs: release-notes
     runs-on: ubuntu-latest
@@ -333,13 +333,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: make dependencies
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v3
         with:
           name: dependencies
@@ -347,20 +346,19 @@ jobs:
 
   release-branch-forward:
     permissions:
-      contents: none
+      contents: write
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: make release-branch-forward
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: false
   codeql-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We should use GitHub action native tokens and not personal ones from an ancient time.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
Manual cherry-pick of 4b4e66c63aef2fad1e07117856cd6510e8fdbeca

Refers to https://github.com/cri-o/cri-o/pull/8107

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
