### PR TITLE
Update default cni network config in readme

### DIFF
--- a/contrib/cni/README.md
+++ b/contrib/cni/README.md
@@ -28,7 +28,7 @@ Copy the respective files to the configuration directory like so:
 sudo cp 10-crio-bridge.conflist /etc/cni/net.d
 ```
 
-By default, we install the dual stack version: [10-crio-bridge.conflist][dual-stack]
+By default, we install the IPv4 only version: [11-crio-ipv4-bridge.conflist][ipv4-only]
 
 However, if you are installing on a node with ipv6 disabled
 (`sysctl net.ipv6.conf.default.disable_ipv6` and


### PR DESCRIPTION
Is this line correct?
```
By default, we install the dual stack version: 10-crio-bridge.conflist
```

To reproduce on new ubunty system(I used mutlipass on mac):
```
sudo -i

# Ubuntu 24.04.1 LTS
lsb_release -a
# should be empty
ls /etc | grep -ie 'cni\|crio'

CRIO_VERSION=v1.31

curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/Release.key |
    gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg

echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/ /" |
    tee /etc/apt/sources.list.d/cri-o.list

apt-get update -y -qq
apt-get install -y -qq cri-o

systemctl start crio.service

# should show cni and crio
ls /etc | grep -ie 'cni\|crio'
```

What I see is 11-crio-ipv4-bridge.conflist by default:
```
$ ls /etc/cni/net.d/
11-crio-ipv4-bridge.conflist
```

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
