### PR TITLE
emit crio runtime config as part of CRI API's StatusResponse

### DIFF
--- a/server/runtime_status.go
+++ b/server/runtime_status.go
@@ -78,6 +78,7 @@ func (s *Server) Status(ctx context.Context, req *types.StatusRequest) (*types.S
 func (s *Server) createRuntimeInfo() (map[string]string, error) {
 	config := map[string]any{
 		"sandboxImage": s.config.PauseImage,
+		"crio":         s.config.RuntimeConfig,
 	}
 
 	bytes, err := json.Marshal(config)

--- a/test/runtimeconfig.bats
+++ b/test/runtimeconfig.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "crictl info prints out the crio runtime config" {
+	start_crio
+	info_json=$(crictl info -o json)
+
+	jq -e '.config.crio' <<< "$info_json"
+
+	default_runtime=$(jq -r ".config.crio.DefaultRuntime" <<< "$info_json")
+	jq -e ".config.crio.Runtimes.[\"$default_runtime\"]" <<< "$info_json"
+
+	crio_runtime_bin_path=$(jq -r ".config.crio.Runtimes.[\"$default_runtime\"].RuntimePath" <<< "$info_json")
+	[[ "${crio_runtime_bin_path}" == "$RUNTIME_BINARY_PATH" ]]
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#9122 


#### Special notes for your reviewer:

This PR brings the status endpoint implementation to parity with that of containerd. We would like the ability to retrieve the active runtime config through CRI socket invocation. 

The other option is for us to import the cri-o package to reuse the same business logic as `crio status config`. This option is undesirable as importing cri-o brings in a significant dependency overhead

#### Does this PR introduce a user-facing change?


```release-note
Added runtime config block to the `StatusResponse` returned by the CRI Status endpoint.
```
