### PR TITLE
[release-1.31] Refactor man page variables in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ COVERAGE_PATH := ${BUILD_PATH}/coverage
 TESTBIN_PATH := ${BUILD_PATH}/test
 MOCK_PATH := ${PWD}/test/mocks
 
+MANPAGES_MD := $(wildcard docs/*.md)
+MANPAGES    := $(MANPAGES_MD:%.md=%)
+
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 FISHINSTALLDIR=${PREFIX}/share/fish/completions
 ZSHINSTALLDIR=${PREFIX}/share/zsh/site-functions
@@ -531,9 +534,6 @@ mock-ociartifact-types: ${MOCKGEN}
 		-package ociartifactmock \
 		-destination ${MOCK_PATH}/ociartifact/ociartifact.go \
 		github.com/cri-o/cri-o/internal/config/ociartifact Impl
-
-MANPAGES_MD := $(wildcard docs/*.md)
-MANPAGES    := $(MANPAGES_MD:%.md=%)
 
 docs/%.5: docs/%.5.md ${GO_MD2MAN}
 	(${GO_MD2MAN} -in $< -out $@.tmp && touch $@.tmp && mv $@.tmp $@) || \


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

Backport of https://github.com/cri-o/cri-o/pull/8863 into release-1.31.
#### Which issue(s) this PR fixes:

Fixes #9277 

#### Special notes for your reviewer:
Cherry-pick of: 0daeb208f107ab73602b78d2b35b151b938365b9
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `make install` for building the man pages. 
```
