### PR TITLE
Switch to `RFC3339Nano` log format

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -165,7 +165,7 @@ func main() {
 
 	app.Before = func(c *cli.Context) (err error) {
 		logrus.SetFormatter(&logrus.TextFormatter{
-			TimestampFormat: "2006-01-02 15:04:05.000000000Z07:00",
+			TimestampFormat: time.RFC3339Nano,
 			FullTimestamp:   true,
 		})
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This sanitizes the logs timestamps to use a standard format rather than our own definition.

#### Which issue(s) this PR fixes:

Follow-up on https://github.com/cri-o/cri-o/pull/8582#issuecomment-2340371941
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Switched to use `RFC3339Nano` timestamp log format (`2006-01-02T15:04:05.999999999Z07:00`)
```
