### PR TITLE
Trim `crio version Version: …` prefix from `crio -v`

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -134,7 +134,7 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	app.Version = strings.TrimSpace(strings.ReplaceAll(info.String(), "\n", "\n   "))
+	app.Version = strings.TrimSpace(strings.ReplaceAll(strings.TrimPrefix(info.String(), "Version: "), "\n", "\n   "))
 
 	app.Flags, app.Metadata, err = criocli.GetFlagsAndMetadata()
 	if err != nil {

--- a/internal/criocli/version.go
+++ b/internal/criocli/version.go
@@ -44,7 +44,7 @@ var VersionCommand = &cli.Command{
 			res = j
 
 		}
-		fmt.Println(res)
+		fmt.Print(res)
 		return nil
 	},
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We duplicated the `version` name for the output of `crio -v`, which is now fixed for all variants:

- `crio -v`
- `crio -h` (Section "VERSION")
- `crio version`

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
