### PR TITLE
Mark v1.27 as EOL

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,7 +24,7 @@ import (
 const Version = "1.31.0"
 
 // ReleaseMinorVersions are the currently supported minor versions.
-var ReleaseMinorVersions = []string{"1.30", "1.29", "1.28", "1.27"}
+var ReleaseMinorVersions = []string{"1.30", "1.29", "1.28"}
 
 // Variables injected during build-time
 var (


### PR DESCRIPTION


#### What type of PR is this?


/kind deprecation


#### What this PR does / why we need it:
We can release one more v1.27 in the beginning of July (like Kubernetes does), but after that is should marked as end of life.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/hold

Should merge after the July patches.
#### Does this PR introduce a user-facing change?

```release-note
None
```
