### PR TITLE
[release-1.30] OCPBUGS-46026: Cherry-pick changes from containers/storage project

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.1.10
 	github.com/containers/podman/v4 v4.9.3
-	github.com/containers/storage v1.51.1-0.20250123153027-e1bc50e6f958
+	github.com/containers/storage v1.51.1-0.20241210064209-75435e49ced3
 	github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -747,8 +747,8 @@ github.com/containers/ocicrypt v1.1.10 h1:r7UR6o8+lyhkEywetubUUgcKFjOWOaWz8cEBrC
 github.com/containers/ocicrypt v1.1.10/go.mod h1:YfzSSr06PTHQwSTUKqDSjish9BeW1E4HUmreluQcMd8=
 github.com/containers/podman/v4 v4.9.3 h1:3tEnvIqijxBYtILRdHcbn0UNHAyUiQ1Y5hcvkYmutZA=
 github.com/containers/podman/v4 v4.9.3/go.mod h1:J2qLop+mWjAOxh0QQyYPdnPA3jI6ay2eU0OKakgMniQ=
-github.com/containers/storage v1.51.1-0.20250123153027-e1bc50e6f958 h1:jcI4WOwt+Q4t2tGCVk03i/wbmIDfLTHkt+iKbpMZpuA=
-github.com/containers/storage v1.51.1-0.20250123153027-e1bc50e6f958/go.mod h1:W+4hYMT3FHhVMqf+J//T3+uDRfqKh5IPx+6m4xb8EhY=
+github.com/containers/storage v1.51.1-0.20241210064209-75435e49ced3 h1:gxrr8HDgDQI8kXGi08/PeQhQpT/SiirchFkolq454qU=
+github.com/containers/storage v1.51.1-0.20241210064209-75435e49ced3/go.mod h1:1vrhsjgb/mfuIOGk1TIX6890/LGWhC8Kqzps3Bh0CRA=
 github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09 h1:OoRAFlvDGCUqDLampLQjk0yeeSGdF9zzst/3G9IkBbc=
 github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09/go.mod h1:m2r/smMKsKwgMSAoFKHaa68ImdCSNuKE1MxvQ64xuCQ=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=

--- a/vendor/github.com/containers/storage/pkg/chrootarchive/archive.go
+++ b/vendor/github.com/containers/storage/pkg/chrootarchive/archive.go
@@ -46,7 +46,7 @@ func Untar(tarArchive io.Reader, dest string, options *archive.TarOptions) error
 // This should be used to prevent a potential attacker from manipulating `dest`
 // such that it would provide access to files outside of `dest` through things
 // like symlinks. Normally `ResolveSymlinksInScope` would handle this, however
-// sanitizing symlinks in this manner is inherently racey:
+// sanitizing symlinks in this manner is inherrently racey:
 // ref: CVE-2018-15664
 func UntarWithRoot(tarArchive io.Reader, dest string, options *archive.TarOptions, root string) error {
 	return untarHandler(tarArchive, dest, options, true, root)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -351,7 +351,7 @@ github.com/containers/ocicrypt/utils/keyprovider
 # github.com/containers/podman/v4 v4.9.3
 ## explicit; go 1.18
 github.com/containers/podman/v4/pkg/checkpoint/crutils
-# github.com/containers/storage v1.51.1-0.20250123153027-e1bc50e6f958
+# github.com/containers/storage v1.51.1-0.20241210064209-75435e49ced3
 ## explicit; go 1.19
 github.com/containers/storage
 github.com/containers/storage/drivers


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/assign kwilczynski

#### What this PR does / why we need it:

Manually cherry-pick changes from [containers/storage](https://github.com/containers/storage) project.

These changes carry fixes that need to be backported to CRI-O.

Related:

- https://github.com/containers/storage/pull/2156
- https://github.com/containers/storage/pull/2162
- https://github.com/containers/storage/pull/2185

> [!NOTE] 
> This cherry-pick brings the following Pull Request as a dependency:
> - https://github.com/containers/storage/pull/1833

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```