### PR TITLE
server: fix error handling for container status retrieval

### DIFF
--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/truncindex"
@@ -30,7 +31,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *types.RemoveContainer
 		// The RemoveContainer RPC is idempotent, and must not return an error
 		// if the container has already been removed. Ref:
 		// https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto#L74-L75
-		if errors.Is(err, truncindex.ErrNotExist) {
+		if strings.Contains(err.Error(), truncindex.ErrNotExist.Error()) {
 			return &types.RemoveContainerResponse{}, nil
 		}
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/containers/storage/pkg/truncindex"
 	"golang.org/x/net/context"
@@ -25,7 +25,7 @@ func (s *Server) StopContainer(ctx context.Context, req *types.StopContainerRequ
 		// The StopContainer RPC is idempotent, and must not return an error if
 		// the container has already been stopped. Ref:
 		// https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto#L67-L68
-		if errors.Is(err, truncindex.ErrNotExist) {
+		if strings.Contains(err.Error(), truncindex.ErrNotExist.Error()) {
 			return &types.StopContainerResponse{}, nil
 		}
 		return nil, status.Errorf(codes.NotFound, "could not find container %q: %v", req.ContainerId, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
/kind cleanup

#### What this PR does / why we need it:
This change addresses issues where the Kubelet logs show numerous "ID does not exist" errors when attempting to retrieve container statuses.

I observed multiple instances of the following error in the Kubelet logs

```sh
Aug 18 08:43:01 ci-ln-c2xlq7b-72292-rcnfj-worker-a-86x2f kubenswrapper[2264]: I0818 08:43:01.586636    2264 pod_container_deletor.go:53] "DeleteContainer returned error" containerID={"Type":"cri-o","ID":"11f958631d8e575f086c6499b2ca431eb875f9f2f8e253f5882b06d69798d7e6"} err="failed to get container status \"11f958631d8e575f086c6499b2ca431eb875f9f2f8e253f5882b06d69798d7e6\": rpc error: code = NotFound desc = could not find container \"11f958631d8e575f086c6499b2ca431eb875f9f2f8e253f5882b06d69798d7e6\": container with ID starting with 11f958631d8e575f086c6499b2ca431eb875f9f2f8e253f5882b06d69798d7e6 not found: ID does not exist"
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
