### PR TITLE
[release-1.31] OCPBUGS-42908: Cherry-pick changes from containers/storage/pull#2134

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/containers/image/v5 v5.32.2
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.2.0
-	github.com/containers/storage v1.55.0
+	github.com/containers/storage v1.55.1-0.20241015045236-02f1845caa18
 	github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty v1.1.23

--- a/go.sum
+++ b/go.sum
@@ -740,8 +740,8 @@ github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYgle
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.2.0 h1:X14EgRK3xNFvJEfI5O4Qn4T3E25ANudSOZz/sirVuPM=
 github.com/containers/ocicrypt v1.2.0/go.mod h1:ZNviigQajtdlxIZGibvblVuIFBKIuUI2M0QM12SD31U=
-github.com/containers/storage v1.55.0 h1:wTWZ3YpcQf1F+dSP4KxG9iqDfpQY1otaUXjPpffuhgg=
-github.com/containers/storage v1.55.0/go.mod h1:28cB81IDk+y7ok60Of6u52RbCeBRucbFOeLunhER1RQ=
+github.com/containers/storage v1.55.1-0.20241015045236-02f1845caa18 h1:YRxFFfDzvXL7WY8OiCKYDbiWQcUPkA7f5mbcfwATHIE=
+github.com/containers/storage v1.55.1-0.20241015045236-02f1845caa18/go.mod h1:28cB81IDk+y7ok60Of6u52RbCeBRucbFOeLunhER1RQ=
 github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09 h1:OoRAFlvDGCUqDLampLQjk0yeeSGdF9zzst/3G9IkBbc=
 github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09/go.mod h1:m2r/smMKsKwgMSAoFKHaa68ImdCSNuKE1MxvQ64xuCQ=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=

--- a/vendor/github.com/containers/storage/userns.go
+++ b/vendor/github.com/containers/storage/userns.go
@@ -1,18 +1,21 @@
+//go:build linux
+
 package storage
 
 import (
 	"fmt"
 	"os"
 	"os/user"
-	"path/filepath"
 	"strconv"
 
 	drivers "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/containers/storage/types"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	libcontainerUser "github.com/moby/sys/user"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 // getAdditionalSubIDs looks up the additional IDs configured for
@@ -85,40 +88,59 @@ const nobodyUser = 65534
 // parseMountedFiles returns the maximum UID and GID found in the /etc/passwd and
 // /etc/group files.
 func parseMountedFiles(containerMount, passwdFile, groupFile string) uint32 {
+	var (
+		passwd *os.File
+		group  *os.File
+		size   int
+		err    error
+	)
 	if passwdFile == "" {
-		passwdFile = filepath.Join(containerMount, "etc/passwd")
+		passwd, err = secureOpen(containerMount, "/etc/passwd")
+	} else {
+		// User-specified override from a volume. Will not be in
+		// container root.
+		passwd, err = os.Open(passwdFile)
 	}
-	if groupFile == "" {
-		groupFile = filepath.Join(groupFile, "etc/group")
-	}
-
-	size := 0
-
-	users, err := libcontainerUser.ParsePasswdFile(passwdFile)
 	if err == nil {
-		for _, u := range users {
-			// Skip the "nobody" user otherwise we end up with 65536
-			// ids with most images
-			if u.Name == "nobody" {
-				continue
-			}
-			if u.Uid > size && u.Uid != nobodyUser {
-				size = u.Uid
-			}
-			if u.Gid > size && u.Gid != nobodyUser {
-				size = u.Gid
+		defer passwd.Close()
+
+		users, err := libcontainerUser.ParsePasswd(passwd)
+		if err == nil {
+			for _, u := range users {
+				// Skip the "nobody" user otherwise we end up with 65536
+				// ids with most images
+				if u.Name == "nobody" || u.Name == "nogroup" {
+					continue
+				}
+				if u.Uid > size && u.Uid != nobodyUser {
+					size = u.Uid + 1
+				}
+				if u.Gid > size && u.Gid != nobodyUser {
+					size = u.Gid + 1
+				}
 			}
 		}
 	}
 
-	groups, err := libcontainerUser.ParseGroupFile(groupFile)
+	if groupFile == "" {
+		group, err = secureOpen(containerMount, "/etc/group")
+	} else {
+		// User-specified override from a volume. Will not be in
+		// container root.
+		group, err = os.Open(groupFile)
+	}
 	if err == nil {
-		for _, g := range groups {
-			if g.Name == "nobody" {
-				continue
-			}
-			if g.Gid > size && g.Gid != nobodyUser {
-				size = g.Gid
+		defer group.Close()
+
+		groups, err := libcontainerUser.ParseGroup(group)
+		if err == nil {
+			for _, g := range groups {
+				if g.Name == "nobody" || g.Name == "nogroup" {
+					continue
+				}
+				if g.Gid > size && g.Gid != nobodyUser {
+					size = g.Gid + 1
+				}
 			}
 		}
 	}
@@ -308,4 +330,15 @@ func getAutoUserNSIDMappings(
 	uidMap := append(availableUIDs.zip(requestedContainerUIDs), additionalUIDMappings...)
 	gidMap := append(availableGIDs.zip(requestedContainerGIDs), additionalGIDMappings...)
 	return uidMap, gidMap, nil
+}
+
+// Securely open (read-only) a file in a container mount.
+func secureOpen(containerMount, file string) (*os.File, error) {
+	tmpFile, err := securejoin.OpenInRoot(containerMount, file)
+	if err != nil {
+		return nil, err
+	}
+	defer tmpFile.Close()
+
+	return securejoin.Reopen(tmpFile, unix.O_RDONLY)
 }

--- a/vendor/github.com/containers/storage/userns_unsupported.go
+++ b/vendor/github.com/containers/storage/userns_unsupported.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package storage
+
+import (
+	"errors"
+
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/types"
+)
+
+func (s *store) getAutoUserNS(_ *types.AutoUserNsOptions, _ *Image, _ rwLayerStore, _ []roLayerStore) ([]idtools.IDMap, []idtools.IDMap, error) {
+	return nil, nil, errors.New("user namespaces are not supported on this platform")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -357,7 +357,7 @@ github.com/containers/ocicrypt/keywrap/pkcs7
 github.com/containers/ocicrypt/spec
 github.com/containers/ocicrypt/utils
 github.com/containers/ocicrypt/utils/keyprovider
-# github.com/containers/storage v1.55.0
+# github.com/containers/storage v1.55.1-0.20241015045236-02f1845caa18
 ## explicit; go 1.21
 github.com/containers/storage
 github.com/containers/storage/drivers


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from https://github.com/containers/storage/pull#2134 as these changes contain a fix that needs to be backported to CRI-O release 1.31, part of OpenShift 4.18 release.

Related:

- https://github.com/containers/storage/pull/2134

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```