### PR TITLE
Fix issues when running on Linux with seccomp disabled

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -532,6 +532,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		return nil, fmt.Errorf("filter image annotations: %w", err)
 	}
 
+	if s.config.Seccomp().IsDisabled() {
+		specgen.Config.Linux.Seccomp = nil
+	}
+
 	if !ctr.Privileged() {
 		notifier, ref, err := s.config.Seccomp().Setup(
 			ctx,

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -893,6 +893,10 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 
 	sb.SetNamespaceOptions(securityContext.NamespaceOptions)
 
+	if s.config.Seccomp().IsDisabled() {
+		g.Config.Linux.Seccomp = nil
+	}
+
 	seccompRef := types.SecurityProfile_Unconfined.String()
 	if !privileged {
 		_, ref, err := s.config.Seccomp().Setup(

--- a/server/server.go
+++ b/server/server.go
@@ -508,7 +508,9 @@ func New(
 		log.Debugf(ctx, "Metrics are disabled")
 	}
 
-	if err := s.startSeccompNotifierWatcher(ctx); err != nil {
+	if s.config.Seccomp().IsDisabled() {
+		log.Infof(ctx, "Seccomp is disabled. Not starting notifier watcher")
+	} else if err := s.startSeccompNotifierWatcher(ctx); err != nil {
 		return nil, fmt.Errorf("start seccomp notifier watcher: %w", err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

While I re-allowed building cri-o for Linux without seccomp in #8686 I later found some issues with it when actually running it. So this PR fixes some issues I found when running cri-o on a Linux system where both cri-o and runtime were compiled without seccomp support.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
