### PR TITLE
Fix build-rpm.sh exited 141

### DIFF
--- a/hack/build-rpms.sh
+++ b/hack/build-rpms.sh
@@ -12,7 +12,8 @@ os::util::ensure::system_binary_exists createrepo
 os::build::rpm::get_nvra_vars
 
 OS_RPM_SPECFILE="$(find "${OS_ROOT}" -name *cri-o.spec)"
-OS_RPM_NAME="$(rpmspec -q --qf '%{name}\n' "${OS_RPM_SPECFILE}" | head -1)"
+OS_RPM_SPEC="$(rpmspec -q --qf '%{name}\n' "${OS_RPM_SPECFILE}")"
+OS_RPM_NAME="$(echo "$OS_RPM_SPEC" | head -1)"
 
 os::log::info "Building release RPMs for ${OS_RPM_SPECFILE} ..."
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind failing-test
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Hopefully it should fix 
```
 [ERROR] hack/build-rpms.sh:15: `OS_RPM_NAME="$(rpmspec -q --qf '%{name}\n' "${OS_RPM_SPECFILE}" | head -1)"` exited with status 141. 
```

https://tldp.org/LDP/lpg/node20.html
https://stackoverflow.com/questions/19120263/why-exit-code-141-with-grep-q
https://github.com/jqlang/jq/issues/1017#issuecomment-845399005

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
