### PR TITLE
Block clone with namespace flag in seccomp default profile

### DIFF
--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -42,7 +42,7 @@ func DefaultProfile() *seccomp.Seccomp {
 		}{
 			{"clone", 1, 23},
 			{"clone3", 1, 24},
-			{"unshare", 1, 363},
+			{"unshare", 1, 358},
 		}
 
 		prof := seccomp.DefaultProfile()

--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -17,6 +17,7 @@ import (
 	json "github.com/json-iterator/go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/config/seccomp/seccompociartifact"
@@ -29,44 +30,81 @@ var (
 )
 
 // DefaultProfile is used to allow mutations from the DefaultProfile from the seccomp library.
-// Specifically, it is used to filter `unshare` from the default profile, as it is a risky syscall for unprivileged containers
-// to have access to.
+// Specifically, it is used to filter syscalls which can create namespaces from the default
+// profile, as it is risky for unprivileged containers to have access to create Linux
+// namespaces.
 func DefaultProfile() *seccomp.Seccomp {
 	defaultProfileOnce.Do(func() {
-		const (
-			unshareName              = "unshare"
-			unshareParentStructIndex = 1
-			unshareIndex             = 358
-		)
+		removeSyscalls := []struct {
+			Name              string
+			ParentStructIndex int
+			Index             int
+		}{
+			{"clone", 1, 23},
+			{"clone3", 1, 24},
+			{"unshare", 1, 363},
+		}
+
 		prof := seccomp.DefaultProfile()
 		// We know the default profile at compile time
 		// though a vendor change may update it.
 		// Panic on error and have CI catch errors on vendor bumps,
 		// to avoid combing through.
-		if prof.Syscalls[unshareParentStructIndex].Names[unshareIndex] != unshareName {
-			for i, name := range prof.Syscalls[unshareParentStructIndex].Names {
-				if name == unshareName {
-					_, file, _, _ := runtime.Caller(1)
-					logrus.Errorf("Change the `unshareIndex` variable in %s to %d", file, i)
-					break
+		for _, remove := range removeSyscalls {
+			if prof.Syscalls[remove.ParentStructIndex].Names[remove.Index] != remove.Name {
+				for i, name := range prof.Syscalls[remove.ParentStructIndex].Names {
+					if name == remove.Name {
+						_, file, _, _ := runtime.Caller(1)
+						logrus.Errorf("Change the Index for %q in %s to %d", remove.Name, file, i)
+						break
+					}
 				}
+				logrus.Fatalf(
+					"Default seccomp profile updated and syscall moved. Found unexpected syscall: %q",
+					prof.Syscalls[remove.ParentStructIndex].Names[remove.Index],
+				)
 			}
-			logrus.Fatalf(
-				"Default seccomp profile updated and unshare syscall moved. Found unexpected syscall: %q",
-				prof.Syscalls[unshareParentStructIndex].Names[unshareIndex],
-			)
+			removeStringFromSlice(prof.Syscalls[remove.ParentStructIndex].Names, remove.Index)
 		}
-		removeStringFromSlice(prof.Syscalls[unshareParentStructIndex].Names, unshareIndex)
 
 		prof.Syscalls = append(prof.Syscalls, &seccomp.Syscall{
 			Names: []string{
-				unshareName,
+				"clone",
+				"clone3",
+				"unshare",
 			},
 			Action: seccomp.ActAllow,
 			Includes: seccomp.Filter{
 				Caps: []string{"CAP_SYS_ADMIN"},
 			},
 		})
+
+		var flagsIndex uint = 0
+		if runtime.GOARCH == "s390" || runtime.GOARCH == "s390x" {
+			flagsIndex = 1
+		}
+
+		prof.Syscalls = append(prof.Syscalls, &seccomp.Syscall{
+			Names: []string{
+				"clone",
+			},
+			Action: seccomp.ActAllow,
+			Args: []*seccomp.Arg{
+				{
+					Index:    flagsIndex,
+					Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET | unix.CLONE_NEWCGROUP,
+					ValueTwo: 0,
+					Op:       seccomp.OpMaskedEqual,
+				},
+			},
+		},
+			&seccomp.Syscall{
+				Names: []string{
+					"clone",
+				},
+				Action: seccomp.ActErrno,
+				Errno:  "EPERM",
+			})
 		defaultProfile = prof
 	})
 

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -77,7 +77,7 @@ function teardown() {
 	crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 8. test running with ctr runtime/default don't allow unshare
+# 8. test running with ctr runtime/default doesn't allow unshare
 @test "ctr seccomp profiles runtime/default block unshare" {
 	unset CONTAINER_SECCOMP_PROFILE
 	restart_crio
@@ -87,4 +87,23 @@ function teardown() {
 
 	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 	run ! crictl exec --sync "$ctr_id" /bin/sh -c "unshare"
+}
+
+# 9. test running with ctr runtime/default don't allow clone with namespace flags
+@test "ctr seccomp profiles runtime/default blocks clone creating namespaces" {
+	unset CONTAINER_SECCOMP_PROFILE
+	restart_crio
+
+	jq --arg TESTDATA "$TESTDATA" '.linux.security_context.seccomp.profile_type = 0 |
+          .mounts = [{
+            host_path: $TESTDATA,
+            container_path: "/testdata",
+          }]' \
+		"$TESTDATA/container_sleep.json" > "$TESTDIR/container.json"
+
+	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
+	crictl exec --sync "$ctr_id" /usr/bin/make -C / clone-ns
+	run crictl exec --sync "$ctr_id" /clone-ns
+	[[ "$output" =~ "Operation not permitted" ]]
 }

--- a/test/testdata/clone-ns.c
+++ b/test/testdata/clone-ns.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sched.h>
+
+int entry() {
+        system("id");
+        return 0;
+}
+
+int main() {
+        void *stack = malloc(1024*1024);
+        if (clone(entry, (stack+1024*1024), CLONE_NEWUSER|CLONE_NEWNET, 0) == -1) {
+          perror("clone");
+        }
+}

--- a/test/testdata/clone-without-ns.c
+++ b/test/testdata/clone-without-ns.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sched.h>
+
+int entry() {
+        system("id");
+        return 0;
+}
+
+int main() {
+        void *stack = malloc(1024*1024);
+        if (clone(entry, (stack+1024*1024), 0, 0) == -1) {
+          perror("clone");
+        }
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The default seccomp policy used by CRI-O did not previously block clone(2) system call (syscall) with CLONE_NEWNS and other namespace creation flags. Changes here block those flags. In addition, also disable the clone3(2) syscall as it is not currently possible to filter a struct argument (struct clone_args) with seccomp; this matches the approach containerd took.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
The default seccomp policy now blocks clone and clone3 system calls that create a Linux namespace. This matches the default seccomp policy containerd uses.
```
