### PR TITLE
Sanitize CRI-O version set in the User-Agent header

### DIFF
--- a/server/useragent/useragent.go
+++ b/server/useragent/useragent.go
@@ -2,10 +2,14 @@ package useragent
 
 import (
 	"fmt"
+	"regexp"
 	"runtime"
 
 	"github.com/cri-o/cri-o/internal/version"
 )
+
+// Simplest semver "X.Y.Z" format.
+var versionRegex = regexp.MustCompile(`(\d+\.\d+\.\d+)`)
 
 // Get is the User-Agent the CRI-O daemon uses to identify itself.
 func Get() (string, error) {
@@ -13,12 +17,21 @@ func Get() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("get version: %w", err)
 	}
-	httpVersion := make([]VersionInfo, 0, 4)
-	httpVersion = append(httpVersion,
-		VersionInfo{Name: "cri-o", Version: info.Version},
-		VersionInfo{Name: "go", Version: info.GoVersion},
-		VersionInfo{Name: "os", Version: runtime.GOOS},
-		VersionInfo{Name: "arch", Version: runtime.GOARCH})
 
-	return AppendVersions("", httpVersion...), nil
+	// Ensure that the CRI-O version set in the User-Agent header
+	// is always of the simplest semver format, and remove everything
+	// else that might have been added as part of the build process.
+	versionString := info.Version
+	if s := versionRegex.FindString(versionString); s != "" {
+		versionString = s
+	}
+
+	httpVersion := AppendVersions("", []VersionInfo{
+		{Name: "cri-o", Version: versionString},
+		{Name: "go", Version: info.GoVersion},
+		{Name: "os", Version: runtime.GOOS},
+		{Name: "arch", Version: runtime.GOARCH},
+	}...)
+
+	return httpVersion, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The version CRI-O uses to set the **User-Agent** header when making requests against a remote container registry can be overridden during the build process, and it might contain more information than just a simple semver compatible version string in the "X.Y.Z" format. For example, the OpenShift-specific build of CRI-O includes release and build information as part of the version string, such as the following:

```console
1.27.8-2.rhaos4.14.gitbfac241.el9
```

This extra information, while useful as part of binary package metadata or when requesting a version using command-line switches such as `--version`, would not necessarily be useful when included in the User-Agent header. Usually, there isn't any need for the User-Agent header to include a very detailed version, release and build information.

Thus, ensure that even if the version string has been overridden and some extra information appended to it, the version included as part of the User-Agent header will only ever contain a simple version string, with any surplus information removed.

While at it, remove the not needed `VersionInfo` type slice and `append()` usage.

Related to:

- https://github.com/openshift/os/issues/1542
- https://github.com/kubernetes/registry.k8s.io/issues/286
- https://github.com/containers/image/pull/201
- https://github.com/containerd/containerd/issues/6474

This also potentially addresses the following valid concern raised by @AkihiroSuda in a different project:

![Screenshot from 2024-07-10 12-33-04](https://github.com/cri-o/cri-o/assets/250723/a3149076-faac-48a9-87ed-983717e0ebee)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
