### PR TITLE
Refactoring factory/container to remove references of lib/sandbox

### DIFF
--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/config/capabilities"
 	"github.com/cri-o/cri-o/internal/hostport"
-	"github.com/cri-o/cri-o/internal/lib"
+	"github.com/cri-o/cri-o/internal/lib/constants"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
@@ -141,7 +141,7 @@ var _ = t.Describe("Container", func() {
 			Expect(sut.Spec().Config.Annotations[annotations.Stdin]).To(Equal(strconv.FormatBool(sut.Config().Stdin)))
 			Expect(sut.Spec().Config.Annotations[annotations.StdinOnce]).To(Equal(strconv.FormatBool(sut.Config().StdinOnce)))
 			Expect(sut.Spec().Config.Annotations[annotations.ResolvPath]).To(Equal(sb.ResolvPath()))
-			Expect(sut.Spec().Config.Annotations[annotations.ContainerManager]).To(Equal(lib.ContainerManagerCRIO))
+			Expect(sut.Spec().Config.Annotations[annotations.ContainerManager]).To(Equal(constants.ContainerManagerCRIO))
 			Expect(sut.Spec().Config.Annotations[annotations.MountPoint]).To(Equal(mountPoint))
 			Expect(sut.Spec().Config.Annotations[annotations.SeccompProfilePath]).To(Equal("foo"))
 			Expect(sut.Spec().Config.Annotations[annotations.Created]).ToNot(BeNil())

--- a/internal/factory/container/namespaces.go
+++ b/internal/factory/container/namespaces.go
@@ -9,12 +9,12 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
-	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/lib/namespace"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/pkg/config"
 )
 
-func (c *container) SpecAddNamespaces(sb *sandbox.Sandbox, targetCtr *oci.Container, serverConfig *config.Config) error {
+func (c *container) SpecAddNamespaces(sb SandboxIFace, targetCtr *oci.Container, serverConfig *config.Config) error {
 	// Join the namespace paths for the pod sandbox container.
 	if err := ConfigureGeneratorGivenNamespacePaths(sb.NamespacePaths(), &c.spec); err != nil {
 		return fmt.Errorf("failed to configure namespaces in container create: %w", err)
@@ -68,7 +68,7 @@ func (c *container) SpecAddNamespaces(sb *sandbox.Sandbox, targetCtr *oci.Contai
 
 // ConfigureGeneratorGivenNamespacePaths takes a map of nsType -> nsPath. It configures the generator
 // to add or replace the defaults to these paths.
-func ConfigureGeneratorGivenNamespacePaths(managedNamespaces []*sandbox.ManagedNamespace, g *generate.Generator) error {
+func ConfigureGeneratorGivenNamespacePaths(managedNamespaces []*namespace.ManagedNamespace, g *generate.Generator) error {
 	typeToSpec := map[nsmgr.NSType]rspec.LinuxNamespaceType{
 		nsmgr.IPCNS:  rspec.IPCNamespace,
 		nsmgr.NETNS:  rspec.NetworkNamespace,

--- a/internal/factory/container/sandbox.go
+++ b/internal/factory/container/sandbox.go
@@ -1,0 +1,38 @@
+package container
+
+import (
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/lib/namespace"
+)
+
+// SandboxIFace represents an interface for interacting with sandbox related information.
+// This is to ensure we don't import the lib sandbox and just use its methods.
+type SandboxIFace interface {
+	// LogDir returns the location of the logging directory for the sandbox.
+	LogDir() string
+
+	// Annotations returns a list of annotations for the sandbox.
+	Annotations() map[string]string
+
+	// ID returns the id of the sandbox.
+	ID() string
+
+	// Name returns the name of the sandbox.
+	Name() string
+
+	// ResolvPath returns the resolv path for the sandbox.
+	ResolvPath() string
+
+	// IPs returns the ip of the sandbox.
+	IPs() []string
+
+	// NamespacePaths returns all the paths of the namespaces of the sandbox.
+	NamespacePaths() []*namespace.ManagedNamespace
+
+	// PidNsPath returns the path to the pid namespace of the sandbox.
+	PidNsPath() string
+
+	// NamespaceOptions returns the namespace options for the sandbox.
+	NamespaceOptions() *types.NamespaceOption
+}

--- a/internal/lib/constants/constants.go
+++ b/internal/lib/constants/constants.go
@@ -1,0 +1,6 @@
+package constants
+
+// ContainerManagerCRIO specifies an annotation value which indicates that the
+// container has been created by CRI-O. Usually used together with the key
+// `io.container.manager`.
+const ContainerManagerCRIO = "cri-o"

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -21,6 +21,7 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/hostport"
+	"github.com/cri-o/cri-o/internal/lib/constants"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	statsserver "github.com/cri-o/cri-o/internal/lib/stats"
 	"github.com/cri-o/cri-o/internal/log"
@@ -31,11 +32,6 @@ import (
 	"github.com/cri-o/cri-o/pkg/annotations"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 )
-
-// ContainerManagerCRIO specifies an annotation value which indicates that the
-// container has been created by CRI-O. Usually used together with the key
-// `io.container.manager`.
-const ContainerManagerCRIO = "cri-o"
 
 // ContainerServer implements the ImageServer.
 type ContainerServer struct {
@@ -389,7 +385,7 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 	}
 
 	// Do not interact with containers of others
-	if manager, ok := m.Annotations[annotations.ContainerManager]; ok && manager != ContainerManagerCRIO {
+	if manager, ok := m.Annotations[annotations.ContainerManager]; ok && manager != constants.ContainerManagerCRIO {
 		return ErrIsNonCrioContainer
 	}
 

--- a/internal/lib/namespace/namespace.go
+++ b/internal/lib/namespace/namespace.go
@@ -1,0 +1,30 @@
+package namespace
+
+import "github.com/cri-o/cri-o/internal/config/nsmgr"
+
+// ManagedNamespace is a structure that holds all the necessary information a caller would
+// need for a sandbox managed namespace
+// Where nsmgr.Namespace does hold similar information, ManagedNamespace exists to allow this library
+// to not return data not necessarily in a Namespace (for instance, when a namespace is not managed
+// by CRI-O, but instead is based off of the infra pid).
+type ManagedNamespace struct {
+	nsPath string
+	nsType nsmgr.NSType
+}
+
+// Type returns the namespace type.
+func (m *ManagedNamespace) Type() nsmgr.NSType {
+	return m.nsType
+}
+
+// Type returns the namespace path.
+func (m *ManagedNamespace) Path() string {
+	return m.nsPath
+}
+
+func NewManagedNamespace(nsPath string, nsType nsmgr.NSType) *ManagedNamespace {
+	return &ManagedNamespace{
+		nsPath: nsPath,
+		nsType: nsType,
+	}
+}

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	sboxfactory "github.com/cri-o/cri-o/internal/factory/sandbox"
-	"github.com/cri-o/cri-o/internal/lib"
+	"github.com/cri-o/cri-o/internal/lib/constants"
 	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
@@ -280,7 +280,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	g.AddAnnotation(annotations.NamespaceOptions, string(nsOptsJSON))
 	g.AddAnnotation(annotations.KubeName, kubeName)
 	g.AddAnnotation(annotations.HostNetwork, fmt.Sprintf("%v", hostNetwork))
-	g.AddAnnotation(annotations.ContainerManager, lib.ContainerManagerCRIO)
+	g.AddAnnotation(annotations.ContainerManager, constants.ContainerManagerCRIO)
 	if podContainer.Config.Config.StopSignal != "" {
 		// this key is defined in image-spec conversion document at https://github.com/opencontainers/image-spec/pull/492/files#diff-8aafbe2c3690162540381b8cdb157112R57
 		g.AddAnnotation("org.opencontainers.image.stopSignal", podContainer.Config.Config.StopSignal)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	ctrfactory "github.com/cri-o/cri-o/internal/factory/container"
 	sboxfactory "github.com/cri-o/cri-o/internal/factory/sandbox"
-	"github.com/cri-o/cri-o/internal/lib"
+	"github.com/cri-o/cri-o/internal/lib/constants"
 	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/linklogs"
 	"github.com/cri-o/cri-o/internal/log"
@@ -658,7 +658,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	g.AddAnnotation(annotations.NamespaceOptions, string(nsOptsJSON))
 	g.AddAnnotation(annotations.KubeName, kubeName)
 	g.AddAnnotation(annotations.HostNetwork, strconv.FormatBool(hostNetwork))
-	g.AddAnnotation(annotations.ContainerManager, lib.ContainerManagerCRIO)
+	g.AddAnnotation(annotations.ContainerManager, constants.ContainerManagerCRIO)
 	if podContainer.Config.Config.StopSignal != "" {
 		// this key is defined in image-spec conversion document at https://github.com/opencontainers/image-spec/pull/492/files#diff-8aafbe2c3690162540381b8cdb157112R57
 		g.AddAnnotation("org.opencontainers.image.stopSignal", podContainer.Config.Config.StopSignal)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup


#### What this PR does / why we need it:

Instead of passing whole sandbox object we will pass parameters that are needed This will remove interdependencies for future refactor. Also ManagedNamespace extracted to its own package inside lib so that it can be referenced for both sandbox and container.

#### Which issue(s) this PR fixes:

Part of #8289 


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

```release-note
Restructuring of packages.
```