### PR TITLE
Switch to golang native error joining and errgroup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.33.0
 	go.opentelemetry.io/otel/trace v1.33.0
 	go.uber.org/mock v0.5.0
+	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.29.0
 	google.golang.org/grpc v1.69.4
 	google.golang.org/protobuf v1.36.3
@@ -222,7 +223,6 @@ require (
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
-	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.7.0 // indirect

--- a/internal/iptables/iptables_linux.go
+++ b/internal/iptables/iptables_linux.go
@@ -19,13 +19,13 @@ limitations under the License.
 package iptables
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"time"
 
 	"golang.org/x/sys/unix"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -34,22 +34,16 @@ type locker struct {
 	lock14 *net.UnixListener
 }
 
-func (l *locker) Close() error {
-	errList := []error{}
-
+func (l *locker) Close() (err error) {
 	if l.lock16 != nil {
-		if err := l.lock16.Close(); err != nil {
-			errList = append(errList, err)
-		}
+		err = errors.Join(l.lock16.Close())
 	}
 
 	if l.lock14 != nil {
-		if err := l.lock14.Close(); err != nil {
-			errList = append(errList, err)
-		}
+		err = errors.Join(err, l.lock14.Close())
 	}
 
-	return utilerrors.NewAggregate(errList)
+	return err
 }
 
 func grabIptablesLocks(lockfilePath14x, lockfilePath16x string) (iptablesLocker, error) {

--- a/server/sandbox_stop_freebsd.go
+++ b/server/sandbox_stop_freebsd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
-	errorUtils "k8s.io/apimachinery/pkg/util/errors"
+	"golang.org/x/sync/errgroup"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -30,17 +30,18 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		return nil
 	}
 
-	funcs := []func() error{}
+	errorGroup := &errgroup.Group{}
+
 	for _, ctr := range sb.Containers().List() {
 		if ctr.State().Status == oci.ContainerStateStopped {
 			continue
 		}
 
-		funcs = append(funcs, func() error {
+		errorGroup.Go(func() error {
 			return s.stopContainer(ctx, ctr, stopTimeoutFromContext(ctx))
 		})
 	}
-	if err := errorUtils.AggregateGoroutines(funcs...); err != nil {
+	if err := errorGroup.Wait(); err != nil {
 		return fmt.Errorf("stop containers in parallel: %w", err)
 	}
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Using the sync/errgroup package is slightly more lean compared to the `k8s.io/apimachinery/pkg/util/errors` package. We can also avoid using the package in other places like the hostport manager and rely on golang native error joining.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
