### PR TITLE
temporarily enable debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ GO_FILES := $(shell find . -type f -name '*.go' -not -name '*_test.go')
 GINKGO_SKIP_PACKAGES = test/nri
 
 # Set DEBUG=1 to enable debug symbols in binaries
-DEBUG ?= 0
+DEBUG ?= 1
 ifeq ($(DEBUG),0)
 SHRINKFLAGS = -s -w
 else


### PR DESCRIPTION
turn on debug symbols temporarily for kubernetes CI.

```release-note
NONE
```