### PR TITLE
Don't fail CI on GitHub pages push

### DIFF
--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -309,7 +309,11 @@ To verify the bill of materials (SBOM) in [SPDX](https://spdx.org) format using 
 	const maxRetries = 10
 	for i := 0; i <= maxRetries; i++ {
 		if err := command.New("git", "pull", "--rebase").RunSuccess(); err != nil {
-			return fmt.Errorf("pull and rebase from remote: %w", err)
+			logrus.Errorf("Pull and rebase from remote failed (skipping): %v", err)
+			// A failed release notes GitHub pages update is not critical and
+			// we need the release notes as part of the next CI step to
+			// actually create the release.
+			return nil
 		}
 
 		err := repo.Push(branch)


### PR DESCRIPTION



#### What type of PR is this?

/kind ci


#### What this PR does / why we need it:
Updating the [release notes GitHub pages](https://cri-o.github.io/cri-o) can lead into merge conflicts if multiple jobs run on a single branch in parallel (for example for merge commits and tags). We do not consider this as fatal error any more, because we need the release notes output for the next CI steps.

Failure ref: https://github.com/cri-o/cri-o/actions/runs/9350292608/job/25733441349#step:5:271

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
