### PR TITLE
Issue #9125 - Memory swap limit bytes metrics for the containers

### DIFF
--- a/internal/lib/stats/descriptors.go
+++ b/internal/lib/stats/descriptors.go
@@ -68,6 +68,11 @@ var (
 		Help:      "Memory limit for the container in bytes.",
 		LabelKeys: baseLabelKeys,
 	}
+	containerSpecMemorySwapLimitBytes = &types.MetricDescriptor{
+		Name:      "container_spec_memory_swap_limit_bytes",
+		Help:      "Memory swap limit for the container in bytes.",
+		LabelKeys: baseLabelKeys,
+	}
 	containerMemoryFailcnt = &types.MetricDescriptor{
 		Name:      "container_memory_failcnt",
 		Help:      "Number of memory usage hits limits",

--- a/internal/lib/stats/memory_metrics.go
+++ b/internal/lib/stats/memory_metrics.go
@@ -11,6 +11,7 @@ import (
 // Size after which we consider memory to be "unlimited". This is not
 // MaxInt64 due to rounding by the kernel.
 const maxMemorySize = uint64(1 << 62)
+const maxSwapMemorySize = uint64(1 << 62)
 
 func generateSandboxMemoryMetrics(sb *sandbox.Sandbox, mem *cgmgr.MemoryStats) []*types.Metric {
 	memoryMetrics := []*containerMetric{
@@ -52,6 +53,18 @@ func generateSandboxMemoryMetrics(sb *sandbox.Sandbox, mem *cgmgr.MemoryStats) [
 				// This approach is more useful for monitoring tools than reporting the physical limit.
 				limit := mem.Limit
 				if limit > maxMemorySize {
+					return metricValues{{value: 0, metricType: types.MetricType_GAUGE}}
+				}
+
+				return metricValues{{value: limit, metricType: types.MetricType_GAUGE}}
+			},
+		},
+		{
+			desc: containerSpecMemorySwapLimitBytes,
+			valueFunc: func() metricValues {
+				// Memory swap limit for the container..
+				limit := mem.SwapLimit
+				if limit > maxSwapMemorySize {
 					return metricValues{{value: 0, metricType: types.MetricType_GAUGE}}
 				}
 

--- a/internal/lib/stats/metrics.go
+++ b/internal/lib/stats/metrics.go
@@ -66,6 +66,7 @@ func (ss *StatsServer) PopulateMetricDescriptors(includedKeys []string) map[stri
 			containerMemoryMappedFile,
 			containerMemorySwap,
 			containerSpecMemoryLimitBytes,
+			containerSpecMemorySwapLimitBytes,
 			containerMemoryFailcnt,
 			containerMemoryUsageBytes,
 			containerMemoryMaxUsageBytes,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
#9125 - This PR adds the container_spec_memory_swap_limit_bytes metric to the CRI-O metrics suite, which reports the SWAP memory limit for containers in bytes. This metric is valuable for monitoring and alerting on SWAP memory configuration versus usage. It allows users to easily calculate SWAP memory usage percentages and visualize resource allocation versus consumption in monitoring systems like Prometheus and Grafana.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Added `container_spec_memory_swap_limit_bytes` metric
```
