### PR TITLE
Fix lint timeout option

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --timeout=10m
 
   lint-markdown:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ run:
     # needs devmapper headers installed
     - exclude_graphdriver_devicemapper
   concurrency: 6
-  deadline: 10m
+  timeout: 10m
 linters:
   disable-all: true
   enable:
@@ -64,6 +64,7 @@ linters:
     - nosprintfhostport
     - perfsprint
     - prealloc
+    - promlinter
     - protogetter
     - reassign
     - revive
@@ -115,7 +116,6 @@ linters:
     # - nonamedreturns
     # - paralleltest
     # - predeclared
-    # - promlinter
     # - tagliatelle
     # - testpackage
     # - thelper


### PR DESCRIPTION
#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Fix the linter timeout option. Also enable the `promlinter` which does not report anything.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
