### PR TITLE
RuntimeHandler inheritance

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -345,6 +345,9 @@ Root directory used to store runtime data
 **runtime_type**="oci"
 Type of the runtime used for this runtime handler. "oci", "vm"
 
+**inherit_default_runtime**=false
+Override the runtime path, runtime config path, runtime root and runtime type from the default runtime on load.
+
 **runtime_config_path**=""
 Path to the runtime configuration file, should only be used with VM runtime types
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -264,6 +264,10 @@ type RuntimeHandler struct {
 	// Output of the "features" subcommand.
 	// This is populated dynamically and not read from config.
 	features runtimeHandlerFeatures
+
+	// Inheritance request
+	// Fill in the Runtime information (paths and type) from the default runtime
+	InheritDefaultRuntime bool `toml:"inherit_default_runtime,omitempty"`
 }
 
 // Multiple runtime Handlers in a map.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1458,6 +1458,20 @@ var _ = t.Describe("Config", func() {
 			// Then
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("should succeed with empty runtime type and runtime_config_path when inheriting from default", func() {
+			// Given
+			sut.Runtimes["inherited"] = &config.RuntimeHandler{
+				RuntimeConfigPath: invalidPath, RuntimeType: "invalid", InheritDefaultRuntime: true,
+			}
+			err := sut.ReloadRuntimes(sut)
+			Expect(err).ToNot(HaveOccurred())
+
+			// When
+			err = sut.Validate(false)
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	t.Describe("RuntimeHandlerFeatures", func() {

--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -285,6 +285,16 @@ func (c *Config) ReloadRuntimes(newConfig *Config) error {
 		return nil
 	}
 
+	// Update the default runtime paths in all runtimes that are asking for inheritance
+	for _, runtime := range c.Runtimes {
+		if runtime.InheritDefaultRuntime {
+			runtime.RuntimePath = c.Runtimes[c.DefaultRuntime].RuntimePath
+			runtime.RuntimeType = c.Runtimes[c.DefaultRuntime].RuntimeType
+			runtime.RuntimeConfigPath = c.Runtimes[c.DefaultRuntime].RuntimeConfigPath
+			runtime.RuntimeRoot = c.Runtimes[c.DefaultRuntime].RuntimeRoot
+		}
+	}
+
 	if err := c.ValidateRuntimes(); err != nil {
 		return fmt.Errorf("unabled to reload runtimes: %w", err)
 	}

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -428,6 +428,30 @@ var _ = t.Describe("Config", func() {
 			Expect(sut.Runtimes).To(HaveKeyWithValue("existing", newRuntime))
 			Expect(sut.Runtimes["existing"].PrivilegedWithoutHostDevices).To(BeTrue())
 		})
+
+		It("should inherit runtime config", func() {
+			// Given
+			newRuntime := &config.RuntimeHandler{
+				RuntimePath:           invalidPath,
+				InheritDefaultRuntime: true,
+			}
+			defaultRuntime := &config.RuntimeHandler{
+				RuntimePath: existingRuntimePath,
+			}
+			newConfig := &config.Config{}
+			newConfig.DefaultRuntime = "default"
+			newConfig.Runtimes = make(config.Runtimes)
+			newConfig.Runtimes["default"] = defaultRuntime
+			newConfig.Runtimes["new"] = newRuntime
+
+			// When
+			err := sut.ReloadRuntimes(newConfig)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sut.Runtimes).To(HaveKeyWithValue("new", newRuntime))
+			Expect(sut.Runtimes["new"].RuntimePath).To(Equal(existingRuntimePath))
+		})
 	})
 
 	t.Describe("ReloadPinnedImages", func() {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1231,6 +1231,7 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 # runtime_path = "/path/to/the/executable"
 # runtime_type = "oci"
 # runtime_root = "/path/to/the/root"
+# inherit_default_runtime = false
 # monitor_path = "/path/to/container/monitor"
 # monitor_cgroup = "/cgroup/path"
 # monitor_exec_cgroup = "/cgroup/path"
@@ -1251,6 +1252,9 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 #   state.
 # - runtime_config_path (optional, string): the path for the runtime configuration
 #   file. This can only be used with when using the VM runtime_type.
+# - inherit_default_runtime (optional, bool): when true the runtime_path,
+#   runtime_type, runtime_root and runtime_config_path will be replaced by
+#   the values from the default runtime on load time.
 # - privileged_without_host_devices (optional, bool): an option for restricting
 #   host devices from being passed to privileged containers.
 # - allowed_annotations (optional, array of strings): an option for specifying
@@ -1321,6 +1325,7 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 {{ $.Comment }}runtime_path = "{{ $runtime_handler.RuntimePath }}"
 {{ $.Comment }}runtime_type = "{{ $runtime_handler.RuntimeType }}"
 {{ $.Comment }}runtime_root = "{{ $runtime_handler.RuntimeRoot }}"
+{{ $.Comment }}inherit_default_runtime = {{ $runtime_handler.InheritDefaultRuntime }}
 {{ $.Comment }}runtime_config_path = "{{ $runtime_handler.RuntimeConfigPath }}"
 {{ $.Comment }}container_min_memory = "{{ $runtime_handler.ContainerMinMemory }}"
 {{ $.Comment }}monitor_path = "{{ $runtime_handler.MonitorPath }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This allows custom RuntimeHandlers to always inherit the default configured runtime paths. This helps with adding extra annotations or other "minor" changes while following what rest of the system does.

#### Which issue(s) this PR fixes:

Fixes #8753

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

This is a minimal proof of concept so I could test whether the configuration flow would make sense. I actually do not know if it covers all code paths.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
A runtime handler definition in the configuration file can use a new option `use_default_runtime`. Setting it to true causes the values for runtime path, runtime type and runtime root to be inherited from the currently configured default runtime.
```
