### PR TITLE
Add `release-1.33` to active prerelease version

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,7 +24,7 @@ import (
 const Version = "1.33.0"
 
 // ReleaseMinorVersions are the currently supported minor versions.
-var ReleaseMinorVersions = []string{"1.32", "1.31", "1.30", "1.29"}
+var ReleaseMinorVersions = []string{"1.33", "1.32", "1.31", "1.30", "1.29"}
 
 // Variables injected during build-time.
 var (


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
This allows to build prerelease packages for release-1.33.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/packaging/pull/214
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
