### PR TITLE
OCPBUGS-54662: [release-1.32] Disable pull-progress-timeout per default

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -383,7 +383,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--profile-port**="": Port for the pprof profiler. (default: 6060)
 
-**--pull-progress-timeout**="": The timeout for an image pull to make progress until the pull operation gets canceled. This value will be also used for calculating the pull progress interval to --pull-progress-timeout / 10. Can be set to 0 to disable the timeout as well as the progress output. (default: 10s)
+**--pull-progress-timeout**="": The timeout for an image pull to make progress until the pull operation gets canceled. This value will be also used for calculating the pull progress interval to --pull-progress-timeout / 10. Can be set to 0 to disable the timeout as well as the progress output. (default: 0s)
 
 **--rdt-config-file**="": Path to the RDT configuration file for configuring the resctrl pseudo-filesystem.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -494,7 +494,7 @@ Path to the temporary directory to use for storing big files, used to store imag
 **auto_reload_registries**=false
 If true, CRI-O will automatically reload the mirror registry when there is an update to the 'registries.conf.d' directory. Default value is set to 'false'.
 
-**pull_progress_timeout**="10s"
+**pull_progress_timeout**="0s"
 The timeout for an image pull to make progress until the pull operation gets canceled. This value will be also used for calculating the pull progress interval to pull_progress_timeout / 10. Can be set to 0 to disable the timeout as well as the progress output.
 
 ## CRIO.NETWORK TABLE

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -956,7 +956,7 @@ func DefaultConfig() (*Config, error) {
 			PauseCommand:        "/pause",
 			ImageVolumes:        ImageVolumesMkdir,
 			SignaturePolicyDir:  "/etc/crio/policies",
-			PullProgressTimeout: 10 * time.Second,
+			PullProgressTimeout: 0,
 		},
 		NetworkConfig: NetworkConfig{
 			NetworkDir: cniConfigDir,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
Follow-up on https://github.com/cri-o/cri-o/pull/9108 and multiple requests to disable the timeout per default.

Cherry-picked: 44d9073dd1133856ffd0858b5d550ce7427335d6 (https://github.com/cri-o/cri-o/pull/9130)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

```release-note
Disabled `pull-progress-timeout` per default. 
```
