### PR TITLE
Cleanup/refactor create sandbox container

### DIFF
--- a/internal/config/node/cgroups_unsupported.go
+++ b/internal/config/node/cgroups_unsupported.go
@@ -3,6 +3,10 @@
 
 package node
 
+func CgroupIsV2() bool {
+	return false
+}
+
 // CgroupHasMemorySwap returns whether the memory swap controller is present
 func CgroupHasMemorySwap() bool {
 	return false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR is made of cherry-pics from #8008: The refactoring that is done there can make sense outside of the PR.
The goal here is to reduce the complexity of createSandboxContainer() by extracting some functions. Some are moved to the factory/container code, others are just made sub-functions in the same file.

Hopefully, this can make createSandboxContainer() easier to maintain.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
I'm not sure that the way I split the functions makes sense in the way the "container" object is used. My focus was on code readability, and extracting related parts of the code as sub-functions. We can discuss it and adapt.
See this as a first draft.


#### Does this PR introduce a user-facing change?

```release-note
None
```
