### PR TITLE
Handle AppArmor as enabled in rootless mode for CRI-O

### DIFF
--- a/vendor/github.com/containers/common/pkg/apparmor/apparmor_linux.go
+++ b/vendor/github.com/containers/common/pkg/apparmor/apparmor_linux.go
@@ -29,7 +29,13 @@ var profileDirectory = "/etc/apparmor.d"
 // for the existence of the `apparmor_parser` binary, which will be required to
 // apply profiles.
 func IsEnabled() bool {
-	return supported.NewAppArmorVerifier().IsSupported() == nil
+	if err := supported.NewAppArmorVerifier().IsSupported(); err != nil {
+		if errors.Is(err, supported.ErrRootlessNotSupported) {
+			return true
+		}
+		return false
+	}
+	return true
 }
 
 // profileData holds information about the given profile for generation.

--- a/vendor/github.com/containers/common/pkg/apparmor/internal/supported/supported.go
+++ b/vendor/github.com/containers/common/pkg/apparmor/internal/supported/supported.go
@@ -23,8 +23,9 @@ type ApparmorVerifier struct {
 }
 
 var (
-	singleton *ApparmorVerifier
-	once      sync.Once
+	singleton               *ApparmorVerifier
+	once                    sync.Once
+	ErrRootlessNotSupported = errors.New("AppArmor is not supported on rootless containers")
 )
 
 // NewAppArmorVerifier can be used to retrieve a new ApparmorVerifier instance.
@@ -42,7 +43,7 @@ func NewAppArmorVerifier() *ApparmorVerifier {
 // - the `apparmor_parser` binary is not discoverable
 func (a *ApparmorVerifier) IsSupported() error {
 	if a.impl.UnshareIsRootless() {
-		return errors.New("AppAmor is not supported on rootless containers")
+		return ErrRootlessNotSupported
 	}
 	if !a.impl.RuncIsEnabled() {
 		return errors.New("AppArmor not supported by the host system")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
When printing the CRI-O version, there is `AppArmorEnabled` that indicates whether AppArmor is enabled or not. However, in case of running it as non-root it reports AppArmor as not enabled even though it is actually enabled on the host. For example, `apparmor_status`  binary confirms that the default CRI-O profile is loaded. 

```
crio version
INFO[2025-03-31T13:00:26.638381533Z] Updating config from single file: /etc/crio/crio.conf
INFO[2025-03-31T13:00:26.638417334Z] Updating config from drop-in file: /etc/crio/crio.conf
INFO[2025-03-31T13:00:26.638433367Z] Skipping not-existing config file "/etc/crio/crio.conf"
INFO[2025-03-31T13:00:26.638455635Z] Updating config from path: /etc/crio/crio.conf.d
INFO[2025-03-31T13:00:26.638506983Z] Updating config from drop-in file: /etc/crio/crio.conf.d/10-crio.conf
Version:        1.32.2
GitCommit:      318db72eb0b3d18c22c995aa7614a13142287296
GitCommitDate:  2025-03-02T18:05:31Z
GitTreeState:   dirty
BuildDate:      1970-01-01T00:00:00Z
GoVersion:      go1.23.3
Compiler:       gc
Platform:       linux/amd64
Linkmode:       static
BuildTags:
  static
  netgo
  osusergo
  exclude_graphdriver_btrfs
  seccomp
  apparmor
  selinux
  exclude_graphdriver_devicemapper
LDFlags:          unknown
SeccompEnabled:   true
AppArmorEnabled:  false
```
```
sudo apparmor_status | grep crio
   crio-default
```
common's apparmor package depends on [IsRootless()](https://github.com/containers/storage/blob/3fc5c230951d11da1627aca51b8153befc77fd16/pkg/unshare/unshare_linux.go#L417), which considers several conditions to determine whether a process is rootless or not. One such condition is the presence of the `CAP_SYS_ADMIN` capability. For example, if `CAP_SYS_ADMIN` capability is missing or a process is running as non-root it ultimately causes CRI-O to report that AppArmor is not enabled even when it actually is. This patch does not modify IsRootless() but allows reporting AppArmor as enabled when it is, even if running in rootless mode.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
```
NONE
```
#### Does this PR introduce a user-facing change?
```
Probably no, but can't say for sure :)
```