### PR TITLE
Fix container stats label filter

### DIFF
--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -16,14 +16,21 @@ func (s *Server) ListContainerStats(ctx context.Context, req *types.ListContaine
 	if err != nil {
 		return nil, err
 	}
-	filter := req.Filter
-	if filter != nil {
+	if req.Filter != nil {
 		cFilter := &types.ContainerFilter{
 			Id:            req.Filter.Id,
 			PodSandboxId:  req.Filter.PodSandboxId,
 			LabelSelector: req.Filter.LabelSelector,
 		}
 		ctrList = s.filterContainerList(ctx, cFilter, ctrList)
+
+		filteredCtrList := []*oci.Container{}
+		for _, ctr := range ctrList {
+			if filterContainer(ctr.CRIContainer(), cFilter) {
+				filteredCtrList = append(filteredCtrList, ctr)
+			}
+		}
+		ctrList = filteredCtrList
 	}
 
 	return &types.ListContainerStatsResponse{

--- a/test/stats.bats
+++ b/test/stats.bats
@@ -51,6 +51,10 @@ function teardown() {
 	# Assuming the two containers can't have exactly same memory usage
 	echo "checking $ctr1_mem != $ctr2_mem"
 	[ "$ctr1_mem" != "$ctr2_mem" ]
+
+	# Test if the label filtering works
+	[ "$(crictl stats | wc -l)" == 3 ]
+	[ "$(crictl stats --label tier=backend | wc -l)" == 2 ]
 }
 
 @test "pod stats" {


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We need to filter the labels for each container to be able to support the corresponding cri-tools feature.


#### Which issue(s) this PR fixes:

Fixes: https://github.com/kubernetes-sigs/cri-tools/issues/950


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed container stats label filtering.
```
