### PR TITLE
Disable network ping tests for actuated runners

### DIFF
--- a/test/network_ping.bats
+++ b/test/network_ping.bats
@@ -12,6 +12,11 @@ function teardown() {
 }
 
 @test "Ping pod from the host / another pod" {
+	if [[ "$ARCH" != "$ARCH_X86_64" ]]; then
+		# https://github.com/cri-o/cri-o/issues/8388
+		skip "not supported on GitHub actions runners using arch $ARCH"
+	fi
+
 	pod1_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	ctr1_id=$(crictl create "$pod1_id" "$TESTDATA"/container_config_ping.json "$TESTDATA"/sandbox_config.json)
 	ping_pod "$ctr1_id"


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Disabling the tests on arm runners for now.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/8388

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
