### PR TITLE
Move hostport tests to use ginkgo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,7 @@ linters:
     - tagalign
     - tenv
     - testableexamples
+    - testifylint
     - tparallel
     - typecheck
     - unconvert
@@ -116,7 +117,6 @@ linters:
     # - predeclared
     # - promlinter
     # - tagliatelle
-    # - testifylint
     # - testpackage
     # - thelper
     # - varnamelen

--- a/internal/hostport/fake_iptables_test.go
+++ b/internal/hostport/fake_iptables_test.go
@@ -18,40 +18,43 @@ package hostport
 
 import (
 	"bytes"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	utiliptables "github.com/cri-o/cri-o/internal/iptables"
 )
 
-func TestRestoreFlushRules(t *testing.T) {
-	iptables := newFakeIPTables()
-	rules := [][]string{
-		{"-A", "KUBE-HOSTPORTS", "-m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-5N7UH5JAXCVP5UJR"},
-		{"-A", "POSTROUTING", "-m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s 127.0.0.0/8 -j MASQUERADE"},
-	}
-	natRules := bytes.NewBuffer(nil)
-	writeLine(natRules, "*nat")
-	for _, rule := range rules {
-		_, err := iptables.EnsureChain(utiliptables.TableNAT, utiliptables.Chain(rule[1]))
-		assert.NoError(t, err)
-		_, err = iptables.ensureRule(utiliptables.RulePosition(rule[0]), utiliptables.TableNAT, utiliptables.Chain(rule[1]), rule[2])
-		assert.NoError(t, err)
+var _ = t.Describe("RestoreFlushRules", func() {
+	It("should succeed", func() {
+		iptables := newFakeIPTables()
+		rules := [][]string{
+			{"-A", "KUBE-HOSTPORTS", "-m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-5N7UH5JAXCVP5UJR"},
+			{"-A", "POSTROUTING", "-m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s 127.0.0.0/8 -j MASQUERADE"},
+		}
+		natRules := bytes.NewBuffer(nil)
+		writeLine(natRules, "*nat")
+		for _, rule := range rules {
+			_, err := iptables.EnsureChain(utiliptables.TableNAT, utiliptables.Chain(rule[1]))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = iptables.ensureRule(utiliptables.RulePosition(rule[0]), utiliptables.TableNAT, utiliptables.Chain(rule[1]), rule[2])
+			Expect(err).NotTo(HaveOccurred())
 
-		writeLine(natRules, utiliptables.MakeChainLine(utiliptables.Chain(rule[1])))
-	}
-	writeLine(natRules, "COMMIT")
-	assert.NoError(t, iptables.Restore(utiliptables.TableNAT, natRules.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters))
-	natTable, ok := iptables.tables[string(utiliptables.TableNAT)]
-	assert.True(t, ok)
-	// check KUBE-HOSTPORTS chain, should have been cleaned up
-	hostportChain, ok := natTable.chains["KUBE-HOSTPORTS"]
-	assert.True(t, ok)
-	assert.Equal(t, 0, len(hostportChain.rules))
+			writeLine(natRules, utiliptables.MakeChainLine(utiliptables.Chain(rule[1])))
+		}
+		writeLine(natRules, "COMMIT")
+		err := iptables.Restore(utiliptables.TableNAT, natRules.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters)
+		Expect(err).NotTo(HaveOccurred())
+		natTable, ok := iptables.tables[string(utiliptables.TableNAT)]
+		Expect(ok).To(BeTrue())
+		// check KUBE-HOSTPORTS chain, should have been cleaned up
+		hostportChain, ok := natTable.chains["KUBE-HOSTPORTS"]
+		Expect(ok).To(BeTrue())
+		Expect(hostportChain.rules).To(BeEmpty())
 
-	// check builtin chains, should not been cleaned up
-	postroutingChain, ok := natTable.chains["POSTROUTING"]
-	assert.True(t, ok, string(postroutingChain.name))
-	assert.Equal(t, 1, len(postroutingChain.rules))
-}
+		// check builtin chains, should not been cleaned up
+		postroutingChain, ok := natTable.chains["POSTROUTING"]
+		Expect(ok).To(BeTrue())
+		Expect(postroutingChain.rules).To(HaveLen(1))
+	})
+})

--- a/internal/hostport/hostport_manager_test.go
+++ b/internal/hostport/hostport_manager_test.go
@@ -20,738 +20,738 @@ import (
 	"bytes"
 	"net"
 	"strings"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 
 	utiliptables "github.com/cri-o/cri-o/internal/iptables"
 )
 
-func TestOpenCloseHostports(t *testing.T) {
-	openPortCases := []struct {
-		podPortMapping *PodPortMapping
-		expectError    bool
-	}{
-		// no portmaps
-		{
-			&PodPortMapping{
-				Namespace: "ns1",
-				Name:      "n0",
+var _ = t.Describe("HostPortManager", func() {
+	It("OpenCloseHostports", func() {
+		openPortCases := []struct {
+			podPortMapping *PodPortMapping
+			expectError    bool
+		}{
+			// no portmaps
+			{
+				&PodPortMapping{
+					Namespace: "ns1",
+					Name:      "n0",
+				},
+				false,
 			},
-			false,
-		},
-		// allocate port 80/TCP, 8080/TCP and 443/TCP
-		{
-			&PodPortMapping{
-				Namespace: "ns1",
-				Name:      "n1",
-				PortMappings: []*PortMapping{
+			// allocate port 80/TCP, 8080/TCP and 443/TCP
+			{
+				&PodPortMapping{
+					Namespace: "ns1",
+					Name:      "n1",
+					PortMappings: []*PortMapping{
+						{HostPort: 80, Protocol: v1.ProtocolTCP},
+						{HostPort: 8080, Protocol: v1.ProtocolTCP},
+						{HostPort: 443, Protocol: v1.ProtocolTCP},
+					},
+				},
+				false,
+			},
+			// fail to allocate port previously allocated 80/TCP
+			{
+				&PodPortMapping{
+					Namespace: "ns1",
+					Name:      "n2",
+					PortMappings: []*PortMapping{
+						{HostPort: 80, Protocol: v1.ProtocolTCP},
+					},
+				},
+				true,
+			},
+			// fail to allocate port previously allocated 8080/TCP
+			{
+				&PodPortMapping{
+					Namespace: "ns1",
+					Name:      "n3",
+					PortMappings: []*PortMapping{
+						{HostPort: 8081, Protocol: v1.ProtocolTCP},
+						{HostPort: 8080, Protocol: v1.ProtocolTCP},
+					},
+				},
+				true,
+			},
+			// allocate port 8081/TCP
+			{
+				&PodPortMapping{
+					Namespace: "ns1",
+					Name:      "n3",
+					PortMappings: []*PortMapping{
+						{HostPort: 8081, Protocol: v1.ProtocolTCP},
+					},
+				},
+				false,
+			},
+			// allocate port 7777/SCTP
+			{
+				&PodPortMapping{
+					Namespace: "ns1",
+					Name:      "n4",
+					PortMappings: []*PortMapping{
+						{HostPort: 7777, Protocol: v1.ProtocolSCTP},
+					},
+				},
+				false,
+			},
+			// same HostPort different HostIP
+			{
+				&PodPortMapping{
+					Namespace: "ns1",
+					Name:      "n5",
+					PortMappings: []*PortMapping{
+						{HostPort: 8888, Protocol: v1.ProtocolUDP, HostIP: "127.0.0.1"},
+						{HostPort: 8888, Protocol: v1.ProtocolUDP, HostIP: "127.0.0.2"},
+					},
+				},
+				false,
+			},
+			// same HostPort different protocol
+			{
+				&PodPortMapping{
+					Namespace: "ns1",
+					Name:      "n6",
+					PortMappings: []*PortMapping{
+						{HostPort: 9999, Protocol: v1.ProtocolTCP},
+						{HostPort: 9999, Protocol: v1.ProtocolUDP},
+					},
+				},
+				false,
+			},
+		}
+
+		iptables := newFakeIPTables()
+		iptables.protocol = utiliptables.ProtocolIPv4
+		portOpener := newFakeSocketManager()
+		manager := &hostportManager{
+			hostPortMap: make(map[hostport]closeable),
+			iptables:    iptables,
+			portOpener:  portOpener.openFakeSocket,
+		}
+
+		// open all hostports defined in the test cases
+		for _, tc := range openPortCases {
+			mapping, err := manager.openHostports(tc.podPortMapping)
+			for hostport, socket := range mapping {
+				manager.hostPortMap[hostport] = socket
+			}
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+				continue
+			}
+			Expect(err).NotTo(HaveOccurred())
+			// SCTP ports are not allocated
+			countSctp := 0
+			for _, pm := range tc.podPortMapping.PortMappings {
+				if pm.Protocol == v1.ProtocolSCTP {
+					countSctp++
+				}
+			}
+			Expect(len(mapping)).To(BeEquivalentTo(len(tc.podPortMapping.PortMappings) - countSctp))
+		}
+
+		// We have following ports open: 80/TCP, 443/TCP, 8080/TCP, 8081/TCP,
+		// 127.0.0.1:8888/TCP, 127.0.0.2:8888/TCP, 9999/TCP and 9999/UDP open now.
+		Expect(manager.hostPortMap).To(HaveLen(8))
+		closePortCases := []struct {
+			portMappings []*PortMapping
+			expectError  bool
+		}{
+			{
+				portMappings: nil,
+			},
+			{
+				portMappings: []*PortMapping{
 					{HostPort: 80, Protocol: v1.ProtocolTCP},
 					{HostPort: 8080, Protocol: v1.ProtocolTCP},
 					{HostPort: 443, Protocol: v1.ProtocolTCP},
 				},
 			},
-			false,
-		},
-		// fail to allocate port previously allocated 80/TCP
-		{
-			&PodPortMapping{
-				Namespace: "ns1",
-				Name:      "n2",
-				PortMappings: []*PortMapping{
+			{
+				portMappings: []*PortMapping{
 					{HostPort: 80, Protocol: v1.ProtocolTCP},
 				},
 			},
-			true,
-		},
-		// fail to allocate port previously allocated 8080/TCP
-		{
-			&PodPortMapping{
-				Namespace: "ns1",
-				Name:      "n3",
-				PortMappings: []*PortMapping{
+			{
+				portMappings: []*PortMapping{
 					{HostPort: 8081, Protocol: v1.ProtocolTCP},
 					{HostPort: 8080, Protocol: v1.ProtocolTCP},
 				},
 			},
-			true,
-		},
-		// allocate port 8081/TCP
-		{
-			&PodPortMapping{
-				Namespace: "ns1",
-				Name:      "n3",
-				PortMappings: []*PortMapping{
+			{
+				portMappings: []*PortMapping{
 					{HostPort: 8081, Protocol: v1.ProtocolTCP},
 				},
 			},
-			false,
-		},
-		// allocate port 7777/SCTP
-		{
-			&PodPortMapping{
-				Namespace: "ns1",
-				Name:      "n4",
-				PortMappings: []*PortMapping{
+			{
+				portMappings: []*PortMapping{
+					{HostPort: 7070, Protocol: v1.ProtocolTCP},
+				},
+			},
+			{
+				portMappings: []*PortMapping{
 					{HostPort: 7777, Protocol: v1.ProtocolSCTP},
 				},
 			},
-			false,
-		},
-		// same HostPort different HostIP
-		{
-			&PodPortMapping{
-				Namespace: "ns1",
-				Name:      "n5",
-				PortMappings: []*PortMapping{
+			{
+				portMappings: []*PortMapping{
 					{HostPort: 8888, Protocol: v1.ProtocolUDP, HostIP: "127.0.0.1"},
 					{HostPort: 8888, Protocol: v1.ProtocolUDP, HostIP: "127.0.0.2"},
 				},
 			},
-			false,
-		},
-		// same HostPort different protocol
-		{
-			&PodPortMapping{
-				Namespace: "ns1",
-				Name:      "n6",
-				PortMappings: []*PortMapping{
+			{
+				portMappings: []*PortMapping{
 					{HostPort: 9999, Protocol: v1.ProtocolTCP},
 					{HostPort: 9999, Protocol: v1.ProtocolUDP},
 				},
 			},
-			false,
-		},
-	}
-
-	iptables := newFakeIPTables()
-	iptables.protocol = utiliptables.ProtocolIPv4
-	portOpener := newFakeSocketManager()
-	manager := &hostportManager{
-		hostPortMap: make(map[hostport]closeable),
-		iptables:    iptables,
-		portOpener:  portOpener.openFakeSocket,
-	}
-
-	// open all hostports defined in the test cases
-	for _, tc := range openPortCases {
-		mapping, err := manager.openHostports(tc.podPortMapping)
-		for hostport, socket := range mapping {
-			manager.hostPortMap[hostport] = socket
 		}
-		if tc.expectError {
-			assert.Error(t, err)
-			continue
+
+		// close all the hostports opened in previous step
+		for _, tc := range closePortCases {
+			err := manager.closeHostports(tc.portMappings)
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+				continue
+			}
+			Expect(err).NotTo(HaveOccurred())
 		}
-		assert.NoError(t, err)
-		// SCTP ports are not allocated
-		countSctp := 0
-		for _, pm := range tc.podPortMapping.PortMappings {
-			if pm.Protocol == v1.ProtocolSCTP {
-				countSctp++
+		// assert all elements in hostPortMap were cleared
+		Expect(manager.hostPortMap).To(BeEmpty())
+	})
+
+	It("HostportManager", func() {
+		iptables := newFakeIPTables()
+		iptables.protocol = utiliptables.ProtocolIPv4
+		portOpener := newFakeSocketManager()
+		manager := &hostportManager{
+			hostPortMap: make(map[hostport]closeable),
+			iptables:    iptables,
+			portOpener:  portOpener.openFakeSocket,
+		}
+		testCases := []struct {
+			mapping     *PodPortMapping
+			expectError bool
+		}{
+			// open HostPorts 8080/TCP, 8081/UDP and 8083/SCTP
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod1",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("10.1.1.2"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8080,
+							ContainerPort: 80,
+							Protocol:      v1.ProtocolTCP,
+						},
+						{
+							HostPort:      8081,
+							ContainerPort: 81,
+							Protocol:      v1.ProtocolUDP,
+						},
+						{
+							HostPort:      8083,
+							ContainerPort: 83,
+							Protocol:      v1.ProtocolSCTP,
+						},
+					},
+				},
+				expectError: false,
+			},
+			// fail to open HostPort due to conflict 8083/SCTP
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod2",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("10.1.1.3"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8082,
+							ContainerPort: 80,
+							Protocol:      v1.ProtocolTCP,
+						},
+						{
+							HostPort:      8081,
+							ContainerPort: 81,
+							Protocol:      v1.ProtocolUDP,
+						},
+						{
+							HostPort:      8083,
+							ContainerPort: 83,
+							Protocol:      v1.ProtocolSCTP,
+						},
+					},
+				},
+				expectError: true,
+			},
+			// open port 443
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod3",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("10.1.1.4"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8443,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+						},
+					},
+				},
+				expectError: false,
+			},
+			// fail to open HostPort 8443 already allocated
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod3",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("192.168.12.12"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8443,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+						},
+					},
+				},
+				expectError: true,
+			},
+			// skip HostPort with PodIP and HostIP using different families
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod4",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("2001:beef::2"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8444,
+							ContainerPort: 444,
+							Protocol:      v1.ProtocolTCP,
+							HostIP:        "192.168.1.1",
+						},
+					},
+				},
+				expectError: false,
+			},
+
+			// open same HostPort on different IP
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod5",
+					Namespace:   "ns5",
+					IP:          net.ParseIP("10.1.1.5"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8888,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+							HostIP:        "127.0.0.2",
+						},
+						{
+							HostPort:      8888,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+							HostIP:        "127.0.0.1",
+						},
+					},
+				},
+				expectError: false,
+			},
+			// open same HostPort on different
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod6",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("10.1.1.2"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      9999,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+						},
+						{
+							HostPort:      9999,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolUDP,
+						},
+					},
+				},
+				expectError: false,
+			},
+		}
+
+		// Add Hostports
+		for _, tc := range testCases {
+			err := manager.Add("id", tc.mapping, "cbr0")
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+				continue
+			}
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		// Check port opened
+		expectedPorts := []hostport{
+			{IPv4, "", 8080, "tcp"},
+			{IPv4, "", 8081, "udp"},
+			{IPv4, "", 8443, "tcp"},
+			{IPv4, "127.0.0.1", 8888, "tcp"},
+			{IPv4, "127.0.0.2", 8888, "tcp"},
+			{IPv4, "", 9999, "tcp"},
+			{IPv4, "", 9999, "udp"},
+		}
+		openedPorts := make(map[hostport]bool)
+		for hp, port := range portOpener.mem {
+			if !port.closed {
+				openedPorts[hp] = true
 			}
 		}
