### PR TITLE
Remove `LDFlags` field from `version`

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -42,7 +42,6 @@ type Info struct {
 	Platform        string   `json:"platform,omitempty"`
 	Linkmode        string   `json:"linkmode,omitempty"`
 	BuildTags       []string `json:"buildTags,omitempty"`
-	LDFlags         string   `json:"ldFlags,omitempty"`
 	SeccompEnabled  bool     `json:"seccompEnabled"`
 	AppArmorEnabled bool     `json:"appArmorEnabled"`
 	Dependencies    []string `json:"dependencies,omitempty"`
@@ -154,7 +153,6 @@ func Get(verbose bool) (*Info, error) {
 	gitTreeState := "clean"
 	gitCommitDate := unknown
 	buildTags := []string{}
-	ldFlags := unknown
 
 	for _, s := range info.Settings {
 		switch s.Key {
@@ -171,9 +169,6 @@ func Get(verbose bool) (*Info, error) {
 
 		case "-tags":
 			buildTags = strings.Split(s.Value, ",")
-
-		case "-ldflags":
-			ldFlags = s.Value
 		}
 	}
 
@@ -198,7 +193,6 @@ func Get(verbose bool) (*Info, error) {
 		Platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 		Linkmode:        linkmode,
 		BuildTags:       buildTags,
-		LDFlags:         ldFlags,
 		SeccompEnabled:  seccomp.IsEnabled(),
 		AppArmorEnabled: apparmor.IsEnabled(),
 		Dependencies:    dependencies,


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The field is not set any more since go 1.19, means it will always refer to `unknown`. We remove the field to avoid confusion.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `LDFlags` field from `version` output, because the field will always refer to `unknown`.
```
