### PR TITLE
Make unit tests work rootless

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,9 +250,14 @@ jobs:
         run:
           - runner: ubuntu-latest
             arch: amd64
+            type: root
+          - runner: ubuntu-latest
+            arch: amd64
+            type: rootless
           - runner: actuated-arm64-4cpu-16gb
             arch: arm64
-    name: unit / ${{ matrix.run.arch }}
+            type: root
+    name: unit / ${{ matrix.run.arch }} / ${{ matrix.run.type }}
     runs-on: ${{ matrix.run.runner }}
     steps:
       - uses: alexellis/arkade-get@d543d47741e9217ba62ff0214444add9a35825f3
@@ -271,19 +276,23 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: go-unit-${{ matrix.run.arch }}-${{ hashFiles('**/go.sum') }}
+          key: go-unit-${{ matrix.run.arch }}-${{ matrix.run.type }}-${{ hashFiles('**/go.sum') }}
       - run: scripts/github-actions-packages
       - name: Update mocks
         run: |
           make mockgen -j $(nproc)
           hack/tree_status.sh
-      - name: Run unit tests
+      - name: Run unit tests as root
+        if: ${{ matrix.run.type == 'root' }}
         run: |
           sudo PATH="$PATH" GOCACHE="$(go env GOCACHE)" GOMODCACHE="$(go env GOMODCACHE)" make testunit
           sudo chown -R $(id -u):$(id -g) "$(go env GOCACHE)" "$(go env GOMODCACHE)"
+      - name: Run unit tests rootless
+        if: ${{ matrix.run.type == 'rootless' }}
+        run: make testunit
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: unit-${{ matrix.run.arch }}
+          name: unit-${{ matrix.run.arch }}-${{ matrix.run.type }}
           path: build/coverage
 
   coverage:
@@ -295,7 +304,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: unit-amd64
+          name: unit-amd64-root
           path: build/coverage
       - uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c # v4.4.1
         with:

