### PR TITLE
Set default masked paths

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -914,6 +914,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 
 		specgen.SetLinuxCgroupsPath(s.config.CgroupManager().ContainerCgroupPath(sb.CgroupParent(), containerID))
 
+		securityContext.MaskedPaths = appendDefaultMaskedPaths(securityContext.MaskedPaths)
+		log.Debugf(ctx, "Using masked paths: %v", strings.Join(securityContext.MaskedPaths, ", "))
+
 		err = ctr.SpecSetPrivileges(ctx, securityContext, &s.config)
 		if err != nil {
 			return nil, err

--- a/server/masked_paths.go
+++ b/server/masked_paths.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/containers/common/pkg/config"
+)
+
+// appendDefaultMaskedPaths is retrieving the default masked paths and appends
+// the existing ones to it.
+func appendDefaultMaskedPaths(additionalPaths []string) []string {
+	paths := slices.Concat(defaultLinuxMaskedPaths(), additionalPaths)
+	slices.Sort(paths)
+
+	return slices.Compact(paths)
+}
+
+// defaultLinuxMaskedPaths will be used to evaluate the default masked paths once.
+var defaultLinuxMaskedPaths = sync.OnceValue(func() []string {
+	maskedPaths := slices.Concat(
+		config.DefaultMaskedPaths,
+		[]string{"/proc/asound", "/proc/interrupts"},
+	)
+
+	for _, cpu := range possibleCPUs() {
+		path := fmt.Sprintf("/sys/devices/system/cpu/cpu%d/thermal_throttle", cpu)
+		if _, err := os.Stat(path); err == nil {
+			maskedPaths = append(maskedPaths, path)
+		}
+	}
+
+	return maskedPaths
+})
+
+// possibleCPUs returns the number of possible CPUs on this host.
+func possibleCPUs() (cpus []int) {
+	if ncpu := possibleCPUsParsed(); ncpu != nil {
+		return ncpu
+	}
+
+	for i := range runtime.NumCPU() {
+		cpus = append(cpus, i)
+	}
+
+	return cpus
+}
+
+// possibleCPUsParsed is parsing the amount of possible CPUs on this host from
+// /sys/devices.
+var possibleCPUsParsed = sync.OnceValue(func() (cpus []int) {
+	data, err := os.ReadFile("/sys/devices/system/cpu/possible")
+	if err != nil {
+		return nil
+	}
+
+	ranges := strings.Split(strings.TrimSpace(string(data)), ",")
+
+	for _, r := range ranges {
+		if rStart, rEnd, ok := strings.Cut(r, "-"); !ok {
+			cpu, err := strconv.Atoi(rStart)
+			if err != nil {
+				return nil
+			}
+			cpus = append(cpus, cpu)
+		} else {
+			var start, end int
+			start, err := strconv.Atoi(rStart)
+			if err != nil {
+				return nil
+			}
+			end, err = strconv.Atoi(rEnd)
+			if err != nil {
+				return nil
+			}
+			for i := start; i <= end; i++ {
+				cpus = append(cpus, i)
+			}
+		}
+	}
+
+	return cpus
+})

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1553,3 +1553,11 @@ EOF
 		exit 1
 	fi
 }
+
+@test "ctr masked paths" {
+	start_crio
+	ctr_id=$(crictl run "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+
+	# verify that at least a default masked path exists
+	crictl inspect "$ctr_id" | jq -e '.info.runtimeSpec.linux.maskedPaths | index("/proc/acpi")'
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
 Adding default masked paths to non privileged containers.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/9068
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed runtime default masked paths for non privileged containers to:
- /proc/acpi
- /proc/asound
- /proc/interrupts
- /proc/kcore
- /proc/keys
- /proc/latency_stats
- /proc/sched_debug
- /proc/scsi
- /proc/timer_list
- /proc/timer_stats
- /sys/devices/system/cpu/cpu<ID>/thermal_throttle
- /sys/devices/virtual/powercap
- /sys/firmware
- /sys/fs/selinux
```
