### PR TITLE
Fix context cancellation when image pull progress timeout is `0`

### DIFF
--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -260,8 +260,10 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 // the cancel function will be called.
 func consumeImagePullProgress(ctx context.Context, cancel context.CancelFunc, pullProgressTimeout time.Duration, progress <-chan imageTypes.ProgressProperties, remoteCandidateName storage.RegistryImageReference) {
 	timer := time.AfterFunc(pullProgressTimeout, func() {
-		log.Warnf(ctx, "Timed out on waiting up to %s for image pull progress updates", pullProgressTimeout)
-		cancel()
+		if pullProgressTimeout != 0 {
+			log.Warnf(ctx, "Timed out on waiting up to %s for image pull progress updates", pullProgressTimeout)
+			cancel()
+		}
 	})
 	timer.Stop()       // don't start the timer immediately
 	defer timer.Stop() // ensure that the timer is stopped when we exit the progress loop


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test
/kind bug

#### What this PR does / why we need it:
Debugging the test since it seems to flake heavily.

We should never cancel the context when the pull timeout is `0`, means we now add an additional check to prevent this corner case.

Deflakes the integration tests and also fixes possible issues around a disabled pull progress timeout.

#### Which issue(s) this PR fixes:

Fixes https://github.com/cri-o/cri-o/issues/8872
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed context cancellation when image pull progress timeout is `0` (`--pull-progress-timeout=0` / `pull_progress_timeout=0`)
```
