### PR TITLE
[release-1.28] release-notes: Skip first commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ GOSEC_VERSION := 2.15.0
 RELEASE_NOTES := ${BUILD_BIN_PATH}/release-notes
 ZEITGEIST := ${BUILD_BIN_PATH}/zeitgeist
 ZEITGEIST_VERSION := v0.4.1
-RELEASE_NOTES_VERSION := v0.15.1
+RELEASE_NOTES_VERSION := v0.17.0
 SHFMT := ${BUILD_BIN_PATH}/shfmt
 SHFMT_VERSION := v3.6.0
 SHELLCHECK := ${BUILD_BIN_PATH}/shellcheck
@@ -261,7 +261,7 @@ define curl_to
 endef
 
 $(RELEASE_NOTES): $(BUILD_BIN_PATH)
-	$(call curl_to,https://github.com/kubernetes/release/releases/download/$(RELEASE_NOTES_VERSION)/release-notes-linux-amd64,$(RELEASE_NOTES))
+	$(call curl_to,https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes/release/$(RELEASE_NOTES_VERSION)/release-notes-amd64-linux,$(RELEASE_NOTES))
 
 $(SHFMT): $(BUILD_BIN_PATH)
 	$(call curl_to,https://github.com/mvdan/sh/releases/download/$(SHFMT_VERSION)/shfmt_$(SHFMT_VERSION)_linux_amd64,$(SHFMT))

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -88,7 +88,7 @@ dependencies:
         match: NIX_VERSION
 
   - name: release-notes
-    version: 0.15.1
+    version: 0.17.0
     refPaths:
       - path: Makefile
         match: RELEASE_NOTES_VERSION

--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -230,6 +230,7 @@ To verify the bill of materials (SBOM) in [SPDX](https://spdx.org) format using 
 		"--repo-path=/tmp/cri-o-repo",
 		"--required-author=",
 		"--start-rev="+startTag,
+		"--skip-first-commit",
 		"--end-sha="+head,
 		"--output="+outputFilePath,
 		"--toc",


### PR DESCRIPTION



#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Skip the first commit to avoid issues like https://github.com/cri-o/cri-o/issues/8249
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Manual cherry-pick of https://github.com/cri-o/cri-o/pull/8273
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
