### PR TITLE
[OCPBUGS-48334] watchdog: Decouple CNI plugin initialization from CRI-O health checks

### DIFF
--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -59,7 +59,7 @@ func (w *Watchdog) Start(ctx context.Context) error {
 
 	log.Infof(ctx, "Starting systemd watchdog using interval: %v", interval)
 
-	go wait.Forever(func() {
+	go wait.Until(func() {
 		if err := w.runHealthCheckers(ctx, interval); err != nil {
 			log.Errorf(ctx, "Will not notify watchdog because CRI-O is unhealthy: %v", err)
 			return
@@ -81,7 +81,7 @@ func (w *Watchdog) Start(ctx context.Context) error {
 		}); err != nil {
 			log.Errorf(ctx, "Failed to notify watchdog: %v", err)
 		}
-	}, interval)
+	}, interval, ctx.Done())
 
 	return nil
 }

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -102,16 +102,12 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	}
 	hostNetwork := securityContext.NamespaceOptions.Network == types.NamespaceMode_NODE
 
-	if err := s.config.CNIPluginReadyOrError(); err != nil && !hostNetwork {
-		// if the cni plugin isn't ready yet, we should wait until it is
-		// before proceeding
-		watcher := s.config.CNIPluginAddWatcher()
-		log.Infof(ctx, "CNI plugin not ready. Waiting to create %s as it is not host network", sboxName)
-		if ready := <-watcher; !ready {
-			return nil, fmt.Errorf("server shutdown before network was ready: %w", err)
+	if !hostNetwork {
+		if err := s.waitForCNIPlugin(ctx, sboxName); err != nil {
+			return nil, err
 		}
-		log.Infof(ctx, "CNI plugin is now ready. Continuing to create %s", sboxName)
 	}
+
 	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox network ready")
 
 	// validate the runtime handler


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-48334
The idea is decouple CRI-O's readiness from the CNI plugin readiness.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Decouple CNI plugin initialization from CRI-O health checks.
```