-		assert.EqualValues(t, len(mapping), len(tc.podPortMapping.PortMappings)-countSctp)
-	}
-
-	// We have following ports open: 80/TCP, 443/TCP, 8080/TCP, 8081/TCP,
-	// 127.0.0.1:8888/TCP, 127.0.0.2:8888/TCP, 9999/TCP and 9999/UDP open now.
-	assert.EqualValues(t, len(manager.hostPortMap), 8)
-	closePortCases := []struct {
-		portMappings []*PortMapping
-		expectError  bool
-	}{
-		{
-			portMappings: nil,
-		},
-		{
-			portMappings: []*PortMapping{
-				{HostPort: 80, Protocol: v1.ProtocolTCP},
-				{HostPort: 8080, Protocol: v1.ProtocolTCP},
-				{HostPort: 443, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			portMappings: []*PortMapping{
-				{HostPort: 80, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			portMappings: []*PortMapping{
-				{HostPort: 8081, Protocol: v1.ProtocolTCP},
-				{HostPort: 8080, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			portMappings: []*PortMapping{
-				{HostPort: 8081, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			portMappings: []*PortMapping{
-				{HostPort: 7070, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			portMappings: []*PortMapping{
-				{HostPort: 7777, Protocol: v1.ProtocolSCTP},
-			},
-		},
-		{
-			portMappings: []*PortMapping{
-				{HostPort: 8888, Protocol: v1.ProtocolUDP, HostIP: "127.0.0.1"},
-				{HostPort: 8888, Protocol: v1.ProtocolUDP, HostIP: "127.0.0.2"},
-			},
-		},
-		{
-			portMappings: []*PortMapping{
-				{HostPort: 9999, Protocol: v1.ProtocolTCP},
-				{HostPort: 9999, Protocol: v1.ProtocolUDP},
-			},
-		},
-	}
-
-	// close all the hostports opened in previous step
-	for _, tc := range closePortCases {
-		err := manager.closeHostports(tc.portMappings)
-		if tc.expectError {
-			assert.Error(t, err)
-			continue
+		Expect(len(openedPorts)).To(BeEquivalentTo(len(expectedPorts)))
+		for _, hp := range expectedPorts {
+			_, ok := openedPorts[hp]
+			Expect(ok).To(BeTrue())
 		}
-		assert.NoError(t, err)
-	}
-	// assert all elements in hostPortMap were cleared
-	assert.Zero(t, len(manager.hostPortMap))
-}
 
-func TestHostportManager(t *testing.T) {
-	iptables := newFakeIPTables()
-	iptables.protocol = utiliptables.ProtocolIPv4
-	portOpener := newFakeSocketManager()
-	manager := &hostportManager{
-		hostPortMap: make(map[hostport]closeable),
-		iptables:    iptables,
-		portOpener:  portOpener.openFakeSocket,
-	}
-	testCases := []struct {
-		mapping     *PodPortMapping
-		expectError bool
-	}{
-		// open HostPorts 8080/TCP, 8081/UDP and 8083/SCTP
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod1",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("10.1.1.2"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8080,
-						ContainerPort: 80,
-						Protocol:      v1.ProtocolTCP,
-					},
-					{
-						HostPort:      8081,
-						ContainerPort: 81,
-						Protocol:      v1.ProtocolUDP,
-					},
-					{
-						HostPort:      8083,
-						ContainerPort: 83,
-						Protocol:      v1.ProtocolSCTP,
+		// Check Iptables-save result after adding hostports
+		raw := bytes.NewBuffer(nil)
+		err := iptables.SaveInto(utiliptables.TableNAT, raw)
+		Expect(err).NotTo(HaveOccurred())
+
+		lines := strings.Split(raw.String(), "\n")
+		expectedLines := map[string]bool{
+			`*nat`:                                true,
+			`:KUBE-HOSTPORTS - [0:0]`:             true,
+			`:CRIO-HOSTPORTS-MASQ - [0:0]`:        true,
+			`:OUTPUT - [0:0]`:                     true,
+			`:PREROUTING - [0:0]`:                 true,
+			`:POSTROUTING - [0:0]`:                true,
+			`:KUBE-HP-IJHALPHTORMHHPPK - [0:0]`:   true,
+			`:CRIO-MASQ-IJHALPHTORMHHPPK - [0:0]`: true,
+			`:KUBE-HP-63UPIDJXVRSZGSUZ - [0:0]`:   true,
+			`:CRIO-MASQ-63UPIDJXVRSZGSUZ - [0:0]`: true,
+			`:KUBE-HP-WFBOALXEP42XEMJK - [0:0]`:   true,
+			`:CRIO-MASQ-WFBOALXEP42XEMJK - [0:0]`: true,
+			`:KUBE-HP-XU6AWMMJYOZOFTFZ - [0:0]`:   true,
+			`:CRIO-MASQ-XU6AWMMJYOZOFTFZ - [0:0]`: true,
+			`:KUBE-HP-TUKTZ736U5JD5UTK - [0:0]`:   true,
+			`:CRIO-MASQ-TUKTZ736U5JD5UTK - [0:0]`: true,
+			`:KUBE-HP-CAAJ45HDITK7ARGM - [0:0]`:   true,
+			`:CRIO-MASQ-CAAJ45HDITK7ARGM - [0:0]`: true,
+			`:KUBE-HP-WFUNFVXVDLD5ZVXN - [0:0]`:   true,
+			`:CRIO-MASQ-WFUNFVXVDLD5ZVXN - [0:0]`: true,
+			`:KUBE-HP-4MFWH2F2NAOMYD6A - [0:0]`:   true,
+			`:CRIO-MASQ-4MFWH2F2NAOMYD6A - [0:0]`: true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-WFBOALXEP42XEMJK":                                                               true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod3_ns1 hostport 8443\" -j CRIO-MASQ-WFBOALXEP42XEMJK":                                                                                   true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-63UPIDJXVRSZGSUZ":                                                               true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8081\" -j CRIO-MASQ-63UPIDJXVRSZGSUZ":                                                                                   true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-IJHALPHTORMHHPPK":                                                               true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8080\" -j CRIO-MASQ-IJHALPHTORMHHPPK":                                                                                   true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp --dport 8083 -j KUBE-HP-XU6AWMMJYOZOFTFZ":                                                             true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8083\" -j CRIO-MASQ-XU6AWMMJYOZOFTFZ":                                                                                   true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod5_ns5 hostport 8888\" -m tcp -p tcp --dport 8888 -j KUBE-HP-TUKTZ736U5JD5UTK":                                                               true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod5_ns5 hostport 8888\" -j CRIO-MASQ-TUKTZ736U5JD5UTK":                                                                                   true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod5_ns5 hostport 8888\" -m tcp -p tcp --dport 8888 -j KUBE-HP-CAAJ45HDITK7ARGM":                                                               true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod5_ns5 hostport 8888\" -j CRIO-MASQ-CAAJ45HDITK7ARGM":                                                                                   true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod6_ns1 hostport 9999\" -m udp -p udp --dport 9999 -j KUBE-HP-4MFWH2F2NAOMYD6A":                                                               true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod6_ns1 hostport 9999\" -j CRIO-MASQ-4MFWH2F2NAOMYD6A":                                                                                   true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod6_ns1 hostport 9999\" -m tcp -p tcp --dport 9999 -j KUBE-HP-WFUNFVXVDLD5ZVXN":                                                               true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod6_ns1 hostport 9999\" -j CRIO-MASQ-WFUNFVXVDLD5ZVXN":                                                                                   true,
+			"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                true,
+			"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                            true,
+			"-A POSTROUTING -m comment --comment \"kube hostport masquerading\" -m conntrack --ctstate DNAT -j CRIO-HOSTPORTS-MASQ":                                                                  true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s 127.0.0.0/8 -j MASQUERADE":                                                            true,
+			"-A CRIO-MASQ-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m conntrack --ctorigdstport 8080 -m tcp -p tcp --dport 80 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE":   true,
+			"-A KUBE-HP-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.2:80":                                                         true,
+			"-A CRIO-MASQ-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m conntrack --ctorigdstport 8081 -m udp -p udp --dport 81 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE":   true,
+			"-A KUBE-HP-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination 10.1.1.2:81":                                                         true,
+			"-A CRIO-MASQ-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m conntrack --ctorigdstport 8083 -m sctp -p sctp --dport 83 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE": true,
+			"-A KUBE-HP-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp -j DNAT --to-destination 10.1.1.2:83":                                                       true,
+			"-A CRIO-MASQ-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m conntrack --ctorigdstport 8443 -m tcp -p tcp --dport 443 -s 10.1.1.4/32 -d 10.1.1.4/32 -j MASQUERADE":  true,
+			"-A KUBE-HP-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.4:443":                                                        true,
+			"-A CRIO-MASQ-TUKTZ736U5JD5UTK -m comment --comment \"pod5_ns5 hostport 8888\" -m conntrack --ctorigdstport 8888 -m tcp -p tcp --dport 443 -s 10.1.1.5/32 -d 10.1.1.5/32 -j MASQUERADE":  true,
+			"-A KUBE-HP-TUKTZ736U5JD5UTK -m comment --comment \"pod5_ns5 hostport 8888\" -m tcp -p tcp -d 127.0.0.1/32 -j DNAT --to-destination 10.1.1.5:443":                                        true,
+			"-A CRIO-MASQ-CAAJ45HDITK7ARGM -m comment --comment \"pod5_ns5 hostport 8888\" -m conntrack --ctorigdstport 8888 -m tcp -p tcp --dport 443 -s 10.1.1.5/32 -d 10.1.1.5/32 -j MASQUERADE":  true,
+			"-A KUBE-HP-CAAJ45HDITK7ARGM -m comment --comment \"pod5_ns5 hostport 8888\" -m tcp -p tcp -d 127.0.0.2/32 -j DNAT --to-destination 10.1.1.5:443":                                        true,
+			"-A CRIO-MASQ-WFUNFVXVDLD5ZVXN -m comment --comment \"pod6_ns1 hostport 9999\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE":  true,
+			"-A KUBE-HP-WFUNFVXVDLD5ZVXN -m comment --comment \"pod6_ns1 hostport 9999\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.2:443":                                                        true,
+			"-A CRIO-MASQ-4MFWH2F2NAOMYD6A -m comment --comment \"pod6_ns1 hostport 9999\" -m conntrack --ctorigdstport 9999 -m udp -p udp --dport 443 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE":  true,
+			"-A KUBE-HP-4MFWH2F2NAOMYD6A -m comment --comment \"pod6_ns1 hostport 9999\" -m udp -p udp -j DNAT --to-destination 10.1.1.2:443":                                                        true,
+			`COMMIT`: true,
+		}
+		for _, line := range lines {
+			GinkgoWriter.Printf("Line: %s\n", line)
+			if strings.TrimSpace(line) != "" {
+				_, ok := expectedLines[strings.TrimSpace(line)]
+				Expect(ok).To(BeTrue())
+			}
+		}
+
+		// Remove all added hostports
+		for _, tc := range testCases {
+			if !tc.expectError {
+				err := manager.Remove("id", tc.mapping)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+
+		// Check Iptables-save result after deleting hostports
+		raw.Reset()
+		err = iptables.SaveInto(utiliptables.TableNAT, raw)
+		Expect(err).NotTo(HaveOccurred())
+		lines = strings.Split(raw.String(), "\n")
+		remainingChains := make(map[string]bool)
+		for _, line := range lines {
+			if strings.HasPrefix(line, ":") {
+				remainingChains[strings.TrimSpace(line)] = true
+			}
+		}
+		expectDeletedChains := []string{
+			"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR",
+			"KUBE-HP-TUKTZ736U5JD5UTK", "KUBE-HP-CAAJ45HDITK7ARGM", "KUBE-HP-WFUNFVXVDLD5ZVXN", "KUBE-HP-4MFWH2F2NAOMYD6A",
+		}
+		for _, chain := range expectDeletedChains {
+			_, ok := remainingChains[chain]
+			Expect(ok).To(BeFalse())
+		}
+
+		// check if all ports are closed
+		for _, port := range portOpener.mem {
+			Expect(port.closed).To(BeTrue())
+		}
+		// Clear all elements in hostPortMap
+		Expect(manager.hostPortMap).To(BeEmpty())
+	})
+
+	It("GetHostportChain", func() {
+		m := make(map[string]int)
+		chain := getHostportChain("prefix", "testrdma-2", &PortMapping{HostPort: 57119, Protocol: "TCP", ContainerPort: 57119})
+		m[string(chain)] = 1
+		chain = getHostportChain("prefix", "testrdma-2", &PortMapping{HostPort: 55429, Protocol: "TCP", ContainerPort: 55429})
+		m[string(chain)] = 1
+		chain = getHostportChain("prefix", "testrdma-2", &PortMapping{HostPort: 56833, Protocol: "TCP", ContainerPort: 56833})
+		m[string(chain)] = 1
+		chain = getHostportChain("different-prefix", "testrdma-2", &PortMapping{HostPort: 56833, Protocol: "TCP", ContainerPort: 56833})
+		m[string(chain)] = 1
+		Expect(m).To(HaveLen(4))
+	})
+
+	It("HostportManagerIPv6", func() {
+		iptables := newFakeIPTables()
+		iptables.protocol = utiliptables.ProtocolIPv6
+		portOpener := newFakeSocketManager()
+		manager := &hostportManager{
+			hostPortMap: make(map[hostport]closeable),
+			iptables:    iptables,
+			portOpener:  portOpener.openFakeSocket,
+		}
+		testCases := []struct {
+			mapping     *PodPortMapping
+			expectError bool
+		}{
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod1",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("2001:beef::2"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8080,
+							ContainerPort: 80,
+							Protocol:      v1.ProtocolTCP,
+						},
+						{
+							HostPort:      8081,
+							ContainerPort: 81,
+							Protocol:      v1.ProtocolUDP,
+						},
+						{
+							HostPort:      8083,
+							ContainerPort: 83,
+							Protocol:      v1.ProtocolSCTP,
+						},
 					},
 				},
+				expectError: false,
 			},
-			expectError: false,
-		},
-		// fail to open HostPort due to conflict 8083/SCTP
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod2",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("10.1.1.3"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8082,
-						ContainerPort: 80,
-						Protocol:      v1.ProtocolTCP,
-					},
-					{
-						HostPort:      8081,
-						ContainerPort: 81,
-						Protocol:      v1.ProtocolUDP,
-					},
-					{
-						HostPort:      8083,
-						ContainerPort: 83,
-						Protocol:      v1.ProtocolSCTP,
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod2",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("2001:beef::3"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8082,
+							ContainerPort: 80,
+							Protocol:      v1.ProtocolTCP,
+						},
+						{
+							HostPort:      8081,
+							ContainerPort: 81,
+							Protocol:      v1.ProtocolUDP,
+						},
+						{
+							HostPort:      8083,
+							ContainerPort: 83,
+							Protocol:      v1.ProtocolSCTP,
+						},
 					},
 				},
+				expectError: true,
 			},
-			expectError: true,
-		},
-		// open port 443
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod3",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("10.1.1.4"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8443,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod3",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("2001:beef::4"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8443,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+						},
 					},
 				},
+				expectError: false,
 			},
-			expectError: false,
-		},
-		// fail to open HostPort 8443 already allocated
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod3",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("192.168.12.12"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8443,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod4",
+					Namespace:   "ns2",
+					IP:          net.ParseIP("192.168.2.2"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8443,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+						},
 					},
 				},
