### PR TITLE
contrib/cni/*: Change CNI config to latest spec

### DIFF
--- a/contrib/cni/10-crio-bridge.conflist
+++ b/contrib/cni/10-crio-bridge.conflist
@@ -1,24 +1,20 @@
 {
-  "cniVersion": "1.0.0",
-  "name": "crio",
-  "plugins": [
-    {
-      "type": "bridge",
-      "bridge": "cni0",
-      "isGateway": true,
-      "ipMasq": true,
-      "hairpinMode": true,
-      "ipam": {
-        "type": "host-local",
-        "routes": [
-            { "dst": "0.0.0.0/0" },
-            { "dst": "::/0" }
-        ],
-        "ranges": [
-            [{ "subnet": "10.85.0.0/16" }],
-            [{ "subnet": "1100:200::/24" }]
-        ]
-      }
-    }
-  ]
+	"cniVersion": "1.0.0",
+	"name": "crio-bridge",
+	"type": "bridge",
+	"bridge": "cni0",
+	"isGateway": true,
+	"ipMasq": true,
+  	"hairpinMode": true,
+	"ipam": {
+		"type": "host-local",
+		"routes": [
+			{ "dst": "0.0.0.0/0" },
+      { "dst": "::/0" }
+		],
+    "ranges": [
+      [{ "subnet": "10.85.0.0/16" }],
+      [{ "subnet": "1100:200::/24" }]
+    ]
+	}
 }

--- a/contrib/cni/README.md
+++ b/contrib/cni/README.md
@@ -63,7 +63,7 @@ Download the `CNI` plugins source tree:
 ```bash
 git clone https://github.com/containernetworking/plugins
 cd plugins
-git checkout v1.1.1
+git checkout main
 ```
 
 Build the `CNI` plugins:


### PR DESCRIPTION
Changes in the CNI specification have been leading to issues with older configuration file formats.
Previously used fields or structures are causing
parsing errors like missing 'type' errors in
configurations. Checking out main brain than a
particular release version to ensure latest
plugin build.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind documentation

#### What this PR does / why we need it:

While setting up CNI networking and using the 10-crio-bridge.conflist file as per the README, an error occurred:
"Error loading CNI config file /etc/cni/net.d/10-crio-bridge.conf: error parsing configuration: missing 'type'." This issue arose because the old format of the specification was not being parsed correctly. It's necessary to use the new format, which can be found on the official [Container Networking GitHub page](https://github.com/containernetworking/cni#).

To resolve this issue, it's recommended to get the latest build plugins by checking out from the main branch of the repository.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
