### PR TITLE
server: clean up container after it failed to start

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -480,6 +480,10 @@ func (h *HighPerformanceHooks) addOrRemoveCpusetFromManager(mgr cgroups.Manager,
 		targetCpus = currentCpus.Difference(cpus)
 	}
 
+	if targetCpus.Equals(currentCpus) {
+		return nil
+	}
+
 	// if we're writing to cpuset.cpus.exclusive, libcontainer manager doesn't have a field to manage it,
 	// so write to a file instead.
 	if file == cpusetCpusExclusive {

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -86,6 +86,9 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 			if err := s.nri.stopContainer(ctx, sandbox, c); err != nil {
 				log.Warnf(ctx, "NRI stop failed for container %q: %v", c.ID(), err)
 			}
+			if err := s.removeContainerInPod(ctx, sandbox, c); err != nil {
+				log.Warnf(ctx, "Failed to delete container in runtime %s: %v", c.ID(), err)
+			}
 		}
 		if err := s.ContainerStateToDisk(ctx, c); err != nil {
 			log.Warnf(ctx, "Unable to write containers %s state to disk: %v", c.ID(), err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind design
#### What this PR does / why we need it:
The kubelet isn't going to try again to start a container, instead opting to recreate it.
Thus, this container will get leaked (until the pod cgroup is deleted)

This has impacts in disabling cpu load balancing on v2, as the container cgroup sticking around
means the target cpus are in use, breaking the kernel's exclusivity rule

Also note: we do clean up a failed container creation

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove a container after it fails to start, to prevent copies of it from piling up until it succeeds.
```
