### PR TITLE
Pin govulncheck to specific version to match Go version requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,7 +341,7 @@ jobs:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Run Govulncheck
+      - name: Run govulncheck
         run: make verify-govulncheck
-      - name: Run Gosec
+      - name: Run gosec
         run: make verify-gosec

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -109,6 +109,12 @@ dependencies:
       - path: Makefile
         match: GO_MOD_OUTDATED_VERSION
 
+  - name: govulncheck
+    version: v1.1.3
+    refPaths:
+      - path: hack/govulncheck.sh
+        match: GOVULNCHECK_VERSION
+
   - name: gosec
     version: 2.19.0
     refPaths:

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -1,34 +1,39 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
-# Install dependencies
+# The govulncheck version should match supported Go version.
+GOVULNCHECK_VERSION="v1.1.3"
+
+# Install build time dependencies.
 sudo apt-get update
 sudo apt-get install -y pkg-config libgpgme-dev libbtrfs-dev libseccomp-dev btrfs-progs
 
-# Set environment variables
+# Set environment variables.
+export GOGC=off
 export GO111MODULE=on
-export GOSUMDB=sum.golang.org
-export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
-GOPATH_BIN=$(go env GOPATH)/bin
-export PATH="$PATH:$GOPATH_BIN"
+export GOSUMDB="sum.golang.org"
+export PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig"
+GOPATH_BIN="$(go env GOPATH)"/bin
+export PATH="${PATH}:${GOPATH_BIN}"
 
-go install golang.org/x/vuln/cmd/govulncheck@latest
+# Install govulncheck.
+go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
-# Generate report
+# Generate the report.
 report=$(mktemp)
 trap 'rm "$report"' EXIT
 "$GOPATH_BIN"/govulncheck -json -tags=test,exclude_graphdriver_devicemapper ./... >"$report"
 
-# Parse vulnerabilities from report
+# Parse vulnerabilities from the report.
 modvulns=$(jq -Sr '.vulnerability.modules[]? | select(.path != "stdlib") | [.path, "affected package(s): \(.packages[].path)", "found version: \(.found_version)", "fixed version: \(.fixed_version)"]' <"$report")
 libvulns=$(jq -Sr '.vulnerability.modules[]? | select(.path == "stdlib") | [.path, "affected package(s): \(.packages[].path)", "found version: \(.found_version)", "fixed version: \(.fixed_version)"]' <"$report")
 
-# Print vulnerabilities
+# Print vulnerabilities information, if any.
 echo "$modvulns"
 echo "$libvulns"
 
-# Exit with non-zero status if there are any vulnerabilities in module dependencies
+# Exit with non-zero status if there were any vulnerabilities detected in module dependencies.
 if [[ -n "$modvulns" ]]; then
     exit 1
 fi


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Per the following document:

- Release History / [Release Policy](https://go.dev/doc/devel/release#policy)

> Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. We fix critical problems, including [critical security problems](https://go.dev/security), in supported releases as needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and so on).

There are no guarantees of backward compatibility for the `govulncheck` utility, as such, latest version might require much modern language features, either directly for itself or for one of its dependencies. An example of such an issue can be seen as follows: 

```console
Error: ../../../go/pkg/mod/golang.org/x/vuln@v1.1.3/internal/openvex/handler.go:12:2: package slices is not in GOROOT (/opt/hostedtoolcache/go/1.20.14/x64/src/slices)
note: imported by a module that requires go 1.21
```

_(the above is related to the following: [575859: internal/openvex: add statements to handler](https://go-review.googlesource.com/c/vuln/+/575859))_

The above occurs when attempting to install `govulncheck` using the `latest` tag (which in this particular case would install version `1.1.3`) on an older version of Go (1.20) where version 1.21 or newer is required.

Thus, pin down `govulncheck` releases to a specific version for a specific Go version to avoid issues when the utility is being installed on a incompatble version of Go.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```