### PR TITLE
Fix CVE-2024-24790

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-go 1.22.0
+go 1.22.6
 
-toolchain go1.22.2
+toolchain go1.22.6
 
 module github.com/cri-o/cri-o
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.22.6
+go 1.22.0
 
 toolchain go1.22.6
 


### PR DESCRIPTION
Bump go version to fix CVE.

Please note I dont know how to work with GO.
I hope this bumps the version.

Referring to this problem:
https://github.com/cri-o/cri-o/issues/8547
