### PR TITLE
ci: fix reload config for empty pinned image test

### DIFF
--- a/contrib/test/ci/integration.yml
+++ b/contrib/test/ci/integration.yml
@@ -53,7 +53,6 @@
         state: present
       loop: "{{ ['cgroups.bats'] | product(kata_skip_cgroups_tests) \
         + ['command.bats'] | product(kata_skip_command_tests) \
-        + ['reload_config.bats'] | product(kata_skip_reload_config) \
         + ['crio-check.bats'] | product(kata_skip_crio_check_tests) \
         + ['crio-wipe.bats'] | product(kata_skip_crio_wipe_tests) \
         + ['ctr.bats'] | product(kata_skip_ctr_tests) \

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -99,8 +99,6 @@ kata_skip_cgroups_tests:
 kata_skip_command_tests:
   - 'test "crio commands"'
   - 'test "log max boundary testing"'
-kata_skip_reload_config:
-  - 'test "reload config should remove pinned images when an empty list is provided"'
 kata_skip_crio_check_tests:
   - 'test "storage directory check should wipe everything on repair errors"'
 kata_skip_crio_wipe_tests:

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -485,7 +485,28 @@ function reload_crio() {
     kill -HUP "$CRIO_PID"
 }
 
+# wait_for_log <log message> [line to skip]
+#
+# Wait for a given log message in crio log file.
+#
+# If a second parameter is given, the log will be truncated from start to the
+# first occurrence of the second parameter. This allow to catch messages after
+# the given string.
+#
+# The function registers the timestamp of the first occurrence it finds to an
+# environment variable "LAST_TIMESTAMP".
+# This variable can then be used as the second parameter to the function, making
+# sure that we can find repetitions of the same log messages over time.
+#
+# $1 : log message to wait for
+# $2 : previous string that needs to be skipped
+#
 function wait_for_log() {
+    export LAST_TIMESTAMP
+    local LOGFILE="$CRIO_LOG"
+    if [ "$2" != "" ]; then
+        LOGFILE=$(mktemp "$TESTDIR"/wait_for_log_XXXXXX)
+    fi
     CNT=0
     while true; do
         if [[ $CNT -gt 50 ]]; then
@@ -493,7 +514,18 @@ function wait_for_log() {
             exit 1
         fi
 
-        if grep -iq "$1" "$CRIO_LOG"; then
+        if [ "$2" != "" ]; then
+            # create a temp log file containing only the logs after the given string
+            sed -e "1,/$2/d" <"$CRIO_LOG" >"$LOGFILE"
+        fi
+        status=0 # initialize the variable to make shellcheck happy
+        run grep -i -m 1 "$1" "$LOGFILE"
+        if [ "$status" -eq 0 ]; then
+            # register only the time part of the timestamp
+            # this should be a string with no space in it, and that is unique in the log
+            # NOTE: log time format = 2006-01-02T15:04:05.999999999Z
+            TIMESTAMP_REGEXP="[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}.[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]*."
+            LAST_TIMESTAMP=$(echo "$output" | grep -oE "time=\"$TIMESTAMP_REGEXP" | cut -d" " -f2)
             break
         fi
 

--- a/test/reload_config.bats
+++ b/test/reload_config.bats
@@ -276,9 +276,7 @@ EOF
 	# Add a pinned image to the configuration
 	printf '[crio.image]\npinned_images = ["%s", ""]\n' $EXAMPLE_IMAGE > "$CRIO_CONFIG_DIR"/01-overwrite
 	reload_crio
-	wait_for_log 'Set config pinned_images to \\"quay.io/crio/fedora-crio-ci:latest\\"'
 	wait_for_log "Configuration reload completed"
-	wait_for_log 'pinned_images = \[\\"quay.io/crio/fedora-crio-ci:latest\\"\]'
 
 	# Verify that the image is pinned
 	output=$(crictl images -o json | jq ".images[] | select(.repoTags[] == \"$EXAMPLE_IMAGE\") |.pinned")
@@ -287,9 +285,7 @@ EOF
 	# Remove the pinned image from the configuration
 	printf '[crio.image]\npinned_images = []\n' > "$CRIO_CONFIG_DIR"/01-overwrite
 	reload_crio
-	wait_for_log 'Set config pinned_images to \\"\[\]\\"'
-	wait_for_log "Configuration reload completed"
-	wait_for_log 'pinned_images = \[\]'
+	wait_for_log "Configuration reload completed" "$LAST_TIMESTAMP"
 
 	# Verify that the image is no longer pinned
 	output=$(crictl images -o json | jq ".images[] | select(.repoTags[] == \"$EXAMPLE_IMAGE\") |.pinned")


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
Modify the "wait_for_log" function in helpers.bash to allow it to catch multiple occurrences of the same message.
Use that in the failing test to synchronize and wait for config reload to be finished before checking the content of the configuration.


#### Which issue(s) this PR fixes:
Fixes #8324

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
