### PR TITLE
.packit.yaml: Fix `%global commit0 <sha>` generation

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,13 +18,13 @@ packages:
       get-current-version: "bash -ec 'grep \"^const Version\" internal/version/version.go | cut -d\\\" -f2'"
       post-upstream-clone:
         # Use the Fedora Rawhide specfile
-        - "git clone https://src.fedoraproject.org/rpms/cri-o .packit_rpm --depth=1"
+        - git clone https://src.fedoraproject.org/rpms/cri-o .packit_rpm --depth=1
         # Drop the "sources" file
-        - "rm -fv .packit_rpm/sources"
+        - rm -fv .packit_rpm/sources
         # Update %global commit0 <sha> in specfile
-        - "sed -i \"s/^%global commit0.*/%global commit0 $(git rev-parse HEAD)/\" .packit_rpm/cri-o.spec"
+        - sed -i "s/^%global commit0.*/%global commit0 $(git rev-parse HEAD)/" .packit_rpm/cri-o.spec
         # Remove downstream patches (if any)
-        - "sed -ri '/^Patch[0-9].*/d' .packit_rpm/cri-o.spec"
+        - sed -ri "/^Patch[0-9].*/d" .packit_rpm/cri-o.spec
   fedora-40:
     # v1.28.x
     # Propose minor and patch releases downstream


### PR DESCRIPTION
The `$(git rev-parse HEAD)` isn't expanded properly otherwise.

<!--  Thanks for sending a pull request!

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

.packit.yaml: Fix `%global commit0 <sha>` generation

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

/cc @haircommander 