### PR TITLE
Avoid accessing mirrored registry

### DIFF
--- a/server/image_pull_test.go
+++ b/server/image_pull_test.go
@@ -33,6 +33,9 @@ var _ = t.Describe("ImagePull", func() {
 				imageServerMock.EXPECT().CandidatesForPotentiallyShortImageName(
 					gomock.Any(), "image").
 					Return([]storage.RegistryImageReference{imageCandidate}, nil),
+				imageServerMock.EXPECT().GetImageReferencesFromRegistry(
+					gomock.Any(), gomock.Any()).
+					Return([]storage.RegistryImageReference{imageCandidate}, nil),
 				imageServerMock.EXPECT().PullImage(gomock.Any(), imageCandidate, gomock.Any()).
 					Return(canonicalImageCandidate, nil),
 			)
@@ -69,6 +72,9 @@ var _ = t.Describe("ImagePull", func() {
 			gomock.InOrder(
 				imageServerMock.EXPECT().CandidatesForPotentiallyShortImageName(
 					gomock.Any(), "image").
+					Return([]storage.RegistryImageReference{imageCandidate}, nil),
+				imageServerMock.EXPECT().GetImageReferencesFromRegistry(
+					gomock.Any(), gomock.Any()).
 					Return([]storage.RegistryImageReference{imageCandidate}, nil),
 				imageServerMock.EXPECT().PullImage(gomock.Any(), imageCandidate, gomock.Any()).
 					Return(storage.RegistryImageReference{}, t.TestError),

--- a/server/server.go
+++ b/server/server.go
@@ -97,6 +97,8 @@ type Server struct {
 // pullArguments are used to identify a pullOperation via an input image name and
 // possibly specified credentials.
 type pullArguments struct {
+	// image is a user-specified image.
+	// It can be a shortname and not reflected by registries.conf.
 	image         string
 	sandboxCgroup string
 	credentials   imageTypes.DockerAuthConfig

--- a/test/image.bats
+++ b/test/image.bats
@@ -395,3 +395,16 @@ EOF
 
 	crictl pull "$IMAGE_LIST_TAG"
 }
+
+@test "pull mirrored image when registries.conf is set" {
+	CONTAINER_REGISTRIES_CONF_DIR="$TESTDIR/containers/registries.conf.d"
+	mkdir -p "$CONTAINER_REGISTRIES_CONF_DIR"
+	cat << EOF > "$CONTAINER_REGISTRIES_CONF_DIR/99-registry.conf"
+[[registry]]
+prefix = "example.com"
+location = "quay.io/crio"
+EOF
+	CONTAINER_REGISTRIES_CONF_DIR=$CONTAINER_REGISTRIES_CONF_DIR start_crio
+	crictl pull "example.com/fedora-crio-ci:latest"
+	wait_for_log "Trying to pull quay.io/crio/fedora-crio-ci:latest"
+}

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	sysregistriesv2 "github.com/containers/image/v5/pkg/sysregistriesv2"
 	types "github.com/containers/image/v5/types"
 	storage "github.com/containers/storage"
 	storage0 "github.com/cri-o/cri-o/internal/storage"
@@ -70,6 +71,21 @@ func (m *MockImageServer) DeleteImage(systemContext *types.SystemContext, id sto
 func (mr *MockImageServerMockRecorder) DeleteImage(systemContext, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteImage", reflect.TypeOf((*MockImageServer)(nil).DeleteImage), systemContext, id)
+}
+
+// GetImageReferencesFromRegistry mocks base method.
+func (m *MockImageServer) GetImageReferencesFromRegistry(registry *sysregistriesv2.Registry, imageName storage0.RegistryImageReference) ([]storage0.RegistryImageReference, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageReferencesFromRegistry", registry, imageName)
+	ret0, _ := ret[0].([]storage0.RegistryImageReference)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageReferencesFromRegistry indicates an expected call of GetImageReferencesFromRegistry.
+func (mr *MockImageServerMockRecorder) GetImageReferencesFromRegistry(registry, imageName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageReferencesFromRegistry", reflect.TypeOf((*MockImageServer)(nil).GetImageReferencesFromRegistry), registry, imageName)
 }
 
 // GetStore mocks base method.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR fixes the issue that it tries to access registries which are mirrored in registries.conf.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-56561
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed the bug that cri-o tried to access to registries which are mirrored in registries.conf[.d]
```
