### PR TITLE
Use go 1.23 for nix (static) builds

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -14,6 +14,8 @@ dependencies:
         match: GO_VERSION
       - path: .github/workflows/tag-reconciler.yml
         match: GO_VERSION
+      - path: nix/derivation.nix
+        match: buildGo123Module
 
   - name: golangci-lint
     version: v1.60.3

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,7 +1,7 @@
 { stdenv
 , pkgs
 }:
-with pkgs; buildGo122Module {
+with pkgs; buildGo123Module /* use go 1.23 */ {
   name = "cri-o";
   # Use Pure to avoid exuding the .git directory
   src = nix-gitignore.gitignoreSourcePure [ ../.gitignore ] ./..;


### PR DESCRIPTION

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:
Build static binaries using the latest go.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use go 1.23 for nix (static) builds.
```
