### PR TITLE
server: propagate the pinned status of an image when queried via crictl 

### DIFF
--- a/server/image_status.go
+++ b/server/image_status.go
@@ -52,6 +52,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 			Spec: &types.ImageSpec{
 				Annotations: status.Annotations,
 			},
+			Pinned: status.Pinned,
 		},
 	}
 	if req.Verbose {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

```bash
$ sudo crictl inspecti registry.k8s.io/pause:3.9 | jq .status.pinned
true
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
