### PR TITLE
Cleanup: ensure image volume path

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -438,17 +439,13 @@ func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, im
 
 func (s *Server) ensureImageVolumesPath(ctx context.Context, mounts []*types.Mount) (string, error) {
 	// Check if we need to anything at all
-	noop := true
-
-	for _, m := range mounts {
-		if m.Image != nil && m.Image.Image != "" {
-			noop = false
-
-			break
+	if !slices.ContainsFunc(mounts, func(m *types.Mount) bool {
+		if m.GetImage() != nil && m.GetImage().GetImage() != "" {
+			return true
 		}
-	}
 
-	if noop {
+		return false
+	}) {
 		return "", nil
 	}
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
Use the slices package instead of the additional `noop` variable to ensure the image volume path.

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
