### PR TITLE
[release 1.29] internal/oci: remove redundant ShouldBeStopped check for stopping containers 

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -577,20 +577,6 @@ func (c *Container) verifyPid() (string, error) {
 	return state, nil
 }
 
-// ShouldBeStopped checks whether the container state is in a place
-// where attempting to stop it makes sense
-// a container is not stoppable if it's paused or stopped
-// if it's paused, that's an error, and is reported as such
-func (c *Container) ShouldBeStopped() error {
-	switch c.State().Status {
-	case ContainerStateStopped: // no-op
-		return ErrContainerStopped
-	case ContainerStatePaused:
-		return errors.New("cannot stop paused container")
-	}
-	return nil
-}
-
 // Spoofed returns whether this container is spoofed.
 // A container should be spoofed when it doesn't have to exist in the container runtime,
 // but does need to exist in the storage. The main use of this is when an infra container

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -427,42 +427,6 @@ var _ = t.Describe("Container", func() {
 			Expect(err).NotTo(BeNil())
 		})
 	})
-	t.Describe("ShouldBeStopped", func() {
-		It("should fail to stop if already stopped", func() {
-			// Given
-			state := &oci.ContainerState{}
-			state.Status = oci.ContainerStateStopped
-			sut.SetState(state)
-			// When
-			err := sut.ShouldBeStopped()
-
-			// Then
-			Expect(err).To(Equal(oci.ErrContainerStopped))
-		})
-		It("should fail to stop if paused", func() {
-			// Given
-			state := &oci.ContainerState{}
-			state.Status = oci.ContainerStatePaused
-			sut.SetState(state)
-			// When
-			err := sut.ShouldBeStopped()
-
-			// Then
-			Expect(err).NotTo(Equal(oci.ErrContainerStopped))
-			Expect(err).NotTo(BeNil())
-		})
-		It("should succeed to stop if started", func() {
-			// Given
-			state := &oci.ContainerState{}
-			state.Status = oci.ContainerStateRunning
-			sut.SetState(state)
-			// When
-			err := sut.ShouldBeStopped()
-
-			// Then
-			Expect(err).To(BeNil())
-		})
-	})
 	t.Describe("Living", func() {
 		It("should be false if pid uninitialized", func() {
 			// Given

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -869,6 +869,14 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container, bm kwait.BackoffManager)
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
 
 	c.opLock.Lock()
+	defer func() {
+		// Kill the exec PIDs after the main container to avoid pod lifecycle regressions:
+		// Ref: https://github.com/kubernetes/kubernetes/issues/124743
+		c.KillExecPIDs()
+		c.state.Finished = time.Now()
+		c.opLock.Unlock()
+		c.SetAsDoneStopping()
+	}()
 	if c.state.Status == ContainerStatePaused {
 		if _, err := r.runtimeCmd("resume", c.ID()); err != nil {
 			log.Errorf(ctx, "Failed to unpause container %s: %v", c.Name(), err)
@@ -881,8 +889,6 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container, bm kwait.BackoffManager)
 			// The initial container process either doesn't exist, or isn't ours.
 			// Set state accordingly.
 			c.state.Finished = time.Now()
-			c.opLock.Unlock()
-			c.SetAsDoneStopping()
 			return
 		}
 	}
@@ -898,9 +904,12 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container, bm kwait.BackoffManager)
 				close(done)
 				return
 			}
-
-			// The PID is still active and belongs to the container, continue to wait.
-			time.Sleep(stopProcessWatchSleep)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(stopProcessWatchSleep):
+				// Continue watching
+			}
 		}
 	}()
 
@@ -922,8 +931,7 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container, bm kwait.BackoffManager)
 	// Do not start the stuck process reminder immediately.
 	blockedTimer.Stop()
 
-	// We cannot use ExponentialBackoff() here as its stop conditions are not flexible enough.
-	kwait.BackoffUntil(func() {
+	for {
 		select {
 		case newTimeout := <-c.stopTimeoutChan:
 			// If a new timeout comes in, interrupt the old one, and start a new one.
@@ -936,30 +944,28 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container, bm kwait.BackoffManager)
 
 		case <-time.After(time.Until(targetTime)):
 			log.Warnf(ctx, "Stopping container %s with stop signal timed out. Killing...", c.ID())
-
-			if _, err := r.runtimeCmd("kill", c.ID(), "KILL"); err != nil {
-				log.Errorf(ctx, "Killing container %v failed: %v", c.ID(), err)
-			}
-
-			if err := c.Living(); err != nil {
-				stop()
-			}
-
-			// Reschedule the timer so that the periodic reminder can continue.
-			blockedTimer.Reset(stopProcessBlockedInterval)
+			goto killContainer
 
 		case <-done:
 			stop()
+			return
+		case <-ctx.Done():
+			return
 		}
+	}
+killContainer:
+	// We cannot use ExponentialBackoff() here as its stop conditions are not flexible enough.
+	kwait.BackoffUntil(func() {
+		if _, err := r.runtimeCmd("kill", c.ID(), "KILL"); err != nil {
+			log.Errorf(ctx, "Killing container %v failed: %v", c.ID(), err)
+		}
+
+		if err := c.Living(); err != nil {
+			stop()
+		}
+		// Reschedule the timer so that the periodic reminder can continue.
+		blockedTimer.Reset(stopProcessBlockedInterval)
 	}, bm, true, ctx.Done())
-
-	// Kill the exec PIDs after the main container to avoid pod lifecycle regressions:
-	// Ref: https://github.com/kubernetes/kubernetes/issues/124743
-	c.KillExecPIDs()
-
-	c.state.Finished = time.Now()
-	c.opLock.Unlock()
-	c.SetAsDoneStopping()
 }
 
 // DeleteContainer deletes a container.

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -832,13 +832,6 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 		return nil
 	}
 
