### PR TITLE
Run the runtime RuntimeType validation first

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1569,6 +1569,9 @@ func (c *NetworkConfig) Validate(onExecution bool) error {
 
 // Validate checks if the whole runtime is valid.
 func (r *RuntimeHandler) Validate(name string) error {
+	if err := r.ValidateRuntimeType(name); err != nil {
+		return err
+	}
 	if err := r.ValidateRuntimePath(name); err != nil {
 		return err
 	}
@@ -1578,10 +1581,7 @@ func (r *RuntimeHandler) Validate(name string) error {
 	if err := r.ValidateRuntimeAllowedAnnotations(); err != nil {
 		return err
 	}
-	if err := r.ValidateNoSyncLog(); err != nil {
-		return err
-	}
-	return r.ValidateRuntimeType(name)
+	return r.ValidateNoSyncLog()
 }
 
 func (r *RuntimeHandler) ValidateRuntimeVMBinaryPattern() bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Validations for the runtimes table sometimes depend on `runtime_type` to
determine which configuration options are valid.

For example
```
runtime_type = vim
runtime_config_path = /usr/share/defaults/kata-containers/configuration.toml
```
would cause "runtime_config_path can only be used with the 'vm' runtime type" instead of the more desirable error that "vim" is not a valid runtime type. (`ValidateRuntimeConfigPath` runs before `ValidateRuntimeType`)

Give this dependency on a valid `runtime_type` we should run this validation first.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
