### PR TITLE
Use custom storage check options for CRI-O internal wipe

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -151,11 +151,12 @@ func main() {
 
 	app.Commands = criocli.DefaultCommands
 	app.Commands = append(app.Commands,
+		criocli.CheckCommand,
 		criocli.ConfigCommand,
 		criocli.PublishCommand,
+		criocli.StatusCommand,
 		criocli.VersionCommand,
 		criocli.WipeCommand,
-		criocli.StatusCommand,
 	)
 
 	slices.SortFunc(app.Commands, func(a, b *cli.Command) int {

--- a/completions/bash/crio
+++ b/completions/bash/crio
@@ -2,7 +2,8 @@ _cli_bash_autocomplete() {
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    opts="complete
+    opts="check
+complete
 completion
 config
 man

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -2,7 +2,7 @@
 
 function __fish_crio_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i complete completion help h config man markdown md status config c containers container cs s info i version wipe help h
+        if contains -- $i check complete completion help h config man markdown md status config c containers container cs s info i version wipe help h
             return 1
         end
     end
@@ -172,6 +172,31 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l help -s h -d 'show help'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l version -s v -d 'print the version'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l help -s h -d 'show help'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l version -s v -d 'print the version'
+complete -c crio -n '__fish_seen_subcommand_from check' -f -l help -s h -d 'show help'
+complete -r -c crio -n '__fish_crio_no_subcommand' -a 'check' -d 'Check CRI-O storage directory for errors.
+
+This command can also repair damaged containers, images and layers.
+
+By default, the data integrity of the storage directory is verified,
+which can be an I/O and CPU-intensive operation. The --quick option
+can be used to reduce the number of checks run.
+
+When using the --repair option, especially with the --force option,
+CRI-O and any currently running containers should be stopped if
+possible to ensure no concurrent access to the storage directory
+occurs.
+
+The --wipe option can be used to automatically attempt to remove
+containers and images on a repair failure. This option, combined
+with the --force option, can be used to entirely remove the storage
+directory content in case of irrecoverable errors. This should be
+used as a last resort, and similarly to the --repair option, it\'s
+best if CRI-O and any currently running containers are stopped.'
+complete -c crio -n '__fish_seen_subcommand_from check' -f -l age -s a -r -d 'Maximum allowed age for unreferenced layers'
+complete -c crio -n '__fish_seen_subcommand_from check' -f -l force -s f -d 'Remove damaged containers'
+complete -c crio -n '__fish_seen_subcommand_from check' -f -l repair -s r -d 'Remove damaged images and layers'
+complete -c crio -n '__fish_seen_subcommand_from check' -f -l quick -s q -d 'Perform only quick checks'
+complete -c crio -n '__fish_seen_subcommand_from check' -f -l wipe -s w -d 'Wipe storage directory on repair failure'
 complete -c crio -n '__fish_seen_subcommand_from complete completion' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'complete completion' -d 'Generate bash, fish or zsh completions.'
 complete -c crio -n '__fish_seen_subcommand_from complete completion' -f -l help -s h -d 'show help'

--- a/completions/zsh/_crio
+++ b/completions/zsh/_crio
@@ -2,6 +2,25 @@ _cli_zsh_autocomplete() {
 
   local -a cmds
   cmds=(
+        "check:Check CRI-O storage directory for errors.
+
+This command can also repair damaged containers, images and layers.
+
+By default, the data integrity of the storage directory is verified,
+which can be an I/O and CPU-intensive operation. The --quick option
+can be used to reduce the number of checks run.
+
+When using the --repair option, especially with the --force option,
+CRI-O and any currently running containers should be stopped if
+possible to ensure no concurrent access to the storage directory
+occurs.
+
+The --wipe option can be used to automatically attempt to remove
+containers and images on a repair failure. This option, combined
+with the --force option, can be used to entirely remove the storage
+directory content in case of irrecoverable errors. This should be
+used as a last resort, and similarly to the --repair option, it's
+best if CRI-O and any currently running containers are stopped."
         'complete:Generate bash, fish or zsh completions.'
         'completion:Generate bash, fish or zsh completions.'
         'config:Outputs a commented version of the configuration file that could be used

--- a/contrib/test/ci/integration.yml
+++ b/contrib/test/ci/integration.yml
@@ -55,6 +55,7 @@
       loop: "{{ ['cgroups.bats'] | product(kata_skip_cgroups_tests) \
         + ['command.bats'] | product(kata_skip_command_tests) \
         + ['reload_config.bats'] | product(kata_skip_reload_config) \
+        + ['crio-check.bats'] | product(kata_skip_crio_check_tests) \
         + ['crio-wipe.bats'] | product(kata_skip_crio_wipe_tests) \
         + ['ctr.bats'] | product(kata_skip_ctr_tests) \
         + ['devices.bats'] | product(kata_skip_devices_tests) \

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -101,12 +101,15 @@ kata_skip_command_tests:
   - 'test "log max boundary testing"'
 kata_skip_reload_config:
   - 'test "reload config should remove pinned images when an empty list is provided"'
+kata_skip_crio_check_tests:
+  - 'test "storage directory check should wipe everything on repair errors"'
 kata_skip_crio_wipe_tests:
   - 'test "clear neither when remove persist"'
   - "test \"don't clear containers on a forced restart of crio\""
   - "test \"don't clear containers if clean shutdown supported file not present\""
   - "test \"internal_wipe don't clear containers on a forced restart of crio\""
   - 'test "internal_wipe eventually cleans network on forced restart of crio if network is slow to come up"'
+  - 'test "recover from badly corrupted storage directory"'
 kata_skip_ctr_tests:
   - 'test "ctr logging"'
   - 'test "ctr journald logging"'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -441,6 +441,38 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 # COMMANDS
 
+## check
+
+Check CRI-O storage directory for errors.
+
+This command can also repair damaged containers, images and layers.
+
+By default, the data integrity of the storage directory is verified,
+which can be an I/O and CPU-intensive operation. The --quick option
+can be used to reduce the number of checks run.
+
+When using the --repair option, especially with the --force option,
+CRI-O and any currently running containers should be stopped if
+possible to ensure no concurrent access to the storage directory
+occurs.
+
+The --wipe option can be used to automatically attempt to remove
+containers and images on a repair failure. This option, combined
+with the --force option, can be used to entirely remove the storage
+directory content in case of irrecoverable errors. This should be
+used as a last resort, and similarly to the --repair option, it's
+best if CRI-O and any currently running containers are stopped.
+
+**--age, -a**="": Maximum allowed age for unreferenced layers (default: "24h")
+
+**--force, -f**: Remove damaged containers
+
+**--quick, -q**: Perform only quick checks
+
+**--repair, -r**: Remove damaged images and layers
+
+**--wipe, -w**: Wipe storage directory on repair failure
+
 ## complete, completion
 
 Generate bash, fish or zsh completions.

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -62,7 +62,7 @@ CRI-O reads its storage defaults from the containers-storage.conf(5) file locate
   Whether CRI-O should wipe containers after a reboot and images after an upgrade when the server starts.
   If set to false, one must run `crio wipe` to wipe the containers and images in these situations.
 
-**internal_repair**=false
+**internal_repair**=true
   InternalRepair is whether CRI-O should check if the container and image storage was corrupted after a sudden restart.
   If it was, CRI-O also attempts to repair the storage.
 

--- a/internal/criocli/check.go
+++ b/internal/criocli/check.go
@@ -1,0 +1,195 @@
+package criocli
+
+import (
+	"fmt"
+
+	"github.com/containers/storage"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+
+	"github.com/cri-o/cri-o/internal/lib"
+	"github.com/cri-o/cri-o/utils"
+)
+
+type checkErrors map[string][]error
+
+var CheckCommand = &cli.Command{
+	Name:   "check",
+	Usage:  usageText,
+	Action: crioCheck,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "age",
+			Aliases: []string{"a"},
+			Value:   "24h",
+			Usage:   "Maximum allowed age for unreferenced layers",
+		},
+		&cli.BoolFlag{
+			Name:    "force",
+			Aliases: []string{"f"},
+			Usage:   "Remove damaged containers",
+		},
+		&cli.BoolFlag{
+			Name:    "repair",
+			Aliases: []string{"r"},
+			Usage:   "Remove damaged images and layers",
+		},
+		&cli.BoolFlag{
+			Name:    "quick",
+			Aliases: []string{"q"},
+			Usage:   "Perform only quick checks",
+		},
+		&cli.BoolFlag{
+			Name:    "wipe",
+			Aliases: []string{"w"},
+			Usage:   "Wipe storage directory on repair failure",
+		},
+	},
+}
+
+func crioCheck(c *cli.Context) error {
+	config, err := GetConfigFromContext(c)
+	if err != nil {
+		return fmt.Errorf("unable to load configuration: %w", err)
+	}
+
+	store, err := config.GetStore()
+	if err != nil {
+		return fmt.Errorf("unable to open storage: %w", err)
+	}
+	defer func() {
+		if _, err := store.Shutdown(true); err != nil {
+			logrus.Errorf("Unable to shutdown storage: %v", err)
+		}
+	}()
+
+	graphRoot := store.GraphRoot()
+	logrus.Infof("Checking storage directory %s for errors", graphRoot)
+
+	checkOptions := storage.CheckEverything()
+	if c.Bool("quick") {
+		// This is not the same as the "quick" check that CRI-O performs during its start-up
+		// following an unclean shutdown, as this one would set the `LayerDigests` option,
+		// which is I/O and CPU intensive, whereas the other one does not.
+		checkOptions = storage.CheckMost()
+	}
+
+	// The maximum unreferenced layer age.
+	layerAge := c.String("age")
+	if layerAge != "" {
+		age, err := utils.ParseDuration(layerAge)
+		if err != nil {
+			return fmt.Errorf("unable to parse age duration: %w", err)
+		}
+		checkOptions.LayerUnreferencedMaximumAge = &age
+	}
+
+	report, err := store.Check(checkOptions)
+	if err != nil {
+		return fmt.Errorf("unable to check storage: %w", err)
+	}
+
+	// Walk each report and show details...
+	for prefix, checkReport := range map[string]checkErrors{
+		"layer":           report.Layers,
+		"read-only layer": report.ROLayers,
+		"image":           report.Images,
+		"read-only image": report.ROImages,
+		"container":       report.Containers,
+	} {
+		for identifier, errs := range checkReport {
+			for _, err := range errs {
+				logrus.Debugf("%s: %s: %v", prefix, identifier, err)
+			}
+		}
+	}
+
+	seenStorageErrors := lib.CheckReportHasErrors(report)
+	logrus.Debugf("Storage directory %s has errors: %t", graphRoot, seenStorageErrors)
+
+	if !c.Bool("repair") {
+		if seenStorageErrors {
+			logrus.Warnf("Errors found while checking storage directory %s for errors", graphRoot)
+			return fmt.Errorf(
+				"%d layer errors, %d read-only layer errors, %d image errors, %d read-only image errors, %d container errors",
+				len(report.Layers),
+				len(report.ROLayers),
+				len(report.Images),
+				len(report.ROImages),
+				len(report.Containers),
+			)
+		}
+		return nil
+	}
+
+	force := c.Bool("force")
+	if force {
+		logrus.Warn("The `force` option has been set, repair will attempt to remove damaged containers")
+	}
+	logrus.Infof("Attempting to repair storage directory %s", graphRoot)
+
+	errs := store.Repair(report, &storage.RepairOptions{
+		RemoveContainers: force,
+	})
+	if len(errs) != 0 {
+		for _, err := range errs {
+			logrus.Error(err)
+		}
+
+		if c.Bool("wipe") {
+			// Depending on whether the `force` option is set or not, this will remove the
+			// storage directory completely while ignoring any running containers. Otherwise,
+			// this will fail if there are any containers currently running.
+			if force {
+				logrus.Warn("The `force` option has been set, storage directory will be forcefully removed")
+			}
+			logrus.Infof("Wiping storage directory %s", graphRoot)
+			return lib.RemoveStorageDirectory(config, store, force)
+		}
+
+		return errs[0]
+	}
+
+	if len(report.ROLayers) > 0 || len(report.ROImages) > 0 || (!force && len(report.Containers) > 0) {
+		if force {
+			// Any damaged containers would have been deleted at this point.
+			return fmt.Errorf(
+				"%d read-only layer errors, %d read-only image errors",
+				len(report.ROLayers),
+				len(report.ROImages),
+			)
+		}
+		return fmt.Errorf(
+			"%d read-only layer errors, %d read-only image errors, %d container errors",
+			len(report.ROLayers),
+			len(report.ROImages),
+			len(report.Containers),
+		)
+	}
+
+	return nil
+}
+
+// The `Description` field will not be rendered when the documentation
+// is generated, and using `Usage` makes the formatting wrong when the
+// command-line help is rendered. Shell completions might also be
+// incorrect.
+var usageText = `Check CRI-O storage directory for errors.
+
+This command can also repair damaged containers, images and layers.
+
+By default, the data integrity of the storage directory is verified,
+which can be an I/O and CPU-intensive operation. The --quick option
+can be used to reduce the number of checks run.
+
+When using the --repair option, especially with the --force option,
+CRI-O and any currently running containers should be stopped if
+possible to ensure no concurrent access to the storage directory
+occurs.
+
+The --wipe option can be used to automatically attempt to remove
+containers and images on a repair failure. This option, combined
+with the --force option, can be used to entirely remove the storage
+directory content in case of irrecoverable errors. This should be
+used as a last resort, and similarly to the --repair option, it's
+best if CRI-O and any currently running containers are stopped.`

--- a/internal/criocli/wipe.go
+++ b/internal/criocli/wipe.go
@@ -64,6 +64,11 @@ func crioWipe(c *cli.Context) error {
 	// Note: this is only needed if the node rebooted.
 	// If there wasn't time to sync, we should clear the storage directory
 	if shouldWipeContainers && lib.ShutdownWasUnclean(config) {
+		logrus.Infof(
+			"File %s not found. Wiping storage directory %s because of suspected unclean shutdown",
+			config.CleanShutdownFile,
+			store.GraphRoot(),
+		)
 		return lib.HandleUncleanShutdown(config, store)
 	}
 

--- a/internal/criocli/wipe.go
+++ b/internal/criocli/wipe.go
@@ -69,7 +69,8 @@ func crioWipe(c *cli.Context) error {
 			config.CleanShutdownFile,
 			store.GraphRoot(),
 		)
-		return lib.HandleUncleanShutdown(config, store)
+		// This will fail if there are any containers currently running.
+		return lib.RemoveStorageDirectory(config, store, false)
 	}
 
 	// If crio is configured to wipe internally (and `--force` wasn't set)

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -811,7 +811,7 @@ func HandleUncleanShutdown(config *libconfig.Config, store cstorage.Store) error
 		logrus.Infof("Failed to wipe storage: %v", err)
 	}
 	// Unmount storage or else we will fail with -EBUSY.
-	if _, err := store.Shutdown(false); err != nil {
+	if _, err := store.Shutdown(true); err != nil {
 		return fmt.Errorf("failed to shutdown storage: %w", err)
 	}
 	// Completely remove storage, whatever is left (possibly orphaned layers).

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -112,10 +112,7 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 				return nil, err
 			}
 		}
-		options := cstorage.RepairOptions{
-			RemoveContainers: true,
-		}
-		if errs := store.Repair(report, &options); len(errs) > 0 {
+		if errs := store.Repair(report, cstorage.RepairEverything()); len(errs) > 0 {
 			err = HandleUncleanShutdown(config, store)
 			if err != nil {
 				return nil, err

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -111,7 +111,7 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 
 		wipeStorage := false
 		report, err := store.Check(checkQuick())
-		if err == nil && checkReportHasErrors(report) {
+		if err == nil && CheckReportHasErrors(report) {
 			log.Warnf(ctx, "Attempting to repair storage directory %s because of unclean shutdown", graphRoot)
 			if errs := store.Repair(report, cstorage.RepairEverything()); len(errs) > 0 {
 				wipeStorage = true
@@ -880,9 +880,9 @@ func checkQuick() *cstorage.CheckOptions {
 	}
 }
 
-// checkReportHasErrors checks if the report from a completed storage check includes
+// CheckReportHasErrors checks if the report from a completed storage check includes
 // any recoverable errors that storage repair could fix.
-func checkReportHasErrors(report cstorage.CheckReport) bool {
+func CheckReportHasErrors(report cstorage.CheckReport) bool {
 	// The `storage.Check()` returns a report object and an error,
 	// where errors are most likely irrecoverable and should be
 	// handled as such; the report, on the contrary, can contain

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -804,17 +804,17 @@ func ShutdownWasUnclean(config *libconfig.Config) bool {
 }
 
 func HandleUncleanShutdown(config *libconfig.Config, store cstorage.Store) error {
-	logrus.Infof("File %s not found. Wiping storage directory %s because of suspected dirty shutdown", config.CleanShutdownFile, store.GraphRoot())
-	// If we do not do this, we may leak other resources that are not directly in the graphroot.
-	// Erroring here should not be fatal though, it's a best effort cleanup
+	// If we do not do this, we may leak other resources that are not directly
+	// in the graphroot. Erroring here should not be fatal though, it's a best
+	// effort cleanup.
 	if err := store.Wipe(); err != nil {
-		logrus.Infof("Failed to wipe storage cleanly: %v", err)
+		logrus.Infof("Failed to wipe storage: %v", err)
 	}
-	// unmount storage or else we will fail with EBUSY
+	// Unmount storage or else we will fail with -EBUSY.
 	if _, err := store.Shutdown(false); err != nil {
-		return fmt.Errorf("failed to shutdown storage before wiping: %w", err)
+		return fmt.Errorf("failed to shutdown storage: %w", err)
 	}
-	// totally remove storage, whatever is left (possibly orphaned layers)
+	// Completely remove storage, whatever is left (possibly orphaned layers).
 	if err := os.RemoveAll(store.GraphRoot()); err != nil {
 		return fmt.Errorf("failed to remove storage directory: %w", err)
 	}

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -122,7 +122,8 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 		}
 		if wipeStorage {
 			log.Warnf(ctx, "Wiping storage directory %s because of unclean shutdown", graphRoot)
-			if err := HandleUncleanShutdown(config, store); err != nil {
+			// This will fail if there are any containers currently running.
+			if err := RemoveStorageDirectory(config, store, false); err != nil {
 				return nil, err
 			}
 		}
@@ -811,7 +812,7 @@ func ShutdownWasUnclean(config *libconfig.Config) bool {
 	return true
 }
 
-func HandleUncleanShutdown(config *libconfig.Config, store cstorage.Store) error {
+func RemoveStorageDirectory(config *libconfig.Config, store cstorage.Store, force bool) error {
 	// If we do not do this, we may leak other resources that are not directly
 	// in the graphroot. Erroring here should not be fatal though, it's a best
 	// effort cleanup.
@@ -827,7 +828,11 @@ func HandleUncleanShutdown(config *libconfig.Config, store cstorage.Store) error
 		// Since a container started by Podman can be running, we will
 		// try to detect this and return an error rather than proceed
 		// with a storage wipe.
-		if errors.Is(err, cstorage.ErrLayerUsedByContainer) {
+		//
+		// The storage directory removal can also be forced, which will
+		// then delete everything irregardless of whether there are any
+		// containers running at the moment.
+		if !force && errors.Is(err, cstorage.ErrLayerUsedByContainer) {
 			return fmt.Errorf("failed to shutdown storage: %w", err)
 		}
 		logrus.Warnf("Failed to shutdown storage: %v", err)

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -106,16 +106,23 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 	}
 
 	if config.InternalRepair && ShutdownWasUnclean(config) {
+		graphRoot := store.GraphRoot()
+		log.Warnf(ctx, "Checking storage directory %s for errors because of unclean shutdown", graphRoot)
+
+		wipeStorage := false
 		report, err := store.Check(checkQuick())
-		if err != nil {
-			err = HandleUncleanShutdown(config, store)
-			if err != nil {
-				return nil, err
+		if err == nil && checkReportHasErrors(report) {
+			log.Warnf(ctx, "Attempting to repair storage directory %s because of unclean shutdown", graphRoot)
+			if errs := store.Repair(report, cstorage.RepairEverything()); len(errs) > 0 {
+				wipeStorage = true
 			}
+		} else if err != nil {
+			// Storage check has failed with irrecoverable errors.
+			wipeStorage = true
 		}
-		if errs := store.Repair(report, cstorage.RepairEverything()); len(errs) > 0 {
-			err = HandleUncleanShutdown(config, store)
-			if err != nil {
+		if wipeStorage {
+			log.Warnf(ctx, "Wiping storage directory %s because of unclean shutdown", graphRoot)
+			if err := HandleUncleanShutdown(config, store); err != nil {
 				return nil, err
 			}
 		}
@@ -866,4 +873,16 @@ func checkQuick() *cstorage.CheckOptions {
 		ImageData:      true,
 		ContainerData:  true,
 	}
+}
+
+// checkReportHasErrors checks if the report from a completed storage check includes
+// any recoverable errors that storage repair could fix.
+func checkReportHasErrors(report cstorage.CheckReport) bool {
+	// The `storage.Check()` returns a report object and an error,
+	// where errors are most likely irrecoverable and should be
+	// handled as such; the report, on the contrary, can contain
+	// errors that the `storage.Repair()` could potentially fix.
+	return len(report.Layers) > 0 || len(report.ROLayers) > 0 ||
+		len(report.Images) > 0 || len(report.ROImages) > 0 ||
+		len(report.Containers) > 0
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -869,7 +869,7 @@ func DefaultConfig() (*Config, error) {
 			VersionFile:       CrioVersionPathTmp,
 			CleanShutdownFile: CrioCleanShutdownFile,
 			InternalWipe:      true,
-			InternalRepair:    false,
+			InternalRepair:    true,
 		},
 		APIConfig: APIConfig{
 			Listen:             CrioSocketPath,

--- a/test/crio-check.bats
+++ b/test/crio-check.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+function run_crio_check() {
+	local log_level=("-l" "${CRIO_BINARY_LOG_LEVEL:-"info"}")
+
+	"$CRIO_BINARY_PATH" -c "$CRIO_CONFIG" -d "$CRIO_CONFIG_DIR" "${log_level[@]}" check "$@"
+}
+
+@test "storage directory check should find no issues" {
+	setup_crio
+
+	# Should verify no storage directory errors.
+	run_crio_check
+}
+
+@test "storage directory check should find errors" {
+	setup_crio
+
+	# Remove random layer from the storage directory.
+	remove_random_storage_layer
+
+	run ! run_crio_check
+}
+
+@test "storage directory check should repair errors" {
+	setup_crio
+
+	# Remove random layer from the storage directory.
+	remove_random_storage_layer
+
+	# Should repair damaged storage directory.
+	run_crio_check --repair
+
+	# Should verify no storage directory errors.
+	CRIO_BINARY_LOG_LEVEL="debug" run run_crio_check
+
+	[[ "$output" == *"Storage directory ${TESTDIR}/crio has errors: false"* ]]
+}
+
+@test "storage directory check should wipe everything on repair errors" {
+	start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	# This will corrupt the storage directory.
+	cp -r "$TESTDIR"/crio/overlay{,.old}
+	umount -R -l -f "$TESTDIR"/crio/overlay
+	rm -Rf "$TESTDIR"/crio/overlay
+	cp -r "$TESTDIR"/crio/overlay{.old,}
+
+	# Should wipe badly damaged storage directory.
+	#
+	# The output is suppressed, as the c/storage library
+	# can generate a large volume of log lines while the
+	# repair process runs. A smaller image like "busybux"
+	# could help alleviate this issue.
+	run_crio_check --repair --force --wipe &> /dev/null
+
+	# Storage directory wipe should leave only the metadata behind.
+	size=$(du -sb "$TESTDIR"/crio | cut -f 1)
+
+	# The storage directory wipe did not work if there is more data than 128 KiB left.
+	if ((size > 1024 * 128)); then
+		echo "The crio check storage directory wipe did not work" >&3
+		return 1
+	fi
+
+	# Should verify no storage directory errors.
+	CRIO_BINARY_LOG_LEVEL="debug" run run_crio_check
+
+	[[ "$output" == *"Storage directory ${TESTDIR}/crio has errors: false"* ]]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -738,3 +738,7 @@ function annotations_equal() {
     received_contains_expected=$?
     [[ $expected_contains_received -eq 0 ]] && [[ $received_contains_expected -eq 0 ]]
 }
+
+function remove_random_storage_layer() {
+    find "$TESTDIR"/crio/overlay -maxdepth 1 | grep '.*/[a-f0-9\-]\{64\}.*' | head -1 | xargs rm -Rf
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/containers/storage/pkg/unshare"
 	. "github.com/onsi/ginkgo/v2"
@@ -389,6 +390,98 @@ var _ = t.Describe("Utils", func() {
 			Expect(newuid).To(Equal(uid))
 			Expect(newgid).To(Equal(gid))
 			Expect(newaddgids).To(Equal(addgids))
+		})
+	})
+
+	t.Describe("ParseDuration", func() {
+		It("should succeed with duration value with unit", func() {
+			// Given
+			// When
+			duration, err := utils.ParseDuration("5s")
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(duration).To(Equal(5 * time.Second))
+		})
+
+		It("should succeed with duration value without unit", func() {
+			// Given
+			// When
+			duration, err := utils.ParseDuration("5")
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(duration).To(Equal(5 * time.Second))
+		})
+
+		It("should succeed with negative duration value with unit", func() {
+			// Given
+			// When
+			duration, err := utils.ParseDuration("-5s")
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(duration).To(Equal(5 * time.Second))
+		})
+
+		It("should succeed with negative duration value without unit", func() {
+			// Given
+			// When
+			duration, err := utils.ParseDuration("-5")
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(duration).To(Equal(5 * time.Second))
+		})
+
+		It("should succeed with zero as duration value without unit", func() {
+			// Given
+			// When
+			duration, err := utils.ParseDuration("0")
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(duration).To(Equal(time.Duration(0)))
+		})
+
+		It("should succeed with floating point duration with unit", func() {
+			// Given
+			// When
+			duration, err := utils.ParseDuration("1.234s")
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(duration).To(Equal(time.Duration(1.234 * float64(time.Second))))
+		})
+
+		It("should fail with invalid floating point duration without unit", func() {
+			// Given
+			// When
+			duration, err := utils.ParseDuration("1.234")
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(duration).To(Equal(time.Duration(0)))
+		})
+
+		It("should fail with invalid duration", func() {
+			// Given
+			// When
+			duration, err := utils.ParseDuration("test")
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(duration).To(Equal(time.Duration(0)))
+		})
+
+		It("should fail with empty duration", func() {
+			// Given
+			// When
+			duration, err := utils.ParseDuration("")
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(duration).To(Equal(time.Duration(0)))
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When enabled, the internal repair feature uses the `storage.CheckEverything()`  helper function to configure what the `storage.Check()` should check for when scanning the storage directory. The following options are enabled:

```go
func CheckEverything() *CheckOptions {
	return &CheckOptions{
		LayerDigests:   true,
		LayerMountable: true,
		LayerContents:  true,
		LayerData:      true,
		ImageData:      true,
		ContainerData:  true,
	}
}
```

Two of these options, `LayerDigests` and `LayerContents`, are known to be I/O and CPU intensive, and both of these options are used to perform storage integrity checks and require the contents of the images to be read, checksums generated, and the current state compared against the desired state. As such, depending on the number of images, the layers each image has, and the number of files within each layer, it can take a considerable amount of time before the storage scan with both of these options enabled will complete.

Even though CRI-O only performs storage checks and repairs following an unclean shutdown, with the two checks mentioned earlier options enabled, it can take CRI-O some time to finish storage repairs. During this time, it won't be able to serve API requests. This can lead to the kubelet not being able to get responses to its requests in time, and eventually assuming that CRI-O is not responsive and proceed to make this specific node `NotReady`, which is undesirable. 

Thus, to mitigate the problem with storage scans potentially taking a long time to complete, we are going to switch to a custom configuration for the `storage.Check()` that turns off these expensive checks and only turns on checks that allow CRI-O to perform a "quick" scan of the storage directory.

This quick scan should cover most of the common types of storage failures and take significantly less time to complete. However, this comes at the expense of container image integrity verification, where files that are missing from the image or files that have their content altered will no longer be detected.

The goal of the internal repair is to ensure that CRI-O can recover from issues surrounding a corrupted storage directory on start-up, with an added option only to remove corrupted images and containers when attempting a repair, compared to removing the entire storage directory content. Hence, trading scan run time for correctness is acceptable.

While at it, change the internal repair option to be enabled by default and add a new `crio check` sub-command, which allows to check the storage directory for errors and repair it, if needed.

Related:

- https://github.com/containers/storage/pull/1569
- https://github.com/cri-o/cri-o/pull/7190
- https://github.com/cri-o/cri-o/issues/7177

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Update the type of checks the internal repair feature performs on CRI-O's start-up following an unclean shutdown, enable the internal repair option by default, and add a new `crio check` sub-command.
```
