### PR TITLE
Support `artifactType` OCI artifacts

### DIFF
--- a/internal/ociartifact/store.go
+++ b/internal/ociartifact/store.go
@@ -169,7 +169,18 @@ func (s *Store) PullManifest(
 	}
 
 	if slices.Contains(imageMimeTypes, mimeType) && slices.Contains(configMediaTypes, mediaType) {
-		return nil, ErrIsAnImage
+		ociManifest, err := manifest.OCI1FromManifest(manifestBytes)
+		// Unable to parse an OCI manifest, assume an image
+		if err != nil {
+			return nil, ErrIsAnImage
+		}
+
+		// No artifact type set, assume an image
+		if ociManifest.ArtifactType == "" {
+			return nil, ErrIsAnImage
+		}
+
+		log.Debugf(ctx, "Found artifact type: %s", ociManifest.ArtifactType)
 	}
 
 	log.Infof(ctx, "Pulling OCI artifact %s with manifest mime type %q and config media type %q", strRef, mimeType, mediaType)


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

If the `artifactType` field is set, then we treat the image as OCI artifact. This allows to specify artifacts which still use `application/vnd.oci.image.manifest.v1+json` as manifest media type and/or `application/vnd.oci.image.config.v1+json` config media type.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/9152#issuecomment-2827357097
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