--- a/internal/config/seccomp/seccomp_test.go
+++ b/internal/config/seccomp/seccomp_test.go
@@ -90,6 +90,12 @@ var _ = t.Describe("Config", func() {
 	})
 
 	t.Describe("Setup", func() {
+		BeforeEach(func() {
+			if sut.IsDisabled() {
+				Skip("tests need to run as root and enabled seccomp")
+			}
+		})
+
 		It("should succeed with custom profile from field", func() {
 			// Given
 			generator, err := generate.New("linux")

--- a/internal/factory/container/namespaces_test.go
+++ b/internal/factory/container/namespaces_test.go
@@ -3,6 +3,7 @@ package container_test
 import (
 	"os"
 
+	"github.com/containers/storage/pkg/unshare"
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	nsmgrtest "github.com/cri-o/cri-o/internal/config/nsmgr/test"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
@@ -165,6 +166,10 @@ var _ = t.Describe("Container:SpecAddNamespaces", func() {
 		Expect(found).To(BeTrue())
 	})
 	It("should use target PID namespace", func() {
+		if unshare.IsRootless() {
+			Skip("need to run as root")
+		}
+
 		// Given
 		ctrConfig := &types.ContainerConfig{
 			Metadata: &types.ContainerMetadata{Name: "name"},

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/unshare"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
 	. "github.com/onsi/ginkgo/v2"
@@ -475,6 +476,10 @@ var _ = t.Describe("Container", func() {
 			Expect(err).To(HaveOccurred())
 		})
 		It("should succeed if pid is running", func() {
+			if unshare.IsRootless() {
+				Skip("need to run as root")
+			}
+
 			// Given
 			state := &oci.ContainerState{}
 			state.Pid = alwaysRunningPid
@@ -514,6 +519,10 @@ var _ = t.Describe("Container", func() {
 			Expect(processState).To(BeEmpty())
 		})
 		It("should succeed if pid is running", func() {
+			if unshare.IsRootless() {
+				Skip("need to run as root")
+			}
+
 			// Given
 			state := &oci.ContainerState{}
 			state.Pid = alwaysRunningPid
@@ -611,6 +620,10 @@ var _ = t.Describe("Container", func() {
 			Expect(err).To(HaveOccurred())
 		})
 		It("should succeed", func() {
+			if unshare.IsRootless() {
+				Skip("need to run as root")
+			}
+
 			// Given
 			state := &oci.ContainerState{}
 			state.Pid = alwaysRunningPid

--- a/internal/oci/runtime_oci_test.go
+++ b/internal/oci/runtime_oci_test.go
@@ -51,6 +51,7 @@ var _ = t.Describe("Oci", func() {
 
 			cfg, err := libconfig.DefaultConfig()
 			Expect(err).ToNot(HaveOccurred())
+			cfg.ContainerAttachSocketDir = t.MustTempDir("attach-socket")
 			r, err := oci.New(cfg)
 			Expect(err).ToNot(HaveOccurred())
 			runtime = oci.NewRuntimeOCI(r, &libconfig.RuntimeHandler{})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -848,9 +848,11 @@ var _ = t.Describe("Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should create the  NetworkDir", func() {
+		It("should create the NetworkDir", func() {
 			// Given
-			tmpDir := path.Join(os.TempDir(), invalidPath)
+			tmpDir := t.MustTempDir("network")
+			Expect(os.RemoveAll(tmpDir)).ToNot(HaveOccurred())
+
 			sut.NetworkConfig.NetworkDir = tmpDir
 			sut.NetworkConfig.PluginDirs = []string{validDirPath}
 
@@ -859,7 +861,6 @@ var _ = t.Describe("Config", func() {
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())
-			os.RemoveAll(tmpDir)
 		})
 
 		It("should fail on invalid NetworkDir", func() {

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -341,6 +341,11 @@ var _ = t.Describe("Config", func() {
 	})
 
 	t.Describe("ReloadRuntimes", func() {
+		var existingRuntimePath string
+		BeforeEach(func() {
+			existingRuntimePath = t.MustTempFile("runc")
+		})
+
 		It("should succeed without any config change", func() {
 			// Given
 			// When
@@ -365,7 +370,7 @@ var _ = t.Describe("Config", func() {
 		It("should add a new runtime", func() {
 			// Given
 			newRuntimeHandler := &config.RuntimeHandler{
-				RuntimePath:                  "/usr/bin/runc",
+				RuntimePath:                  existingRuntimePath,
 				PrivilegedWithoutHostDevices: true,
 			}
 			newConfig := &config.Config{}
@@ -383,7 +388,7 @@ var _ = t.Describe("Config", func() {
 		It("should change the default runtime", func() {
 			// Given
 			sut.Runtimes["existing"] = &config.RuntimeHandler{
-				RuntimePath: "/usr/bin/runc",
+				RuntimePath: existingRuntimePath,
 			}
 			newConfig := &config.Config{}
 			newConfig.Runtimes = sut.Runtimes
@@ -400,12 +405,12 @@ var _ = t.Describe("Config", func() {
 		It("should overwrite existing runtime", func() {
 			// Given
 			existingRuntime := &config.RuntimeHandler{
-				RuntimePath: "/usr/bin/runc",
+				RuntimePath: existingRuntimePath,
 			}
 			sut.Runtimes["existing"] = existingRuntime
 
 			newRuntime := &config.RuntimeHandler{
-				RuntimePath:                  "/usr/bin/runc",
+				RuntimePath:                  existingRuntimePath,
 				PrivilegedWithoutHostDevices: true,
 			}
 			newConfig := &config.Config{}

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -8,6 +8,7 @@ import (
 
 	criu "github.com/checkpoint-restore/go-criu/v7/utils"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/unshare"
 	"github.com/cri-o/cri-o/internal/mockutils"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
@@ -445,6 +446,10 @@ var _ = t.Describe("ContainerRestore", func() {
 		}
 		for _, image := range images {
 			It(fmt.Sprintf("should succeed (%s)", image.config), func() {
+				if unshare.IsRootless() {
+					Skip("should run as root")
+				}
+
 				// Given
 				addContainerAndSandbox()
 				testContainer.SetStateAndSpoofPid(&oci.ContainerState{

--- a/server/sandbox_run_test.go
+++ b/server/sandbox_run_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"context"
 
+	"github.com/containers/storage/pkg/unshare"
 	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -25,6 +26,10 @@ var _ = t.Describe("RunPodSandbox", func() {
 		// TODO(sgrunert): refactor the internal function to reduce the
 		// cyclomatic complexity and test it separately
 		It("should fail when container creation errors", func() {
+			if unshare.IsRootless() {
+				Skip("should run as root")
+			}
+
 			// Given
 			gomock.InOrder(
 				runtimeServerMock.EXPECT().CreatePodSandbox(gomock.Any(),

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -145,6 +145,8 @@ var beforeEach = func() {
 	serverConfig.LogDir = path.Join(testPath, "log")
 	serverConfig.CleanShutdownFile = path.Join(testPath, "clean.shutdown")
 	serverConfig.EnablePodEvents = true
+	serverConfig.Seccomp().SetNotifierPath(t.MustTempDir("seccomp-notifier"))
+	serverConfig.NRI.SocketPath = t.MustTempDir("nri")
 
 	// We want a directory that is guaranteed to exist, but it must
 	// be empty so we don't erroneously load anything and make tests


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
- Make tests which require root optional
- Fix the reload tests if runc is not in `/usr/bin/runc`
- Make the network dir test more independent from previous runs
- Set the NRI socket path and seccomp notifier path to something rootless writeable
- Add a rootless unit test run to CI to verify that it works in the future

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
