### PR TITLE
OCPBUGS-53431: [release-1.31] Backport c/image `3161ab1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/containers/common v0.60.3-0.20241001153533-18930ed8933b
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/conmon-rs v0.6.5
-	github.com/containers/image/v5 v5.32.3-0.20241128085047-0c20855557c9
+	github.com/containers/image/v5 v5.32.3-0.20250321090242-db55860a7cf9
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.2.0
 	github.com/containers/storage v1.55.1-0.20250123153357-a030a4472622

--- a/go.sum
+++ b/go.sum
@@ -732,8 +732,8 @@ github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6J
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/conmon-rs v0.6.5 h1:mxdEBF/pjBmryj1ABrTDUqxDyxoZrpo8A1/9+JNvtZU=
 github.com/containers/conmon-rs v0.6.5/go.mod h1:+1QRvqdKmaFgaKL7IfsnXncePoH4K+5qkyBIAl/m9Zs=
-github.com/containers/image/v5 v5.32.3-0.20241128085047-0c20855557c9 h1:RqjeydhQ73aFkYASllZ2/cAHYvmLHrLbxh5hnWVvoa8=
-github.com/containers/image/v5 v5.32.3-0.20241128085047-0c20855557c9/go.mod h1:v1l73VeMugfj/QtKI+jhYbwnwFCFnNGckvbST3rQ5Hk=
+github.com/containers/image/v5 v5.32.3-0.20250321090242-db55860a7cf9 h1:bFVDgCjoYm+Fr6DkQDjjqBTkA3Cgwjrr7Z2+uULJTPc=
+github.com/containers/image/v5 v5.32.3-0.20250321090242-db55860a7cf9/go.mod h1:v1l73VeMugfj/QtKI+jhYbwnwFCFnNGckvbST3rQ5Hk=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=
 github.com/containers/kubensmnt v1.2.0/go.mod h1:1/HG09N/a1+WSD3zkurzeWtqlKRSfUUnlIF/08zloqk=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/github.com/containers/image/v5/storage/storage_dest.go
+++ b/vendor/github.com/containers/image/v5/storage/storage_dest.go
@@ -515,7 +515,7 @@ func (s *storageImageDestination) tryReusingBlobAsPending(blobDigest digest.Dige
 				return false, private.ReusedBlob{}, fmt.Errorf(`looking for layers with digest %q: %w`, uncompressedDigest, err)
 			}
 			if found, reused := reusedBlobFromLayerLookup(layers, blobDigest, size, options); found {
-				s.lockProtected.blobDiffIDs[blobDigest] = uncompressedDigest
+				s.lockProtected.blobDiffIDs[reused.Digest] = uncompressedDigest
 				return true, reused, nil
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -268,7 +268,7 @@ github.com/containers/conmon/runner/config
 ## explicit; go 1.22
 github.com/containers/conmon-rs/internal/proto
 github.com/containers/conmon-rs/pkg/client
-# github.com/containers/image/v5 v5.32.3-0.20241128085047-0c20855557c9
+# github.com/containers/image/v5 v5.32.3-0.20250321090242-db55860a7cf9
 ## explicit; go 1.21.0
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
This will fix an issue with pulling certain docker schema 1 images in CRI-O.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Requires https://github.com/containers/image/pull/2800
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug when trying to pull certain docker schema 1 images in CRI-O.
```