+				expectError: true,
 			},
-			expectError: true,
-		},
-		// skip HostPort with PodIP and HostIP using different families
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod4",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::2"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8444,
-						ContainerPort: 444,
-						Protocol:      v1.ProtocolTCP,
-						HostIP:        "192.168.1.1",
-					},
-				},
-			},
-			expectError: false,
-		},
-
-		// open same HostPort on different IP
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod5",
-				Namespace:   "ns5",
-				IP:          net.ParseIP("10.1.1.5"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8888,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
-						HostIP:        "127.0.0.2",
-					},
-					{
-						HostPort:      8888,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
-						HostIP:        "127.0.0.1",
-					},
-				},
-			},
-			expectError: false,
-		},
-		// open same HostPort on different
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod6",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("10.1.1.2"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      9999,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
-					},
-					{
-						HostPort:      9999,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolUDP,
-					},
-				},
-			},
-			expectError: false,
-		},
-	}
-
-	// Add Hostports
-	for _, tc := range testCases {
-		err := manager.Add("id", tc.mapping, "cbr0")
-		if tc.expectError {
-			assert.Error(t, err)
-			continue
 		}
-		assert.NoError(t, err)
-	}
 
-	// Check port opened
-	expectedPorts := []hostport{
-		{IPv4, "", 8080, "tcp"},
-		{IPv4, "", 8081, "udp"},
-		{IPv4, "", 8443, "tcp"},
-		{IPv4, "127.0.0.1", 8888, "tcp"},
-		{IPv4, "127.0.0.2", 8888, "tcp"},
-		{IPv4, "", 9999, "tcp"},
-		{IPv4, "", 9999, "udp"},
-	}
-	openedPorts := make(map[hostport]bool)
-	for hp, port := range portOpener.mem {
-		if !port.closed {
-			openedPorts[hp] = true
+		// Add Hostports
+		for _, tc := range testCases {
+			err := manager.Add("id", tc.mapping, "cbr0")
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+				continue
+			}
+			Expect(err).NotTo(HaveOccurred())
 		}
-	}
-	assert.EqualValues(t, len(openedPorts), len(expectedPorts))
-	for _, hp := range expectedPorts {
-		_, ok := openedPorts[hp]
-		assert.EqualValues(t, true, ok)
-	}
 
