### PR TITLE
[release-1.29] Only restore container if all bind mounts are defined

### DIFF
--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -63,7 +63,7 @@ func (s *Server) CRImportCheckpoint(
 		return "", errors.New(`attribute "image" missing from container definition`)
 	}
 
-	if createConfig.Metadata == nil && createConfig.Metadata.Name == "" {
+	if createConfig.Metadata == nil || createConfig.Metadata.Name == "" {
 		return "", errors.New(`attribute "metadata" missing from container definition`)
 	}
 
@@ -288,12 +288,15 @@ func (s *Server) CRImportCheckpoint(
 
 		bindMountFound := false
 		for _, createMount := range createMounts {
-			if createMount.ContainerPath == m.Destination {
-				mount.HostPath = createMount.HostPath
-				mount.Readonly = createMount.Readonly
-				mount.Propagation = createMount.Propagation
-				bindMountFound = true
+			if createMount.ContainerPath != m.Destination {
+				continue
 			}
+
+			bindMountFound = true
+			mount.HostPath = createMount.HostPath
+			mount.Readonly = createMount.Readonly
+			mount.Propagation = createMount.Propagation
+			break
 		}
 
 		if !bindMountFound {

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/containers/podman/v4/pkg/annotations"
@@ -60,6 +61,10 @@ func (s *Server) CRImportCheckpoint(
 	// Ensure that the image to restore the checkpoint from has been provided.
 	if createConfig.Image == nil || createConfig.Image.Image == "" {
 		return "", errors.New(`attribute "image" missing from container definition`)
+	}
+
+	if createConfig.Metadata == nil && createConfig.Metadata.Name == "" {
+		return "", errors.New(`attribute "metadata" missing from container definition`)
 	}
 
 	inputImage := createConfig.Image.Image
@@ -147,69 +152,25 @@ func (s *Server) CRImportCheckpoint(
 		ctrID = ""
 	}
 
-	ctrMetadata := types.ContainerMetadata{}
 	originalAnnotations := make(map[string]string)
-	originalLabels := make(map[string]string)
 
-	if dumpSpec.Annotations[annotations.ContainerManager] == "libpod" {
-		// This is an import from Podman
-		ctrMetadata.Name = config.Name
-		ctrMetadata.Attempt = 0
-	} else {
-		if err := json.Unmarshal([]byte(dumpSpec.Annotations[annotations.Metadata]), &ctrMetadata); err != nil {
-			return "", fmt.Errorf("failed to read %q: %w", annotations.Metadata, err)
+	if err := json.Unmarshal([]byte(dumpSpec.Annotations[annotations.Annotations]), &originalAnnotations); err != nil {
+		return "", fmt.Errorf("failed to read %q: %w", annotations.Annotations, err)
+	}
+
+	if sandboxUID != "" {
+		if _, ok := originalAnnotations[kubetypes.KubernetesPodUIDLabel]; ok {
+			originalAnnotations[kubetypes.KubernetesPodUIDLabel] = sandboxUID
 		}
-		if createConfig.Metadata != nil && createConfig.Metadata.Name != "" {
-			ctrMetadata.Name = createConfig.Metadata.Name
-		}
-		if err := json.Unmarshal([]byte(dumpSpec.Annotations[annotations.Annotations]), &originalAnnotations); err != nil {
-			return "", fmt.Errorf("failed to read %q: %w", annotations.Annotations, err)
-		}
+	}
 
-		if err := json.Unmarshal([]byte(dumpSpec.Annotations[annotations.Labels]), &originalLabels); err != nil {
-			return "", fmt.Errorf("failed to read %q: %w", annotations.Labels, err)
-		}
-		if sandboxUID != "" {
-			if _, ok := originalLabels[kubetypes.KubernetesPodUIDLabel]; ok {
-				originalLabels[kubetypes.KubernetesPodUIDLabel] = sandboxUID
-			}
-			if _, ok := originalAnnotations[kubetypes.KubernetesPodUIDLabel]; ok {
-				originalAnnotations[kubetypes.KubernetesPodUIDLabel] = sandboxUID
-			}
-		}
+	if createAnnotations != nil {
+		// The hash also needs to be update or Kubernetes thinks the container needs to be restarted
+		_, ok1 := createAnnotations["io.kubernetes.container.hash"]
+		_, ok2 := originalAnnotations["io.kubernetes.container.hash"]
 
-		if createLabels != nil {
-			fixupLabels := []string{
-				// Update the container name. It has already been update in metadata.Name.
-				// It also needs to be updated in the container labels.
-				kubetypes.KubernetesContainerNameLabel,
-				// Update pod name in the labels.
-				kubetypes.KubernetesPodNameLabel,
-				// Also update namespace.
-				kubetypes.KubernetesPodNamespaceLabel,
-			}
-
-			for _, annotation := range fixupLabels {
-				_, ok1 := createLabels[annotation]
-				_, ok2 := originalLabels[annotation]
-
-				// If the value is not set in the original container or
-				// if it is not set in the new container, just skip
-				// the step of updating metadata.
-				if ok1 && ok2 {
-					originalLabels[annotation] = createLabels[annotation]
-				}
-			}
-		}
-
-		if createAnnotations != nil {
-			// The hash also needs to be update or Kubernetes thinks the container needs to be restarted
-			_, ok1 := createAnnotations["io.kubernetes.container.hash"]
-			_, ok2 := originalAnnotations["io.kubernetes.container.hash"]
-
-			if ok1 && ok2 {
-				originalAnnotations["io.kubernetes.container.hash"] = createAnnotations["io.kubernetes.container.hash"]
-			}
+		if ok1 && ok2 {
+			originalAnnotations["io.kubernetes.container.hash"] = createAnnotations["io.kubernetes.container.hash"]
 		}
 	}
 
@@ -257,8 +218,8 @@ func (s *Server) CRImportCheckpoint(
 	}
 	containerConfig := &types.ContainerConfig{
 		Metadata: &types.ContainerMetadata{
-			Name:    ctrMetadata.Name,
-			Attempt: ctrMetadata.Attempt,
+			Name:    createConfig.Metadata.Name,
+			Attempt: createConfig.Metadata.Attempt,
 		},
 		Image: &types.ImageSpec{
 			Image: rootFSImage,
@@ -268,7 +229,9 @@ func (s *Server) CRImportCheckpoint(
 			SecurityContext: &types.LinuxContainerSecurityContext{},
 		},
 		Annotations: originalAnnotations,
-		Labels:      originalLabels,
+		// The labels are nod changed or adapted. They are just taken from the CRI
+		// request without any modification (in contrast to the annotations).
+		Labels: createLabels,
 	}
 
 	if createConfig.Linux != nil {
@@ -305,6 +268,13 @@ func (s *Server) CRImportCheckpoint(
 		"/run/.containerenv": true,
 	}
 
+	// It is necessary to ensure that all bind mounts in the checkpoint archive are defined
+	// in the create container requested coming in via the CRI. If this check would not
+	// be here it would be possible to create a checkpoint archive that mounts some random
+	// file/directory on the host with the user knowing as it will happen without specifying
+	// it in the container definition.
+	missingMount := []string{}
+
 	for _, m := range dumpSpec.Mounts {
 		// Following mounts are ignored as they might point to the
 		// wrong location and if ignored the mounts will correctly
@@ -314,31 +284,37 @@ func (s *Server) CRImportCheckpoint(
 		}
 		mount := &types.Mount{
 			ContainerPath: m.Destination,
-			HostPath:      m.Source,
 		}
 
+		bindMountFound := false
 		for _, createMount := range createMounts {
 			if createMount.ContainerPath == m.Destination {
 				mount.HostPath = createMount.HostPath
+				mount.Readonly = createMount.Readonly
+				mount.Propagation = createMount.Propagation
+				bindMountFound = true
 			}
 		}
 
-		for _, opt := range m.Options {
-			switch opt {
-			case "ro":
-				mount.Readonly = true
-			case "rprivate":
-				mount.Propagation = types.MountPropagation_PROPAGATION_PRIVATE
-			case "rshared":
-				mount.Propagation = types.MountPropagation_PROPAGATION_BIDIRECTIONAL
-			case "rslaved":
-				mount.Propagation = types.MountPropagation_PROPAGATION_HOST_TO_CONTAINER
-			}
+		if !bindMountFound {
+			missingMount = append(missingMount, m.Destination)
+			// If one mount is missing we can skip over any further code as we have
+			// to abort the restore process anyway. Not using break to get all missing
+			// mountpoints in one error message.
+			continue
 		}
 
 		log.Debugf(ctx, "Adding mounts %#v", mount)
 		containerConfig.Mounts = append(containerConfig.Mounts, mount)
 	}
+	if len(missingMount) > 0 {
+		return "", fmt.Errorf(
+			"restoring %q expects following bind mounts defined (%s)",
+			inputImage,
+			strings.Join(missingMount, ","),
+		)
+	}
+
 	sandboxConfig := &types.PodSandboxConfig{
 		Metadata: &types.PodSandboxMetadata{
 			Name:      sb.Metadata().Name,

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -66,6 +66,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			)
 
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "does-not-exist.tar",
 				},
@@ -91,6 +92,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			archive.Close()
 			defer os.RemoveAll("empty.tar")
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "empty.tar",
 				},
@@ -113,6 +115,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			Expect(err).To(BeNil())
 			defer os.RemoveAll("no.tar")
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "no.tar",
 				},
@@ -147,6 +150,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -184,6 +188,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -197,7 +202,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			)
 
 			// Then
-			Expect(err.Error()).To(ContainSubstring(`failed to read "io.kubernetes.cri-o.Metadata": unexpected end of JSON input`))
+			Expect(err.Error()).To(ContainSubstring(`failed to read "io.kubernetes.cri-o.Annotations": unexpected end of JSON input`))
 		})
 	})
 	t.Describe("ContainerRestore from archive into new pod", func() {
@@ -222,6 +227,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -267,6 +273,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -315,6 +322,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -330,57 +338,6 @@ var _ = t.Describe("ContainerRestore", func() {
 
 			// Then
 			Expect(err.Error()).To(Equal(`failed to read "io.kubernetes.cri-o.Annotations": unexpected end of JSON input`))
-		})
-	})
-	t.Describe("ContainerRestore from archive into new pod", func() {
-		It("should fail because archive contains no io.kubernetes.cri-o.Labels", func() {
-			// Given
-			addContainerAndSandbox()
-			testContainer.SetStateAndSpoofPid(&oci.ContainerState{
-				State: specs.State{Status: oci.ContainerStateRunning},
-			})
-
-			err := os.WriteFile(
-				"spec.dump",
-				[]byte(
-					`{"annotations":{"io.kubernetes.cri-o.Metadata"`+
-						`:"{\"name\":\"container-to-restore\"}",`+
-						`"io.kubernetes.cri-o.Annotations": "{\"name\":\"NAME\"}"}}`),
-				0o644,
-			)
-			Expect(err).To(BeNil())
-			defer os.RemoveAll("spec.dump")
-			err = os.WriteFile("config.dump", []byte(`{"rootfsImageName": "image"}`), 0o644)
-			Expect(err).To(BeNil())
-			defer os.RemoveAll("config.dump")
-			outFile, err := os.Create("archive.tar")
-			Expect(err).To(BeNil())
-			defer outFile.Close()
-			input, err := archive.TarWithOptions(".", &archive.TarOptions{
-				Compression:      archive.Uncompressed,
-				IncludeSourceDir: true,
-				IncludeFiles:     []string{"spec.dump", "config.dump"},
-			})
-			Expect(err).To(BeNil())
-			defer os.RemoveAll("archive.tar")
-			_, err = io.Copy(outFile, input)
-			Expect(err).To(BeNil())
-			containerConfig := &types.ContainerConfig{
-				Image: &types.ImageSpec{
-					Image: "archive.tar",
-				},
-			}
-			// When
-
-			_, err = sut.CRImportCheckpoint(
-				context.Background(),
-				containerConfig,
-				"",
-				"",
-			)
-
-			// Then
-			Expect(err.Error()).To(Equal(`failed to read "io.kubernetes.cri-o.Labels": unexpected end of JSON input`))
 		})
 	})
 	t.Describe("ContainerRestore from archive into new pod", func() {
@@ -503,6 +460,10 @@ var _ = t.Describe("ContainerRestore", func() {
 					Metadata: &types.ContainerMetadata{
 						Name: "new-container-name",
 					},
+					Mounts: []*types.Mount{{
+						ContainerPath: "/data",
+						HostPath:      "/data",
+					}},
 				}
 
 				size := uint64(100)
@@ -609,6 +570,7 @@ var _ = t.Describe("ContainerRestore", func() {
 					Return(false, nil),
 			)
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "localhost/checkpoint-image:tag1",
 				},

--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -30,9 +30,15 @@ function teardown() {
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# Replace original container with checkpoint image
 	RESTORE_JSON=$(mktemp)
+	RESTORE2_JSON=$(mktemp)
 	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$RESTORE_JSON"
-	ctr_id=$(crictl create "$pod_id" "$RESTORE_JSON" "$TESTDATA"/sandbox_config.json)
+	# This should fail because the bind mounts are not part of the create request
+	run crictl create "$pod_id" "$RESTORE_JSON" "$TESTDATA"/sandbox_config.json
+	[ "$status" -eq 1 ]
+	jq ". +{mounts:[{\"container_path\":\"/etc/issue\",\"host_path\":\"$BIND_MOUNT_FILE\"},{\"container_path\":\"/data\",\"host_path\":\"$BIND_MOUNT_DIR\"}]}" "$RESTORE_JSON" > "$RESTORE2_JSON"
+	ctr_id=$(crictl create "$pod_id" "$RESTORE2_JSON" "$TESTDATA"/sandbox_config.json)
 	rm -f "$RESTORE_JSON"
+	rm -f "$RESTORE2_JSON"
 	rm -f "$TESTDATA"/checkpoint.json
 	crictl start "$ctr_id"
 	restored=$(crictl inspect --output go-template --template "{{(index .info.restored)}}" "$ctr_id")


### PR DESCRIPTION
This is a manual cherry-pick of commit 429ef7c36

```mail
commit 429ef7c366406280cfa3daa15812d14b22953a7a
Author: Adrian Reber <areber@redhat.com>
Date:   Mon Sep 30 23:37:13 2024

    Only restore container if all bind mounts are defined
    
    To avoid the situation where a container that is restored via a registry
    mounts unexpected host paths into the container, this changes the
    restore behaviour of CRI-O.
    
    Previously all bind mounted paths in the original container which were
    defined for example like this:
    
        volumeMounts:
        - mountPath: /data
          name: data-volume
      volumes:
      - name: data-volume
        hostPath:
          path: /srv/container/data
    
    Were automatically mounted in the restored container without and
    definition necessary. This lead to the situation that the user does not
    know which path will be mounted if starting a restored container.
    
    Now CRI-O will refuse to restore a container if not all bind mounts are
    defined via the CRI CreateContainer RPC in the CreateContainerRequest
    message.
    
    CRI-O will now return an error that will look something likes this:
    
    Error: the container to restore (7f...be) expects following bind mounts defined (/data,/data2)
    
    Now the user has to explicitly add those bind mounts in the same way as
    it was done during initial container creation.
    
    Signed-off-by: Adrian Reber <areber@redhat.com>
```

/assign kwilczynski

> [!NOTE] 
> This cherry-pickl brings the following Pull Request as a dependency:
> - https://github.com/cri-o/cri-o/pull/8786

```release-note
Only restore container if all bind mounts are defined.
```