### PR TITLE
internal/hostport: fix linter warning

### DIFF
--- a/internal/hostport/hostport_iptables.go
+++ b/internal/hostport/hostport_iptables.go
@@ -456,8 +456,6 @@ func filterChains(chains map[utiliptables.Chain]string, filterChains []utiliptab
 }
 
 // Join all words with spaces, terminate with newline and write to buf.
-//
-//nolint:interfacer
 func writeLine(buf *bytes.Buffer, words ...string) {
 	buf.WriteString(strings.Join(words, " ") + "\n")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This fixes the following warning:

> level=warning msg="[runner/nolint_filter] Found unknown linters in //nolint directives: interfacer"

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
