### PR TITLE
CRI-O reads its configuration from /etc first and then /usr.

### DIFF
--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -9,11 +9,17 @@ const (
 	containerExitsDir        = "/var/run/crio/exits"
 	ContainerAttachSocketDir = "/var/run/crio"
 
-	// CrioConfigPath is the default location for the conf file.
-	CrioConfigPath = "/etc/crio/crio.conf"
+	// CrioConfigPathEtc is the default location for the conf file.
+	CrioConfigPathEtc = "/etc/crio/crio.conf"
 
-	// CrioConfigDropInPath is the default location for the drop-in config files.
-	CrioConfigDropInPath = "/etc/crio/crio.conf.d"
+	// CrioConfigPathUsr is the second location for the conf file.
+	CrioConfigPathUsr = "/usr/lib/crio/crio.conf"
+
+	// CrioConfigDropInPathEtc is the default location for the drop-in config files.
+	CrioConfigDropInPathEtc = "/etc/crio/crio.conf.d"
+
+	// CrioConfigDropInPathUsr is the second default location for the drop-in config files.
+	CrioConfigDropInPathUsr = "/usr/lib/crio/crio.conf.d"
 
 	// CrioSocketPath is where the unix socket is located.
 	CrioSocketPath = "/var/run/crio/crio.sock"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The configuration files would be searched and merged from top to bottom:

1. `/etc/crio/crio.conf` (file)
2. `/usr/lib/crio/crio.conf` (file)
3. `--config` (file)
4. `/etc/crio/crio.conf.d/*` (dir)
5. `/usr/lib/crio/crio.conf.d/*` (dir)
6. `--config-dir`  (dir)
7. `CLI` parameters


#### Which issue(s) this PR fixes:

Fixes #9075

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

```release-note
CRI-O reads its configuration from /etc first and then /usr.

The configuration files would be searched and merged from top to bottom:

1. /etc/crio/crio.conf (file)
2. /usr/lib/crio/crio.conf (file)
3. --config (file)
4. /etc/crio/crio.conf.d/* (dir)
5. /usr/lib/crio/crio.conf.d/* (dir)
6. --config-dir  (dir)
7. CLI parameters

```
