### PR TITLE
internal/config/ociartifact/ociartifact: Do not hard-code 'sha256' in error message

### DIFF
--- a/internal/config/ociartifact/ociartifact.go
+++ b/internal/config/ociartifact/ociartifact.go
@@ -290,8 +290,8 @@ func verifyDigest(layer *manifest.LayerInfo, layerBytes []byte) error {
 	layerBytesHex := hex.EncodeToString(sum)
 	if layerBytesHex != layer.BlobInfo.Digest.Hex() {
 		return fmt.Errorf(
-			"sha256 mismatch between real layer bytes (%s) and manifest descriptor (%s)",
-			layerBytesHex, layer.BlobInfo.Digest.Hex(),
+			"%s mismatch between real layer bytes (%s) and manifest descriptor (%s)",
+			digestAlgorithm, layerBytesHex, layer.BlobInfo.Digest.Hex(),
 		)
 	}
 

--- a/internal/config/ociartifact/ociartifact_test.go
+++ b/internal/config/ociartifact/ociartifact_test.go
@@ -351,7 +351,7 @@ var _ = t.Describe("OCIArtifact", func() {
 
 			// Then
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("mismatch between real layer bytes"))
+			Expect(err.Error()).To(ContainSubstring("sha256 mismatch between real layer bytes"))
 			Expect(res).To(BeNil())
 		})
 


### PR DESCRIPTION
#### What type of PR is this?

`sha256` is currently the most common digest hash, but [the OCI spec allows for other hashing algorithms][1].

/kind cleanup

[1]: https://github.com/opencontainers/image-spec/blob/v1.0/descriptor.md#registered-algorithms

#### What this PR does / why we need it:

This should make debugging digest mismatches less confusing,.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
