### PR TITLE
build(deps): bump ocicni to v0.4.3

### DIFF
--- a/test/mocks/ocicni/types.go
+++ b/test/mocks/ocicni/types.go
@@ -40,6 +40,20 @@ func (m *MockCNIPlugin) EXPECT() *MockCNIPluginMockRecorder {
 	return m.recorder
 }
 
+// GC mocks base method.
+func (m *MockCNIPlugin) GC(arg0 context.Context, arg1 []*ocicni.PodNetwork) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GC", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GC indicates an expected call of GC.
+func (mr *MockCNIPluginMockRecorder) GC(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GC", reflect.TypeOf((*MockCNIPlugin)(nil).GC), arg0, arg1)
+}
+
 // GetDefaultNetworkName mocks base method.
 func (m *MockCNIPlugin) GetDefaultNetworkName() string {
 	m.ctrl.T.Helper()
@@ -154,6 +168,20 @@ func (m *MockCNIPlugin) Status() error {
 func (mr *MockCNIPluginMockRecorder) Status() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockCNIPlugin)(nil).Status))
+}
+
+// StatusWithContext mocks base method.
+func (m *MockCNIPlugin) StatusWithContext(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StatusWithContext", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StatusWithContext indicates an expected call of StatusWithContext.
+func (mr *MockCNIPluginMockRecorder) StatusWithContext(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusWithContext", reflect.TypeOf((*MockCNIPlugin)(nil).StatusWithContext), arg0)
 }
 
 // TearDownPod mocks base method.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind dependency-change

#### What this PR does / why we need it:
This PR bumps the ocicni lib to use version 0.4.3, which features support for the CNI verb [STATUS](https://github.com/containernetworking/cni/blob/main/SPEC.md#status-check-plugin-status). 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
