### PR TITLE
Remove `LimitNOFILE` from systemd service file

### DIFF
--- a/contrib/systemd/crio.service
+++ b/contrib/systemd/crio.service
@@ -17,7 +17,6 @@ ExecStart=/usr/local/bin/crio \
           $CRIO_METRICS_OPTIONS
 ExecReload=/bin/kill -s HUP $MAINPID
 TasksMax=infinity
-LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
 OOMScoreAdjust=-999


### PR DESCRIPTION


#### What type of PR is this?


/kind deprecation


#### What this PR does / why we need it:

Explicit configuration for `LimitNOFILE` in the reference `crio.service` systemd service file is removed.

CRI-O's rlimits are inherited by containers, so the daemon's `LimitNOFILE` affects `RLIMIT_NOFILE` within containers. It is recommended to use the default systemd `LimitNOFILE` configuration.

Administrators on platforms running versions less than systemd 240 should explicitly configure `LimitNOFILE=1024:524288` or risk falling back to the kernel default of `4096`.


#### Which issue(s) this PR fixes:

Fixes: https://github.com/cri-o/cri-o/issues/7703


#### Special notes for your reviewer:
cc @cri-o/cri-o-maintainers 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Explicit configuration for `LimitNOFILE` in the reference `crio.service` systemd service file is removed.

Warning: Administrators on platforms running versions less than systemd 240 should explicitly configure `LimitNOFILE=1024:524288` or risk falling back to the kernel default of `4096`.
```
