### PR TITLE
Trigger `test` workflow after release branch fast forward

### DIFF
--- a/.github/workflows/release-branch-forward.yml
+++ b/.github/workflows/release-branch-forward.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   release-branch-forward:
     permissions:
+      actions: write
       contents: write
     if: github.ref == 'refs/heads/main' && github.repository == 'cri-o/cri-o'
     runs-on: ubuntu-latest

--- a/scripts/release-branch-forward/release_branch_forward.go
+++ b/scripts/release-branch-forward/release_branch_forward.go
@@ -122,5 +122,10 @@ func run() error {
 		return fmt.Errorf("unable to push to remote branch: %w", err)
 	}
 
+	logrus.Infof("Running GitHub `test` workflow")
+	if err := command.NewWithWorkDir(repo.Dir(), "gh", "workflow", "run", "test", "--ref", latestReleaseBranch).RunSilentSuccess(); err != nil {
+		return fmt.Errorf("unable to run GitHub workflow: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind ci


#### What this PR does / why we need it:
This updates https://storage.googleapis.com/cri-o/latest-release-1.31.txt and therefore also the packages for that release branch.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/kubernetes/kubernetes/issues/126734#issuecomment-2295914145
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
