### PR TITLE
Re-allow building without seccomp installed

### DIFF
--- a/internal/config/seccomp/notifier.go
+++ b/internal/config/seccomp/notifier.go
@@ -1,5 +1,5 @@
-//go:build linux && cgo
-// +build linux,cgo
+//go:build seccomp && linux && cgo
+// +build seccomp,linux,cgo
 
 package seccomp
 

--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -1,5 +1,5 @@
-//go:build linux && cgo
-// +build linux,cgo
+//go:build seccomp && linux && cgo
+// +build seccomp,linux,cgo
 
 package seccomp
 

--- a/internal/config/seccomp/seccomp_unsupported.go
+++ b/internal/config/seccomp/seccomp_unsupported.go
@@ -12,20 +12,18 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-// Config is the global seccomp configuration type
+// Config is the global seccomp configuration type.
 type Config struct {
 	enabled bool
 }
 
 // Notifier wraps a seccomp notifier instance for a container.
-type Notifier struct {
-}
+type Notifier struct{}
 
 // Notification is a seccomp notification which gets sent to the CRI-O server.
-type Notification struct {
-}
+type Notification struct{}
 
-// New creates a new default seccomp configuration instance
+// New creates a new default seccomp configuration instance.
 func New() *Config {
 	return &Config{
 		enabled: false,
@@ -110,10 +108,11 @@ func (c *Config) IsDisabled() bool {
 	return true
 }
 
-// Profile returns the currently loaded seccomp profile
+// Profile returns the currently loaded seccomp profile.
 func (c *Config) Profile() *seccomp.Seccomp {
 	return nil
 }
+
 func DefaultProfile() *seccomp.Seccomp {
 	return nil
 }

--- a/internal/config/seccomp/seccomp_unsupported.go
+++ b/internal/config/seccomp/seccomp_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !(linux && cgo)
-// +build !linux !cgo
+//go:build !(seccomp && linux && cgo)
+// +build !seccomp !linux !cgo
 
 package seccomp
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

I think #3300 regressed #218 by unconditionally compiling with seccomp enabled. #6488 fixed this for non-linux and non-cgo build platforms, but the issue still exists when one uses a cgo-enabled Linux build host but still wants to build without seccomp. In such case build ends quickly with pkg-config error: `Package 'libseccomp' not found`.

This patch makes `internal/config/seccomp` respect the seccomp buildtag.

#### Which issue(s) this PR fixes:

Fixes #218 regression

#### Special notes for your reviewer:

```release-note
Fixed building CRI-O without libseccomp.
```

#### Does this PR introduce a user-facing change?

None?
