### PR TITLE
Always clear env even when `monitor_env` is unset

### DIFF
--- a/cmd/crio/daemon_linux.go
+++ b/cmd/crio/daemon_linux.go
@@ -6,7 +6,7 @@ import (
 )
 
 func sdNotify() {
-	if _, err := systemdDaemon.SdNotify(true, "READY=1"); err != nil {
+	if _, err := systemdDaemon.SdNotify(false, "READY=1"); err != nil {
 		logrus.Warnf("Failed to sd_notify systemd: %v", err)
 	}
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
Streamline the behavior to always unset the environment variables even when `monitor_env` is not set. This allows to call `SdNotify(false, "READY=1")` as well without breaking any OCI runtime.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Follow-up on https://github.com/cri-o/cri-o/pull/8808
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
