### PR TITLE
[WIP] Add mechanism to monitor conmon

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -554,7 +554,15 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 
 	c.AddContainer(ctx, ctr)
 
-	return c.ctrIDIndex.Add(id)
+	if err := c.ctrIDIndex.Add(id); err != nil {
+		return err
+	}
+
+	if err := c.runtime.StartWatchContainerMonitor(ctx, ctr); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func restoreVolumes(m *rspec.Spec, ctr *oci.Container) error {

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -77,6 +77,7 @@ type Container struct {
 	runtimePath           string // runtime path for a given platform
 	execPIDs              map[int]bool
 	runtimeUser           *types.ContainerUser
+	watched               bool // if true, the container monitor is being watched
 }
 
 func (c *Container) CRIAttributes() *types.ContainerAttributes {
@@ -115,7 +116,18 @@ type ContainerState struct {
 	// is the same as the corresponding PID on the host.
 	InitStartTime string `json:"initStartTime,omitempty"`
 	// Checkpoint/Restore related states
-	CheckpointedAt time.Time `json:"checkpointedTime,omitempty"`
+	CheckpointedAt          time.Time                `json:"checkpointedTime,omitempty"`
+	ContainerMonitorProcess *ContainerMonitorProcess `json:"containerMonitorProcess,omitempty"`
+}
+
+// ContainerMonitorProcess represents a process of conmon, conmon-rs, etc.
+// It's used to check the identity of the process.
+type ContainerMonitorProcess struct {
+	Pid int `json:"pid,omitempty"`
+	// The unix start time of the monitor's PID.
+	// This is used to track whether the PID we have stored
+	// is the same as the corresponding PID on the host.
+	StartTime string `json:"startTime,omitempty"`
 }
 
 // NewContainer creates a container object.

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -81,6 +81,9 @@ type RuntimeImpl interface {
 	CheckpointContainer(context.Context, *Container, *rspec.Spec, bool) error
 	RestoreContainer(context.Context, *Container, string, string) error
 	IsContainerAlive(*Container) bool
+	// StartWatchContainerMonitor starts goroutine to watch the container monitor process.
+	// It's called as many times as the number of containers.
+	StartWatchContainerMonitor(context.Context, *Container) error
 }
 
 // New creates a new Runtime with options provided.
@@ -533,4 +536,13 @@ func (r *Runtime) IsContainerAlive(c *Container) (bool, error) {
 	}
 
 	return impl.IsContainerAlive(c), nil
+}
+
+func (r *Runtime) StartWatchContainerMonitor(ctx context.Context, c *Container) error {
+	impl, err := r.RuntimeImpl(c)
+	if err != nil {
+		return err
+	}
+
+	return impl.StartWatchContainerMonitor(ctx, c)
 }

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -311,3 +311,7 @@ func (r *runtimePod) ReopenContainerLog(ctx context.Context, c *Container) error
 func (r *runtimePod) IsContainerAlive(c *Container) bool {
 	return c.Living() == nil
 }
+
+func (r *runtimePod) StartWatchContainerMonitor(ctx context.Context, c *Container) error {
+	return nil
+}

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -1340,3 +1340,7 @@ func EncodeKataVirtualVolumeToBase64(ctx context.Context, volume *katavolume.Kat
 func (r *runtimeVM) IsContainerAlive(c *Container) bool {
 	return r.kill(c.ID(), "", 0, false) == nil
 }
+
+func (r *runtimeVM) StartWatchContainerMonitor(ctx context.Context, c *Container) error {
+	return nil
+}

--- a/test/conmon.bats
+++ b/test/conmon.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+  if [[ $RUNTIME_TYPE != oci ]]; then
+    skip "not using conmonrs"
+  fi
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "cri-o logs the error when conmon exits" {
+	start_crio
+
+	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	conmon_pid=$(jq '.containerMonitorProcess.pid'< "$TESTDIR/crio/overlay-containers/$ctr_id/userdata/state.json")
+
+	kill -9 "$conmon_pid"
+	sleep 10
+	wait_for_log "Monitor for container"
+}
+
+@test "cri-o doesn't log the error when conmon doesn't exit" {
+	start_crio
+
+	crictl run "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json
+	sleep 10
+	run ! wait_for_log "Monitor for container"
+}
+
+#@test "cri-o stops monitoring when the container stops" {
+#	start_crio
+#
+#	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+#	crictl stop "$ctr_id"
+#	wait_for_log "DeleteMonitoringProcess"
+#}
+
+@test "cri-o continues to monitor when cri-o restarts" {
+	start_crio
+	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	conmon_pid=$(jq '.containerMonitorProcess.pid'< "$TESTDIR/crio/overlay-containers/$ctr_id/userdata/state.json")
+
+  restart_crio
+	kill -9 "$conmon_pid"
+	sleep 10
+	wait_for_log "Monitor for container"
+}

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -245,6 +245,20 @@ func (mr *MockRuntimeImplMockRecorder) StartContainer(arg0, arg1 any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).StartContainer), arg0, arg1)
 }
 
+// StartWatchContainerMonitor mocks base method.
+func (m *MockRuntimeImpl) StartWatchContainerMonitor(arg0 context.Context, arg1 *oci.Container) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartWatchContainerMonitor", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartWatchContainerMonitor indicates an expected call of StartWatchContainerMonitor.
+func (mr *MockRuntimeImplMockRecorder) StartWatchContainerMonitor(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWatchContainerMonitor", reflect.TypeOf((*MockRuntimeImpl)(nil).StartWatchContainerMonitor), arg0, arg1)
+}
+
 // StopContainer mocks base method.
 func (m *MockRuntimeImpl) StopContainer(arg0 context.Context, arg1 *oci.Container, arg2 int64) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR adds mechanism to monitor conmon processes, and logs errors when they exited before the container stops.

It monitors conmon by polling with signal 0 periodically.

There's a concern about its performance impact. A goroutine has a minimum stack size 8KB + other usage. If the node runs 1000 containers, cri-o uses more memory usage by 10MB - 100MB order I guess.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Log errors when conmon stops unexpectedly
```
