### PR TITLE
Delete deprecated registries config

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -143,7 +143,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l profile-mem -r -d 'Write a
 complete -c crio -n '__fish_crio_no_subcommand' -f -l profile-port -r -d 'Port for the pprof profiler.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l rdt-config-file -r -d 'Path to the RDT configuration file for configuring the resctrl pseudo-filesystem.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l read-only -d 'Setup all unprivileged containers to run as read-only. Automatically mounts the containers\' tmpfs on \'/run\', \'/tmp\' and \'/var/tmp\'.'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l registry -r -d 'Registry to be prepended when pulling unqualified images. Can be specified multiple times.'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l registry -r -d 'Registry to be prepended when pulling unqualified images. Can be specified multiple times. This option is deprecated, and it has no effect.'
 complete -c crio -n '__fish_crio_no_subcommand' -l root -s r -r -d 'The CRI-O root directory.'
 complete -c crio -n '__fish_crio_no_subcommand' -l runroot -r -d 'The CRI-O state directory.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l runtimes -r -d 'OCI runtimes, format is \'runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path:container_min_memory\'.'

--- a/contrib/test/ci/setup.yml
+++ b/contrib/test/ci/setup.yml
@@ -71,12 +71,5 @@
       [crio]
       storage_driver = "overlay"
 
-- name: add quay.io and docker.io as default registries
-  copy:
-    dest: /etc/crio/crio.conf.d/01-registries.conf
-    content: |
-      [crio.image]
-      registries = [ "quay.io", "docker.io" ]
-
 - name: build parallel
   include_tasks: "build/parallel.yml"

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -387,7 +387,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--read-only**: Setup all unprivileged containers to run as read-only. Automatically mounts the containers' tmpfs on '/run', '/tmp' and '/var/tmp'.
 
-**--registry**="": Registry to be prepended when pulling unqualified images. Can be specified multiple times.
+**--registry**="": Registry to be prepended when pulling unqualified images. Can be specified multiple times. This option is deprecated, and it has no effect.
 
 **--root, -r**="": The CRI-O root directory. (default: "/var/lib/containers/storage")
 

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -638,7 +638,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		&cli.StringSliceFlag{
 			Name:    "registry",
 			Value:   cli.NewStringSlice(defConf.Registries...),
-			Usage:   "Registry to be prepended when pulling unqualified images. Can be specified multiple times.",
+			Usage:   "Registry to be prepended when pulling unqualified images. Can be specified multiple times. This option is deprecated, and it has no effect.",
 			EnvVars: []string{"CONTAINER_REGISTRY"},
 		},
 		&cli.StringFlag{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -543,6 +543,8 @@ type ImageConfig struct {
 	// ImageVolumes controls how volumes specified in image config are handled
 	ImageVolumes ImageVolumesType `toml:"image_volumes"`
 	// Registries holds a list of registries used to pull unqualified images
+	// Deprecated: Support for this option has been dropped, and it has no effect.
+	// Please refer to containers-registries.conf(5) for configuring unqualified-search registries.
 	Registries []string `toml:"registries"`
 	// Temporary directory for big files
 	BigFilesTemporaryDir string `toml:"big_files_temporary_dir"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup
/kind deprecation

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Since #4455, `registries` option has been no effect.

https://github.com/cri-o/cri-o/blob/9712c53d2291f0436a75cacecb70ad9a3a823eed/pkg/config/config.go#L765-L770

However, there are some places that don't mention explicitly that the option has been deprecated.
This PR changes the messages which don't mention the deprecation, and removes the remained configuration.

#### Which issue(s) this PR fixes:

None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
Since the deprecation has already been released and there was a release note, I'm not sure if we should need a new release-note for this.
I made it `None` for now.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
