### PR TITLE
Use nanosecond timestamp for evented pleg pod status

### DIFF
--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -41,7 +41,7 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *types.PodSandboxStat
 	var containerStatuses []*types.ContainerStatus
 	var timestamp int64
 	if s.config.EnablePodEvents {
-		timestamp = time.Now().Unix()
+		timestamp = time.Now().UnixNano()
 		containerStatuses, err = s.getContainerStatusesFromSandboxID(ctx, req.PodSandboxId)
 		if err != nil {
 			return nil, status.Errorf(codes.Unknown, "could not get container statuses of the sandbox Id %q: %v", req.PodSandboxId, err)


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Using the right value to address issues in the evented pleg implementation.
#### Which issue(s) this PR fixes:

Fixes https://github.com/cri-o/cri-o/issues/8580


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed evented pleg pod sandbox status timestamp to use a time in nanosecond resolution. 
```
