### PR TITLE
Mark `release-1.28` as EOL

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,7 +24,7 @@ import (
 const Version = "1.32.0"
 
 // ReleaseMinorVersions are the currently supported minor versions.
-var ReleaseMinorVersions = []string{"1.31", "1.30", "1.29", "1.28"}
+var ReleaseMinorVersions = []string{"1.31", "1.30", "1.29"}
 
 // Variables injected during build-time.
 var (


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Following the same end of life cycle like Kubernetes: https://kubernetes.io/releases/#release-v1-28

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
