### PR TITLE
Mark v1.30 as EOL

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -19,7 +19,7 @@ dependencies:
         match: Version
 
   - name: supported versions
-    version: '{"1.33", "1.32", "1.31", "1.30"}'
+    version: '{"1.33", "1.32", "1.31"}'
     refPaths:
       - path: internal/version/version.go
         match: ReleaseMinorVersions

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,7 +24,7 @@ import (
 const Version = "1.34.0"
 
 // ReleaseMinorVersions are the currently supported minor versions.
-var ReleaseMinorVersions = []string{"1.33", "1.32", "1.31", "1.30"}
+var ReleaseMinorVersions = []string{"1.33", "1.32", "1.31"}
 
 // Variables injected during build-time.
 var (

--- a/roadmap.md
+++ b/roadmap.md
@@ -87,7 +87,6 @@ Some of these features can be seen below:
 ## Known Risks
 
 - Relying on different SIGs for CRI-O features:
-
   - We have a need to discuss our enhancements with different SIGs to get all
     required information and drive the change. This can lead into helpful, but maybe
     not expected input and delay the deliverable.


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Kubernetes v1.30 will be end of life on June 28, which also means that we follow in CRI-O.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
