### PR TITLE
OCPBUGS-45112: Prevent systemd from blocking irqbalance restarts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,7 @@ install.completions: ## Install the completions.
 install.systemd: ## Install the systemd unit files.
 	install ${SELINUXOPT} -D -m 644 contrib/systemd/crio.service $(PREFIX)/lib/systemd/system/crio.service
 	install ${SELINUXOPT} -D -m 644 contrib/systemd/crio-wipe.service $(PREFIX)/lib/systemd/system/crio-wipe.service
+	install ${SELINUXOPT} -D -m 644 contrib/systemd/irqbalance.conf $(PREFIX)/lib/systemd/system/irqbalance.service.d/restart-limits.conf
 
 .PHONY: uninstall
 uninstall: ## Uninstall all files.

--- a/contrib/systemd/irqbalance.conf
+++ b/contrib/systemd/irqbalance.conf
@@ -1,0 +1,10 @@
+# cri-o high performance runtime handler reconfigures and restarts irqbalance
+# after every container with pinned cpus and moved interrupts is created.
+# Systemd does not like this and will block further restarts when the
+# StartLimitBurst (default 5) is crossed within the default timeout (10s).
+# That is too strict as during system startup many such containers might
+# be launched.
+# Install this to /etc/systemd/system/irqbalance.service.d/restart-limits.conf
+# to prevent systemd from blocking the necessary restarts.
+[Unit]
+StartLimitBurst=100

--- a/contrib/test/ci/cri-o.spec
+++ b/contrib/test/ci/cri-o.spec
@@ -141,6 +141,7 @@ rm -f %{_unitdir}/%{repo}.service
 %config(noreplace) %{_sysconfdir}/cni/net.d/200-loopback.conf
 %config(noreplace) %{_sysconfdir}/crictl.yaml
 %{_unitdir}/%{service_name}.service
+%{_unitdir}/irqbalance.service.d/restart-limits.conf
 %dir %{_sharedstatedir}/containers
 %dir %{_datadir}/oci-umount
 %dir %{_datadir}/oci-umount/oci-umount.d


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

cri-o high performance runtime handler reconfigures and restarts irqbalance after every container with pinned cpus and moved interrupts is created. Systemd does not like this and will block further restarts when the StartLimitBurst (default 5) is crossed within the default timeout (10s). That is too strict as during system startup many such containers might be launched.

Install the provided file to /etc/systemd/system/irqbalance.service.d/ to prevent systemd from blocking the necessary restarts.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes https://issues.redhat.com/browse/OCPBUGS-45112

#### Special notes for your reviewer:

This requires additional change to whatever build process is used to place the provided file into the proper location on the container node.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
cri-o high performance runtime handler reconfigures and restarts irqbalance after every container with pinned cpus and moved interrupts is created. Systemd does not like this and will block further restarts when the StartLimitBurst (default 5) is crossed within the default timeout (10s). That is too strict as during system startup many such containers might be launched.

Install the provided file to /etc/systemd/system/irqbalance.service.d/ to prevent systemd from blocking the necessary restarts.
```
