### PR TITLE
Make container and image removal/stop idempotent

### DIFF
--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/truncindex"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -26,6 +27,12 @@ func (s *Server) RemoveContainer(ctx context.Context, req *types.RemoveContainer
 	// save container description to print
 	c, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
+		// The RemoveContainer RPC is idempotent, and must not return an error
+		// if the container has already been removed. Ref:
+		// https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto#L74-L75
+		if errors.Is(err, truncindex.ErrNotExist) {
+			return &types.RemoveContainerResponse{}, nil
+		}
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 

--- a/server/container_remove_test.go
+++ b/server/container_remove_test.go
@@ -50,6 +50,16 @@ var _ = t.Describe("ContainerRemove", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should succeed if container is not found", func() {
+			// Given
+			// When
+			_, err := sut.RemoveContainer(context.Background(),
+				&types.RemoveContainerRequest{ContainerId: "id"})
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("should fail on container remove error", func() {
 			// Given
 			// When

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/containers/storage/pkg/truncindex"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,6 +22,12 @@ func (s *Server) StopContainer(ctx context.Context, req *types.StopContainerRequ
 	log.Infof(ctx, "Stopping container: %s (timeout: %ds)", req.ContainerId, req.Timeout)
 	c, err := s.GetContainerFromShortID(ctx, req.ContainerId)
 	if err != nil {
+		// The StopContainer RPC is idempotent, and must not return an error if
+		// the container has already been stopped. Ref:
+		// https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto#L67-L68
+		if errors.Is(err, truncindex.ErrNotExist) {
+			return &types.StopContainerResponse{}, nil
+		}
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)
 	}
 

--- a/server/container_stop_test.go
+++ b/server/container_stop_test.go
@@ -44,14 +44,14 @@ var _ = t.Describe("ContainerStop", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should fail with invalid container id", func() {
+		It("should succeed with not existing container ID", func() {
 			// Given
 			// When
 			_, err := sut.StopContainer(context.Background(),
 				&types.StopContainerRequest{ContainerId: "id"})
 
 			// Then
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/server/image_remove_test.go
+++ b/server/image_remove_test.go
@@ -2,7 +2,9 @@ package server_test
 
 import (
 	"context"
+	"fmt"
 
+	storagetypes "github.com/containers/storage"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -112,6 +114,28 @@ var _ = t.Describe("ImageRemove", func() {
 
 			// Then
 			Expect(err).To(HaveOccurred())
+		})
+
+		// https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto#L156-L157
+		It("should succeed if image is not found", func() {
+			// Given
+			const testSHA256 = "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"
+			parsedTestSHA256, err := storage.ParseStorageImageIDFromOutOfProcessData(testSHA256)
+			Expect(err).ToNot(HaveOccurred())
+			gomock.InOrder(
+				imageServerMock.EXPECT().HeuristicallyTryResolvingStringAsIDPrefix(testSHA256).
+					Return(&parsedTestSHA256),
+				imageServerMock.EXPECT().DeleteImage(
+					gomock.Any(), parsedTestSHA256).
+					Return(fmt.Errorf("invalid image: %w", storagetypes.ErrImageUnknown)),
+			)
+
+			// When
+			_, err = sut.RemoveImage(context.Background(),
+				&types.RemoveImageRequest{Image: &types.ImageSpec{Image: testSHA256}})
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -119,8 +119,7 @@ function teardown() {
 
 	start_crio
 
-	run -1 crictl stop "$ctr_id"
-	[[ "${output}" == *"not found"* ]]
+	crictl stop "$ctr_id"
 }
 
 @test "crio restore with bad state and pod removed" {


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Fully conform to the CRI as well as the new tests from https://github.com/kubernetes-sigs/cri-tools/pull/1536
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Made `StopContainer`, `RemoveContainer` and `RemoveImage` idempotent per CRI API definition:
https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto
```
