### PR TITLE
Allow mounting a cgroup v2 namespace for privileged containers

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -11,6 +11,9 @@ const (
 	// CgroupRW specifies mounting v2 cgroups as an rw filesystem.
 	Cgroup2RWAnnotation = "io.kubernetes.cri-o.cgroup2-mount-hierarchy-rw"
 
+	// Cgroup2NSPrivilegedAnnotation allows mounting a cgroup namespace for privileged containers.
+	Cgroup2NSPrivilegedAnnotation = "io.kubernetes.cri-o.cgroup2-ns-privileged"
+
 	// UnifiedCgroupAnnotation specifies the unified configuration for cgroup v2.
 	UnifiedCgroupAnnotation = "io.kubernetes.cri-o.UnifiedCgroup"
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -309,6 +309,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	}
 
 	cgroup2RW := node.CgroupIsV2() && sb.Annotations()[crioann.Cgroup2RWAnnotation] == "true"
+	cgroup2NSPrivileged := node.CgroupIsV2() && sb.Annotations()[crioann.Cgroup2NSPrivilegedAnnotation] == "true"
 
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container volume configuration")
 	idMapSupport := s.Runtime().RuntimeSupportsIDMap(sb.RuntimeHandler())
@@ -561,7 +562,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 	}
 
 	// When running on cgroupv2, automatically add a cgroup namespace for not privileged containers.
-	if !ctr.Privileged() && node.CgroupIsV2() {
+	if (!ctr.Privileged() || cgroup2NSPrivileged) && node.CgroupIsV2() {
 		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.CgroupNamespace), ""); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature

#### What this PR does / why we need it:
Adds the `io.kubernetes.cri-o.cgroup2-ns-privileged` annotation, which allows to mount a cgroup2 namespace different from the host namespace into privileged containers.
This is needed if one would want to run containers inside of privileged cri-o containers with cgroup nesting.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added the `io.kubernetes.cri-o.cgroup2-ns-privileged` annotation which allows mounting a cgroup v2 namespace for privileged containers.
```
