### PR TITLE
Make image volumes writable

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1470,3 +1470,17 @@ func configureTimezone(tz, containerRunDir, mountPoint, mountLabel, etcPath, con
 
 	return nil
 }
+
+type imageVolumesPath struct {
+	mounts string
+	work   string
+}
+
+func (s *Server) getImageVolumesPaths() *imageVolumesPath {
+	rootPath := filepath.Join(filepath.Dir(s.ContainerServer.Config().ContainerExitsDir), "image-volumes")
+
+	return &imageVolumesPath{
+		mounts: filepath.Join(rootPath, "mounts"),
+		work:   filepath.Join(rootPath, "work"),
+	}
+}

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -88,6 +88,11 @@ func (s *Server) removeContainerInPod(ctx context.Context, sb *sandbox.Sandbox, 
 	s.ReleaseContainerName(ctx, c.Name())
 	s.removeContainer(ctx, c)
 
+	imageVolumesWorkPath := filepath.Join(s.getImageVolumesPaths().work, c.ID())
+	if err := os.RemoveAll(imageVolumesWorkPath); err != nil {
+		log.Warnf(ctx, "Unable to remove image volumes working path %q: %v", imageVolumesWorkPath, err)
+	}
+
 	if err := s.ContainerServer.CtrIDIndex().Delete(c.ID()); err != nil {
 		return fmt.Errorf("failed to delete container %s in pod sandbox %s from index: %w", c.Name(), sb.ID(), err)
 	}


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now maintain an additional `upperdir`/`workdir` part of the image volume mount to be able to write to it. The files will be removed on container deletion and will be therefore not persistent.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/cri-o/issues/9174

#### Special notes for your reviewer:
Refers to https://github.com/kubernetes/kubernetes/issues/131557
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make image volumes writable: The created files within volumes will be available for each container until its deletion.
```
