### PR TITLE
Make ImageVolume garbage collection work

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -96,6 +96,7 @@ type ContainerVolume struct {
 	RecursiveReadOnly bool                   `json:"recursive_read_only"`
 	Propagation       types.MountPropagation `json:"propagation"`
 	SelinuxRelabel    bool                   `json:"selinux_relabel"`
+	Image             *types.ImageSpec       `json:"image,omitempty"` // A possible image for OCI volume mounts
 }
 
 // ContainerState represents the status of a container.

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -66,6 +66,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 			RecursiveReadOnly: cv.RecursiveReadOnly,
 			Propagation:       cv.Propagation,
 			SelinuxRelabel:    cv.SelinuxRelabel,
+			Image:             cv.Image,
 		})
 	}
 	resp.Status.Mounts = mounts

--- a/test/oci_volumes.bats
+++ b/test/oci_volumes.bats
@@ -39,6 +39,11 @@ function teardown() {
 	# Image removal should be blocked
 	run ! crictl rmi $IMAGE
 
+	# The kubelet garbage collection expects the image ID set in the container status mount
+	IMAGE_ID=$(crictl inspecti quay.io/crio/artifact:v1 | jq -e .status.id)
+	IMAGE_MOUNT_ID=$(crictl inspect "$CTR_ID" | jq -e '.status.mounts[0].image.image')
+	[[ "$IMAGE_ID" == "$IMAGE_MOUNT_ID" ]]
+
 	# Remove the container
 	crictl rm -f "$CTR_ID"
 


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We need to return the image ID for the localhost mount, otherwise the kubelet garbage collection is not able to handle them.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/kubernetes/enhancements/issues/4639

Follow-up on https://github.com/cri-o/cri-o/pull/8317
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
