### PR TITLE
[release-1.28] OCPBUGS-42651: Cherry-pick changes from containers/common/pull#2185

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
 	github.com/containers/buildah v1.31.2
-	github.com/containers/common v0.55.5-0.20240105071436-8fedf2e32c8a
+	github.com/containers/common v0.55.5-0.20241001151746-9148450afb7b
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.5.1
 	github.com/containers/image/v5 v5.27.1-0.20240528120211-942a2226c1cd

--- a/go.sum
+++ b/go.sum
@@ -899,8 +899,8 @@ github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
 github.com/containers/buildah v1.31.2 h1:Pfbuzq5dtbLYtj95zDu1rLbVo9bnboknv18ZmlfXVA4=
 github.com/containers/buildah v1.31.2/go.mod h1:EnrujxgRtUi0+2DrxXAzyQ/GybLliqT0+06PMLSTlvw=
-github.com/containers/common v0.55.5-0.20240105071436-8fedf2e32c8a h1:4ib0EL6D+cP+OrSH0SvUVtxm0WSqZ+krILDfE3Z+Ubw=
-github.com/containers/common v0.55.5-0.20240105071436-8fedf2e32c8a/go.mod h1:5mVCpfMBWyO+zaD7Fw+DBHFa42YFKROwle1qpEKcX3U=
+github.com/containers/common v0.55.5-0.20241001151746-9148450afb7b h1:6TBgJNVg+qpjYZOA8+VTxgaGDEUw0Bvsh3LhBBmoENw=
+github.com/containers/common v0.55.5-0.20241001151746-9148450afb7b/go.mod h1:5mVCpfMBWyO+zaD7Fw+DBHFa42YFKROwle1qpEKcX3U=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.5.1 h1:Qquw9pE0KOeJkb3MhuUIFTvUzI08m9f4SpkuSY0kVSs=

--- a/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go
+++ b/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/common/pkg/umask"
 	"github.com/containers/storage/pkg/idtools"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
@@ -346,7 +347,10 @@ func addFIPSModeSubscription(mounts *[]rspec.Mount, containerRunDir, mountPoint,
 
 	srcBackendDir := "/usr/share/crypto-policies/back-ends/FIPS"
 	destDir := "/etc/crypto-policies/back-ends"
-	srcOnHost := filepath.Join(mountPoint, srcBackendDir)
+	srcOnHost, err := securejoin.SecureJoin(mountPoint, srcBackendDir)
+	if err != nil {
+		return fmt.Errorf("resolve %s in the container: %w", srcBackendDir, err)
+	}
 	if _, err := os.Stat(srcOnHost); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.55.5-0.20240105071436-8fedf2e32c8a
+# github.com/containers/common v0.55.5-0.20241001151746-9148450afb7b
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from https://github.com/containers/common/pull/2185 as these changes contain a fix that needs to be backported to CRI-O release 1.28, part of OpenShift 4.15 release.

Related:

- https://github.com/containers/common/pull/2185

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```