### PR TITLE
Fix tag-reconciler job by using `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/tag-reconciler.yml
+++ b/.github/workflows/tag-reconciler.yml
@@ -6,7 +6,7 @@ on:
 env:
   GO_VERSION: '1.22'
 jobs:
-  patch-release:
+  tag-reconciler:
     permissions:
       contents: write
     if: github.ref == 'refs/heads/main' && github.repository == 'cri-o/cri-o'
@@ -19,3 +19,5 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: make tag-reconciler
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -12,6 +12,8 @@ dependencies:
       match: GO_VERSION
     - path: .github/workflows/patch-release.yml
       match: GO_VERSION
+    - path: .github/workflows/tag-reconciler.yml
+      match: GO_VERSION
     - path: contrib/test/ci/vars.yml
       match: golang_version
 


### PR DESCRIPTION

#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
By this, we also:

- Add the go version check to `dependencies.yaml`
- Fix the name of the tag reconciler job

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixing the GitHub action run: https://github.com/cri-o/cri-o/actions/runs/8981671336
#### Special notes for your reviewer:
cc @olad5 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
