### PR TITLE
Add subcommand to check the node state and perform repairing of storage

### DIFF
--- a/internal/criocli/check.go
+++ b/internal/criocli/check.go
@@ -1,7 +1,9 @@
 package criocli
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/containers/storage"
 	"github.com/sirupsen/logrus"
@@ -44,6 +46,18 @@ var CheckCommand = &cli.Command{
 			Aliases: []string{"w"},
 			Usage:   "Wipe storage directory on repair failure",
 		},
+		&cli.BoolFlag{
+			Name:  "check-layer-state",
+			Usage: "Check if the state marker matches the state file contents. If they don't match, perform storage directory repair. --repair flag must be specified as well.",
+		},
+		&cli.StringFlag{
+			Name:  "state-marker",
+			Usage: "State marker",
+		},
+		&cli.StringFlag{
+			Name:  "state-file",
+			Usage: "Path to state file",
+		},
 	},
 }
 
@@ -82,6 +96,29 @@ func crioCheck(c *cli.Context) error {
 			return fmt.Errorf("unable to parse age duration: %w", err)
 		}
 		checkOptions.LayerUnreferencedMaximumAge = &age
+	}
+
+	if c.Bool("check-state-mraker") {
+		if !c.Bool("repair") {
+			return errors.New("--repair flag must be specified")
+		}
+		statemarker := c.String("state-marker")
+		statefile := c.String("state-file")
+		if statefile == "" {
+			return errors.New("state file must be specified in state marker checking mode")
+		}
+		curMarker, err := os.ReadFile(statefile)
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if string(curMarker) == statemarker {
+			// no need to repair
+			logrus.Infof("No change to the state marker. Returning without repairing.")
+			return nil
+		}
+		if err := os.WriteFile(statefile, []byte(statemarker), 0o600); err != nil {
+			return fmt.Errorf("failed to update state marker file: %w", err)
+		}
 	}
 
 	report, err := store.Check(checkOptions)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind feature


#### What this PR does / why we need it:

Discussed in: https://github.com/openshift/enhancements/pull/1600#pullrequestreview-2268904850

This PR adds a subcommand discussed in [this thread](https://github.com/openshift/enhancements/pull/1600#pullrequestreview-2268904850). cc @mtrmac @haircommander @harche

```
crio check-layer-state <layer_integrity_state_marker> <layer_integrity_state_file>
```

This intends to run before crio starts as a CRI runtime.

This subcommand is used for detecting incompatible changes in storage configuration and performing repairing of the storage.

Concretely:

- When it starts for the first time on the node, it creates a file (call it "state file") at the location specified by layer_integrity_state_file with the contents of layer_integrity_state_marker (call it "state marker").
- Everytime this command starts on the node, it checks that the specified layer_integrity_state_marker exactly matches the contents of the state file at layer_integrity_state_file. If it doesn't match, it starts repairing the storage.

Caller (e.g. MCO) populate the state marker with configurations whose changes trigger repairing of the storage, e.g. `"version=1;store-format=1;ALS="estargz:/var/"`.


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added a subcommand to check the node state and perform repairing of the storage
```
