### PR TITLE
[release-1.25] OCPBUGS-41248: server/*: Fix a bug where the GID is not added to /etc/group when run_as_group is set

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -222,11 +222,19 @@ func setupContainerUser(ctx context.Context, specgen *generate.Generator, rootfs
 	}
 
 	genPasswd := true
+	genGroup := true
 	for _, mount := range specgen.Config.Mounts {
-		if mount.Destination == "/etc" ||
-			mount.Destination == "/etc/" ||
-			mount.Destination == "/etc/passwd" {
+		switch mount.Destination {
+		case "/etc", "/etc/":
 			genPasswd = false
+			genGroup = false
+		case "/etc/passwd":
+			genPasswd = false
+		case "/etc/group":
+			genGroup = false
+		}
+
+		if !genPasswd && !genGroup {
 			break
 		}
 	}
@@ -248,6 +256,28 @@ func setupContainerUser(ctx context.Context, specgen *generate.Generator, rootfs
 				Options:     []string{"rw", "bind", "nodev", "nosuid", "noexec"},
 			}
 			specgen.AddMount(mnt)
+		}
+	}
+	if genGroup {
+		if sc.RunAsGroup != nil {
+			gid = uint32(sc.RunAsGroup.Value)
+		}
+
+		// verify gid exists in containers /etc/group, else generate a group with the group entry
+		groupPath, err := utils.GenerateGroup(gid, rootfs, ctrRunDir)
+		if err != nil {
+			return err
+		}
+		if groupPath != "" {
+			if err := securityLabel(groupPath, mountLabel, false, false); err != nil {
+				return err
+			}
+			specgen.AddMount(rspec.Mount{
+				Type:        "bind",
+				Source:      groupPath,
+				Destination: "/etc/group",
+				Options:     []string{"rw", "bind", "nodev", "nosuid", "noexec"},
+			})
 		}
 	}
 

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -337,3 +337,32 @@ function teardown() {
 	output=$(crictl exec --sync "$ctr_id" ls -ld /etc)
 	[[ "$output" == *"test test"* ]]
 }
+
+@test "verify RunAsGroup in container" {
+	start_crio
+
+	jq '
+    .linux.security_context.run_as_user = { value: 1000 }
+    | .linux.security_context.run_as_group = { value: 1001 }
+  ' "$TESTDATA"/sandbox_config.json > "$TESTDIR/modified_sandbox_config.json"
+
+	jq '
+    .linux.security_context.run_as_user = { value: 1000 }
+    | .linux.security_context.run_as_group = { value: 1002 }
+  ' "$TESTDATA"/container_sleep.json > "$TESTDIR/modified_container_sleep_config"
+
+	# Create a new pod using the modified sandbox configuration
+	pod_id=$(crictl runp "$TESTDIR/modified_sandbox_config.json")
+
+	# Create a new container within the pod using the modified container configuration
+	ctr_id=$(crictl create "$pod_id" "$TESTDIR/modified_container_sleep_config" "$TESTDIR/modified_sandbox_config.json")
+	crictl start "$ctr_id"
+
+	# Verify that the gid is present in the /etc/group file
+	exec_output=$(crictl exec "$ctr_id" cat /etc/group)
+	echo "$exec_output" | grep "x:1002" || fail "RunAsGroup ID 1002 not found in /etc/group"
+
+	# Clean up the pod and container
+	crictl stop "$ctr_id"
+	crictl stopp "$pod_id"
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -246,56 +246,146 @@ func GetUserInfo(rootfs, userName string) (uid, gid uint32, additionalGids []uin
 // GeneratePasswd generates a container specific passwd file,
 // iff uid is not defined in the containers /etc/passwd
 func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir string) (string, error) {
-	// if UID exists inside of container rootfs /etc/passwd then
-	// don't generate passwd
 	if _, err := GetUser(rootfs, strconv.Itoa(int(uid))); err == nil {
 		return "", nil
 	}
-	passwdFile := filepath.Join(rundir, "passwd")
-	originPasswdFile, err := securejoin.SecureJoin(rootfs, "/etc/passwd")
-	if err != nil {
-		return "", fmt.Errorf("unable to follow symlinks to passwd file: %w", err)
+
+	passwdFilePath, stat, err := secureFilePath(rootfs, "/etc/passwd")
+	if err != nil || stat.Size == 0 {
+		return "", err
 	}
-	var st unix.Stat_t
-	err = unix.Stat(originPasswdFile, &st)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", fmt.Errorf("unable to stat passwd file %s: %w", originPasswdFile, err)
-	}
-	// Check if passwd file is world writable.
-	if st.Mode&0o022 != 0 {
+
+	if checkFilePermissions(&stat, uid, stat.Uid) {
 		return "", nil
 	}
 
-	if uid == st.Uid && st.Mode&0o200 != 0 {
-		return "", nil
+	origContent, err := readFileContent(passwdFilePath)
+	if err != nil || origContent == nil {
+		return "", err
 	}
 
-	orig, err := os.ReadFile(originPasswdFile)
-	if err != nil {
-		// If no /etc/passwd in container ignore and return
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", fmt.Errorf("read passwd file: %w", err)
-	}
 	if username == "" {
 		username = "default"
 	}
 	if homedir == "" {
 		homedir = "/tmp"
 	}
-	pwd := fmt.Sprintf("%s%s:x:%d:%d:%s user:%s:/sbin/nologin\n", orig, username, uid, gid, username, homedir)
-	if err := os.WriteFile(passwdFile, []byte(pwd), os.FileMode(st.Mode)&os.ModePerm); err != nil {
-		return "", fmt.Errorf("failed to create temporary passwd file: %w", err)
-	}
-	if err := os.Chown(passwdFile, int(st.Uid), int(st.Gid)); err != nil {
-		return "", fmt.Errorf("failed to chown temporary passwd file: %w", err)
+
+	pwdContent := fmt.Sprintf("%s%s:x:%d:%d:%s user:%s:/sbin/nologin\n", string(origContent), username, uid, gid, username, homedir)
+	passwdFile := filepath.Join(rundir, "passwd")
+
+	return createAndSecureFile(passwdFile, pwdContent, os.FileMode(stat.Mode), int(stat.Uid), int(stat.Gid))
+}
+
+// GenerateGroup generates a container specific group file,
+// iff gid is not defined in the containers /etc/group
+func GenerateGroup(gid uint32, rootfs, rundir string) (string, error) {
+	if _, err := GetGroup(rootfs, strconv.Itoa(int(gid))); err == nil {
+		return "", nil
 	}
 
-	return passwdFile, nil
+	groupFilePath, stat, err := secureFilePath(rootfs, "/etc/group")
+	if err != nil {
+		return "", err
+	}
+
+	if checkFilePermissions(&stat, gid, stat.Gid) {
+		return "", nil
+	}
+
+	origContent, err := readFileContent(groupFilePath)
+	if err != nil || origContent == nil {
+		return "", err
+	}
+
+	groupContent := fmt.Sprintf("%s%d:x:%d:\n", string(origContent), gid, gid)
+	groupFile := filepath.Join(rundir, "group")
+
+	return createAndSecureFile(groupFile, groupContent, os.FileMode(stat.Mode), int(stat.Uid), int(stat.Gid))
+}
+
+func secureFilePath(rootfs, file string) (string, unix.Stat_t, error) {
+	path, err := securejoin.SecureJoin(rootfs, file)
+	if err != nil {
+		return "", unix.Stat_t{}, fmt.Errorf("unable to follow symlinks to %s file: %w", file, err)
+	}
+
+	var st unix.Stat_t
+	err = unix.Stat(path, &st)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", unix.Stat_t{}, nil // File does not exist
+		}
+		return "", unix.Stat_t{}, fmt.Errorf("unable to stat file %s: %w", path, err)
+	}
+	return path, st, nil
+}
+
+// checkFilePermissions checks file permissions to decide whether to skip file modification.
+func checkFilePermissions(stat *unix.Stat_t, id, statID uint32) bool {
+	if stat.Mode&0o022 != 0 {
+		return true
+	}
+
+	// Check if the UID/GID matches and if the file is owner writable.
+	if id == statID && stat.Mode&0o200 != 0 {
+		return true
+	}
+
+	return false
+}
+
+func readFileContent(path string) ([]byte, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // File does not exist
+		}
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+	return content, nil
+}
+
+func createAndSecureFile(path, content string, mode os.FileMode, uid, gid int) (string, error) {
+	if err := os.WriteFile(path, []byte(content), mode&os.ModePerm); err != nil {
+		return "", fmt.Errorf("failed to create file: %w", err)
+	}
+	if err := os.Chown(path, uid, gid); err != nil {
+		return "", fmt.Errorf("failed to chown file: %w", err)
+	}
+	return path, nil
+}
+
+// GetGroup searches for a group in the container's /etc/group file using the provided
+// container mount path and group identifier (either name or ID). It returns a matching
+// user.Group structure if found. If no matching group is located, it returns
+// ErrNoGroupEntries.
+func GetGroup(containerMount, groupIDorName string) (*user.Group, error) {
+	var inputIsName bool
+	gid, err := strconv.Atoi(groupIDorName)
+	if err != nil {
+		inputIsName = true
+	}
+	groupDest, err := securejoin.SecureJoin(containerMount, "/etc/group")
+	if err != nil {
+		return nil, err
+	}
+	groups, err := user.ParseGroupFileFilter(groupDest, func(g user.Group) bool {
+		if inputIsName {
+			return g.Name == groupIDorName
+		}
+		return g.Gid == gid
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if len(groups) > 0 {
+		return &groups[0], nil
+	}
+	if !inputIsName {
+		return &user.Group{Gid: gid}, user.ErrNoGroupEntries
+	}
+	return nil, user.ErrNoGroupEntries
 }
 
 // GetUser takes a containermount path and user name or ID and returns

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containers/podman/v4/pkg/lookup"
 	"github.com/cri-o/cri-o/internal/dbusmgr"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/user"
@@ -249,7 +248,7 @@ func GetUserInfo(rootfs, userName string) (uid, gid uint32, additionalGids []uin
 func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir string) (string, error) {
 	// if UID exists inside of container rootfs /etc/passwd then
 	// don't generate passwd
-	if _, err := lookup.GetUser(rootfs, strconv.Itoa(int(uid))); err == nil {
+	if _, err := GetUser(rootfs, strconv.Itoa(int(uid))); err == nil {
 		return "", nil
 	}
 	passwdFile := filepath.Join(rundir, "passwd")
@@ -297,6 +296,39 @@ func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir st
 	}
 
 	return passwdFile, nil
+}
+
+// GetUser takes a containermount path and user name or ID and returns
+// a matching User structure from /etc/passwd.  If it cannot locate a user
+// with the provided information, an ErrNoPasswdEntries is returned.
+// When the provided user name was an ID, a User structure with Uid
+// set is returned along with ErrNoPasswdEntries.
+func GetUser(containerMount, userIDorName string) (*user.User, error) {
+	var inputIsName bool
+	uid, err := strconv.Atoi(userIDorName)
+	if err != nil {
+		inputIsName = true
+	}
+	passwdDest, err := securejoin.SecureJoin(containerMount, "/etc/passwd")
+	if err != nil {
+		return nil, err
+	}
+	users, err := user.ParsePasswdFileFilter(passwdDest, func(u user.User) bool {
+		if inputIsName {
+			return u.Name == userIDorName
+		}
+		return u.Uid == uid
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if len(users) > 0 {
+		return &users[0], nil
+	}
+	if !inputIsName {
+		return &user.User{Uid: uid}, user.ErrNoPasswdEntries
+	}
+	return nil, user.ErrNoPasswdEntries
 }
 
 // Int32Ptr is a utility function to assign to integer pointer variables

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -211,6 +211,11 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
 
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
+
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "root")
 			Expect(err).To(BeNil())
@@ -230,6 +235,11 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
 
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
+
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon")
 			Expect(err).To(BeNil())
@@ -248,6 +258,11 @@ var _ = t.Describe("Utils", func() {
 			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "25")
@@ -274,6 +289,16 @@ var _ = t.Describe("Utils", func() {
 			Expect(newuid).To(Equal(uid))
 			Expect(newgid).To(Equal(gid))
 			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should succeed with gid that doesn't exist in /etc/group", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+
+			// groupPath should not be empty because an updated /etc/group file is created.
+			groupPath, err := utils.GenerateGroup(6000, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).ToNot(BeEmpty())
 		})
 
 		It("should fail with username that desn't exist in /etc/passwd", func() {
@@ -313,6 +338,11 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
 
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
+
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "2:22")
 			Expect(err).To(BeNil())
@@ -331,6 +361,11 @@ var _ = t.Describe("Utils", func() {
 			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).To(BeEmpty())
+
+			// groupPath should not be empty because an updated /etc/group file is created.
+			groupPath, err := utils.GenerateGroup(6000, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).ToNot(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon:250")
@@ -351,6 +386,11 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).To(BeNil())
 			Expect(passwdFile).ToNot(BeEmpty())
 
+			// groupPath should not be empty because an updated /etc/group file is created.
+			groupPath, err := utils.GenerateGroup(6000, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).ToNot(BeEmpty())
+
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:250")
 			Expect(err).To(BeNil())
@@ -369,6 +409,11 @@ var _ = t.Describe("Utils", func() {
 			passwdFile, err := utils.GeneratePasswd("", uid, gid, "", dir, dir)
 			Expect(err).To(BeNil())
 			Expect(passwdFile).ToNot(BeEmpty())
+
+			// groupPath should be empty because an updated /etc/group file isn't created.
+			groupPath, err := utils.GenerateGroup(gid, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).To(BeEmpty())
 
 			// Double check that the uid, gid, and additional gids didn't change.
 			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:mail")


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/cri-o/cri-o/pull/8251

/assign kwilczynski

> [!NOTE] 
> This cherry-pickl brings the following Pull Request as a dependency:
> - https://github.com/cri-o/cri-o/pull/7893


```release-note
Fix a bug where the GID is not added to /etc/group when run_as_group is set
```