### PR TITLE
[release-1.29] Fix failing test following a backport from cri-o/cri-o/pull#8795

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,18 +21,9 @@ jobs:
         run:
           - runner: ubuntu-latest
             arch: amd64
-          - runner: actuated-arm64-4cpu-16gb
-            arch: arm64
     name: binaries / ${{ matrix.run.arch }}
     runs-on: ${{ matrix.run.runner }}
     steps:
-      - uses: alexellis/arkade-get@master
-        with:
-          crane: latest
-          print-summary: false
-      - name: Install vmmeter
-        run: crane export --platform linux/${{ matrix.run.arch }} ghcr.io/openfaasltd/vmmeter:latest | sudo tar -xvf - -C /usr/local/bin
-      - uses: self-actuated/vmmeter-action@master
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
@@ -63,8 +54,6 @@ jobs:
         run:
           - runner: ubuntu-latest
             arch: amd64
-          - runner: actuated-arm64-8cpu-32gb
-            arch: arm64
         runtime:
           - name: conmon
             type: oci
@@ -73,13 +62,6 @@ jobs:
     name: critest / ${{ matrix.runtime.name }} / ${{ matrix.run.arch }}
     runs-on: ${{ matrix.run.runner }}
     steps:
-      - uses: alexellis/arkade-get@master
-        with:
-          crane: latest
-          print-summary: false
-      - name: Install vmmeter
-        run: crane export --platform linux/${{ matrix.run.arch }} ghcr.io/openfaasltd/vmmeter:latest | sudo tar -xvf - -C /usr/local/bin
-      - uses: self-actuated/vmmeter-action@master
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,18 +246,9 @@ jobs:
         run:
           - runner: ubuntu-latest
             arch: amd64
-          - runner: actuated-arm64-4cpu-16gb
-            arch: arm64
     name: unit / ${{ matrix.run.arch }}
     runs-on: ${{ matrix.run.runner }}
     steps:
-      - uses: alexellis/arkade-get@master
-        with:
-          crane: latest
-          print-summary: false
-      - name: Install vmmeter
-        run: crane export --platform linux/${{ matrix.run.arch }} ghcr.io/openfaasltd/vmmeter:latest | sudo tar -xvf - -C /usr/local/bin
-      - uses: self-actuated/vmmeter-action@master
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -375,6 +375,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind ci
/kind failing-test

#### What this PR does / why we need it:

To fix a failing test following a merge of the changes from Pull Request #8795, where a unit test that verifies whether a given pod sandbox ID has been set was missing the required `Metadata` property when setting up `types.ContainerConfig` object for use in the test.

Related:

- https://github.com/cri-o/cri-o/pull/8795
- https://github.com/cri-o/cri-o/pull/8722

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

To be merged after:

- https://github.com/cri-o/cri-o/pull/8806

#### Does this PR introduce a user-facing change?`

```release-note
None
```
