### PR TITLE
go.{mod,sum}: update NRI deps to latest HEAD, fix WASM ignoring context deadlines. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/containerd v1.7.25
 	github.com/containerd/containerd/api v1.8.0
 	github.com/containerd/fifo v1.1.0
-	github.com/containerd/nri v0.9.0
+	github.com/containerd/nri v0.9.1-0.20250205193013-895502851bc5
 	github.com/containerd/otelttrpc v0.1.0
 	github.com/containerd/ttrpc v1.2.7
 	github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/containerd/go-runc v1.1.0 h1:OX4f+/i2y5sUT7LhmcJH7GYrjjhHa1QI4e8yO0gG
 github.com/containerd/go-runc v1.1.0/go.mod h1:xJv2hFF7GvHtTJd9JqTS2UVxMkULUYw4JN5XAUZqH5U=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
-github.com/containerd/nri v0.9.0 h1:jribDJs/oQ95vLO4Yn19HKFYriZGWKiG6nKWjl9Y/x4=
-github.com/containerd/nri v0.9.0/go.mod h1:sDRoMy5U4YolsWthg7TjTffAwPb6LEr//83O+D3xVU4=
+github.com/containerd/nri v0.9.1-0.20250205193013-895502851bc5 h1:qmPtFFfcr9448P0m50+hii5VI/8k7g+SscCTtdfFZO4=
+github.com/containerd/nri v0.9.1-0.20250205193013-895502851bc5/go.mod h1:sDRoMy5U4YolsWthg7TjTffAwPb6LEr//83O+D3xVU4=
 github.com/containerd/otelttrpc v0.1.0 h1:UOX68eVTE8H/T45JveIg+I22Ev2aFj4qPITCmXsskjw=
 github.com/containerd/otelttrpc v0.1.0/go.mod h1:XhoA2VvaGPW1clB2ULwrBZfXVuEWuyOd2NUD1IM0yTg=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU=

--- a/vendor/github.com/containerd/nri/pkg/adaptation/adaptation.go
+++ b/vendor/github.com/containerd/nri/pkg/adaptation/adaptation.go
@@ -30,6 +30,8 @@ import (
 	"github.com/containerd/nri/pkg/api"
 	"github.com/containerd/nri/pkg/log"
 	"github.com/containerd/ttrpc"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
 const (
@@ -129,7 +131,21 @@ func New(name, version string, syncFn SyncFn, updateFn UpdateFn, opts ...Option)
 		return nil, fmt.Errorf("failed to create NRI adaptation, nil UpdateFn")
 	}
 
-	wasmPlugins, err := api.NewPluginPlugin(context.Background())
+	wasmWithCloseOnContextDone := func(ctx context.Context) (wazero.Runtime, error) {
+		var (
+			cfg = wazero.NewRuntimeConfig().WithCloseOnContextDone(true)
+			r   = wazero.NewRuntimeWithConfig(ctx, cfg)
+		)
+		if _, err := wasi_snapshot_preview1.Instantiate(ctx, r); err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+
+	wasmPlugins, err := api.NewPluginPlugin(
+		context.Background(),
+		api.WazeroRuntime(wasmWithCloseOnContextDone),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize WASM service: %w", err)
 	}

--- a/vendor/github.com/containerd/nri/pkg/adaptation/plugin.go
+++ b/vendor/github.com/containerd/nri/pkg/adaptation/plugin.go
@@ -336,6 +336,7 @@ func (p *plugin) start(name, version string) (err error) {
 // close a plugin shutting down its multiplexed ttrpc connections.
 func (p *plugin) close() {
 	if p.impl.isWasm() {
+		p.closed = true
 		return
 	}
 

--- a/vendor/github.com/containerd/nri/pkg/api/resources.go
+++ b/vendor/github.com/containerd/nri/pkg/api/resources.go
@@ -72,6 +72,12 @@ func FromOCILinuxResources(o *rspec.LinuxResources, _ map[string]string) *LinuxR
 			Limit: p.Limit,
 		}
 	}
+	if len(o.Unified) != 0 {
+		l.Unified = make(map[string]string)
+		for k, v := range o.Unified {
+			l.Unified[k] = v
+		}
+	}
 	return l
 }
 
@@ -98,6 +104,12 @@ func FromCRILinuxResources(c *cri.LinuxContainerResources) *LinuxResources {
 				PageSize: l.PageSize,
 				Limit:    l.Limit,
 			})
+	}
+	if len(c.Unified) != 0 {
+		r.Unified = make(map[string]string)
+		for k, v := range c.Unified {
+			r.Unified[k] = v
+		}
 	}
 	return r
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -201,7 +201,7 @@ github.com/containerd/go-runc
 # github.com/containerd/log v0.1.0
 ## explicit; go 1.20
 github.com/containerd/log
-# github.com/containerd/nri v0.9.0
+# github.com/containerd/nri v0.9.1-0.20250205193013-895502851bc5
 ## explicit; go 1.21
 github.com/containerd/nri/pkg/adaptation
 github.com/containerd/nri/pkg/api


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Pull in latest NRI as dependency. This should fix WASM plugins failing to honor context deadlines.

#### Which issue(s) this PR fixes:

`None`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
