### PR TITLE
Switch to our log module for logging in iptables module

### DIFF
--- a/internal/hostport/hostport_manager.go
+++ b/internal/hostport/hostport_manager.go
@@ -18,6 +18,7 @@ package hostport
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base32"
 	"fmt"
@@ -57,11 +58,11 @@ type hostportManager struct {
 }
 
 // NewHostportManager creates a new HostPortManager.
-func NewHostportManager() HostPortManager {
+func NewHostportManager(ctx context.Context) HostPortManager {
 	exec := utilexec.New()
 	return &hostportManager{
-		ip4tables: utiliptables.New(exec, utiliptables.ProtocolIPv4),
-		ip6tables: utiliptables.New(exec, utiliptables.ProtocolIPv6),
+		ip4tables: utiliptables.New(ctx, exec, utiliptables.ProtocolIPv4),
+		ip6tables: utiliptables.New(ctx, exec, utiliptables.ProtocolIPv6),
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -397,7 +397,7 @@ func New(
 	if config.RuntimeConfig.DisableHostPortMapping {
 		hostportManager = hostport.NewNoopHostportManager()
 	} else {
-		hostportManager = hostport.NewHostportManager()
+		hostportManager = hostport.NewHostportManager(ctx)
 	}
 
 	idMappings, err := getIDMappings(config)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Replaced klog with logrus to align with other logging in the codebase.
It isn't a big change for users since there's already the klog shim.
The replacement aligns with the way of the klog shim.

https://github.com/cri-o/cri-o/blob/f552e82b023c8e8034a1ecd85bbbecbaa7d61afc/internal/log/klog.go#L12-L38

The only change in behaviour is that the error logs are no longer shown from `iptables.go` just like other error logs when we run unit tests.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Change log levels and formats for some iptables logs and klog related logs. 
```
