### PR TITLE
[release-1.29] Fix build errors on go >= 1.23

### DIFF
--- a/internal/resourcestore/resourcecleaner.go
+++ b/internal/resourcestore/resourcecleaner.go
@@ -66,7 +66,7 @@ func retry(ctx context.Context, description string, fn func() error) error {
 	}
 
 	waitErr := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		log.Infof(ctx, description)
+		log.Infof(ctx, "%s", description)
 		if err := fn(); err != nil {
 			log.Errorf(ctx, "Failed to cleanup (probably retrying): %v", err)
 			return false, nil

--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -234,7 +234,7 @@ func (*HighPerformanceHooks) PostStop(ctx context.Context, c *oci.Container, s *
 
 func shouldCPULoadBalancingBeDisabled(annotations fields.Set) bool {
 	if annotations[crioannotations.CPULoadBalancingAnnotation] == annotationTrue {
-		log.Warnf(context.TODO(), annotationValueDeprecationWarning(crioannotations.CPULoadBalancingAnnotation))
+		log.Warnf(context.TODO(), "%s", annotationValueDeprecationWarning(crioannotations.CPULoadBalancingAnnotation))
 	}
 
 	return annotations[crioannotations.CPULoadBalancingAnnotation] == annotationTrue ||
@@ -243,7 +243,7 @@ func shouldCPULoadBalancingBeDisabled(annotations fields.Set) bool {
 
 func shouldCPUQuotaBeDisabled(annotations fields.Set) bool {
 	if annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue {
-		log.Warnf(context.TODO(), annotationValueDeprecationWarning(crioannotations.CPUQuotaAnnotation))
+		log.Warnf(context.TODO(), "%s", annotationValueDeprecationWarning(crioannotations.CPUQuotaAnnotation))
 	}
 
 	return annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue ||
@@ -252,7 +252,7 @@ func shouldCPUQuotaBeDisabled(annotations fields.Set) bool {
 
 func shouldIRQLoadBalancingBeDisabled(annotations fields.Set) bool {
 	if annotations[crioannotations.IRQLoadBalancingAnnotation] == annotationTrue {
-		log.Warnf(context.TODO(), annotationValueDeprecationWarning(crioannotations.IRQLoadBalancingAnnotation))
+		log.Warnf(context.TODO(), "%s", annotationValueDeprecationWarning(crioannotations.IRQLoadBalancingAnnotation))
 	}
 
 	return annotations[crioannotations.IRQLoadBalancingAnnotation] == annotationTrue ||
@@ -969,7 +969,7 @@ func ShouldCPUQuotaBeDisabled(ctx context.Context, cid string, cSpec *specs.Spec
 		return false
 	}
 	if annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue {
-		log.Warnf(context.TODO(), annotationValueDeprecationWarning(crioannotations.CPUQuotaAnnotation))
+		log.Warnf(context.TODO(), "%s", annotationValueDeprecationWarning(crioannotations.CPUQuotaAnnotation))
 	}
 
 	return annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue ||

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -779,7 +779,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		}
 
 		// Now that we've succeeded in stopping the network, cleanup namespaces
-		log.Infof(ctx, nsCleanupDescription)
+		log.Infof(ctx, "%s", nsCleanupDescription)
 		return nsCleanupFunc()
 	})
 	if result != nil {

--- a/utils/errdefs/grpc.go
+++ b/utils/errdefs/grpc.go
@@ -44,17 +44,17 @@ func ToGRPC(err error) error {
 
 	switch {
 	case IsInvalidArgument(err):
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Errorf(codes.InvalidArgument, "%v", err.Error())
 	case IsNotFound(err):
-		return status.Errorf(codes.NotFound, err.Error())
+		return status.Errorf(codes.NotFound, "%v", err.Error())
 	case IsAlreadyExists(err):
-		return status.Errorf(codes.AlreadyExists, err.Error())
+		return status.Errorf(codes.AlreadyExists, "%v", err.Error())
 	case IsFailedPrecondition(err):
-		return status.Errorf(codes.FailedPrecondition, err.Error())
+		return status.Errorf(codes.FailedPrecondition, "%v", err.Error())
 	case IsUnavailable(err):
-		return status.Errorf(codes.Unavailable, err.Error())
+		return status.Errorf(codes.Unavailable, "%v", err.Error())
 	case IsNotImplemented(err):
-		return status.Errorf(codes.Unimplemented, err.Error())
+		return status.Errorf(codes.Unimplemented, "%v", err.Error())
 	}
 
 	return err


### PR DESCRIPTION

#### What type of PR is this?

/kind ci


#### What this PR does / why we need it:
Manual cherry-pick of: 99b02b97b4b46606fb53026079c772485953504e
From https://github.com/cri-o/cri-o/pull/8485
#### Which issue(s) this PR fixes:

Fixes: https://github.com/cri-o/cri-o/issues/8923


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed build issue with newer golang versions.
```
