### PR TITLE
[release-1.26] OCPBUGS-45908: Only restore container if all bind mounts are defined

### DIFF
--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -69,7 +69,7 @@ func (s *Server) CRImportCheckpoint(
 		return "", errors.New(`attribute "image" missing from container definition`)
 	}
 
-	if createConfig.Metadata == nil && createConfig.Metadata.Name == "" {
+	if createConfig.Metadata == nil || createConfig.Metadata.Name == "" {
 		return "", errors.New(`attribute "metadata" missing from container definition`)
 	}
 
@@ -265,12 +265,15 @@ func (s *Server) CRImportCheckpoint(
 
 		bindMountFound := false
 		for _, createMount := range createMounts {
-			if createMount.ContainerPath == m.Destination {
-				mount.HostPath = createMount.HostPath
-				mount.Readonly = createMount.Readonly
-				mount.Propagation = createMount.Propagation
-				bindMountFound = true
+			if createMount.ContainerPath != m.Destination {
+				continue
 			}
+
+			bindMountFound = true
+			mount.HostPath = createMount.HostPath
+			mount.Readonly = createMount.Readonly
+			mount.Propagation = createMount.Propagation
+			break
 		}
 
 		if !bindMountFound {

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -62,21 +63,26 @@ func (s *Server) CRImportCheckpoint(
 ) (ctrID string, retErr error) {
 	var mountPoint string
 
-	input := createConfig.Image.Image
+	// Ensure that the image to restore the checkpoint from has been provided.
+	if createConfig.Image == nil || createConfig.Image.Image == "" {
+		return "", errors.New(`attribute "image" missing from container definition`)
+	}
+
+	inputImage := createConfig.Image.Image
 	createMounts := createConfig.Mounts
 	createAnnotations := createConfig.Annotations
 
-	checkpointIsOCIImage, err := s.checkIfCheckpointOCIImage(ctx, input)
+	checkpointIsOCIImage, err := s.checkIfCheckpointOCIImage(ctx, inputImage)
 	if err != nil {
 		return "", err
 	}
 
 	if checkpointIsOCIImage {
-		log.Debugf(ctx, "Restoring from oci image %s\n", input)
+		log.Debugf(ctx, "Restoring from oci image %s\n", inputImage)
 
-		imageRef, err := istorage.Transport.ParseStoreReference(s.ContainerServer.StorageImageServer().GetStore(), input)
+		imageRef, err := istorage.Transport.ParseStoreReference(s.ContainerServer.StorageImageServer().GetStore(), inputImage)
 		if err != nil {
-			return "", fmt.Errorf("failed to parse image name: %s: %w", input, err)
+			return "", fmt.Errorf("failed to parse image name: %s: %w", inputImage, err)
 		}
 		img, err := istorage.Transport.GetStoreImage(s.ContainerServer.StorageImageServer().GetStore(), imageRef)
 		if err != nil {
@@ -86,23 +92,24 @@ func (s *Server) CRImportCheckpoint(
 		if err != nil {
 			return "", err
 		}
-		input = img.ID
+		inputImage = img.ID
 
-		logrus.Debugf("Checkpoint image %s mounted at %v\n", input, mountPoint)
+		logrus.Debugf("Checkpoint image %s mounted at %v\n", inputImage, mountPoint)
 
 		defer func() {
-			if _, err := s.ContainerServer.StorageImageServer().GetStore().UnmountImage(input, true); err != nil {
-				logrus.Errorf("Could not unmount checkpoint image %s: %q", input, err)
+			if _, err := s.ContainerServer.StorageImageServer().GetStore().UnmountImage(inputImage, true); err != nil {
+				logrus.Errorf("Could not unmount checkpoint image %s: %q", inputImage, err)
 			}
 		}()
 	} else {
 		// First get the container definition from the
 		// tarball to a temporary directory
-		archiveFile, err := os.Open(input)
+		archiveFile, err := os.Open(inputImage)
 		if err != nil {
-			return "", fmt.Errorf("failed to open checkpoint archive %s for import: %w", input, err)
+			return "", fmt.Errorf("failed to open checkpoint archive %s for import: %w", inputImage, err)
 		}
 		defer errorhandling.CloseQuiet(archiveFile)
+
 		options := &archive.TarOptions{
 			// Here we only need the files config.dump and spec.dump
 			ExcludePatterns: []string{
@@ -224,11 +231,14 @@ func (s *Server) CRImportCheckpoint(
 		Labels:      originalLabels,
 	}
 
-	if createConfig.Linux.Resources != nil {
-		containerConfig.Linux.Resources = createConfig.Linux.Resources
-	}
-	if createConfig.Linux.SecurityContext != nil {
-		containerConfig.Linux.SecurityContext = createConfig.Linux.SecurityContext
+	if createConfig.Linux != nil {
+		if createConfig.Linux.Resources != nil {
+			containerConfig.Linux.Resources = createConfig.Linux.Resources
+		}
+
+		if createConfig.Linux.SecurityContext != nil {
+			containerConfig.Linux.SecurityContext = createConfig.Linux.SecurityContext
+		}
 	}
 
 	ignoreMounts := map[string]bool{
@@ -346,7 +356,7 @@ func (s *Server) CRImportCheckpoint(
 
 	newContainer.SetCreated()
 	newContainer.SetRestore(true)
-	newContainer.SetRestoreArchive(input)
+	newContainer.SetRestoreArchive(inputImage)
 	newContainer.SetRestoreIsOCIImage(checkpointIsOCIImage)
 
 	if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -56,6 +57,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			)
 
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "does-not-exist.tar",
 				},
@@ -81,6 +83,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			archive.Close()
 			defer os.RemoveAll("empty.tar")
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "empty.tar",
 				},
@@ -103,6 +106,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			Expect(err).To(BeNil())
 			defer os.RemoveAll("no.tar")
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "no.tar",
 				},
@@ -137,6 +141,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -174,6 +179,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -187,7 +193,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			)
 
 			// Then
-			Expect(err.Error()).To(ContainSubstring(`failed to read "io.kubernetes.cri-o.Metadata": unexpected end of JSON input`))
+			Expect(err.Error()).To(ContainSubstring(`failed to read "io.kubernetes.cri-o.Annotations": unexpected end of JSON input`))
 		})
 	})
 	t.Describe("ContainerRestore from archive into new pod", func() {
@@ -212,6 +218,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -257,6 +264,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -305,6 +313,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -320,6 +329,160 @@ var _ = t.Describe("ContainerRestore", func() {
 
 			// Then
 			Expect(err.Error()).To(Equal(`failed to read "io.kubernetes.cri-o.Annotations": unexpected end of JSON input`))
+		})
+	})
+	t.Describe("ContainerRestore from archive into new pod", func() {
+		It("should fail with 'PodSandboxId should not be empty'", func() {
+			// Given
+			addContainerAndSandbox()
+			testContainer.SetStateAndSpoofPid(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateRunning},
+			})
+
+			err := os.WriteFile(
+				"spec.dump",
+				[]byte(
+					`{"annotations":{"io.kubernetes.cri-o.Metadata"`+
+						`:"{\"name\":\"container-to-restore\"}",`+
+						`"io.kubernetes.cri-o.Annotations": "{\"name\":\"NAME\"}",`+
+						`"io.kubernetes.cri-o.Labels": "{\"io.kubernetes.container.name\":\"counter\"}"}}`),
+				0o644,
+			)
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("spec.dump")
+			err = os.WriteFile("config.dump", []byte(`{"rootfsImageName": "image"}`), 0o644)
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("config.dump")
+			outFile, err := os.Create("archive.tar")
+			Expect(err).To(BeNil())
+			defer outFile.Close()
+			input, err := archive.TarWithOptions(".", &archive.TarOptions{
+				Compression:      archive.Uncompressed,
+				IncludeSourceDir: true,
+				IncludeFiles:     []string{"spec.dump", "config.dump"},
+			})
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("archive.tar")
+			_, err = io.Copy(outFile, input)
+			Expect(err).To(BeNil())
+			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
+				Image: &types.ImageSpec{
+					Image: "archive.tar",
+				},
+			}
+			// When
+
+			_, err = sut.CRImportCheckpoint(
+				context.Background(),
+				containerConfig,
+				"",
+				"",
+			)
+
+			// Then
+			Expect(err.Error()).To(Equal(`PodSandboxId should not be empty`))
+		})
+	})
+	t.Describe("ContainerRestore from archive into new pod", func() {
+		It("should succeed", func() {
+			// Given
+			addContainerAndSandbox()
+			testContainer.SetStateAndSpoofPid(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateRunning},
+			})
+
+			err := os.WriteFile(
+				"spec.dump",
+				[]byte(`{"annotations":{"io.kubernetes.cri-o.Metadata"`+
+					`:"{\"name\":\"container-to-restore\"}",`+
+					`"io.kubernetes.cri-o.Annotations": "{\"name\":\"NAME\"}",`+
+					`"io.kubernetes.cri-o.Labels": "{\"io.kubernetes.container.name\":\"counter\"}",`+
+					`"io.kubernetes.cri-o.SandboxID": "sandboxID"},`+
+					`"mounts": [{"destination": "/proc"},`+
+					`{"destination":"/data","source":"/data","options":`+
+					`["rw","ro","rbind","rprivate","rshared","rslaved"]}],`+
+					`"linux": {"maskedPaths": ["/proc/acpi"], "readonlyPaths": ["/proc/asound"]}}`),
+				0o644,
+			)
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("spec.dump")
+			err = os.WriteFile("config.dump", []byte(`{"rootfsImageName": "image"}`), 0o644)
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("config.dump")
+			outFile, err := os.Create("archive.tar")
+			Expect(err).To(BeNil())
+			defer outFile.Close()
+			input, err := archive.TarWithOptions(".", &archive.TarOptions{
+				Compression:      archive.Uncompressed,
+				IncludeSourceDir: true,
+				IncludeFiles:     []string{"spec.dump", "config.dump"},
+			})
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("archive.tar")
+			_, err = io.Copy(outFile, input)
+			Expect(err).To(BeNil())
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "archive.tar",
+				},
+				Linux: &types.LinuxContainerConfig{
+					Resources:       &types.LinuxContainerResources{},
+					SecurityContext: &types.LinuxContainerSecurityContext{},
+				},
+				Metadata: &types.ContainerMetadata{
+					Name: "new-container-name",
+				},
+				Mounts: []*types.Mount{{
+					ContainerPath: "/data",
+					HostPath:      "/data",
+				}},
+			}
+
+			size := uint64(100)
+			gomock.InOrder(
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
+					Return([]string{"image"}, nil),
+
+				imageServerMock.EXPECT().ImageStatus(
+					gomock.Any(), gomock.Any()).
+					Return(&storage.ImageResult{
+						ID:   "image",
+						User: "10", Size: &size,
+						Annotations: map[string]string{
+							crioann.CheckpointAnnotationName: "foo",
+						},
+					}, nil),
+
+				runtimeServerMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any()).
+					Return(storage.ContainerInfo{
+						Config: &v1.Image{
+							Config: v1.ImageConfig{
+								Entrypoint: []string{"sh"},
+							},
+						},
+					},
+						nil,
+					),
+				runtimeServerMock.EXPECT().StartContainer(gomock.Any()).
+					Return(emptyDir, nil),
+			)
+
+			// When
+
+			_, err = sut.CRImportCheckpoint(
+				context.Background(),
+				containerConfig,
+				"",
+				"",
+			)
+
+			// Then
+			Expect(err).To(BeNil())
 		})
 	})
 	t.Describe("ContainerRestore from OCI archive", func() {
@@ -360,6 +523,7 @@ var _ = t.Describe("ContainerRestore", func() {
 					Return(false, nil),
 			)
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "localhost/checkpoint-image:tag1",
 				},

--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -29,9 +29,16 @@ function teardown() {
 	rmdir "$BIND_MOUNT_DIR"
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# Replace original container with checkpoint image
-	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
-	rm -f "$TESTDATA"/restore.json
+	RESTORE_JSON=$(mktemp)
+	RESTORE2_JSON=$(mktemp)
+	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$RESTORE_JSON"
+	# This should fail because the bind mounts are not part of the create request
+	run crictl create "$pod_id" "$RESTORE_JSON" "$TESTDATA"/sandbox_config.json
+	[ "$status" -eq 1 ]
+	jq ". +{mounts:[{\"container_path\":\"/etc/issue\",\"host_path\":\"$BIND_MOUNT_FILE\"},{\"container_path\":\"/data\",\"host_path\":\"$BIND_MOUNT_DIR\"}]}" "$RESTORE_JSON" > "$RESTORE2_JSON"
+	ctr_id=$(crictl create "$pod_id" "$RESTORE2_JSON" "$TESTDATA"/sandbox_config.json)
+	rm -f "$RESTORE_JSON"
+	rm -f "$RESTORE2_JSON"
 	rm -f "$TESTDATA"/checkpoint.json
 	crictl start "$ctr_id"
 	rm -f "$BIND_MOUNT_FILE"


### PR DESCRIPTION
This is a manual cherry-pick of commit 429ef7c36

```mail
commit 429ef7c366406280cfa3daa15812d14b22953a7a
Author: Adrian Reber <areber@redhat.com>
Date:   Mon Sep 30 23:37:13 2024

    Only restore container if all bind mounts are defined
    
    To avoid the situation where a container that is restored via a registry
    mounts unexpected host paths into the container, this changes the
    restore behaviour of CRI-O.
    
    Previously all bind mounted paths in the original container which were
    defined for example like this:
    
        volumeMounts:
        - mountPath: /data
          name: data-volume
      volumes:
      - name: data-volume
        hostPath:
          path: /srv/container/data
    
    Were automatically mounted in the restored container without and
    definition necessary. This lead to the situation that the user does not
    know which path will be mounted if starting a restored container.
    
    Now CRI-O will refuse to restore a container if not all bind mounts are
    defined via the CRI CreateContainer RPC in the CreateContainerRequest
    message.
    
    CRI-O will now return an error that will look something likes this:
    
    Error: the container to restore (7f...be) expects following bind mounts defined (/data,/data2)
    
    Now the user has to explicitly add those bind mounts in the same way as
    it was done during initial container creation.
    
    Signed-off-by: Adrian Reber <areber@redhat.com>
```

/assign kwilczynski

> [!NOTE] 
> This cherry-pickl brings the following Pull Requests as a dependency:
> - https://github.com/cri-o/cri-o/pull/8150
> - https://github.com/cri-o/cri-o/pull/8786

```release-note
- Only restore container if all bind mounts are defined.
- Ensure that the "image" attribute has been provided.
```