-	// Check Iptables-save result after adding hostports
-	raw := bytes.NewBuffer(nil)
-	err := iptables.SaveInto(utiliptables.TableNAT, raw)
-	assert.NoError(t, err)
-
-	lines := strings.Split(raw.String(), "\n")
-	expectedLines := map[string]bool{
-		`*nat`:                                true,
-		`:KUBE-HOSTPORTS - [0:0]`:             true,
-		`:CRIO-HOSTPORTS-MASQ - [0:0]`:        true,
-		`:OUTPUT - [0:0]`:                     true,
-		`:PREROUTING - [0:0]`:                 true,
-		`:POSTROUTING - [0:0]`:                true,
-		`:KUBE-HP-IJHALPHTORMHHPPK - [0:0]`:   true,
-		`:CRIO-MASQ-IJHALPHTORMHHPPK - [0:0]`: true,
-		`:KUBE-HP-63UPIDJXVRSZGSUZ - [0:0]`:   true,
-		`:CRIO-MASQ-63UPIDJXVRSZGSUZ - [0:0]`: true,
-		`:KUBE-HP-WFBOALXEP42XEMJK - [0:0]`:   true,
-		`:CRIO-MASQ-WFBOALXEP42XEMJK - [0:0]`: true,
-		`:KUBE-HP-XU6AWMMJYOZOFTFZ - [0:0]`:   true,
-		`:CRIO-MASQ-XU6AWMMJYOZOFTFZ - [0:0]`: true,
-		`:KUBE-HP-TUKTZ736U5JD5UTK - [0:0]`:   true,
-		`:CRIO-MASQ-TUKTZ736U5JD5UTK - [0:0]`: true,
-		`:KUBE-HP-CAAJ45HDITK7ARGM - [0:0]`:   true,
-		`:CRIO-MASQ-CAAJ45HDITK7ARGM - [0:0]`: true,
-		`:KUBE-HP-WFUNFVXVDLD5ZVXN - [0:0]`:   true,
-		`:CRIO-MASQ-WFUNFVXVDLD5ZVXN - [0:0]`: true,
-		`:KUBE-HP-4MFWH2F2NAOMYD6A - [0:0]`:   true,
-		`:CRIO-MASQ-4MFWH2F2NAOMYD6A - [0:0]`: true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-WFBOALXEP42XEMJK":                                                               true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod3_ns1 hostport 8443\" -j CRIO-MASQ-WFBOALXEP42XEMJK":                                                                                   true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-63UPIDJXVRSZGSUZ":                                                               true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8081\" -j CRIO-MASQ-63UPIDJXVRSZGSUZ":                                                                                   true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-IJHALPHTORMHHPPK":                                                               true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8080\" -j CRIO-MASQ-IJHALPHTORMHHPPK":                                                                                   true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp --dport 8083 -j KUBE-HP-XU6AWMMJYOZOFTFZ":                                                             true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8083\" -j CRIO-MASQ-XU6AWMMJYOZOFTFZ":                                                                                   true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod5_ns5 hostport 8888\" -m tcp -p tcp --dport 8888 -j KUBE-HP-TUKTZ736U5JD5UTK":                                                               true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod5_ns5 hostport 8888\" -j CRIO-MASQ-TUKTZ736U5JD5UTK":                                                                                   true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod5_ns5 hostport 8888\" -m tcp -p tcp --dport 8888 -j KUBE-HP-CAAJ45HDITK7ARGM":                                                               true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod5_ns5 hostport 8888\" -j CRIO-MASQ-CAAJ45HDITK7ARGM":                                                                                   true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod6_ns1 hostport 9999\" -m udp -p udp --dport 9999 -j KUBE-HP-4MFWH2F2NAOMYD6A":                                                               true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod6_ns1 hostport 9999\" -j CRIO-MASQ-4MFWH2F2NAOMYD6A":                                                                                   true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod6_ns1 hostport 9999\" -m tcp -p tcp --dport 9999 -j KUBE-HP-WFUNFVXVDLD5ZVXN":                                                               true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod6_ns1 hostport 9999\" -j CRIO-MASQ-WFUNFVXVDLD5ZVXN":                                                                                   true,
-		"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                true,
-		"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                            true,
-		"-A POSTROUTING -m comment --comment \"kube hostport masquerading\" -m conntrack --ctstate DNAT -j CRIO-HOSTPORTS-MASQ":                                                                  true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s 127.0.0.0/8 -j MASQUERADE":                                                            true,
-		"-A CRIO-MASQ-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m conntrack --ctorigdstport 8080 -m tcp -p tcp --dport 80 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE":   true,
-		"-A KUBE-HP-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.2:80":                                                         true,
-		"-A CRIO-MASQ-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m conntrack --ctorigdstport 8081 -m udp -p udp --dport 81 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE":   true,
-		"-A KUBE-HP-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination 10.1.1.2:81":                                                         true,
-		"-A CRIO-MASQ-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m conntrack --ctorigdstport 8083 -m sctp -p sctp --dport 83 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE": true,
-		"-A KUBE-HP-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp -j DNAT --to-destination 10.1.1.2:83":                                                       true,
-		"-A CRIO-MASQ-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m conntrack --ctorigdstport 8443 -m tcp -p tcp --dport 443 -s 10.1.1.4/32 -d 10.1.1.4/32 -j MASQUERADE":  true,
-		"-A KUBE-HP-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.4:443":                                                        true,
-		"-A CRIO-MASQ-TUKTZ736U5JD5UTK -m comment --comment \"pod5_ns5 hostport 8888\" -m conntrack --ctorigdstport 8888 -m tcp -p tcp --dport 443 -s 10.1.1.5/32 -d 10.1.1.5/32 -j MASQUERADE":  true,
-		"-A KUBE-HP-TUKTZ736U5JD5UTK -m comment --comment \"pod5_ns5 hostport 8888\" -m tcp -p tcp -d 127.0.0.1/32 -j DNAT --to-destination 10.1.1.5:443":                                        true,
-		"-A CRIO-MASQ-CAAJ45HDITK7ARGM -m comment --comment \"pod5_ns5 hostport 8888\" -m conntrack --ctorigdstport 8888 -m tcp -p tcp --dport 443 -s 10.1.1.5/32 -d 10.1.1.5/32 -j MASQUERADE":  true,
-		"-A KUBE-HP-CAAJ45HDITK7ARGM -m comment --comment \"pod5_ns5 hostport 8888\" -m tcp -p tcp -d 127.0.0.2/32 -j DNAT --to-destination 10.1.1.5:443":                                        true,
-		"-A CRIO-MASQ-WFUNFVXVDLD5ZVXN -m comment --comment \"pod6_ns1 hostport 9999\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE":  true,
-		"-A KUBE-HP-WFUNFVXVDLD5ZVXN -m comment --comment \"pod6_ns1 hostport 9999\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.2:443":                                                        true,
-		"-A CRIO-MASQ-4MFWH2F2NAOMYD6A -m comment --comment \"pod6_ns1 hostport 9999\" -m conntrack --ctorigdstport 9999 -m udp -p udp --dport 443 -s 10.1.1.2/32 -d 10.1.1.2/32 -j MASQUERADE":  true,
-		"-A KUBE-HP-4MFWH2F2NAOMYD6A -m comment --comment \"pod6_ns1 hostport 9999\" -m udp -p udp -j DNAT --to-destination 10.1.1.2:443":                                                        true,
-		`COMMIT`: true,
-	}
-	for _, line := range lines {
-		t.Logf("Line: %s", line)
-		if strings.TrimSpace(line) != "" {
-			_, ok := expectedLines[strings.TrimSpace(line)]
-			assert.EqualValues(t, true, ok)
+		// Check port opened
+		expectedPorts := []hostport{{IPv6, "", 8080, "tcp"}, {IPv6, "", 8081, "udp"}, {IPv6, "", 8443, "tcp"}}
+		openedPorts := make(map[hostport]bool)
+		for hp, port := range portOpener.mem {
+			if !port.closed {
+				openedPorts[hp] = true
+			}
 		}
-	}
-
-	// Remove all added hostports
-	for _, tc := range testCases {
-		if !tc.expectError {
-			err := manager.Remove("id", tc.mapping)
-			assert.NoError(t, err)
+		Expect(len(openedPorts)).To(BeEquivalentTo(len(expectedPorts)))
+		for _, hp := range expectedPorts {
+			_, ok := openedPorts[hp]
+			Expect(ok).To(BeTrue())
 		}
-	}
 
-	// Check Iptables-save result after deleting hostports
-	raw.Reset()
-	err = iptables.SaveInto(utiliptables.TableNAT, raw)
-	assert.NoError(t, err)
-	lines = strings.Split(raw.String(), "\n")
-	remainingChains := make(map[string]bool)
-	for _, line := range lines {
-		if strings.HasPrefix(line, ":") {
-			remainingChains[strings.TrimSpace(line)] = true
+		// Check Iptables-save result after adding hostports
+		raw := bytes.NewBuffer(nil)
+		err := iptables.SaveInto(utiliptables.TableNAT, raw)
+		Expect(err).NotTo(HaveOccurred())
+
+		lines := strings.Split(raw.String(), "\n")
+		expectedLines := map[string]bool{
+			`*nat`:                                true,
+			`:KUBE-HOSTPORTS - [0:0]`:             true,
+			`:CRIO-HOSTPORTS-MASQ - [0:0]`:        true,
+			`:OUTPUT - [0:0]`:                     true,
+			`:PREROUTING - [0:0]`:                 true,
+			`:POSTROUTING - [0:0]`:                true,
+			`:KUBE-HP-IJHALPHTORMHHPPK - [0:0]`:   true,
+			`:CRIO-MASQ-IJHALPHTORMHHPPK - [0:0]`: true,
+			`:KUBE-HP-63UPIDJXVRSZGSUZ - [0:0]`:   true,
+			`:CRIO-MASQ-63UPIDJXVRSZGSUZ - [0:0]`: true,
+			`:KUBE-HP-WFBOALXEP42XEMJK - [0:0]`:   true,
+			`:CRIO-MASQ-WFBOALXEP42XEMJK - [0:0]`: true,
+			`:KUBE-HP-XU6AWMMJYOZOFTFZ - [0:0]`:   true,
+			`:CRIO-MASQ-XU6AWMMJYOZOFTFZ - [0:0]`: true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-WFBOALXEP42XEMJK":                                                                       true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod3_ns1 hostport 8443\" -j CRIO-MASQ-WFBOALXEP42XEMJK":                                                                                           true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-63UPIDJXVRSZGSUZ":                                                                       true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8081\" -j CRIO-MASQ-63UPIDJXVRSZGSUZ":                                                                                           true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-IJHALPHTORMHHPPK":                                                                       true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8080\" -j CRIO-MASQ-IJHALPHTORMHHPPK":                                                                                           true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp --dport 8083 -j KUBE-HP-XU6AWMMJYOZOFTFZ":                                                                     true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8083\" -j CRIO-MASQ-XU6AWMMJYOZOFTFZ":                                                                                           true,
+			"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                        true,
+			"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                    true,
+			"-A POSTROUTING -m comment --comment \"kube hostport masquerading\" -m conntrack --ctstate DNAT -j CRIO-HOSTPORTS-MASQ":                                                                          true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s ::1/128 -j MASQUERADE":                                                                        true,
+			"-A CRIO-MASQ-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m conntrack --ctorigdstport 8080 -m tcp -p tcp --dport 80 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE":   true,
+			"-A KUBE-HP-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination [2001:beef::2]:80":                                                           true,
+			"-A CRIO-MASQ-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m conntrack --ctorigdstport 8081 -m udp -p udp --dport 81 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE":   true,
+			"-A KUBE-HP-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination [2001:beef::2]:81":                                                           true,
+			"-A CRIO-MASQ-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m conntrack --ctorigdstport 8083 -m sctp -p sctp --dport 83 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE": true,
+			"-A KUBE-HP-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp -j DNAT --to-destination [2001:beef::2]:83":                                                         true,
+			"-A CRIO-MASQ-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m conntrack --ctorigdstport 8443 -m tcp -p tcp --dport 443 -s 2001:beef::4/32 -d 2001:beef::4/32 -j MASQUERADE":  true,
+			"-A KUBE-HP-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination [2001:beef::4]:443":                                                          true,
+			`COMMIT`: true,
 		}
-	}
-	expectDeletedChains := []string{
-		"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR",
-		"KUBE-HP-TUKTZ736U5JD5UTK", "KUBE-HP-CAAJ45HDITK7ARGM", "KUBE-HP-WFUNFVXVDLD5ZVXN", "KUBE-HP-4MFWH2F2NAOMYD6A",
-	}
-	for _, chain := range expectDeletedChains {
-		_, ok := remainingChains[chain]
-		assert.EqualValues(t, false, ok)
-	}
-
-	// check if all ports are closed
-	for _, port := range portOpener.mem {
-		assert.EqualValues(t, true, port.closed)
-	}
-	// Clear all elements in hostPortMap
-	assert.Zero(t, len(manager.hostPortMap))
-}
-
-func TestGetHostportChain(t *testing.T) {
-	m := make(map[string]int)
-	chain := getHostportChain("prefix", "testrdma-2", &PortMapping{HostPort: 57119, Protocol: "TCP", ContainerPort: 57119})
-	m[string(chain)] = 1
-	chain = getHostportChain("prefix", "testrdma-2", &PortMapping{HostPort: 55429, Protocol: "TCP", ContainerPort: 55429})
-	m[string(chain)] = 1
-	chain = getHostportChain("prefix", "testrdma-2", &PortMapping{HostPort: 56833, Protocol: "TCP", ContainerPort: 56833})
-	m[string(chain)] = 1
-	chain = getHostportChain("different-prefix", "testrdma-2", &PortMapping{HostPort: 56833, Protocol: "TCP", ContainerPort: 56833})
-	m[string(chain)] = 1
-	if len(m) != 4 {
-		t.Fatal(m)
-	}
-}
-
-func TestHostportManagerIPv6(t *testing.T) {
-	iptables := newFakeIPTables()
-	iptables.protocol = utiliptables.ProtocolIPv6
-	portOpener := newFakeSocketManager()
-	manager := &hostportManager{
-		hostPortMap: make(map[hostport]closeable),
-		iptables:    iptables,
-		portOpener:  portOpener.openFakeSocket,
-	}
-	testCases := []struct {
-		mapping     *PodPortMapping
-		expectError bool
-	}{
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod1",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::2"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8080,
-						ContainerPort: 80,
-						Protocol:      v1.ProtocolTCP,
-					},
-					{
-						HostPort:      8081,
-						ContainerPort: 81,
-						Protocol:      v1.ProtocolUDP,
-					},
-					{
-						HostPort:      8083,
-						ContainerPort: 83,
-						Protocol:      v1.ProtocolSCTP,
-					},
-				},
-			},
-			expectError: false,
-		},
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod2",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::3"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8082,
-						ContainerPort: 80,
-						Protocol:      v1.ProtocolTCP,
-					},
-					{
-						HostPort:      8081,
-						ContainerPort: 81,
-						Protocol:      v1.ProtocolUDP,
-					},
-					{
-						HostPort:      8083,
-						ContainerPort: 83,
-						Protocol:      v1.ProtocolSCTP,
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod3",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::4"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8443,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
-					},
-				},
-			},
-			expectError: false,
-		},
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod4",
-				Namespace:   "ns2",
-				IP:          net.ParseIP("192.168.2.2"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8443,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
-					},
-				},
-			},
-			expectError: true,
-		},
-	}
-
-	// Add Hostports
-	for _, tc := range testCases {
-		err := manager.Add("id", tc.mapping, "cbr0")
-		if tc.expectError {
-			assert.Error(t, err)
-			continue
+		for _, line := range lines {
+			GinkgoWriter.Printf("Line: %s\n", line)
+			if strings.TrimSpace(line) != "" {
+				_, ok := expectedLines[strings.TrimSpace(line)]
+				Expect(ok).To(BeTrue())
+			}
 		}
-		assert.NoError(t, err)
-	}
 
-	// Check port opened
-	expectedPorts := []hostport{{IPv6, "", 8080, "tcp"}, {IPv6, "", 8081, "udp"}, {IPv6, "", 8443, "tcp"}}
-	openedPorts := make(map[hostport]bool)
-	for hp, port := range portOpener.mem {
-		if !port.closed {
-			openedPorts[hp] = true
+		// Remove all added hostports
+		for _, tc := range testCases {
+			if !tc.expectError {
+				err := manager.Remove("id", tc.mapping)
+				Expect(err).NotTo(HaveOccurred())
+			}
 		}
-	}
-	assert.EqualValues(t, len(openedPorts), len(expectedPorts))
-	for _, hp := range expectedPorts {
-		_, ok := openedPorts[hp]
-		assert.EqualValues(t, true, ok)
-	}
 
-	// Check Iptables-save result after adding hostports
-	raw := bytes.NewBuffer(nil)
-	err := iptables.SaveInto(utiliptables.TableNAT, raw)
-	assert.NoError(t, err)
-
-	lines := strings.Split(raw.String(), "\n")
-	expectedLines := map[string]bool{
-		`*nat`:                                true,
-		`:KUBE-HOSTPORTS - [0:0]`:             true,
-		`:CRIO-HOSTPORTS-MASQ - [0:0]`:        true,
-		`:OUTPUT - [0:0]`:                     true,
-		`:PREROUTING - [0:0]`:                 true,
-		`:POSTROUTING - [0:0]`:                true,
-		`:KUBE-HP-IJHALPHTORMHHPPK - [0:0]`:   true,
-		`:CRIO-MASQ-IJHALPHTORMHHPPK - [0:0]`: true,
-		`:KUBE-HP-63UPIDJXVRSZGSUZ - [0:0]`:   true,
-		`:CRIO-MASQ-63UPIDJXVRSZGSUZ - [0:0]`: true,
-		`:KUBE-HP-WFBOALXEP42XEMJK - [0:0]`:   true,
-		`:CRIO-MASQ-WFBOALXEP42XEMJK - [0:0]`: true,
-		`:KUBE-HP-XU6AWMMJYOZOFTFZ - [0:0]`:   true,
-		`:CRIO-MASQ-XU6AWMMJYOZOFTFZ - [0:0]`: true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-WFBOALXEP42XEMJK":                                                                       true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod3_ns1 hostport 8443\" -j CRIO-MASQ-WFBOALXEP42XEMJK":                                                                                           true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-63UPIDJXVRSZGSUZ":                                                                       true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8081\" -j CRIO-MASQ-63UPIDJXVRSZGSUZ":                                                                                           true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-IJHALPHTORMHHPPK":                                                                       true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8080\" -j CRIO-MASQ-IJHALPHTORMHHPPK":                                                                                           true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp --dport 8083 -j KUBE-HP-XU6AWMMJYOZOFTFZ":                                                                     true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8083\" -j CRIO-MASQ-XU6AWMMJYOZOFTFZ":                                                                                           true,
-		"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                        true,
-		"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                    true,
-		"-A POSTROUTING -m comment --comment \"kube hostport masquerading\" -m conntrack --ctstate DNAT -j CRIO-HOSTPORTS-MASQ":                                                                          true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s ::1/128 -j MASQUERADE":                                                                        true,
-		"-A CRIO-MASQ-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m conntrack --ctorigdstport 8080 -m tcp -p tcp --dport 80 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE":   true,
-		"-A KUBE-HP-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination [2001:beef::2]:80":                                                           true,
-		"-A CRIO-MASQ-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m conntrack --ctorigdstport 8081 -m udp -p udp --dport 81 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE":   true,
-		"-A KUBE-HP-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination [2001:beef::2]:81":                                                           true,
-		"-A CRIO-MASQ-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m conntrack --ctorigdstport 8083 -m sctp -p sctp --dport 83 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE": true,
-		"-A KUBE-HP-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp -j DNAT --to-destination [2001:beef::2]:83":                                                         true,
-		"-A CRIO-MASQ-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m conntrack --ctorigdstport 8443 -m tcp -p tcp --dport 443 -s 2001:beef::4/32 -d 2001:beef::4/32 -j MASQUERADE":  true,
-		"-A KUBE-HP-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination [2001:beef::4]:443":                                                          true,
-		`COMMIT`: true,
-	}
-	for _, line := range lines {
-		t.Logf("Line: %s", line)
-		if strings.TrimSpace(line) != "" {
-			_, ok := expectedLines[strings.TrimSpace(line)]
-			assert.EqualValues(t, true, ok)
+		// Check Iptables-save result after deleting hostports
+		raw.Reset()
+		err = iptables.SaveInto(utiliptables.TableNAT, raw)
+		Expect(err).NotTo(HaveOccurred())
+		lines = strings.Split(raw.String(), "\n")
+		remainingChains := make(map[string]bool)
+		for _, line := range lines {
+			if strings.HasPrefix(line, ":") {
+				remainingChains[strings.TrimSpace(line)] = true
+			}
 		}
-	}
-
-	// Remove all added hostports
-	for _, tc := range testCases {
-		if !tc.expectError {
-			err := manager.Remove("id", tc.mapping)
-			assert.NoError(t, err)
+		expectDeletedChains := []string{"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR"}
+		for _, chain := range expectDeletedChains {
+			_, ok := remainingChains[chain]
+			Expect(ok).To(BeFalse())
 		}
-	}
 
-	// Check Iptables-save result after deleting hostports
-	raw.Reset()
-	err = iptables.SaveInto(utiliptables.TableNAT, raw)
-	assert.NoError(t, err)
-	lines = strings.Split(raw.String(), "\n")
-	remainingChains := make(map[string]bool)
-	for _, line := range lines {
-		if strings.HasPrefix(line, ":") {
-			remainingChains[strings.TrimSpace(line)] = true
+		// check if all ports are closed
+		for _, port := range portOpener.mem {
+			Expect(port.closed).To(BeTrue())
 		}
-	}
-	expectDeletedChains := []string{"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR"}
-	for _, chain := range expectDeletedChains {
-		_, ok := remainingChains[chain]
-		assert.EqualValues(t, false, ok)
-	}
-
-	// check if all ports are closed
-	for _, port := range portOpener.mem {
-		assert.EqualValues(t, true, port.closed)
-	}
-}
+	})
+})

