### PR TITLE
crio status: add `goroutines` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,13 +251,14 @@ The following API entry points are currently supported:
 
 <!-- markdownlint-disable MD013 -->
 
-| Path              | Content-Type       | Description                                                                        |
-| ----------------- | ------------------ | ---------------------------------------------------------------------------------- |
-| `/info`           | `application/json` | General information about the runtime, like `storage_driver` and `storage_root`.   |
-| `/containers/:id` | `application/json` | Dedicated container information, like `name`, `pid` and `image`.                   |
-| `/config`         | `application/toml` | The complete TOML configuration (defaults to `/etc/crio/crio.conf`) used by CRI-O. |
-| `/pause/:id`      | `application/json` | Pause a running container.                                                         |
-| `/unpause/:id`    | `application/json` | Unpause a paused container.                                                        |
+| Path                | Content-Type       | Description                                                                        |
+| ------------------- | ------------------ | ---------------------------------------------------------------------------------- |
+| `/info`             | `application/json` | General information about the runtime, like `storage_driver` and `storage_root`.   |
+| `/containers/:id`   | `application/json` | Dedicated container information, like `name`, `pid` and `image`.                   |
+| `/config`           | `application/toml` | The complete TOML configuration (defaults to `/etc/crio/crio.conf`) used by CRI-O. |
+| `/pause/:id`        | `application/json` | Pause a running container.                                                         |
+| `/unpause/:id`      | `application/json` | Unpause a paused container.                                                        |
+| `/debug/goroutines` | `text/plain`       | Print the goroutine stacks.                                                        |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -2,7 +2,7 @@
 
 function __fish_crio_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i check complete completion help h config man markdown md status config c containers container cs s info i version wipe help h
+        if contains -- $i check complete completion help h config man markdown md status config c containers container cs s info i goroutines g version wipe help h
             return 1
         end
     end
@@ -221,6 +221,8 @@ complete -r -c crio -n '__fish_seen_subcommand_from status' -a 'containers conta
 complete -c crio -n '__fish_seen_subcommand_from containers container cs s' -f -l id -s i -r -d 'the container ID'
 complete -c crio -n '__fish_seen_subcommand_from info i' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_seen_subcommand_from status' -a 'info i' -d 'Retrieve generic information about CRI-O, such as the cgroup and storage driver.'
+complete -c crio -n '__fish_seen_subcommand_from goroutines g' -f -l help -s h -d 'show help'
+complete -r -c crio -n '__fish_seen_subcommand_from status' -a 'goroutines g' -d 'Display the goroutine stack.'
 complete -c crio -n '__fish_seen_subcommand_from version' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'version' -d 'display detailed version information'
 complete -c crio -n '__fish_seen_subcommand_from version' -f -l json -s j -d 'print JSON instead of text'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -519,6 +519,10 @@ Display detailed information about the provided container ID.
 
 Retrieve generic information about CRI-O, such as the cgroup and storage driver.
 
+### goroutines, g
+
+Display the goroutine stack.
+
 ## version
 
 display detailed version information

--- a/internal/criocli/status.go
+++ b/internal/criocli/status.go
@@ -48,7 +48,16 @@ var StatusCommand = &cli.Command{
 		Aliases: []string{"i"},
 		Name:    "info",
 		Usage:   "Retrieve generic information about CRI-O, such as the cgroup and storage driver.",
+	}, {
+		Action:  goroutines,
+		Aliases: []string{"g"},
+		Name:    "goroutines",
+		Usage:   "Display the goroutine stack.",
 	}},
+}
+
+func crioClient(c *cli.Context) (client.CrioClient, error) {
+	return client.New(c.String(socketArg))
 }
 
 func configSubCommand(c *cli.Context) error {
@@ -135,6 +144,18 @@ func info(c *cli.Context) error {
 	return nil
 }
 
-func crioClient(c *cli.Context) (client.CrioClient, error) {
-	return client.New(c.String(socketArg))
+func goroutines(c *cli.Context) error {
+	crioClient, err := crioClient(c)
+	if err != nil {
+		return err
+	}
+
+	goroutineStack, err := crioClient.GoRoutinesInfo(c.Context)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(goroutineStack)
+
+	return nil
 }

--- a/server/inspect.go
+++ b/server/inspect.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/pkg/types"
+	"github.com/cri-o/cri-o/utils"
 )
 
 func (s *Server) getIDMappingsInfo() types.IDMappings {
@@ -124,6 +125,7 @@ const (
 	InspectInfoEndpoint       = "/info"
 	InspectPauseEndpoint      = "/pause"
 	InspectUnpauseEndpoint    = "/unpause"
+	InspectGoRoutinesEndpoint = "/debug/goroutines"
 )
 
 // GetExtendInterfaceMux returns the mux used to serve extend interface requests.
@@ -241,6 +243,14 @@ func (s *Server) GetExtendInterfaceMux(enableProfile bool) *chi.Mux {
 		w.Header().Set("Content-Type", "text/html")
 		if _, err := w.Write([]byte("200 OK")); err != nil {
 			logrus.Errorf("Unable to write response JSON: %v", err)
+		}
+	}))
+
+	mux.Get(InspectGoRoutinesEndpoint, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		if err := utils.WriteGoroutineStacksTo(w); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 	}))
 

--- a/test/status.bats
+++ b/test/status.bats
@@ -59,3 +59,8 @@ function teardown() {
 @test "should fail to retrieve the container with invalid socket" {
 	run -1 "${CRIO_BINARY_PATH}" status --socket wrong.sock s
 }
+
+@test "status should succeed to retrieve the goroutines" {
+	run -0 "${CRIO_BINARY_PATH}" status --socket="${CRIO_SOCKET}" goroutines
+	[[ "$output" == *"goroutine"* ]]
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -105,16 +105,25 @@ func WriteGoroutineStacksToFile(path string) error {
 	}
 	defer f.Close()
 
-	// Print goroutines stacks using the same format
-	// as if an unrecoverable panic would occur. The
-	// internal buffer is 64 MiB, which hopefully
-	// will be sufficient.
-	err = pprof.Lookup("goroutine").WriteTo(f, 2)
-	if err != nil {
+	if err := WriteGoroutineStacksTo(f); err != nil {
 		return err
 	}
 
 	return f.Sync()
+}
+
+// WriteGoroutineStacksToFile write goroutine stacks
+// to the specified file.
+func WriteGoroutineStacksTo(f io.Writer) error {
+	// Print goroutines stacks using the same format
+	// as if an unrecoverable panic would occur. The
+	// internal buffer is 64 MiB, which hopefully
+	// will be sufficient.
+	if err := pprof.Lookup("goroutine").WriteTo(f, 2); err != nil {
+		return fmt.Errorf("write goroutines: %w", err)
+	}
+
+	return nil
 }
 
 // GenerateID generates a random unique id.


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
The subcommand can be used to query the CRI-O goroutines in the same way as writing them to disk using `SIGUSR1`. This also allows to query the goroutines using the HTTP endpoint:

```shell
sudo curl --unix-socket /var/run/crio/crio.sock http://crio/debug/goroutines
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added crio status `goroutines` subcommand and `/debug/goroutines` HTTP endpoint.
```
