### PR TITLE
Wait for configuration reload completion to stabilize e2e tests

### DIFF
--- a/contrib/test/ci/integration.yml
+++ b/contrib/test/ci/integration.yml
@@ -54,7 +54,6 @@
         state: present
       loop: "{{ ['cgroups.bats'] | product(kata_skip_cgroups_tests) \
         + ['command.bats'] | product(kata_skip_command_tests) \
-        + ['reload_config.bats'] | product(kata_skip_reload_config_tests) \
         + ['config.bats'] | product(kata_skip_config_tests) \
         + ['config_migrate.bats'] | product(kata_skip_config_migrate_tests) \
         + ['crio-wipe.bats'] | product(kata_skip_crio_wipe_tests) \

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -99,10 +99,6 @@ kata_skip_cgroups_tests:
 kata_skip_command_tests:
   - 'test "crio commands"'
   - 'test "log max boundary testing"'
-kata_skip_reload_config_tests:
-  - "test \"reload config should update 'pinned_images'\""
-  - "test \"reload config should update 'pinned_images' and only 'pause_image' is pinned\""
-  - "test \"reload config should update 'pause_image' and it becomes 'pinned_images'\""
 kata_skip_config_tests:
   - 'test "choose different default runtime should succeed"'
   - 'test "runc not existing when default_runtime changed should succeed"'

--- a/server/server.go
+++ b/server/server.go
@@ -583,6 +583,7 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			// ImageServer compiles the list with regex for both
 			// pinned and sandbox/pause images, we need to update them
 			s.StorageImageServer().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
+			logrus.Info("Configuration reload completed")
 		}
 	}()
 

--- a/test/reload_config.bats
+++ b/test/reload_config.bats
@@ -243,6 +243,7 @@ EOF
 	reload_crio
 	# image becomes pinned
 	expect_log_success $OPTION $EXAMPLE_IMAGE
+	wait_for_log "Configuration reload completed"
 	output=$(crictl images -o json | jq ".images[] | select(.repoTags[] == \"$EXAMPLE_IMAGE\") |.pinned")
 	[ "$output" == "true" ]
 }
@@ -251,6 +252,7 @@ EOF
 	OPTION="pause_image"
 	printf '[crio.image]\npinned_images = [""]\n' > "$CRIO_CONFIG_DIR"/00-default
 	reload_crio
+	wait_for_log "Configuration reload completed"
 	output=$(crictl images -o json | jq '.images[] | select(.pinned == true) | .repoTags[]')
 	# only pause image is pinned
 	[[ "$output" == *"pause"* ]]
@@ -262,6 +264,7 @@ EOF
 	printf '[crio.image]\npinned_images = [""]\npause_image = "%s"\n' $EXAMPLE_IMAGE > "$CRIO_CONFIG_DIR"/04-overwrite
 	reload_crio
 	expect_log_success $OPTION $EXAMPLE_IMAGE
+	wait_for_log "Configuration reload completed"
 	output=$(crictl images -o json | jq '.images[] | select(.pinned == true) | .repoTags[]')
 	# pause image is pinned
 	[[ "$output" == *"fedora-crio-ci"* ]]


### PR DESCRIPTION
Fixes https://github.com/cri-o/cri-o/issues/8074
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind ci
/kind flake

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR makes some "reload config" tests to wait for the completion of reload.
Currently, those tests in `reload_config.bats` don't wait for `PinnedImagesList` updated.

- reload config should update 'pinned_images'
- reload config should update 'pinned_images' and only 'pause_image' is pinned
- reload config should update 'pause_image' and it becomes 'pinned_images'

It causes a race condition and test failures.
Specifically, The test sends SIGHUP and runs `crictl images`.
It expects the results to be updated with the reloaded new config.
However when `crictl images` runs before `PinnedImagesList` is updated, the `regexForPinnedImages` are not updated, and the image which should be pinned won't be regarded as pinned.

https://github.com/cri-o/cri-o/blob/7a172352193ed137dd284ef7d68545d6d8c4d2cc/internal/storage/image.go#L904-L921

https://github.com/cri-o/cri-o/blob/7a172352193ed137dd284ef7d68545d6d8c4d2cc/internal/storage/image.go#L307-L312

example: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/cri-o_cri-o/8102/pull-ci-cri-o-cri-o-main-ci-fedora-integration/1786581177407115264/artifacts/fedora-integration/cri-o-gather/artifacts/testout.txt

#### Which issue(s) this PR fixes:

None

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
