### PR TITLE
Revert "temporarily enable debug symbols"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ GO_FILES := $(shell find . -type f -name '*.go' -not -name '*_test.go')
 GINKGO_SKIP_PACKAGES = test/nri
 
 # Set DEBUG=1 to enable debug symbols in binaries
-DEBUG ?= 1
+DEBUG ?= 0
 ifeq ($(DEBUG),0)
 SHRINKFLAGS = -s -w
 else


### PR DESCRIPTION
This reverts commit ab7d879dc8e30a6a80128c523c65abfc13d597b4.

Fixes #9268

```release-note
NONE
```