### PR TITLE
Add additional bind mount to image volumes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -188,7 +188,7 @@ jobs:
             defaultRuntime: runc
             runtimeType: pod
             critest: 0
-            userns: 1
+            userns: 0
             jobs: 2
             timeout: 120
 
@@ -198,7 +198,7 @@ jobs:
             defaultRuntime: runc
             runtimeType: pod
             critest: 0
-            userns: 1
+            userns: 0
             jobs: 2
             timeout: 120
 

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -61,6 +61,7 @@ kata_skip_files:
   - "metrics.bats"
   - "network_ping.bats"
   - "nri.bats"
+  - "oci_volumes.bats"
   - "policy.bats"
   - "restore.bats" # restore operations are failing with Kata
   - "seccomp_notifier.bats"

--- a/test/oci_volumes.bats
+++ b/test/oci_volumes.bats
@@ -12,11 +12,15 @@ function teardown() {
 	cleanup_test
 }
 
-@test "OCI image volume mount lifecycle" {
-	start_crio
+CONTAINER_PATH=/volume
+IMAGE=quay.io/crio/artifact:v1
 
-	CONTAINER_PATH=/volume
-	IMAGE=quay.io/crio/artifact:v1
+@test "OCI image volume mount lifecycle" {
+	if [[ "$TEST_USERNS" == "1" ]]; then
+		skip "test fails in a user namespace"
+	fi
+
+	start_crio
 
 	# Prepull the artifact
 	crictl pull "$IMAGE"
@@ -50,4 +54,60 @@ function teardown() {
 
 	# Image removal should work now
 	crictl rmi $IMAGE
+}
+
+@test "OCI image volume SELinux" {
+	if ! is_selinux_enforcing; then
+		skip "not enforcing"
+	fi
+
+	# RHEL/CentOS 7's container-selinux package replaces container_file_t with svirt_sandbox_file_t
+	# under the hood. This causes the annotation to not work correctly.
+	if is_rhel_7; then
+		skip "fails on RHEL 7 or earlier"
+	fi
+
+	start_crio
+
+	# Prepull the artifact
+	crictl pull "$IMAGE"
+
+	# Build a second sandbox using a different level
+	jq '.metadata.name = "sb-1" |
+		.metadata.uid = "new-uid" |
+		.linux.security_context.selinux_options.level = "s0:c200,c100"' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
+
+	# Set mounts in the same way as the kubelet would do
+	jq --arg IMAGE "$IMAGE" --arg CONTAINER_PATH "$CONTAINER_PATH" \
+		'.mounts = [{
+			host_path: "",
+			container_path: $CONTAINER_PATH,
+			image: { image: $IMAGE },
+			readonly: true
+		}]' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR/container.json"
+
+	CTR_ID1=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+	CTR_ID2=$(crictl run "$TESTDIR/container.json" "$TESTDIR/sandbox.json")
+
+	# Assert the right labels
+	crictl exec -s "$CTR_ID1" ls -Z "$CONTAINER_PATH" | grep -q "s0:c4,c5"
+	crictl exec -s "$CTR_ID2" ls -Z "$CONTAINER_PATH" | grep -q "s0:c100,c200"
+}
+
+@test "OCI image volume does not exist locally" {
+	start_crio
+
+	# Set mounts in the same way as the kubelet would do
+	jq --arg IMAGE "$IMAGE" --arg CONTAINER_PATH "$CONTAINER_PATH" \
+		'.mounts = [{
+			host_path: "",
+			container_path: $CONTAINER_PATH,
+			image: { image: $IMAGE },
+			readonly: true
+		}]' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR/container.json"
+
+	run ! crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json"
 }


### PR DESCRIPTION
#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
This should allow using different SELinux contexts if multiple pods use a single image.

Inherited from https://github.com/cri-o/cri-o/commit/61d4a591b2f57bae57e6718d84e3f41404a2f251#diff-1e0877112035840d3e2f073c693665f8daffa241a440e54a866ad7382b510ea2R1240
#### Which issue(s) this PR fixes:

Follow-up on https://github.com/cri-o/cri-o/pull/8317

Refers to:
- https://github.com/containers/storage/issues/1994
- https://github.com/kubernetes/kubernetes/issues/126956
- https://github.com/kubernetes/website/pull/47588

#### Special notes for your reviewer:
/hold

This needs to be well tested.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
