### PR TITLE
Drop GOSUMDB/GOPROXY and fix unary operator error while building crio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 GO ?= go
 
-export GOPROXY=https://proxy.golang.org
-export GOSUMDB=https://sum.golang.org
-
 TRIMPATH ?= -trimpath
 GO_ARCH=$(shell $(GO) env GOARCH)
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)

--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if test $(${GO:-go} env GOOS) != "linux" ; then
+if [ "$(${GO:-go} env GOOS)" != "linux" ] ; then
 	exit 0
 fi
 tmpdir="$PWD/tmp.$RANDOM"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
This PR addresses the following issues that occurred while building CRI-O locally.
```sh
$ make binaries
go: golang.org/toolchain@v0.0.1-go1.22.2.linux-amd64: verifying module: invalid GOSUMDB: malformed verifier id
go: golang.org/toolchain@v0.0.1-go1.22.2.linux-amd64: verifying module: invalid GOSUMDB: malformed verifier id
/bin/sh: line 1: [: too many arguments
go: golang.org/toolchain@v0.0.1-go1.22.2.linux-amd64: verifying module: invalid GOSUMDB: malformed verifier id
go build  -trimpath  -ldflags '-s -w -X github.com/cri-o/cri-o/internal/version.buildDate='2024-05-03T19:42:28Z' ' -tags "containers_image_ostree_stub      containers_image_openpgp seccomp selinux " -o bin/crio github.com/cri-o/cri-o/cmd/crio
go: golang.org/toolchain@v0.0.1-go1.22.2.linux-amd64: verifying module: invalid GOSUMDB: malformed verifier id
make: *** [Makefile:185: bin/crio] Error 1
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