--- a/internal/hostport/meta_hostport_manager_test.go
+++ b/internal/hostport/meta_hostport_manager_test.go
@@ -4,359 +4,361 @@ import (
 	"bytes"
 	"net"
 	"strings"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 
 	utiliptables "github.com/cri-o/cri-o/internal/iptables"
 )
 
-func TestMetaHostportManager(t *testing.T) {
-	// ipv4
-	iptables := newFakeIPTables()
-	iptables.protocol = utiliptables.ProtocolIPv4
-	portOpener := newFakeSocketManager()
-	// ipv6
-	ip6tables := newFakeIPTables()
-	ip6tables.protocol = utiliptables.ProtocolIPv6
-	port6Opener := newFakeSocketManager()
+var _ = t.Describe("MetaHostportManager", func() {
+	It("should succeed", func() {
+		// ipv4
+		iptables := newFakeIPTables()
+		iptables.protocol = utiliptables.ProtocolIPv4
+		portOpener := newFakeSocketManager()
+		// ipv6
+		ip6tables := newFakeIPTables()
+		ip6tables.protocol = utiliptables.ProtocolIPv6
+		port6Opener := newFakeSocketManager()
 
-	manager := metaHostportManager{
-		ipv4HostportManager: &hostportManager{
-			hostPortMap: make(map[hostport]closeable),
-			iptables:    iptables,
-			portOpener:  portOpener.openFakeSocket,
-		},
-		ipv6HostportManager: &hostportManager{
-			hostPortMap: make(map[hostport]closeable),
-			iptables:    ip6tables,
-			portOpener:  port6Opener.openFakeSocket,
-		},
-	}
+		manager := metaHostportManager{
+			ipv4HostportManager: &hostportManager{
+				hostPortMap: make(map[hostport]closeable),
+				iptables:    iptables,
+				portOpener:  portOpener.openFakeSocket,
+			},
+			ipv6HostportManager: &hostportManager{
+				hostPortMap: make(map[hostport]closeable),
+				iptables:    ip6tables,
+				portOpener:  port6Opener.openFakeSocket,
+			},
+		}
 
-	testCases := []struct {
-		mapping     *PodPortMapping
-		expectError bool
-	}{
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod1",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("192.168.2.7"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8080,
-						ContainerPort: 80,
-						Protocol:      v1.ProtocolTCP,
-					},
-					{
-						HostPort:      8081,
-						ContainerPort: 81,
-						Protocol:      v1.ProtocolUDP,
-					},
-					{
-						HostPort:      8083,
-						ContainerPort: 83,
-						Protocol:      v1.ProtocolSCTP,
-					},
-					{
-						HostPort:      8084,
-						ContainerPort: 84,
-						Protocol:      v1.ProtocolTCP,
-						HostIP:        "127.0.0.1",
+		testCases := []struct {
+			mapping     *PodPortMapping
+			expectError bool
+		}{
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod1",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("192.168.2.7"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8080,
+							ContainerPort: 80,
+							Protocol:      v1.ProtocolTCP,
+						},
+						{
+							HostPort:      8081,
+							ContainerPort: 81,
+							Protocol:      v1.ProtocolUDP,
+						},
+						{
+							HostPort:      8083,
+							ContainerPort: 83,
+							Protocol:      v1.ProtocolSCTP,
+						},
+						{
+							HostPort:      8084,
+							ContainerPort: 84,
+							Protocol:      v1.ProtocolTCP,
+							HostIP:        "127.0.0.1",
+						},
 					},
 				},
+				expectError: false,
 			},
-			expectError: false,
-		},
-		// same pod and portmappings,
-		// but different IP must work
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod1",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::3"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8080,
-						ContainerPort: 80,
-						Protocol:      v1.ProtocolTCP,
-					},
-					{
-						HostPort:      8081,
-						ContainerPort: 81,
-						Protocol:      v1.ProtocolUDP,
-					},
-					{
-						HostPort:      8083,
-						ContainerPort: 83,
-						Protocol:      v1.ProtocolSCTP,
-					},
-					{
-						HostPort:      8084,
-						ContainerPort: 84,
-						Protocol:      v1.ProtocolTCP,
-						HostIP:        "127.0.0.1",
+			// same pod and portmappings,
+			// but different IP must work
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod1",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("2001:beef::3"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8080,
+							ContainerPort: 80,
+							Protocol:      v1.ProtocolTCP,
+						},
+						{
+							HostPort:      8081,
+							ContainerPort: 81,
+							Protocol:      v1.ProtocolUDP,
+						},
+						{
+							HostPort:      8083,
+							ContainerPort: 83,
+							Protocol:      v1.ProtocolSCTP,
+						},
+						{
+							HostPort:      8084,
+							ContainerPort: 84,
+							Protocol:      v1.ProtocolTCP,
+							HostIP:        "127.0.0.1",
+						},
 					},
 				},
