### PR TITLE
Change default tracing endpoint to 127.0.0.1

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -426,7 +426,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--timezone, --tz**="": To set the timezone for a container in CRI-O. If an empty string is provided, CRI-O retains its default behavior. Use 'Local' to match the timezone of the host machine.
 
-**--tracing-endpoint**="": Address on which the gRPC tracing collector will listen. (default: "0.0.0.0:4317")
+**--tracing-endpoint**="": Address on which the gRPC tracing collector will listen. (default: "127.0.0.1:4317")
 
 **--tracing-sampling-rate-per-million**="": Number of samples to collect per million OpenTelemetry spans. Set to 1000000 to always sample. (default: 0)
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -533,7 +533,7 @@ The certificate key for the secure metrics server.
 **enable_tracing**=false
 Globally enable or disable OpenTelemetry trace data exporting.
 
-**tracing_endpoint**="0.0.0.0:4317"
+**tracing_endpoint**="127.0.0.1:4317"
 Address on which the gRPC trace collector will listen.
 
 **tracing_sampling_rate_per_million**=""

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -946,7 +946,7 @@ func DefaultConfig() (*Config, error) {
 			MetricsCollectors: collectors.All(),
 		},
 		TracingConfig: TracingConfig{
-			TracingEndpoint:               "0.0.0.0:4317",
+			TracingEndpoint:               "127.0.0.1:4317",
 			TracingSamplingRatePerMillion: 0,
 			EnableTracing:                 false,
 		},

--- a/tutorials/tracing.md
+++ b/tutorials/tracing.md
@@ -14,7 +14,7 @@ enable_tracing = true
 ```
 
 Traces in CRI-O get exported via the [OpenTelemetry Protocol][otlp] by using an
-[gRPC][grpc] endpoint. This endpoint defaults to `0.0.0.0:4317`, but can be
+[gRPC][grpc] endpoint. This endpoint defaults to `127.0.0.1:4317`, but can be
 configured by using the `--tracing-endpoint` flag or the corresponding TOML
 configuration:
 
@@ -23,7 +23,7 @@ configuration:
 
 ```toml
 [crio.tracing]
-tracing_endpoint = "0.0.0.0:4317"
+tracing_endpoint = "127.0.0.1:4317"
 ```
 
 The final configuration aspect of OpenTelemetry tracing in CRI-O is the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

It is prudent to move this endpoint to listen on 127.0.0.1 as a sensible default, which would improve the default security stance a little more, especially as there aren't any reasons for these services to listen on anything else than localhost.

We don't have to change conmon-rs because it already uses localhost.

https://github.com/containers/conmon-rs/blob/main/conmon-rs/server/src/config.rs#L119-L125

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes a part of #7448 

#### Special notes for your reviewer:

Users who are using this endpoint via not localhost(127.0.0.1) will need to set the tracingEndpoint option explicitly.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Move the tracing endpoint listener to use 127.0.0.1 as the new default.
```
