### PR TITLE
[release-1.30] Pin govulncheck to specific version to match Go version requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -367,7 +367,7 @@ jobs:
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Run Govulncheck
+      - name: Run govulncheck
         run: make verify-govulncheck
-      - name: Run Gosec
+      - name: Run gosec
         run: make verify-gosec

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -107,6 +107,12 @@ dependencies:
       - path: Makefile
         match: GO_MOD_OUTDATED_VERSION
 
+  - name: govulncheck
+    version: v1.1.3
+    refPaths:
+      - path: hack/govulncheck.sh
+        match: GOVULNCHECK_VERSION
+
   - name: gosec
     version: 2.18.2
     refPaths:

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -1,35 +1,39 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
-# Install dependencies
+# The govulncheck version should match supported Go version.
+GOVULNCHECK_VERSION="v1.1.3"
+
+# Install build time dependencies.
 sudo apt-get update
 sudo apt-get install -y pkg-config libgpgme-dev libbtrfs-dev libseccomp-dev libdevmapper-dev btrfs-progs
 
-# Set environment variables
+# Set environment variables.
+export GOGC=off
 export GO111MODULE=on
-export GOSUMDB=sum.golang.org
-export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
-GOPATH_BIN=$(go env GOPATH)/bin
-export PATH="$PATH:$GOPATH_BIN"
+export GOSUMDB="sum.golang.org"
+export PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig"
+GOPATH_BIN="$(go env GOPATH)"/bin
+export PATH="${PATH}:${GOPATH_BIN}"
 
-# Install gosec
-go install golang.org/x/vuln/cmd/govulncheck@latest
+# Install govulncheck.
+go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
-# Generate report
+# Generate the report.
 report=$(mktemp)
 trap 'rm "$report"' EXIT
 "$GOPATH_BIN"/govulncheck -json -tags=test ./... >"$report"
 
-# Parse vulnerabilities from report
+# Parse vulnerabilities from the report.
 modvulns=$(jq -Sr '.vulnerability.modules[]? | select(.path != "stdlib") | [.path, "affected package(s): \(.packages[].path)", "found version: \(.found_version)", "fixed version: \(.fixed_version)"]' <"$report")
 libvulns=$(jq -Sr '.vulnerability.modules[]? | select(.path == "stdlib") | [.path, "affected package(s): \(.packages[].path)", "found version: \(.found_version)", "fixed version: \(.fixed_version)"]' <"$report")
 
-# Print vulnerabilities
+# Print vulnerabilities information, if any.
 echo "$modvulns"
 echo "$libvulns"
 
-# Exit with non-zero status if there are any vulnerabilities in module dependencies
+# Exit with non-zero status if there were any vulnerabilities detected in module dependencies.
 if [[ -n "$modvulns" ]]; then
     exit 1
 fi


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/cri-o/cri-o/pull/8572

/assign kwilczynski

```release-note
None
```