### PR TITLE
Remove old golang build tags

### DIFF
--- a/cmd/crio/daemon_unsupported.go
+++ b/cmd/crio/daemon_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package main
 

--- a/internal/config/apparmor/apparmor_unsupported.go
+++ b/internal/config/apparmor/apparmor_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package apparmor
 

--- a/internal/config/capabilities/capabilities_unsupported.go
+++ b/internal/config/capabilities/capabilities_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package capabilities
 

--- a/internal/config/cgmgr/cgmgr_linux.go
+++ b/internal/config/cgmgr/cgmgr_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgmgr
 

--- a/internal/config/cgmgr/cgmgr_unsupported.go
+++ b/internal/config/cgmgr/cgmgr_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package cgmgr
 

--- a/internal/config/cgmgr/cgroupfs_linux.go
+++ b/internal/config/cgmgr/cgroupfs_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgmgr
 

--- a/internal/config/cgmgr/stats_unsupported.go
+++ b/internal/config/cgmgr/stats_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package cgmgr
 

--- a/internal/config/cgmgr/systemd_linux.go
+++ b/internal/config/cgmgr/systemd_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgmgr
 

--- a/internal/config/cnimgr/cnimgr_test_inject.go
+++ b/internal/config/cnimgr/cnimgr_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/internal/config/device/device_unsupported.go
+++ b/internal/config/device/device_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package device
 

--- a/internal/config/node/cgroups_linux.go
+++ b/internal/config/node/cgroups_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package node
 

--- a/internal/config/node/cgroups_unsupported.go
+++ b/internal/config/node/cgroups_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package node
 

--- a/internal/config/node/node_linux.go
+++ b/internal/config/node/node_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package node
 

--- a/internal/config/node/node_unsupported.go
+++ b/internal/config/node/node_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package node
 

--- a/internal/config/node/systemd_linux.go
+++ b/internal/config/node/systemd_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package node
 

--- a/internal/config/node/systemd_unsupported.go
+++ b/internal/config/node/systemd_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package node
 

--- a/internal/config/nsmgr/nsmgr_unsupported.go
+++ b/internal/config/nsmgr/nsmgr_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package nsmgr
 

--- a/internal/config/nsmgr/types_freebsd.go
+++ b/internal/config/nsmgr/types_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package nsmgr
 

--- a/internal/config/nsmgr/types_linux.go
+++ b/internal/config/nsmgr/types_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package nsmgr
 

--- a/internal/config/ociartifact/ociartifact_test_inject.go
+++ b/internal/config/ociartifact/ociartifact_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/internal/config/seccomp/notifier.go
+++ b/internal/config/seccomp/notifier.go
@@ -1,5 +1,4 @@
 //go:build seccomp && linux && cgo
-// +build seccomp,linux,cgo
 
 package seccomp
 

--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -1,5 +1,4 @@
 //go:build seccomp && linux && cgo
-// +build seccomp,linux,cgo
 
 package seccomp
 

--- a/internal/config/seccomp/seccomp_unsupported.go
+++ b/internal/config/seccomp/seccomp_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !(seccomp && linux && cgo)
-// +build !seccomp !linux !cgo
 
 package seccomp
 

--- a/internal/config/seccomp/seccompociartifact/seccompociartifact_test_inject.go
+++ b/internal/config/seccomp/seccompociartifact/seccompociartifact_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/internal/dbusmgr/dbusmgr.go
+++ b/internal/dbusmgr/dbusmgr.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Code in this package is heavily adapted from https://github.com/opencontainers/runc/blob/7362fa2d282feffb9b19911150e01e390a23899d/libcontainer/cgroups/systemd
 // Credit goes to the runc authors.

--- a/internal/factory/container/device_unsupported.go
+++ b/internal/factory/container/device_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package container
 

--- a/internal/hostport/hostport_manager_unsupported.go
+++ b/internal/hostport/hostport_manager_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package hostport
 

--- a/internal/iptables/iptables_unsupported.go
+++ b/internal/iptables/iptables_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package iptables
 

--- a/internal/lib/container_server_test_inject.go
+++ b/internal/lib/container_server_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/internal/lib/container_server_unsupported.go
+++ b/internal/lib/container_server_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package lib
 

--- a/internal/lib/sandbox/sandbox_test_inject.go
+++ b/internal/lib/sandbox/sandbox_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/internal/lib/sandbox/sandbox_unsupported.go
+++ b/internal/lib/sandbox/sandbox_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package sandbox
 

