### PR TITLE
test: ensure correct parsing of supplemental groups policy in JSON

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -931,7 +931,7 @@ function create_test_rro_mounts() {
 
 @test "ctr has gid in supplemental groups with Merge policy" {
 	start_crio
-	jq '	  .linux.security_context.supplemental_groups_policy = "Merge"' \
+	jq '	  .linux.security_context.supplemental_groups_policy = 0' \
 		"$TESTDATA"/sandbox_config.json > "$newconfig"
 
 	pod_id=$(crictl runp "$newconfig")
@@ -946,7 +946,7 @@ function create_test_rro_mounts() {
 
 @test "ctr has only specified gid in supplemental groups with Strict policy" {
 	start_crio
-	jq '	  .linux.security_context.supplemental_groups_policy = "Strict"' \
+	jq '	  .linux.security_context.supplemental_groups_policy = 1' \
 		"$TESTDATA"/sandbox_config.json > "$newconfig"
 
 	pod_id=$(crictl runp "$newconfig")


### PR DESCRIPTION
Updated jq command to correctly set the supplemental groups policy in sandbox_config.json

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci
/kind failing-test

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
Fixes this issue:
```sh
 level=fatal msg="load podSandboxConfig: json: cannot unmarshal string into Go struct field LinuxSandboxSecurityContext.linux.security_context.supplemental_groups_policy of type v1.SupplementalGroupsPolicy"
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
