### PR TITLE
Fix version output in help

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -132,7 +132,7 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	app.Version = version.Version + "\n" + info.String()
+	app.Version = strings.TrimSpace(strings.ReplaceAll(info.String(), "\n", "\n   "))
 
 	app.Flags, app.Metadata, err = criocli.GetFlagsAndMetadata()
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
Before:
```
VERSION:
   1.30.2
Version:        1.30.2
GitCommit:      unknown
GitCommitDate:  unknown
GitTreeState:   clean
BuildDate:      1980-01-01T00:00:00Z
GoVersion:      go1.22.3
Compiler:       gc
Platform:       linux/amd64
Linkmode:       dynamic
BuildTags:
  apparmor
  seccomp
  selinux
  containers_image_openpgp
  containers_image_ostree_stub
LDFlags:          unknown
SeccompEnabled:   true
AppArmorEnabled:  false

DESCRIPTION:
   OCI-based implementation of Kubernetes Container Runtime Interface
```

After:
```
VERSION:
   Version:        1.31.0
   GitCommit:      f68b12ced5b49799aaa42097540def6a67dc6643
   GitCommitDate:  2024-07-02T10:59:18Z
   GitTreeState:   clean
   BuildDate:      1980-01-01T00:00:00Z
   GoVersion:      go1.22.3
   Compiler:       gc
   Platform:       linux/amd64
   Linkmode:       dynamic
   BuildTags:
     containers_image_ostree_stub
     apparmor
     containers_image_openpgp
     seccomp
     selinux
     exclude_graphdriver_devicemapper
   LDFlags:          unknown
   SeccompEnabled:   true
   AppArmorEnabled:  false

DESCRIPTION:
   OCI-based implementation of Kubernetes Container Runtime Interface
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed version output formatting in `crio -h`.
```
