### PR TITLE
Respect image pull timeout set by RPC context

### DIFF
--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -630,6 +630,24 @@ var _ = t.Describe("Image", func() {
 			Expect(err.Error()).To(ContainSubstring("context canceled"))
 			Expect(res).To(BeNil())
 		})
+
+		It("should fail on timed out context", func() {
+			// Given
+			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox:latest")
+			Expect(err).ToNot(HaveOccurred())
+
+			// When
+			ctx, cancel := context.WithTimeout(context.Background(), 0)
+			defer cancel()
+			res, err := sut.PullImage(ctx, imageRef, &storage.ImageCopyOptions{
+				SourceCtx: &types.SystemContext{SignaturePolicyPath: "../../test/policy.json"},
+			})
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("context deadline exceeded"))
+			Expect(res).To(BeNil())
+		})
 	})
 
 	t.Describe("CompileRegexpsForPinnedImages", func() {

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -243,8 +243,12 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 	progress := make(chan imageTypes.ProgressProperties)
 	defer close(progress) // nolint:gocritic
 
+	if deadline, ok := ctx.Deadline(); ok {
+		log.Debugf(ctx, "Pull timeout is: %s", time.Until(deadline))
+	}
+
 	// Cancel the pull if no progress is made
-	pullCtx, cancel := context.WithCancel(context.Background())
+	pullCtx, cancel := context.WithCancel(ctx)
 	go consumeImagePullProgress(ctx, cancel, progress, remoteCandidateName)
 
 	_, err = s.StorageImageServer().PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows to set a pull timeout (currently not used neither by the kubelet nor cri-tools) using the CRI context. Future consumers can then limit the pul not only if no network traffic is available (introduced in \#7887), but also in a more general way.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Respect image pull timeout set by RPC context to potentially abort an ongoing image pull.
```
