### PR TITLE
Fix kubelet image GC by using new `image_id` CRI field

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -127,12 +127,19 @@ type ContainerState struct {
 func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations, annotations map[string]string, userRequestedImage string, imageName *references.RegistryImageReference, imageID *storage.StorageImageID, someRepoDigest string, md *types.ContainerMetadata, sandbox string, terminal, stdin, stdinOnce bool, runtimeHandler, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
+
+	imageIDString := ""
+	if imageID != nil {
+		imageIDString = imageID.IDStringForOutOfProcessConsumptionOnly()
+	}
+
 	externalImageRef := ""
 	if someRepoDigest != "" {
 		externalImageRef = someRepoDigest
-	} else if imageID != nil {
-		externalImageRef = imageID.IDStringForOutOfProcessConsumptionOnly()
+	} else {
+		externalImageRef = imageIDString
 	}
+
 	c := &Container{
 		criContainer: &types.Container{
 			Id:           id,
@@ -145,6 +152,7 @@ func NewContainer(id, name, bundlePath, logPath string, labels, crioAnnotations,
 				Image: userRequestedImage,
 			},
 			ImageRef: externalImageRef,
+			ImageId:  imageIDString,
 		},
 		name:            name,
 		bundlePath:      bundlePath,

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -37,12 +37,17 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 	if imageName := c.ImageName(); imageName != nil {
 		imageNameInSpec = imageName.StringForOutOfProcessConsumptionOnly()
 	}
+	imageID := ""
+	if c.ImageID() != nil {
+		imageID = c.ImageID().IDStringForOutOfProcessConsumptionOnly()
+	}
 	resp := &types.ContainerStatusResponse{
 		Status: &types.ContainerStatus{
 			Id:          containerID,
 			Metadata:    c.Metadata(),
 			Labels:      c.Labels(),
 			Annotations: c.Annotations(),
+			ImageId:     imageID,
 			ImageRef:    imageRef,
 			Image: &types.ImageSpec{
 				Image: imageNameInSpec,


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Using the implementation of https://github.com/kubernetes/kubernetes/pull/123508 to fix https://github.com/cri-o/cri-o/issues/7143

Also incorporating https://github.com/kubernetes/kubernetes/pull/123583 now.

#### Which issue(s) this PR fixes:


Fixes #7143


#### Special notes for your reviewer:
taking over https://github.com/cri-o/cri-o/pull/7815
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed kubelet image garbage collection when images being referenced as digests instead of IDs. 
```
