### PR TITLE
OCPBUGS-54658: Increase pull-progress-timeout to `30s`

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -383,7 +383,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--profile-port**="": Port for the pprof profiler. (default: 6060)
 
-**--pull-progress-timeout**="": The timeout for an image pull to make progress until the pull operation gets canceled. This value will be also used for calculating the pull progress interval to --pull-progress-timeout / 10. Can be set to 0 to disable the timeout as well as the progress output. (default: 10s)
+**--pull-progress-timeout**="": The timeout for an image pull to make progress until the pull operation gets canceled. This value will be also used for calculating the pull progress interval to --pull-progress-timeout / 10. Can be set to 0 to disable the timeout as well as the progress output. (default: 30s)
 
 **--rdt-config-file**="": Path to the RDT configuration file for configuring the resctrl pseudo-filesystem.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -494,7 +494,7 @@ Path to the temporary directory to use for storing big files, used to store imag
 **auto_reload_registries**=false
 If true, CRI-O will automatically reload the mirror registry when there is an update to the 'registries.conf.d' directory. Default value is set to 'false'.
 
-**pull_progress_timeout**="10s"
+**pull_progress_timeout**="30s"
 The timeout for an image pull to make progress until the pull operation gets canceled. This value will be also used for calculating the pull progress interval to pull_progress_timeout / 10. Can be set to 0 to disable the timeout as well as the progress output.
 
 ## CRIO.NETWORK TABLE

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -935,7 +935,7 @@ func DefaultConfig() (*Config, error) {
 			PauseCommand:        "/pause",
 			ImageVolumes:        ImageVolumesMkdir,
 			SignaturePolicyDir:  "/etc/crio/policies",
-			PullProgressTimeout: 10 * time.Second,
+			PullProgressTimeout: 30 * time.Second,
 		},
 		NetworkConfig: NetworkConfig{
 			NetworkDir: cniConfigDir,


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
There are use cases where a higher timeout is required because zscaler scans all transfers. To fulfill those we now use a slightly higher default value.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
Needs to be backported down to 1.29.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Increased `pull-progress-timeout` to default to `30s`.
```
