### PR TITLE
Move to IRQBALANCE_BANNED_CPULIST 

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -908,17 +908,17 @@ func (h *HighPerformanceHooks) handleIRQBalanceOneShot(ctx context.Context, cNam
 // updateNewIRQSMPAffinityMask updates SMP IRQ affinity and IRQ balance configuration files.
 func (h *HighPerformanceHooks) updateNewIRQSMPAffinityMask(ctx context.Context, cID, cName string,
 	cpus cpuset.CPUSet, enable bool,
-) (cpuset.CPUSet, error) {
-	content, err := os.ReadFile(h.irqSMPAffinityFile)
-	if err != nil {
-		return cpuset.CPUSet{}, err
+) (newIRQBalanceSetting cpuset.CPUSet, err error) {
+	content, readErr := os.ReadFile(h.irqSMPAffinityFile)
+	if readErr != nil {
+		return cpuset.CPUSet{}, readErr
 	}
 
 	originalIRQSMPSetting := strings.TrimSpace(string(content))
 
-	newIRQSMPSetting, newIRQBalanceSetting, err := calcIRQSMPAffinityMask(cpus, originalIRQSMPSetting, calculateCPUSizeFromMask(originalIRQSMPSetting), enable)
-	if err != nil {
-		return cpuset.CPUSet{}, err
+	newIRQSMPSetting, newIRQBalanceSetting, calcErr := calcIRQSMPAffinityMask(cpus, originalIRQSMPSetting, calculateCPUSizeFromMask(originalIRQSMPSetting), enable)
+	if calcErr != nil {
+		return cpuset.CPUSet{}, calcErr
 	}
 
 	log.Debugf(ctx, "Container %q (%q) enable %t cpus %q set %q: %q -> %q; %q: %q",
@@ -1191,6 +1191,7 @@ func RestoreIrqBalanceConfig(ctx context.Context, irqBalanceConfigFile, irqBanne
 	currentMaskArray, err := mapHexCharToByte(strings.TrimSpace(string(content)))
 	if err != nil {
 		log.Errorf(ctx, "Restore irqbalance config: failed to map hex char to byte: %v", err)
+
 		return err
 	}
 

--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -38,17 +38,18 @@ const (
 )
 
 const (
-	annotationTrue         = "true"
-	annotationDisable      = "disable"
-	annotationEnable       = "enable"
-	annotationHousekeeping = "housekeeping"
-	schedDomainDir         = "/proc/sys/kernel/sched_domain"
-	cgroupMountPoint       = "/sys/fs/cgroup"
-	irqBalanceBannedCpus   = "IRQBALANCE_BANNED_CPUS"
-	irqBalancedName        = "irqbalance"
-	sysCPUDir              = "/sys/devices/system/cpu"
-	sysCPUSaveDir          = "/var/run/crio/cpu"
-	milliCPUToCPU          = 1000
+	annotationTrue             = "true"
+	annotationDisable          = "disable"
+	annotationEnable           = "enable"
+	annotationHousekeeping     = "housekeeping"
+	schedDomainDir             = "/proc/sys/kernel/sched_domain"
+	cgroupMountPoint           = "/sys/fs/cgroup"
+	irqBalanceBannedCPUsLegacy = "IRQBALANCE_BANNED_CPUS"
+	irqBalanceBannedCPUs       = "IRQBALANCE_BANNED_CPULIST"
+	irqBalancedName            = "irqbalance"
+	sysCPUDir                  = "/sys/devices/system/cpu"
+	sysCPUSaveDir              = "/var/run/crio/cpu"
+	milliCPUToCPU              = 1000
 )
 
 const (
@@ -838,7 +839,7 @@ func (h *HighPerformanceHooks) setIRQLoadBalancing(ctx context.Context, c *oci.C
 	// Now, restart the irqbalance service or run irqbalance --oneshot command.
 	// On failure, this will log errors but will not return them, as it is not critical for the pod to start.
 	if !h.handleIRQBalanceRestart(ctx, c.Name()) {
-		h.handleIRQBalanceOneShot(ctx, c.Name(), newIRQBalanceSetting)
+		h.handleIRQBalanceOneShot(ctx, c.Name(), newIRQBalanceSetting.String())
 	}
 
 	return nil
@@ -883,7 +884,7 @@ func (h *HighPerformanceHooks) handleIRQBalanceOneShot(ctx context.Context, cNam
 		return
 	}
 
-	env := fmt.Sprintf("%s=%s", irqBalanceBannedCpus, newIRQBalanceSetting)
+	env := fmt.Sprintf("%s=%s", irqBalanceBannedCPUs, newIRQBalanceSetting)
 	log.Debugf(ctx, "Container %q running '%s %s %s'", cName, env, irqBalanceFullPath, "--oneshot")
 
 	if err := commandRunner.RunCommand(
@@ -899,17 +900,17 @@ func (h *HighPerformanceHooks) handleIRQBalanceOneShot(ctx context.Context, cNam
 // updateNewIRQSMPAffinityMask updates SMP IRQ affinity and IRQ balance configuration files.
 func (h *HighPerformanceHooks) updateNewIRQSMPAffinityMask(ctx context.Context, cID, cName string,
 	cpus cpuset.CPUSet, enable bool,
-) (newIRQBalanceSetting string, err error) {
+) (cpuset.CPUSet, error) {
 	content, err := os.ReadFile(h.irqSMPAffinityFile)
 	if err != nil {
-		return "", err
+		return cpuset.CPUSet{}, err
 	}
 
 	originalIRQSMPSetting := strings.TrimSpace(string(content))
 
-	newIRQSMPSetting, newIRQBalanceSetting, err := calcIRQSMPAffinityMask(cpus, originalIRQSMPSetting, enable)
+	newIRQSMPSetting, newIRQBalanceSetting, err := calcIRQSMPAffinityMask(cpus, originalIRQSMPSetting, calculateCPUSizeFromMask(originalIRQSMPSetting), enable)
 	if err != nil {
-		return "", err
+		return cpuset.CPUSet{}, err
 	}
 
 	log.Debugf(ctx, "Container %q (%q) enable %t cpus %q set %q: %q -> %q; %q: %q",
@@ -919,7 +920,7 @@ func (h *HighPerformanceHooks) updateNewIRQSMPAffinityMask(ctx context.Context, 
 	)
 
 	if err := os.WriteFile(h.irqSMPAffinityFile, []byte(newIRQSMPSetting), 0o644); err != nil {
-		return "", err
+		return cpuset.CPUSet{}, err
 	}
 
 	// Rollback IRQ SMP affinity file to maintain consistency if something goes wrong.
@@ -938,7 +939,7 @@ func (h *HighPerformanceHooks) updateNewIRQSMPAffinityMask(ctx context.Context, 
 	}
 
 	if err := updateIrqBalanceConfigFile(h.irqBalanceConfigFile, newIRQBalanceSetting); err != nil {
-		return "", err
+		return cpuset.CPUSet{}, err
 	}
 
 	return newIRQBalanceSetting, nil
@@ -1179,12 +1180,9 @@ func RestoreIrqBalanceConfig(ctx context.Context, irqBalanceConfigFile, irqBanne
 		return err
 	}
 
-	current := strings.TrimSpace(string(content))
-	// remove ","; now each element is "0-9,a-f"
-	s := strings.ReplaceAll(current, ",", "")
-
-	currentMaskArray, err := mapHexCharToByte(s)
+	currentMaskArray, err := mapHexCharToByte(strings.TrimSpace(string(content)))
 	if err != nil {
+		log.Errorf(ctx, "Restore irqbalance config: failed to map hex char to byte: %v", err)
 		return err
 	}
 
@@ -1195,9 +1193,9 @@ func RestoreIrqBalanceConfig(ctx context.Context, irqBalanceConfigFile, irqBanne
 		return nil
 	}
 
-	bannedCPUMasks, err := retrieveIrqBannedCPUMasks(irqBalanceConfigFile)
+	bannedCPUs, err := retrieveIrqBannedCPUList(irqBalanceConfigFile)
 	if err != nil {
-		// Ignore returning err as given irqBalanceConfigFile may not exist.
+		// Ignore returning error as given irqBalanceConfigFile may not exist.
 		log.Infof(ctx, "Restore irqbalance config: failed to get current CPU ban list, ignoring")
 
 		return nil
@@ -1213,7 +1211,7 @@ func RestoreIrqBalanceConfig(ctx context.Context, irqBalanceConfigFile, irqBanne
 
 		defer irqBannedCPUsConfig.Close()
 
-		_, err = irqBannedCPUsConfig.WriteString(bannedCPUMasks)
+		_, err = irqBannedCPUsConfig.WriteString(bannedCPUs.String())
 		if err != nil {
 			return err
 		}
@@ -1228,17 +1226,20 @@ func RestoreIrqBalanceConfig(ctx context.Context, irqBalanceConfigFile, irqBanne
 		return err
 	}
 
-	origBannedCPUMasks := strings.TrimSpace(string(content))
+	origBannedCPUs, err := mapHexCharToCPUSet(strings.TrimSpace(string(content)))
+	if err != nil {
+		return err
+	}
 
-	if bannedCPUMasks == origBannedCPUMasks {
+	if bannedCPUs.Equals(origBannedCPUs) {
 		log.Infof(ctx, "Restore irqbalance config: nothing to do")
 
 		return nil
 	}
 
-	log.Infof(ctx, "Restore irqbalance banned CPU list in %q to %q", irqBalanceConfigFile, origBannedCPUMasks)
+	log.Infof(ctx, "Restore irqbalance banned CPU list in %q to %q", irqBalanceConfigFile, origBannedCPUs)
 
-	if err := updateIrqBalanceConfigFile(irqBalanceConfigFile, origBannedCPUMasks); err != nil {
+	if err := updateIrqBalanceConfigFile(irqBalanceConfigFile, origBannedCPUs); err != nil {
 		return err
 	}
 

--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -836,10 +836,18 @@ func (h *HighPerformanceHooks) setIRQLoadBalancing(ctx context.Context, c *oci.C
 	if err != nil {
 		return err
 	}
+
+	irqBalanceSetting := newIRQBalanceSetting.String()
+	if irqBalanceSetting == "" {
+		// using this value to indicate that banned CPU list is empty
+		// temporary workaround until https://github.com/Irqbalance/irqbalance/pull/358 propagates d/s
+		irqBalanceSetting = "-"
+	}
+
 	// Now, restart the irqbalance service or run irqbalance --oneshot command.
 	// On failure, this will log errors but will not return them, as it is not critical for the pod to start.
 	if !h.handleIRQBalanceRestart(ctx, c.Name()) {
-		h.handleIRQBalanceOneShot(ctx, c.Name(), newIRQBalanceSetting.String())
+		h.handleIRQBalanceOneShot(ctx, c.Name(), irqBalanceSetting)
 	}
 
 	return nil
@@ -1196,7 +1204,7 @@ func RestoreIrqBalanceConfig(ctx context.Context, irqBalanceConfigFile, irqBanne
 	bannedCPUs, err := retrieveIrqBannedCPUList(irqBalanceConfigFile)
 	if err != nil {
 		// Ignore returning error as given irqBalanceConfigFile may not exist.
-		log.Infof(ctx, "Restore irqbalance config: failed to get current CPU ban list, ignoring")
+		log.Errorf(ctx, "Restore irqbalance config: failed to get current CPU ban list: %v, ignoring", err)
 
 		return nil
 	}
@@ -1211,7 +1219,12 @@ func RestoreIrqBalanceConfig(ctx context.Context, irqBalanceConfigFile, irqBanne
 
 		defer irqBannedCPUsConfig.Close()
 
-		_, err = irqBannedCPUsConfig.WriteString(bannedCPUs.String())
+		bannedCPUsAsString := bannedCPUs.String()
+		if bannedCPUsAsString == "" {
+			bannedCPUsAsString = "-"
+		}
+
+		_, err = irqBannedCPUsConfig.WriteString(bannedCPUsAsString)
 		if err != nil {
 			return err
 		}

--- a/internal/runtimehandlerhooks/utils_linux.go
+++ b/internal/runtimehandlerhooks/utils_linux.go
@@ -220,7 +220,7 @@ func retrieveIrqBannedCPUList(irqBalanceConfigFile string) (cpuset.CPUSet, error
 	for line := range lines {
 		// try to read from the legacy variable first and merge both values.
 		// after the first iteration, it'll comment this line, so
-		// it will not enter this flow again (because the prefix won't match).
+		// it will not enter this flow again since the prefix no longer matches.
 		if strings.HasPrefix(line, irqBalanceBannedCPUsLegacy+"=") {
 			list := strings.Trim(strings.Split(line, "=")[1], "\"")
 
@@ -232,14 +232,18 @@ func retrieveIrqBannedCPUList(irqBalanceConfigFile string) (cpuset.CPUSet, error
 
 		if strings.HasPrefix(line, irqBalanceBannedCPUs+"=") {
 			list := strings.Trim(strings.Split(line, "=")[1], "\"")
+			// if the list is "-", it means that no CPUs are banned, so return an empty set
+			if list == "-" {
+				setFromNewValue = cpuset.New()
+			} else {
+				setFromNewValue, err = cpuset.Parse(list)
+			}
 
-			setFromNewValue, err = cpuset.Parse(list)
 			if err != nil {
 				return cpuset.New(), err
 			}
 		}
 	}
-
 	return setFromOldValue.Union(setFromNewValue), nil
 }
 

--- a/internal/runtimehandlerhooks/utils_linux.go
+++ b/internal/runtimehandlerhooks/utils_linux.go
@@ -107,15 +107,6 @@ func mapHexCharToCPUSet(s string) (cpuset.CPUSet, error) {
 	return mapByteToCPUSet(toByte), nil
 }
 
-// take a byte array and invert each byte.
-func invertByteArray(in []byte) (out []byte) {
-	for _, b := range in {
-		out = append(out, byte(0xff)-b)
-	}
-
-	return out
-}
-
 // take a byte array and returns true when bits of every byte element
 // set to 1, otherwise returns false.
 func isAllBitSet(in []byte) bool {

--- a/internal/runtimehandlerhooks/utils_linux.go
+++ b/internal/runtimehandlerhooks/utils_linux.go
@@ -132,11 +132,11 @@ func isAllBitSet(in []byte) bool {
 // the current mask string, as well as bool set. It then returns an updated mask string and inverted mask, with those
 // CPUs enabled or disable in the mask.
 func calcIRQSMPAffinityMask(containerCPUSet cpuset.CPUSet, current string, size int, set bool) (string, cpuset.CPUSet, error) {
+	var updatedSMPAffinityCPUs cpuset.CPUSet
+
 	if size == 0 {
 		return "", cpuset.New(), fmt.Errorf("cannot compute IRQ SMP affinity mask: cpu size is 0")
 	}
-
-	var updatedSMPAffinityCPUs cpuset.CPUSet
 
 	// only ascii string supported
 	if !isASCII(current) {
@@ -194,7 +194,7 @@ func updateIrqBalanceConfigFile(irqBalanceConfigFile string, newIRQBalanceSettin
 
 	for i, line := range lines {
 		// Comment out the old deprecated variable
-		if strings.HasPrefix(line, irqBalanceBannedCpusLegacy+"=") {
+		if strings.HasPrefix(line, irqBalanceBannedCPUsLegacy+"=") {
 			lines[i] = "#" + line
 		}
 
@@ -230,7 +230,7 @@ func retrieveIrqBannedCPUList(irqBalanceConfigFile string) (cpuset.CPUSet, error
 		// try to read from the legacy variable first and merge both values.
 		// after the first iteration, it'll comment this line, so
 		// it will not enter this flow again (because the prefix won't match).
-		if strings.HasPrefix(line, irqBalanceBannedCpusLegacy+"=") {
+		if strings.HasPrefix(line, irqBalanceBannedCPUsLegacy+"=") {
 			list := strings.Trim(strings.Split(line, "=")[1], "\"")
 
 			setFromOldValue, err = mapHexCharToCPUSet(list)

--- a/internal/runtimehandlerhooks/utils_linux.go
+++ b/internal/runtimehandlerhooks/utils_linux.go
@@ -2,6 +2,7 @@ package runtimehandlerhooks
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -126,7 +127,7 @@ func calcIRQSMPAffinityMask(containerCPUSet cpuset.CPUSet, current string, size 
 	var updatedSMPAffinityCPUs cpuset.CPUSet
 
 	if size == 0 {
-		return "", cpuset.New(), fmt.Errorf("cannot compute IRQ SMP affinity mask: cpu size is 0")
+		return "", cpuset.New(), errors.New("cannot compute IRQ SMP affinity mask: cpu size is 0")
 	}
 
 	// only ascii string supported
@@ -244,6 +245,7 @@ func retrieveIrqBannedCPUList(irqBalanceConfigFile string) (cpuset.CPUSet, error
 			}
 		}
 	}
+
 	return setFromOldValue.Union(setFromNewValue), nil
 }
 

--- a/internal/runtimehandlerhooks/utils_linux_test.go
+++ b/internal/runtimehandlerhooks/utils_linux_test.go
@@ -1,0 +1,119 @@
+package runtimehandlerhooks
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/utils/cpuset"
+)
+
+func TestMapByteToCPUSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected cpuset.CPUSet
+	}{
+		{
+			name:     "Single byte, all CPUs set",
+			input:    []byte{0xFF}, // 11111111 -> CPUs 0-7
+			expected: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			name:     "Single byte, alternate CPUs set",
+			input:    []byte{0xAA}, // 10101010 -> CPUs 1, 3, 5, 7
+			expected: cpuset.New(1, 3, 5, 7),
+		},
+		{
+			name:     "Two bytes, mixed CPUs set",
+			input:    []byte{0x01, 0x02}, // 00000001 00000010 -> CPUs 0, 9
+			expected: cpuset.New(0, 9),
+		},
+		{
+			name:     "Two bytes, all CPUs set",
+			input:    []byte{0xFF, 0xFF}, // 11111111 11111111 -> CPUs 0-15
+			expected: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+		},
+		{
+			name:  "Four bytes, mixed CPUs set",
+			input: []byte{0x81, 0x24, 0x18, 0xC3},
+			// Byte 0:  0x81 -> 10000001 -> CPUs 0, 7
+			// Byte 1:  0x24 -> 00100100 -> CPUs 10, 13
+			// Byte 2:  0x18 -> 00011000 -> CPUs 19, 20
+			// Byte 3:  0xC3 -> 11000011 -> CPUs 24, 25, 30, 31
+			expected: cpuset.New(0, 7, 10, 13, 19, 20, 24, 25, 30, 31),
+		},
+		{
+			name:     "Empty input",
+			input:    []byte{},
+			expected: cpuset.New(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapByteToCPUSet(tt.input)
+			if !result.Equals(tt.expected) {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMapHexCharToByte(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []byte
+		wantErr  bool
+	}{
+		{
+			name:     "Valid CPU mask with even-length hex, split into 8 characters",
+			input:    "ffffffff,ffffcffc",                                    // Two chunks, each 8 hex characters
+			expected: []byte{0xfc, 0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, // Reverse order of bytes (8 bytes)
+			wantErr:  false,
+		},
+		{
+			name:     "Valid CPU mask with multiple chunks, split into 8 characters",
+			input:    "1a2b3c4d,5e6f7a8b,9c0d1e2f",                                                   // Multiple chunks
+			expected: []byte{0x2f, 0x1e, 0x0d, 0x9c, 0x8b, 0x7a, 0x6f, 0x5e, 0x4d, 0x3c, 0x2b, 0x1a}, // Reverse order of bytes
+			wantErr:  false,
+		},
+		{
+			name:     "Single CPU mask character, split into 8 characters",
+			input:    "f,00000000", // Single character and zero padding
+			expected: []byte{0x00, 0x00, 0x00, 0x00, 0x0f},
+			wantErr:  false,
+		},
+		{
+			name:     "Empty CPU mask input",
+			input:    "",
+			expected: []byte{},
+			wantErr:  false,
+		},
+		{
+			name:    "Invalid CPU mask with non-hex characters",
+			input:   "1g2h3i,4j5k6l", // 'g', 'h', 'i', 'j', 'k', 'l' are invalid
+			wantErr: true,
+		},
+		{
+			name:    "Invalid CPU mask with wrong format",
+			input:   "xyz,abc", // Non-hex string should trigger an error
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapHexCharToByte(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mapHexCharToByte() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("mapHexCharToByte() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/runtimehandlerhooks/utils_test.go
+++ b/internal/runtimehandlerhooks/utils_test.go
@@ -172,5 +172,5 @@ const confTemplate = `# irqbalance is a daemon process that distributes interrup
 #IRQBALANCE_ARGS=
 
 IRQBALANCE_BANNED_CPUS=
-IRQBALANCE_BANNED_CPU_LIST=
+IRQBALANCE_BANNED_CPULIST=
 `

--- a/test/irqbalance.bats
+++ b/test/irqbalance.bats
@@ -169,6 +169,10 @@ irqbalance_cpu_ban_list_save() {
 
 	local expected_banned_cpus
 	expected_banned_cpus=$(sed -n 's/^IRQBALANCE_BANNED_CPULIST=\"\?\([^\"]*\)\"\?/\1/p' "$IRQBALANCE_CONF")
+	# CRI-O writes "-" to represent an empty banned CPU list
+	if [ -z "$expected_banned_cpus" ]; then
+		expected_banned_cpus="-"
+	fi
 
 	# when
 	IRQBALANCE_CONFIG_FILE="${IRQBALANCE_CONF}" IRQBALANCE_CONFIG_RESTORE_FILE="$BANNEDCPUS_CONF" start_crio


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind dependency-change

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
The IRQBALANCE_BANNED_CPUS variable is deprecated and will not be used anymore in the near future.

The newer IRQBALANCE_BANNED_CPULIST variable is already supported by irqbalanced (https://github.com/Irqbalance/irqbalance/blob/v1.9.0/cputree.c#L135) and should be used.

Implementing this requires new code for byte/hex formatted cpu mask to CPUSet formatting code.

#### Which issue(s) this PR fixes:
None

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal rewrite to use CPU-list (cpuset) semantics across IRQ load‑balancing and CPU affinity flows; improved saving/restoring, error handling and logging; config now supports a CPULIST form for banned CPUs while public interfaces remain unchanged.
* **Tests**
  * Expanded unit and integration tests and helpers (including CPULIST conversion utilities and shell helpers) to validate CPULIST behavior, conversions, and save/restore/restart scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->