### PR TITLE
Fix incorrect tab handling while converting Info to string and add unit tests

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -217,6 +217,7 @@ func (i *Info) String() string {
 		value := v.FieldByName(field.Name)
 
 		valueString := ""
+		isMultiLineValue := false
 		switch field.Type.Kind() {
 		case reflect.Bool:
 			valueString = strconv.FormatBool(value.Bool())
@@ -227,13 +228,19 @@ func (i *Info) String() string {
 				const sep = "\n  "
 				valueString = sep + strings.Join(s, sep)
 			}
+			isMultiLineValue = true
 
 		case reflect.String:
 			valueString = value.String()
 		}
 
 		if strings.TrimSpace(valueString) != "" {
-			fmt.Fprintf(w, "%s:\t%s", field.Name, valueString)
+			fmt.Fprintf(w, "%s:", field.Name)
+			if isMultiLineValue {
+				fmt.Fprint(w, valueString)
+			} else {
+				fmt.Fprintf(w, "\t%s", valueString)
+			}
 			if i+1 < t.NumField() {
 				fmt.Fprintf(w, "\n")
 			}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -12,7 +12,62 @@ var _ = t.Describe("Version", func() {
 	tempFileName := "tempVersionFile"
 	tempVersion := "1.1.1"
 	tempVersion2 := "1.13.1"
-
+	testInfo := Info{
+		Version:         "1.0.0",
+		GitCommit:       "abcdef123456",
+		GitCommitDate:   "2024-08-13T12:34:56Z",
+		GitTreeState:    "clean",
+		BuildDate:       "2024-08-13T12:34:56Z",
+		GoVersion:       "go1.20.5",
+		Compiler:        "gc",
+		Platform:        "linux/amd64",
+		Linkmode:        "external",
+		BuildTags:       []string{"tag1", "tag2"},
+		LDFlags:         "-X main.Version=1.0.0",
+		SeccompEnabled:  true,
+		AppArmorEnabled: false,
+		Dependencies:    []string{"dep1", "dep2"},
+	}
+	testInfoStr := `Version:        1.0.0
+GitCommit:      abcdef123456
+GitCommitDate:  2024-08-13T12:34:56Z
+GitTreeState:   clean
+BuildDate:      2024-08-13T12:34:56Z
+GoVersion:      go1.20.5
+Compiler:       gc
+Platform:       linux/amd64
+Linkmode:       external
+BuildTags:
+  tag1
+  tag2
+LDFlags:          -X main.Version=1.0.0
+SeccompEnabled:   true
+AppArmorEnabled:  false
+Dependencies:
+  dep1
+  dep2`
+	testJSONInfoStr := `{
+  "version": "1.0.0",
+  "gitCommit": "abcdef123456",
+  "gitCommitDate": "2024-08-13T12:34:56Z",
+  "gitTreeState": "clean",
+  "buildDate": "2024-08-13T12:34:56Z",
+  "goVersion": "go1.20.5",
+  "compiler": "gc",
+  "platform": "linux/amd64",
+  "linkmode": "external",
+  "buildTags": [
+    "tag1",
+    "tag2"
+  ],
+  "ldFlags": "-X main.Version=1.0.0",
+  "seccompEnabled": true,
+  "appArmorEnabled": false,
+  "dependencies": [
+    "dep1",
+    "dep2"
+  ]
+}`
 	t.Describe("test setting version", func() {
 		It("should succeed to parse version", func() {
 			_, err := parseVersionConstant("1.1.1", "")
@@ -168,6 +223,17 @@ var _ = t.Describe("Version", func() {
 			upgrade, err := shouldCrioWipe(tempFileName, newVersion)
 			Expect(upgrade).To(BeTrue())
 			Expect(err).To(HaveOccurred())
+		})
+	})
+	t.Describe("test generating string from info", func() {
+		It("should succeed returning a formatted string", func() {
+			infoString := testInfo.String()
+			Expect(infoString).To(Equal(testInfoStr))
+		})
+		It("should succeed returning a JSON document", func() {
+			jsonInfoString, err := testInfo.JSONString()
+			Expect(jsonInfoString).To(Equal(testJSONInfoStr))
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Fixes incorrect tab character handling in the internal/version/String
function when dealing with array values. Previously, a tab was added
after field names containing arrays, which was unnecessary as array
values should be on the next line.


#### Which issue(s) this PR fixes:
Additional tab character on String method. Which was causing additional space being created after key name for slice values.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
