### PR TITLE
server/*: Fix a bug where the GID is not added to /etc/group when run_as_group is set

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -179,56 +179,146 @@ func GetUserInfo(rootfs, userName string) (uid, gid uint32, additionalGids []uin
 // GeneratePasswd generates a container specific passwd file,
 // iff uid is not defined in the containers /etc/passwd
 func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir string) (string, error) {
-	// if UID exists inside of container rootfs /etc/passwd then
-	// don't generate passwd
 	if _, err := GetUser(rootfs, strconv.Itoa(int(uid))); err == nil {
 		return "", nil
 	}
-	passwdFile := filepath.Join(rundir, "passwd")
-	originPasswdFile, err := securejoin.SecureJoin(rootfs, "/etc/passwd")
-	if err != nil {
-		return "", fmt.Errorf("unable to follow symlinks to passwd file: %w", err)
+
+	passwdFilePath, stat, err := secureFilePath(rootfs, "/etc/passwd")
+	if err != nil || stat.Size == 0 {
+		return "", err
 	}
-	var st unix.Stat_t
-	err = unix.Stat(originPasswdFile, &st)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", fmt.Errorf("unable to stat passwd file %s: %w", originPasswdFile, err)
-	}
-	// Check if passwd file is world writable.
-	if st.Mode&0o022 != 0 {
+
+	if checkFilePermissions(&stat, uid, stat.Uid) {
 		return "", nil
 	}
 
-	if uid == st.Uid && st.Mode&0o200 != 0 {
-		return "", nil
+	origContent, err := readFileContent(passwdFilePath)
+	if err != nil || origContent == nil {
+		return "", err
 	}
 
-	orig, err := os.ReadFile(originPasswdFile)
-	if err != nil {
-		// If no /etc/passwd in container ignore and return
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", fmt.Errorf("read passwd file: %w", err)
-	}
 	if username == "" {
 		username = "default"
 	}
 	if homedir == "" {
 		homedir = "/tmp"
 	}
-	pwd := fmt.Sprintf("%s%s:x:%d:%d:%s user:%s:/sbin/nologin\n", orig, username, uid, gid, username, homedir)
-	if err := os.WriteFile(passwdFile, []byte(pwd), os.FileMode(st.Mode)&os.ModePerm); err != nil {
-		return "", fmt.Errorf("failed to create temporary passwd file: %w", err)
-	}
-	if err := os.Chown(passwdFile, int(st.Uid), int(st.Gid)); err != nil {
-		return "", fmt.Errorf("failed to chown temporary passwd file: %w", err)
+
+	pwdContent := fmt.Sprintf("%s%s:x:%d:%d:%s user:%s:/sbin/nologin\n", string(origContent), username, uid, gid, username, homedir)
+	passwdFile := filepath.Join(rundir, "passwd")
+
+	return createAndSecureFile(passwdFile, pwdContent, os.FileMode(stat.Mode), int(stat.Uid), int(stat.Gid))
+}
+
+// GenerateGroup generates a container specific group file,
+// iff gid is not defined in the containers /etc/group
+func GenerateGroup(gid uint32, rootfs, rundir string) (string, error) {
+	if _, err := GetGroup(rootfs, strconv.Itoa(int(gid))); err == nil {
+		return "", nil
 	}
 
-	return passwdFile, nil
+	groupFilePath, stat, err := secureFilePath(rootfs, "/etc/group")
+	if err != nil {
+		return "", err
+	}
+
+	if checkFilePermissions(&stat, gid, stat.Gid) {
+		return "", nil
+	}
+
+	origContent, err := readFileContent(groupFilePath)
+	if err != nil || origContent == nil {
+		return "", err
+	}
+
+	groupContent := fmt.Sprintf("%s%d:x:%d:\n", string(origContent), gid, gid)
+	groupFile := filepath.Join(rundir, "group")
+
+	return createAndSecureFile(groupFile, groupContent, os.FileMode(stat.Mode), int(stat.Uid), int(stat.Gid))
+}
+
+func secureFilePath(rootfs, file string) (string, unix.Stat_t, error) {
+	path, err := securejoin.SecureJoin(rootfs, file)
+	if err != nil {
+		return "", unix.Stat_t{}, fmt.Errorf("unable to follow symlinks to %s file: %w", file, err)
+	}
+
+	var st unix.Stat_t
+	err = unix.Stat(path, &st)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", unix.Stat_t{}, nil // File does not exist
+		}
+		return "", unix.Stat_t{}, fmt.Errorf("unable to stat file %s: %w", path, err)
+	}
+	return path, st, nil
+}
+
+// checkFilePermissions checks file permissions to decide whether to skip file modification.
+func checkFilePermissions(stat *unix.Stat_t, id, statID uint32) bool {
+	if stat.Mode&0o022 != 0 {
+		return true
+	}
+
+	// Check if the UID/GID matches and if the file is owner writable.
+	if id == statID && stat.Mode&0o200 != 0 {
+		return true
+	}
+
+	return false
+}
+
+func readFileContent(path string) ([]byte, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // File does not exist
+		}
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+	return content, nil
+}
+
+func createAndSecureFile(path, content string, mode os.FileMode, uid, gid int) (string, error) {
+	if err := os.WriteFile(path, []byte(content), mode&os.ModePerm); err != nil {
+		return "", fmt.Errorf("failed to create file: %w", err)
+	}
+	if err := os.Chown(path, uid, gid); err != nil {
+		return "", fmt.Errorf("failed to chown file: %w", err)
+	}
+	return path, nil
+}
+
+// GetGroup searches for a group in the container's /etc/group file using the provided
+// container mount path and group identifier (either name or ID). It returns a matching
+// user.Group structure if found. If no matching group is located, it returns
+// ErrNoGroupEntries.
+func GetGroup(containerMount, groupIDorName string) (*user.Group, error) {
+	var inputIsName bool
+	gid, err := strconv.Atoi(groupIDorName)
+	if err != nil {
+		inputIsName = true
+	}
+	groupDest, err := securejoin.SecureJoin(containerMount, "/etc/group")
+	if err != nil {
+		return nil, err
+	}
+	groups, err := user.ParseGroupFileFilter(groupDest, func(g user.Group) bool {
+		if inputIsName {
+			return g.Name == groupIDorName
+		}
+		return g.Gid == gid
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if len(groups) > 0 {
+		return &groups[0], nil
+	}
+	if !inputIsName {
+		return &user.Group{Gid: gid}, user.ErrNoGroupEntries
+	}
+	return nil, user.ErrNoGroupEntries
 }
 
 // GetUser takes a containermount path and user name or ID and returns

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -178,6 +178,11 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(passwdFile).To(BeEmpty())
 
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
+
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "root")
 			Expect(err).ToNot(HaveOccurred())
@@ -197,6 +202,11 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(passwdFile).To(BeEmpty())
 
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
+
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon")
 			Expect(err).ToNot(HaveOccurred())
@@ -215,6 +225,11 @@ var _ = t.Describe("Utils", func() {
 			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(passwdFile).To(BeEmpty())
+
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "25")
@@ -241,6 +256,16 @@ var _ = t.Describe("Utils", func() {
 			Expect(newuid).To(Equal(uid))
 			Expect(newgid).To(Equal(gid))
 			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should succeed with gid that doesn't exist in /etc/group", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+
+			// groupPath should not be empty because an updated /etc/group file is created.
+			groupPath, err := utils.GenerateGroup(6000, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).ToNot(BeEmpty())
 		})
 
 		It("should fail with username that desn't exist in /etc/passwd", func() {
@@ -280,6 +305,11 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(passwdFile).To(BeEmpty())
 
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
+
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "2:22")
 			Expect(err).ToNot(HaveOccurred())
@@ -298,6 +328,11 @@ var _ = t.Describe("Utils", func() {
 			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(passwdFile).To(BeEmpty())
+
+			// groupPath should not be empty because an updated /etc/group file is created.
+			groupPath, err := utils.GenerateGroup(6000, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).ToNot(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon:250")
@@ -318,6 +353,11 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(passwdFile).ToNot(BeEmpty())
 
+			// groupPath should not be empty because an updated /etc/group file is created.
+			groupPath, err := utils.GenerateGroup(6000, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).ToNot(BeEmpty())
+
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:250")
 			Expect(err).ToNot(HaveOccurred())
@@ -336,6 +376,11 @@ var _ = t.Describe("Utils", func() {
 			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(passwdFile).ToNot(BeEmpty())
+
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:mail")


### PR DESCRIPTION
When securityContext of runAsGroup is added the
gid has to be added in /etc/group. Test case for
the same is also being added

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind bug

#### What this PR does / why we need it:

This PR has changes to add gid [value of RunAsGroup in SecurityContext] under /etc/group

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes #8216

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where the GID is not added to /etc/group when run_as_group is set
```
