### PR TITLE
Require go 1.24 for build

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -16,9 +16,8 @@ dependencies:
         match: GO_VERSION
       - path: nix/derivation.nix
         match: buildGo124Module
-      # TODO: move go.mod to 1.24 once we have full prow CI support
-      # - path: go.mod
-      #   match: go
+      - path: go.mod
+        match: go
 
   # For a new minor (1.x.0) release, move the "development version"
   # below to the "supported versions" section (by omitting the patch version)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.23.4
+go 1.24
 
 module github.com/cri-o/cri-o
 

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -35,7 +34,7 @@ func TestAddOCIBindsForDev(t *testing.T) {
 
 	sut := &Server{}
 
-	_, binds, err := sut.addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, false, "")
+	_, binds, err := sut.addOCIBindMounts(t.Context(), ctr, "", "", nil, false, false, false, false, false, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -87,7 +86,7 @@ func TestAddOCIBindsForSys(t *testing.T) {
 
 	sut := &Server{}
 
-	_, binds, err := sut.addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, false, "")
+	_, binds, err := sut.addOCIBindMounts(t.Context(), ctr, "", "", nil, false, false, false, false, false, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -137,7 +136,7 @@ func TestAddOCIBindsRROMounts(t *testing.T) {
 		t.Fatalf("Should set container configuration, got: %v", err)
 	}
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	sut := &Server{}
 
@@ -210,7 +209,7 @@ func TestAddOCIBindsRROMountsError(t *testing.T) {
 		},
 	}
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
@@ -271,7 +270,7 @@ func TestAddOCIBindsCGroupRW(t *testing.T) {
 
 	sut := &Server{}
 
-	_, _, err = sut.addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, true, false, false, "")
+	_, _, err = sut.addOCIBindMounts(t.Context(), ctr, "", "", nil, false, false, true, false, false, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -311,7 +310,7 @@ func TestAddOCIBindsCGroupRW(t *testing.T) {
 
 	var hasCgroupRO bool
 
-	_, _, err = sut.addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, false, "")
+	_, _, err = sut.addOCIBindMounts(t.Context(), ctr, "", "", nil, false, false, false, false, false, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -364,12 +363,12 @@ func TestAddOCIBindsErrorWithoutIDMap(t *testing.T) {
 
 	sut := &Server{}
 
-	_, _, err = sut.addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, false, false, "")
+	_, _, err = sut.addOCIBindMounts(t.Context(), ctr, "", "", nil, false, false, false, false, false, "")
 	if err == nil {
 		t.Errorf("Should have failed to create id mapped mount with no id map support")
 	}
 
-	_, _, err = sut.addOCIBindMounts(context.Background(), ctr, "", "", nil, false, false, false, true, false, "")
+	_, _, err = sut.addOCIBindMounts(t.Context(), ctr, "", "", nil, false, false, false, true, false, "")
 	if err != nil {
 		t.Errorf("%v", err)
 	}

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -45,7 +45,7 @@ func TestGetInfo(t *testing.T) {
 }
 
 func TestGetContainerInfo(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	s := &Server{}
 	created := time.Now()
 	labels := map[string]string{
@@ -184,7 +184,7 @@ func TestGetContainerInfo(t *testing.T) {
 }
 
 func TestGetContainerInfoCtrNotFound(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	s := &Server{}
 	getContainerFunc := func(ctx context.Context, id string) *oci.Container {
 		return nil
@@ -207,7 +207,7 @@ func TestGetContainerInfoCtrNotFound(t *testing.T) {
 }
 
 func TestGetContainerInfoCtrStateNil(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	s := &Server{}
 	created := time.Now()
 	labels := map[string]string{}
@@ -254,7 +254,7 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 }
 
 func TestGetContainerInfoSandboxNotFound(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	s := &Server{}
 	created := time.Now()
 	labels := map[string]string{}


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Kubernetes v1.33 will require that version to be built and we have to align because of the future vendored sources.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Require go 1.24 for build.
```
