### PR TITLE
Add `conntrack-tools` to CI system packages

### DIFF
--- a/contrib/test/ci/system-packages.yml
+++ b/contrib/test/ci/system-packages.yml
@@ -13,6 +13,7 @@
     state: present
     enablerepo: powertools
     name:
+      - conntrack-tools
       - container-selinux
       - curl
       - expect


### PR DESCRIPTION

#### What type of PR is this?


/kind ci

#### What this PR does / why we need it:
This also adds a bunch of other netfilter related dependencies which may solve https://github.com/cri-o/cri-o/issues/8270

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
