### PR TITLE
[release-1.29] Build s390x binaries using musl libc

### DIFF
--- a/nix/default-s390x.nix
+++ b/nix/default-s390x.nix
@@ -1,6 +1,6 @@
 (import ./nixpkgs.nix {
   crossSystem = {
-    config = "s390x-unknown-linux-gnu";
+    config = "s390x-unknown-linux-musl";
   };
   overlays = [ (import ./overlay.nix) ];
 }).callPackage ./derivation.nix

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,4 +1,6 @@
-{ pkgs }:
+{ stdenv
+, pkgs
+}:
 with pkgs; buildGo121Module {
   name = "cri-o";
   src = ./..;
@@ -15,9 +17,10 @@ with pkgs; buildGo121Module {
     pkg-config
     which
   ];
-  buildInputs = [
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isMusl) [
     glibc
     glibc.static
+  ] ++ [
     gpgme
     libassuan
     libgpgerror


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Manual cherry-pick of 2edec2888ee27af5b225a1a2b739fbdef968985d


#### Which issue(s) this PR fixes:

Fixes the failing build in https://github.com/cri-o/packaging/actions/runs/8962233518

#### Special notes for your reviewer:
Refers to https://github.com/cri-o/cri-o/pull/8070

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Build s390x statically linked binaries using musl libc.
```
