### PR TITLE
RuntimeHandler inheritance bug-fix

### DIFF
--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -285,16 +285,6 @@ func (c *Config) ReloadRuntimes(newConfig *Config) error {
 		return nil
 	}
 
-	// Update the default runtime paths in all runtimes that are asking for inheritance
-	for _, runtime := range c.Runtimes {
-		if runtime.InheritDefaultRuntime {
-			runtime.RuntimePath = c.Runtimes[c.DefaultRuntime].RuntimePath
-			runtime.RuntimeType = c.Runtimes[c.DefaultRuntime].RuntimeType
-			runtime.RuntimeConfigPath = c.Runtimes[c.DefaultRuntime].RuntimeConfigPath
-			runtime.RuntimeRoot = c.Runtimes[c.DefaultRuntime].RuntimeRoot
-		}
-	}
-
 	if err := c.ValidateRuntimes(); err != nil {
 		return fmt.Errorf("unabled to reload runtimes: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug

#### What this PR does / why we need it:

The original inheritance PR missed few important bits

- the reload code path was not the only one that loads configs
- an empty RuntimePath has a special meaning and inheriting it does not inherit the parent runtime
- golang does a copy during interation, not a reference and the updated values were forgotten
- the unit test ignores some of the checks during CI when not on a bare metal

This patch fixes all of these and adds better logging and also tests that actually catch the above mistakes.

#### Which issue(s) this PR fixes:

Fixes https://github.com/cri-o/cri-o/issues/8753

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

I apologize for missing the issue during the first submission, but it all looked like working. It was just an accident though..

This fix was manually tested including the negative cases both by running unit tests with the code commented out (which I did before too...) and by manually editing crio configs on a real bare metal node.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
