### PR TITLE
Use `monitor_env` for calling the OCI runtime

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1411,6 +1411,7 @@ func (r *runtimeOCI) runtimeCmd(args ...string) (string, error) {
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	cmd.Env = r.handler.MonitorEnv
 	if v, found := os.LookupEnv("XDG_RUNTIME_DIR"); found {
 		cmd.Env = append(cmd.Env, "XDG_RUNTIME_DIR="+v)
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We do not unset the env for calling the runtime directly, but we do when calling conmon(-rs). This behavioral difference should be aligned.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug to always inherit `monitor_env` when calling the OCI runtime.
```
