### PR TITLE
Update pause image to 3.10

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -120,3 +120,19 @@ dependencies:
     refPaths:
       - path: Makefile
         match: MDTOC_VERSION
+
+  - name: pause
+    version: 3.10
+    refPaths:
+      - path: docs/crio.8.md
+        match: "registry.k8s.io/pause:"
+      - path: docs/crio.conf.5.md
+        match: "registry.k8s.io/pause:"
+      - path: internal/storage/image_test.go
+        match: "registry.k8s.io/pause:"
+      - path: pkg/config/config_linux.go
+        match: "registry.k8s.io/pause:"
+      - path: pkg/config/config_unsupported.go
+        match: "registry.k8s.io/pause:"
+      - path: test/common.sh
+        match: "registry.k8s.io/pause:"

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -364,7 +364,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--pause-command**="": Path to the pause executable in the pause image. (default: "/pause")
 
-**--pause-image**="": Image which contains the pause executable. (default: "registry.k8s.io/pause:3.9")
+**--pause-image**="": Image which contains the pause executable. (default: "registry.k8s.io/pause:3.10")
 
 **--pause-image-auth-file**="": Path to a config file containing credentials for --pause-image.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -441,7 +441,7 @@ CRI-O reads its configured registries defaults from the system wide containers-r
 **global_auth_file**=""
   The path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.
 
-**pause_image**="registry.k8s.io/pause:3.9"
+**pause_image**="registry.k8s.io/pause:3.10"
   The on-registry image used to instantiate infra containers.
   The value should start with a registry host name.
   This option supports live configuration reload.

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -653,12 +653,12 @@ var _ = t.Describe("Image", func() {
 
 	t.Describe("CompileRegexpsForPinnedImages", func() {
 		It("should return regexps for exact patterns", func() {
-			patterns := []string{"quay.io/crio/pause:latest", "docker.io/crio/sandbox:latest", "registry.k8s.io/pause:3.9"}
+			patterns := []string{"quay.io/crio/pause:latest", "docker.io/crio/sandbox:latest", "registry.k8s.io/pause:3.10"}
 			regexps := storage.CompileRegexpsForPinnedImages(patterns)
 			Expect(regexps).To(HaveLen(len(patterns)))
 			Expect(regexps[0].MatchString("quay.io/crio/pause:latest")).To(BeTrue())
 			Expect(regexps[1].MatchString("docker.io/crio/sandbox:latest")).To(BeTrue())
-			Expect(regexps[2].MatchString("registry.k8s.io/pause:3.9")).To(BeTrue())
+			Expect(regexps[2].MatchString("registry.k8s.io/pause:3.10")).To(BeTrue())
 		})
 
 		It("should return regexps for keyword patterns", func() {

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -21,7 +21,7 @@ const (
 	// ImageVolumesBind option is for using bind mounted volumes.
 	ImageVolumesBind ImageVolumesType = "bind"
 	// DefaultPauseImage is default pause image.
-	DefaultPauseImage string = "registry.k8s.io/pause:3.9"
+	DefaultPauseImage string = "registry.k8s.io/pause:3.10"
 )
 
 var (

--- a/pkg/config/config_unsupported.go
+++ b/pkg/config/config_unsupported.go
@@ -15,7 +15,7 @@ const (
 	// ImageVolumesBind option is for using bind mounted volumes
 	ImageVolumesBind ImageVolumesType = "invalid ImageVolumesBind"
 	// DefaultPauseImage is default pause image
-	DefaultPauseImage string = "registry.k8s.io/pause:3.9"
+	DefaultPauseImage string = "registry.k8s.io/pause:3.10"
 )
 
 func selinuxEnabled() bool {

--- a/test/common.sh
+++ b/test/common.sh
@@ -107,7 +107,7 @@ ARCH=$(uname -m)
 ARCH_X86_64=x86_64
 
 IMAGES=(
-    registry.k8s.io/pause:3.9
+    registry.k8s.io/pause:3.10
     quay.io/crio/fedora-crio-ci:latest
     quay.io/crio/hello-wasm:latest
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:

Update the pause image to 3.10 per:

- https://github.com/kubernetes/kubernetes/issues/125092

Supersedes:

- https://github.com/cri-o/cri-o/pull/8215

Related to:

- https://github.com/kubernetes/kubernetes/pull/125112


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Update pause image to 3.10.
```