--- a/internal/lib/stats/stats_server_unsupported.go
+++ b/internal/lib/stats/stats_server_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package statsserver
 

--- a/internal/nri/container_linux.go
+++ b/internal/nri/container_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package nri
 

--- a/internal/nri/container_other.go
+++ b/internal/nri/container_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package nri
 

--- a/internal/nri/sandbox_linux.go
+++ b/internal/nri/sandbox_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package nri
 

--- a/internal/nri/sandbox_other.go
+++ b/internal/nri/sandbox_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package nri
 

--- a/internal/oci/container_freebsd.go
+++ b/internal/oci/container_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd && cgo
-// +build freebsd,cgo
 
 package oci
 

--- a/internal/oci/container_freebsd_nocgo.go
+++ b/internal/oci/container_freebsd_nocgo.go
@@ -1,5 +1,4 @@
 //go:build freebsd && !cgo
-// +build freebsd,!cgo
 
 package oci
 

--- a/internal/oci/container_test_inject.go
+++ b/internal/oci/container_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/internal/oci/container_unsupported.go
+++ b/internal/oci/container_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package oci
 

--- a/internal/oci/finished.go
+++ b/internal/oci/finished.go
@@ -1,5 +1,4 @@
 //go:build linux && !arm && !386
-// +build linux,!arm,!386
 
 package oci
 

--- a/internal/oci/finished_32.go
+++ b/internal/oci/finished_32.go
@@ -1,5 +1,4 @@
 //go:build (linux && arm) || (linux && 386)
-// +build linux,arm linux,386
 
 package oci
 

--- a/internal/oci/finished_unsupported.go
+++ b/internal/oci/finished_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package oci
 

--- a/internal/oci/oci_unix.go
+++ b/internal/oci/oci_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package oci
 

--- a/internal/oci/oci_unsupported.go
+++ b/internal/oci/oci_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package oci
 

--- a/internal/resourcestore/resourcecleaner_defaults.go
+++ b/internal/resourcestore/resourcecleaner_defaults.go
@@ -1,5 +1,4 @@
 //go:build !test
-// +build !test
 
 package resourcestore
 

--- a/internal/resourcestore/resourcecleaner_test_inject.go
+++ b/internal/resourcestore/resourcecleaner_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_unsupported.go
+++ b/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package runtimehandlerhooks
 

--- a/internal/runtimehandlerhooks/runtime_handler_hooks_unsupported.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package runtimehandlerhooks
 

--- a/internal/signals/signal_unix.go
+++ b/internal/signals/signal_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package signals
 

--- a/internal/storage/image_unsupported.go
+++ b/internal/storage/image_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package storage
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package tools
 

--- a/internal/version/linkmode_dynamic.go
+++ b/internal/version/linkmode_dynamic.go
@@ -1,5 +1,4 @@
 //go:build !static
-// +build !static
 
 package version
 

--- a/internal/version/linkmode_static.go
+++ b/internal/version/linkmode_static.go
@@ -1,5 +1,4 @@
 //go:build static
-// +build static
 
 package version
 

--- a/pkg/config/config_test_inject.go
+++ b/pkg/config/config_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !freebsd
-// +build !windows,!freebsd
 
 package config
 

--- a/pkg/config/config_unsupported.go
+++ b/pkg/config/config_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd && !windows
-// +build !linux,!freebsd,!windows
 
 package config
 

--- a/server/container_create_generic.go
+++ b/server/container_create_generic.go
@@ -1,5 +1,4 @@
 //go:build windows || darwin || freebsd
-// +build windows darwin freebsd
 
 package server
 

--- a/server/container_create_unsupported.go
+++ b/server/container_create_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package server
 

--- a/server/container_remove_unsupported.go
+++ b/server/container_remove_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package server
 

--- a/server/label_unsupported.go
+++ b/server/label_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package server
 

--- a/server/listen_unix.go
+++ b/server/listen_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package server
 

--- a/server/sandbox_run_unsupported.go
+++ b/server/sandbox_run_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package server
 

--- a/server/sandbox_stop_unsupported.go
+++ b/server/sandbox_stop_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package server
 

--- a/server/server_test_inject.go
+++ b/server/server_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/server/server_unsupported.go
+++ b/server/server_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package server
 

--- a/utils/cmdrunner/cmdrunner_test_inject.go
+++ b/utils/cmdrunner/cmdrunner_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/utils/utils_unix.go
+++ b/utils/utils_unix.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package utils
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The old tags are deprecated since go 1.17.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
