### PR TITLE
[release-1.25] OCPBUGS-45905: Only restore container if all bind mounts are defined

### DIFF
--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -8,6 +8,7 @@ import (
 
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/checkpoint-restore/go-criu/v6/stats"
+	"github.com/containers/podman/v4/pkg/annotations"
 	"github.com/containers/podman/v4/pkg/checkpoint/crutils"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -29,8 +30,10 @@ func (c *ContainerServer) ContainerRestore(ctx context.Context, opts *ContainerC
 	}
 
 	// Get config.json
-	configFile := filepath.Join(ctr.Dir(), "config.json")
-	ctrSpec, err := generate.NewFromFile(configFile)
+	// This file is generated twice by earlier code. Once in BundlePath() and
+	// once in Dir(). This code takes the version from Dir(), modifies it and
+	// overwrites both versions (Dir() and BundlePath())
+	ctrSpec, err := generate.NewFromFile(filepath.Join(ctr.Dir(), "config.json"))
 	if err != nil {
 		return "", err
 	}
@@ -49,15 +52,6 @@ func (c *ContainerServer) ContainerRestore(ctx context.Context, opts *ContainerC
 		opts.Pod = ctr.Sandbox()
 	}
 	sb, err := c.LookupSandbox(opts.Pod)
-	if err != nil {
-		return "", err
-	}
-	ic := sb.InfraContainer()
-	if ic == nil {
-		return "", fmt.Errorf("infra container of sandbox %v not found", sb.Name())
-	}
-	infraConfigFile := filepath.Join(ic.BundlePath(), "config.json")
-	specgen, err := generate.NewFromFile(infraConfigFile)
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +88,55 @@ func (c *ContainerServer) ContainerRestore(ctx context.Context, opts *ContainerC
 		}
 	}
 
