### PR TITLE
Check for nil values when importing container definition

### DIFF
--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -74,7 +74,7 @@ func (s *Server) CRImportCheckpoint(
 
 	var restoreArchivePath string
 	if restoreStorageImageID != nil {
-		log.Debugf(ctx, "Restoring from oci image %s\n", inputImage)
+		log.Debugf(ctx, "Restoring from oci image %s", inputImage)
 
 		// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
 		mountPoint, err = s.ContainerServer.StorageImageServer().GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -57,19 +57,24 @@ func (s *Server) CRImportCheckpoint(
 ) (ctrID string, retErr error) {
 	var mountPoint string
 
-	input := createConfig.Image.Image
+	// Ensure that the image to restore the checkpoint from has been provided.
+	if createConfig.Image == nil || createConfig.Image.Image == "" {
+		return "", errors.New(`attribute "image" missing from container definition`)
+	}
+
+	inputImage := createConfig.Image.Image
 	createMounts := createConfig.Mounts
 	createAnnotations := createConfig.Annotations
 	createLabels := createConfig.Labels
 
-	restoreStorageImageID, err := s.checkIfCheckpointOCIImage(ctx, input)
+	restoreStorageImageID, err := s.checkIfCheckpointOCIImage(ctx, inputImage)
 	if err != nil {
 		return "", err
 	}
 
 	var restoreArchivePath string
 	if restoreStorageImageID != nil {
-		log.Debugf(ctx, "Restoring from oci image %s\n", input)
+		log.Debugf(ctx, "Restoring from oci image %s\n", inputImage)
 
 		// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
 		mountPoint, err = s.ContainerServer.StorageImageServer().GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
@@ -88,9 +93,9 @@ func (s *Server) CRImportCheckpoint(
 	} else {
 		// First get the container definition from the
 		// tarball to a temporary directory
-		archiveFile, err := os.Open(input)
+		archiveFile, err := os.Open(inputImage)
 		if err != nil {
-			return "", fmt.Errorf("failed to open checkpoint archive %s for import: %w", input, err)
+			return "", fmt.Errorf("failed to open checkpoint archive %s for import: %w", inputImage, err)
 		}
 		defer func(f *os.File) {
 			if err := f.Close(); err != nil {
@@ -98,7 +103,7 @@ func (s *Server) CRImportCheckpoint(
 			}
 		}(archiveFile)
 
-		restoreArchivePath = input
+		restoreArchivePath = inputImage
 		options := &archive.TarOptions{
 			// Here we only need the files config.dump and spec.dump
 			ExcludePatterns: []string{
@@ -270,11 +275,14 @@ func (s *Server) CRImportCheckpoint(
 		Labels:      originalLabels,
 	}
 
-	if createConfig.Linux.Resources != nil {
-		containerConfig.Linux.Resources = createConfig.Linux.Resources
-	}
-	if createConfig.Linux.SecurityContext != nil {
-		containerConfig.Linux.SecurityContext = createConfig.Linux.SecurityContext
+	if createConfig.Linux != nil {
+		if createConfig.Linux.Resources != nil {
+			containerConfig.Linux.Resources = createConfig.Linux.Resources
+		}
+
+		if createConfig.Linux.SecurityContext != nil {
+			containerConfig.Linux.SecurityContext = createConfig.Linux.SecurityContext
+		}
 	}
 
 	if dumpSpec.Linux != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Protocol Buffers specification does not mandate that the Linux Resources for a container definition be present or that any of its attributes be required—most values are left to be the default, often unset, values. This means that the container definition stored as JSON document also does not require nor mandate that the "linux" attribute (with any of its sub-attributes) has to be present, etc. As such, once the JSON document is parsed, any missing sections will be set to `nil` within the `ContainerConfig` type, and attempting to access such object attributes to dereference them will result in a panic.

Thus, add `nil` check to ensure that the `Linux` field of the `ContainerConfig` type has been set before accessing any fields from within it, which would prevent a potential panic.

While at it, add a `nil` and empty value check to verify whether the "image" section and attribute have been set, making it the one and only mandatory field within the JSON document that is the container definition. This also short-circuits error handling further down the execution stack, so we can fail early instead.

#### Which issue(s) this PR fixes:

Fixes https://github.com/cri-o/cri-o/issues/8083.

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Check for nil values when importing container definition for a given container checkpoint to be restored.
```
