### PR TITLE
Log version only for main CRI-O command

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -172,7 +172,6 @@ func main() {
 			TimestampFormat: "2006-01-02 15:04:05.000000000Z07:00",
 			FullTimestamp:   true,
 		})
-		info.LogVersion()
 
 		level, err := logrus.ParseLevel(config.LogLevel)
 		if err != nil {
@@ -217,6 +216,8 @@ func main() {
 	}
 
 	app.Action = func(c *cli.Context) error {
+		info.LogVersion()
+
 		ctx, cancel := context.WithCancel(context.Background())
 
 		cpuProfilePath := c.String("profile-cpu")


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
Having subcommands like `crio status` or `crio config` to log the version seems a bit odd, so we now silence this behavior and log the version only on the main `crio` command.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Log version only for main CRI-O command, not on others like `crio config` or `crio status`.
```