-	if err := c.runtime.RestoreContainer(ctx, ctr, specgen.Config, ic.State().Pid, sb.CgroupParent()); err != nil {
+	// We need to adapt the to be restored container to the sandbox created for this container.
+
+	// The container will be restored in another sandbox. Adapt to
+	// namespaces of the new sandbox
+	for i, n := range ctrSpec.Config.Linux.Namespaces {
+		if n.Path == "" {
+			// The namespace in the original container did not point to
+			// an existing interface. Leave it as it is.
+			// CRIU will restore the namespace
+			continue
+		}
+		for _, np := range sb.NamespacePaths() {
+			if string(np.Type()) == string(n.Type) {
+				ctrSpec.Config.Linux.Namespaces[i].Path = np.Path()
+				break
+			}
+		}
+	}
+
+	// Update Sandbox Name
+	ctrSpec.AddAnnotation(annotations.SandboxName, sb.Name())
+	// Update Sandbox ID
+	ctrSpec.AddAnnotation(annotations.SandboxID, opts.Pod)
+
+	mData := fmt.Sprintf(
+		"k8s_%s_%s_%s_%s0",
+		ctr.Name(),
+		sb.KubeName(),
+		sb.Namespace(),
+		sb.Metadata().Uid,
+	)
+	ctrSpec.AddAnnotation(annotations.Name, mData)
+
+	ctr.SetSandbox(opts.Pod)
+
+	saveOptions := generate.ExportOptions{}
+	if err := ctrSpec.SaveToFile(filepath.Join(ctr.Dir(), "config.json"), saveOptions); err != nil {
+		return "", err
+	}
+	if err := ctrSpec.SaveToFile(filepath.Join(ctr.BundlePath(), "config.json"), saveOptions); err != nil {
+		return "", err
+	}
+
+	if err := c.runtime.RestoreContainer(
+		ctx,
+		ctr,
+		sb.CgroupParent(),
+		sb.MountLabel(),
+	); err != nil {
 		return "", fmt.Errorf("failed to restore container %s: %w", ctr.ID(), err)
 	}
 	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {

--- a/internal/lib/restore_test.go
+++ b/internal/lib/restore_test.go
@@ -87,7 +87,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			// Then
 			Expect(err).NotTo(BeNil())
 			Expect(res).To(Equal(""))
-			Expect(err.Error()).To(Equal(`infra container of sandbox  not found`))
+			Expect(err.Error()).To(Equal(`failed to restore container containerID: a complete checkpoint for this container cannot be found, cannot restore: stat checkpoint/inventory.img: no such file or directory`))
 		})
 	})
 	t.Describe("ContainerRestore", func() {

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -75,7 +75,7 @@ type RuntimeImpl interface {
 		int32, io.ReadWriteCloser) error
 	ReopenContainerLog(context.Context, *Container) error
 	CheckpointContainer(context.Context, *Container, *rspec.Spec, bool) error
-	RestoreContainer(context.Context, *Container, *rspec.Spec, int, string) error
+	RestoreContainer(context.Context, *Container, string, string) error
 }
 
 // New creates a new Runtime with options provided
@@ -397,11 +397,11 @@ func (r *Runtime) CheckpointContainer(ctx context.Context, c *Container, specgen
 }
 
 // RestoreContainer restores a container.
-func (r *Runtime) RestoreContainer(ctx context.Context, c *Container, sbSpec *rspec.Spec, infraPid int, cgroupParent string) error {
+func (r *Runtime) RestoreContainer(ctx context.Context, c *Container, cgroupParent, mountLabel string) error {
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
 	}
 
-	return impl.RestoreContainer(ctx, c, sbSpec, infraPid, cgroupParent)
+	return impl.RestoreContainer(ctx, c, cgroupParent, mountLabel)
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -18,7 +18,6 @@ import (
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/containernetworking/plugins/pkg/ns"
 	conmonconfig "github.com/containers/conmon/runner/config"
-	"github.com/containers/podman/v4/pkg/annotations"
 	"github.com/containers/podman/v4/pkg/checkpoint/crutils"
 	"github.com/containers/podman/v4/pkg/criu"
 	"github.com/containers/storage/pkg/pools"
@@ -31,7 +30,6 @@ import (
 	"github.com/fsnotify/fsnotify"
 	json "github.com/json-iterator/go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
@@ -1527,7 +1525,7 @@ func (r *runtimeOCI) CheckpointContainer(ctx context.Context, c *Container, spec
 }
 
 // RestoreContainer restores a container.
-func (r *runtimeOCI) RestoreContainer(ctx context.Context, c *Container, sbSpec *rspec.Spec, infraPid int, cgroupParent string) error {
+func (r *runtimeOCI) RestoreContainer(ctx context.Context, c *Container, cgroupParent, mountLabel string) error {
 	if err := r.checkpointRestoreSupported(); err != nil {
 		return err
 	}
@@ -1554,78 +1552,6 @@ func (r *runtimeOCI) RestoreContainer(ctx context.Context, c *Container, sbSpec 
 		return fmt.Errorf("error removing container %s winsz file: %w", c.ID(), err)
 	}
 
-	// Figure out if this container will be restored in another sandbox
-	oldSbID := c.Sandbox()
-	if oldSbID == "" {
-		return fmt.Errorf("failed to detect sandbox of to be restored container %s", c.ID())
-	}
-	newSbID := sbSpec.Annotations[annotations.SandboxID]
-	if newSbID == "" {
-		return fmt.Errorf("failed to detect destination sandbox of to be restored container %s", c.ID())
-	}
-
-	// Get config.json to adapt for restore (mostly annotations for restore in another sandbox)
-	configFile := filepath.Join(c.BundlePath(), "config.json")
-	specgen, err := generate.NewFromFile(configFile)
-	if err != nil {
-		return err
-	}
-
-	if oldSbID != newSbID {
-		// The container will be restored in another (not the original) sandbox
-		// Adapt to namespaces of the new sandbox
-		for i, n := range specgen.Config.Linux.Namespaces {
-			if n.Path == "" {
-				// The namespace in the original container did not point to
-				// an existing interface. Leave it as it is.
-				continue
-			}
-			for _, on := range sbSpec.Linux.Namespaces {
-				if on.Type == n.Type {
-					var nsPath string
-					if n.Type == rspec.NetworkNamespace {
-						// Type for network namespaces is 'network'.
-						// The kernel link is 'net'.
-						nsPath = fmt.Sprintf("/proc/%d/ns/%s", infraPid, "net")
-					} else {
-						nsPath = fmt.Sprintf("/proc/%d/ns/%s", infraPid, n.Type)
-					}
-					specgen.Config.Linux.Namespaces[i].Path = nsPath
-					break
-				}
-			}
-		}
-
-		// Update Sandbox Name
-		specgen.AddAnnotation(annotations.SandboxName, sbSpec.Annotations[annotations.Name])
-		// Update Sandbox ID
-		specgen.AddAnnotation(annotations.SandboxID, newSbID)
-
-		// Update Name
-		ctrMetadata := types.ContainerMetadata{}
-		err = json.Unmarshal([]byte(sbSpec.Annotations[annotations.Metadata]), &ctrMetadata)
-		if err != nil {
-			return err
-		}
-		ctrName := ctrMetadata.Name
-
-		podMetadata := types.PodSandboxMetadata{}
-		err = json.Unmarshal([]byte(specgen.Config.Annotations[annotations.Metadata]), &podMetadata)
-		if err != nil {
-			return err
-		}
-		uid := podMetadata.Uid
-		mData := fmt.Sprintf("k8s_%s_%s_%s_%s0", ctrName, sbSpec.Annotations[annotations.KubeName], sbSpec.Annotations[annotations.Namespace], uid)
-		specgen.AddAnnotation(annotations.Name, mData)
-
-		c.SetSandbox(newSbID)
-
-		saveOptions := generate.ExportOptions{}
-		if err := specgen.SaveToFile(configFile, saveOptions); err != nil {
-			return err
-		}
-	}
-
 	c.state.InitPid = 0
 	c.state.InitStartTime = ""
 
@@ -1638,7 +1564,7 @@ func (r *runtimeOCI) RestoreContainer(ctx context.Context, c *Container, sbSpec 
 	if err := crutils.CRCreateFileWithLabel(
 		c.BundlePath(),
 		metadata.RestoreLogFile,
-		specgen.Config.Linux.MountLabel,
+		mountLabel,
 	); err != nil {
 		return err
 	}

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -157,11 +157,10 @@ func (r *runtimePod) CheckpointContainer(
 func (r *runtimePod) RestoreContainer(
 	ctx context.Context,
 	c *Container,
-	sbSpec *rspec.Spec,
-	infraPid int,
 	cgroupParent string,
+	mountLabel string,
 ) error {
-	return r.oci.RestoreContainer(ctx, c, sbSpec, infraPid, cgroupParent)
+	return r.oci.RestoreContainer(ctx, c, cgroupParent, mountLabel)
 }
 
 func (r *runtimePod) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -1054,7 +1054,7 @@ func (r *runtimeVM) CheckpointContainer(ctx context.Context, c *Container, specg
 }
 
 // RestoreContainer not implemented for runtimeVM
-func (r *runtimeVM) RestoreContainer(ctx context.Context, c *Container, sbSpec *rspec.Spec, infraPid int, cgroupParent string) error {
+func (r *runtimeVM) RestoreContainer(ctx context.Context, c *Container, cgroupParent, mountLabel string) error {
 	logrus.Debug("runtimeVM.RestoreContainer() start")
 	defer logrus.Debug("runtimeVM.RestoreContainer() end")
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -346,11 +346,9 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 		// it to the checkpoint code.
 		ctrID, err := s.CRImportCheckpoint(
 			ctx,
-			req.Config.Image.Image,
+			req.Config,
 			req.PodSandboxId,
 			req.SandboxConfig.Metadata.Uid,
-			req.Config.Mounts,
-			req.Config.Annotations,
 		)
 		if err != nil {
 			return nil, err

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -33,7 +33,7 @@ func (s *Server) CRImportCheckpoint(
 		return "", errors.New(`attribute "image" missing from container definition`)
 	}
 
-	if createConfig.Metadata == nil && createConfig.Metadata.Name == "" {
+	if createConfig.Metadata == nil || createConfig.Metadata.Name == "" {
 		return "", errors.New(`attribute "metadata" missing from container definition`)
 	}
 
@@ -197,12 +197,15 @@ func (s *Server) CRImportCheckpoint(
 
 		bindMountFound := false
 		for _, createMount := range createMounts {
-			if createMount.ContainerPath == m.Destination {
-				mount.HostPath = createMount.HostPath
-				mount.Readonly = createMount.Readonly
-				mount.Propagation = createMount.Propagation
-				bindMountFound = true
+			if createMount.ContainerPath != m.Destination {
+				continue
 			}
+
+			bindMountFound = true
+			mount.HostPath = createMount.HostPath
+			mount.Readonly = createMount.Readonly
+			mount.Propagation = createMount.Propagation
+			break
 		}
 
 		if !bindMountFound {

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/containers/podman/v4/pkg/annotations"
@@ -32,9 +33,14 @@ func (s *Server) CRImportCheckpoint(
 		return "", errors.New(`attribute "image" missing from container definition`)
 	}
 
+	if createConfig.Metadata == nil && createConfig.Metadata.Name == "" {
+		return "", errors.New(`attribute "metadata" missing from container definition`)
+	}
+
 	inputImage := createConfig.Image.Image
 	createMounts := createConfig.Mounts
 	createAnnotations := createConfig.Annotations
+	createLabels := createConfig.Labels
 
 	// First get the container definition from the
 	// tarball to a temporary directory
@@ -89,43 +95,25 @@ func (s *Server) CRImportCheckpoint(
 		ctrID = ""
 	}
 
-	ctrMetadata := types.ContainerMetadata{}
 	originalAnnotations := make(map[string]string)
-	originalLabels := make(map[string]string)
 
-	if dumpSpec.Annotations[annotations.ContainerManager] == "libpod" {
-		// This is an import from Podman
-		ctrMetadata.Name = config.Name
-		ctrMetadata.Attempt = 0
-	} else {
-		if err := json.Unmarshal([]byte(dumpSpec.Annotations[annotations.Metadata]), &ctrMetadata); err != nil {
-			return "", fmt.Errorf("failed to read %q: %w", annotations.Metadata, err)
+	if err := json.Unmarshal([]byte(dumpSpec.Annotations[annotations.Annotations]), &originalAnnotations); err != nil {
+		return "", fmt.Errorf("failed to read %q: %w", annotations.Annotations, err)
+	}
+
+	if sandboxUID != "" {
+		if _, ok := originalAnnotations[kubetypes.KubernetesPodUIDLabel]; ok {
+			originalAnnotations[kubetypes.KubernetesPodUIDLabel] = sandboxUID
 		}
+	}
 
-		if err := json.Unmarshal([]byte(dumpSpec.Annotations[annotations.Annotations]), &originalAnnotations); err != nil {
-			return "", fmt.Errorf("failed to read %q: %w", annotations.Annotations, err)
-		}
+	if createAnnotations != nil {
+		// The hash also needs to be update or Kubernetes thinks the container needs to be restarted
+		_, ok1 := createAnnotations["io.kubernetes.container.hash"]
+		_, ok2 := originalAnnotations["io.kubernetes.container.hash"]
 
-		if err := json.Unmarshal([]byte(dumpSpec.Annotations[annotations.Labels]), &originalLabels); err != nil {
-			return "", fmt.Errorf("failed to read %q: %w", annotations.Labels, err)
-		}
-		if sandboxUID != "" {
-			if _, ok := originalLabels[kubetypes.KubernetesPodUIDLabel]; ok {
-				originalLabels[kubetypes.KubernetesPodUIDLabel] = sandboxUID
-			}
-			if _, ok := originalAnnotations[kubetypes.KubernetesPodUIDLabel]; ok {
-				originalAnnotations[kubetypes.KubernetesPodUIDLabel] = sandboxUID
-			}
-		}
-
-		if createAnnotations != nil {
-			// The hash also needs to be update or Kubernetes thinks the container needs to be restarted
-			_, ok1 := createAnnotations["io.kubernetes.container.hash"]
-			_, ok2 := originalAnnotations["io.kubernetes.container.hash"]
-
-			if ok1 && ok2 {
-				originalAnnotations["io.kubernetes.container.hash"] = createAnnotations["io.kubernetes.container.hash"]
-			}
+		if ok1 && ok2 {
+			originalAnnotations["io.kubernetes.container.hash"] = createAnnotations["io.kubernetes.container.hash"]
 		}
 	}
 
@@ -151,8 +139,8 @@ func (s *Server) CRImportCheckpoint(
 
 	containerConfig := &types.ContainerConfig{
 		Metadata: &types.ContainerMetadata{
-			Name:    ctrMetadata.Name,
-			Attempt: ctrMetadata.Attempt,
+			Name:    createConfig.Metadata.Name,
+			Attempt: createConfig.Metadata.Attempt,
 		},
 		Image: &types.ImageSpec{Image: config.RootfsImageName},
 		Linux: &types.LinuxContainerConfig{
@@ -160,7 +148,9 @@ func (s *Server) CRImportCheckpoint(
 			SecurityContext: &types.LinuxContainerSecurityContext{},
 		},
 		Annotations: originalAnnotations,
-		Labels:      originalLabels,
+		// The labels are nod changed or adapted. They are just taken from the CRI
+		// request without any modification (in contrast to the annotations).
+		Labels: createLabels,
 	}
 
 	if createConfig.Linux != nil {
@@ -187,6 +177,13 @@ func (s *Server) CRImportCheckpoint(
 		"/run/.containerenv": true,
 	}
 
+	// It is necessary to ensure that all bind mounts in the checkpoint archive are defined
+	// in the create container requested coming in via the CRI. If this check would not
+	// be here it would be possible to create a checkpoint archive that mounts some random
+	// file/directory on the host with the user knowing as it will happen without specifying
+	// it in the container definition.
+	missingMount := []string{}
+
 	for _, m := range dumpSpec.Mounts {
 		// Following mounts are ignored as they might point to the
 		// wrong location and if ignored the mounts will correctly
@@ -196,31 +193,37 @@ func (s *Server) CRImportCheckpoint(
 		}
 		mount := &types.Mount{
 			ContainerPath: m.Destination,
-			HostPath:      m.Source,
 		}
 
+		bindMountFound := false
 		for _, createMount := range createMounts {
 			if createMount.ContainerPath == m.Destination {
 				mount.HostPath = createMount.HostPath
+				mount.Readonly = createMount.Readonly
+				mount.Propagation = createMount.Propagation
+				bindMountFound = true
 			}
 		}
 
-		for _, opt := range m.Options {
-			switch opt {
-			case "ro":
-				mount.Readonly = true
-			case "rprivate":
-				mount.Propagation = types.MountPropagation_PROPAGATION_PRIVATE
-			case "rshared":
-				mount.Propagation = types.MountPropagation_PROPAGATION_BIDIRECTIONAL
-			case "rslaved":
-				mount.Propagation = types.MountPropagation_PROPAGATION_HOST_TO_CONTAINER
-			}
+		if !bindMountFound {
+			missingMount = append(missingMount, m.Destination)
+			// If one mount is missing we can skip over any further code as we have
+			// to abort the restore process anyway. Not using break to get all missing
+			// mountpoints in one error message.
+			continue
 		}
 
 		logrus.Debugf("Adding mounts %#v", mount)
 		containerConfig.Mounts = append(containerConfig.Mounts, mount)
 	}
+	if len(missingMount) > 0 {
+		return "", fmt.Errorf(
+			"restoring %q expects following bind mounts defined (%s)",
+			inputImage,
+			strings.Join(missingMount, ","),
+		)
+	}
+
 	sandboxConfig := &types.PodSandboxConfig{
 		Metadata: &types.PodSandboxMetadata{
 			Name:      sb.Metadata().Name,

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -23,10 +23,13 @@ import (
 // taken from Podman
 func (s *Server) CRImportCheckpoint(
 	ctx context.Context,
-	input, sbID, sandboxUID string,
-	createMounts []*types.Mount,
-	createAnnotations map[string]string,
+	createConfig *types.ContainerConfig,
+	sbID, sandboxUID string,
 ) (ctrID string, retErr error) {
+	input := createConfig.Image.Image
+	createMounts := createConfig.Mounts
+	createAnnotations := createConfig.Annotations
+
 	// First get the container definition from the
 	// tarball to a temporary directory
 	archiveFile, err := os.Open(input)
@@ -152,6 +155,13 @@ func (s *Server) CRImportCheckpoint(
 		},
 		Annotations: originalAnnotations,
 		Labels:      originalLabels,
+	}
+
+	if createConfig.Linux.Resources != nil {
+		containerConfig.Linux.Resources = createConfig.Linux.Resources
+	}
+	if createConfig.Linux.SecurityContext != nil {
+		containerConfig.Linux.SecurityContext = createConfig.Linux.SecurityContext
 	}
 
 	ignoreMounts := map[string]bool{

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 var _ = t.Describe("ContainerRestore", func() {
@@ -37,14 +38,18 @@ var _ = t.Describe("ContainerRestore", func() {
 	t.Describe("ContainerRestore from archive into new pod", func() {
 		It("should fail because archive does not exist", func() {
 			// Given
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "does-not-exist.tar",
+				},
+			}
+
 			// When
 			_, err := sut.CRImportCheckpoint(
 				context.Background(),
-				"does-not-exist.tar",
+				containerConfig,
 				"",
 				"",
-				nil,
-				nil,
 			)
 
 			// Then
@@ -58,14 +63,17 @@ var _ = t.Describe("ContainerRestore", func() {
 			Expect(err).To(BeNil())
 			archive.Close()
 			defer os.RemoveAll("empty.tar")
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "empty.tar",
+				},
+			}
 			// When
 			_, err = sut.CRImportCheckpoint(
 				context.Background(),
-				"empty.tar",
+				containerConfig,
 				"",
 				"",
-				nil,
-				nil,
 			)
 			// Then
 			Expect(err.Error()).To(ContainSubstring(`failed to read "spec.dump": failed to read`))
@@ -77,17 +85,20 @@ var _ = t.Describe("ContainerRestore", func() {
 			err := os.WriteFile("no.tar", []byte("notar"), 0o644)
 			Expect(err).To(BeNil())
 			defer os.RemoveAll("no.tar")
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "no.tar",
+				},
+			}
 			// When
 			_, err = sut.CRImportCheckpoint(
 				context.Background(),
-				"empty.tar",
+				containerConfig,
 				"",
 				"",
-				nil,
-				nil,
 			)
 			// Then
-			Expect(err.Error()).To(Equal(`failed to open checkpoint archive empty.tar for import: open empty.tar: no such file or directory`))
+			Expect(err.Error()).To(ContainSubstring(`unpacking of checkpoint archive`))
 		})
 	})
 	t.Describe("ContainerRestore from archive into new pod", func() {
@@ -108,14 +119,17 @@ var _ = t.Describe("ContainerRestore", func() {
 			defer os.RemoveAll("archive.tar")
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "archive.tar",
+				},
+			}
 			// When
 			_, err = sut.CRImportCheckpoint(
 				context.Background(),
-				"archive.tar",
+				containerConfig,
 				"",
 				"",
-				nil,
-				nil,
 			)
 			// Then
 			Expect(err.Error()).To(ContainSubstring(`failed to read "spec.dump": failed to unmarshal `))
@@ -142,14 +156,17 @@ var _ = t.Describe("ContainerRestore", func() {
 			defer os.RemoveAll("archive.tar")
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "archive.tar",
+				},
+			}
 			// When
 			_, err = sut.CRImportCheckpoint(
 				context.Background(),
-				"archive.tar",
+				containerConfig,
 				"",
 				"",
-				nil,
-				nil,
 			)
 
 			// Then
@@ -177,15 +194,18 @@ var _ = t.Describe("ContainerRestore", func() {
 			defer os.RemoveAll("archive.tar")
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "archive.tar",
+				},
+			}
 			// When
 
 			_, err = sut.CRImportCheckpoint(
 				context.Background(),
-				"archive.tar",
+				containerConfig,
 				"",
 				"",
-				nil,
-				nil,
 			)
 
 			// Then
@@ -219,15 +239,18 @@ var _ = t.Describe("ContainerRestore", func() {
 			defer os.RemoveAll("archive.tar")
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "archive.tar",
+				},
+			}
 			// When
 
 			_, err = sut.CRImportCheckpoint(
 				context.Background(),
-				"archive.tar",
+				containerConfig,
 				"",
 				"",
-				nil,
-				nil,
 			)
 
 			// Then
@@ -264,15 +287,18 @@ var _ = t.Describe("ContainerRestore", func() {
 			defer os.RemoveAll("archive.tar")
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "archive.tar",
+				},
+			}
 			// When
 
 			_, err = sut.CRImportCheckpoint(
 				context.Background(),
-				"archive.tar",
+				containerConfig,
 				"",
 				"",
-				nil,
-				nil,
 			)
 
 			// Then

--- a/server/container_restore_test.go
+++ b/server/container_restore_test.go
@@ -8,8 +8,11 @@ import (
 	"github.com/containers/podman/v4/pkg/criu"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -39,6 +42,7 @@ var _ = t.Describe("ContainerRestore", func() {
 		It("should fail because archive does not exist", func() {
 			// Given
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "does-not-exist.tar",
 				},
@@ -64,6 +68,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			archive.Close()
 			defer os.RemoveAll("empty.tar")
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "empty.tar",
 				},
@@ -86,6 +91,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			Expect(err).To(BeNil())
 			defer os.RemoveAll("no.tar")
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "no.tar",
 				},
@@ -120,6 +126,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -157,6 +164,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -170,7 +178,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			)
 
 			// Then
-			Expect(err.Error()).To(ContainSubstring(`failed to read "io.kubernetes.cri-o.Metadata": unexpected end of JSON input`))
+			Expect(err.Error()).To(ContainSubstring(`failed to read "io.kubernetes.cri-o.Annotations": unexpected end of JSON input`))
 		})
 	})
 	t.Describe("ContainerRestore from archive into new pod", func() {
@@ -195,6 +203,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -240,6 +249,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -288,6 +298,7 @@ var _ = t.Describe("ContainerRestore", func() {
 			_, err = io.Copy(outFile, input)
 			Expect(err).To(BeNil())
 			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
 				Image: &types.ImageSpec{
 					Image: "archive.tar",
 				},
@@ -303,6 +314,157 @@ var _ = t.Describe("ContainerRestore", func() {
 
 			// Then
 			Expect(err.Error()).To(Equal(`failed to read "io.kubernetes.cri-o.Annotations": unexpected end of JSON input`))
+		})
+	})
+	t.Describe("ContainerRestore from archive into new pod", func() {
+		It("should fail with 'PodSandboxId should not be empty'", func() {
+			// Given
+			addContainerAndSandbox()
+			testContainer.SetStateAndSpoofPid(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateRunning},
+			})
+
+			err := os.WriteFile(
+				"spec.dump",
+				[]byte(
+					`{"annotations":{"io.kubernetes.cri-o.Metadata"`+
+						`:"{\"name\":\"container-to-restore\"}",`+
+						`"io.kubernetes.cri-o.Annotations": "{\"name\":\"NAME\"}",`+
+						`"io.kubernetes.cri-o.Labels": "{\"io.kubernetes.container.name\":\"counter\"}"}}`),
+				0o644,
+			)
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("spec.dump")
+			err = os.WriteFile("config.dump", []byte(`{"rootfsImageName": "image"}`), 0o644)
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("config.dump")
+			outFile, err := os.Create("archive.tar")
+			Expect(err).To(BeNil())
+			defer outFile.Close()
+			input, err := archive.TarWithOptions(".", &archive.TarOptions{
+				Compression:      archive.Uncompressed,
+				IncludeSourceDir: true,
+				IncludeFiles:     []string{"spec.dump", "config.dump"},
+			})
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("archive.tar")
+			_, err = io.Copy(outFile, input)
+			Expect(err).To(BeNil())
+			containerConfig := &types.ContainerConfig{
+				Metadata: &types.ContainerMetadata{Name: "name"},
+				Image: &types.ImageSpec{
+					Image: "archive.tar",
+				},
+			}
+			// When
+
+			_, err = sut.CRImportCheckpoint(
+				context.Background(),
+				containerConfig,
+				"",
+				"",
+			)
+
+			// Then
+			Expect(err.Error()).To(Equal(`PodSandboxId should not be empty`))
+		})
+	})
+	t.Describe("ContainerRestore from archive into new pod", func() {
+		It("should succeed", func() {
+			// Given
+			addContainerAndSandbox()
+			testContainer.SetStateAndSpoofPid(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateRunning},
+			})
+
+			err := os.WriteFile(
+				"spec.dump",
+				[]byte(`{"annotations":{"io.kubernetes.cri-o.Metadata"`+
+					`:"{\"name\":\"container-to-restore\"}",`+
+					`"io.kubernetes.cri-o.Annotations": "{\"name\":\"NAME\"}",`+
+					`"io.kubernetes.cri-o.Labels": "{\"io.kubernetes.container.name\":\"counter\"}",`+
+					`"io.kubernetes.cri-o.SandboxID": "sandboxID"},`+
+					`"mounts": [{"destination": "/proc"},`+
+					`{"destination":"/data","source":"/data","options":`+
+					`["rw","ro","rbind","rprivate","rshared","rslaved"]}],`+
+					`"linux": {"maskedPaths": ["/proc/acpi"], "readonlyPaths": ["/proc/asound"]}}`),
+				0o644,
+			)
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("spec.dump")
+			err = os.WriteFile("config.dump", []byte(`{"rootfsImageName": "image"}`), 0o644)
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("config.dump")
+			outFile, err := os.Create("archive.tar")
+			Expect(err).To(BeNil())
+			defer outFile.Close()
+			input, err := archive.TarWithOptions(".", &archive.TarOptions{
+				Compression:      archive.Uncompressed,
+				IncludeSourceDir: true,
+				IncludeFiles:     []string{"spec.dump", "config.dump"},
+			})
+			Expect(err).To(BeNil())
+			defer os.RemoveAll("archive.tar")
+			_, err = io.Copy(outFile, input)
+			Expect(err).To(BeNil())
+			containerConfig := &types.ContainerConfig{
+				Image: &types.ImageSpec{
+					Image: "archive.tar",
+				},
+				Linux: &types.LinuxContainerConfig{
+					Resources:       &types.LinuxContainerResources{},
+					SecurityContext: &types.LinuxContainerSecurityContext{},
+				},
+				Metadata: &types.ContainerMetadata{
+					Name: "new-container-name",
+				},
+				Mounts: []*types.Mount{{
+					ContainerPath: "/data",
+					HostPath:      "/data",
+				}},
+			}
+
+			size := uint64(100)
+			gomock.InOrder(
+				imageServerMock.EXPECT().ResolveNames(
+					gomock.Any(), gomock.Any()).
+					Return([]string{"image"}, nil),
+
+				imageServerMock.EXPECT().ImageStatus(
+					gomock.Any(), gomock.Any()).
+					Return(&storage.ImageResult{
+						ID:   "image",
+						User: "10", Size: &size,
+					}, nil),
+
+				runtimeServerMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any()).
+					Return(storage.ContainerInfo{
+						Config: &v1.Image{
+							Config: v1.ImageConfig{
+								Entrypoint: []string{"sh"},
+							},
+						},
+					},
+						nil,
+					),
+				runtimeServerMock.EXPECT().StartContainer(gomock.Any()).
+					Return(emptyDir, nil),
+			)
+
+			// When
+
+			_, err = sut.CRImportCheckpoint(
+				context.Background(),
+				containerConfig,
+				"",
+				"",
+			)
+
+			// Then
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -14,7 +14,31 @@ function teardown() {
 	cleanup_test
 }
 
-@test "checkpoint and restore one container into a new pod using --export" {
+@test "checkpoint and restore one container into a new pod (drop infra:true)" {
+	CONTAINER_DROP_INFRA_CTR=true CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	BIND_MOUNT_FILE=$(mktemp)
+	BIND_MOUNT_DIR=$(mktemp -d)
+	jq ". +{mounts:[{\"container_path\":\"/etc/issue\",\"host_path\":\"$BIND_MOUNT_FILE\"},{\"container_path\":\"/data\",\"host_path\":\"$BIND_MOUNT_DIR\"}]}" "$TESTDATA"/container_sleep.json > "$TESTDATA"/checkpoint.json
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/checkpoint.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	crictl checkpoint --export="$TESTDIR"/cp.tar "$ctr_id"
+	crictl rm -f "$ctr_id"
+	crictl rmp -f "$pod_id"
+	rm -f "$BIND_MOUNT_FILE"
+	rmdir "$BIND_MOUNT_DIR"
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	# Replace original container with checkpoint image
+	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
+	rm -f "$TESTDATA"/restore.json
+	rm -f "$TESTDATA"/checkpoint.json
+	crictl start "$ctr_id"
+	rm -f "$BIND_MOUNT_FILE"
+	rmdir "$BIND_MOUNT_DIR"
+}
+
+@test "checkpoint and restore one container into a new pod (drop infra:false)" {
 	CONTAINER_DROP_INFRA_CTR=false CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)

--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -29,9 +29,16 @@ function teardown() {
 	rmdir "$BIND_MOUNT_DIR"
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# Replace original container with checkpoint image
-	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$TESTDATA"/restore.json
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/restore.json "$TESTDATA"/sandbox_config.json)
-	rm -f "$TESTDATA"/restore.json
+	RESTORE_JSON=$(mktemp)
+	RESTORE2_JSON=$(mktemp)
+	jq ".image.image=\"$TESTDIR/cp.tar\"" "$TESTDATA"/container_sleep.json > "$RESTORE_JSON"
+	# This should fail because the bind mounts are not part of the create request
+	run crictl create "$pod_id" "$RESTORE_JSON" "$TESTDATA"/sandbox_config.json
+	[ "$status" -eq 1 ]
+	jq ". +{mounts:[{\"container_path\":\"/etc/issue\",\"host_path\":\"$BIND_MOUNT_FILE\"},{\"container_path\":\"/data\",\"host_path\":\"$BIND_MOUNT_DIR\"}]}" "$RESTORE_JSON" > "$RESTORE2_JSON"
+	ctr_id=$(crictl create "$pod_id" "$RESTORE2_JSON" "$TESTDATA"/sandbox_config.json)
+	rm -f "$RESTORE_JSON"
+	rm -f "$RESTORE2_JSON"
 	rm -f "$TESTDATA"/checkpoint.json
 	crictl start "$ctr_id"
 	rm -f "$BIND_MOUNT_FILE"

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -183,17 +183,17 @@ func (mr *MockRuntimeImplMockRecorder) ReopenContainerLog(arg0, arg1 interface{}
 }
 
 // RestoreContainer mocks base method.
-func (m *MockRuntimeImpl) RestoreContainer(arg0 context.Context, arg1 *oci.Container, arg2 *specs.Spec, arg3 int, arg4 string) error {
+func (m *MockRuntimeImpl) RestoreContainer(arg0 context.Context, arg1 *oci.Container, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestoreContainer", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RestoreContainer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RestoreContainer indicates an expected call of RestoreContainer.
-func (mr *MockRuntimeImplMockRecorder) RestoreContainer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) RestoreContainer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).RestoreContainer), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).RestoreContainer), arg0, arg1, arg2, arg3)
 }
 
 // SignalContainer mocks base method.


### PR DESCRIPTION
This is a manual cherry-pick of commit 429ef7c36

```mail
commit 429ef7c366406280cfa3daa15812d14b22953a7a
Author: Adrian Reber <areber@redhat.com>
Date:   Mon Sep 30 23:37:13 2024

    Only restore container if all bind mounts are defined
    
    To avoid the situation where a container that is restored via a registry
    mounts unexpected host paths into the container, this changes the
    restore behaviour of CRI-O.
    
    Previously all bind mounted paths in the original container which were
    defined for example like this:
    
        volumeMounts:
        - mountPath: /data
          name: data-volume
      volumes:
      - name: data-volume
        hostPath:
          path: /srv/container/data
    
    Were automatically mounted in the restored container without and
    definition necessary. This lead to the situation that the user does not
    know which path will be mounted if starting a restored container.
    
    Now CRI-O will refuse to restore a container if not all bind mounts are
    defined via the CRI CreateContainer RPC in the CreateContainerRequest
    message.
    
    CRI-O will now return an error that will look something likes this:
    
    Error: the container to restore (7f...be) expects following bind mounts defined (/data,/data2)
    
    Now the user has to explicitly add those bind mounts in the same way as
    it was done during initial container creation.
    
    Signed-off-by: Adrian Reber <areber@redhat.com>
```

/assign kwilczynski

> [!NOTE] 
> This cherry-pickl brings the following Pull Requests as a dependency:
> - https://github.com/cri-o/cri-o/pull/6379
> - https://github.com/cri-o/cri-o/pull/8150
> - https://github.com/cri-o/cri-o/pull/8786

```release-note
- Only restore container if all bind mounts are defined.
- Ensure that the "image" attribute has been provided.
- Add support to checkpoint and restore containers in pods without infrastructure containers.
```