### PR TITLE
Add container_spec_memory_limit_bytes metric

### DIFF
--- a/internal/lib/stats/descriptors.go
+++ b/internal/lib/stats/descriptors.go
@@ -63,6 +63,11 @@ var (
 		Help:      "Container swap usage in bytes.",
 		LabelKeys: baseLabelKeys,
 	}
+	containerSpecMemoryLimitBytes = &types.MetricDescriptor{
+		Name:      "container_spec_memory_limit_bytes",
+		Help:      "Memory limit for the container in bytes.",
+		LabelKeys: baseLabelKeys,
+	}
 	containerMemoryFailcnt = &types.MetricDescriptor{
 		Name:      "container_memory_failcnt",
 		Help:      "Number of memory usage hits limits",

--- a/internal/lib/stats/memory_metrics.go
+++ b/internal/lib/stats/memory_metrics.go
@@ -1,6 +1,7 @@
 package statsserver
 
 import (
+	"math"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/config/cgmgr"
@@ -38,6 +39,17 @@ func generateSandboxMemoryMetrics(sb *sandbox.Sandbox, mem *cgmgr.MemoryStats) [
 			desc: containerMemorySwap,
 			valueFunc: func() metricValues {
 				return metricValues{{value: mem.SwapUsage, metricType: types.MetricType_GAUGE}}
+			},
+		},
+		{
+			desc: containerSpecMemoryLimitBytes,
+			valueFunc: func() metricValues {
+				limit := mem.Limit
+				if limit == math.MaxUint64 {
+					// For unlimited memory, use the system's memory limit
+					limit = cgmgr.MemLimitGivenSystem(limit)
+				}
+				return metricValues{{value: limit, metricType: types.MetricType_GAUGE}}
 			},
 		},
 		{

--- a/internal/lib/stats/metrics.go
+++ b/internal/lib/stats/metrics.go
@@ -65,6 +65,7 @@ func (ss *StatsServer) PopulateMetricDescriptors(includedKeys []string) map[stri
 			containerMemoryKernelUsage,
 			containerMemoryMappedFile,
 			containerMemorySwap,
+			containerSpecMemoryLimitBytes,
 			containerMemoryFailcnt,
 			containerMemoryUsageBytes,
 			containerMemoryMaxUsageBytes,


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR adds the container_spec_memory_limit_bytes metric to the CRI-O metrics suite, which reports the memory limit for containers in bytes. This metric is valuable for monitoring and alerting on memory configuration versus usage. It allows users to easily calculate memory usage percentages and visualize resource allocation versus consumption in monitoring systems like Prometheus and Grafana.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

The implementation follows the existing pattern for metrics in CRI-O. The new metric has been added to the "memory" metrics section and implemented in the generateSandboxMemoryMetrics function to collect memory limit data from cgroup stats.

#### Does this PR introduce a user-facing change?

None

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added new metric `container_spec_memory_limit_bytes` to display the memory limit of containers in bytes.
```
