### PR TITLE
Block clone with namespace flag in seccomp default profile

### DIFF
--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -17,6 +17,7 @@ import (
 	json "github.com/json-iterator/go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/config/seccomp/seccompociartifact"
@@ -29,44 +30,81 @@ var (
 )
 
 // DefaultProfile is used to allow mutations from the DefaultProfile from the seccomp library.
-// Specifically, it is used to filter `unshare` from the default profile, as it is a risky syscall for unprivileged containers
-// to have access to.
+// Specifically, it is used to filter syscalls which can create namespaces from the default
+// profile, as it is risky for unprivileged containers to have access to create Linux
+// namespaces.
 func DefaultProfile() *seccomp.Seccomp {
 	defaultProfileOnce.Do(func() {
-		const (
-			unshareName              = "unshare"
-			unshareParentStructIndex = 1
-			unshareIndex             = 358
-		)
+		removeSyscalls := []struct {
+			Name              string
+			ParentStructIndex int
+			Index             int
+		}{
+			{"clone", 1, 23},
+			{"clone3", 1, 24},
+			{"unshare", 1, 363},
+		}
+
 		prof := seccomp.DefaultProfile()
 		// We know the default profile at compile time
 		// though a vendor change may update it.
 		// Panic on error and have CI catch errors on vendor bumps,
 		// to avoid combing through.
-		if prof.Syscalls[unshareParentStructIndex].Names[unshareIndex] != unshareName {
-			for i, name := range prof.Syscalls[unshareParentStructIndex].Names {
-				if name == unshareName {
-					_, file, _, _ := runtime.Caller(1)
-					logrus.Errorf("Change the `unshareIndex` variable in %s to %d", file, i)
-					break
+		for _, remove := range removeSyscalls {
+			if prof.Syscalls[remove.ParentStructIndex].Names[remove.Index] != remove.Name {
+				for i, name := range prof.Syscalls[remove.ParentStructIndex].Names {
+					if name == remove.Name {
+						_, file, _, _ := runtime.Caller(1)
+						logrus.Errorf("Change the Index for %q in %s to %d", remove.Name, file, i)
+						break
+					}
 				}
+				logrus.Fatalf(
+					"Default seccomp profile updated and syscall moved. Found unexpected syscall: %q",
+					prof.Syscalls[remove.ParentStructIndex].Names[remove.Index],
+				)
 			}
-			logrus.Fatalf(
-				"Default seccomp profile updated and unshare syscall moved. Found unexpected syscall: %q",
-				prof.Syscalls[unshareParentStructIndex].Names[unshareIndex],
-			)
+			removeStringFromSlice(prof.Syscalls[remove.ParentStructIndex].Names, remove.Index)
 		}
-		removeStringFromSlice(prof.Syscalls[unshareParentStructIndex].Names, unshareIndex)
 
 		prof.Syscalls = append(prof.Syscalls, &seccomp.Syscall{
 			Names: []string{
-				unshareName,
+				"clone",
+				"clone3",
+				"unshare",
 			},
 			Action: seccomp.ActAllow,
 			Includes: seccomp.Filter{
 				Caps: []string{"CAP_SYS_ADMIN"},
 			},
 		})
+
+		var flagsIndex uint = 0
+		if runtime.GOARCH == "s390" || runtime.GOARCH == "s390x" {
+			flagsIndex = 1
+		}
+
+		prof.Syscalls = append(prof.Syscalls, &seccomp.Syscall{
+			Names: []string{
+				"clone",
+			},
+			Action: seccomp.ActAllow,
+			Args: []*seccomp.Arg{
+				{
+					Index:    flagsIndex,
+					Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET | unix.CLONE_NEWCGROUP,
+					ValueTwo: 0,
+					Op:       seccomp.OpMaskedEqual,
+				},
+			},
+		},
+			&seccomp.Syscall{
+				Names: []string{
+					"clone",
+				},
+				Action: seccomp.ActErrno,
+				Errno:  "EPERM",
+			})
 		defaultProfile = prof
 	})
 

--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/containers/common/pkg/seccomp"
@@ -46,24 +47,8 @@ func DefaultProfile() *seccomp.Seccomp {
 		}
 
 		prof := seccomp.DefaultProfile()
-		// We know the default profile at compile time
-		// though a vendor change may update it.
-		// Panic on error and have CI catch errors on vendor bumps,
-		// to avoid combing through.
 		for _, remove := range removeSyscalls {
-			if prof.Syscalls[remove.ParentStructIndex].Names[remove.Index] != remove.Name {
-				for i, name := range prof.Syscalls[remove.ParentStructIndex].Names {
-					if name == remove.Name {
-						_, file, _, _ := runtime.Caller(1)
-						logrus.Errorf("Change the Index for %q in %s to %d", remove.Name, file, i)
-						break
-					}
-				}
-				logrus.Fatalf(
-					"Default seccomp profile updated and syscall moved. Found unexpected syscall: %q",
-					prof.Syscalls[remove.ParentStructIndex].Names[remove.Index],
-				)
-			}
+			validateSyscallIndex(prof, remove.Name, remove.ParentStructIndex, remove.Index)
 			removeStringFromSlice(prof.Syscalls[remove.ParentStructIndex].Names, remove.Index)
 		}
 
@@ -129,6 +114,29 @@ func DefaultProfile() *seccomp.Seccomp {
 	})
 
 	return defaultProfile
+}
+
+// validateSyscallIndex checks if the syscall's index matches the default profile's index.
+// We know the default profile at compile time, though a vendor change may update it.
+// Panic on error and have CI catch errors on vendor bumps to avoid combing through.
+func validateSyscallIndex(prof *seccomp.Seccomp, name string, parentStructIndex, index int) {
+	if prof.Syscalls[parentStructIndex].Names[index] == name {
+		return
+	}
+
+	var msg string
+	i := slices.Index(prof.Syscalls[parentStructIndex].Names, name)
+	if i == -1 {
+		msg = fmt.Sprintf("Change the ParentStructIndex for %q", name)
+	} else {
+		msg = fmt.Sprintf("Change the Index for %q to %d", name, i)
+	}
+	logrus.Fatalf(
+		`The default internal seccomp policy has been changed, and CRI-O can't adjust some risky syscalls.
+You are likely seeing this error because "github.com/containers/common/pkg/seccomp" was updated.
+Please contact the developers or change "DefaultProfile()" in "internal/config/seccomp/seccomp.go"
+to match the updated policy as per the following hint: %s`, msg,
+	)
 }
 
 func removeStringFromSlice(s []string, i int) []string {

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -77,7 +77,7 @@ function teardown() {
 	crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 8. test running with ctr runtime/default don't allow unshare
+# 8. test running with ctr runtime/default doesn't allow unshare
 @test "ctr seccomp profiles runtime/default block unshare" {
 	unset CONTAINER_SECCOMP_PROFILE
 	restart_crio
@@ -87,4 +87,23 @@ function teardown() {
 
 	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 	run ! crictl exec --sync "$ctr_id" /bin/sh -c "unshare"
+}
+
+# 9. test running with ctr runtime/default don't allow clone with namespace flags
+@test "ctr seccomp profiles runtime/default blocks clone creating namespaces" {
+	unset CONTAINER_SECCOMP_PROFILE
+	restart_crio
+
+	jq --arg TESTDATA "$TESTDATA" '.linux.security_context.seccomp.profile_type = 0 |
+          .mounts = [{
+            host_path: $TESTDATA,
+            container_path: "/testdata",
+          }]' \
+		"$TESTDATA/container_sleep.json" > "$TESTDIR/container.json"
+
+	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
+	crictl exec --sync "$ctr_id" /usr/bin/make -C / clone-ns
+	run crictl exec --sync "$ctr_id" /clone-ns
+	[[ "$output" =~ "Operation not permitted" ]]
 }

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -23,7 +23,6 @@ function teardown() {
 # SecurityProfile_Unconfined = 1
 # SecurityProfile_Localhost = 2
 
-# 1. test running with ctr unconfined
 # test that we can run with a syscall which would be otherwise blocked
 @test "ctr seccomp profiles unconfined" {
 	jq '	  .linux.security_context.seccomp.profile_type = 1' \
@@ -34,7 +33,6 @@ function teardown() {
 	crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 2. test running with ctr runtime/default
 # test that we cannot run with a syscall blocked by the default seccomp profile
 @test "ctr seccomp profiles runtime/default" {
 	jq '	  .linux.security_context.seccomp.profile_type = 0' \
@@ -45,7 +43,6 @@ function teardown() {
 	run ! crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 4. test running with ctr wrong profile name
 @test "ctr seccomp profiles wrong profile name" {
 	jq '	  .linux.security_context.seccomp.profile_type = 2 | .linux.security_context.seccomp.localhost_ref = "wontwork"' \
 		"$TESTDATA"/container_sleep.json > "$TESTDIR"/seccomp.json
@@ -55,7 +52,6 @@ function teardown() {
 	[[ "$output" =~ "wontwork" ]]
 }
 
-# 5. test running with ctr localhost/profile_name
 @test "ctr seccomp profiles localhost profile name" {
 	jq '	  .linux.security_context.seccomp.profile_type = 2 | .linux.security_context.seccomp.localhost_ref = "'"$TESTDIR"'/seccomp_profile1.json"' \
 		"$TESTDATA"/container_sleep.json > "$TESTDIR"/seccomp.json
@@ -65,7 +61,6 @@ function teardown() {
 	run ! crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 7. test running with ctr unconfined if seccomp_override_empty is false
 # test that we can run with a syscall which would be otherwise blocked
 @test "ctr seccomp overrides unconfined profile with runtime/default when overridden" {
 	export CONTAINER_SECCOMP_PROFILE="$TESTDIR"/seccomp_profile1.json
@@ -77,8 +72,7 @@ function teardown() {
 	crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 8. test running with ctr runtime/default doesn't allow unshare
-@test "ctr seccomp profiles runtime/default block unshare" {
+@test "ctr seccomp profiles runtime/default blocks unshare" {
 	unset CONTAINER_SECCOMP_PROFILE
 	restart_crio
 
@@ -89,7 +83,6 @@ function teardown() {
 	run ! crictl exec --sync "$ctr_id" /bin/sh -c "unshare"
 }
 
-# 9. test running with ctr runtime/default don't allow clone with namespace flags
 @test "ctr seccomp profiles runtime/default blocks clone creating namespaces" {
 	unset CONTAINER_SECCOMP_PROFILE
 	restart_crio
@@ -103,7 +96,43 @@ function teardown() {
 
 	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
-	crictl exec --sync "$ctr_id" /usr/bin/make -C / clone-ns
-	run crictl exec --sync "$ctr_id" /clone-ns
-	[[ "$output" =~ "Operation not permitted" ]]
+	crictl exec --sync "$ctr_id" /usr/bin/gcc /clone-ns.c -o /usr/bin/clone-ns
+	run crictl exec --sync "$ctr_id" /usr/bin/clone-ns with_flags
+	[[ "$output" =~ Operation\ not\ permitted.* ]]
+}
+
+@test "ctr seccomp profiles runtime/default allows clone not creating namespaces" {
+	unset CONTAINER_SECCOMP_PROFILE
+	restart_crio
+
+	jq --arg TESTDATA "$TESTDATA" '.linux.security_context.seccomp.profile_type = 0 |
+          .mounts = [{
+            host_path: $TESTDATA,
+            container_path: "/testdata",
+          }]' \
+		"$TESTDATA/container_sleep.json" > "$TESTDIR/container.json"
+
+	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
+	crictl exec --sync "$ctr_id" /usr/bin/gcc /clone-ns.c -o /usr/bin/clone-ns
+	crictl exec --sync "$ctr_id" /usr/bin/clone-ns without_flags
+}
+
+@test "ctr seccomp profiles runtime/default with SYS_ADMIN capability allows clone creating namespaces" {
+	unset CONTAINER_SECCOMP_PROFILE
+	export CONTAINER_ADD_INHERITABLE_CAPABILITIES=true
+	restart_crio
+
+	jq --arg TESTDATA "$TESTDATA" '.linux.security_context.seccomp.profile_type = 0 |
+	        .linux.security_context.capabilities.add_capabilities = ["SYS_ADMIN"] |
+          .mounts = [{
+            host_path: $TESTDATA,
+            container_path: "/testdata",
+          }]' \
+		"$TESTDATA/container_sleep.json" > "$TESTDIR/container.json"
+
+	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
+	crictl exec --sync "$ctr_id" /usr/bin/gcc /clone-ns.c -o /usr/bin/clone-ns
+	crictl exec --sync "$ctr_id" /usr/bin/clone-ns with_flags
 }

--- a/test/testdata/clone-ns.c
+++ b/test/testdata/clone-ns.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sched.h>
+
+int entry() {
+        system("id");
+        return 0;
+}
+
+int main() {
+        void *stack = malloc(1024*1024);
+        if (clone(entry, (stack+1024*1024), CLONE_NEWUSER|CLONE_NEWNET, 0) == -1) {
+          perror("clone");
+        }
+}

--- a/test/testdata/clone-ns.c
+++ b/test/testdata/clone-ns.c
@@ -2,16 +2,31 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sched.h>
 
 int entry() {
-        system("id");
-        return 0;
+    system("id");
+    return 0;
 }
 
-int main() {
-        void *stack = malloc(1024*1024);
-        if (clone(entry, (stack+1024*1024), CLONE_NEWUSER|CLONE_NEWNET, 0) == -1) {
-          perror("clone");
-        }
+int main(int argc, char *argv[]) {
+    void *stack = malloc(1024*1024);
+    int flag;
+
+    if (argc != 2) {
+        perror("argument required, 'with_flags' or 'without_flags'");
+    }
+
+    if (strcmp(argv[1], "with_flags") == 0) {
+        flag = CLONE_NEWUSER|CLONE_NEWNET;
+    } else if (strcmp(argv[1], "without_flags") == 0) {
+        flag = 0;
+    } else {
+        perror("invalid argument");
+    }
+
+    if (clone(entry, (stack+1024*1024), flag, 0) == -1) {
+        perror("clone");
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Taking over https://github.com/cri-o/cri-o/pull/8437

> The default seccomp policy used by CRI-O did not previously block clone(2) system call (syscall) with CLONE_NEWNS and other namespace creation flags. Changes here block those flags. In addition, also disable the clone3(2) syscall as it is not currently possible to filter a struct argument (struct clone_args) with seccomp; this matches the approach containerd took.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The default seccomp policy now blocks clone and clone3 system calls that can create a Linux namespace. This matches the default seccomp policy containerd uses.
```
