### PR TITLE
nri: pass around context and log failed pid for not spoofed containers

### DIFF
--- a/internal/nri/domain.go
+++ b/internal/nri/domain.go
@@ -19,13 +19,13 @@ type Domain interface {
 	GetName() string
 
 	// ListPodSandboxes list all pods.
-	ListPodSandboxes() []PodSandbox
+	ListPodSandboxes(context.Context) []PodSandbox
 
 	// ListContainer list all containers.
 	ListContainers() []Container
 
 	// GetPodSandbox returns the pod for the given ID.
-	GetPodSandbox(string) (PodSandbox, bool)
+	GetPodSandbox(context.Context, string) (PodSandbox, bool)
 
 	// GetContainer returns the container for the given ID.
 	GetContainer(string) (Container, bool)
@@ -55,11 +55,11 @@ func (t *domainTable) set(d Domain) {
 	t.domain = d
 }
 
-func (t *domainTable) listPodSandboxes() []PodSandbox {
+func (t *domainTable) listPodSandboxes(ctx context.Context) []PodSandbox {
 	t.Lock()
 	defer t.Unlock()
 
-	return t.domain.ListPodSandboxes()
+	return t.domain.ListPodSandboxes(ctx)
 }
 
 func (t *domainTable) listContainers() []Container {

--- a/internal/nri/nri.go
+++ b/internal/nri/nri.go
@@ -410,7 +410,7 @@ func (l *local) syncPlugin(ctx context.Context, syncFn nri.SyncCB) error {
 
 	log.Infof(ctx, "Synchronizing NRI (plugin) with current runtime state")
 
-	pods := podSandboxesToNRI(domains.listPodSandboxes())
+	pods := podSandboxesToNRI(domains.listPodSandboxes(ctx))
 	containers := containersToNRI(domains.listContainers())
 
 	for _, ctr := range containers {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now pass around the context to understand where the "Failed to get pid" message is coming from. We also don't have to log the message in case that the container is spoofed, otherwise the message may be misleading.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reduced "Failed to get pid for pod infra container" NRI message for spoofed containers and lowering the verbosity to `DEBUG`. 
```
