### PR TITLE
[release-1.30]: OCPBUGS-55241: crio wipe should remove storage only once per reboot

### DIFF
--- a/internal/criocli/wipe.go
+++ b/internal/criocli/wipe.go
@@ -2,6 +2,7 @@ package criocli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	cstorage "github.com/containers/storage"
@@ -68,8 +69,22 @@ func crioWipe(c *cli.Context) error {
 			config.CleanShutdownFile,
 			store.GraphRoot(),
 		)
+
+		const wipeMarkerFile = "/run/crio/crio-wipe-done"
+		if _, err := os.Stat(wipeMarkerFile); err == nil {
+			logrus.Infof("Unclean shutdown check already succeeded by previous crio wipe command")
+
+			return nil
+		}
+
 		// This will fail if there are any containers currently running.
-		return lib.RemoveStorageDirectory(config, store, false)
+		if err := lib.RemoveStorageDirectory(config, store, false); err != nil {
+			return fmt.Errorf("failed to remove storage directory %w", err)
+		}
+
+		if err = os.WriteFile(wipeMarkerFile, []byte("done"), 0o644); err != nil {
+			logrus.Warnf("Failed to create crio wipe marker file: %v", err)
+		}
 	}
 
 	// If crio is configured to wipe internally (and `--force` wasn't set)


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

#### What type of PR is this?

/kind bug

#### Special notes for your reviewer: Backporting the fix https://github.com/cri-o/cri-o/pull/9059

#### Does this PR introduce a user-facing change?

```release-note

Prevent multiple crio wipes on reboot

```
