### PR TITLE
config: pass down PullOptions from the storage configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -159,6 +159,9 @@ type RootConfig struct {
 	// StorageOption is a list of storage driver specific options.
 	StorageOptions []string `toml:"storage_option"`
 
+	// PullOptions is a map of pull options that are passed to the storage driver.
+	pullOptions map[string]string
+
 	// LogDir is the default log directory where all logs will go unless kubelet
 	// tells us to put them somewhere else.
 	LogDir string `toml:"log_dir"`
@@ -192,6 +195,7 @@ func (c *RootConfig) GetStore() (storage.Store, error) {
 		ImageStore:         c.ImageStore,
 		GraphDriverName:    c.Storage,
 		GraphDriverOptions: c.StorageOptions,
+		PullOptions:        c.pullOptions,
 	})
 }
 
@@ -879,6 +883,7 @@ func DefaultConfig() (*Config, error) {
 			ImageStore:        storeOpts.ImageStore,
 			Storage:           storeOpts.GraphDriverName,
 			StorageOptions:    storeOpts.GraphDriverOptions,
+			pullOptions:       storeOpts.PullOptions,
 			LogDir:            "/var/log/crio/pods",
 			VersionFile:       CrioVersionPathTmp,
 			CleanShutdownFile: CrioCleanShutdownFile,
@@ -1075,6 +1080,7 @@ func (c *RootConfig) Validate(onExecution bool) error {
 		c.Root = store.GraphRoot()
 		c.Storage = store.GraphDriverName()
 		c.StorageOptions = store.GraphOptions()
+		c.pullOptions = store.PullOptions()
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It is necessary to use composefs from CRI-O.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Maintain the pull options as-is as they are read from the `storage.conf` file, so we don't lose options like `convert_images` that are necessary to convert existing images to a format usable with composefs.

> [!NOTE]  
> Do not expose this configuration via the CRI-O drop-in configuration, as the `PullOptions` API is still experimental in `containers/storage` package.

#### Does this PR introduce a user-facing change?

```release-note
None
```
