### PR TITLE
Refactor man page variables in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ COVERAGE_PATH := ${BUILD_PATH}/coverage
 TESTBIN_PATH := ${BUILD_PATH}/test
 MOCK_PATH := ./test/mocks
 
+MANPAGES_MD := $(wildcard docs/*.md)
+MANPAGES    := $(MANPAGES_MD:%.md=%)
+
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 FISHINSTALLDIR=${PREFIX}/share/fish/completions
 ZSHINSTALLDIR=${PREFIX}/share/zsh/site-functions
@@ -533,9 +536,6 @@ mock-systemd: ${MOCKGEN}
 		-package systemdmock \
 		-destination ${MOCK_PATH}/systemd/systemd.go \
 		github.com/cri-o/cri-o/internal/watchdog Systemd
-
-MANPAGES_MD := $(wildcard docs/*.md)
-MANPAGES    := $(MANPAGES_MD:%.md=%)
 
 docs/%.5: docs/%.5.md ${GO_MD2MAN}
 	(${GO_MD2MAN} -in $< -out $@.tmp && touch $@.tmp && mv $@.tmp $@) || \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

From scratch, it failed `make install` with the error `cannot stat 'docs/crio.conf.5': No such file or directory`.
It is because `MANPAGES` variable is defined later than the `install.man` target, and `crio.conf.5` and `crio.conf.d.5` are not created.

This PR moves the definition of `MANPAGES` to the top so that install.man creates `MANPAGES`.

```
$ make install
go build -trimpath  -ldflags '-s -w -X github.com/cri-o/cri-o/internal/version.buildDate='2024-12-18T17:10:25Z' ' -tags "containers_image_ostree_stub  exclude_graphdriver_btrfs btrfs_noversion containers_image_openpgp seccomp selinux  exclude_graphdriver_devicemapper" -o bin/crio ./cmd/crio
make -C pinns
make[1]: Entering directory '/home/atokubi/cri-o/pinns'
cc -std=c99 -Os -Wall -Werror -Wextra -static -O3 -o src/pinns.o -c src/pinns.c
cc -std=c99 -Os -Wall -Werror -Wextra -static -O3 -o src/sysctl.o -c src/sysctl.c
cc -o ../bin/pinns src/pinns.o src/sysctl.o -std=c99 -Os -Wall -Werror -Wextra -static  
strip -s ../bin/pinns
make[1]: Leaving directory '/home/atokubi/cri-o/pinns'
install -Z -D -m 755 bin/crio /usr/local/bin/crio
install -Z -D -m 755 bin/pinns /usr/local/bin/pinns
install -Z -d -m 755 /usr/local/share/man/man5
install -Z -d -m 755 /usr/local/share/man/man8
install -Z -m 644 docs/crio.conf.5 docs/crio.conf.d.5 -t /usr/local/share/man/man5
install: cannot stat 'docs/crio.conf.5': No such file or directory
install: cannot stat 'docs/crio.conf.d.5': No such file or directory
make: *** [Makefile:269: install.man-nobuild] Error 1
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
