### PR TITLE
change conmon install

### DIFF
--- a/contrib/test/ci/build/conmon.yml
+++ b/contrib/test/ci/build/conmon.yml
@@ -16,7 +16,7 @@
 
 - name: install conmon
   make:
-    target: "install"
+    target: "install.bin"
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/containers/conmon"
     params:
       PREFIX: "/" # install conmon to the PATH so it can be downloaded to the test directory as needed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/65489/rehearse-65489-periodic-ci-cri-o-cri-o-main-periodics-setup-periodic/1928178947531476992/artifacts/setup-periodic/cri-o-setup-test/build-log.txt

```
gmake[1]: go-md2man: No such file or directory
gmake[1]: *** [Makefile:9: conmon.8] Error 127
gmake: *** [Makefile:95: docs] Error 2
```

setup ci failed with `go-md2man: No such file or directory`. It should be installed crun steps, but somehow PATH doesn't seem to be configured properly.
Anyway in CI, we don't need docs, I changed the make target to install only bin files.

The Makefile in conmon was changed recently. 
https://github.com/containers/conmon/commit/5b51069234aa0a577d075edd99d5aaf08b64727d

After it's merged, I'll open a PR to fix setup in o/release.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
