### PR TITLE
Require go 1.23 for build

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -16,6 +16,8 @@ dependencies:
         match: GO_VERSION
       - path: nix/derivation.nix
         match: buildGo123Module
+      - path: go.mod
+        match: go
 
   - name: golangci-lint
     version: v1.62.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,4 @@
-go 1.22.0
-
-toolchain go1.22.2
+go 1.23
 
 module github.com/cri-o/cri-o
 

--- a/hack/build-rpms.sh
+++ b/hack/build-rpms.sh
@@ -32,12 +32,17 @@ cp -r "${ci_data}/." "${rpm_tmp_dir}/SOURCES"
 # resolves to both IPv4 and IPv6 addresses. This result in occasional
 # "Network is unreachable" errors. Workaround: disable IPv6 for yum.
 if [ -w /etc/yum.conf ] && ! grep -q '^ip_resolve' /etc/yum.conf; then
-	os::log::info "Disabling IPv6 for yum ..."
-	echo 'ip_resolve=4' >> /etc/yum.conf
+    os::log::info "Disabling IPv6 for yum ..."
+    echo 'ip_resolve=4' >>/etc/yum.conf
 fi
 # Just in case builddep isn't an installed plugin
 dnf -y install 'dnf-command(builddep)'
 dnf builddep -y "${OS_RPM_SPECFILE}" || true
+
+# Ensure to use latest golang
+GO_VERSION=$(curl -sSfL "https://go.dev/VERSION?m=text" | head -n1)
+curl -sSfL -o- "https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz" | tar xfz - -C /usr/local
+export PATH=/usr/local/go/bin:$PATH
 
 rpmbuild -ba "${OS_RPM_SPECFILE}" \
     --define "_sourcedir ${rpm_tmp_dir}/SOURCES" \


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Using the latest golang version for building CRI-O `main`.
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Require go 1.23 to build CRI-O.
```
