### PR TITLE
Use context timeout/deadline for container stop

### DIFF
--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -53,7 +53,7 @@ func (s *Server) removeContainerInPod(ctx context.Context, sb *sandbox.Sandbox, 
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 	if !sb.Stopped() {
-		if err := s.stopContainer(ctx, c, int64(10)); err != nil {
+		if err := s.stopContainer(ctx, c, stopTimeoutFromContext(ctx)); err != nil {
 			return fmt.Errorf("failed to stop container for removal %w", err)
 		}
 	}

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -472,7 +472,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	}
 	resourceCleaner.Add(ctx, "runSandbox: stopping container "+container.ID(), func() error {
 		// Clean-up steps from RemovePodSandbox
-		if err := s.stopContainer(ctx, container, int64(10)); err != nil {
+		if err := s.stopContainer(ctx, container, stopTimeoutFromContext(ctx)); err != nil {
 			return fmt.Errorf("failed to stop container for removal")
 		}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -997,7 +997,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	}
 	resourceCleaner.Add(ctx, "runSandbox: stopping container "+container.ID(), func() error {
 		// Clean-up steps from RemovePodSandbox
-		if err := s.stopContainer(ctx, container, int64(10)); err != nil {
+		if err := s.stopContainer(ctx, container, stopTimeoutFromContext(ctx)); err != nil {
 			return errors.New("failed to stop container for removal")
 		}
 

--- a/server/sandbox_stop_freebsd.go
+++ b/server/sandbox_stop_freebsd.go
@@ -56,7 +56,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 				}
 				c := ctr
 				waitGroup.Go(func() error {
-					if err := s.stopContainer(ctx, c, int64(10)); err != nil {
+					if err := s.stopContainer(ctx, c, stopTimeoutFromContext(ctx)); err != nil {
 						return fmt.Errorf("failed to stop container for pod sandbox %s: %v", sb.ID(), err)
 					}
 					if err := s.nri.stopContainer(ctx, sb, c); err != nil {
@@ -76,7 +76,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		}
 	}
 
-	if err := s.stopContainer(ctx, podInfraContainer, int64(10)); err != nil && !errors.Is(err, storage.ErrContainerUnknown) && !errors.Is(err, oci.ErrContainerStopped) {
+	if err := s.stopContainer(ctx, podInfraContainer, stopTimeoutFromContext(ctx)); err != nil && !errors.Is(err, storage.ErrContainerUnknown) && !errors.Is(err, oci.ErrContainerStopped) {
 		return fmt.Errorf("failed to stop infra container for pod sandbox %s: %v", sb.ID(), err)
 	}
 

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -61,7 +61,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 				}
 				c := ctr
 				waitGroup.Go(func() error {
-					if err := s.stopContainer(ctx, c, int64(10)); err != nil {
+					if err := s.stopContainer(ctx, c, stopTimeoutFromContext(ctx)); err != nil {
 						return fmt.Errorf("failed to stop container for pod sandbox %s: %w", sb.ID(), err)
 					}
 					return nil
@@ -73,7 +73,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		}
 	}
 
-	if err := s.stopContainer(ctx, podInfraContainer, int64(10)); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
+	if err := s.stopContainer(ctx, podInfraContainer, stopTimeoutFromContext(ctx)); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
 		return fmt.Errorf("failed to stop infra container for pod sandbox %s: %w", sb.ID(), err)
 	}
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -24,6 +24,9 @@ import (
 
 const (
 	maxLabelSize = 4096
+
+	// defaultStopTimeout is the default container stop timeout in seconds.
+	defaultStopTimeout = 10
 )
 
 func validateLabels(labels map[string]string) error {
@@ -222,4 +225,18 @@ func (s *Server) FilterDisallowedAnnotations(toFind, toFilter map[string]string,
 	allowed = append(allowed, s.config.Workloads.AllowedAnnotations(toFind)...)
 
 	return s.config.Workloads.FilterDisallowedAnnotations(allowed, toFilter)
+}
+
+// stopTimeoutFromContext returns the stop timeout in seconds for the provided
+// context. If the context has no timeout or deadline set, then it will default
+// to 10s.
+func stopTimeoutFromContext(ctx context.Context) int64 {
+	timeout := int64(defaultStopTimeout)
+	deadline, ok := ctx.Deadline()
+	if ok {
+		timeout = time.Until(deadline).Milliseconds() / 1000
+	}
+
+	log.Debugf(ctx, "Using stop timeout: %v", timeout)
+	return timeout
 }

--- a/test/common.sh
+++ b/test/common.sh
@@ -26,6 +26,7 @@ PINNS_BINARY_PATH=${PINNS_BINARY_PATH:-${CRIO_ROOT}/bin/pinns}
 
 # Path of the crictl binary.
 CRICTL_BINARY=${CRICTL_BINARY:-$(command -v crictl)}
+CRICTL_TIMEOUT=${CRICTL_TIMEOUT:-30s}
 # Path of the conmon binary set as a variable to allow overwriting.
 CONMON_BINARY=${CONMON_BINARY:-$(command -v conmon)}
 # Cgroup for the conmon process

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1427,8 +1427,8 @@ EOF
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
 
 	crictl start "$ctr_id"
-	crictl stopp "$pod_id"
-	crictl rmp "$pod_id"
+	CRICTL_TIMEOUT=10m crictl stop -t 10 "$ctr_id"
+	crictl rmp -f "$pod_id"
 
 	grep -q "Stopping container ${ctr_id} with stop signal timed out." "$CRIO_LOG"
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -84,7 +84,7 @@ function crio() {
 
 # Run crictl using the binary specified by $CRICTL_BINARY.
 function crictl() {
-    "$CRICTL_BINARY" -t 10m --config "$CRICTL_CONFIG_FILE" -r "unix://$CRIO_SOCKET" -i "unix://$CRIO_SOCKET" "$@"
+    "$CRICTL_BINARY" -t "$CRICTL_TIMEOUT" --config "$CRICTL_CONFIG_FILE" -r "unix://$CRIO_SOCKET" -i "unix://$CRIO_SOCKET" "$@"
 }
 
 # Run the runtime binary with the specified RUNTIME_ROOT

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -42,6 +42,16 @@ EOF
 	crictl rmp "$pod_id"
 }
 
+@test "pod remove with timeout from context" {
+	start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	# the sleep command in the container needs to be killed within the deadline
+	# of the context passed down from crictl
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	CRICTL_TIMEOUT=5s crictl rmp -f "$pod_id"
+}
+
 @test "pod stop ignores not found sandboxes" {
 	start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We can use the deadline from the CRI context for stopping containers. This allows a more dynamic behavior compared to the static 10s before. Tools like `crictl` can be used to remove containers given a strict timeout this way.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use the context timeout / deadline for stopping containers if provided.
```
