### PR TITLE
[release-1.30] Block clone with namespace flag in seccomp default profile

### DIFF
--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -83,26 +83,46 @@ func DefaultProfile() *seccomp.Seccomp {
 			flagsIndex = 1
 		}
 
-		prof.Syscalls = append(prof.Syscalls, &seccomp.Syscall{
-			Names: []string{
-				"clone",
-			},
-			Action: seccomp.ActAllow,
-			Args: []*seccomp.Arg{
-				{
-					Index:    flagsIndex,
-					Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET | unix.CLONE_NEWCGROUP,
-					ValueTwo: 0,
-					Op:       seccomp.OpMaskedEqual,
-				},
-			},
-		},
+		prof.Syscalls = append(prof.Syscalls,
 			&seccomp.Syscall{
-				Names: []string{
-					"clone",
+				Name:   "clone",
+				Action: seccomp.ActAllow,
+				Args: []*seccomp.Arg{
+					{
+						Index:    flagsIndex,
+						Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET | unix.CLONE_NEWCGROUP,
+						ValueTwo: 0,
+						Op:       seccomp.OpMaskedEqual,
+					},
 				},
+			},
+			&seccomp.Syscall{
+				Name:   "clone",
 				Action: seccomp.ActErrno,
 				Errno:  "EPERM",
+				Args: []*seccomp.Arg{
+					{Index: flagsIndex, Value: unix.CLONE_NEWNS, ValueTwo: unix.CLONE_NEWNS, Op: seccomp.OpMaskedEqual},
+					{Index: flagsIndex, Value: unix.CLONE_NEWUTS, ValueTwo: unix.CLONE_NEWUTS, Op: seccomp.OpMaskedEqual},
+					{Index: flagsIndex, Value: unix.CLONE_NEWIPC, ValueTwo: unix.CLONE_NEWIPC, Op: seccomp.OpMaskedEqual},
+					{Index: flagsIndex, Value: unix.CLONE_NEWUSER, ValueTwo: unix.CLONE_NEWUSER, Op: seccomp.OpMaskedEqual},
+					{Index: flagsIndex, Value: unix.CLONE_NEWPID, ValueTwo: unix.CLONE_NEWPID, Op: seccomp.OpMaskedEqual},
+					{Index: flagsIndex, Value: unix.CLONE_NEWNET, ValueTwo: unix.CLONE_NEWNET, Op: seccomp.OpMaskedEqual},
+					{Index: flagsIndex, Value: unix.CLONE_NEWCGROUP, ValueTwo: unix.CLONE_NEWCGROUP, Op: seccomp.OpMaskedEqual},
+				},
+				Excludes: seccomp.Filter{
+					Caps: []string{"CAP_SYS_ADMIN"},
+				},
+			},
+			// Because seccomp currently can't compare the data inside struct and the flags in clone3 are hidden in a struct,
+			// seccomp can't block clone3 based on its flags. To force it to use only clone, we make clone3 return ENOSYS,
+			// so that glibc can fall back to clone in the same way as https://github.com/moby/moby/pull/42681.
+			&seccomp.Syscall{
+				Name:   "clone3",
+				Action: seccomp.ActErrno,
+				Errno:  "ENOSYS",
+				Excludes: seccomp.Filter{
+					Caps: []string{"CAP_SYS_ADMIN"},
+				},
 			})
 		defaultProfile = prof
 	})

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -77,7 +77,7 @@ function teardown() {
 	crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 8. test running with ctr runtime/default don't allow unshare
+# 8. test running with ctr runtime/default doesn't allow unshare
 @test "ctr seccomp profiles runtime/default block unshare" {
 	unset CONTAINER_SECCOMP_PROFILE
 	restart_crio
@@ -87,4 +87,23 @@ function teardown() {
 
 	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 	run ! crictl exec --sync "$ctr_id" /bin/sh -c "unshare"
+}
+
+# 9. test running with ctr runtime/default don't allow clone with namespace flags
+@test "ctr seccomp profiles runtime/default blocks clone creating namespaces" {
+	unset CONTAINER_SECCOMP_PROFILE
+	restart_crio
+
+	jq --arg TESTDATA "$TESTDATA" '.linux.security_context.seccomp.profile_type = 0 |
+          .mounts = [{
+            host_path: $TESTDATA,
+            container_path: "/testdata",
+          }]' \
+		"$TESTDATA/container_sleep.json" > "$TESTDIR/container.json"
+
+	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
+	crictl exec --sync "$ctr_id" /usr/bin/make -C / clone-ns
+	run crictl exec --sync "$ctr_id" /clone-ns
+	[[ "$output" =~ "Operation not permitted" ]]
 }

--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -23,7 +23,6 @@ function teardown() {
 # SecurityProfile_Unconfined = 1
 # SecurityProfile_Localhost = 2
 
-# 1. test running with ctr unconfined
 # test that we can run with a syscall which would be otherwise blocked
 @test "ctr seccomp profiles unconfined" {
 	jq '	  .linux.security_context.seccomp.profile_type = 1' \
@@ -34,7 +33,6 @@ function teardown() {
 	crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 2. test running with ctr runtime/default
 # test that we cannot run with a syscall blocked by the default seccomp profile
 @test "ctr seccomp profiles runtime/default" {
 	jq '	  .linux.security_context.seccomp.profile_type = 0' \
@@ -45,7 +43,6 @@ function teardown() {
 	run ! crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 4. test running with ctr wrong profile name
 @test "ctr seccomp profiles wrong profile name" {
 	jq '	  .linux.security_context.seccomp.profile_type = 2 | .linux.security_context.seccomp.localhost_ref = "wontwork"' \
 		"$TESTDATA"/container_sleep.json > "$TESTDIR"/seccomp.json
@@ -55,7 +52,6 @@ function teardown() {
 	[[ "$output" =~ "wontwork" ]]
 }
 
-# 5. test running with ctr localhost/profile_name
 @test "ctr seccomp profiles localhost profile name" {
 	jq '	  .linux.security_context.seccomp.profile_type = 2 | .linux.security_context.seccomp.localhost_ref = "'"$TESTDIR"'/seccomp_profile1.json"' \
 		"$TESTDATA"/container_sleep.json > "$TESTDIR"/seccomp.json
@@ -65,7 +61,6 @@ function teardown() {
 	run ! crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 7. test running with ctr unconfined if seccomp_override_empty is false
 # test that we can run with a syscall which would be otherwise blocked
 @test "ctr seccomp overrides unconfined profile with runtime/default when overridden" {
 	export CONTAINER_SECCOMP_PROFILE="$TESTDIR"/seccomp_profile1.json
@@ -77,8 +72,7 @@ function teardown() {
 	crictl exec --sync "$ctr_id" chmod 777 .
 }
 
-# 8. test running with ctr runtime/default doesn't allow unshare
-@test "ctr seccomp profiles runtime/default block unshare" {
+@test "ctr seccomp profiles runtime/default blocks unshare" {
 	unset CONTAINER_SECCOMP_PROFILE
 	restart_crio
 
@@ -89,7 +83,6 @@ function teardown() {
 	run ! crictl exec --sync "$ctr_id" /bin/sh -c "unshare"
 }
 
-# 9. test running with ctr runtime/default don't allow clone with namespace flags
 @test "ctr seccomp profiles runtime/default blocks clone creating namespaces" {
 	unset CONTAINER_SECCOMP_PROFILE
 	restart_crio
@@ -103,7 +96,43 @@ function teardown() {
 
 	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
-	crictl exec --sync "$ctr_id" /usr/bin/make -C / clone-ns
-	run crictl exec --sync "$ctr_id" /clone-ns
-	[[ "$output" =~ "Operation not permitted" ]]
+	crictl exec --sync "$ctr_id" /usr/bin/gcc /clone-ns.c -o /usr/bin/clone-ns
+	run crictl exec --sync "$ctr_id" /usr/bin/clone-ns with_flags
+	[[ "$output" =~ Operation\ not\ permitted.* ]]
+}
+
+@test "ctr seccomp profiles runtime/default allows clone not creating namespaces" {
+	unset CONTAINER_SECCOMP_PROFILE
+	restart_crio
+
+	jq --arg TESTDATA "$TESTDATA" '.linux.security_context.seccomp.profile_type = 0 |
+          .mounts = [{
+            host_path: $TESTDATA,
+            container_path: "/testdata",
+          }]' \
+		"$TESTDATA/container_sleep.json" > "$TESTDIR/container.json"
+
+	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
+	crictl exec --sync "$ctr_id" /usr/bin/gcc /clone-ns.c -o /usr/bin/clone-ns
+	crictl exec --sync "$ctr_id" /usr/bin/clone-ns without_flags
+}
+
+@test "ctr seccomp profiles runtime/default with SYS_ADMIN capability allows clone creating namespaces" {
+	unset CONTAINER_SECCOMP_PROFILE
+	export CONTAINER_ADD_INHERITABLE_CAPABILITIES=true
+	restart_crio
+
+	jq --arg TESTDATA "$TESTDATA" '.linux.security_context.seccomp.profile_type = 0 |
+	        .linux.security_context.capabilities.add_capabilities = ["SYS_ADMIN"] |
+          .mounts = [{
+            host_path: $TESTDATA,
+            container_path: "/testdata",
+          }]' \
+		"$TESTDATA/container_sleep.json" > "$TESTDIR/container.json"
+
+	ctr_id=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
+	crictl exec --sync "$ctr_id" /usr/bin/cp /testdata/clone-ns.c /
+	crictl exec --sync "$ctr_id" /usr/bin/gcc /clone-ns.c -o /usr/bin/clone-ns
+	crictl exec --sync "$ctr_id" /usr/bin/clone-ns with_flags
 }

--- a/test/testdata/clone-ns.c
+++ b/test/testdata/clone-ns.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sched.h>
+
+int entry() {
+        system("id");
+        return 0;
+}
+
+int main() {
+        void *stack = malloc(1024*1024);
+        if (clone(entry, (stack+1024*1024), CLONE_NEWUSER|CLONE_NEWNET, 0) == -1) {
+          perror("clone");
+        }
+}

--- a/test/testdata/clone-ns.c
+++ b/test/testdata/clone-ns.c
@@ -2,16 +2,31 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sched.h>
 
 int entry() {
-        system("id");
-        return 0;
+    system("id");
+    return 0;
 }
 
-int main() {
-        void *stack = malloc(1024*1024);
-        if (clone(entry, (stack+1024*1024), CLONE_NEWUSER|CLONE_NEWNET, 0) == -1) {
-          perror("clone");
-        }
+int main(int argc, char *argv[]) {
+    void *stack = malloc(1024*1024);
+    int flag;
+
+    if (argc != 2) {
+        perror("argument required, 'with_flags' or 'without_flags'");
+    }
+
+    if (strcmp(argv[1], "with_flags") == 0) {
+        flag = CLONE_NEWUSER|CLONE_NEWNET;
+    } else if (strcmp(argv[1], "without_flags") == 0) {
+        flag = 0;
+    } else {
+        perror("invalid argument");
+    }
+
+    if (clone(entry, (stack+1024*1024), flag, 0) == -1) {
+        perror("clone");
+    }
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/cri-o/cri-o/pull/8514

/assign kwilczynski

```release-note
The default seccomp policy now blocks clone and clone3 system calls that can create a Linux namespace. This matches the default seccomp policy containerd uses.
```