### PR TITLE
Log how configuration gets loaded

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -57,7 +57,7 @@ func catchShutdown(ctx context.Context, cancel context.CancelFunc, gserver *grpc
 		for s := range sig {
 			log.WithFields(ctx, logrus.Fields{
 				"signal": s,
-			}).Debug("received signal")
+			}).Debug("Received signal")
 			switch s {
 			case unix.SIGUSR1:
 				writeCrioGoroutineStacks()
@@ -163,15 +163,15 @@ func main() {
 	})
 
 	app.Before = func(c *cli.Context) (err error) {
-		config, err := criocli.GetAndMergeConfigFromContext(c)
-		if err != nil {
-			return err
-		}
-
 		logrus.SetFormatter(&logrus.TextFormatter{
 			TimestampFormat: "2006-01-02 15:04:05.000000000Z07:00",
 			FullTimestamp:   true,
 		})
+
+		config, err := criocli.GetAndMergeConfigFromContext(c)
+		if err != nil {
+			return fmt.Errorf("get and merge config from context: %w", err)
+		}
 
 		level, err := logrus.ParseLevel(config.LogLevel)
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path"
@@ -1069,7 +1070,7 @@ var _ = t.Describe("Config", func() {
 			).To(Succeed())
 
 			// When
-			err := sut.UpdateFromFile(f)
+			err := sut.UpdateFromFile(context.Background(), f)
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())
@@ -1102,7 +1103,7 @@ var _ = t.Describe("Config", func() {
 				// When
 				defaultcfg := defaultConfig()
 				defaultcfg.StorageOptions = tc.opts
-				err := defaultcfg.UpdateFromFile(f)
+				err := defaultcfg.UpdateFromFile(context.Background(), f)
 
 				// Then
 				Expect(err).ToNot(HaveOccurred())
@@ -1132,7 +1133,7 @@ var _ = t.Describe("Config", func() {
 				// When
 				defaultcfg := defaultConfig()
 				defaultcfg.Root = tc.graphRoot
-				err := defaultcfg.UpdateFromFile(f)
+				err := defaultcfg.UpdateFromFile(context.Background(), f)
 
 				// Then
 				Expect(err).ToNot(HaveOccurred())
@@ -1162,7 +1163,7 @@ var _ = t.Describe("Config", func() {
 				// When
 				defaultcfg := defaultConfig()
 				defaultcfg.RunRoot = tc.runRoot
-				err := defaultcfg.UpdateFromFile(f)
+				err := defaultcfg.UpdateFromFile(context.Background(), f)
 
 				// Then
 				Expect(err).ToNot(HaveOccurred())
@@ -1192,7 +1193,7 @@ var _ = t.Describe("Config", func() {
 				// When
 				defaultcfg := defaultConfig()
 				defaultcfg.Storage = tc.storageDriver
-				err := defaultcfg.UpdateFromFile(f)
+				err := defaultcfg.UpdateFromFile(context.Background(), f)
 
 				// Then
 				Expect(err).ToNot(HaveOccurred())
@@ -1208,7 +1209,7 @@ var _ = t.Describe("Config", func() {
 			).To(Succeed())
 
 			// When
-			err := sut.UpdateFromFile(f)
+			err := sut.UpdateFromFile(context.Background(), f)
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())
@@ -1227,7 +1228,7 @@ var _ = t.Describe("Config", func() {
 			).To(Succeed())
 
 			// When
-			err := sut.UpdateFromFile(f)
+			err := sut.UpdateFromFile(context.Background(), f)
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())
@@ -1239,7 +1240,7 @@ var _ = t.Describe("Config", func() {
 		It("should fail when file does not exist", func() {
 			// Given
 			// When
-			err := sut.UpdateFromFile("/invalid/file")
+			err := sut.UpdateFromFile(context.Background(), "/invalid/file")
 
 			// Then
 			Expect(err).To(HaveOccurred())
@@ -1248,7 +1249,7 @@ var _ = t.Describe("Config", func() {
 		It("should fail when toml decode fails", func() {
 			// Given
 			// When
-			err := sut.UpdateFromFile("config.go")
+			err := sut.UpdateFromFile(context.Background(), "config.go")
 
 			// Then
 			Expect(err).To(HaveOccurred())
@@ -1320,7 +1321,7 @@ var _ = t.Describe("Config", func() {
 			)).To(Succeed())
 
 			// When
-			err := sut.UpdateFromPath(configDir)
+			err := sut.UpdateFromPath(context.Background(), configDir)
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())
@@ -1337,7 +1338,7 @@ var _ = t.Describe("Config", func() {
 			)).To(Succeed())
 
 			// When
-			err := sut.UpdateFromPath(configDir)
+			err := sut.UpdateFromPath(context.Background(), configDir)
 
 			// Then
 			Expect(err).To(HaveOccurred())
@@ -1346,7 +1347,7 @@ var _ = t.Describe("Config", func() {
 		It("should succeed with not existing path", func() {
 			// Given
 			// When
-			err := sut.UpdateFromPath("not-existing")
+			err := sut.UpdateFromPath(context.Background(), "not-existing")
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -18,8 +19,8 @@ import (
 
 // Reload reloads the configuration for the single crio.conf and the drop-in
 // configuration directory.
-func (c *Config) Reload() error {
-	logrus.Infof("Reloading configuration")
+func (c *Config) Reload(ctx context.Context) error {
+	log.Infof(ctx, "Reloading configuration")
 
 	// Reload the config
 	newConfig, err := DefaultConfig()
@@ -28,21 +29,19 @@ func (c *Config) Reload() error {
 	}
 
 	if _, err := os.Stat(c.singleConfigPath); !os.IsNotExist(err) {
-		logrus.Infof("Updating config from file %s", c.singleConfigPath)
-		if err := newConfig.UpdateFromFile(c.singleConfigPath); err != nil {
-			return err
+		if err := newConfig.UpdateFromFile(ctx, c.singleConfigPath); err != nil {
+			return fmt.Errorf("update config from single file: %w", err)
 		}
 	} else {
-		logrus.Infof("Skipping not-existing config file %q", c.singleConfigPath)
+		log.Infof(ctx, "Skipping not-existing config file %q", c.singleConfigPath)
 	}
 
 	if _, err := os.Stat(c.dropInConfigDir); !os.IsNotExist(err) {
-		logrus.Infof("Updating config from path %s", c.dropInConfigDir)
-		if err := newConfig.UpdateFromPath(c.dropInConfigDir); err != nil {
-			return err
+		if err := newConfig.UpdateFromPath(ctx, c.dropInConfigDir); err != nil {
+			return fmt.Errorf("update config from path: %w", err)
 		}
 	} else {
-		logrus.Infof("Skipping not-existing config path %q", c.dropInConfigDir)
+		log.Infof(ctx, "Skipping not-existing config path %q", c.dropInConfigDir)
 	}
 
 	// Reload all available options

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -19,7 +20,7 @@ var _ = t.Describe("Config", func() {
 		modifyDefaultConfig := func(old, new string) {
 			filePath := t.MustTempFile("config")
 			Expect(sut.ToFile(filePath)).To(Succeed())
-			Expect(sut.UpdateFromFile(filePath)).To(Succeed())
+			Expect(sut.UpdateFromFile(context.Background(), filePath)).To(Succeed())
 
 			read, err := os.ReadFile(filePath)
 			Expect(err).ToNot(HaveOccurred())
@@ -33,10 +34,10 @@ var _ = t.Describe("Config", func() {
 			// Given
 			filePath := t.MustTempFile("config")
 			Expect(sut.ToFile(filePath)).To(Succeed())
-			Expect(sut.UpdateFromFile(filePath)).To(Succeed())
+			Expect(sut.UpdateFromFile(context.Background(), filePath)).To(Succeed())
 
 			// When
-			err := sut.Reload()
+			err := sut.Reload(context.Background())
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())
@@ -50,7 +51,7 @@ var _ = t.Describe("Config", func() {
 			)
 
 			// When
-			err := sut.Reload()
+			err := sut.Reload(context.Background())
 
 			// Then
 			Expect(err).To(HaveOccurred())
@@ -64,7 +65,7 @@ var _ = t.Describe("Config", func() {
 			)
 
 			// When
-			err := sut.Reload()
+			err := sut.Reload(context.Background())
 
 			// Then
 			Expect(err).To(HaveOccurred())
@@ -78,7 +79,7 @@ var _ = t.Describe("Config", func() {
 			)
 
 			// When
-			err := sut.Reload()
+			err := sut.Reload(context.Background())
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())

--- a/server/server.go
+++ b/server/server.go
@@ -575,7 +575,7 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 		for {
 			// Block until the signal is received
 			<-ch
-			if err := s.config.Reload(); err != nil {
+			if err := s.config.Reload(ctx); err != nil {
 				logrus.Errorf("Unable to reload configuration: %v", err)
 				continue
 			}

--- a/test/reload_config.bats
+++ b/test/reload_config.bats
@@ -61,7 +61,7 @@ function expect_log_failure() {
 	reload_crio
 
 	# then
-	expect_log_failure "unable to decode configuration"
+	wait_for_log "unable to decode configuration"
 }
 
 @test "reload config should succeed with 'pause_image'" {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now log how the initial CRI-O configuration gets assembled, like:

```
INFO[…] Updating config from single file: /etc/crio/crio.conf
INFO[…] Updating config from drop-in file: /etc/crio/crio.conf
INFO[…] Skipping not-existing config file "/etc/crio/crio.conf"
INFO[…] Updating config from path: /etc/crio/crio.conf.d
INFO[…] Updating config from drop-in file: /etc/crio/crio.conf.d/00-default.conf
INFO[…] Updating config from drop-in file: /etc/crio/crio.conf.d/10-runtimes.conf
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Log exactly how configuration gets loaded into memory on `SIGHUP` and CRI-O start.
```
