### PR TITLE
Fix HostPort manager when one backend is unavailable

### DIFF
--- a/internal/hostport/meta_hostport_manager_test.go
+++ b/internal/hostport/meta_hostport_manager_test.go
@@ -28,20 +28,12 @@ var _ = t.Describe("MetaHostportManager", func() {
 		ip6tables := newFakeIPTables()
 		ip6tables.protocol = utiliptables.ProtocolIPv6
 
-		manager := metaHostportManager{
-			managers: map[utilnet.IPFamily]*hostportManagers{
-				utilnet.IPv4: {
-					iptables: &hostportManagerIPTables{
-						iptables: iptables,
-					},
-				},
-				utilnet.IPv6: {
-					iptables: &hostportManagerIPTables{
-						iptables: ip6tables,
-					},
-				},
-			},
-		}
+		manager := newMetaHostportManagerInternal(
+			&hostportManagerIPTables{iptables: iptables},
+			&hostportManagerIPTables{iptables: ip6tables},
+			nil,
+			nil,
+		)
 
 		// Add Hostports
 		for _, tc := range metaTestCases {
@@ -67,22 +59,13 @@ var _ = t.Describe("MetaHostportManager", func() {
 	It("should work when only nftables is available", func() {
 		nft4 := knftables.NewFake(knftables.IPv4Family, hostPortsTable)
 		nft6 := knftables.NewFake(knftables.IPv6Family, hostPortsTable)
-		manager := metaHostportManager{
-			managers: map[utilnet.IPFamily]*hostportManagers{
-				utilnet.IPv4: {
-					nftables: &hostportManagerNFTables{
-						nft:    nft4,
-						family: knftables.IPv4Family,
-					},
-				},
-				utilnet.IPv6: {
-					nftables: &hostportManagerNFTables{
-						nft:    nft6,
-						family: knftables.IPv6Family,
-					},
-				},
-			},
-		}
+
+		manager := newMetaHostportManagerInternal(
+			nil,
+			nil,
+			&hostportManagerNFTables{nft: nft4, family: knftables.IPv4Family},
+			&hostportManagerNFTables{nft: nft6, family: knftables.IPv6Family},
+		)
 
 		// Add Hostports
 		for _, tc := range metaTestCases {
@@ -110,28 +93,13 @@ var _ = t.Describe("MetaHostportManager", func() {
 		ip6tables.protocol = utiliptables.ProtocolIPv6
 		nft4 := knftables.NewFake(knftables.IPv4Family, hostPortsTable)
 		nft6 := knftables.NewFake(knftables.IPv6Family, hostPortsTable)
-		manager := metaHostportManager{
-			managers: map[utilnet.IPFamily]*hostportManagers{
-				utilnet.IPv4: {
-					iptables: &hostportManagerIPTables{
-						iptables: iptables,
-					},
-					nftables: &hostportManagerNFTables{
-						nft:    nft4,
-						family: knftables.IPv4Family,
-					},
-				},
-				utilnet.IPv6: {
-					iptables: &hostportManagerIPTables{
-						iptables: ip6tables,
-					},
-					nftables: &hostportManagerNFTables{
-						nft:    nft6,
-						family: knftables.IPv6Family,
-					},
-				},
-			},
-		}
+
+		manager := newMetaHostportManagerInternal(
+			&hostportManagerIPTables{iptables: iptables},
+			&hostportManagerIPTables{iptables: ip6tables},
+			&hostportManagerNFTables{nft: nft4, family: knftables.IPv4Family},
+			&hostportManagerNFTables{nft: nft6, family: knftables.IPv6Family},
+		)
 
 		// Add Hostports
 		for _, tc := range metaTestCases {
@@ -203,20 +171,13 @@ var _ = t.Describe("MetaHostportManager", func() {
 		iptables.protocol = utiliptables.ProtocolIPv4
 		ip6tables := newFakeIPTables()
 		ip6tables.protocol = utiliptables.ProtocolIPv6
-		manager := metaHostportManager{
-			managers: map[utilnet.IPFamily]*hostportManagers{
-				utilnet.IPv4: {
-					iptables: &hostportManagerIPTables{
-						iptables: iptables,
-					},
-				},
-				utilnet.IPv6: {
-					iptables: &hostportManagerIPTables{
-						iptables: ip6tables,
-					},
-				},
-			},
-		}
+
+		manager := newMetaHostportManagerInternal(
+			&hostportManagerIPTables{iptables: iptables},
+			&hostportManagerIPTables{iptables: ip6tables},
+			nil,
+			nil,
+		)
 
 		// Add the legacy mappings.
 		for _, tc := range legacyIPTablesTestCases {
@@ -231,28 +192,13 @@ var _ = t.Describe("MetaHostportManager", func() {
 		// existing fakeIPTables state, but now with nftables support as well.
 		nft4 := knftables.NewFake(knftables.IPv4Family, hostPortsTable)
 		nft6 := knftables.NewFake(knftables.IPv6Family, hostPortsTable)
-		manager = metaHostportManager{
-			managers: map[utilnet.IPFamily]*hostportManagers{
-				utilnet.IPv4: {
-					iptables: &hostportManagerIPTables{
-						iptables: iptables,
-					},
-					nftables: &hostportManagerNFTables{
-						nft:    nft4,
-						family: knftables.IPv4Family,
-					},
-				},
-				utilnet.IPv6: {
-					iptables: &hostportManagerIPTables{
-						iptables: ip6tables,
-					},
-					nftables: &hostportManagerNFTables{
-						nft:    nft6,
-						family: knftables.IPv6Family,
-					},
-				},
-			},
-		}
+
+		manager = newMetaHostportManagerInternal(
+			&hostportManagerIPTables{iptables: iptables},
+			&hostportManagerIPTables{iptables: ip6tables},
+			&hostportManagerNFTables{nft: nft4, family: knftables.IPv4Family},
+			&hostportManagerNFTables{nft: nft6, family: knftables.IPv6Family},
+		)
 
 		// Add the remaining hostports.
 		for _, tc := range metaTestCases {
@@ -289,19 +235,13 @@ var _ = t.Describe("MetaHostportManager", func() {
 		iptables := newFakeIPTables()
 		iptables.protocol = utiliptables.ProtocolIPv4
 		nft4 := knftables.NewFake(knftables.IPv4Family, hostPortsTable)
-		manager := metaHostportManager{
-			managers: map[utilnet.IPFamily]*hostportManagers{
-				utilnet.IPv4: {
-					iptables: &hostportManagerIPTables{
-						iptables: iptables,
-					},
-					nftables: &hostportManagerNFTables{
-						nft:    nft4,
-						family: knftables.IPv4Family,
-					},
-				},
-			},
-		}
+
+		manager := newMetaHostportManagerInternal(
+			&hostportManagerIPTables{iptables: iptables},
+			nil,
+			&hostportManagerNFTables{nft: nft4, family: knftables.IPv4Family},
+			nil,
+		)
 
 		// Add Hostports
 		for _, tc := range metaTestCases {

--- a/internal/iptables/iptables.go
+++ b/internal/iptables/iptables.go
@@ -220,12 +220,6 @@ type runner struct {
 // newInternal returns a new Interface which will exec iptables, and allows the
 // caller to change the iptables-restore lockfile path.
 func newInternal(ctx context.Context, exec utilexec.Interface, protocol Protocol, lockfilePath14x, lockfilePath16x string) Interface {
-	version, err := getIPTablesVersion(exec, protocol)
-	if err != nil {
-		log.Warnf(ctx, "Error checking iptables version, assuming version at least: %s (version=%q)", err, MinCheckVersion)
-		version = MinCheckVersion
-	}
-
 	if lockfilePath16x == "" {
 		lockfilePath16x = LockfilePath16x
 	}
@@ -237,13 +231,24 @@ func newInternal(ctx context.Context, exec utilexec.Interface, protocol Protocol
 	runner := &runner{
 		exec:            exec,
 		protocol:        protocol,
-		hasCheck:        version.AtLeast(MinCheckVersion),
-		hasRandomFully:  version.AtLeast(RandomFullyMinVersion),
-		waitFlag:        getIPTablesWaitFlag(version),
-		restoreWaitFlag: getIPTablesRestoreWaitFlag(version, exec, protocol),
 		lockfilePath14x: lockfilePath14x,
 		lockfilePath16x: lockfilePath16x,
 	}
+
+	version, err := getIPTablesVersion(exec, protocol)
+	if err != nil {
+		// The only likely error is "no such file or directory", in which case any
+		// further commands will fail the same way, so we don't need to do
+		// anything special here.
+		log.Debugf(ctx, "Error checking iptables version: %v", err)
+
+		return runner
+	}
+
+	runner.hasCheck = version.AtLeast(MinCheckVersion)
+	runner.hasRandomFully = version.AtLeast(RandomFullyMinVersion)
+	runner.waitFlag = getIPTablesWaitFlag(version)
+	runner.restoreWaitFlag = getIPTablesRestoreWaitFlag(version, exec, protocol)
 
 	return runner
 }


### PR DESCRIPTION
The new iptables-and-nftables MetaHostPortManager code was falling victim to a classic golang gotcha. If `newHostportManagerIPTables` returned a `nil` value (of type `*hostportManagerIPTables`), then that value would get assigned to `mh.managers[utilnet.IPv4].iptables`, but that value is a `HostPortManager`, so the value would be typecast, becoming a non-`nil` `HostPortManager` value wrapping the `nil` `*hostportManagerIPTables` value, and then later, this code

https://github.com/cri-o/cri-o/blob/9d143f94054fc5c8338673f35f7c0164490363b3/internal/hostport/meta_hostport_manager.go#L143-L149

would see that it was non-`nil` and attempt to call a method on it, which would then SEGV because the underlying `*hostportManagerIPTables` was `nil`.

There are a few possible ways to fix this... this is one of them... 

This wasn't caught by unit tests because the unit tests don't use `NewMetaHostportManager` (since it's not fully mock-able) and it wasn't caught by e2e tests because the e2e environment has both iptables and nftables installed.

I also pulled in a cri-o-ified version of [kubernetes/kubernetes@`b031258`](https://github.com/kubernetes/kubernetes/pull/129826/commits/b03125896923d59a2d12a17e16d6289be9fce6e8) to get rid of the superfluous error messages also seen in #9220.

Fixes #9220
/kind bug
/kind cleanup

#### Does this PR introduce a user-facing change?
```release-note
Fixes a crash introduced in 1.33.0 when cleaning up a pod that uses HostPorts
on a system that has either just iptables (but not nftables) or just nftables
(but not iptables).
```
