### PR TITLE
Validate stream server TLS config on startup

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1028,6 +1028,18 @@ func (c *APIConfig) Validate(onExecution bool) error {
 		c.GRPCMaxRecvMsgSize = defaultGRPCMaxMsgSize
 	}
 
+	if c.StreamEnableTLS {
+		if c.StreamTLSCert == "" {
+			return errors.New("stream TLS cert path is empty")
+		}
+		if c.StreamTLSKey == "" {
+			return errors.New("stream TLS key path is empty")
+		}
+		if c.StreamTLSCA == "" {
+			return errors.New("stream TLS CA path is empty")
+		}
+	}
+
 	if onExecution {
 		return RemoveUnusedSocket(c.Listen)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -187,6 +187,66 @@ var _ = t.Describe("Config", func() {
 			// Then
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("should succeed if stream server TLS enabled", func() {
+			// Given
+			sut = runtimeValidConfig()
+			sut.StreamEnableTLS = true
+			sut.StreamTLSCert = "cert"
+			sut.StreamTLSKey = "key"
+			sut.StreamTLSCA = "ca"
+
+			// When
+			err := sut.APIConfig.Validate(false)
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail if stream server TLS enabled and cert is empty", func() {
+			// Given
+			sut = runtimeValidConfig()
+			sut.StreamEnableTLS = true
+			sut.StreamTLSCert = ""
+			sut.StreamTLSKey = "key"
+			sut.StreamTLSCA = "ca"
+
+			// When
+			err := sut.APIConfig.Validate(false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail if stream server TLS enabled and key is empty", func() {
+			// Given
+			sut = runtimeValidConfig()
+			sut.StreamEnableTLS = true
+			sut.StreamTLSCert = "cert"
+			sut.StreamTLSKey = ""
+			sut.StreamTLSCA = "ca"
+
+			// When
+			err := sut.APIConfig.Validate(false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail if stream server TLS enabled and CA is empty", func() {
+			// Given
+			sut = runtimeValidConfig()
+			sut.StreamEnableTLS = true
+			sut.StreamTLSCert = "cert"
+			sut.StreamTLSKey = "key"
+			sut.StreamTLSCA = ""
+
+			// When
+			err := sut.APIConfig.Validate(false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	t.Describe("ValidateRuntimeConfig", func() {

--- a/server/server.go
+++ b/server/server.go
@@ -504,13 +504,14 @@ func New(
 		// config or it throws an error.
 		cert, err := tls.LoadX509KeyPair(config.StreamTLSCert, config.StreamTLSKey)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("load stream server x509 key pair: %w", err)
 		}
 		streamServerConfig.TLSConfig = &tls.Config{
 			GetConfigForClient: certCache.GetConfigForClient,
 			Certificates:       []tls.Certificate{cert},
 			MinVersion:         tls.VersionTLS12,
 		}
+		log.Debugf(ctx, "Applying stream server TLS configuration")
 	}
 	s.stream.ctx = ctx
 	s.stream.runtimeServer = s


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
We now pre-check if the configuration fields are set correctly and add more verbose output to the server start. Unit tests have been added around this use case as well.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Validate stream server TLS config on startup if TLS should be used.
```
