### PR TITLE
[release-1.29] pinns: write sysctls in correct process when userns

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -157,6 +157,7 @@ kata_skip_network_tests:
   - 'test "Clean up network if pod sandbox gets killed"'
 kata_skip_pod_tests:
   - 'test "pass pod sysctls to runtime"'
+  - 'test "pass pod sysctls to runtime when in userns"'
   - 'test "skip pod sysctls to runtime if host"'
   - 'test "restart crio and still get pod status"'
   - 'test "systemd cgroup_parent correctly set"'

--- a/internal/config/nsmgr/nsmgr_linux.go
+++ b/internal/config/nsmgr/nsmgr_linux.go
@@ -132,6 +132,8 @@ func (mgr *NamespaceManager) NewPodNamespaces(cfg *PodNamespacesConfig) ([]Names
 		return nil, fmt.Errorf("failed to pin namespaces %v: %s %w", cfg.Namespaces, output, err)
 	}
 
+	logrus.Debugf("Got output from pinns: %s", output)
+
 	returnedNamespaces := make([]Namespace, 0, len(cfg.Namespaces))
 	for _, ns := range cfg.Namespaces {
 		ns, err := GetNamespace(ns.Path, ns.Type)

--- a/pinns/src/pinns.c
+++ b/pinns/src/pinns.c
@@ -166,6 +166,10 @@ int main(int argc, char **argv) {
     if (unshare(unshare_flags) < 0) {
       pexit("Failed to unshare namespaces");
     }
+
+    if (sysctls_count != 0 && configure_sysctls(sysctls, sysctls_count) < 0) {
+      pexit("Failed to configure sysctls after unshare");
+    }
   } else {
     /* if we create a user or mount namespace, we need a new process. */
     if (socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_CLOEXEC, 0, p))
@@ -203,6 +207,10 @@ int main(int argc, char **argv) {
       /* Now create all the other namespaces that are owned by the correct user.  */
       if (unshare(unshare_flags & ~CLONE_NEWUSER) < 0)
         pexit("Failed to unshare namespaces");
+
+      if (sysctls_count != 0 && configure_sysctls(sysctls, sysctls_count) < 0) {
+        pexit("Failed to configure sysctls after unshare");
+      }
 
       /* Notify that the namespaces are created.  */
       if (TEMP_FAILURE_RETRY(write(p[1], "0", 1)) < 0)
@@ -243,10 +251,6 @@ int main(int argc, char **argv) {
       pexit("Failed to read from the sync pipe");
 
     close(p[0]);
-  }
-
-  if (sysctls_count != 0 && configure_sysctls(sysctls, sysctls_count) < 0) {
-    pexit("Failed to configure sysctls after unshare");
   }
 
   if (bind_user) {

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -157,6 +157,41 @@ function teardown() {
 	[[ "$output" == *"net.ipv4.ip_forward = 1"* ]]
 }
 
+@test "pass pod sysctls to runtime when in userns" {
+	if test -n "$CONTAINER_UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+	CONTAINER_DEFAULT_SYSCTLS="net.ipv4.ip_forward=1" start_crio
+
+	# TODO: kernel* ones fail with permission denied.
+	jq '	  .linux.sysctls = {
+			"net.ipv4.ip_local_port_range": "1024 65000",
+		} |
+		.linux.security_context.namespace_options.userns_options = {
+			"mode": 0,
+			"uids": [{
+				"host_id": 100000,
+				"container_id": 0,
+				"length": 65355
+			}],
+			"gids": [{
+				"host_id": 100000,
+				"container_id": 0,
+				"length": 65355
+			}]
+		}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/sandbox.json)
+	crictl start "$ctr_id"
+
+	output=$(crictl exec --sync "$ctr_id" sysctl net.ipv4.ip_local_port_range)
+	[[ "$output" == *"net.ipv4.ip_local_port_range = 1024	65000"* ]]
+
+	output=$(crictl exec --sync "$ctr_id" sysctl net.ipv4.ip_forward)
+	[[ "$output" == *"net.ipv4.ip_forward = 1"* ]]
+}
+
 @test "fail to pass pod sysctls to runtime if invalid spaces" {
 	CONTAINER_DEFAULT_SYSCTLS="net.ipv4.ip_forward = 1" crio &
 	run ! wait_until_reachable


### PR DESCRIPTION
#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a bug where pinns wasn't setting the sysctls at the correct time when it was also pinning a user namespace 
```