### PR TITLE
container: add support for domainname

### DIFF
--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -112,6 +112,9 @@ type Container interface {
 	// SpecAddDevices adds devices from the server config, and container CRI config
 	SpecAddDevices([]device.Device, []device.Device, bool, bool) error
 
+	// SpecAddDomainName adds a domain name to the container's spec.
+	SpecAddDomainName(string)
+
 	// AddUnifiedResourcesFromAnnotations adds the cgroup-v2 resources specified in the io.kubernetes.cri-o.UnifiedCgroup annotation
 	AddUnifiedResourcesFromAnnotations(annotationsMap map[string]string) error
 
@@ -169,6 +172,11 @@ func New() (Container, error) {
 func (c *container) SpecAddMount(r rspec.Mount) {
 	c.spec.RemoveMount(r.Destination)
 	c.spec.AddMount(r)
+}
+
+// SpecAddDomainName adds a specified domain name to the spec.
+func (c *container) SpecAddDomainName(domainName string) {
+	c.spec.SetDomainName(domainName)
 }
 
 // SpecAddAnnotation adds all annotations to the spec.

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -64,6 +64,14 @@ var _ = t.Describe("Container", func() {
 			Expect(sut.Spec().Mounts()).To(HaveLen(defaultMounts + 1))
 		})
 	})
+	t.Describe("SpecAddDomainName", func() {
+		It("should set the domain name in the spec", func() {
+			domainName := "example.com"
+			sut.SpecAddDomainName(domainName)
+			Expect(sut.Spec().Config.Domainname).To(Equal(domainName))
+		})
+	})
+
 	t.Describe("Spec", func() {
 		It("should return the spec", func() {
 			Expect(sut.Spec()).ToNot(BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes # https://github.com/cri-o/cri-o/issues/8927

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add support for domainname
```
