### PR TITLE
Add container storage metric

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -332,7 +332,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--metrics-cert**="": Certificate for the secure metrics endpoint.
 
-**--metrics-collectors**="": Enabled metrics collectors. (default: "image_pulls_layer_size", "containers_events_dropped_total", "containers_oom_total", "processes_defunct", "operations_total", "operations_latency_seconds", "operations_latency_seconds_total", "operations_errors_total", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_failure_total", "image_pulls_success_total", "image_layer_reuse_total", "containers_oom_count_total", "containers_seccomp_notifier_count_total", "resources_stalled_at_stage")
+**--metrics-collectors**="": Enabled metrics collectors. (default: "image_pulls_layer_size", "containers_events_dropped_total", "containers_oom_total", "processes_defunct", "operations_total", "operations_latency_seconds", "operations_latency_seconds_total", "operations_errors_total", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_failure_total", "image_pulls_success_total", "image_layer_reuse_total", "containers_oom_count_total", "containers_seccomp_notifier_count_total", "resources_stalled_at_stage", "storage_configuration_type")
 
 **--metrics-host**="": Host for the metrics endpoint. (default: "127.0.0.1")
 

--- a/server/otel-collector/collectors/collectors.go
+++ b/server/otel-collector/collectors/collectors.go
@@ -63,6 +63,9 @@ const (
 
 	// ResourcesStalledAtStage is the key for the resources stalled at different stages in container and pod creation.
 	ResourcesStalledAtStage Collector = crioPrefix + "resources_stalled_at_stage"
+
+	// StorageConfigurationType is the key for the type of storage CRI-O is configured with.
+	StorageConfigurationType Collector = crioPrefix + "storage_configuration_type"
 )
 
 // FromSlice converts a string slice to a Collectors type.
@@ -101,6 +104,7 @@ func All() Collectors {
 		ContainersOOMCountTotal.Stripped(),
 		ContainersSeccompNotifierCountTotal.Stripped(),
 		ResourcesStalledAtStage.Stripped(),
+		StorageConfigurationType.Stripped(),
 	}
 }
 

--- a/server/otel-collector/collectors/collectors_test.go
+++ b/server/otel-collector/collectors/collectors_test.go
@@ -53,11 +53,12 @@ var _ = t.Describe("Collectors", func() {
 				collectors.ContainersOOMCountTotal,
 				collectors.ContainersSeccompNotifierCountTotal,
 				collectors.ResourcesStalledAtStage,
+				collectors.StorageConfigurationType,
 			} {
 				Expect(all.Contains(collector)).To(BeTrue())
 			}
 
-			Expect(all).To(HaveLen(16))
+			Expect(all).To(HaveLen(17))
 		})
 	})
 

--- a/server/server.go
+++ b/server/server.go
@@ -562,6 +562,10 @@ func New(
 		return nil, err
 	}
 
+	// Set container storage metrics.
+	// These metrics only need to be stored once so we are computing them on startup.
+	metrics.Instance().MetricStorageContainerType(s.getInfo().StorageImage, s.getInfo().StorageRoot)
+
 	return s, nil
 }
 

--- a/test/imagefsinfo.bats
+++ b/test/imagefsinfo.bats
@@ -31,3 +31,15 @@ function teardown() {
 	image_output=$(jq -e '.status.imageFilesystems[0]' <<< "$output")
 	[ "$container_output" != "$image_output" ]
 }
+
+# This is the only test we have for integration tests
+# Integration tests overwrite locations for graphroot
+@test "testing metrics for container_storage with graphroot different from default" {
+
+	HOST="127.0.0.1"
+	PORT=$(free_port)
+
+	CONTAINER_ENABLE_METRICS=true CONTAINER_METRICS_PORT=$PORT start_crio
+	metric_type=$(curl -sf "http://${HOST}:${PORT}/metrics" | grep container_storage | awk '{print $2}')
+	[ "$metric_type" == 2 ]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
For enablement of KEP-4191, we realize that having a metric would be useful. This metric lives in the container runtime because container runtime configures the storage.

We add container_storage as a metric and label it 0 or 1 for the type of storage we have.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add the metric storage_configuration_type to distinguish between image_storage usage and default usage.
```
