### PR TITLE
Keep the monitor exits from stopping when the watcher gets error

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -780,12 +780,7 @@ func (s *Server) monitorExits(ctx context.Context, watcher *fsnotify.Watcher, do
 		case event := <-watcher.Events:
 			go s.handleExit(ctx, event)
 		case err := <-watcher.Errors:
-			log.Debugf(ctx, "Watch error: %v", err)
-			if s.config.EnablePodEvents {
-				close(s.ContainerEventsChan)
-			}
-			close(done)
-			return
+			log.Errorf(ctx, "Watch error: %v", err)
 		case <-s.monitorsChan:
 			log.Debugf(ctx, "Closing exit monitor...")
 			close(done)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Currently when the watcher in "exit monitor" gets an error, whole "exit monitor" stops and it is never restarted again.
In other words, if the watcher gets an error, cri-o continues to work but it can no longer watch exits.

Watcher errors (= errors in `fsnotify`) are supposed to be something recoverable, and therefore `fsnotify` doesn't stop if it gets an error (see the usage of `sendError` in the codes below).

https://github.com/fsnotify/fsnotify/blob/main/backend_inotify.go#L410-L573
https://github.com/fsnotify/fsnotify/blob/main/backend_windows.go#L483-L647

This PR keeps the monitor from stopping when the watcher gets error, and makes it keep monitoring.
It also fixes `close of closed channel` when cri-o shuts down. (#8031)

#### Which issue(s) this PR fixes:

Fixes #8031 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

Even if this PR is merged, there is slight possibility that some events are ignored when it gets an error although it will be able to much more events than the current behaviour.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix the bug that cri-o stops watching container exits after it gets an fsnotify error
```
