### PR TITLE
[Docs] Fetch latest containernetworking/plugins tag instead of v1.1.1

### DIFF
--- a/contrib/cni/README.md
+++ b/contrib/cni/README.md
@@ -63,7 +63,7 @@ Download the `CNI` plugins source tree:
 ```bash
 git clone https://github.com/containernetworking/plugins
 cd plugins
-git checkout v1.1.1
+git checkout $(git tag -l | sort -V | tail -n 1)
 ```
 
 Build the `CNI` plugins:


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
The docs in https://github.com/cri-o/cri-o/blob/main/contrib/cni/README.md indicate to switch to containernetworking/plugins v1.1.1 tag.

After this PR the docs indicate to pick the latest tag instead. This is essential because:
- Problems were fixed in 1.2.0: https://github.com/cri-o/ocicni/issues/77#issuecomment-1574048987.
- Tag v1.1.1 is old and randomally picked.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
NONE

#### Special notes for your reviewer:
At the time of writing, this is the output of the suggested command:
```
container-networking-plugins]> echo $(git tag -l | sort -V | tail -n 1)
v1.6.1
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
