### PR TITLE
Re-enable exit code matching in restore test

### DIFF
--- a/test/restore.bats
+++ b/test/restore.bats
@@ -170,8 +170,7 @@ function teardown() {
 
 	output=$(crictl inspect -o table "$ctr_id")
 	[[ "${output}" == *"CONTAINER_EXITED"* ]]
-	# TODO: may be cri-tool should display Exit Code
-	#[[ "${output}" == *"Exit Code: 255"* ]]
+	[[ "${output}" == *"Exit Code: 137"* ]]
 
 	crictl stopp "$pod_id"
 	crictl rmp "$pod_id"


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
crictl displays the exit code, which can also be matched now.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?


```release-note
None
```