-	if err := c.ShouldBeStopped(); err != nil {
-		if errors.Is(err, ErrContainerStopped) {
-			err = nil
-		}
-		return err
-	}
-
 	// The initial container process either doesn't exist, or isn't ours.
 	if err := c.Living(); err != nil {
 		c.state.Finished = time.Now()

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -869,6 +869,11 @@ func (r *runtimeOCI) StopLoopForContainer(c *Container, bm kwait.BackoffManager)
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
 
 	c.opLock.Lock()
+	if c.state.Status == ContainerStatePaused {
+		if _, err := r.runtimeCmd("resume", c.ID()); err != nil {
+			log.Errorf(ctx, "Failed to unpause container %s: %v", c.Name(), err)
+		}
+	}
 
 	// Begin the actual kill.
 	if _, err := r.runtimeCmd("kill", c.ID(), c.GetStopSignal()); err != nil {

--- a/internal/oci/runtime_oci_test.go
+++ b/internal/oci/runtime_oci_test.go
@@ -109,7 +109,7 @@ var _ = t.Describe("Oci", func() {
 			go runtime.StopLoopForContainer(sut, bm)
 
 			// Then
-			waitOnContainerTimeout(sut, longTimeout, mediumTimeout, sleepProcess)
+			waitOnContainerTimeout(sut, shortTimeout, mediumTimeout, sleepProcess)
 		})
 		It("should fall back to KILL after timeout", func() {
 			// Given

--- a/internal/oci/runtime_oci_test.go
+++ b/internal/oci/runtime_oci_test.go
@@ -72,20 +72,6 @@ var _ = t.Describe("Oci", func() {
 			cmdrunner.ResetPrependedCmd()
 		})
 
-		It("should fail to stop if container paused", func() {
-			state := &oci.ContainerState{}
-			state.Status = oci.ContainerStatePaused
-			sut.SetState(state)
-
-			Expect(sut.ShouldBeStopped()).NotTo(BeNil())
-		})
-		It("should fail to stop if container stopped", func() {
-			state := &oci.ContainerState{}
-			state.Status = oci.ContainerStateStopped
-			sut.SetState(state)
-
-			Expect(sut.ShouldBeStopped()).To(Equal(oci.ErrContainerStopped))
-		})
 		It("should return early if runtime command fails and process stopped", func() {
 			// Given
 			gomock.InOrder(

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -48,15 +48,6 @@ func (s *Server) stopContainer(ctx context.Context, ctr *oci.Container, timeout 
 		}
 	}
 
-	if ctr.StateNoLock().Status == oci.ContainerStatePaused {
-		if err := s.Runtime().UnpauseContainer(ctx, ctr); err != nil {
-			return fmt.Errorf("failed to stop container %s: %v", ctr.Name(), err)
-		}
-		if err := s.Runtime().UpdateContainerStatus(ctx, ctr); err != nil {
-			return fmt.Errorf("failed to update container status %s: %v", ctr.Name(), err)
-		}
-	}
-
 	if err := s.Runtime().StopContainer(ctx, ctr, timeout); err != nil {
 		return fmt.Errorf("failed to stop container %s: %w", ctr.ID(), err)
 	}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1200,3 +1200,27 @@ EOF
 
 	run ! crictl inspect "$ctr_id"
 }
+
+@test "ctr multiple stop calls" {
+	start_crio
+
+	# Create a container with a long-running command to simulate a scenario where
+	# a container takes a while to stop gracefully.
+	jq '.command = ["/bin/sh", "-c", "sleep 600"]' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	ctr_id=$(crictl run "$newconfig" "$TESTDATA"/sandbox_config.json)
+
+	# Issue the first crictl stop command with a long timeout.
+	crictl stop --timeout 3600 "$ctr_id" &
+	sleep 5 # Ensure the first stop command has time to start.
+
+	# Attempt to issue another crictl stop command while the first one is still active.
+	crictl stop --timeout 0 "$ctr_id" &> /dev/null
+
+	# Verify that the container has either stopped or exited.
+	final_state=$(crictl inspect "$ctr_id" | grep -Po '(?<="state": ")[^"]*')
+	if [ "$final_state" != "CONTAINER_STOPPED" ] && [ "$final_state" != "CONTAINER_EXITED" ]; then
+		echo "Test failed: Container did not stop or exit as expected."
+		exit 1
+	fi
+}


### PR DESCRIPTION
This is a manual cherry-pick of #8300 

/assign sohankunkerkar

```release-note
Fixed a bug where stopping a container would block all further stop attempts for the same container.
```