### PR TITLE
Fix typo in `version_update_mask` regex

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,10 +26,9 @@ packages:
         # Remove downstream patches (if any)
         - sed -ri "/^Patch[0-9].*/d" .packit_rpm/cri-o.spec
   fedora-40:
-    # v1.28.x
+    # v1.29.x
     # Propose minor and patch releases downstream
-    # TODO: Use mask '\d+\.\d+\' after f40 switches to v1.29.x
-    version_update_mask: '\d+\'
+    version_update_mask: '\d+\.\d+\.'
     specfile_path: .packit_rpm/cri-o.spec
     files_to_sync:
       - .packit.yaml


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

It fixes a configuration error that prevents Packit `propose_downstream` from working in/for Fedora 40.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Note the missing `.` (or extra `\`) at the end. I can see that `v1.29.x` is already in `f40` so I used the "extended" regex. But perhaps you'd rather switch from `f40` to `f41` now?

#### Does this PR introduce a user-facing change?

```release-note
None
```