+				expectError: false,
 			},
-			expectError: false,
-		},
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod3",
-				Namespace:   "ns1",
-				IP:          net.ParseIP("2001:beef::4"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8443,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod3",
+					Namespace:   "ns1",
+					IP:          net.ParseIP("2001:beef::4"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8443,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+						},
 					},
 				},
+				expectError: false,
 			},
-			expectError: false,
-		},
-		// port already taken by other pod
-		// but using another IP family
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod4",
-				Namespace:   "ns2",
-				IP:          net.ParseIP("192.168.2.2"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8443,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
+			// port already taken by other pod
+			// but using another IP family
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod4",
+					Namespace:   "ns2",
+					IP:          net.ParseIP("192.168.2.2"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8443,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+						},
 					},
 				},
+				expectError: false,
 			},
-			expectError: false,
-		},
-		// port already taken by other pod
-		// but using same IP family must fail
-		{
-			mapping: &PodPortMapping{
-				Name:        "pod5",
-				Namespace:   "ns3",
-				IP:          net.ParseIP("192.168.12.12"),
-				HostNetwork: false,
-				PortMappings: []*PortMapping{
-					{
-						HostPort:      8443,
-						ContainerPort: 443,
-						Protocol:      v1.ProtocolTCP,
+			// port already taken by other pod
+			// but using same IP family must fail
+			{
+				mapping: &PodPortMapping{
+					Name:        "pod5",
+					Namespace:   "ns3",
+					IP:          net.ParseIP("192.168.12.12"),
+					HostNetwork: false,
+					PortMappings: []*PortMapping{
+						{
+							HostPort:      8443,
+							ContainerPort: 443,
+							Protocol:      v1.ProtocolTCP,
+						},
 					},
 				},
+				expectError: true,
 			},
-			expectError: true,
-		},
-	}
-
-	// Add Hostports
-	for _, tc := range testCases {
-		err := manager.Add("id", tc.mapping, "")
-		if tc.expectError {
-			assert.Error(t, err)
-			continue
 		}
-		assert.NoError(t, err)
-	}
 
-	// Check port opened IPv4
-	expectedPorts := []hostport{{IPv4, "", 8080, "tcp"}, {IPv4, "", 8081, "udp"}, {IPv4, "127.0.0.1", 8084, "tcp"}, {IPv4, "", 8443, "tcp"}}
-	openedPorts := make(map[hostport]bool)
-	for hp, port := range portOpener.mem {
-		if !port.closed {
-			openedPorts[hp] = true
+		// Add Hostports
+		for _, tc := range testCases {
+			err := manager.Add("id", tc.mapping, "")
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+				continue
+			}
+			Expect(err).NotTo(HaveOccurred())
 		}
-	}
-	assert.EqualValues(t, len(openedPorts), len(expectedPorts))
-	for _, hp := range expectedPorts {
-		_, ok := openedPorts[hp]
-		assert.EqualValues(t, true, ok)
-	}
-	// Check port opened IPv6
-	expectedv6Ports := []hostport{{IPv6, "", 8080, "tcp"}, {IPv6, "", 8081, "udp"}, {IPv6, "", 8443, "tcp"}}
-	openedv6Ports := make(map[hostport]bool)
-	for hp, port := range port6Opener.mem {
-		if !port.closed {
-			openedv6Ports[hp] = true
+
+		// Check port opened IPv4
+		expectedPorts := []hostport{{IPv4, "", 8080, "tcp"}, {IPv4, "", 8081, "udp"}, {IPv4, "127.0.0.1", 8084, "tcp"}, {IPv4, "", 8443, "tcp"}}
+		openedPorts := make(map[hostport]bool)
+		for hp, port := range portOpener.mem {
+			if !port.closed {
+				openedPorts[hp] = true
+			}
 		}
-	}
-	assert.EqualValues(t, len(openedv6Ports), len(expectedv6Ports))
-	for _, hp := range expectedv6Ports {
-		_, ok := openedv6Ports[hp]
-		assert.EqualValues(t, true, ok)
-	}
-
-	// Check IPv4 Iptables-save result after adding hostports
-	raw := bytes.NewBuffer(nil)
-
-	err := iptables.SaveInto(utiliptables.TableNAT, raw)
-	assert.NoError(t, err)
-
-	lines := strings.Split(raw.String(), "\n")
-	expectedLines := map[string]bool{
-		`*nat`:                                true,
-		`:KUBE-HOSTPORTS - [0:0]`:             true,
-		`:CRIO-HOSTPORTS-MASQ - [0:0]`:        true,
-		`:OUTPUT - [0:0]`:                     true,
-		`:PREROUTING - [0:0]`:                 true,
-		`:POSTROUTING - [0:0]`:                true,
-		`:KUBE-HP-IJHALPHTORMHHPPK - [0:0]`:   true,
-		`:CRIO-MASQ-IJHALPHTORMHHPPK - [0:0]`: true,
-		`:KUBE-HP-63UPIDJXVRSZGSUZ - [0:0]`:   true,
-		`:CRIO-MASQ-63UPIDJXVRSZGSUZ - [0:0]`: true,
-		`:KUBE-HP-WFBOALXEP42XEMJK - [0:0]`:   true,
-		`:CRIO-MASQ-WFBOALXEP42XEMJK - [0:0]`: true,
-		`:KUBE-HP-XU6AWMMJYOZOFTFZ - [0:0]`:   true,
-		`:CRIO-MASQ-XU6AWMMJYOZOFTFZ - [0:0]`: true,
-		`:KUBE-HP-CHN66X54O4WXZ5CW - [0:0]`:   true,
-		`:CRIO-MASQ-CHN66X54O4WXZ5CW - [0:0]`: true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-63UPIDJXVRSZGSUZ":                                                                     true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8081\" -j CRIO-MASQ-63UPIDJXVRSZGSUZ":                                                                                         true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-IJHALPHTORMHHPPK":                                                                     true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8080\" -j CRIO-MASQ-IJHALPHTORMHHPPK":                                                                                         true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp --dport 8083 -j KUBE-HP-XU6AWMMJYOZOFTFZ":                                                                   true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8083\" -j CRIO-MASQ-XU6AWMMJYOZOFTFZ":                                                                                         true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8084\" -m tcp -p tcp --dport 8084 -j KUBE-HP-CHN66X54O4WXZ5CW":                                                                     true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8084\" -j CRIO-MASQ-CHN66X54O4WXZ5CW":                                                                                         true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod4_ns2 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-WFBOALXEP42XEMJK":                                                                     true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod4_ns2 hostport 8443\" -j CRIO-MASQ-WFBOALXEP42XEMJK":                                                                                         true,
-		"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                      true,
-		"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                  true,
-		"-A POSTROUTING -m comment --comment \"kube hostport masquerading\" -m conntrack --ctstate DNAT -j CRIO-HOSTPORTS-MASQ":                                                                        true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s ::1/128 -j MASQUERADE":                                                                      true,
-		"-A CRIO-MASQ-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m conntrack --ctorigdstport 8080 -m tcp -p tcp --dport 80 -s 192.168.2.7/32 -d 192.168.2.7/32 -j MASQUERADE":   true,
-		"-A KUBE-HP-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination 192.168.2.7:80":                                                            true,
-		"-A CRIO-MASQ-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m conntrack --ctorigdstport 8081 -m udp -p udp --dport 81 -s 192.168.2.7/32 -d 192.168.2.7/32 -j MASQUERADE":   true,
-		"-A KUBE-HP-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination 192.168.2.7:81":                                                            true,
-		"-A CRIO-MASQ-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m conntrack --ctorigdstport 8083 -m sctp -p sctp --dport 83 -s 192.168.2.7/32 -d 192.168.2.7/32 -j MASQUERADE": true,
-		"-A KUBE-HP-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp -j DNAT --to-destination 192.168.2.7:83":                                                          true,
-		"-A CRIO-MASQ-CHN66X54O4WXZ5CW -m comment --comment \"pod1_ns1 hostport 8084\" -m conntrack --ctorigdstport 8084 -m tcp -p tcp --dport 84 -s 192.168.2.7/32 -d 192.168.2.7/32 -j MASQUERADE":   true,
-		"-A KUBE-HP-CHN66X54O4WXZ5CW -m comment --comment \"pod1_ns1 hostport 8084\" -m tcp -p tcp -d 127.0.0.1/32 -j DNAT --to-destination 192.168.2.7:84":                                            true,
-		"-A CRIO-MASQ-WFBOALXEP42XEMJK -m comment --comment \"pod4_ns2 hostport 8443\" -m conntrack --ctorigdstport 8443 -m tcp -p tcp --dport 443 -s 192.168.2.2/32 -d 192.168.2.2/32 -j MASQUERADE":  true,
-		"-A KUBE-HP-WFBOALXEP42XEMJK -m comment --comment \"pod4_ns2 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination 192.168.2.2:443":                                                           true,
-		`COMMIT`: true,
-	}
-	for _, line := range lines {
-		t.Logf("Line: %s", line)
-		if strings.TrimSpace(line) != "" {
-			_, ok := expectedLines[strings.TrimSpace(line)]
-			assert.EqualValues(t, true, ok)
+		Expect(len(openedPorts)).To(BeEquivalentTo(len(expectedPorts)))
+		for _, hp := range expectedPorts {
+			_, ok := openedPorts[hp]
+			Expect(ok).To(BeTrue())
 		}
-	}
-
-	// Remove all added hostports
-	for _, tc := range testCases {
-		if !tc.expectError {
-			err := manager.Remove("id", tc.mapping)
-			assert.NoError(t, err)
+		// Check port opened IPv6
+		expectedv6Ports := []hostport{{IPv6, "", 8080, "tcp"}, {IPv6, "", 8081, "udp"}, {IPv6, "", 8443, "tcp"}}
+		openedv6Ports := make(map[hostport]bool)
+		for hp, port := range port6Opener.mem {
+			if !port.closed {
+				openedv6Ports[hp] = true
+			}
 		}
-	}
-
-	// Check IPv6 Iptables-save result after deleting hostports
-	raw.Reset()
-	err = iptables.SaveInto(utiliptables.TableNAT, raw)
-	assert.NoError(t, err)
-	lines = strings.Split(raw.String(), "\n")
-	remainingChains := make(map[string]bool)
-	for _, line := range lines {
-		if strings.HasPrefix(line, ":") {
-			remainingChains[strings.TrimSpace(line)] = true
+		Expect(len(openedv6Ports)).To(BeEquivalentTo(len(expectedv6Ports)))
+		for _, hp := range expectedv6Ports {
+			_, ok := openedv6Ports[hp]
+			Expect(ok).To(BeTrue())
 		}
-	}
-	expectDeletedChains := []string{"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR", "KUBE-HP-CHN66X54O4WXZ5CW"}
-	for _, chain := range expectDeletedChains {
-		_, ok := remainingChains[chain]
-		assert.EqualValues(t, false, ok)
-	}
 
-	// Check Iptables-save result after adding hostports
-	rawv6 := bytes.NewBuffer(nil)
+		// Check IPv4 Iptables-save result after adding hostports
+		raw := bytes.NewBuffer(nil)
 
-	err = ip6tables.SaveInto(utiliptables.TableNAT, rawv6)
-	assert.NoError(t, err)
+		err := iptables.SaveInto(utiliptables.TableNAT, raw)
+		Expect(err).NotTo(HaveOccurred())
 
-	linesv6 := strings.Split(rawv6.String(), "\n")
-	expectedv6Lines := map[string]bool{
-		`*nat`:                                true,
-		`:KUBE-HOSTPORTS - [0:0]`:             true,
-		`:CRIO-HOSTPORTS-MASQ - [0:0]`:        true,
-		`:OUTPUT - [0:0]`:                     true,
-		`:PREROUTING - [0:0]`:                 true,
-		`:POSTROUTING - [0:0]`:                true,
-		`:KUBE-HP-IJHALPHTORMHHPPK - [0:0]`:   true,
-		`:CRIO-MASQ-IJHALPHTORMHHPPK - [0:0]`: true,
-		`:KUBE-HP-63UPIDJXVRSZGSUZ - [0:0]`:   true,
-		`:CRIO-MASQ-63UPIDJXVRSZGSUZ - [0:0]`: true,
-		`:KUBE-HP-WFBOALXEP42XEMJK - [0:0]`:   true,
-		`:CRIO-MASQ-WFBOALXEP42XEMJK - [0:0]`: true,
-		`:KUBE-HP-XU6AWMMJYOZOFTFZ - [0:0]`:   true,
-		`:CRIO-MASQ-XU6AWMMJYOZOFTFZ - [0:0]`: true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-WFBOALXEP42XEMJK":                                                                      true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod3_ns1 hostport 8443\" -j CRIO-MASQ-WFBOALXEP42XEMJK":                                                                                          true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-63UPIDJXVRSZGSUZ":                                                                      true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8081\" -j CRIO-MASQ-63UPIDJXVRSZGSUZ":                                                                                          true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-IJHALPHTORMHHPPK":                                                                      true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8080\" -j CRIO-MASQ-IJHALPHTORMHHPPK":                                                                                          true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp --dport 8083 -j KUBE-HP-XU6AWMMJYOZOFTFZ":                                                                    true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8083\" -j CRIO-MASQ-XU6AWMMJYOZOFTFZ":                                                                                          true,
-		"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                       true,
-		"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                   true,
-		"-A POSTROUTING -m comment --comment \"kube hostport masquerading\" -m conntrack --ctstate DNAT -j CRIO-HOSTPORTS-MASQ":                                                                         true,
-		"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s ::1/128 -j MASQUERADE":                                                                       true,
-		"-A CRIO-MASQ-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE": true,
-		"-A KUBE-HP-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination [2001:beef::2]:80":                                                          true,
-		"-A CRIO-MASQ-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE": true,
-		"-A KUBE-HP-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination [2001:beef::2]:81":                                                          true,
-		"-A CRIO-MASQ-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE": true,
-		"-A KUBE-HP-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp -j DNAT --to-destination [2001:beef::2]:83":                                                        true,
-		"-A CRIO-MASQ-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 2001:beef::4/32 -d 2001:beef::4/32 -j MASQUERADE": true,
-		"-A KUBE-HP-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination [2001:beef::4]:443":                                                         true,
-		`COMMIT`: true,
-	}
-	for _, line := range linesv6 {
-		if strings.TrimSpace(line) != "" {
-			_, ok := expectedv6Lines[strings.TrimSpace(line)]
-			assert.EqualValues(t, true, ok)
+		lines := strings.Split(raw.String(), "\n")
+		expectedLines := map[string]bool{
+			`*nat`:                                true,
+			`:KUBE-HOSTPORTS - [0:0]`:             true,
+			`:CRIO-HOSTPORTS-MASQ - [0:0]`:        true,
+			`:OUTPUT - [0:0]`:                     true,
+			`:PREROUTING - [0:0]`:                 true,
+			`:POSTROUTING - [0:0]`:                true,
+			`:KUBE-HP-IJHALPHTORMHHPPK - [0:0]`:   true,
+			`:CRIO-MASQ-IJHALPHTORMHHPPK - [0:0]`: true,
+			`:KUBE-HP-63UPIDJXVRSZGSUZ - [0:0]`:   true,
+			`:CRIO-MASQ-63UPIDJXVRSZGSUZ - [0:0]`: true,
+			`:KUBE-HP-WFBOALXEP42XEMJK - [0:0]`:   true,
+			`:CRIO-MASQ-WFBOALXEP42XEMJK - [0:0]`: true,
+			`:KUBE-HP-XU6AWMMJYOZOFTFZ - [0:0]`:   true,
+			`:CRIO-MASQ-XU6AWMMJYOZOFTFZ - [0:0]`: true,
+			`:KUBE-HP-CHN66X54O4WXZ5CW - [0:0]`:   true,
+			`:CRIO-MASQ-CHN66X54O4WXZ5CW - [0:0]`: true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-63UPIDJXVRSZGSUZ":                                                                     true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8081\" -j CRIO-MASQ-63UPIDJXVRSZGSUZ":                                                                                         true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-IJHALPHTORMHHPPK":                                                                     true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8080\" -j CRIO-MASQ-IJHALPHTORMHHPPK":                                                                                         true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp --dport 8083 -j KUBE-HP-XU6AWMMJYOZOFTFZ":                                                                   true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8083\" -j CRIO-MASQ-XU6AWMMJYOZOFTFZ":                                                                                         true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8084\" -m tcp -p tcp --dport 8084 -j KUBE-HP-CHN66X54O4WXZ5CW":                                                                     true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8084\" -j CRIO-MASQ-CHN66X54O4WXZ5CW":                                                                                         true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod4_ns2 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-WFBOALXEP42XEMJK":                                                                     true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod4_ns2 hostport 8443\" -j CRIO-MASQ-WFBOALXEP42XEMJK":                                                                                         true,
+			"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                      true,
+			"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                  true,
+			"-A POSTROUTING -m comment --comment \"kube hostport masquerading\" -m conntrack --ctstate DNAT -j CRIO-HOSTPORTS-MASQ":                                                                        true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s ::1/128 -j MASQUERADE":                                                                      true,
+			"-A CRIO-MASQ-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m conntrack --ctorigdstport 8080 -m tcp -p tcp --dport 80 -s 192.168.2.7/32 -d 192.168.2.7/32 -j MASQUERADE":   true,
+			"-A KUBE-HP-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination 192.168.2.7:80":                                                            true,
+			"-A CRIO-MASQ-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m conntrack --ctorigdstport 8081 -m udp -p udp --dport 81 -s 192.168.2.7/32 -d 192.168.2.7/32 -j MASQUERADE":   true,
+			"-A KUBE-HP-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination 192.168.2.7:81":                                                            true,
+			"-A CRIO-MASQ-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m conntrack --ctorigdstport 8083 -m sctp -p sctp --dport 83 -s 192.168.2.7/32 -d 192.168.2.7/32 -j MASQUERADE": true,
+			"-A KUBE-HP-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp -j DNAT --to-destination 192.168.2.7:83":                                                          true,
+			"-A CRIO-MASQ-CHN66X54O4WXZ5CW -m comment --comment \"pod1_ns1 hostport 8084\" -m conntrack --ctorigdstport 8084 -m tcp -p tcp --dport 84 -s 192.168.2.7/32 -d 192.168.2.7/32 -j MASQUERADE":   true,
+			"-A KUBE-HP-CHN66X54O4WXZ5CW -m comment --comment \"pod1_ns1 hostport 8084\" -m tcp -p tcp -d 127.0.0.1/32 -j DNAT --to-destination 192.168.2.7:84":                                            true,
+			"-A CRIO-MASQ-WFBOALXEP42XEMJK -m comment --comment \"pod4_ns2 hostport 8443\" -m conntrack --ctorigdstport 8443 -m tcp -p tcp --dport 443 -s 192.168.2.2/32 -d 192.168.2.2/32 -j MASQUERADE":  true,
+			"-A KUBE-HP-WFBOALXEP42XEMJK -m comment --comment \"pod4_ns2 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination 192.168.2.2:443":                                                           true,
+			`COMMIT`: true,
 		}
-	}
-
-	// Remove all added hostports
-	for _, tc := range testCases {
-		if !tc.expectError {
-			err := manager.Remove("id", tc.mapping)
-			assert.NoError(t, err)
+		for _, line := range lines {
+			GinkgoWriter.Printf("Line: %s\n", line)
+			if strings.TrimSpace(line) != "" {
+				_, ok := expectedLines[strings.TrimSpace(line)]
+				Expect(ok).To(BeTrue())
+			}
 		}
-	}
 
-	// Check Iptables-save result after deleting hostports
-	rawv6.Reset()
-	err = ip6tables.SaveInto(utiliptables.TableNAT, rawv6)
-	assert.NoError(t, err)
-	linesv6 = strings.Split(rawv6.String(), "\n")
-	remainingv6Chains := make(map[string]bool)
-	for _, line := range linesv6 {
-		if strings.HasPrefix(line, ":") {
-			remainingv6Chains[strings.TrimSpace(line)] = true
+		// Remove all added hostports
+		for _, tc := range testCases {
+			if !tc.expectError {
+				err := manager.Remove("id", tc.mapping)
+				Expect(err).NotTo(HaveOccurred())
+			}
 		}
-	}
-	expectv6DeletedChains := []string{"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR"}
-	for _, chain := range expectv6DeletedChains {
-		_, ok := remainingv6Chains[chain]
-		assert.EqualValues(t, false, ok)
-	}
 
-	// check if all ports are closed
-	for _, port := range portOpener.mem {
-		assert.EqualValues(t, true, port.closed)
-	}
-}
+		// Check IPv6 Iptables-save result after deleting hostports
+		raw.Reset()
+		err = iptables.SaveInto(utiliptables.TableNAT, raw)
+		Expect(err).NotTo(HaveOccurred())
+		lines = strings.Split(raw.String(), "\n")
+		remainingChains := make(map[string]bool)
+		for _, line := range lines {
+			if strings.HasPrefix(line, ":") {
+				remainingChains[strings.TrimSpace(line)] = true
+			}
+		}
+		expectDeletedChains := []string{"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR", "KUBE-HP-CHN66X54O4WXZ5CW"}
+		for _, chain := range expectDeletedChains {
+			_, ok := remainingChains[chain]
+			Expect(ok).To(BeFalse())
+		}
+
+		// Check Iptables-save result after adding hostports
+		rawv6 := bytes.NewBuffer(nil)
+
+		err = ip6tables.SaveInto(utiliptables.TableNAT, rawv6)
+		Expect(err).NotTo(HaveOccurred())
+
+		linesv6 := strings.Split(rawv6.String(), "\n")
+		expectedv6Lines := map[string]bool{
+			`*nat`:                                true,
+			`:KUBE-HOSTPORTS - [0:0]`:             true,
+			`:CRIO-HOSTPORTS-MASQ - [0:0]`:        true,
+			`:OUTPUT - [0:0]`:                     true,
+			`:PREROUTING - [0:0]`:                 true,
+			`:POSTROUTING - [0:0]`:                true,
+			`:KUBE-HP-IJHALPHTORMHHPPK - [0:0]`:   true,
+			`:CRIO-MASQ-IJHALPHTORMHHPPK - [0:0]`: true,
+			`:KUBE-HP-63UPIDJXVRSZGSUZ - [0:0]`:   true,
+			`:CRIO-MASQ-63UPIDJXVRSZGSUZ - [0:0]`: true,
+			`:KUBE-HP-WFBOALXEP42XEMJK - [0:0]`:   true,
+			`:CRIO-MASQ-WFBOALXEP42XEMJK - [0:0]`: true,
+			`:KUBE-HP-XU6AWMMJYOZOFTFZ - [0:0]`:   true,
+			`:CRIO-MASQ-XU6AWMMJYOZOFTFZ - [0:0]`: true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-WFBOALXEP42XEMJK":                                                                      true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod3_ns1 hostport 8443\" -j CRIO-MASQ-WFBOALXEP42XEMJK":                                                                                          true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-63UPIDJXVRSZGSUZ":                                                                      true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8081\" -j CRIO-MASQ-63UPIDJXVRSZGSUZ":                                                                                          true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-IJHALPHTORMHHPPK":                                                                      true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8080\" -j CRIO-MASQ-IJHALPHTORMHHPPK":                                                                                          true,
+			"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp --dport 8083 -j KUBE-HP-XU6AWMMJYOZOFTFZ":                                                                    true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"pod1_ns1 hostport 8083\" -j CRIO-MASQ-XU6AWMMJYOZOFTFZ":                                                                                          true,
+			"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                       true,
+			"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                                                                   true,
+			"-A POSTROUTING -m comment --comment \"kube hostport masquerading\" -m conntrack --ctstate DNAT -j CRIO-HOSTPORTS-MASQ":                                                                         true,
+			"-A CRIO-HOSTPORTS-MASQ -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s ::1/128 -j MASQUERADE":                                                                       true,
+			"-A CRIO-MASQ-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE": true,
+			"-A KUBE-HP-IJHALPHTORMHHPPK -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination [2001:beef::2]:80":                                                          true,
+			"-A CRIO-MASQ-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE": true,
+			"-A KUBE-HP-63UPIDJXVRSZGSUZ -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination [2001:beef::2]:81":                                                          true,
+			"-A CRIO-MASQ-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 2001:beef::2/32 -d 2001:beef::2/32 -j MASQUERADE": true,
+			"-A KUBE-HP-XU6AWMMJYOZOFTFZ -m comment --comment \"pod1_ns1 hostport 8083\" -m sctp -p sctp -j DNAT --to-destination [2001:beef::2]:83":                                                        true,
+			"-A CRIO-MASQ-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m conntrack --ctorigdstport 9999 -m tcp -p tcp --dport 443 -s 2001:beef::4/32 -d 2001:beef::4/32 -j MASQUERADE": true,
+			"-A KUBE-HP-WFBOALXEP42XEMJK -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination [2001:beef::4]:443":                                                         true,
+			`COMMIT`: true,
+		}
+		for _, line := range linesv6 {
+			if strings.TrimSpace(line) != "" {
+				_, ok := expectedv6Lines[strings.TrimSpace(line)]
+				Expect(ok).To(BeTrue())
+			}
+		}
+
+		// Remove all added hostports
+		for _, tc := range testCases {
+			if !tc.expectError {
+				err := manager.Remove("id", tc.mapping)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+
+		// Check Iptables-save result after deleting hostports
+		rawv6.Reset()
+		err = ip6tables.SaveInto(utiliptables.TableNAT, rawv6)
+		Expect(err).NotTo(HaveOccurred())
+		linesv6 = strings.Split(rawv6.String(), "\n")
+		remainingv6Chains := make(map[string]bool)
+		for _, line := range linesv6 {
+			if strings.HasPrefix(line, ":") {
+				remainingv6Chains[strings.TrimSpace(line)] = true
+			}
+		}
+		expectv6DeletedChains := []string{"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR"}
+		for _, chain := range expectv6DeletedChains {
+			_, ok := remainingv6Chains[chain]
+			Expect(ok).To(BeFalse())
+		}
+
+		// check if all ports are closed
+		for _, port := range portOpener.mem {
+			Expect(port.closed).To(BeTrue())
+		}
+	})
+})

--- a/internal/hostport/noop_hostport_manager_test.go
+++ b/internal/hostport/noop_hostport_manager_test.go
@@ -1,19 +1,19 @@
 package hostport
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-// To make CodeCov happy.
-func TestNoopHostportManager(t *testing.T) {
-	manager := NewNoopHostportManager()
-	assert.NotNil(t, manager)
+var _ = t.Describe("NoopHostportManager", func() {
+	It("should succeed", func() {
+		manager := NewNoopHostportManager()
+		Expect(manager).NotTo(BeNil())
 
-	err := manager.Add("id", nil, "")
-	assert.NoError(t, err)
+		err := manager.Add("id", nil, "")
+		Expect(err).NotTo(HaveOccurred())
 
-	err = manager.Remove("id", nil)
-	assert.NoError(t, err)
-}
+		err = manager.Remove("id", nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/test/nri/nri_suite_test.go
+++ b/test/nri/nri_suite_test.go
@@ -123,7 +123,7 @@ func (t *nriTest) StartPlugins(waitSync bool) []*event {
 			continue
 		}
 		e := p.WaitEvent(PluginSyncedEvent, pluginSyncTimeout)
-		require.True(t, e != nil, "test %s plugin #%d (%s) startup", t.namespace, i, p.Name())
+		require.NotNil(t, e, "test %s plugin #%d (%s) startup", t.namespace, i, p.Name())
 		events = append(events, e)
 	}
 

--- a/test/nri/nri_test.go
+++ b/test/nri/nri_test.go
@@ -214,7 +214,7 @@ func TestEnvironmentInjection(stdT *testing.T) {
 	stdout, _, exitCode := t.execShellScript(ctr, "set -e; echo $TEST_VARIABLE")
 	expected := "TEST_VALUE\n"
 
-	require.Equal(t, exitCode, int32(0), "exit code 0")
+	require.Equal(t, int32(0), exitCode, "exit code 0")
 	require.Equal(t, expected, string(stdout), "test output")
 }
 
@@ -257,8 +257,8 @@ func TestAnnotationInjection(stdT *testing.T) {
 	pod, ctr := t.runContainer()
 	require.NotNil(t, t.plugins[0].WaitEvent(PostCreateContainerEvent(pod, ctr), eventTimeout), "container post-creation event")
 
-	require.True(t, annotated != nil, "received post-create event")
-	require.True(t, annotated.GetAnnotations()[testKey] == testValue, "annotation updated")
+	require.NotNil(t, annotated, "received post-create event")
+	require.Equal(t, annotated.GetAnnotations()[testKey], testValue, "annotation updated")
 }
 
 func TestDeviceInjection(stdT *testing.T) {
@@ -300,7 +300,7 @@ func TestDeviceInjection(stdT *testing.T) {
 	stdout, _, exitCode := t.execShellScript(ctr, "set -e; stat -c %F-%a-%u:%g-%t:%T /dev/pie")
 	expected := "character special file-664-11:22-1f:29\n"
 
-	require.Equal(t, exitCode, int32(0), "exit code 0")
+	require.Equal(t, int32(0), exitCode, "exit code 0")
 	require.Equal(t, expected, string(stdout), "test output")
 }
 
@@ -364,7 +364,7 @@ func testXxxsetAdjustment(stdT *testing.T, adjust func() *api.ContainerAdjustmen
 
 	stdout, _, exitCode := t.execShellScript(ctr, testScript)
 	t.Logf("*** got stdout %s, exitCode %d", stdout, exitCode)
-	require.Equal(t, exitCode, int32(0), "exit code 0")
+	require.Equal(t, int32(0), exitCode, "exit code 0")
 	require.Equal(t, expectedResult, string(stdout), "test output")
 }
 
@@ -455,13 +455,13 @@ func testXxxsetAdjustmentUpdate(stdT *testing.T, adjust func() *api.ContainerAdj
 
 	stdout, _, exitCode := t.execShellScript(ctr, testScript)
 	t.Logf("*** got stdout %s, exitCode %d", stdout, exitCode)
-	require.Equal(t, exitCode, int32(0), "exit code 0")
+	require.Equal(t, int32(0), exitCode, "exit code 0")
 	require.Equal(t, expectedAdjustResult, string(stdout), "test output")
 
 	t.runContainer()
 	stdout, _, exitCode = t.execShellScript(ctr, testScript)
 	t.Logf("*** got stdout %s, exitCode %d", stdout, exitCode)
-	require.Equal(t, exitCode, int32(0), "exit code 0")
+	require.Equal(t, int32(0), exitCode, "exit code 0")
 	require.Equal(t, expectedUpdateResult, string(stdout), "test output")
 }
 


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
We should stick to use ginkgo as main testing framework for this project rather than testify. We also apply testifylint to the nri tests, which are still using this dependency.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
