### PR TITLE
Add conmon-rs streaming server support for `Exec` and `Attach`

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -384,6 +384,10 @@ runtime type. Setting this option to true can cause data loss, e.g. when a machi
 **default_annotations**={}
 A mapping of keys to values of annotations set on containers run by this runtime handler, if not overridden by the pod spec.
 
+**stream_websockets**=false
+Enable the WebSocket protocol for container exec, attach and port forward.
+conmon-rs (`runtime_type = "pod"`) supports this configuration for exec and attach. Forwarding ports will be supported in future releases.
+
 ### CRIO.RUNTIME.WORKLOADS TABLE
 
 The "crio.runtime.workloads" table defines a list of workloads - a way to customize the behavior of a pod and container.

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containernetworking/plugins v1.7.1
 	github.com/containers/common v0.63.1
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/conmon-rs v0.6.6
+	github.com/containers/conmon-rs v0.6.7-0.20250626143653-25c2ef8b3da5
 	github.com/containers/image/v5 v5.35.0
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.2.1
@@ -91,7 +91,7 @@ require (
 )
 
 require (
-	capnproto.org/go/capnp/v3 v3.0.1-alpha.2 // indirect
+	capnproto.org/go/capnp/v3 v3.1.0-alpha.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Microsoft/hcsshim v0.12.9 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-capnproto.org/go/capnp/v3 v3.0.1-alpha.2 h1:W/cf+XEArUSwcBBE/9wS2NpWDkM5NLQOjmzEiHZpYi0=
-capnproto.org/go/capnp/v3 v3.0.1-alpha.2/go.mod h1:2vT5D2dtG8sJGEoEKU17e+j7shdaYp1Myl8X03B3hmc=
+capnproto.org/go/capnp/v3 v3.1.0-alpha.1 h1:8/sMnWuatR99G0L0vmnrXj0zVP0MrlyClRqSmqGYydo=
+capnproto.org/go/capnp/v3 v3.1.0-alpha.1/go.mod h1:2vT5D2dtG8sJGEoEKU17e+j7shdaYp1Myl8X03B3hmc=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
@@ -106,8 +106,8 @@ github.com/containers/common v0.63.1 h1:6g02gbW34PaRVH4Heb2Pk11x0SdbQ+8AfeKKeQGq
 github.com/containers/common v0.63.1/go.mod h1:+3GCotSqNdIqM3sPs152VvW7m5+Mg8Kk+PExT3G9hZw=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/conmon-rs v0.6.6 h1:rIqbAN08iOd3Am70IXfuKpYzE/OyuVDKLXjbIr2u+AM=
-github.com/containers/conmon-rs v0.6.6/go.mod h1:QiO/GnwvYwu2pMSAG9bkyUu4cDotVDGXIeuuPpMNhdo=
+github.com/containers/conmon-rs v0.6.7-0.20250626143653-25c2ef8b3da5 h1:74v2Kt+6Lv6K8s2CkZTLrJn4i04bGcuqCXH857w2X+w=
+github.com/containers/conmon-rs v0.6.7-0.20250626143653-25c2ef8b3da5/go.mod h1:F2fvsYBN5uO966WmWqr2oZHe/nQ4WY519HNmmCLungA=
 github.com/containers/image/v5 v5.35.0 h1:T1OeyWp3GjObt47bchwD9cqiaAm/u4O4R9hIWdrdrP8=
 github.com/containers/image/v5 v5.35.0/go.mod h1:8vTsgb+1gKcBL7cnjyNOInhJQfTUQjJoO2WWkKDoebM=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -83,6 +83,8 @@ type RuntimeImpl interface {
 	IsContainerAlive(*Container) bool
 	// ProbeMonitor is used to check the liveness of the container monitor process.
 	ProbeMonitor(context.Context, *Container) error
+	ServeExecContainer(context.Context, *Container, []string, bool, bool, bool, bool) (string, error)
+	ServeAttachContainer(context.Context, *Container, bool, bool, bool) (string, error)
 }
 
 // New creates a new Runtime with options provided.
@@ -240,6 +242,16 @@ func (r *Runtime) RuntimeDefaultAnnotations(runtimeHandler string) (map[string]s
 	}
 
 	return rh.RuntimeDefaultAnnotations(), nil
+}
+
+// RuntimeStreamWebsockets returns the configured websocket streaming option for this handler.
+func (r *Runtime) RuntimeStreamWebsockets(runtimeHandler string) (bool, error) {
+	rh, err := r.getRuntimeHandler(runtimeHandler)
+	if err != nil {
+		return false, err
+	}
+
+	return rh.RuntimeStreamWebsockets(), nil
 }
 
 func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
@@ -544,4 +556,22 @@ func (r *Runtime) ProbeMonitor(ctx context.Context, c *Container) error {
 	}
 
 	return impl.ProbeMonitor(ctx, c)
+}
+
+func (r *Runtime) ServeExecContainer(ctx context.Context, c *Container, cmd []string, tty, stdin, stdout, stderr bool) (string, error) {
+	impl, err := r.RuntimeImpl(c)
+	if err != nil {
+		return "", err
+	}
+
+	return impl.ServeExecContainer(ctx, c, cmd, tty, stdin, stdout, stderr)
+}
+
+func (r *Runtime) ServeAttachContainer(ctx context.Context, c *Container, stdin, stdout, stderr bool) (string, error) {
+	impl, err := r.RuntimeImpl(c)
+	if err != nil {
+		return "", err
+	}
+
+	return impl.ServeAttachContainer(ctx, c, stdin, stdout, stderr)
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1768,3 +1768,11 @@ func (r *runtimeOCI) ProbeMonitor(ctx context.Context, c *Container) error {
 
 	return nil
 }
+
+func (r *runtimeOCI) ServeExecContainer(context.Context, *Container, []string, bool, bool, bool, bool) (string, error) {
+	return "", nil
+}
+
+func (r *runtimeOCI) ServeAttachContainer(context.Context, *Container, bool, bool, bool) (string, error) {
+	return "", nil
+}

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/containers/common/pkg/resize"
@@ -315,4 +316,48 @@ func (r *runtimePod) IsContainerAlive(c *Container) bool {
 func (r *runtimePod) ProbeMonitor(ctx context.Context, c *Container) error {
 	// Not implemented
 	return nil
+}
+
+func (r *runtimePod) ServeExecContainer(ctx context.Context, c *Container, cmd []string, tty, stdin, stdout, stderr bool) (string, error) {
+	res, err := r.client.ServeExecContainer(ctx, &conmonClient.ServeExecContainerConfig{
+		ID:      c.ID(),
+		Command: cmd,
+		Tty:     tty,
+		Stdin:   stdin,
+		Stdout:  stdout,
+		Stderr:  stderr,
+	})
+	if err != nil {
+		if isUnimplementedRPCErr(err) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("call ServeExecContainer RPC: %w", err)
+	}
+
+	return res.URL, nil
+}
+
+func (r *runtimePod) ServeAttachContainer(ctx context.Context, c *Container, stdin, stdout, stderr bool) (string, error) {
+	res, err := r.client.ServeAttachContainer(ctx, &conmonClient.ServeAttachContainerConfig{
+		ID:     c.ID(),
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+	if err != nil {
+		if isUnimplementedRPCErr(err) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("call ServeAttachContainer RPC: %w", err)
+	}
+
+	return res.URL, nil
+}
+
+func isUnimplementedRPCErr(err error) bool {
+	const errUnimplementedString = "Method not implemented."
+
+	return strings.Contains(err.Error(), errUnimplementedString)
 }

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -1345,3 +1345,11 @@ func (r *runtimeVM) ProbeMonitor(ctx context.Context, c *Container) error {
 	// Not implemented
 	return nil
 }
+
+func (r *runtimeVM) ServeExecContainer(context.Context, *Container, []string, bool, bool, bool, bool) (string, error) {
+	return "", nil
+}
+
+func (r *runtimeVM) ServeAttachContainer(context.Context, *Container, bool, bool, bool) (string, error) {
+	return "", nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -271,6 +271,13 @@ type RuntimeHandler struct {
 	// Default annotations specified for runtime handler if they're not overridden by
 	// the pod spec.
 	DefaultAnnotations map[string]string `toml:"default_annotations,omitempty"`
+
+	// StreamWebsockets can be used to enable the WebSocket protocol for
+	// container exec, attach and port forward.
+	//
+	// conmon-rs (runtime_type = "pod") supports this configuration for exec
+	// and attach. Forwarding ports will be supported in future releases.
+	StreamWebsockets bool `toml:"stream_websockets,omitempty"`
 }
 
 // Multiple runtime Handlers in a map.
@@ -1901,6 +1908,11 @@ func (r *RuntimeHandler) RuntimeSupportsMountFlag(flag string) bool {
 // RuntimeDefaultAnnotations returns the default annotations for this handler.
 func (r *RuntimeHandler) RuntimeDefaultAnnotations() map[string]string {
 	return r.DefaultAnnotations
+}
+
+// RuntimeStreamWebsockets returns the configured websocket streaming option for this handler.
+func (r *RuntimeHandler) RuntimeStreamWebsockets() bool {
+	return r.StreamWebsockets
 }
 
 func validateAllowedAndGenerateDisallowedAnnotations(allowed []string) (disallowed []string, _ error) {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1245,6 +1245,7 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 # platform_runtime_paths = { "os/arch" = "/path/to/binary" }
 # no_sync_log = false
 # default_annotations = {}
+# stream_websockets = false
 # Where:
 # - runtime-handler: Name used to identify the runtime.
 # - runtime_path (optional, string): Absolute path to the runtime executable in
@@ -1298,6 +1299,7 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 #   This option is only valid for the 'oci' runtime type. Setting this option to true can cause data loss, e.g.
 #   when a machine crash happens.
 # - default_annotations (optional, map): Default annotations if not overridden by the pod spec.
+# - stream_websockets (optional, bool): Enable the WebSocket protocol for container exec, attach and port forward.
 #
 # Using the seccomp notifier feature:
 #

--- a/server/container_attach_test.go
+++ b/server/container_attach_test.go
@@ -22,6 +22,8 @@ var _ = t.Describe("ContainerAttach", func() {
 	t.Describe("ContainerAttach", func() {
 		It("should succeed", func() {
 			// Given
+			addContainerAndSandbox()
+
 			// When
 			response, err := sut.Attach(context.Background(),
 				&types.AttachRequest{

--- a/server/container_exec_test.go
+++ b/server/container_exec_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // The actual test suite.
-var _ = t.Describe("ContainerStart", func() {
+var _ = t.Describe("ContainerExec", func() {
 	// Prepare the sut
 	BeforeEach(func() {
 		beforeEach()
@@ -19,9 +19,11 @@ var _ = t.Describe("ContainerStart", func() {
 
 	AfterEach(afterEach)
 
-	t.Describe("ContainerStart", func() {
+	t.Describe("ContainerExec", func() {
 		It("should succeed", func() {
 			// Given
+			addContainerAndSandbox()
+
 			// When
 			response, err := sut.Exec(context.Background(),
 				&types.ExecRequest{

--- a/server/container_execsync_test.go
+++ b/server/container_execsync_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // The actual test suite.
-var _ = t.Describe("ContainerStart", func() {
+var _ = t.Describe("ContainerExecSync", func() {
 	// Prepare the sut
 	BeforeEach(func() {
 		beforeEach()
@@ -18,7 +18,7 @@ var _ = t.Describe("ContainerStart", func() {
 
 	AfterEach(afterEach)
 
-	t.Describe("ContainerStart", func() {
+	t.Describe("ContainerExecSync", func() {
 		It("should fail with invalid container ID", func() {
 			// Given
 			// When

--- a/test/conmonrs.bats
+++ b/test/conmonrs.bats
@@ -3,6 +3,10 @@
 load helpers
 
 function setup() {
+	if [[ $RUNTIME_TYPE != pod ]]; then
+		skip "not using conmonrs"
+	fi
+
 	setup_test
 }
 
@@ -10,15 +14,51 @@ function teardown() {
 	cleanup_test
 }
 
-@test "conmonrs is used" {
-	if [[ $RUNTIME_TYPE != pod ]]; then
-		skip "not using conmonrs"
-	fi
+function prepare_stream_server() {
+	setup_crio
 
+	cat << EOF > "$CRIO_CONFIG_DIR/99-websocket.conf"
+[crio.runtime]
+default_runtime = "websocket"
+[crio.runtime.runtimes.websocket]
+runtime_path = "$RUNTIME_BINARY_PATH"
+runtime_type = "pod"
+monitor_path = ""
+stream_websockets = true
+EOF
+	unset CONTAINER_DEFAULT_RUNTIME
+	unset CONTAINER_RUNTIMES
+
+	start_crio_no_setup
+}
+
+@test "conmonrs is used" {
 	start_crio
 
 	crictl run "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
 
 	# Validate that we actually used conmonrs
 	grep -q "Using conmonrs version:" "$CRIO_LOG"
+}
+
+@test "conmonrs streaming server for exec" {
+	prepare_stream_server
+	POD=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	CTR=$(crictl create "$POD" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$CTR"
+
+	OUTPUT=$(crictl exec -r websocket "$CTR" echo test)
+	[ "$OUTPUT" == "test" ]
+	grep -q "Using exec URL from container monitor" "$CRIO_LOG"
+}
+
+@test "conmonrs streaming server for attach" {
+	prepare_stream_server
+	POD=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	CTR=$(crictl create "$POD" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$CTR"
+
+	OUTPUT=$(crictl attach -r websocket -i "$CTR")
+	[[ "$OUTPUT" == *"Redis is starting"* ]]
+	grep -q "Using attach URL from container monitor" "$CRIO_LOG"
 }

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -231,6 +231,36 @@ func (mr *MockRuntimeImplMockRecorder) RestoreContainer(arg0, arg1, arg2, arg3 a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).RestoreContainer), arg0, arg1, arg2, arg3)
 }
 
+// ServeAttachContainer mocks base method.
+func (m *MockRuntimeImpl) ServeAttachContainer(arg0 context.Context, arg1 *oci.Container, arg2, arg3, arg4 bool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServeAttachContainer", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServeAttachContainer indicates an expected call of ServeAttachContainer.
+func (mr *MockRuntimeImplMockRecorder) ServeAttachContainer(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServeAttachContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ServeAttachContainer), arg0, arg1, arg2, arg3, arg4)
+}
+
+// ServeExecContainer mocks base method.
+func (m *MockRuntimeImpl) ServeExecContainer(arg0 context.Context, arg1 *oci.Container, arg2 []string, arg3, arg4, arg5, arg6 bool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServeExecContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServeExecContainer indicates an expected call of ServeExecContainer.
+func (mr *MockRuntimeImplMockRecorder) ServeExecContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServeExecContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ServeExecContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+}
+
 // SignalContainer mocks base method.
 func (m *MockRuntimeImpl) SignalContainer(arg0 context.Context, arg1 *oci.Container, arg2 syscall.Signal) error {
 	m.ctrl.T.Helper()

--- a/vendor/capnproto.org/go/capnp/v3/arena.go
+++ b/vendor/capnproto.org/go/capnp/v3/arena.go
@@ -14,27 +14,25 @@ type Arena interface {
 	// This must not be larger than 1<<32.
 	NumSegments() int64
 
-	// Data loads the data for the segment with the given ID.  IDs are in
-	// the range [0, NumSegments()).
-	// must be tightly packed in the range [0, NumSegments()).
-	Data(id SegmentID) ([]byte, error)
+	// Segment returns the segment identified with the specified id. This
+	// may return nil if the segment with the specified ID does not exist.
+	Segment(id SegmentID) *Segment
 
 	// Allocate selects a segment to place a new object in, creating a
 	// segment or growing the capacity of a previously loaded segment if
-	// necessary.  If Allocate does not return an error, then the
-	// difference of the capacity and the length of the returned slice
-	// must be at least minsz.  segs is a map of segments keyed by ID
-	// using arrays returned by the Data method (although the length of
-	// these slices may have changed by previous allocations).  Allocate
-	// must not modify segs.
+	// necessary.  If Allocate does not return an error, then the returned
+	// segment may store up to minsz bytes starting at the returned address
+	// offset.
+	//
+	// Some allocators may specifically choose to grow the passed seg (if
+	// non nil), but that is not a requirement.
 	//
 	// If Allocate creates a new segment, the ID must be one larger than
 	// the last segment's ID or zero if it is the first segment.
 	//
-	// If Allocate returns an previously loaded segment's ID, then the
-	// arena is responsible for preserving the existing data in the
-	// returned byte slice.
-	Allocate(minsz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error)
+	// If Allocate returns an previously loaded segment, then the arena is
+	// responsible for preserving the existing data.
+	Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, address, error)
 
 	// Release all resources associated with the Arena. Callers MUST NOT
 	// use the Arena after it has been released.
@@ -47,55 +45,90 @@ type Arena interface {
 	Release()
 }
 
+// singleSegmentPool is a pool of *SingleSegmentArena.
+var singleSegmentPool = sync.Pool{
+	New: func() any {
+		return &SingleSegmentArena{}
+	},
+}
+
 // SingleSegmentArena is an Arena implementation that stores message data
 // in a continguous slice.  Allocation is performed by first allocating a
 // new slice and copying existing data. SingleSegment arena does not fail
 // unless the caller attempts to access another segment.
-type SingleSegmentArena []byte
+type SingleSegmentArena struct {
+	seg Segment
+
+	// bp is the bufferpool assotiated with this arena if it was initialized
+	// for writing.
+	bp *bufferpool.Pool
+
+	// fromPool determines if this should return to the pool when released.
+	fromPool bool
+}
+
+func zeroSlice(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
 
 // SingleSegment constructs a SingleSegmentArena from b.  b MAY be nil.
 // Callers MAY use b to populate the segment for reading, or to reserve
 // memory of a specific size.
-func SingleSegment(b []byte) *SingleSegmentArena {
-	return (*SingleSegmentArena)(&b)
+func SingleSegment(b []byte) Arena {
+	if b == nil {
+		ssa := singleSegmentPool.Get().(*SingleSegmentArena)
+		ssa.fromPool = true
+		ssa.bp = &bufferpool.Default
+		return ssa
+	}
+
+	return &SingleSegmentArena{seg: Segment{data: b}}
 }
 
-func (ssa SingleSegmentArena) NumSegments() int64 {
+func (ssa *SingleSegmentArena) NumSegments() int64 {
 	return 1
 }
 
-func (ssa SingleSegmentArena) Data(id SegmentID) ([]byte, error) {
+func (ssa *SingleSegmentArena) Segment(id SegmentID) *Segment {
 	if id != 0 {
-		return nil, errors.New("segment " + str.Utod(id) + " requested in single segment arena")
+		return nil
 	}
-	return ssa, nil
+	return &ssa.seg
 }
 
-func (ssa *SingleSegmentArena) Allocate(sz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error) {
-	data := []byte(*ssa)
-	if segs[0] != nil {
-		data = segs[0].data
+func (ssa *SingleSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	if seg != nil && seg != &ssa.seg {
+		return nil, 0, errors.New("segment is not associated with arena")
 	}
+	data := ssa.seg.data
 	if len(data)%int(wordSize) != 0 {
-		return 0, nil, errors.New("segment size is not a multiple of word size")
+		return nil, 0, errors.New("segment size is not a multiple of word size")
 	}
+	ssa.seg.BindTo(msg)
 	if hasCapacity(data, sz) {
-		return 0, data, nil
+		addr := address(len(ssa.seg.data))
+		ssa.seg.data = ssa.seg.data[:len(ssa.seg.data)+int(sz)]
+		return &ssa.seg, addr, nil
 	}
 	inc, err := nextAlloc(int64(len(data)), int64(maxAllocSize()), sz)
 	if err != nil {
-		return 0, nil, err
+		return nil, 0, err
 	}
-	buf := bufferpool.Default.Get(cap(data) + inc)
-	copied := copy(buf, data)
-	buf = buf[:copied]
-	bufferpool.Default.Put(data)
-	*ssa = buf
-	return 0, *ssa, nil
+	if ssa.bp == nil {
+		return nil, 0, errors.New("cannot allocate on read-only SingleSegmentArena")
+	}
+	addr := address(len(ssa.seg.data))
+	ssa.seg.data = ssa.bp.Get(cap(data) + inc)[:len(data)+int(sz)]
+	copy(ssa.seg.data, data)
+	zeroSlice(data)
+	ssa.bp.Put(data)
+	return &ssa.seg, addr, nil
 }
 
-func (ssa SingleSegmentArena) String() string {
-	return "single-segment arena [len=" + str.Itod(len(ssa)) + " cap=" + str.Itod(cap(ssa)) + "]"
+func (ssa *SingleSegmentArena) String() string {
+	return "single-segment arena [len=" + str.Itod(len(ssa.seg.data)) + " cap=" + str.Itod(cap(ssa.seg.data)) + "]"
 }
 
 // Return this arena to an internal sync.Pool of arenas that can be
@@ -108,17 +141,35 @@ func (ssa SingleSegmentArena) String() string {
 // Calling Release is optional; if not done the garbage collector
 // will release the memory per usual.
 func (ssa *SingleSegmentArena) Release() {
-	bufferpool.Default.Put(*ssa)
-	*ssa = nil
+	if ssa.bp != nil {
+		zeroSlice(ssa.seg.data)
+		ssa.bp.Put(ssa.seg.data)
+	}
+	ssa.seg.BindTo(nil)
+	ssa.seg.data = nil
+	if ssa.fromPool {
+		ssa.fromPool = false // Prevent double return
+		singleSegmentPool.Put(ssa)
+	}
 }
 
 // MultiSegment is an arena that stores object data across multiple []byte
 // buffers, allocating new buffers of exponentially-increasing size when
 // full. This avoids the potentially-expensive slice copying of SingleSegment.
 type MultiSegmentArena struct {
-	ss    [][]byte
-	delim int    // index of first segment in ss that is NOT in buf
-	buf   []byte // full-sized buffer that was demuxed into ss.
+	segs []Segment
+
+	// rawData is set when the individual segments were all demuxed from
+	// the passed raw data slice.
+	rawData []byte
+
+	// bp is the bufferpool assotiated with this arena's segments if it was
+	// initialized for writing.
+	bp *bufferpool.Pool
+
+	// fromPool is true if this msa instance was obtained from the
+	// multiSegmentPool and should be returned there upon release.
+	fromPool bool
 }
 
 // MultiSegment returns a new arena that allocates new segments when
@@ -126,7 +177,10 @@ type MultiSegmentArena struct {
 // buffer for reading or to reserve memory of a specific size.
 func MultiSegment(b [][]byte) *MultiSegmentArena {
 	if b == nil {
-		return multiSegmentPool.Get().(*MultiSegmentArena)
+		msa := multiSegmentPool.Get().(*MultiSegmentArena)
+		msa.fromPool = true
+		msa.bp = &bufferpool.Default
+		return msa
 	}
 	return multiSegment(b)
 }
@@ -141,104 +195,192 @@ func MultiSegment(b [][]byte) *MultiSegmentArena {
 // Calling Release is optional; if not done the garbage collector
 // will release the memory per usual.
 func (msa *MultiSegmentArena) Release() {
-	for i, v := range msa.ss {
-		msa.ss[i] = nil
+	// When this was demuxed from a single slice, return the entire slice.
+	if msa.rawData != nil && msa.bp != nil {
+		zeroSlice(msa.rawData)
+		msa.bp.Put(msa.rawData)
+		msa.bp = nil
+	}
+	msa.rawData = nil
 
-		// segment not in buf?
-		if i >= msa.delim {
-			bufferpool.Default.Put(v)
+	for i := range msa.segs {
+		if msa.bp != nil {
+			zeroSlice(msa.segs[i].data)
+			msa.bp.Put(msa.segs[i].data)
 		}
+		msa.segs[i].data = nil
+		msa.segs[i].BindTo(nil)
 	}
 
-	bufferpool.Default.Put(msa.buf) // nil is ok
-	*msa = MultiSegmentArena{ss: msa.ss[:0]}
-	multiSegmentPool.Put(msa)
+	if msa.segs != nil {
+		msa.segs = msa.segs[:0]
+	}
+
+	if msa.fromPool {
+		// Prevent double inclusion if it is used after release.
+		msa.fromPool = false
+
+		multiSegmentPool.Put(msa)
+	}
 }
 
 // Like MultiSegment, but doesn't use the pool
 func multiSegment(b [][]byte) *MultiSegmentArena {
-	return &MultiSegmentArena{ss: b}
+	var bp *bufferpool.Pool
+	var segs []Segment
+	if b == nil {
+		bp = &bufferpool.Default
+		segs = make([]Segment, 0, 5) // Typical size.
+	} else {
+		segs = make([]Segment, len(b))
+		for i := range b {
+			segs[i].data = b[i]
+			segs[i].id = SegmentID(i)
+		}
+	}
+	return &MultiSegmentArena{segs: segs, bp: bp}
 }
 
 var multiSegmentPool = sync.Pool{
 	New: func() any {
-		return multiSegment(make([][]byte, 0, 16))
+		return multiSegment(nil)
 	},
 }
 
 // demuxArena slices data into a multi-segment arena.  It assumes that
 // len(data) >= hdr.totalSize().
-func (msa *MultiSegmentArena) demux(hdr streamHeader, data []byte) error {
+//
+// bp should point to the bufferpool which will receive back data once the
+// arena is released. It may be nil if this should not be returned anywhere.
+func (msa *MultiSegmentArena) demux(hdr streamHeader, data []byte, bp *bufferpool.Pool) error {
 	maxSeg := hdr.maxSegment()
 	if int64(maxSeg) > int64(maxInt-1) {
 		return errors.New("number of segments overflows int")
 	}
 
-	msa.buf = data
-	msa.delim = int(maxSeg + 1)
+	// Grow list of existing segments as needed.
+	numSegs := int(maxSeg + 1)
+	if cap(msa.segs) >= numSegs {
+		msa.segs = msa.segs[:numSegs]
+	} else {
+		inc := numSegs - len(msa.segs)
+		msa.segs = append(msa.segs, make([]Segment, inc)...)
+	}
 
-	// We might be forced to allocate here, but hopefully it won't
-	// happen to often.  We assume msa was freshly obtained from a
-	// pool, and that no segments have been allocated yet.
-	var segment []byte
-	for i := 0; i < msa.delim; i++ {
+	rawData := data
+	for i := SegmentID(0); i <= maxSeg; i++ {
 		sz, err := hdr.segmentSize(SegmentID(i))
 		if err != nil {
 			return err
 		}
 
-		segment, data = data[:sz:sz], data[sz:]
-		msa.ss = append(msa.ss, segment)
+		msa.segs[i].data, data = data[:sz:sz], data[sz:]
+		msa.segs[i].id = i
 	}
 
+	msa.rawData = rawData
+	msa.bp = bp
 	return nil
 }
 
 func (msa *MultiSegmentArena) NumSegments() int64 {
-	return int64(len(msa.ss))
+	return int64(len(msa.segs))
 }
 
-func (msa *MultiSegmentArena) Data(id SegmentID) ([]byte, error) {
-	if int64(id) >= int64(len(msa.ss)) {
-		return nil, errors.New("segment " + str.Utod(id) + " requested (arena only has " +
-			str.Itod(len(msa.ss)) + " segments)")
+func (msa *MultiSegmentArena) Segment(id SegmentID) *Segment {
+	if int(id) >= len(msa.segs) {
+		return nil
 	}
-	return msa.ss[id], nil
+	return &msa.segs[id]
 }
 
-func (msa *MultiSegmentArena) Allocate(sz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error) {
-	var total int64
-	for i, data := range msa.ss {
-		id := SegmentID(i)
-		if s := segs[id]; s != nil {
-			data = s.data
+func (msa *MultiSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	// Prefer allocating in seg if it has capacity.
+	if seg != nil && hasCapacity(seg.data, sz) {
+		// Double check this segment is part of this arena.
+		contains := false
+		for i := range msa.segs {
+			if &msa.segs[i] == seg {
+				contains = true
+				break
+			}
 		}
 
+		if !contains {
+			// This is a usage error.
+			return nil, 0, errors.New("preferred segment is not part of the arena")
+		}
+
+		// Double check this segment is for this message.
+		if seg.Message() != nil && seg.Message() != msg {
+			return nil, 0, errors.New("attempt to allocate in segment for different message")
+		}
+
+		addr := address(len(seg.data))
+		newLen := int(addr) + int(sz)
+		seg.data = seg.data[:newLen]
+		seg.BindTo(msg)
+		return seg, addr, nil
+	}
+
+	var total int64
+	for i := range msa.segs {
+		data := msa.segs[i].data
 		if hasCapacity(data, sz) {
-			return id, data, nil
+			// Found segment with spare capacity.
+			addr := address(len(msa.segs[i].data))
+			newLen := int(addr) + int(sz)
+			msa.segs[i].data = msa.segs[i].data[:newLen]
+			msa.segs[i].BindTo(msg)
+			return &msa.segs[i], addr, nil
 		}
 
 		if total += int64(cap(data)); total < 0 {
 			// Overflow.
-			return 0, nil, errors.New("alloc " + str.Utod(sz) + " bytes: message too large")
+			return nil, 0, errors.New("alloc " + str.Utod(sz) + " bytes: message too large")
 		}
 	}
 
-	n, err := nextAlloc(total, 1<<63-1, sz)
-	if err != nil {
-		return 0, nil, err
+	// Check for read-only arena.
+	if msa.bp == nil {
+		return nil, 0, errors.New("cannot allocate segment in read-only multi-segment arena")
 	}
 
-	buf := bufferpool.Default.Get(n)
-	buf = buf[:0]
+	// If this is the very first segment and the requested allocation
+	// size is zero, modify the requested size to at least one word.
+	//
+	// FIXME: this is to maintain compatibility to existing behavior and
+	// tests in NewMessage(), which assumes this. Remove once arenas
+	// enforce the contract of always having at least one segment.
+	compatFirstSegLenZeroAddSize := Size(0)
+	if len(msa.segs) == 0 && sz == 0 {
+		compatFirstSegLenZeroAddSize = wordSize
+	}
 
-	id := SegmentID(len(msa.ss))
-	msa.ss = append(msa.ss, buf)
-	return id, buf, nil
+	// Determine actual allocation size (may be greater than sz).
+	n, err := nextAlloc(total, 1<<63-1, sz+compatFirstSegLenZeroAddSize)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// We have determined this will be a new segment. Get the backing
+	// buffer for it.
+	buf := msa.bp.Get(n)
+	buf = buf[:sz]
+
+	// Setup the segment.
+	id := SegmentID(len(msa.segs))
+	msa.segs = append(msa.segs, Segment{
+		data: buf,
+		id:   id,
+	})
+	res := &msa.segs[int(id)]
+	res.BindTo(msg)
+	return res, 0, nil
 }
 
 func (msa *MultiSegmentArena) String() string {
-	return "multi-segment arena [" + str.Itod(len(msa.ss)) + " segments]"
+	return "multi-segment arena [" + str.Itod(len(msa.segs)) + " segments]"
 }
 
 // nextAlloc computes how much more space to allocate given the number
@@ -286,4 +428,67 @@ func nextAlloc(curr, max int64, req Size) (int, error) {
 
 func hasCapacity(b []byte, sz Size) bool {
 	return sz <= Size(cap(b)-len(b))
+}
+
+type ReadOnlySingleSegment struct {
+	seg Segment
+}
+
+// NumSegments returns the number of segments in the arena.
+// This must not be larger than 1<<32.
+func (r *ReadOnlySingleSegment) NumSegments() int64 {
+	return 1
+}
+
+// Segment returns the segment identified with the specified id. This
+// may return nil if the segment with the specified ID does not exist.
+func (r *ReadOnlySingleSegment) Segment(id SegmentID) *Segment {
+	if id == 0 {
+		return &r.seg
+	}
+
+	return nil
+}
+
+// Allocate selects a segment to place a new object in, creating a
+// segment or growing the capacity of a previously loaded segment if
+// necessary.  If Allocate does not return an error, then the
+// difference of the capacity and the length of the returned slice
+// must be at least minsz.  Some allocators may specifically choose to
+// grow the passed seg (if non nil).
+//
+// If Allocate creates a new segment, the ID must be one larger than
+// the last segment's ID or zero if it is the first segment.
+//
+// If Allocate returns an previously loaded segment, then the
+// arena is responsible for preserving the existing data.
+func (r *ReadOnlySingleSegment) Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	return nil, 0, errors.New("readOnly segment cannot allocate data")
+}
+
+// Release all resources associated with the Arena. Callers MUST NOT
+// use the Arena after it has been released.
+//
+// Calling Release() is OPTIONAL, but may reduce allocations.
+//
+// Implementations MAY use Release() as a signal to return resources
+// to free lists, or otherwise reuse the Arena.   However, they MUST
+// NOT assume Release() will be called.
+func (r *ReadOnlySingleSegment) Release() {
+	r.seg.data = nil
+}
+
+// ReplaceData replaces the current data of the arena. This should ONLY be
+// called on an empty or released arena, or else it panics.
+func (r *ReadOnlySingleSegment) ReplaceData(b []byte) {
+	if r.seg.data != nil {
+		panic("replacing data on unreleased ReadOnlyArena")
+	}
+
+	r.seg.data = b
+}
+
+// NewReadOnlySingleSegment creates a new read only arena with the given data.
+func NewReadOnlySingleSegment(b []byte) *ReadOnlySingleSegment {
+	return &ReadOnlySingleSegment{seg: Segment{data: b}}
 }

--- a/vendor/capnproto.org/go/capnp/v3/canonical.go
+++ b/vendor/capnproto.org/go/capnp/v3/canonical.go
@@ -10,8 +10,15 @@ import (
 // for equivalent structs, even as the schema evolves.  The blob is
 // suitable for hashing or signing.
 func Canonicalize(s Struct) ([]byte, error) {
-	msg, seg, _ := NewMessage(SingleSegment(nil))
+	msg, seg := NewSingleSegmentMessage(nil)
 	if !s.IsValid() {
+		// Ensure compatbility to existing behavior: even if the struct
+		// is not valid, at least the root pointer is allocated and
+		// returned as canonical. Without this,
+		// TestCanonicalize/Struct{} fails.
+		if _, err := msg.allocRootPointerSpace(); err != nil {
+			return nil, err
+		}
 		return seg.Data(), nil
 	}
 	root, err := NewRootStruct(seg, canonicalStructSize(s))

--- a/vendor/capnproto.org/go/capnp/v3/codec.go
+++ b/vendor/capnproto.org/go/capnp/v3/codec.go
@@ -59,6 +59,15 @@ func (d *Decoder) Decode() (*Message, error) {
 	if err != nil {
 		return nil, exc.WrapError("decode", err)
 	}
+
+	// Special case an empty message to return a new MultiSegment message
+	// ready for writing. This maintains compatibility to tests and older
+	// implementation of message and arenas.
+	if hdr.maxSegment() == 0 && total == 0 {
+		msg, _ := NewMultiSegmentMessage(nil)
+		return msg, nil
+	}
+
 	// TODO(someday): if total size is greater than can fit in one buffer,
 	// attempt to allocate buffer per segment.
 	if total > maxSize-uint64(len(hdr)) || total > uint64(maxInt) {
@@ -66,17 +75,19 @@ func (d *Decoder) Decode() (*Message, error) {
 	}
 
 	// Read segments.
-	buf := bufferpool.Default.Get(int(total))
+	bp := &bufferpool.Default
+	buf := bp.Get(int(total))
 	if _, err := io.ReadFull(d.r, buf); err != nil {
 		return nil, exc.WrapError("decode: read segments", err)
 	}
 
 	arena := MultiSegment(nil)
-	if err = arena.demux(hdr, buf); err != nil {
+	if err = arena.demux(hdr, buf, bp); err != nil {
 		return nil, exc.WrapError("decode", err)
 	}
 
-	return &Message{Arena: arena}, nil
+	msg, _, err := NewMessage(arena)
+	return msg, err
 }
 
 func (d *Decoder) readHeader(maxSize uint64) (streamHeader, error) {
@@ -162,11 +173,12 @@ func Unmarshal(data []byte) (*Message, error) {
 	}
 
 	arena := MultiSegment(nil)
-	if err := arena.demux(hdr, data); err != nil {
+	if err := arena.demux(hdr, data, nil); err != nil {
 		return nil, exc.WrapError("unmarshal", err)
 	}
 
-	return &Message{Arena: arena}, nil
+	msg, _, err := NewMessage(arena)
+	return msg, err
 }
 
 // UnmarshalPacked reads a packed serialized stream into a message.
@@ -195,6 +207,10 @@ func MustUnmarshalRoot(data []byte) Ptr {
 	return p
 }
 
+var (
+	errTooManySegments = errors.New("message has too many segments")
+)
+
 // An Encoder represents a framer for serializing a particular Cap'n
 // Proto stream.
 type Encoder struct {
@@ -219,6 +235,9 @@ func (e *Encoder) Encode(m *Message) error {
 	nsegs := m.NumSegments()
 	if nsegs == 0 {
 		return errors.New("encode: message has no segments")
+	}
+	if nsegs > 1<<32 {
+		return exc.WrapError("encode", errTooManySegments)
 	}
 	e.bufs = append(e.bufs[:0], nil) // first element is placeholder for header
 	maxSeg := SegmentID(nsegs - 1)

--- a/vendor/capnproto.org/go/capnp/v3/encoding/text/marshal.go
+++ b/vendor/capnproto.org/go/capnp/v3/encoding/text/marshal.go
@@ -74,7 +74,7 @@ func (enc *Encoder) Encode(typeID uint64, s capnp.Struct) error {
 
 // EncodeList writes the text representation of struct list l to the stream.
 func (enc *Encoder) EncodeList(typeID uint64, l capnp.List) error {
-	_, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	typ, _ := schema.NewRootType(seg)
 	typ.SetStructType()
 	typ.StructType().SetTypeId(typeID)

--- a/vendor/capnproto.org/go/capnp/v3/exp/bufferpool/pool.go
+++ b/vendor/capnproto.org/go/capnp/v3/exp/bufferpool/pool.go
@@ -2,7 +2,7 @@
 package bufferpool
 
 import (
-	"sync"
+	"math/bits"
 
 	"github.com/colega/zeropool"
 )
@@ -13,35 +13,21 @@ const (
 )
 
 // A default global pool.
-var Default Pool
+//
+// This pool defaults to bucketCount=20 and minAlloc=1024 (max size = ~1MiB).
+var Default Pool = *NewPool(defaultMinSize, defaultBucketCount)
 
-// Pool maintains a list of BucketCount buckets that contain buffers
-// of exponentially-increasing capacity, 1 << 0 to 1 << BucketCount.
+// Pool maintains a list of buffers, exponentially increasing in size. Values
+// MUST be initialized by NewPool().
 //
-// The MinAlloc field specifies the minimum capacity of new buffers
-// allocated by Pool, which improves reuse of small buffers. For the
-// avoidance of doubt:  calls to Get() with size < MinAlloc return a
-// buffer of len(buf) = size and cap(buf) >= MinAlloc. MinAlloc MUST
-// NOT exceed 1 << BucketCount, or method calls to Pool will panic.
-//
-// The zero-value Pool is ready to use, defaulting to BucketCount=20
-// and MinAlloc=1024 (max size = ~1MiB).  Most applications will not
-// benefit from tuning these parameters.
-//
-// As a general rule, increasing MinAlloc reduces GC latency at the
-// expense of increased memory usage.  Increasing BucketCount can
-// reduce GC latency in applications that frequently allocate large
-// buffers.
+// Buffer instances are safe for concurrent access.
 type Pool struct {
-	once                  sync.Once
-	MinAlloc, BucketCount int
-	buckets               bucketSlice
+	minAlloc int
+	buckets  bucketSlice
 }
 
 // Get a buffer of len(buf) == size and cap >= size.
 func (p *Pool) Get(size int) []byte {
-	p.init()
-
 	if buf := p.buckets.Get(size); buf != nil {
 		return buf[:size]
 	}
@@ -52,76 +38,122 @@ func (p *Pool) Get(size int) []byte {
 // Put returns the buffer to the pool.  The first len(buf) bytes
 // of the buffer are zeroed.
 func (p *Pool) Put(buf []byte) {
-	p.init()
-
 	for i := range buf {
 		buf[i] = 0
+	}
+
+	// Do not store buffers less than the min alloc size (prevents storing
+	// buffers that do not conform to the min alloc policy of this pool).
+	if cap(buf) < p.minAlloc {
+		return
 	}
 
 	p.buckets.Put(buf[:cap(buf)])
 }
 
-func (p *Pool) init() {
-	p.once.Do(func() {
-		if p.MinAlloc <= 0 {
-			p.MinAlloc = defaultMinSize
-		}
-
-		if p.BucketCount <= 0 {
-			p.BucketCount = defaultBucketCount
-		}
-
-		if p.MinAlloc > (1 << p.BucketCount) {
-			panic("MinAlloc greater than largest bucket")
-		}
-
-		// Get the index of the bucket responsible for MinAlloc.
-		var idx int
-		for idx = range p.buckets {
-			if 1<<idx >= p.MinAlloc {
-				break
-			}
-		}
-
-		p.buckets = make(bucketSlice, p.BucketCount)
-		for i := range p.buckets {
-			if i < idx {
-				// Set the 'New' function for all "small" buckets to
-				// n.buckets[idx].Get, so as to allow reuse of buffers
-				// smaller than MinAlloc that are passed to Put, while
-				// still maximizing reuse of buffers allocated by Get.
-				// Note that we cannot simply use n.buckets[idx].New,
-				// as this would side-step pooling.
-				p.buckets[i] = zeropool.New(p.buckets[idx].Get)
-			} else {
-				p.buckets[i] = zeropool.New(newAllocFunc(i))
-			}
-		}
-	})
-}
-
-type bucketSlice []zeropool.Pool[[]byte]
-
-func (bs bucketSlice) Get(size int) []byte {
-	for i := range bs {
-		if 1<<i >= size {
-			return bs[i].Get()
-		}
+// NewPool creates a list of BucketCount buckets that contain buffers
+// of exponentially-increasing capacity, 1 << 0 to 1 << BucketCount.
+//
+// The minAlloc field specifies the minimum capacity of new buffers
+// allocated by Pool, which improves reuse of small buffers. For the
+// avoidance of doubt:  calls to Get() with size < minAlloc return a
+// buffer of len(buf) = size and cap(buf) >= minAlloc. MinAlloc MUST
+// NOT exceed 1 << BucketCount, or method calls to Pool will panic.
+//
+// Passing zero to the parameters will default bucketCount to 20
+// and minAlloc to 1024 (max size = ~1MiB).
+//
+// As a general rule, increasing MinAlloc reduces GC latency at the
+// expense of increased memory usage.  Increasing BucketCount can
+// reduce GC latency in applications that frequently allocate large
+// buffers.
+func NewPool(minAlloc, bucketCount int) *Pool {
+	if minAlloc <= 0 {
+		minAlloc = defaultMinSize
 	}
 
+	if bucketCount <= 0 {
+		bucketCount = defaultBucketCount
+	}
+
+	if minAlloc > (1 << bucketCount) {
+		panic("MinAlloc greater than largest bucket")
+	}
+
+	if !isPowerOf2(minAlloc) {
+		panic("MinAlloc not a power of two")
+	}
+
+	return &Pool{
+		minAlloc: minAlloc,
+		buckets:  makeBucketSlice(minAlloc, bucketCount),
+	}
+}
+
+type bucketSlice []*zeropool.Pool[[]byte]
+
+func isPowerOf2(i int) bool {
+	return i&(i-1) == 0
+}
+
+func bucketToGet(size int) int {
+	i := bits.Len(uint(size))
+	if isPowerOf2(size) && size > 0 {
+		// When the size is a power of two, reduce by one (because
+		// bucket i is for sizes <= 1<< i).
+		i -= 1
+	}
+	return i
+}
+
+func bucketToPut(size int) int {
+	i := bits.Len(uint(size))
+
+	// Always put on the bucket whose upper bound is size == 1<<i.
+	i -= 1
+	return i
+}
+
+func (bs bucketSlice) Get(size int) []byte {
+	i := bucketToGet(size)
+	if i < len(bs) {
+		r := bs[i].Get()
+		return r
+	}
 	return nil
 }
 
 func (bs bucketSlice) Put(buf []byte) {
-	for i := range bs {
-		if cap(buf) >= 1<<i && cap(buf) < 1<<(i+1) {
-			bs[i].Put(buf)
-			break
-		}
+	i := bucketToPut(cap(buf))
+	if i < len(bs) {
+		bs[i].Put(buf)
 	}
 }
 
-func newAllocFunc(i int) func() []byte {
+// makeBucketSlice creates a new bucketSlice with the given parameters. These
+// are NOT validated.
+func makeBucketSlice(minAlloc, bucketCount int) bucketSlice {
+	// Create all buckets that are >= the bucket that stores the min
+	// allocation size.
+	minBucket := bucketToGet(minAlloc)
+	buckets := make(bucketSlice, bucketCount)
+	for i := minBucket; i < bucketCount; i++ {
+		bp := zeropool.New(newAllocFuncForBucket(i))
+		buckets[i] = &bp
+	}
+
+	// Buckets smaller than the min bucket size all get/put buffers in the
+	// minimum bucket size.
+	for i := 0; i < minBucket; i++ {
+		buckets[i] = buckets[minBucket]
+	}
+
+	return buckets
+}
+
+// newAllocFuncForBucket returns a function to allocate a byte slice of size
+// 2^i.
+func newAllocFuncForBucket(i int) func() []byte {
 	return func() []byte {
 		return make([]byte, 1<<i)
 	}

--- a/vendor/capnproto.org/go/capnp/v3/list.go
+++ b/vendor/capnproto.org/go/capnp/v3/list.go
@@ -100,7 +100,7 @@ func (p List) Message() *Message {
 	if p.seg == nil {
 		return nil
 	}
-	return p.seg.msg
+	return p.seg.Message()
 }
 
 // IsValid returns whether the list is valid.

--- a/vendor/capnproto.org/go/capnp/v3/pointer.go
+++ b/vendor/capnproto.org/go/capnp/v3/pointer.go
@@ -187,7 +187,7 @@ func (p Ptr) Message() *Message {
 	if p.seg == nil {
 		return nil
 	}
-	return p.seg.msg
+	return p.seg.Message()
 }
 
 // Default returns p if it is valid, otherwise it unmarshals def.

--- a/vendor/capnproto.org/go/capnp/v3/rpc/network.go
+++ b/vendor/capnproto.org/go/capnp/v3/rpc/network.go
@@ -27,7 +27,25 @@ type PeerID struct {
 // attached to the message via SCM_RIGHTS.  This file descriptor would be one
 // end of a newly-created socketpair, with the other end having been sent to the
 // process hosting the capability in RecipientId.
-type ThirdPartyCapID capnp.Ptr
+//
+// Some networks, as an optimization, may permit ThirdPartyToContact to be
+// forwarded across multiple vats. For example, imagine Alice sends a capability
+// to Bob, who passes it along to Carol, who further pass it to Dave. Bob will send
+// a `Provide` message to Alice telling her to expect the capability to be picked
+// up by Carol, and then will pass Carol a `ThirdPartyToContact` pointing to Alice.
+// If `ThirdPartyToContact` is non-forwardable, then Carol must form a connection
+// to Alice, send an `Accept` to receive the capability, and then immediately send
+// a `Provide` to provide it to Dave, before then being able to give a
+// `ThirdPartyToContact` to Dave which points to Alice. This is a bit of a waste.
+// If `ThirdPartyToContact` is forwardable, then Carol can simply pass it along to
+// Dave without making any connection to Alice. Some VatNetwork implementations may
+// require that Carol add a signature to the `ThirdPartyToContact` authenticating
+// that she really did forward it to Dave, which Dave will then present back to
+// Alice. Other implementations may simply pass along an unguessable token and
+// instruct Alice that whoever presents the token should receive the capability.
+// A VatNetwork may choose not to allow forwarding if it doesn't want its security
+// to be dependent on secret bearer tokens nor cryptographic signatures.
+type ThirdPartyToContact capnp.Ptr
 
 // The information that must be sent in a `Provide` message to identify the
 // recipient of the capability.
@@ -41,7 +59,7 @@ type ThirdPartyCapID capnp.Ptr
 // attached to the message via SCM_RIGHTS.  This file descriptor would be one
 // end of a newly-created socketpair, with the other end having been sent to the
 // capability's recipient in ThirdPartyCapId.
-type RecipientID capnp.Ptr
+type ThirdPartyToAwait capnp.Ptr
 
 // The information that must be sent in an `Accept` message to identify the
 // object being accepted.
@@ -50,46 +68,72 @@ type RecipientID capnp.Ptr
 // be the public key fingerprint of the provider vat along with a nonce matching
 // the one in the `RecipientId` used in the `Provide` message sent from that
 // provider.
-type ProvisionID capnp.Ptr
+type ThirdPartyCompletion capnp.Ptr
 
-// Data needed to perform a third-party handoff, returned by
-// Newtork.Introduce.
+// Data needed to perform a third-party handoff.
 type IntroductionInfo struct {
-	SendToRecipient ThirdPartyCapID
-	SendToProvider  RecipientID
+	SendToProvider  ThirdPartyToAwait
+	SendToRecipient ThirdPartyToContact
 }
 
 // A Network is a reference to a multi-party (generally >= 3) network
 // of Cap'n Proto peers. Use this instead of NewConn when establishing
 // connections outside a point-to-point setting.
+//
+// In addition to satisfying the method set, a correct implementation
+// of Network must be comparable.
 type Network interface {
 	// Return the identifier for caller on this network.
 	LocalID() PeerID
 
-	// Connect to another peer by ID. The supplied Options are used
-	// for the connection, with the values for RemotePeerID and Network
-	// overridden by the Network.
-	Dial(PeerID, *Options) (*Conn, error)
+	// Connect to another peer by ID. Re-uses any existing connection
+	// to the peer.
+	Dial(PeerID) (*Conn, error)
 
-	// Accept the next incoming connection on the network, using the
-	// supplied Options for the connection. Generally, callers will
-	// want to invoke this in a loop when launching a server.
-	Accept(context.Context, *Options) (*Conn, error)
+	// Accept and handle incoming connections on the network until
+	// the context is canceled.
+	Serve(context.Context) error
+}
 
-	// Introduce the two connections, in preparation for a third party
-	// handoff. Afterwards, a Provide messsage should be sent to
-	// provider, and a ThirdPartyCapId should be sent to recipient.
-	Introduce(provider, recipient *Conn) (IntroductionInfo, error)
+// A Network3PH is a Network which supports three-party handoff of capabilities.
+// TODO(before merge): could this interface be named better?
+type Network3PH interface {
+	// Introduces both connections for a three-party handoff. After this,
+	// the `ThirdPartyToAwait` will be sent to the `provider` and the
+	// `ThirdPartyToContact` will be sent to the `recipient`.
+	//
+	// An error indicates introduction is not possible between the two `Conn`s.
+	Introduce(provider *Conn, recipient *Conn) (IntroductionInfo, error)
 
-	// Given a ThirdPartyCapID, received from introducedBy, connect
-	// to the third party. The caller should then send an Accept
-	// message over the returned Connection.
-	DialIntroduced(capID ThirdPartyCapID, introducedBy *Conn) (*Conn, ProvisionID, error)
+	// Attempts forwarding of a `ThirdPartyToContact` received from `from` to
+	// `destination`, with both vats being in this Network. This method
+	// return a `ThirdPartyToContact` to send to `destination`.
+	//
+	// An error indicates forwarding is not possible.
+	Forward(from *Conn, destination *Conn, info ThirdPartyToContact) (ThirdPartyToContact, error)
 
-	// Given a RecipientID received in a Provide message via
-	// introducedBy, wait for the recipient to connect, and
-	// return the connection formed. If there is already an
-	// established connection to the relevant Peer, this
-	// SHOULD return the existing connection immediately.
-	AcceptIntroduced(recipientID RecipientID, introducedBy *Conn) (*Conn, error)
+	// Completes a three-party handoff.
+	//
+	// The provided `completion` has been received from `conn` in an `Accept`.
+	//
+	// This method blocks until there is a matching `AwaitThirdParty`, if there is
+	// none currently, and returns the `value` passed to it.
+	//
+	// An error indicates that this completion can never succeed, for example due
+	// to a `completion` that is malformed. The error will be sent in response to the
+	// `Accept`.
+	CompleteThirdParty(ctx context.Context, conn *Conn, completion ThirdPartyCompletion) (any, error)
+
+	// Awaits for completion of a three-party handoff.
+	//
+	// The provided `await` has been received from `conn`.
+	//
+	// While the context is valid, any `CompleteThirdParty` calls that match
+	// the provided `await` should return `value`.
+	//
+	// After the context is canceled, future calls to `CompleteThirdParty` are
+	// not required to return the provided `value`.
+	//
+	// This method SHOULD not block.
+	AwaitThirdParty(ctx context.Context, conn *Conn, await ThirdPartyToAwait, value any)
 }

--- a/vendor/capnproto.org/go/capnp/v3/rpc/serve.go
+++ b/vendor/capnproto.org/go/capnp/v3/rpc/serve.go
@@ -8,18 +8,51 @@ import (
 	"capnproto.org/go/capnp/v3"
 )
 
+// serveOpts are options for the Cap'n Proto server.
+type serveOpts struct {
+	newTransport NewTransportFunc
+}
+
+// defaultServeOpts returns the default server opts.
+func defaultServeOpts() serveOpts {
+	return serveOpts{
+		newTransport: NewStreamTransport,
+	}
+}
+
+type ServeOption func(*serveOpts)
+
+// WithBasicStreamingTransport enables the streaming transport with basic encoding.
+func WithBasicStreamingTransport() ServeOption {
+	return func(opts *serveOpts) {
+		opts.newTransport = NewStreamTransport
+	}
+}
+
+// WithPackedStreamingTransport enables the streaming transport with packed encoding.
+func WithPackedStreamingTransport() ServeOption {
+	return func(opts *serveOpts) {
+		opts.newTransport = NewPackedStreamTransport
+	}
+}
+
 // Serve serves a Cap'n Proto RPC to incoming connections.
 //
 // Serve will take ownership of bootstrapClient and release it after the listener closes.
 //
 // Serve exits with the listener error if the listener is closed by the owner.
-func Serve(lis net.Listener, boot capnp.Client) error {
+func Serve(lis net.Listener, boot capnp.Client, opts ...ServeOption) error {
 	if !boot.IsValid() {
 		err := errors.New("bootstrap client is not valid")
 		return err
 	}
 	// Since we took ownership of the bootstrap client, release it after we're done.
 	defer boot.Release()
+
+	options := defaultServeOpts()
+	for _, o := range opts {
+		o(&options)
+	}
 	for {
 		// Accept incoming connections
 		conn, err := lis.Accept()
@@ -33,7 +66,7 @@ func Serve(lis net.Listener, boot capnp.Client) error {
 			BootstrapClient: boot.AddRef(),
 		}
 		// For each new incoming connection, create a new RPC transport connection that will serve incoming RPC requests
-		transport := NewStreamTransport(conn)
+		transport := options.newTransport(conn)
 		_ = NewConn(transport, &opts)
 	}
 }
@@ -44,7 +77,7 @@ func Serve(lis net.Listener, boot capnp.Client) error {
 // and "tcp" for regular TCP IP4 or IP6 connections.
 //
 // ListenAndServe will take ownership of bootstrapClient and release it on exit.
-func ListenAndServe(ctx context.Context, network, addr string, bootstrapClient capnp.Client) error {
+func ListenAndServe(ctx context.Context, network, addr string, bootstrapClient capnp.Client, opts ...ServeOption) error {
 
 	listener, err := net.Listen(network, addr)
 

--- a/vendor/capnproto.org/go/capnp/v3/rpc/transport.go
+++ b/vendor/capnproto.org/go/capnp/v3/rpc/transport.go
@@ -10,6 +10,7 @@ import (
 
 type Codec = transport.Codec
 type Transport = transport.Transport
+type NewTransportFunc func(io.ReadWriteCloser) Transport
 
 // NewStreamTransport is an alias for as transport.NewStream
 func NewStreamTransport(rwc io.ReadWriteCloser) Transport {

--- a/vendor/capnproto.org/go/capnp/v3/std/capnp/rpc/rpc.capnp.go
+++ b/vendor/capnproto.org/go/capnp/v3/std/capnp/rpc/rpc.capnp.go
@@ -13,24 +13,25 @@ type Message capnp.Struct
 type Message_Which uint16
 
 const (
-	Message_Which_unimplemented  Message_Which = 0
-	Message_Which_abort          Message_Which = 1
-	Message_Which_bootstrap      Message_Which = 8
-	Message_Which_call           Message_Which = 2
-	Message_Which_return         Message_Which = 3
-	Message_Which_finish         Message_Which = 4
-	Message_Which_resolve        Message_Which = 5
-	Message_Which_release        Message_Which = 6
-	Message_Which_disembargo     Message_Which = 13
-	Message_Which_obsoleteSave   Message_Which = 7
-	Message_Which_obsoleteDelete Message_Which = 9
-	Message_Which_provide        Message_Which = 10
-	Message_Which_accept         Message_Which = 11
-	Message_Which_join           Message_Which = 12
+	Message_Which_unimplemented    Message_Which = 0
+	Message_Which_abort            Message_Which = 1
+	Message_Which_bootstrap        Message_Which = 8
+	Message_Which_call             Message_Which = 2
+	Message_Which_return           Message_Which = 3
+	Message_Which_finish           Message_Which = 4
+	Message_Which_resolve          Message_Which = 5
+	Message_Which_release          Message_Which = 6
+	Message_Which_disembargo       Message_Which = 13
+	Message_Which_obsoleteSave     Message_Which = 7
+	Message_Which_obsoleteDelete   Message_Which = 9
+	Message_Which_provide          Message_Which = 10
+	Message_Which_accept           Message_Which = 11
+	Message_Which_thirdPartyAnswer Message_Which = 14
+	Message_Which_join             Message_Which = 12
 )
 
 func (w Message_Which) String() string {
-	const s = "unimplementedabortbootstrapcallreturnfinishresolvereleasedisembargoobsoleteSaveobsoleteDeleteprovideacceptjoin"
+	const s = "unimplementedabortbootstrapcallreturnfinishresolvereleasedisembargoobsoleteSaveobsoleteDeleteprovideacceptthirdPartyAnswerjoin"
 	switch w {
 	case Message_Which_unimplemented:
 		return s[0:13]
@@ -58,8 +59,10 @@ func (w Message_Which) String() string {
 		return s[93:100]
 	case Message_Which_accept:
 		return s[100:106]
+	case Message_Which_thirdPartyAnswer:
+		return s[106:122]
 	case Message_Which_join:
-		return s[106:110]
+		return s[122:126]
 
 	}
 	return "Message_Which(" + strconv.FormatUint(uint64(w), 10) + ")"
@@ -502,6 +505,38 @@ func (s Message) NewAccept() (Accept, error) {
 	return ss, err
 }
 
+func (s Message) ThirdPartyAnswer() (ThirdPartyAnswer, error) {
+	if capnp.Struct(s).Uint16(0) != 14 {
+		panic("Which() != thirdPartyAnswer")
+	}
+	p, err := capnp.Struct(s).Ptr(0)
+	return ThirdPartyAnswer(p.Struct()), err
+}
+
+func (s Message) HasThirdPartyAnswer() bool {
+	if capnp.Struct(s).Uint16(0) != 14 {
+		return false
+	}
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Message) SetThirdPartyAnswer(v ThirdPartyAnswer) error {
+	capnp.Struct(s).SetUint16(0, 14)
+	return capnp.Struct(s).SetPtr(0, capnp.Struct(v).ToPtr())
+}
+
+// NewThirdPartyAnswer sets the thirdPartyAnswer field to a newly
+// allocated ThirdPartyAnswer struct, preferring placement in s's segment.
+func (s Message) NewThirdPartyAnswer() (ThirdPartyAnswer, error) {
+	capnp.Struct(s).SetUint16(0, 14)
+	ss, err := NewThirdPartyAnswer(capnp.Struct(s).Segment())
+	if err != nil {
+		return ThirdPartyAnswer{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, capnp.Struct(ss).ToPtr())
+	return ss, err
+}
+
 func (s Message) Join() (Join, error) {
 	if capnp.Struct(s).Uint16(0) != 12 {
 		panic("Which() != join")
@@ -588,6 +623,9 @@ func (p Message_Future) Provide() Provide_Future {
 }
 func (p Message_Future) Accept() Accept_Future {
 	return Accept_Future{Future: p.Future.Field(0, nil)}
+}
+func (p Message_Future) ThirdPartyAnswer() ThirdPartyAnswer_Future {
+	return ThirdPartyAnswer_Future{Future: p.Future.Field(0, nil)}
 }
 func (p Message_Future) Join() Join_Future {
 	return Join_Future{Future: p.Future.Field(0, nil)}
@@ -936,11 +974,11 @@ const (
 	Return_Which_canceled              Return_Which = 2
 	Return_Which_resultsSentElsewhere  Return_Which = 3
 	Return_Which_takeFromOtherQuestion Return_Which = 4
-	Return_Which_acceptFromThirdParty  Return_Which = 5
+	Return_Which_awaitFromThirdParty   Return_Which = 5
 )
 
 func (w Return_Which) String() string {
-	const s = "resultsexceptioncanceledresultsSentElsewheretakeFromOtherQuestionacceptFromThirdParty"
+	const s = "resultsexceptioncanceledresultsSentElsewheretakeFromOtherQuestionawaitFromThirdParty"
 	switch w {
 	case Return_Which_results:
 		return s[0:7]
@@ -952,8 +990,8 @@ func (w Return_Which) String() string {
 		return s[24:44]
 	case Return_Which_takeFromOtherQuestion:
 		return s[44:65]
-	case Return_Which_acceptFromThirdParty:
-		return s[65:85]
+	case Return_Which_awaitFromThirdParty:
+		return s[65:84]
 
 	}
 	return "Return_Which(" + strconv.FormatUint(uint64(w), 10) + ")"
@@ -1118,21 +1156,21 @@ func (s Return) SetTakeFromOtherQuestion(v uint32) {
 	capnp.Struct(s).SetUint32(8, v)
 }
 
-func (s Return) AcceptFromThirdParty() (capnp.Ptr, error) {
+func (s Return) AwaitFromThirdParty() (capnp.Ptr, error) {
 	if capnp.Struct(s).Uint16(6) != 5 {
-		panic("Which() != acceptFromThirdParty")
+		panic("Which() != awaitFromThirdParty")
 	}
 	return capnp.Struct(s).Ptr(0)
 }
 
-func (s Return) HasAcceptFromThirdParty() bool {
+func (s Return) HasAwaitFromThirdParty() bool {
 	if capnp.Struct(s).Uint16(6) != 5 {
 		return false
 	}
 	return capnp.Struct(s).HasPtr(0)
 }
 
-func (s Return) SetAcceptFromThirdParty(v capnp.Ptr) error {
+func (s Return) SetAwaitFromThirdParty(v capnp.Ptr) error {
 	capnp.Struct(s).SetUint16(6, 5)
 	return capnp.Struct(s).SetPtr(0, v)
 }
@@ -1159,7 +1197,7 @@ func (p Return_Future) Results() Payload_Future {
 func (p Return_Future) Exception() Exception_Future {
 	return Exception_Future{Future: p.Future.Field(0, nil)}
 }
-func (p Return_Future) AcceptFromThirdParty() *capnp.Future {
+func (p Return_Future) AwaitFromThirdParty() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
 
@@ -1503,11 +1541,10 @@ const (
 	Disembargo_context_Which_senderLoopback   Disembargo_context_Which = 0
 	Disembargo_context_Which_receiverLoopback Disembargo_context_Which = 1
 	Disembargo_context_Which_accept           Disembargo_context_Which = 2
-	Disembargo_context_Which_provide          Disembargo_context_Which = 3
 )
 
 func (w Disembargo_context_Which) String() string {
-	const s = "senderLoopbackreceiverLoopbackacceptprovide"
+	const s = "senderLoopbackreceiverLoopbackaccept"
 	switch w {
 	case Disembargo_context_Which_senderLoopback:
 		return s[0:14]
@@ -1515,8 +1552,6 @@ func (w Disembargo_context_Which) String() string {
 		return s[14:30]
 	case Disembargo_context_Which_accept:
 		return s[30:36]
-	case Disembargo_context_Which_provide:
-		return s[36:43]
 
 	}
 	return "Disembargo_context_Which(" + strconv.FormatUint(uint64(w), 10) + ")"
@@ -1526,12 +1561,12 @@ func (w Disembargo_context_Which) String() string {
 const Disembargo_TypeID = 0xf964368b0fbd3711
 
 func NewDisembargo(s *capnp.Segment) (Disembargo, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
 	return Disembargo(st), err
 }
 
 func NewRootDisembargo(s *capnp.Segment) (Disembargo, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
 	return Disembargo(st), err
 }
 
@@ -1631,21 +1666,24 @@ func (s Disembargo_context) SetReceiverLoopback(v uint32) {
 	capnp.Struct(s).SetUint32(0, v)
 }
 
-func (s Disembargo_context) SetAccept() {
-	capnp.Struct(s).SetUint16(4, 2)
-
-}
-
-func (s Disembargo_context) Provide() uint32 {
-	if capnp.Struct(s).Uint16(4) != 3 {
-		panic("Which() != provide")
+func (s Disembargo_context) Accept() ([]byte, error) {
+	if capnp.Struct(s).Uint16(4) != 2 {
+		panic("Which() != accept")
 	}
-	return capnp.Struct(s).Uint32(0)
+	p, err := capnp.Struct(s).Ptr(1)
+	return []byte(p.Data()), err
 }
 
-func (s Disembargo_context) SetProvide(v uint32) {
-	capnp.Struct(s).SetUint16(4, 3)
-	capnp.Struct(s).SetUint32(0, v)
+func (s Disembargo_context) HasAccept() bool {
+	if capnp.Struct(s).Uint16(4) != 2 {
+		return false
+	}
+	return capnp.Struct(s).HasPtr(1)
+}
+
+func (s Disembargo_context) SetAccept(v []byte) error {
+	capnp.Struct(s).SetUint16(4, 2)
+	return capnp.Struct(s).SetData(1, v)
 }
 
 // Disembargo_List is a list of Disembargo.
@@ -1653,7 +1691,7 @@ type Disembargo_List = capnp.StructList[Disembargo]
 
 // NewDisembargo creates a new list of Disembargo.
 func NewDisembargo_List(s *capnp.Segment, sz int32) (Disembargo_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
 	return capnp.StructList[Disembargo](l), err
 }
 
@@ -1799,12 +1837,12 @@ type Accept capnp.Struct
 const Accept_TypeID = 0xd4c9b56290554016
 
 func NewAccept(s *capnp.Segment) (Accept, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
 	return Accept(st), err
 }
 
 func NewRootAccept(s *capnp.Segment) (Accept, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
 	return Accept(st), err
 }
 
@@ -1859,12 +1897,17 @@ func (s Accept) HasProvision() bool {
 func (s Accept) SetProvision(v capnp.Ptr) error {
 	return capnp.Struct(s).SetPtr(0, v)
 }
-func (s Accept) Embargo() bool {
-	return capnp.Struct(s).Bit(32)
+func (s Accept) Embargo() ([]byte, error) {
+	p, err := capnp.Struct(s).Ptr(1)
+	return []byte(p.Data()), err
 }
 
-func (s Accept) SetEmbargo(v bool) {
-	capnp.Struct(s).SetBit(32, v)
+func (s Accept) HasEmbargo() bool {
+	return capnp.Struct(s).HasPtr(1)
+}
+
+func (s Accept) SetEmbargo(v []byte) error {
+	return capnp.Struct(s).SetData(1, v)
 }
 
 // Accept_List is a list of Accept.
@@ -1872,7 +1915,7 @@ type Accept_List = capnp.StructList[Accept]
 
 // NewAccept creates a new list of Accept.
 func NewAccept_List(s *capnp.Segment, sz int32) (Accept_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
 	return capnp.StructList[Accept](l), err
 }
 
@@ -1884,6 +1927,92 @@ func (f Accept_Future) Struct() (Accept, error) {
 	return Accept(p.Struct()), err
 }
 func (p Accept_Future) Provision() *capnp.Future {
+	return p.Future.Field(0, nil)
+}
+
+type ThirdPartyAnswer capnp.Struct
+
+// ThirdPartyAnswer_TypeID is the unique identifier for the type ThirdPartyAnswer.
+const ThirdPartyAnswer_TypeID = 0xb6511ce6c5f0e58c
+
+func NewThirdPartyAnswer(s *capnp.Segment) (ThirdPartyAnswer, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
+	return ThirdPartyAnswer(st), err
+}
+
+func NewRootThirdPartyAnswer(s *capnp.Segment) (ThirdPartyAnswer, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
+	return ThirdPartyAnswer(st), err
+}
+
+func ReadRootThirdPartyAnswer(msg *capnp.Message) (ThirdPartyAnswer, error) {
+	root, err := msg.Root()
+	return ThirdPartyAnswer(root.Struct()), err
+}
+
+func (s ThirdPartyAnswer) String() string {
+	str, _ := text.Marshal(0xb6511ce6c5f0e58c, capnp.Struct(s))
+	return str
+}
+
+func (s ThirdPartyAnswer) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (ThirdPartyAnswer) DecodeFromPtr(p capnp.Ptr) ThirdPartyAnswer {
+	return ThirdPartyAnswer(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s ThirdPartyAnswer) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s ThirdPartyAnswer) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s ThirdPartyAnswer) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s ThirdPartyAnswer) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s ThirdPartyAnswer) Completion() (capnp.Ptr, error) {
+	return capnp.Struct(s).Ptr(0)
+}
+
+func (s ThirdPartyAnswer) HasCompletion() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s ThirdPartyAnswer) SetCompletion(v capnp.Ptr) error {
+	return capnp.Struct(s).SetPtr(0, v)
+}
+func (s ThirdPartyAnswer) AnswerId() uint32 {
+	return capnp.Struct(s).Uint32(0)
+}
+
+func (s ThirdPartyAnswer) SetAnswerId(v uint32) {
+	capnp.Struct(s).SetUint32(0, v)
+}
+
+// ThirdPartyAnswer_List is a list of ThirdPartyAnswer.
+type ThirdPartyAnswer_List = capnp.StructList[ThirdPartyAnswer]
+
+// NewThirdPartyAnswer creates a new list of ThirdPartyAnswer.
+func NewThirdPartyAnswer_List(s *capnp.Segment, sz int32) (ThirdPartyAnswer_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
+	return capnp.StructList[ThirdPartyAnswer](l), err
+}
+
+// ThirdPartyAnswer_Future is a wrapper for a ThirdPartyAnswer promised by a client call.
+type ThirdPartyAnswer_Future struct{ *capnp.Future }
+
+func (f ThirdPartyAnswer_Future) Struct() (ThirdPartyAnswer, error) {
+	p, err := f.Future.Ptr()
+	return ThirdPartyAnswer(p.Struct()), err
+}
+func (p ThirdPartyAnswer_Future) Completion() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
 
@@ -2744,12 +2873,12 @@ type Exception capnp.Struct
 const Exception_TypeID = 0xd625b7063acf691a
 
 func NewException(s *capnp.Segment) (Exception, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3})
 	return Exception(st), err
 }
 
 func NewRootException(s *capnp.Segment) (Exception, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3})
 	return Exception(st), err
 }
 
@@ -2845,12 +2974,36 @@ func (s Exception) SetTrace(v string) error {
 	return capnp.Struct(s).SetText(1, v)
 }
 
+func (s Exception) Details() (Exception_Detail_List, error) {
+	p, err := capnp.Struct(s).Ptr(2)
+	return Exception_Detail_List(p.List()), err
+}
+
+func (s Exception) HasDetails() bool {
+	return capnp.Struct(s).HasPtr(2)
+}
+
+func (s Exception) SetDetails(v Exception_Detail_List) error {
+	return capnp.Struct(s).SetPtr(2, v.ToPtr())
+}
+
+// NewDetails sets the details field to a newly
+// allocated Exception_Detail_List, preferring placement in s's segment.
+func (s Exception) NewDetails(n int32) (Exception_Detail_List, error) {
+	l, err := NewException_Detail_List(capnp.Struct(s).Segment(), n)
+	if err != nil {
+		return Exception_Detail_List{}, err
+	}
+	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
+	return l, err
+}
+
 // Exception_List is a list of Exception.
 type Exception_List = capnp.StructList[Exception]
 
 // NewException creates a new list of Exception.
 func NewException_List(s *capnp.Segment, sz int32) (Exception_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3}, sz)
 	return capnp.StructList[Exception](l), err
 }
 
@@ -2916,176 +3069,269 @@ func NewException_Type_List(s *capnp.Segment, sz int32) (Exception_Type_List, er
 	return capnp.NewEnumList[Exception_Type](s, sz)
 }
 
-const schema_b312981b2552a250 = "x\xda\x9cX}l\x1c\xd5\xb5?\xe7\xde\xf5\xae\x9dx" +
-	"\xb3;\x99\x89\x03yD&\xbc \xbdD/Q\x02\xe8" +
-	"=p\x896\x1fv\x14GN\xe3\xebu\x0a\xa4\xad\xda" +
-	"\xf1\xee\x8d=\xcexf\x98\x1d'\xde\x88(\x09M*" +
-	"\x92b\xd5D@\x13DZ\x88\xa8T(\x15!\x80\x80" +
-	"6\x08\x88\xf8\x03P[\xa8\xf8P\xa9\x88ZPQ\xa1" +
-	"*\x12\x94\x86&\xe4c\xaa33;\xb3\xb1\xd7E\xf4" +
-	"/\x8f\xee\xef\xec\xbd\xe7\x9e\x8f\xdf\xef\\/{>\xbd" +
-	"2\xb5<\xbb\xb1\x05\x980\x9b\xd2\xfe\x9b=G\xc6~" +
-	"[\x1c\xfe\x1e\x88\x19\xc8\xfd\xde\xa3}W\xff\xd7\xa1\xd9" +
-	"O@\x13\xcf\x00\xa8\xe3\xa9\x1d\xea]\xa9\x0c\xc0\xb5\xe3" +
-	")\x1f\x01\xfdc\xcf|\x7f\xe6K\xa7\xfe{\x1fYc" +
-	"b\xdd\x85\x994\x80z8}R}0M\xe6G\xd2" +
-	"?$\xf3k\x8e\x8d\xefn\xff\xc9\xd3wM5\x9f\x05" +
-	"\xa0\xaej>\xa8v7\x93yW\xf3\\\x0e\xe8\xbfx" +
-	"N\xbd\xb9_;q\xcfTs\x86L\xdd7\xf3\xa4:" +
-	">\x93\xdc\xda?s;\xa0\xff5\xef\xde\x15W\xe9\xb3" +
-	"\xee\x03eF\x9dq\x13#\x8b\x8fg\x1eTO\x07\xb6" +
-	"\x9f\x06\xb6\x9b\x1f}\xf1\xdc\xd6\xd4\xf0\xfd\x93v\x0e\x8d" +
-	"\xf5\xd6\x83\xaa\xd1J_\xb2\xf51@\xbf\xe3\xa6'V" +
-	"\x8c\x1f\xbf\xfc\xc7d\xcc.\xbd$r\xb5){@\xcd" +
-	"f\xc9\xeb\x96l\x10\x93\x1fy\xaf\xef\xcc\x9a\xf3~1" +
-	"io\x0a\x9bzC\xee\xa0\xba*G_+r\xe4\xc7" +
-	"\xcd\xcf\xf5\x14\xde\xbf\xf7\xce\xe3\xa0h\xcc\x9fg\xbc\xd6" +
-	"\x91~\xfa\xea\xb7\x01P=\x92{U}80\xfci" +
-	"n\x10\xd0\xb7\x9a\xf7\x7f\xb1\xe9\xde\x93\xbfj\x1c\x8a\xb7" +
-	"r\x07\xd5S\x81\xf5;9\xf2x'\xfb\xe4\xbd\x0b\x19" +
-	"\xe7\x8d\xc9\xd7Cr\xb3\x9a\x9f\x8d\xea\xfe<Y\xef\xcb" +
-	"\x93\x13\xa5YgN\x1e_\xba\xf3\x8dF\x0e\xbf\x97?" +
-	"\xa0~\x14\xd8~\x90\xa7\x9d\xdbVn\x9a\x18x\xea\x95" +
-	"7\x1b\xed\xac\x1eV\x0e\xa8\x0f*\xf4uD!\xe3\x0d" +
-	"\xa7\xbe)\xff\xf8\xe4\xc0[ \xe6 \xfa\xca\xff?\x97" +
-	"\xfb\xc1\xff\x95\xcf\xc2&\xcc`\x0a\x99\xbab\xf6_\x01" +
-	"\xd5U\xb3\xff\x02\x98\xdc\xbdQB\x16\xa8G\xd5E\xea" +
-	"\\\x80k\x97\xab\xed\x08\xf8\xfc\x03W\xd8\xbfy\xfb\xf1" +
-	"\xdf7\xf2Ah\xaf\xaa\xdf\xd6\xe6R\xf24\xba\xdc\xe1" +
-	"\xef\xfc|\xde\xe7\xc7>\xfc\x03\x88\x1c\xf2\xa4\xba7\xf1" +
-	"\x0cr\xe4\xea;\x1a\xf9pJ#w_\xb2\xe6.\xdf" +
-	"\xfdZ\xcfG\x0d\xef\xb6s\xceQu\xdf\x1c\xfa\xda3" +
-	"\x87\xf6\xdd3\xf1\x8d9\x9dw\xb7}\x06\xe2r\x8c\x1d" +
-	"\xea\xcc0\x00\xf5\xa39\xef\xab\xa7\x03\xd3O\x03\xd3\xf8" +
-	"\xe2\x0d\xfdm{D\xbd\xa5\x8d\xbe6\xb5\x91\xf1c\xf8" +
-	"\xa7\x89\xd4\xa1\xf7\xce5\x0c\xc4=m;\xd4\xc3m\xe1" +
-	"\xd7c\xb0\xc6w\x9d\xd2\xd2\x92\xeeXPp:\xd6\xe8" +
-	"\xa6\xd9\x8b(\x16\xf2\x14@\x0a\x01\x94\x8f7\x03\x88\xbf" +
-	"q\x14g\x18\"jHk\xa7;\x00\xc4'\x1c\xc5y" +
-	"\x86\x0aC\x0d\x19\x80rv\x00@\x9c\xe1XL!C" +
-	"\x853\x0d9\x80\x8a\xb8\x1e\xa0\x0f9\x16[i9\x83" +
-	"\x1a\xa6\x00\xd4\x16\xec\x00(\xa6h=\x8f\x0c\xb1\x19\xeb" +
-	"\x82\xacf\xd1\x05\xa6\xa4vk\xb4\xae\x9c=\x09 \xce" +
-	"s,6\xd3\x0eM{4lAT\x9b\xf0(@\xb1" +
-	"\x99v\xd0h=}\xbb\x863\x10U%X\xd7h\xfd" +
-	"Jd\xe8\xdf:*+\x9ea[\xc0\xbb\xcb\xd8\x0c\x0c" +
-	"\x9b\x01\x0b\x9e\xee\x0eJ\x0f\xf3\x099\x00b\x1e\xd07" +
-	",O\xba[\xf4\x12ddw\x19[\x80a\x0b\xa0?" +
-	"\"\xbd!\xbb\xdc]\x06\x00\xcc\x00\xc3\x0c`\xc1\xd1]" +
-	"}\xa4\x82\xf9\x841\xa2-*\xd2*\xf7\xc9\xca(\xb4" +
-	"\x9b^\xa5\xdf\xf6u\xd3\xb4\xb7\xf7\x0f\x19\xcc-\xf7\xea" +
-	"\xaeW\xed\xd7\x0d\x93\xc2\x0c\x88\xc0\x90z\xdd\xb2{]" +
-	"{\xc4\xa8\xa0\xec5\x1ci\x1aV\xc6\xb0\x06c\xd4\xb6" +
-	"\xcc*\xe1hTB<cX2Fk\xc9c\x94;" +
-	"\xa7SVJ\xae\xe1x\xb6\x0b\x94\xc5+x\xaa\xd5\xf7" +
-	"\x834>\xb5\x18@\x1c\xe3(N0\x9c\x8f\x17\xfd(" +
-	"\x93\xcf\x0e\x03\x88g8\x8a\x97\x18\xceg\x17\xfc(\x97" +
-	"/\xba\x00\xe2\x05\x8e\xe2\xd7\x0c\xe7\xf3\xf3\xb4\xcc\x01\x94" +
-	"Wv\x00\x88\x979\x8a7\x19fS\xe7\xfc \x97\xca" +
-	"\xefh\xf5u\x8e\xe2]\x86\xd9\xa6/|\x0d\x9b\x00\x94" +
-	"w\x0e\x00\x88w9\x8a\x0f)9L\xc34\xa2\xf2\x01" +
-	"\x15\xd3\x9f9\x8aO\x18\xe6,\xdb\x92\x90\x0e\xe2%\xdd" +
-	"u6\xe4*\x9e\x8cS\x14-\xf7\xba\xd0N\xa1\x91\xf1" +
-	"\xba+K\xd2\xd8&](\xac\xb3/\xf9A\x02\xac\xb2" +
-	"*\xdb\xa5\x8b\xf9ZCE\x89\xf1\x86\x8c \x05\xe8U" +
-	"\xc3\x9f\x02`>a\xb9\xc8J\xf7<\xbd4$\xcb\xc0" +
-	"\xd7\x961\x0d\xac)\xed\xd7\x85\x19\x9d\x8e\x0d\xb2R\xd1" +
-	"\x07QR\x80\xaf\x8f\x03\xacV\xd1\x05(\x8eQ\xdd\xed" +
-	"E\x86Y\xbc\xe8\x07!V\xf7\xe05\x00\xc5\xdb\x08\xb8" +
-	"\x83\x00~\xc1\x0f\x82\xac\xee\xc3\xc5\x00\xc5\xdd\x04\xdcI" +
-	"@\xea\xbc\x1f\xf6\xcc\xfe\xa09\xf6\x120A@S\x14" +
-	"iu<\x00\xee \xe0n\x02\xd2Q\xb0\xd5\xbbp5" +
-	"@\xf1N\x02\x0e\x11\x909\xebkH\xe2yO\x00L" +
-	"\x10p?\x01-g|-dY\x1c\x06(\x1e\"\xe0" +
-	"!\x02\xd8?}\x0d\x9b\x01\xd4\x07\xb1\x0f\xa0\xf8\x00\x01" +
-	"\x8f\x120\xe3s_\xc3\x16\x00\xf5a\xdc\x01P\xfc\x19" +
-	"\x01O\x120\xf3\xb4\xaf\xe1\x0c\x00\xf5\xf1\xe0\x8cG\x09" +
-	"x\x86\x80\xd6\x7f\xf8\x1a\xce\x04P\x9f\x0a\xdc=F\xc0" +
-	"\x09\x02\xb2\x9f\xf9\x1a\xb6\x02\xa8\xcf\x067\x7f\x92\x80\x17" +
-	"\x08h\xfe\xbb\xafa\x16@}\x0e7\x03\x14O\x10\xf0" +
-	"25\xef\xa8e\x8c8\xa6\x1c\x81viQ\xae\xf3\x89" +
-	"\xf8\x87\xe9j\xd7\x07l\x97\x1a\xb9N\xf6h=W\xd2" +
-	"M\x13\xf3\x09U\x87\xcb\x05Wz\xa3\xae\x85\xf9D\x8e" +
-	"#`\x8ba\x19\x95!\xcc':\x16\x02\xbb\\Y\xb1" +
-	"\xcdm\x12\xf3\x89z\xc6\x88)\xf5\x0a!\xb1XG5" +
-	"d\x0fTlSz\x12rE}\x9b\xc4\xd9\xc0p6" +
-	"\xa0?`\xdb^\xc5su@\x07\xf3\x89PL\xfeQ" +
-	"\xa1S\xd2\xdf\xda\xcfv9\xae\xbd\xcd(\xd39\xf1\xc0" +
-	"\x119\xad\x97J\xd2\xa1\xdb\xc7\x82\x1a\xdd~\xd86\xe8" +
-	"\x92\xb1\x0cDG\x94\x8d\x8a\x1c\x19\xd0]\xe0\x836\xe6" +
-	"\x13I\x89\xe0:.\x09\x8b\\\xf6\x07<\x19pIs" +
-	"\xc2%\x8b\x88\xe9\xff\x87\xa3\xb8\xae\xae\xce\x95\xe5D\x03" +
-	"\xcb8\x8a\x1b\x19\xfa\xc6\x88c\xbb\xd4b\x995\xba\x13" +
-	"\xb7\xa8\x13\xd0\x9c,O\xdb\xa2um\xd6\xabWM[" +
-	"\xc7rtv\xa4F\x8bV\x03\x88\x85\x1c\xc52\x86J" +
-	"M\x8e\x96\xac\x07\x10\xff\xcbQ\xacc\xb8\xabd[\x9e" +
-	"\xb4\xbc8\xe8%\xdd\xe9\xd7\x07LI\xdc=\x0b\xb0\x97" +
-	"#\xe6\x93\x89\x13\x90\x16/97\x88v\xd8\xde\xad\xf1" +
-	"\xb9]D\\\x9d\x1cEo\xa2\x82\x1bH\x05\xd7q\x14" +
-	"\xfdu*(\xfa\x00D/G\xf1\xad\xaf\xac=\xae," +
-	"\x19\x8e!-\xc0\xc4\xfb:\xc7\xfa\x82\xd2\x05\x98$\xcf" +
-	"\xeb\x13yV\xf0J\x0d\x11Q9}\xa0N\x8a\xb3\xdc" +
-	"\x8f\x08\x07\xa9Qc%\xcd\xa6.F|\xd3\x14\xb4|" +
-	",\xc6\xd9\xa6\x0b\x11\xdfdI\xbc\x8b\xad\x04\\\x16\xf0" +
-	"\xcd\xf9\x88o\xe6\xe0#\x00\xc5\xcb\x08X\x88\x0c\xe7g" +
-	"\xce\xf9,$\x9c\x05x\x1c\xa0\xb8\x90\x90eAk\x7f" +
-	"\x11\x11\xce\x92\xe0'\xcb\x08\xb8\x91\xf4\x9a-\x08\xd4]" +
-	"\xbd!\xa0\x95\xebi\xbd\x93Z^\x0f*#\xd4\xda\x84" +
-	"\xda\x83N\xebE\xd2\xdc5\xbaS\x81@<\x9bH\x01" +
-	"\xa9AGM\xaf\x91\x12\xcb1j\x0f\xc3\x06\xb4\xa62" +
-	"\x84_\xd2\xad\x924I\x052~\xb4G\x11\xa5\xe5u" +
-	"\x99\x15\xb9=7$]\x12'O\xdf*\xd7\x92\xf8n" +
-	"\xf4\x86\xa4+Fe{\x90\xd0\xd8\xb3\xb0\x03\xd7\xbah" +
-	"\x8f\xf4\x07\xf2\x92#\x89\x8f\xd3g\xd9k\x03^\x81\xc2" +
-	"\xd7\xa5,\xcb\xf2\x14\xd9\x0e\xf2J\x97\x0b\x0b\xae\xae\xd0" +
-	"\xe75*\xf4\x1dQ\xa1_\xcf\x90\x1b\xf5\xd2\xb7E\xba" +
-	"\xd2*AA\xae\xb1G-/\x01\x92\x8e\xee\x8a\x82a" +
-	"-\xed\xaf:2,\xa3|P\xb2\x8b:($\xca\x82" +
-	"\xcd\x00\xc8\x94\xf9\xc3\x00\xc8\x95\xcb]\x80\xc2\x16\xdd0" +
-	"e\xd9\xb7\xb7I\xd7\xb4\xf52pY&\x0e)\xd9\x96" +
-	"%!W\xf2dy2C_z1b\xce)\x9d\xd4" +
-	"\x97tR\x16\xfd\x88<6\\\x95\xf4R\x96]\xf4\x1b" +
-	"4SD\x1e\xdd\x80\xf1\xc53%\xdd\x99\xd4\xcd_\x9e" +
-	"\xf7\x9a\x87\xdc\xe9\xe8\x8f&\x02\xafZ?;\xa1;}" +
-	"*\xe2Lt$\x14H\x99\x88\x12^\xd8fX\xb2\xbb" +
-	"<%\xfe\xe8tD\x85\x00\xd3\xf3J\xdc\xbe\x1b\x0e&" +
-	"\xd7\x0e\xfa\x84!.\xbfe\x1e\x02\x882G\xe1L\xc3" +
-	",\xb56\xe9\xc3\xa0\x9a\x89x+q\x9b\xf8\xae\xbcu" +
-	"\xd4pe\x17\xd7]\xb3\xba&\xa8}S\xa7-n\xb2" +
-	"\xdd\xad\xbak\x8fr\xab\\g\x9d8\xbe*(\xf1\x7f" +
-	"\xe7xL\x88\x94\xae\x1e\x8e\xe2f\xf2\xfb\xca0\x87\x9b" +
-	"V\x7f\x09!\xfa\x81\xbeU\xc2t\xd54/\x90\xa9A" +
-	"\xbb\xd1\x98\xdb\x19\x89\xd8\xa0\xbd\xb4d[9O\x8ey" +
-	"\"\x1f\x88S\xe8\x85NM\xf2]\x8e\xc2\xac\xa9\x13\xb9" +
-	"a\x10%\x9a\x1c\xc5\x18\x15\xd8\x85\x90\xf9\x94QJ\xa3" +
-	"\xc3Q\xdcF<y>\x1ah\xab\xe4\xb2\xc7Q\xecf" +
-	"\xb59\xb4\xc7\x86\x82\xed\x0c\xe8\xa5\xadS\xe6M\xec\xb1" +
-	"C$!\xacH\x98!\x1dkw\x83\x82\x08\x1b2c" +
-	"\xd8\x96Ha\xfd#\x1e\x17\xe7\xa8E\x85\x16\x07{'" +
-	"\xb99\xc6Q\xece\x88,\xbc\xe6\x9e_\x02\x88\xbd\x1c" +
-	"\xc5\x04\xbd\xb6\"\xf5\x19\xbf\x0f@Lp\x14\xf7S9" +
-	"\x85O0\xe50\x8d\xfews\x14\x0f0TR\xe1\x03" +
-	"L9r\x0d\x808\xc4Q<\xc4h*\xd2+\xb6\x85" +
-	"\xad\xc0\xb0\xb5n\x12\xc1\xee\x0a=T\xa4[\xa8\xac\xd5" +
-	"GM/y\x92\xd4\x0c:G]}\xc00\x0d\xeeU" +
-	"k\x0f\xa3\x9cWu$\xe6\x92\xfb\x00b\x0e\xb0\xdds" +
-	"\xf5\x92\x8c\x8f\xa8\xcbgo4\x14\x84#\x01@\x10\x8d" +
-	"\xf8a\xac\xe0<\xbe\xd1\xa9\xef\xc6\xcdI\xe7\xd5\x0ao" +
-	"y_4z\xf4LWc\x9e\xab[\x95-\xb6\x0b8" +
-	"\x92L\x01\xf1!\x93\xa6\x00\x16\xbe\x83\x97\xd6^rf" +
-	"\x8e\x1erT\xfcA\x91\xd1\xeb\xa6\x8b2\xb22<1" +
-	",\xb24\x80\xd2\xbd>a1zM\xb1@\xfa\x14\xb1" +
-	"9i\x81B)\x88(\xa4\xfd\xaa=\xeaV\xa4\xb9\x85" +
-	"\xf4\xa7\xf64\x01^'\x1eu\xb5\xb2:\x98\x1c3\xae" +
-	"\xeeL\xa2\xa6F\xc1\xa0\x1a\xb8\x8e\xa3X9]0\xca" +
-	"\xd2qeI\xf7P\x967\x0e\x0c\xcb\x92G\xe0\xe4S" +
-	"\xa7d&\xb3t\xa33y\x10\\\x9c0c\xdd\xa3r" +
-	"\xc9\xed\x89L\xe5,\xdbv \xed\x0fJ\xaf\xd76," +
-	"\x0f\xa5\xbb\xd6\x90f9~H\xd7_3l\xed\x1c\xf5" +
-	"\xf6\xa4{v\xd4S0\xd6\xfdSHY\xb2\x1a\xd8\xb4" +
-	"3U8\x0d\x8ey\x97\xfc\x8fc\xbdmX\xff\xe9t" +
-	"\xb7:a\xb8\xaf6\xdd\xed\xda*\xab\xa44\xb58\xff" +
-	"+\x00\x00\xff\xffo\xa6F\xe8"
+type Exception_Detail capnp.Struct
+
+// Exception_Detail_TypeID is the unique identifier for the type Exception_Detail.
+const Exception_Detail_TypeID = 0xd6c14f121d44f8dd
+
+func NewException_Detail(s *capnp.Segment) (Exception_Detail, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
+	return Exception_Detail(st), err
+}
+
+func NewRootException_Detail(s *capnp.Segment) (Exception_Detail, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
+	return Exception_Detail(st), err
+}
+
+func ReadRootException_Detail(msg *capnp.Message) (Exception_Detail, error) {
+	root, err := msg.Root()
+	return Exception_Detail(root.Struct()), err
+}
+
+func (s Exception_Detail) String() string {
+	str, _ := text.Marshal(0xd6c14f121d44f8dd, capnp.Struct(s))
+	return str
+}
+
+func (s Exception_Detail) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Exception_Detail) DecodeFromPtr(p capnp.Ptr) Exception_Detail {
+	return Exception_Detail(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Exception_Detail) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Exception_Detail) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Exception_Detail) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Exception_Detail) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Exception_Detail) DetailId() uint64 {
+	return capnp.Struct(s).Uint64(0)
+}
+
+func (s Exception_Detail) SetDetailId(v uint64) {
+	capnp.Struct(s).SetUint64(0, v)
+}
+
+func (s Exception_Detail) Data() ([]byte, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return []byte(p.Data()), err
+}
+
+func (s Exception_Detail) HasData() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Exception_Detail) SetData(v []byte) error {
+	return capnp.Struct(s).SetData(0, v)
+}
+
+// Exception_Detail_List is a list of Exception_Detail.
+type Exception_Detail_List = capnp.StructList[Exception_Detail]
+
+// NewException_Detail creates a new list of Exception_Detail.
+func NewException_Detail_List(s *capnp.Segment, sz int32) (Exception_Detail_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
+	return capnp.StructList[Exception_Detail](l), err
+}
+
+// Exception_Detail_Future is a wrapper for a Exception_Detail promised by a client call.
+type Exception_Detail_Future struct{ *capnp.Future }
+
+func (f Exception_Detail_Future) Struct() (Exception_Detail, error) {
+	p, err := f.Future.Ptr()
+	return Exception_Detail(p.Struct()), err
+}
+
+const schema_b312981b2552a250 = "x\xda\x9cX}\x8c\x15\xd5\x15?\xe7\xde\xf7\xb1\x8b\xef" +
+	"\xf1\xde\xec\xbc\x05\xa4\x12\xc4BZH! \xa6\xd5\xad" +
+	"\xe6!\xec\x12\x96@\xd9\xd9\xb7T\xa5M\xda\xd9\xf7." +
+	"\xcb\xc0\xec\xcc83\x0b,\x09Al\xdaD\xaa\xa9\x12" +
+	"\xb5j\xa4\x05\xa2\x89X\x8c\x88X\xb1\x95T\x08&j" +
+	"\xb4bD\xa3F\xd2b\xa4\x91\xa6&X\x8b\x05\xf9\x98" +
+	"\xe6\xcc\xcc\x9b\x99}\xfb\xb6\xd6\xfe\xb5\x93\xfb;{\xef" +
+	"\xb9\xe7\xe3\xf7;\xf7\xcd\xbd>\xbb 5/\xef\xb5\x02" +
+	"S\xdct\xc6;\xbel\xc7\xc6?W\xd6\xfe\x0c\x94q" +
+	"\xc8\xbd\x9e\xdd\xbd3\xbe\xf1P\xdb\xb3\x90\xe6Y\x00\xf9" +
+	"Tj\x93|:\x95\x05\x98\x7f*\xe5!\xa0\xb7\xef\xe0" +
+	"/\xae8z\xe2\x9b?'k\x8c\xad\xbb0\x9b\x01\x90" +
+	"?\xcb\x1c\x91\xcfg\xc8\xfcl\xe6Wd~\xed\xbe{" +
+	"\xee\x98\xfa\xdb\xe7\xef\x1bm^\x00\x90\x1fn\xd9.\xef" +
+	"j!\xf3\x1d-+8\xa0w\xf8\x82|k_\xe9\xc5" +
+	"\x07F\x9b3d\xf2\xb4\xdc\x11yf\x8e\xdc\x9a\x91\xdb" +
+	"\x00\xe8}\xdf}\xf0\xa6k\xd4\xf1\x8f\x804.a\x9c" +
+	"fdqWn\xbb|\x9fo{\x8fo\xbbj\xef\xe1" +
+	"\x0b\xebRk\x1fm\xd890\xbe\x94\xdb.\xa7\xf3\xf4" +
+	"\x85\xf9\xa7\x01\xbd\x8e[\x9e\xbd\xe9\x9e\xfdW\xfe\x86\x8c" +
+	"\xd9\xc8K\"\x97w\xe5\xb7\xc9{\xc8z\xfe\xe3y?" +
+	"&\xbfv\x8fm\xce\xeb\x93\x9fj\xd8\x9b\xc2&\xbfS" +
+	"\xd8.\x9f(\xd0\xd7\xfb\x05\xf2\xe3\xd6C\xcb\xca\x1f=" +
+	"x\xf7~\x90J\xcc\x9b\xac\xbd\xd9\x91y~\xc6\xbb\x00" +
+	"(\xdfP|M\xee*\x92\xe1\xcd\xc5\x01@\xef\xeeS" +
+	"g^\xfe\xdbU\xca\xef\x1b\x1dF2\xb9\xbd\xf8\x81\xbc" +
+	"\xd97\x1e.\xd2\xaeF\xcb]_\xae|\xf0\xc8\x1f\x9b" +
+	"\xc7\xedDq\xbb|\xca\xb7>Y\xa4\xebmfgN" +
+	"^\xcaZo7\xdbz\xfeV\xa9\x0d\xe5\xfb$?r" +
+	"\x12\xed]\x1d\x7f\xee\xc8\xfe9\x9b\xdfnv\xbb\xd3\xd2" +
+	"6\xf93\xdf\xf6S\x89v\x9e\xb0`\xe5\xbd\xfd\xcf\xbd" +
+	"z\xbci\x94w\xb5m\x93\xf7\xb4\xd1\xd7\xe3md\xbc" +
+	"\xfc\xc4\x8f\xc4_\x0e\xf4\xbf\x03J;\xa2'}\xefP" +
+	"\xe1\x97\xdf\xad\x9d\x87\x95,\x8b\x1c\x99\xdc%\xff\x1dP" +
+	"\xee\x96\xc94\x0aT\xc3\xbe~\x8d~*\xef\x96\xcf\xca" +
+	"\xdf\x02\x98\xdfZ\xba\x85\xf2q\xe2\\\xe7\x94\xb6\x15\x87" +
+	"\xdf\x05\xa5\x84\x89\xff\x0dB7\xd4\xfe\x81\xbc\xb5\x9d\xbe" +
+	"6\xb7o\x00\xfc\xd3\xce\xab\xcc7\xde}\xe6\xbdfQ" +
+	">\xd1\xfe\x9a|\xba}\"\xd55\x99z\x0f\xff\xe4w" +
+	"\x93\xbf\xd8\xf7\xc9\x07\xa0\x14\x90\xc7}\xb3\x92\x93\xc3\\" +
+	"\x16\x13\xc8am\x029|\xd4\x988\xef\x8e7\x97\x9d" +
+	"n\x9a\xbd\xd6\x89\xbbei\"}\xe5'\xd2\xbe[\xef" +
+	"\xfda{\xe7\xfd\x13>\x07\xe5J\x8c\x1c\xea\xcc2\xf2" +
+	"v\xe2G\xf2V\xdft\xb3o\x1aE\xa9Y\x80OL" +
+	"|R>\xe5\x1b\x9f\xf4\x8d\x9f\xc6\xbf\xde\x9bz\xe8\xe4" +
+	"\x85\xa6\xc6\xd3&m\x92gL\x0a\xbe\x9e\x86E\x9em" +
+	"U\xe7TU\xcb\x80\xb2\xd5\xb1H\xd5\xf5\x1eDe:" +
+	"O\x01\xa4\x10@\xfat\x15\x80\xf2\x0f\x8e\xca9\x86\x88" +
+	"%\xa4\xb5\xb3\x1d\x00\xca\x19\x8e\xcaE\x86\x12\xc3\x122" +
+	"\x00\xe9|?\x80r\x8ec%\x85\x0c%\xceJ\xc8\xa9" +
+	"\xadp)@/r\xac\xe4h9\x8b%LQ \xb0" +
+	"\x03\xa0\x92\xa2\xf5\"2\xc4\x16L\x04Y\xce\xa3\x0dL" +
+	"J\xddQ\xa2u\xe9\xfc\x11\x00\xe5\"\xc7J\x0b\xed\x90" +
+	"\xdeZ\xc2VD9\x8d\xbb\x01*-\xb4C\x89\xd63" +
+	"w\x96p\x1c\xa2,\xf9\xeb%Z\xbf\x1a\x19z\xb7\x0f" +
+	"\x09\xc7\xd5L\x03xw\x0d[\x80a\x0b`\xd9U\xed" +
+	"\x01\xe1b1\xa6\x1d@,\x02z\x9a\xe1\x0a{\xb5Z" +
+	"\x85\xac\xe8\xaea+0l\x05\xf4\x06\x85\xbb\xc6\xacu" +
+	"\xd7\x00\x00\xb3\xc00\x0bX\xb6T[\x1dt\xb0\x18s" +
+	"Q\xb8\x85#\x8cZ\xafp\x86`\xaa\xee:}\xa6\xa7" +
+	"\xea\xba\xb9\xa1o\x8d\xc6\xecZ\x8fj\xbb\xc3}\xaa\xa6" +
+	"S\x98\x01\x11\x18R\xd5\x1af\x8fm\x0ej\x0e\x8a\x1e" +
+	"\xcd\x12\xbafd5c BMC\x1f&\x1c5'" +
+	"\xc0\xb3\x9a!\"\xb4\x9e<F\xb9\xb3:\x85S\xb55" +
+	"\xcb5m\xa0,^\xc5S9\xcf\xf3\xd3\xf8\xdc,\x00" +
+	"e\x1fG\xe5E\x86S\xf0\xb2\x17f\xf2\x85\xb5\x00\xca" +
+	"A\x8e\xcaQ\x86S\xd8%/\xcc\xe5a\x1b@y\x89" +
+	"\xa3\xf2:\xc3)\xfc\"-s\x00\xe9\xd5M\x00\xca+" +
+	"\x1c\x95\xe3\x0c\xf3\xa9\x0b\x9e\x9fK\xe9-Z=\xc6Q" +
+	"\xf9\x90a>\xfd\xa5W\xc24\x80\xf4\xfe6\x00\xe5C" +
+	"\x8e\xca'\x94\x1cV\xc2\x0c\xa2t\x8a\x8a\xe9c\x8e\xca" +
+	"\x19\x86\x05\xc34\x04d\xfcx\x09{\x89\x09\x05\xc7\x15" +
+	"Q\x8a\xc2\xe5\x1e\x1b\xa6RhD\xb4n\x8b\xaa\xd0\xd6" +
+	"\x0b\x1b\xcaK\xcc\x11\xff\x10\x037\x1b\xce\x06ac\xb1" +
+	"\xdePab\xdc5\x9a\x9f\x02t\x87\x83\x7f\x05\xc0b" +
+	"L\x89\xa1\x95\xea\xbaju\x8d\xa8\x01_\\\xc3\x0c\xb0" +
+	"t\xc6K\x84\x19\xad\x8e\xe5\xc2q\xd4\x01\x14\x14\xe0\x1b" +
+	"\xa3\x00\xcb\x0f\xa0\x0dP\xb9\x9f\xean'2\xcc\xe3e" +
+	"\xcf\x0f\xb1\xbc\x03\xaf\x05\xa8<D\xc0c\x04\xf0K\x9e" +
+	"\x1fdy\x17\xce\x02\xa8<J\xc0\x13\x04\xa4.zA" +
+	"\xcf<\xee7\xc7N\x02\xf6\x12\x90\x0e#-\xef\xf1\x81" +
+	"\xc7\x08\xd8G@&\x0c\xb6\xfc\x14.\x04\xa8<A\xc0" +
+	"\x01\x02\xb2\xe7\xbd\x12\x92,?\xe3\x03{\x098H@" +
+	"\xeb9\xaf\xe43\xd1s\xb8\x16\xa0r\x80\x80\x97\x08`" +
+	"\xff\xf6J\xd8\x02 \x1f\xc2^\x80\xca\x8b\x04\xbcB\xc0" +
+	"\xb8/\xbc\x12\xb6\x02\xc8/\xe3&\x80\xcaQ\x02\x8e\x11" +
+	"p\xc5Y\xaf\x84\xe3\x00\xe47\xfc3^!\xe08\x01" +
+	"\xb9\x7fy%\xbc\x02@~\xcbw\xf7u\x02\xde#`" +
+	"\xfc\xe7^\x09s$\x8d\xfe\xcd\x8f\x11\xf0!\x01-\xff" +
+	"\xf4J\x98'\xa5\xc4U\x00\x95\xf7\x08\xf8\x98\x80\xfcg" +
+	"^\x09\xc7\x13\xad\xe16\x80\xca\xc7\x04\x9c\xa1\xae\x1e2" +
+	"\xb4AK\x17\x830U\x18T\x04\xc5x\xde\x08\xf28" +
+	"U\xed7m\xea\xf0\x84\xd2\xd2z\xa1\xaa\xea:\x16c" +
+	"\x0e\x0f\x96\xcb\xb6p\x87l\x03\x8b\xf1\x04\x10\x02\xab5" +
+	"Cs\xd6`1V\xc3\x00\xd8b\x0b\xc7\xd4\xd7\x0b," +
+	"\xc6\x1a\x1c!\xbaP\x1dB\xa2\xf9 ,.\xb3\xdf1" +
+	"u\xe1\x0a(T\xd4\xf5\x02\xdb\x80a\x1b\xa0\xd7o\x9a" +
+	"\xae\xe3\xda*\xa0\x85\xc5XA\x1a\xff\xa9\xdc)\xe8o" +
+	"\xfd\xdf\xb6X\xb6\xb9^\xab\xd19\xd1\x8c\x13:\xadV" +
+	"\xab\xc2\xa2\xdbG\xb2\x1c\xde~\xad\xa9\xd1%#}\x08" +
+	"\x8f\xa8i\x8e\x18\xecWm\xe0\x03&\x16c\xad\x19\xdd" +
+	"9Ao\xf9\x9d\x13\xcd)\xa1U\x82\x8a\x82\x1e\x11}" +
+	">\xcd\xfaT\xd4\x12S\xd1L\x12\x8aosT\xaeK" +
+	"\xb4\x894\x8fXd.G\xe5F\x86\x9e6h\x996" +
+	"uhv\x91jE\x1dn\xf9,)jcvx\xa2" +
+	"K{\xd4a\xddT\xb1\x16\x9e\x1d\x8a\xd9\xcc\x85\x00\xca" +
+	"t\x8e\xca\\\x86R]\xcdf/\x05P\xbe\xc3QY" +
+	"\xc2pK\xd54\\a\xb8Qj\xaa\xaa\xd5\xa7\xf6\xeb" +
+	"\x82\xa8\x7f<`\x0fG,\xc6\xa30 -\x8e8\xd7" +
+	"\xcfI\xc0\x0e\xb9\xe8\xdc.\xe2\xbdN\x8eJO,\xa2" +
+	"\xcbID\x97pT\xfa\x12\"\xaa\xf4\x02(=\x1c\x95" +
+	"\x1f\x7fm\xe9\xb2EU\xb34a\x00\xc6\xde'\x1c\xeb" +
+	"\xf5\x0b\x1c\xa0A\xdd\x97\xc6\xea.\xe1\xd5%DD\xe9" +
+	"\xec\xb6\x84\x92\xe7\xb9\x17\xf2\x15R\x9fGB\x9cO]" +
+	"\x0e\xe9*\xed3F\xa4\xe5\xf9\xf4\xa5\x90\xae\xf2\xa4\xfd" +
+	"\x95\x1c\x01\x93|\xba\xba\x18\xd2U;>\x09P\x99D" +
+	"\xc0td8%{\xc1c\x01_M\xc3\xfd\x00\x95\xe9" +
+	"\x84\xcc\xf5\x99\xe1\xcb\x90\xaff\xfb\xb2>\x97\x80\x1bI" +
+	"\xee\xd94\x7f8\x90o\xf0Y\xe9zZ\xef$bP" +
+	"\xfd\xca\x08\xa4:V\x06\xbf\x1f{\x90${\x91j9" +
+	"\xe0ko\x9a\x04\x94\xdaxHw\x9b\x09\xb9\xd8HM" +
+	"\xa4\x99\x80\xc6h\x1e\xf1\xaa\xaaQ\x15:\x89H\xd6\x0b" +
+	"\xf7\xa8\xa00\xdc.\xdd\x11\x1b\x0ak\x84M\xda\xe6\xaa" +
+	"\xeb\xc4b\xd2\xee\x15\xee\x1aa+Cb\xaa\x9f\xd0\xc8" +
+	"3u\x83\xaa\xb9\x8bm\x13\x07\xfb\x82\x16\xcb\xda\xeep" +
+	"\x94=\xc3\\\xec\x93\x0f\x94\x7f DM\xd4F\x89\xbe" +
+	"\x9fV\xba[Po\x89:\x9f\xdc\xac\xce7\x85u~" +
+	"=C\xae%\x85s\xb5\xb0\x85Q\x85\xb2Xd\x0e\x19" +
+	"n\x0c\xc4\x0d\xdd\x15\xc6\xc2\x98\xd37l\x89\xa0\x8a\x8a" +
+	"~\xc5\xce\xec\xa0\x88H\xd3V\x01 \x93\xa6\xac\x05@" +
+	".]i\x03\x94W\xab\x9a.j\x9e\xb9^\xd8\xba\xa9" +
+	"\xd6\x80\x8b\x1a\x11M\xd54\x0c\x01\x85\xaa+j\x8d4" +
+	"\x9e<1\x0c\x88\x1dP\x0e\x17v\xc3\x0dW\xc5$R" +
+	"\xbf\xe0\xbc\xa5\x09\x0a\xa9\x9a\xb4\xb3\xab\x017\x8d(\xa2" +
+	"M\xab#\x19L\xa2\xf4Q\xcd\xdb\x1b7o\x1e\xbd\x90" +
+	"\xaf\x96_\x13\xb7o\x9e]\xf6\x9a\xf4o\xc8W\xdd\x80" +
+	"Q\xb0\xb3U\xd5j \x90\xaf.\xb5\xba\x87<\x19\x95" +
+	"\xe4\xb4\x87\xf6\xd8\xe9\x8f\xb2\xdf\x11\x07\x8c\xb2\x1f\x86\xa4" +
+	"\xbc^3Dw\xadY4\xc2\xe2\x83\xb1\xa9,b\x8c" +
+	"\xe5\xdb\xe3k\xfb\xad\xc9\x10\xe7\xdd6\x19\x01\x94\x1aG" +
+	"\xc5\x1a\x83\xcc\xea\x9d\xd9\x8b~\x03\x11\xd7;Qgz" +
+	"\xb6\xb8}H\xb3E\x17Wm}x\x91\xdfn\xbaJ" +
+	"[\xdcb\xda\xebT\xdb\x1c\xe2F-a\x1d;~\xb3" +
+	"\xaf~\xff\xcd\xf1\x88\x83)]\xcb8*\xb7&8x" +
+	"\xe5\xc2\xaf\xe0`\xcf\x17^'HW]\x8c}\xfd\x1c" +
+	"01\x0f\x0c\xf3#\x9b\xa73T\xd7\x01sN\xd54" +
+	"\x0a\xae\xd8\xe8\x92_\xb9z)umJ\x16X\xbd\x94" +
+	"\x96o\x8b\xdd\x08Gs\x9a\xc1o\xa3<\xf6qT~" +
+	"\xca\xeaC\xf22\x13\xca\xa6\xd5\xafV\xd7\x8d\x1a\x86q" +
+	"\x99\x19 q\xc1\xd7\x87\x83FG\xb1\xde\xe5Y\xcd4" +
+	"\x14z\x90\xc5\xbfX\xb4\xce\x8a\x9f\xd6R\xba\xa3@$" +
+	"P\xee\x14\xae\xaa\xe9\xca\xa4(\xc2\x0f\x93k\xf7sT" +
+	"v2D\x16\xdcm\xc7\x1f\x00\x94\x9d\x1c\x95\xbd\xf4(" +
+	"\x0c#\xbc\xe7\x11\x00e/G\xe5 \xd5P\xf0R\x1c" +
+	"\xf1B\x91R\xc1;Qz\xe1Z\x00\xe5\x00G\xe5%" +
+	"z\xfa\xb1\xe0iqha\xf8h9\xcehpS\x1d" +
+	"\xd3\xc0\x1c0\xcc%\x86%\xecv\xe8\x91%\xec\xb2\xb3" +
+	"X\x1d\xd2\xdd\xf89U7\xe8\x1c\xb2\xd5~M\xd7\xb8" +
+	";\\\x7f\xd4\x15\xdcaK`!\xbe8 \x16\x00\xa7" +
+	"\xba\xb6Z\x15\xf5#\xb6\xd4\xfc{;\xf18\x10\x85\xa6" +
+	"a\x1c\x18\xc1\x9b\x14-\xae\xe9\x0d\x8d\xba\xb4\x09\x8b\xcd" +
+	"\x8ai\xda\x0b\xce\x0a\x08+|\x8d\x16j\xaa\xab6+" +
+	"\xb3\x9ep<\xaa\x8fhJ\x0a\x13\xbf0H8\x99\xaf" +
+	"\xb0\xbe\x8aA{C\x06]6V\xe9\xbb\xb6j8\xab" +
+	"M\x1bp0\x0e@t\xc8\xe8\x00P\x12\xe6\xd4\x9f\xc4" +
+	"z\x81^\xc4Q\xedS.\xbb\xa8f\x16\x04'\x06\xb5" +
+	"\x9f\x01\x90\xba\x97\xc6\xe4J\xb5\xcf\xfc!@RV\xc5" +
+	"-Q\xae\xfa\xe9\x85\x8c7l\x0e\xd9\x8e\xd0W\x93\x12" +
+	"\xd7'U\xe0\x09\x1dMT\xf8B\x7f\xd2\xce\xda\xaa\xf5" +
+	"?\xc8\x09U\xe9u\x1c\x95\x05c\x05\xa3&,[T" +
+	"U\x17EmE\xffZQu\x09l<uTf\xb2" +
+	"sVX\x8d#\xf1\xac\x98\xb0\x13\xaf\xf3\xd9w\xc6\xa5" +
+	"P0L\xd3\x82\x8c7 \xdc\x1eS3\\\x14\xf6b" +
+	"M\xe8\xb5\xe8\x17\x89\xe45\x03\xc6)\x10\xe54\xdc\xb3" +
+	"#\xa9\x0c\x98\xf8)N\x9a\xbd\x10\xd8\x98\xd3e0\x17" +
+	"otG\xfcX\xb4\xd4\xd4\x8c\xffw\xce]\x18\x13\xef" +
+	"\xd7\x9bs\xb7\xac\x13\xc3$\x80\xf58\xff'\x00\x00\xff" +
+	"\xff\xf4\x84\xb9\x0a"
 
 func RegisterSchema(reg *schemas.Registry) {
 	reg.Register(&schemas.Schema{
@@ -3100,12 +3346,14 @@ func RegisterSchema(reg *schemas.Registry) {
 			0x9e19b28d3db3573a,
 			0xad1a6c0d7dd07497,
 			0xb28c96e23f4cbd58,
+			0xb6511ce6c5f0e58c,
 			0xbbc29655fa89086e,
 			0xd37007fde1f0027d,
 			0xd37d2eb2c2f80e63,
 			0xd4c9b56290554016,
 			0xd562b4df655bdd4d,
 			0xd625b7063acf691a,
+			0xd6c14f121d44f8dd,
 			0xd800b1d6cd6f1ca0,
 			0xdae8b0f61aab5f99,
 			0xe94ccf8031176ec4,

--- a/vendor/capnproto.org/go/capnp/v3/struct.go
+++ b/vendor/capnproto.org/go/capnp/v3/struct.go
@@ -46,7 +46,7 @@ func NewRootStruct(s *Segment, sz ObjectSize) (Struct, error) {
 	if err != nil {
 		return st, err
 	}
-	if err := s.msg.SetRoot(st.ToPtr()); err != nil {
+	if err := s.Message().SetRoot(st.ToPtr()); err != nil {
 		return st, err
 	}
 	return st, nil
@@ -75,7 +75,7 @@ func (p Struct) Message() *Message {
 	if p.seg == nil {
 		return nil
 	}
-	return p.seg.msg
+	return p.seg.Message()
 }
 
 // IsValid returns whether the struct is valid.

--- a/vendor/github.com/containers/conmon-rs/internal/proto/conmon.capnp.go
+++ b/vendor/github.com/containers/conmon-rs/internal/proto/conmon.capnp.go
@@ -176,6 +176,66 @@ func (c Conmon) StartFdSocket(ctx context.Context, params func(Conmon_startFdSoc
 
 }
 
+func (c Conmon) ServeExecContainer(ctx context.Context, params func(Conmon_serveExecContainer_Params) error) (Conmon_serveExecContainer_Results_Future, capnp.ReleaseFunc) {
+
+	s := capnp.Send{
+		Method: capnp.Method{
+			InterfaceID:   0xb737e899dd6633f1,
+			MethodID:      8,
+			InterfaceName: "internal/proto/conmon.capnp:Conmon",
+			MethodName:    "serveExecContainer",
+		},
+	}
+	if params != nil {
+		s.ArgsSize = capnp.ObjectSize{DataSize: 0, PointerCount: 1}
+		s.PlaceArgs = func(s capnp.Struct) error { return params(Conmon_serveExecContainer_Params(s)) }
+	}
+
+	ans, release := capnp.Client(c).SendCall(ctx, s)
+	return Conmon_serveExecContainer_Results_Future{Future: ans.Future()}, release
+
+}
+
+func (c Conmon) ServeAttachContainer(ctx context.Context, params func(Conmon_serveAttachContainer_Params) error) (Conmon_serveAttachContainer_Results_Future, capnp.ReleaseFunc) {
+
+	s := capnp.Send{
+		Method: capnp.Method{
+			InterfaceID:   0xb737e899dd6633f1,
+			MethodID:      9,
+			InterfaceName: "internal/proto/conmon.capnp:Conmon",
+			MethodName:    "serveAttachContainer",
+		},
+	}
+	if params != nil {
+		s.ArgsSize = capnp.ObjectSize{DataSize: 0, PointerCount: 1}
+		s.PlaceArgs = func(s capnp.Struct) error { return params(Conmon_serveAttachContainer_Params(s)) }
+	}
+
+	ans, release := capnp.Client(c).SendCall(ctx, s)
+	return Conmon_serveAttachContainer_Results_Future{Future: ans.Future()}, release
+
+}
+
+func (c Conmon) ServePortForwardContainer(ctx context.Context, params func(Conmon_servePortForwardContainer_Params) error) (Conmon_servePortForwardContainer_Results_Future, capnp.ReleaseFunc) {
+
+	s := capnp.Send{
+		Method: capnp.Method{
+			InterfaceID:   0xb737e899dd6633f1,
+			MethodID:      10,
+			InterfaceName: "internal/proto/conmon.capnp:Conmon",
+			MethodName:    "servePortForwardContainer",
+		},
+	}
+	if params != nil {
+		s.ArgsSize = capnp.ObjectSize{DataSize: 0, PointerCount: 1}
+		s.PlaceArgs = func(s capnp.Struct) error { return params(Conmon_servePortForwardContainer_Params(s)) }
+	}
+
+	ans, release := capnp.Client(c).SendCall(ctx, s)
+	return Conmon_servePortForwardContainer_Results_Future{Future: ans.Future()}, release
+
+}
+
 func (c Conmon) WaitStreaming() error {
 	return capnp.Client(c).WaitStreaming()
 }
@@ -264,6 +324,12 @@ type Conmon_Server interface {
 	CreateNamespaces(context.Context, Conmon_createNamespaces) error
 
 	StartFdSocket(context.Context, Conmon_startFdSocket) error
+
+	ServeExecContainer(context.Context, Conmon_serveExecContainer) error
+
+	ServeAttachContainer(context.Context, Conmon_serveAttachContainer) error
+
+	ServePortForwardContainer(context.Context, Conmon_servePortForwardContainer) error
 }
 
 // Conmon_NewServer creates a new Server from an implementation of Conmon_Server.
@@ -282,7 +348,7 @@ func Conmon_ServerToClient(s Conmon_Server) Conmon {
 // This can be used to create a more complicated Server.
 func Conmon_Methods(methods []server.Method, s Conmon_Server) []server.Method {
 	if cap(methods) == 0 {
-		methods = make([]server.Method, 0, 8)
+		methods = make([]server.Method, 0, 11)
 	}
 
 	methods = append(methods, server.Method{
@@ -378,6 +444,42 @@ func Conmon_Methods(methods []server.Method, s Conmon_Server) []server.Method {
 		},
 		Impl: func(ctx context.Context, call *server.Call) error {
 			return s.StartFdSocket(ctx, Conmon_startFdSocket{call})
+		},
+	})
+
+	methods = append(methods, server.Method{
+		Method: capnp.Method{
+			InterfaceID:   0xb737e899dd6633f1,
+			MethodID:      8,
+			InterfaceName: "internal/proto/conmon.capnp:Conmon",
+			MethodName:    "serveExecContainer",
+		},
+		Impl: func(ctx context.Context, call *server.Call) error {
+			return s.ServeExecContainer(ctx, Conmon_serveExecContainer{call})
+		},
+	})
+
+	methods = append(methods, server.Method{
+		Method: capnp.Method{
+			InterfaceID:   0xb737e899dd6633f1,
+			MethodID:      9,
+			InterfaceName: "internal/proto/conmon.capnp:Conmon",
+			MethodName:    "serveAttachContainer",
+		},
+		Impl: func(ctx context.Context, call *server.Call) error {
+			return s.ServeAttachContainer(ctx, Conmon_serveAttachContainer{call})
+		},
+	})
+
+	methods = append(methods, server.Method{
+		Method: capnp.Method{
+			InterfaceID:   0xb737e899dd6633f1,
+			MethodID:      10,
+			InterfaceName: "internal/proto/conmon.capnp:Conmon",
+			MethodName:    "servePortForwardContainer",
+		},
+		Impl: func(ctx context.Context, call *server.Call) error {
+			return s.ServePortForwardContainer(ctx, Conmon_servePortForwardContainer{call})
 		},
 	})
 
@@ -520,10 +622,61 @@ func (c Conmon_startFdSocket) AllocResults() (Conmon_startFdSocket_Results, erro
 	return Conmon_startFdSocket_Results(r), err
 }
 
+// Conmon_serveExecContainer holds the state for a server call to Conmon.serveExecContainer.
+// See server.Call for documentation.
+type Conmon_serveExecContainer struct {
+	*server.Call
+}
+
+// Args returns the call's arguments.
+func (c Conmon_serveExecContainer) Args() Conmon_serveExecContainer_Params {
+	return Conmon_serveExecContainer_Params(c.Call.Args())
+}
+
+// AllocResults allocates the results struct.
+func (c Conmon_serveExecContainer) AllocResults() (Conmon_serveExecContainer_Results, error) {
+	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveExecContainer_Results(r), err
+}
+
+// Conmon_serveAttachContainer holds the state for a server call to Conmon.serveAttachContainer.
+// See server.Call for documentation.
+type Conmon_serveAttachContainer struct {
+	*server.Call
+}
+
+// Args returns the call's arguments.
+func (c Conmon_serveAttachContainer) Args() Conmon_serveAttachContainer_Params {
+	return Conmon_serveAttachContainer_Params(c.Call.Args())
+}
+
+// AllocResults allocates the results struct.
+func (c Conmon_serveAttachContainer) AllocResults() (Conmon_serveAttachContainer_Results, error) {
+	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveAttachContainer_Results(r), err
+}
+
+// Conmon_servePortForwardContainer holds the state for a server call to Conmon.servePortForwardContainer.
+// See server.Call for documentation.
+type Conmon_servePortForwardContainer struct {
+	*server.Call
+}
+
+// Args returns the call's arguments.
+func (c Conmon_servePortForwardContainer) Args() Conmon_servePortForwardContainer_Params {
+	return Conmon_servePortForwardContainer_Params(c.Call.Args())
+}
+
+// AllocResults allocates the results struct.
+func (c Conmon_servePortForwardContainer) AllocResults() (Conmon_servePortForwardContainer_Results, error) {
+	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_servePortForwardContainer_Results(r), err
+}
+
 // Conmon_List is a list of Conmon.
 type Conmon_List = capnp.CapList[Conmon]
 
-// NewConmon creates a new list of Conmon.
+// NewConmon_List creates a new list of Conmon.
 func NewConmon_List(s *capnp.Segment, sz int32) (Conmon_List, error) {
 	l, err := capnp.NewPointerList(s, sz)
 	return capnp.CapList[Conmon](l), err
@@ -1342,6 +1495,7 @@ const Conmon_LogDriver_Type_TypeID = 0xf026e3d750335bc1
 const (
 	Conmon_LogDriver_Type_containerRuntimeInterface Conmon_LogDriver_Type = 0
 	Conmon_LogDriver_Type_json                      Conmon_LogDriver_Type = 1
+	Conmon_LogDriver_Type_journald                  Conmon_LogDriver_Type = 2
 )
 
 // String returns the enum's constant name.
@@ -1351,6 +1505,8 @@ func (c Conmon_LogDriver_Type) String() string {
 		return "containerRuntimeInterface"
 	case Conmon_LogDriver_Type_json:
 		return "json"
+	case Conmon_LogDriver_Type_journald:
+		return "journald"
 
 	default:
 		return ""
@@ -1365,6 +1521,8 @@ func Conmon_LogDriver_TypeFromString(c string) Conmon_LogDriver_Type {
 		return Conmon_LogDriver_Type_containerRuntimeInterface
 	case "json":
 		return Conmon_LogDriver_Type_json
+	case "journald":
+		return Conmon_LogDriver_Type_journald
 
 	default:
 		return 0
@@ -3112,6 +3270,654 @@ func (f Conmon_TextTextMapEntry_Future) Struct() (Conmon_TextTextMapEntry, error
 	return Conmon_TextTextMapEntry(p.Struct()), err
 }
 
+type Conmon_ServeExecContainerRequest capnp.Struct
+
+// Conmon_ServeExecContainerRequest_TypeID is the unique identifier for the type Conmon_ServeExecContainerRequest.
+const Conmon_ServeExecContainerRequest_TypeID = 0xd01c697281e61c21
+
+func NewConmon_ServeExecContainerRequest(s *capnp.Segment) (Conmon_ServeExecContainerRequest, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3})
+	return Conmon_ServeExecContainerRequest(st), err
+}
+
+func NewRootConmon_ServeExecContainerRequest(s *capnp.Segment) (Conmon_ServeExecContainerRequest, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3})
+	return Conmon_ServeExecContainerRequest(st), err
+}
+
+func ReadRootConmon_ServeExecContainerRequest(msg *capnp.Message) (Conmon_ServeExecContainerRequest, error) {
+	root, err := msg.Root()
+	return Conmon_ServeExecContainerRequest(root.Struct()), err
+}
+
+func (s Conmon_ServeExecContainerRequest) String() string {
+	str, _ := text.Marshal(0xd01c697281e61c21, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_ServeExecContainerRequest) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_ServeExecContainerRequest) DecodeFromPtr(p capnp.Ptr) Conmon_ServeExecContainerRequest {
+	return Conmon_ServeExecContainerRequest(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_ServeExecContainerRequest) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_ServeExecContainerRequest) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_ServeExecContainerRequest) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_ServeExecContainerRequest) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_ServeExecContainerRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return Conmon_TextTextMapEntry_List(p.List()), err
+}
+
+func (s Conmon_ServeExecContainerRequest) HasMetadata() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_ServeExecContainerRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
+	return capnp.Struct(s).SetPtr(0, v.ToPtr())
+}
+
+// NewMetadata sets the metadata field to a newly
+// allocated Conmon_TextTextMapEntry_List, preferring placement in s's segment.
+func (s Conmon_ServeExecContainerRequest) NewMetadata(n int32) (Conmon_TextTextMapEntry_List, error) {
+	l, err := NewConmon_TextTextMapEntry_List(capnp.Struct(s).Segment(), n)
+	if err != nil {
+		return Conmon_TextTextMapEntry_List{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
+	return l, err
+}
+func (s Conmon_ServeExecContainerRequest) Id() (string, error) {
+	p, err := capnp.Struct(s).Ptr(1)
+	return p.Text(), err
+}
+
+func (s Conmon_ServeExecContainerRequest) HasId() bool {
+	return capnp.Struct(s).HasPtr(1)
+}
+
+func (s Conmon_ServeExecContainerRequest) IdBytes() ([]byte, error) {
+	p, err := capnp.Struct(s).Ptr(1)
+	return p.TextBytes(), err
+}
+
+func (s Conmon_ServeExecContainerRequest) SetId(v string) error {
+	return capnp.Struct(s).SetText(1, v)
+}
+
+func (s Conmon_ServeExecContainerRequest) Command() (capnp.TextList, error) {
+	p, err := capnp.Struct(s).Ptr(2)
+	return capnp.TextList(p.List()), err
+}
+
+func (s Conmon_ServeExecContainerRequest) HasCommand() bool {
+	return capnp.Struct(s).HasPtr(2)
+}
+
+func (s Conmon_ServeExecContainerRequest) SetCommand(v capnp.TextList) error {
+	return capnp.Struct(s).SetPtr(2, v.ToPtr())
+}
+
+// NewCommand sets the command field to a newly
+// allocated capnp.TextList, preferring placement in s's segment.
+func (s Conmon_ServeExecContainerRequest) NewCommand(n int32) (capnp.TextList, error) {
+	l, err := capnp.NewTextList(capnp.Struct(s).Segment(), n)
+	if err != nil {
+		return capnp.TextList{}, err
+	}
+	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
+	return l, err
+}
+func (s Conmon_ServeExecContainerRequest) Tty() bool {
+	return capnp.Struct(s).Bit(0)
+}
+
+func (s Conmon_ServeExecContainerRequest) SetTty(v bool) {
+	capnp.Struct(s).SetBit(0, v)
+}
+
+func (s Conmon_ServeExecContainerRequest) Stdin() bool {
+	return capnp.Struct(s).Bit(1)
+}
+
+func (s Conmon_ServeExecContainerRequest) SetStdin(v bool) {
+	capnp.Struct(s).SetBit(1, v)
+}
+
+func (s Conmon_ServeExecContainerRequest) Stdout() bool {
+	return capnp.Struct(s).Bit(2)
+}
+
+func (s Conmon_ServeExecContainerRequest) SetStdout(v bool) {
+	capnp.Struct(s).SetBit(2, v)
+}
+
+func (s Conmon_ServeExecContainerRequest) Stderr() bool {
+	return capnp.Struct(s).Bit(3)
+}
+
+func (s Conmon_ServeExecContainerRequest) SetStderr(v bool) {
+	capnp.Struct(s).SetBit(3, v)
+}
+
+func (s Conmon_ServeExecContainerRequest) CgroupManager() Conmon_CgroupManager {
+	return Conmon_CgroupManager(capnp.Struct(s).Uint16(2))
+}
+
+func (s Conmon_ServeExecContainerRequest) SetCgroupManager(v Conmon_CgroupManager) {
+	capnp.Struct(s).SetUint16(2, uint16(v))
+}
+
+// Conmon_ServeExecContainerRequest_List is a list of Conmon_ServeExecContainerRequest.
+type Conmon_ServeExecContainerRequest_List = capnp.StructList[Conmon_ServeExecContainerRequest]
+
+// NewConmon_ServeExecContainerRequest creates a new list of Conmon_ServeExecContainerRequest.
+func NewConmon_ServeExecContainerRequest_List(s *capnp.Segment, sz int32) (Conmon_ServeExecContainerRequest_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3}, sz)
+	return capnp.StructList[Conmon_ServeExecContainerRequest](l), err
+}
+
+// Conmon_ServeExecContainerRequest_Future is a wrapper for a Conmon_ServeExecContainerRequest promised by a client call.
+type Conmon_ServeExecContainerRequest_Future struct{ *capnp.Future }
+
+func (f Conmon_ServeExecContainerRequest_Future) Struct() (Conmon_ServeExecContainerRequest, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_ServeExecContainerRequest(p.Struct()), err
+}
+
+type Conmon_ServeExecContainerResponse capnp.Struct
+
+// Conmon_ServeExecContainerResponse_TypeID is the unique identifier for the type Conmon_ServeExecContainerResponse.
+const Conmon_ServeExecContainerResponse_TypeID = 0xa9e93cf268b17735
+
+func NewConmon_ServeExecContainerResponse(s *capnp.Segment) (Conmon_ServeExecContainerResponse, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_ServeExecContainerResponse(st), err
+}
+
+func NewRootConmon_ServeExecContainerResponse(s *capnp.Segment) (Conmon_ServeExecContainerResponse, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_ServeExecContainerResponse(st), err
+}
+
+func ReadRootConmon_ServeExecContainerResponse(msg *capnp.Message) (Conmon_ServeExecContainerResponse, error) {
+	root, err := msg.Root()
+	return Conmon_ServeExecContainerResponse(root.Struct()), err
+}
+
+func (s Conmon_ServeExecContainerResponse) String() string {
+	str, _ := text.Marshal(0xa9e93cf268b17735, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_ServeExecContainerResponse) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_ServeExecContainerResponse) DecodeFromPtr(p capnp.Ptr) Conmon_ServeExecContainerResponse {
+	return Conmon_ServeExecContainerResponse(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_ServeExecContainerResponse) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_ServeExecContainerResponse) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_ServeExecContainerResponse) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_ServeExecContainerResponse) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_ServeExecContainerResponse) Url() (string, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return p.Text(), err
+}
+
+func (s Conmon_ServeExecContainerResponse) HasUrl() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_ServeExecContainerResponse) UrlBytes() ([]byte, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return p.TextBytes(), err
+}
+
+func (s Conmon_ServeExecContainerResponse) SetUrl(v string) error {
+	return capnp.Struct(s).SetText(0, v)
+}
+
+// Conmon_ServeExecContainerResponse_List is a list of Conmon_ServeExecContainerResponse.
+type Conmon_ServeExecContainerResponse_List = capnp.StructList[Conmon_ServeExecContainerResponse]
+
+// NewConmon_ServeExecContainerResponse creates a new list of Conmon_ServeExecContainerResponse.
+func NewConmon_ServeExecContainerResponse_List(s *capnp.Segment, sz int32) (Conmon_ServeExecContainerResponse_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	return capnp.StructList[Conmon_ServeExecContainerResponse](l), err
+}
+
+// Conmon_ServeExecContainerResponse_Future is a wrapper for a Conmon_ServeExecContainerResponse promised by a client call.
+type Conmon_ServeExecContainerResponse_Future struct{ *capnp.Future }
+
+func (f Conmon_ServeExecContainerResponse_Future) Struct() (Conmon_ServeExecContainerResponse, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_ServeExecContainerResponse(p.Struct()), err
+}
+
+type Conmon_ServeAttachContainerRequest capnp.Struct
+
+// Conmon_ServeAttachContainerRequest_TypeID is the unique identifier for the type Conmon_ServeAttachContainerRequest.
+const Conmon_ServeAttachContainerRequest_TypeID = 0xca8c8e0d7826ae86
+
+func NewConmon_ServeAttachContainerRequest(s *capnp.Segment) (Conmon_ServeAttachContainerRequest, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
+	return Conmon_ServeAttachContainerRequest(st), err
+}
+
+func NewRootConmon_ServeAttachContainerRequest(s *capnp.Segment) (Conmon_ServeAttachContainerRequest, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
+	return Conmon_ServeAttachContainerRequest(st), err
+}
+
+func ReadRootConmon_ServeAttachContainerRequest(msg *capnp.Message) (Conmon_ServeAttachContainerRequest, error) {
+	root, err := msg.Root()
+	return Conmon_ServeAttachContainerRequest(root.Struct()), err
+}
+
+func (s Conmon_ServeAttachContainerRequest) String() string {
+	str, _ := text.Marshal(0xca8c8e0d7826ae86, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_ServeAttachContainerRequest) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_ServeAttachContainerRequest) DecodeFromPtr(p capnp.Ptr) Conmon_ServeAttachContainerRequest {
+	return Conmon_ServeAttachContainerRequest(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_ServeAttachContainerRequest) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_ServeAttachContainerRequest) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_ServeAttachContainerRequest) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_ServeAttachContainerRequest) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_ServeAttachContainerRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return Conmon_TextTextMapEntry_List(p.List()), err
+}
+
+func (s Conmon_ServeAttachContainerRequest) HasMetadata() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_ServeAttachContainerRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
+	return capnp.Struct(s).SetPtr(0, v.ToPtr())
+}
+
+// NewMetadata sets the metadata field to a newly
+// allocated Conmon_TextTextMapEntry_List, preferring placement in s's segment.
+func (s Conmon_ServeAttachContainerRequest) NewMetadata(n int32) (Conmon_TextTextMapEntry_List, error) {
+	l, err := NewConmon_TextTextMapEntry_List(capnp.Struct(s).Segment(), n)
+	if err != nil {
+		return Conmon_TextTextMapEntry_List{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
+	return l, err
+}
+func (s Conmon_ServeAttachContainerRequest) Id() (string, error) {
+	p, err := capnp.Struct(s).Ptr(1)
+	return p.Text(), err
+}
+
+func (s Conmon_ServeAttachContainerRequest) HasId() bool {
+	return capnp.Struct(s).HasPtr(1)
+}
+
+func (s Conmon_ServeAttachContainerRequest) IdBytes() ([]byte, error) {
+	p, err := capnp.Struct(s).Ptr(1)
+	return p.TextBytes(), err
+}
+
+func (s Conmon_ServeAttachContainerRequest) SetId(v string) error {
+	return capnp.Struct(s).SetText(1, v)
+}
+
+func (s Conmon_ServeAttachContainerRequest) Stdin() bool {
+	return capnp.Struct(s).Bit(0)
+}
+
+func (s Conmon_ServeAttachContainerRequest) SetStdin(v bool) {
+	capnp.Struct(s).SetBit(0, v)
+}
+
+func (s Conmon_ServeAttachContainerRequest) Stdout() bool {
+	return capnp.Struct(s).Bit(1)
+}
+
+func (s Conmon_ServeAttachContainerRequest) SetStdout(v bool) {
+	capnp.Struct(s).SetBit(1, v)
+}
+
+func (s Conmon_ServeAttachContainerRequest) Stderr() bool {
+	return capnp.Struct(s).Bit(2)
+}
+
+func (s Conmon_ServeAttachContainerRequest) SetStderr(v bool) {
+	capnp.Struct(s).SetBit(2, v)
+}
+
+// Conmon_ServeAttachContainerRequest_List is a list of Conmon_ServeAttachContainerRequest.
+type Conmon_ServeAttachContainerRequest_List = capnp.StructList[Conmon_ServeAttachContainerRequest]
+
+// NewConmon_ServeAttachContainerRequest creates a new list of Conmon_ServeAttachContainerRequest.
+func NewConmon_ServeAttachContainerRequest_List(s *capnp.Segment, sz int32) (Conmon_ServeAttachContainerRequest_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
+	return capnp.StructList[Conmon_ServeAttachContainerRequest](l), err
+}
+
+// Conmon_ServeAttachContainerRequest_Future is a wrapper for a Conmon_ServeAttachContainerRequest promised by a client call.
+type Conmon_ServeAttachContainerRequest_Future struct{ *capnp.Future }
+
+func (f Conmon_ServeAttachContainerRequest_Future) Struct() (Conmon_ServeAttachContainerRequest, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_ServeAttachContainerRequest(p.Struct()), err
+}
+
+type Conmon_ServeAttachContainerResponse capnp.Struct
+
+// Conmon_ServeAttachContainerResponse_TypeID is the unique identifier for the type Conmon_ServeAttachContainerResponse.
+const Conmon_ServeAttachContainerResponse_TypeID = 0x94a72d9a2ccb9a30
+
+func NewConmon_ServeAttachContainerResponse(s *capnp.Segment) (Conmon_ServeAttachContainerResponse, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_ServeAttachContainerResponse(st), err
+}
+
+func NewRootConmon_ServeAttachContainerResponse(s *capnp.Segment) (Conmon_ServeAttachContainerResponse, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_ServeAttachContainerResponse(st), err
+}
+
+func ReadRootConmon_ServeAttachContainerResponse(msg *capnp.Message) (Conmon_ServeAttachContainerResponse, error) {
+	root, err := msg.Root()
+	return Conmon_ServeAttachContainerResponse(root.Struct()), err
+}
+
+func (s Conmon_ServeAttachContainerResponse) String() string {
+	str, _ := text.Marshal(0x94a72d9a2ccb9a30, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_ServeAttachContainerResponse) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_ServeAttachContainerResponse) DecodeFromPtr(p capnp.Ptr) Conmon_ServeAttachContainerResponse {
+	return Conmon_ServeAttachContainerResponse(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_ServeAttachContainerResponse) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_ServeAttachContainerResponse) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_ServeAttachContainerResponse) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_ServeAttachContainerResponse) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_ServeAttachContainerResponse) Url() (string, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return p.Text(), err
+}
+
+func (s Conmon_ServeAttachContainerResponse) HasUrl() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_ServeAttachContainerResponse) UrlBytes() ([]byte, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return p.TextBytes(), err
+}
+
+func (s Conmon_ServeAttachContainerResponse) SetUrl(v string) error {
+	return capnp.Struct(s).SetText(0, v)
+}
+
+// Conmon_ServeAttachContainerResponse_List is a list of Conmon_ServeAttachContainerResponse.
+type Conmon_ServeAttachContainerResponse_List = capnp.StructList[Conmon_ServeAttachContainerResponse]
+
+// NewConmon_ServeAttachContainerResponse creates a new list of Conmon_ServeAttachContainerResponse.
+func NewConmon_ServeAttachContainerResponse_List(s *capnp.Segment, sz int32) (Conmon_ServeAttachContainerResponse_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	return capnp.StructList[Conmon_ServeAttachContainerResponse](l), err
+}
+
+// Conmon_ServeAttachContainerResponse_Future is a wrapper for a Conmon_ServeAttachContainerResponse promised by a client call.
+type Conmon_ServeAttachContainerResponse_Future struct{ *capnp.Future }
+
+func (f Conmon_ServeAttachContainerResponse_Future) Struct() (Conmon_ServeAttachContainerResponse, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_ServeAttachContainerResponse(p.Struct()), err
+}
+
+type Conmon_ServePortForwardContainerRequest capnp.Struct
+
+// Conmon_ServePortForwardContainerRequest_TypeID is the unique identifier for the type Conmon_ServePortForwardContainerRequest.
+const Conmon_ServePortForwardContainerRequest_TypeID = 0xc865d8a1122038c5
+
+func NewConmon_ServePortForwardContainerRequest(s *capnp.Segment) (Conmon_ServePortForwardContainerRequest, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2})
+	return Conmon_ServePortForwardContainerRequest(st), err
+}
+
+func NewRootConmon_ServePortForwardContainerRequest(s *capnp.Segment) (Conmon_ServePortForwardContainerRequest, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2})
+	return Conmon_ServePortForwardContainerRequest(st), err
+}
+
+func ReadRootConmon_ServePortForwardContainerRequest(msg *capnp.Message) (Conmon_ServePortForwardContainerRequest, error) {
+	root, err := msg.Root()
+	return Conmon_ServePortForwardContainerRequest(root.Struct()), err
+}
+
+func (s Conmon_ServePortForwardContainerRequest) String() string {
+	str, _ := text.Marshal(0xc865d8a1122038c5, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_ServePortForwardContainerRequest) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_ServePortForwardContainerRequest) DecodeFromPtr(p capnp.Ptr) Conmon_ServePortForwardContainerRequest {
+	return Conmon_ServePortForwardContainerRequest(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_ServePortForwardContainerRequest) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_ServePortForwardContainerRequest) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_ServePortForwardContainerRequest) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_ServePortForwardContainerRequest) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_ServePortForwardContainerRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return Conmon_TextTextMapEntry_List(p.List()), err
+}
+
+func (s Conmon_ServePortForwardContainerRequest) HasMetadata() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_ServePortForwardContainerRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
+	return capnp.Struct(s).SetPtr(0, v.ToPtr())
+}
+
+// NewMetadata sets the metadata field to a newly
+// allocated Conmon_TextTextMapEntry_List, preferring placement in s's segment.
+func (s Conmon_ServePortForwardContainerRequest) NewMetadata(n int32) (Conmon_TextTextMapEntry_List, error) {
+	l, err := NewConmon_TextTextMapEntry_List(capnp.Struct(s).Segment(), n)
+	if err != nil {
+		return Conmon_TextTextMapEntry_List{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
+	return l, err
+}
+func (s Conmon_ServePortForwardContainerRequest) NetNsPath() (string, error) {
+	p, err := capnp.Struct(s).Ptr(1)
+	return p.Text(), err
+}
+
+func (s Conmon_ServePortForwardContainerRequest) HasNetNsPath() bool {
+	return capnp.Struct(s).HasPtr(1)
+}
+
+func (s Conmon_ServePortForwardContainerRequest) NetNsPathBytes() ([]byte, error) {
+	p, err := capnp.Struct(s).Ptr(1)
+	return p.TextBytes(), err
+}
+
+func (s Conmon_ServePortForwardContainerRequest) SetNetNsPath(v string) error {
+	return capnp.Struct(s).SetText(1, v)
+}
+
+// Conmon_ServePortForwardContainerRequest_List is a list of Conmon_ServePortForwardContainerRequest.
+type Conmon_ServePortForwardContainerRequest_List = capnp.StructList[Conmon_ServePortForwardContainerRequest]
+
+// NewConmon_ServePortForwardContainerRequest creates a new list of Conmon_ServePortForwardContainerRequest.
+func NewConmon_ServePortForwardContainerRequest_List(s *capnp.Segment, sz int32) (Conmon_ServePortForwardContainerRequest_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
+	return capnp.StructList[Conmon_ServePortForwardContainerRequest](l), err
+}
+
+// Conmon_ServePortForwardContainerRequest_Future is a wrapper for a Conmon_ServePortForwardContainerRequest promised by a client call.
+type Conmon_ServePortForwardContainerRequest_Future struct{ *capnp.Future }
+
+func (f Conmon_ServePortForwardContainerRequest_Future) Struct() (Conmon_ServePortForwardContainerRequest, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_ServePortForwardContainerRequest(p.Struct()), err
+}
+
+type Conmon_ServePortForwardContainerResponse capnp.Struct
+
+// Conmon_ServePortForwardContainerResponse_TypeID is the unique identifier for the type Conmon_ServePortForwardContainerResponse.
+const Conmon_ServePortForwardContainerResponse_TypeID = 0xf7507d1843e734e4
+
+func NewConmon_ServePortForwardContainerResponse(s *capnp.Segment) (Conmon_ServePortForwardContainerResponse, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_ServePortForwardContainerResponse(st), err
+}
+
+func NewRootConmon_ServePortForwardContainerResponse(s *capnp.Segment) (Conmon_ServePortForwardContainerResponse, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_ServePortForwardContainerResponse(st), err
+}
+
+func ReadRootConmon_ServePortForwardContainerResponse(msg *capnp.Message) (Conmon_ServePortForwardContainerResponse, error) {
+	root, err := msg.Root()
+	return Conmon_ServePortForwardContainerResponse(root.Struct()), err
+}
+
+func (s Conmon_ServePortForwardContainerResponse) String() string {
+	str, _ := text.Marshal(0xf7507d1843e734e4, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_ServePortForwardContainerResponse) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_ServePortForwardContainerResponse) DecodeFromPtr(p capnp.Ptr) Conmon_ServePortForwardContainerResponse {
+	return Conmon_ServePortForwardContainerResponse(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_ServePortForwardContainerResponse) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_ServePortForwardContainerResponse) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_ServePortForwardContainerResponse) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_ServePortForwardContainerResponse) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_ServePortForwardContainerResponse) Url() (string, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return p.Text(), err
+}
+
+func (s Conmon_ServePortForwardContainerResponse) HasUrl() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_ServePortForwardContainerResponse) UrlBytes() ([]byte, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return p.TextBytes(), err
+}
+
+func (s Conmon_ServePortForwardContainerResponse) SetUrl(v string) error {
+	return capnp.Struct(s).SetText(0, v)
+}
+
+// Conmon_ServePortForwardContainerResponse_List is a list of Conmon_ServePortForwardContainerResponse.
+type Conmon_ServePortForwardContainerResponse_List = capnp.StructList[Conmon_ServePortForwardContainerResponse]
+
+// NewConmon_ServePortForwardContainerResponse creates a new list of Conmon_ServePortForwardContainerResponse.
+func NewConmon_ServePortForwardContainerResponse_List(s *capnp.Segment, sz int32) (Conmon_ServePortForwardContainerResponse_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	return capnp.StructList[Conmon_ServePortForwardContainerResponse](l), err
+}
+
+// Conmon_ServePortForwardContainerResponse_Future is a wrapper for a Conmon_ServePortForwardContainerResponse promised by a client call.
+type Conmon_ServePortForwardContainerResponse_Future struct{ *capnp.Future }
+
+func (f Conmon_ServePortForwardContainerResponse_Future) Struct() (Conmon_ServePortForwardContainerResponse, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_ServePortForwardContainerResponse(p.Struct()), err
+}
+
 type Conmon_version_Params capnp.Struct
 
 // Conmon_version_Params_TypeID is the unique identifier for the type Conmon_version_Params.
@@ -4568,222 +5374,816 @@ func (p Conmon_startFdSocket_Results_Future) Response() Conmon_StartFdSocketResp
 	return Conmon_StartFdSocketResponse_Future{Future: p.Future.Field(0, nil)}
 }
 
-const schema_ffaaf7385bc4adad = "x\xda\xc4Y}p\x14\xe7y\x7f\x9e\xdd\x93V\xa7\x0f" +
-	"N\xdb=\x09\x10\xa8\xd2\x10HA\x0d\xe1C\xb8&\x0c" +
-	"\x19I\x80B!\xe0hu`ZH\\\x96\xbbE:" +
-	"\xb8\xdb=v\xf7\x00\x11\xa72I=v\x94\xd81*" +
-	"\x9e\xd8L\x99A\xb6\xa1\x80\xa1\xc6\x1fP\x83\xc1\x03\x18" +
-	"\xc6\x80M]h\xa1\xc6c\\0\xa6\xb6\x19\x7fQ\xbb" +
-	"S\xec\x81n\xe7y\xef\xf6C'\x19\x9fTw\xf2\x07" +
-	"\x83\xee\xd9\xdf>\xef\xc7\xf3\xf9{v\xe2\xe7\xc1\xc6\xc0" +
-	"\xa4\xb27\x86\x00'\xef*(\xb4\xcd\xcb\x1d\xc6\xb6\xcd" +
-	"\xb3\x7f\x05\xe2w\x10\xa0\x00\x05\x80\xfa\xf9\xc2\xbb\x08(" +
-	")B\x03\xa0\xfd_O\x9d\xf8\xe1\xef7|\xda\xe5\x07" +
-	"\xac\xcf\x00\x1ee\x80\xb7\xa7\xd6-\xdf\xc2\xcf\xfb\x8d\x1f" +
-	"\xb0_x\x8b\x00\xa7\x19\xe0\xaf\x97\x866\xfem\xe5\x12" +
-	"\x06\xb0\xaf\xd7/\xbf\xf8\xf8\x07w\xfe#\x14\x08\x04\xfc" +
-	"Xx\x0b\xa5`\x11\xfdYP\xf4;\x04\xb4_\xfb\xe3" +
-	"u\x8bB\xdb\x1ex,\x07\xcd\xd4^\x0d\xbe\x8b\x12\x16" +
-	"\x0b\x00\xd2\xad \xa9\xbe\xff\xc3\xbb\xf6-\xfc\xd5\xa7[" +
-	"\xfckO*\xfeOZ\xbb\xb9\x98\x00\x8f/\xf9`e" +
-	"\xf3\x9c\xd0\x13\xbd\xb5\x05\x08\x17/\xde\x89\xd2\xfab\x01" +
-	"x\xbb\xf2\xab+O\x9d\x8fL\xdd\x01\xf2w\xb0\xcf\xa2" +
-	"?#\\\x9a-\xba\xaax\x0d\xa0=\xfa\x99W\xcet" +
-	"M\x9f\xb0\xd3\xbf\xe8\xe9\xe2\xb3\xb4\xe8e\xb6h\xd7\xdf" +
-	"\xab\x7fr\xe4\xc0\x8f\x09\xc0y\xda\x00\xeb\xb1\xa4\x0b\xa5" +
-	"\xe1%\xa4\xaa\xa2\xe4N@{\xcd\xd2\x13\xcf\xac\x93\xaf" +
-	"\xee\xeag{\xd5%\xdd(\xddQB\xdb\x93fM\xdc" +
-	"\x7f\xbe\xbenw\xee\xf68\xc2\x89\x84\x1b\xc7t\x8e)" +
-	"y\x06\xd0\x9e\xd2\xf3\xfc\xbe\x87?Y\xfb\x0f\x84\xe6r" +
-	"\x0fs\xaed\x05J\x1f\x96\x0c\x05\x90\xae3\xf4\xcf\xcf" +
-	"\\\xdb\xfe\xf0o\x9a\xf6\xe6\xea\xe6\x09\xfd\xeb\xd2\xa3(" +
-	"\xf5\x94\xd2\x9f\x9bKk\xc8:\xfc\xa5\xf7\x8a\x1fn\x9a" +
-	"\xb0\xaf?\xeb\x1c/;\x85\xd2\xe52\xda\xc9\xc52\xba" +
-	"\x07\xf7\xb98\x92\xb7w\xef>\xb6d\xea\x7f\xef\xb4\xe9" +
-	"\x1en\x95Ua}\xd9\x90EH\x8aC\x02'\x05E" +
-	"\x01\xc0\x1e\xf7\xd1\x83\xdb\x1ex:r\xa0?\xe5\xd7\xcb" +
-	"\x8fb\x06&\x15\x88\xa4\xfc\xd4\xbe\x1d\xd3\xbe\xba\xb2\xe6" +
-	"@\xee\xc6i\xfd\xfa\x1f\x88gQZH\xe8zY|" +
-	"\x80\x07\xb4\xcb\x97\xbc\xf1\xc3\x8f\xee\xf9\x8f\xe3~\xa3\x1d" +
-	"\xaf`^z\xa1\x82\xf4\xbd\xaf\xbc\xc45\x9fN\xbc\xea" +
-	"\x07\xdc\xaa(\xe6\x00\xa5\x8aJ\x06x\xef\x7fV\xb4\xa5" +
-	"&\xbc\xee\x07\xdcQ\xd9\xcd|\x8d\x01V\x96\x9c\x08\x07" +
-	"\x1b\xcc\x7f\xf2\x03\xd4\xca\xa3\x04H3\xc0\x8d\x8a\x97\x7f" +
-	"_5\xfd@/\xc0\xa3\x95l\x0f;\x18\xa0\xaa\xe9\xcc" +
-	"\x94\x906\xfb\x9fs.\x80\xd9\xe2t\xe5\x13(]\xad" +
-	"\xa4\x0b\xb8\\I\x96{\xf2\xf3\xedK\xf7n\x08\x9f\xef" +
-	"\xe3e\x1b\x86\xae@i\xebPB\xf6\x0c\xed\x04\xb4o" +
-	"\xde?\xfd\xbe\xea\xea\xf3\x17\xfa\xf5\x9fsC\xaf\xa1t" +
-	"\x9d\xa1?\x1e\xfa>\xa0\xbd\xe9O\xd7\xa4\xeeY6\xed" +
-	"\x9d\x1c4s\xca\x93\xc3\xdeB\xe9\xea0\xb6\x89a\xb4" +
-	"\xe3\x9b\xd3n\xbe\xbcez\xea\xdfsU\x17\xb0\x88\x1e" +
-	"\xde\x85R\xf5p\xfas\xf8\xf0E\xe4>\x0bS\xb3\xc5" +
-	"\xef\xb6\x0e\xb9\xe4\xbf\x81\x87\xaa\xfe\x88.yk\x15\xe9" +
-	"\x9b\xf8\xf3\xd9;\xee\x89KW\xfc\x80\x93U\x9b\x98\x99" +
-	"\x18\xe0\xcf\xa4W\xf6h\x1b\xae]\xede\xa6\xaak\x04" +
-	"\x10G\x10\xe0\xc8\x92\xfa\x96\x7f\xbb\xf2\xdd\xcf@\x1c\xcf" +
-	"y\xb1\x00X?iD7JsF\xd0\xde\x9bGP" +
-	"\xf0\x9d\xf9\xa4f\xd7kW\x7f\xfcy\xee\xde\x83\xa4s" +
-	"\xe1\x88M(%G\xb0D1\xe2N\x0e\xd0\xde\xb6\xea" +
-	"\xc9Gn\x8c\x12\xbf\xc8\x8d+v\xd4C\xd5\xef\xa2t" +
-	"\xa1\x9a]h\xf5\xabt\xd4\x177m\xfc\xdd\xb1\xc9\xb3" +
-	"\xbf\xf0o\xf4b\x0d\xcb\x12\xd7kh\xa3\x15\x7f\xb5\xfe" +
-	"R\xdd\x87Wz\x01\xc4\xdaS\x04\x18SK\x80\x83\xb8" +
-	"\xb3\xe4\xa7+>\xb8\xe1\x07\xcc\xa9eG\xfd\x19\x03\xdc" +
-	"\xe8y\xba\xfe\xbe\xd3\xcf\x7f\xd9O\xf6X_{\x0a\xa5" +
-	"\xcd\xb5\x94=\xba\xffen\xf2\x9d[/}\x95\xe3T" +
-	"\xcc\xf8\x1d\xb5O\xa0\xb4\xa1\x96\xee\xe4\xa1\xda50\xde" +
-	"\x8ek\x96jhJ\xa2pB\xca\xd0-}BT\xd7" +
-	"\x92\xba\xf6\xfd\xa8\x92\xd2R\xd3ff~\xa8k\xd5h" +
-	"\xa4C\x8b\xce\xd45K\x89k\xaa1\xbaE1\x04%" +
-	"i\xca\x01>\x00\x10@\x00\xb1l\x06\x80\\\xc4\xa3\x1c" +
-	"\xe6\xb0\xd3PW\xa5U\xd3\xc2r\xef\x0e\x01\xb1\x1c0" +
-	"\xaf\xe5\xa2\x86\xaaX\xea]JR5SJT5G" +
-	"\xb7\xaafZHX\xbd\x96\x9b\x0b \x97\xf2(\x0f\xe3" +
-	"\xd06T3\xa5k\xa6\x0a\x00X\xee\xd5\x93\xff\xcb\x92" +
-	"-\x8a\xa1\xf0\xf9\x1c\xd0\xadu\x03Xmf\xcej\xad" +
-	"\xa4\x8d7\xad\x16Dy\xa4\xbb\xe0\xdee\x00\xf2\x0b<" +
-	"\xca\x879\x14\x11\xc3H\xc2C\x8b\x01\xe4\x83<\xcao" +
-	"r(r\\\x189\x00\xf1\x1c!\xff\x95G\xf93\x0e" +
-	"E\x9e\x0f#\x0f ~L\xc2\x8fx\x8c\x14!\x87b" +
-	" \x10\xc6\x00\xa5R\x9c\x0b\x10\x09 \x8f\x91r\x92\x17" +
-	"\x14\x84\xb1\x00@*\xc3\xc9\x00\x91\"\x92\x87I^X" +
-	"\x18\xc6B\x00Id\xf8r\x92\x7f\x0f9\xb4\x93\xaa\xa5" +
-	"\xc4\x14K\x01\xe1'\x89\x18\x96\x01\x87e\x80\xb6\x96=" +
-	"\x0a\xf0\xaa\x89C\x00[x\xc4\x90\x97\xaf\x00Ih\xa7" +
-	"\xe3\xb1\xf9J*\x15\x07Aksa\xa5\xc0\xb1\x87m" +
-	"\xb7{\xb8L1\xd5\x16\xc5j'\x03\x93\xac\x14\xb0&" +
-	"\xa5\xc7\xe6\xc4\x9c_\xde\xbe\x00\x9c\x97\xcb\xbd@\xc8n" +
-	"`p\xb61S\xba\xa0\x99*\x19\xc7\xe7\x0d\x8b\xb3\xfe" +
-	"7\x96\xeb\xff\xf8\xe5^\x8f1\x80\xd5\x0dUO\xa9\xda" +
-	"<\xbd\xcd\x0b\xb5V\xb5\xc6L\xe7\xed\xfcn\xfb\x93\xe3" +
-	"\x8e\x05\xb7Y\xb4\xd5Y\x94\xce\x1a\xd23g\xcd\xebM" +
-	"\xf7\x9a\xfco\xcaE\xeeF\xc7\xd5\x01\xc8\xa3y\x94'" +
-	"r\xe8x\xf0x\x92\x8d\xe5Q\x9e\xc2a\xc8\xeaH\xa9" +
-	"9\x9e\x12\x02\x0c\xa5\x14\xab\xdd5m>\xf7\xa6X\x96" +
-	"\x12m\xef\x95\x9f\x94$\xe6\x11\xben9\x1b\xc0}\xcd" +
-	"l3\xf4tj\xbe\xa2)m\xaa\x01\xc0\x8e\xcc\xe2P" +
-	"\x9cAj\xc4\xe0\\\x80N\xb3\xc3\xb4\xd4d\xcc\x8e2" +
-	"\xf0r\x13\x00\xf2R\xde\xc4N\xd2\x9a1*\xe6m\x89" +
-	"\xbbU\xc3\x8c\xeb\x1a\xcb$&\xb2LR\xea\x9e\xbd\x99" +
-	"\xce\xde\xc8\xa3<\xcf3\xc3\x1cJ\x0f\x7f\xce\xa3\xbc\x80" +
-	"\x12\x09f\x12\x89L\x8e\xd5\xc2\xa3\x9c\xe0\xb0s\xb5j" +
-	",\xd3M\x15\x118D\xf8\xba\xd0\x1fP\xe0\x05ns" +
-	"\x82yz\xdb,#\x14_\xad\x1ar\x00\xfdU\x1d\xeb" +
-	"B\x0b:R\xaa\xff<u\xfd\x9c\x87d\xb3x\x94[" +
-	"|\xe7\x99?\xc3;\xa4\xe3k\xae\xe2~|\xad3\xa9" +
-	"\xac\x8d\xc4\xd7\xa9\x18\x04\x0e\x83y\xfa^D\xb5\x16\xc5" +
-	"\xb5\x98\xbe\x86\xde\xcc\x18\xc0bN\x11v7\xfc\x8b*" +
-	"\x00y-\x8f\xf2\xdfx\x1b^?\x19@\xbe\x97G\xf9" +
-	"A\xdf\x86\xef\x9f\x06 \xdf\xc7\xa3\xfc[\xca\xe4\x98\xc9" +
-	"\xe4\xbf&S=\xc8\xa3\xbc\x91\x129\xc7\x12\xb9\xb8\x81" +
-	"L\xf5\x08\x8f\xf2.\x0e\xf9\xb8\x9b\x08k\xd6\xc4cV" +
-	";\x0a\xc0\xa1\x00\xd8\xd0\xae\xc6\xdb\xda-\xe7\xe7\xb7a" +
-	"\xc2\xdb\xde\x84\xa5\x18\xd6\x8fb\x11=\xbaR\xb5Z\xdd" +
-	"\xbc\x94\x939\xeb\xbc@\xec?\xd0\xf9\xaf[\x82\xd75" +
-	"y\x01\xa2G\x8f\xc4\x9eu^S'\xf6\xfc\xd2\xe3\x08" +
-	"b\xcf\x01\xaf\x17\x14\xb7\xb6\xfa(\xdaV\xc3\xebx\xc5" +
-	"\xadG\xbd\x16E\xdcq\xca\xeb\x9c\xc5g\xcfz\xc9A" +
-	"\xdco\xf8\x98\xdb\xfeu\xbe\xbe}\x7f\x97\x8fr\x1e\xea" +
-	"\xf6\xe8\x95xd\xa7\xaf_;\xfe\x9c\x8f\x15\x9f<\xea" +
-	"\xeb\xe5O\xb7\xfa\x18\xf0\xe9S^\xd9\x10\xcfu\xfb\x08" +
-	"\xd2\x85\x9d>*v\xf19_\x93w\xb9\xcbv\xa2\x1f" +
-	"\x1a2\xee\xe7\x0ax\xc7\x08\x99\xb2\xe6&\xc8V\x07\xc8" +
-	"\xa2.\xbeZ\x054l'\xafA\x0d\xcbl\xb6\xf3N" +
-	"\x81\xf3\x92\xa3\xac9\xb7\x1ft\xbc\x1el\xe7\x11\xe7{" +
-	"\x96Me\xb6\x93\xda\xa0&\xb3\xb6\xfb\xbb!\xa3\xd7v" +
-	"\x0a\x11\xb6y\x0a\xfd2G\x91\x13q\xe8\x84\\\x88\xe9" +
-	"\xcb\x15\x9b5\x19\xb5NI\xe7{\xf5[\xa6\x05N\xf9" +
-	"B\x0f\xc3\xf5\xaa\xfb\xcc}m\x0f\xe6\xdbB\xd6\xd51" +
-	"\xeb\xeb\xce\x16r\xc4\xce\x16\x16\xa8k-\xfa\x87\xf3\x95" +
-	"T\xb3f\x19\x1d\x00r-_\x00\xe0\x92Lt\x88\x90" +
-	"x}\x06p\xe2U\x01=F\x81\x0e\x8f\x14/\xfc\x12" +
-	"8\xf1\x8c\x80\x9c;\xc6A\x874\x88\xc7\xbb\x81\x13\x8f" +
-	"\x08\xc8\xbb\xf3\x0at8\xb0\xb8\x97\xde\xdb-`\xc0\xa5" +
-	"S\xe8LR\xc4\x9eM\xc0\x89\x9b\x05,p\x191:" +
-	"\xacM\xdcp\x008\xf1!\x01\x0b\xdd\xa1\x0f:\xe3!" +
-	"q}\x17p\xe2/\x04\x14\\\x1e\x8c\x0e\xc3\x11W\x19" +
-	"\xc0\x89q\x81j\x08\xf9a#\xda\xd1\xac3a\xd6-" +
-	"\xa0\x11m\x87W\xa0\xe3,h4\xa2\xed\xd4r?\xd2" +
-	"p\xbd \x0b\xe5U\x82\x9a\xbd,>S\xd7\x1a2\xaf" +
-	"\xb8\xeb\xdd\xa5\xa0cP =f\xd6>P\xc3\x0c\xd4" +
-	"\x88\xfe\xfa:\x80\xd4\xe6%\xf9~\xba\xb2\xb1\xdc\xb7\xde" +
-	"\x8f\xe6DZ\xa6\xc07:KK\xcfb\x15@d\x17" +
-	"u\xe9/\xa2\xc7\x16\xa4\xbd\xb8\x18 \xf2\x02\xc9\x0f#" +
-	"\x87\x98\xe1\x0b\xd2!\xd6\xd4\x1f$\xf1\x09\xf4\x0a\x8dt" +
-	"\x9c\x91\x80\xc3$\x7f\x1d\xbdZ#\x9d\xc4V\x80\xc8\x09" +
-	"\x92\xbf\xc7H\x03\x9f!\x0d\x97q\x05@\xe4\x12\xc9o" +
-	"2\xd2\x10\xc8\x90\x86/\xd9\xb27\x18\x99\xe08\x14\x85" +
-	"\x820qYI\xe4H^\xce\x11\x99 yQa\x18" +
-	"\x8b\x00\xa4qL>\x96\xe4\xb3H\x1e\x14\xc2\x18\x04\x90" +
-	"\x9a\xb8e\x00\x91F\x92\xff\x94\xe4\xc5Ea,\x06\x90" +
-	"\xfe\x92\xc9\xff\x82\xe41\x92\x97\x04\xc3X\x02 )\x1c" +
-	"\x9dk)\xc9\xef%yiq\x18K\x01\xa4\x0en\x06" +
-	"@\xc4\"\xf9#$/\xc30\x96\x11\x03\xe6\x0c\x80\xc8" +
-	"oI\xfe\x18\xc9\x87\x94\x84q\x08\x80\xf4(\x93o$" +
-	"\xf9\x1e\x92\x87J\xc3\x18\x02\x90v3=\xdbI~\x8c" +
-	"\xebUv\xedei-\x96P[\x14\xe0}\x05\xcdR" +
-	"\x8dd\\S\x12\xe4\x04\xd9.\xaa\xc6\xb4bq\xcd\xed" +
-	"\xa9\xd4\xb5q\x8b\x11\x1b\xec\xc3yt=\xd9LO!" +
-	"\xa4X\xed}\x9e&\x9c\xbc\xcd\x1b>\xca\xe1\x9b~0" +
-	"T4\xa1*Z:5\x13\xf8d\xac\x0f\xe1J\xe8\xcb" +
-	"\x94D\x93\x01|_\xbe\x15\xd5\x93IE\x8b5\x81`" +
-	"\xf4}8\xf8&\xa2S\xd5V\xdf\xad\xf87\x9c\x1b\x11" +
-	"\xd1\xde%\x08C^\xdd\xce\xb4k\xb6\x12\x8b\xc5\xad\xb8" +
-	"\xaeA\x8d\x92\xf8Q\xccU\x15\xccl\xae3\xa1*+" +
-	"\xfb\x8a\x07\xc5!ZU3\x9d\xe0\xf3%^n{\x90" +
-	"C$\x84\xdb\xach\xfa;\xc7\x1c\xf2b\x02|3{" +
-	"q\x9b\x8d\x01\xb0\x97lJ\xce\x9f\"\xb9\xdd\xd6\x00&" +
-	"\x1c\xa6?]:\x07\xfa\xe6\xa5\xdcvg\xc0\xa3\x9b\xc1" +
-	"\x9a\xcd\xed\x04\x07\xc7\x97W\xa5\x05\xd5\xcce[U\x1e" +
-	";\x11\xfb\xa7[\\_\xba\xe5O&\xff\xcfL\x8b\xf5" +
-	"3!*\x8a\x8c\xa5\xb0\xad\xdc1\x8aQ\xd7\xf1\xf4\x1f" +
-	"'\x8e\xa1\xffx\xb1\xba\x0e\x00\x03b\xc5(\x00!\x9e" +
-	"\x8a\x0a\x9aj\x09\xa9x,\x946UCH[f^" +
-	"\xf6\xe9\xa7Y\xf4\xcd\x0a\xca\xddkS\xe82\x96f." +
-	"\xc3\xb9\xb58\xd1\xa1\x18\x8fr\xca\xc7\x91\x92$l\xe7" +
-	"Q\xb6\xa8t\xd5f8\xd2*z;\xc5\xa3|/\x97" +
-	"\xc9\xaa3\xf5\x183q\x008\x0c\x006\x98VLO" +
-	"[\xcee\xd2O\xd50\xdc\xbb\xb5\xe2I5\xf6\x93\xb4" +
-	"\xe5\xcb\xd4\x83\xab\xce\xe4[|\x9fa\xd1\x0a\x9f\xffE" +
-	"\xb3`\x08\x19-\xf1\x18\x16\x01\x87Ey:\x9e\xd30" +
-	"g{cZd\x98\xbb\xc8\xe3\xe4v\x1by\x94\xb7\xf8" +
-	"\xdcn\xf3b\x00\xf9\xefx\x94\xb7\xfb\xdcn\xab\x01 " +
-	"?\xc5\xa3\xbc\x87C\xccN\x0bww\x03\xc8{x\x94" +
-	"\x0fR\xdd\xe73\x1cs?9\xed\x8b<\xca\xc7\xa8\xe8" +
-	"\x07X\xd1\x17\x8f\xd0M\x1f\xe6Q~\xbb\xb7\xd3\x9a," +
-	"\xd6s* \xeb\xf0T\xd3\x84\x9a\xb8\xae\xf9\xc6u\xa6" +
-	"\xa5\xa7\x9a\x96[*\x1a\x11\xaa\x87\xcd:.\xff6\xe7" +
-	"\x0c\x83H\xba,mX\x98g\xdap\x89\xdd \x12\xef" +
-	"\xc0\x12\x94Ko\x07\x90\x12\xfb\x99\"\xb6(!#\xaf" +
-	"\x81\xbd\xcbl\x07p2\x87D\x1a\xdf_\xd0\x91B\xd5" +
-	"7\x10;\xcb\xb2JE\x1d\x80\xeb\xf7\x9c\xd1\x9a\xd6(" +
-	"\xde\xe6\x90\xe6\xe5D\xabB+L]\x1b\xd8\x98\xcb\x17" +
-	"gc\xdd68\xc8\xfaTw\x88\xedt\xc1\"R\xdb" +
-	"VJ\xe2a\xe8%\x12\xa9\x02G9\xb3\xed\x91\xac\x0d" +
-	"\xe62m\xf0p\x9c\x06\x10\x09\x93\xbc\x16\xbdp\x90\xaa" +
-	"\x99\xfa\x91$\x1f\x8b^DHc\x18\xbe\xd6\x99\x91\x8b" +
-	"\x85\x05\x996x\x1cR\x9b:\x96\xe4SH.\x14f" +
-	"\xda\xe0I\xacm\x9eH\xf2\xe9$/\x122m\xf0\x0f" +
-	"\x98\xfe\xa9$\x9fE\xf2`Q\xb6\x0df\xedz#\xc9" +
-	"\xe7!\x87v\xca\xd0\xa3\xaai\xce\x01t\xd3\x87C\xb4" +
-	"\x9c\x00\x13,\xa5\xcd\xf9\xbb\x81\xba\xb9\xb8\xe5kU\xe3" +
-	"\x89\xd8,\xc5\x02T]\x88\xa5\x18m\xaa\x071\xd2\xa6" +
-	"EW\x0d\x82O\xa7\x1dU\x8c6\xfdn\xd5\x80\x90\xd9" +
-	"G\xbc\xc0P}\xfazE\xab\x13\xc1\x83,\x16^\x89" +
-	"\xadu}\xf7\x0c\xe5\xba\xd73_A\x9cTwnq" +
-	"\xf6#\xc8%_\xad\xb8HN\xfe&\x8f\xf2\x17d\xdf" +
-	"\xc6L\xae\xbbN\xd1\xf6\x19\x8f\xf2M\xdf<\xedK\xca" +
-	"u7x\x8c\x04\xfc\x0c\x07\xe9\xea[]\x0fq\x08\xce" +
-	"p\xe6Q\xccC&\xa2\x8f\xe0\x8cG\"\x0e\xdf#\xf9" +
-	"T\xec\x9d\x1e\xc9\xe3\xf5\xb4\x15\x01^\x8d:\xe3\xc5\xce" +
-	"l\x9f\x9d\xdba\xf7\xc3\x1b\xfe\xc0]\xf7`\x1a\xb1\xbc" +
-	"\x1bLwh7\xe8\x063\x93\xbcsZ\xe6\xaf\xcf\xa9" +
-	"\xee m\x00\x0b\xf6\xfd\x06\xda\xaa\x9a\xa1\xfc?\xcc\xb8" +
-	"\x83\xc5\x01\xac\x993Y\xf6\xcdS\xf3J\x96\xce\xd0\x89" +
-	"\xcd\x9c\x04\xcb\xe8\xc8\xf983\xca\xfb8\xe36\x0c\xe3" +
-	"'{_g\x84\x95j\x87;W^\xad$\xd2n|" +
-	"\xffo\x00\x00\x00\xff\xff\xfe\x11AT"
+type Conmon_serveExecContainer_Params capnp.Struct
+
+// Conmon_serveExecContainer_Params_TypeID is the unique identifier for the type Conmon_serveExecContainer_Params.
+const Conmon_serveExecContainer_Params_TypeID = 0x90a3950a51412b8b
+
+func NewConmon_serveExecContainer_Params(s *capnp.Segment) (Conmon_serveExecContainer_Params, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveExecContainer_Params(st), err
+}
+
+func NewRootConmon_serveExecContainer_Params(s *capnp.Segment) (Conmon_serveExecContainer_Params, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveExecContainer_Params(st), err
+}
+
+func ReadRootConmon_serveExecContainer_Params(msg *capnp.Message) (Conmon_serveExecContainer_Params, error) {
+	root, err := msg.Root()
+	return Conmon_serveExecContainer_Params(root.Struct()), err
+}
+
+func (s Conmon_serveExecContainer_Params) String() string {
+	str, _ := text.Marshal(0x90a3950a51412b8b, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_serveExecContainer_Params) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_serveExecContainer_Params) DecodeFromPtr(p capnp.Ptr) Conmon_serveExecContainer_Params {
+	return Conmon_serveExecContainer_Params(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_serveExecContainer_Params) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_serveExecContainer_Params) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_serveExecContainer_Params) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_serveExecContainer_Params) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_serveExecContainer_Params) Request() (Conmon_ServeExecContainerRequest, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return Conmon_ServeExecContainerRequest(p.Struct()), err
+}
+
+func (s Conmon_serveExecContainer_Params) HasRequest() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_serveExecContainer_Params) SetRequest(v Conmon_ServeExecContainerRequest) error {
+	return capnp.Struct(s).SetPtr(0, capnp.Struct(v).ToPtr())
+}
+
+// NewRequest sets the request field to a newly
+// allocated Conmon_ServeExecContainerRequest struct, preferring placement in s's segment.
+func (s Conmon_serveExecContainer_Params) NewRequest() (Conmon_ServeExecContainerRequest, error) {
+	ss, err := NewConmon_ServeExecContainerRequest(capnp.Struct(s).Segment())
+	if err != nil {
+		return Conmon_ServeExecContainerRequest{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, capnp.Struct(ss).ToPtr())
+	return ss, err
+}
+
+// Conmon_serveExecContainer_Params_List is a list of Conmon_serveExecContainer_Params.
+type Conmon_serveExecContainer_Params_List = capnp.StructList[Conmon_serveExecContainer_Params]
+
+// NewConmon_serveExecContainer_Params creates a new list of Conmon_serveExecContainer_Params.
+func NewConmon_serveExecContainer_Params_List(s *capnp.Segment, sz int32) (Conmon_serveExecContainer_Params_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	return capnp.StructList[Conmon_serveExecContainer_Params](l), err
+}
+
+// Conmon_serveExecContainer_Params_Future is a wrapper for a Conmon_serveExecContainer_Params promised by a client call.
+type Conmon_serveExecContainer_Params_Future struct{ *capnp.Future }
+
+func (f Conmon_serveExecContainer_Params_Future) Struct() (Conmon_serveExecContainer_Params, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_serveExecContainer_Params(p.Struct()), err
+}
+func (p Conmon_serveExecContainer_Params_Future) Request() Conmon_ServeExecContainerRequest_Future {
+	return Conmon_ServeExecContainerRequest_Future{Future: p.Future.Field(0, nil)}
+}
+
+type Conmon_serveExecContainer_Results capnp.Struct
+
+// Conmon_serveExecContainer_Results_TypeID is the unique identifier for the type Conmon_serveExecContainer_Results.
+const Conmon_serveExecContainer_Results_TypeID = 0xdebaeed2a782ac80
+
+func NewConmon_serveExecContainer_Results(s *capnp.Segment) (Conmon_serveExecContainer_Results, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveExecContainer_Results(st), err
+}
+
+func NewRootConmon_serveExecContainer_Results(s *capnp.Segment) (Conmon_serveExecContainer_Results, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveExecContainer_Results(st), err
+}
+
+func ReadRootConmon_serveExecContainer_Results(msg *capnp.Message) (Conmon_serveExecContainer_Results, error) {
+	root, err := msg.Root()
+	return Conmon_serveExecContainer_Results(root.Struct()), err
+}
+
+func (s Conmon_serveExecContainer_Results) String() string {
+	str, _ := text.Marshal(0xdebaeed2a782ac80, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_serveExecContainer_Results) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_serveExecContainer_Results) DecodeFromPtr(p capnp.Ptr) Conmon_serveExecContainer_Results {
+	return Conmon_serveExecContainer_Results(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_serveExecContainer_Results) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_serveExecContainer_Results) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_serveExecContainer_Results) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_serveExecContainer_Results) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_serveExecContainer_Results) Response() (Conmon_ServeExecContainerResponse, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return Conmon_ServeExecContainerResponse(p.Struct()), err
+}
+
+func (s Conmon_serveExecContainer_Results) HasResponse() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_serveExecContainer_Results) SetResponse(v Conmon_ServeExecContainerResponse) error {
+	return capnp.Struct(s).SetPtr(0, capnp.Struct(v).ToPtr())
+}
+
+// NewResponse sets the response field to a newly
+// allocated Conmon_ServeExecContainerResponse struct, preferring placement in s's segment.
+func (s Conmon_serveExecContainer_Results) NewResponse() (Conmon_ServeExecContainerResponse, error) {
+	ss, err := NewConmon_ServeExecContainerResponse(capnp.Struct(s).Segment())
+	if err != nil {
+		return Conmon_ServeExecContainerResponse{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, capnp.Struct(ss).ToPtr())
+	return ss, err
+}
+
+// Conmon_serveExecContainer_Results_List is a list of Conmon_serveExecContainer_Results.
+type Conmon_serveExecContainer_Results_List = capnp.StructList[Conmon_serveExecContainer_Results]
+
+// NewConmon_serveExecContainer_Results creates a new list of Conmon_serveExecContainer_Results.
+func NewConmon_serveExecContainer_Results_List(s *capnp.Segment, sz int32) (Conmon_serveExecContainer_Results_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	return capnp.StructList[Conmon_serveExecContainer_Results](l), err
+}
+
+// Conmon_serveExecContainer_Results_Future is a wrapper for a Conmon_serveExecContainer_Results promised by a client call.
+type Conmon_serveExecContainer_Results_Future struct{ *capnp.Future }
+
+func (f Conmon_serveExecContainer_Results_Future) Struct() (Conmon_serveExecContainer_Results, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_serveExecContainer_Results(p.Struct()), err
+}
+func (p Conmon_serveExecContainer_Results_Future) Response() Conmon_ServeExecContainerResponse_Future {
+	return Conmon_ServeExecContainerResponse_Future{Future: p.Future.Field(0, nil)}
+}
+
+type Conmon_serveAttachContainer_Params capnp.Struct
+
+// Conmon_serveAttachContainer_Params_TypeID is the unique identifier for the type Conmon_serveAttachContainer_Params.
+const Conmon_serveAttachContainer_Params_TypeID = 0xa3cb406c522dcab1
+
+func NewConmon_serveAttachContainer_Params(s *capnp.Segment) (Conmon_serveAttachContainer_Params, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveAttachContainer_Params(st), err
+}
+
+func NewRootConmon_serveAttachContainer_Params(s *capnp.Segment) (Conmon_serveAttachContainer_Params, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveAttachContainer_Params(st), err
+}
+
+func ReadRootConmon_serveAttachContainer_Params(msg *capnp.Message) (Conmon_serveAttachContainer_Params, error) {
+	root, err := msg.Root()
+	return Conmon_serveAttachContainer_Params(root.Struct()), err
+}
+
+func (s Conmon_serveAttachContainer_Params) String() string {
+	str, _ := text.Marshal(0xa3cb406c522dcab1, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_serveAttachContainer_Params) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_serveAttachContainer_Params) DecodeFromPtr(p capnp.Ptr) Conmon_serveAttachContainer_Params {
+	return Conmon_serveAttachContainer_Params(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_serveAttachContainer_Params) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_serveAttachContainer_Params) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_serveAttachContainer_Params) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_serveAttachContainer_Params) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_serveAttachContainer_Params) Request() (Conmon_ServeAttachContainerRequest, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return Conmon_ServeAttachContainerRequest(p.Struct()), err
+}
+
+func (s Conmon_serveAttachContainer_Params) HasRequest() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_serveAttachContainer_Params) SetRequest(v Conmon_ServeAttachContainerRequest) error {
+	return capnp.Struct(s).SetPtr(0, capnp.Struct(v).ToPtr())
+}
+
+// NewRequest sets the request field to a newly
+// allocated Conmon_ServeAttachContainerRequest struct, preferring placement in s's segment.
+func (s Conmon_serveAttachContainer_Params) NewRequest() (Conmon_ServeAttachContainerRequest, error) {
+	ss, err := NewConmon_ServeAttachContainerRequest(capnp.Struct(s).Segment())
+	if err != nil {
+		return Conmon_ServeAttachContainerRequest{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, capnp.Struct(ss).ToPtr())
+	return ss, err
+}
+
+// Conmon_serveAttachContainer_Params_List is a list of Conmon_serveAttachContainer_Params.
+type Conmon_serveAttachContainer_Params_List = capnp.StructList[Conmon_serveAttachContainer_Params]
+
+// NewConmon_serveAttachContainer_Params creates a new list of Conmon_serveAttachContainer_Params.
+func NewConmon_serveAttachContainer_Params_List(s *capnp.Segment, sz int32) (Conmon_serveAttachContainer_Params_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	return capnp.StructList[Conmon_serveAttachContainer_Params](l), err
+}
+
+// Conmon_serveAttachContainer_Params_Future is a wrapper for a Conmon_serveAttachContainer_Params promised by a client call.
+type Conmon_serveAttachContainer_Params_Future struct{ *capnp.Future }
+
+func (f Conmon_serveAttachContainer_Params_Future) Struct() (Conmon_serveAttachContainer_Params, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_serveAttachContainer_Params(p.Struct()), err
+}
+func (p Conmon_serveAttachContainer_Params_Future) Request() Conmon_ServeAttachContainerRequest_Future {
+	return Conmon_ServeAttachContainerRequest_Future{Future: p.Future.Field(0, nil)}
+}
+
+type Conmon_serveAttachContainer_Results capnp.Struct
+
+// Conmon_serveAttachContainer_Results_TypeID is the unique identifier for the type Conmon_serveAttachContainer_Results.
+const Conmon_serveAttachContainer_Results_TypeID = 0xedd2e5b018f17bbb
+
+func NewConmon_serveAttachContainer_Results(s *capnp.Segment) (Conmon_serveAttachContainer_Results, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveAttachContainer_Results(st), err
+}
+
+func NewRootConmon_serveAttachContainer_Results(s *capnp.Segment) (Conmon_serveAttachContainer_Results, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_serveAttachContainer_Results(st), err
+}
+
+func ReadRootConmon_serveAttachContainer_Results(msg *capnp.Message) (Conmon_serveAttachContainer_Results, error) {
+	root, err := msg.Root()
+	return Conmon_serveAttachContainer_Results(root.Struct()), err
+}
+
+func (s Conmon_serveAttachContainer_Results) String() string {
+	str, _ := text.Marshal(0xedd2e5b018f17bbb, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_serveAttachContainer_Results) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_serveAttachContainer_Results) DecodeFromPtr(p capnp.Ptr) Conmon_serveAttachContainer_Results {
+	return Conmon_serveAttachContainer_Results(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_serveAttachContainer_Results) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_serveAttachContainer_Results) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_serveAttachContainer_Results) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_serveAttachContainer_Results) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_serveAttachContainer_Results) Response() (Conmon_ServeAttachContainerResponse, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return Conmon_ServeAttachContainerResponse(p.Struct()), err
+}
+
+func (s Conmon_serveAttachContainer_Results) HasResponse() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_serveAttachContainer_Results) SetResponse(v Conmon_ServeAttachContainerResponse) error {
+	return capnp.Struct(s).SetPtr(0, capnp.Struct(v).ToPtr())
+}
+
+// NewResponse sets the response field to a newly
+// allocated Conmon_ServeAttachContainerResponse struct, preferring placement in s's segment.
+func (s Conmon_serveAttachContainer_Results) NewResponse() (Conmon_ServeAttachContainerResponse, error) {
+	ss, err := NewConmon_ServeAttachContainerResponse(capnp.Struct(s).Segment())
+	if err != nil {
+		return Conmon_ServeAttachContainerResponse{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, capnp.Struct(ss).ToPtr())
+	return ss, err
+}
+
+// Conmon_serveAttachContainer_Results_List is a list of Conmon_serveAttachContainer_Results.
+type Conmon_serveAttachContainer_Results_List = capnp.StructList[Conmon_serveAttachContainer_Results]
+
+// NewConmon_serveAttachContainer_Results creates a new list of Conmon_serveAttachContainer_Results.
+func NewConmon_serveAttachContainer_Results_List(s *capnp.Segment, sz int32) (Conmon_serveAttachContainer_Results_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	return capnp.StructList[Conmon_serveAttachContainer_Results](l), err
+}
+
+// Conmon_serveAttachContainer_Results_Future is a wrapper for a Conmon_serveAttachContainer_Results promised by a client call.
+type Conmon_serveAttachContainer_Results_Future struct{ *capnp.Future }
+
+func (f Conmon_serveAttachContainer_Results_Future) Struct() (Conmon_serveAttachContainer_Results, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_serveAttachContainer_Results(p.Struct()), err
+}
+func (p Conmon_serveAttachContainer_Results_Future) Response() Conmon_ServeAttachContainerResponse_Future {
+	return Conmon_ServeAttachContainerResponse_Future{Future: p.Future.Field(0, nil)}
+}
+
+type Conmon_servePortForwardContainer_Params capnp.Struct
+
+// Conmon_servePortForwardContainer_Params_TypeID is the unique identifier for the type Conmon_servePortForwardContainer_Params.
+const Conmon_servePortForwardContainer_Params_TypeID = 0x9d82529754851252
+
+func NewConmon_servePortForwardContainer_Params(s *capnp.Segment) (Conmon_servePortForwardContainer_Params, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_servePortForwardContainer_Params(st), err
+}
+
+func NewRootConmon_servePortForwardContainer_Params(s *capnp.Segment) (Conmon_servePortForwardContainer_Params, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_servePortForwardContainer_Params(st), err
+}
+
+func ReadRootConmon_servePortForwardContainer_Params(msg *capnp.Message) (Conmon_servePortForwardContainer_Params, error) {
+	root, err := msg.Root()
+	return Conmon_servePortForwardContainer_Params(root.Struct()), err
+}
+
+func (s Conmon_servePortForwardContainer_Params) String() string {
+	str, _ := text.Marshal(0x9d82529754851252, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_servePortForwardContainer_Params) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_servePortForwardContainer_Params) DecodeFromPtr(p capnp.Ptr) Conmon_servePortForwardContainer_Params {
+	return Conmon_servePortForwardContainer_Params(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_servePortForwardContainer_Params) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_servePortForwardContainer_Params) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_servePortForwardContainer_Params) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_servePortForwardContainer_Params) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_servePortForwardContainer_Params) Request() (Conmon_ServePortForwardContainerRequest, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return Conmon_ServePortForwardContainerRequest(p.Struct()), err
+}
+
+func (s Conmon_servePortForwardContainer_Params) HasRequest() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_servePortForwardContainer_Params) SetRequest(v Conmon_ServePortForwardContainerRequest) error {
+	return capnp.Struct(s).SetPtr(0, capnp.Struct(v).ToPtr())
+}
+
+// NewRequest sets the request field to a newly
+// allocated Conmon_ServePortForwardContainerRequest struct, preferring placement in s's segment.
+func (s Conmon_servePortForwardContainer_Params) NewRequest() (Conmon_ServePortForwardContainerRequest, error) {
+	ss, err := NewConmon_ServePortForwardContainerRequest(capnp.Struct(s).Segment())
+	if err != nil {
+		return Conmon_ServePortForwardContainerRequest{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, capnp.Struct(ss).ToPtr())
+	return ss, err
+}
+
+// Conmon_servePortForwardContainer_Params_List is a list of Conmon_servePortForwardContainer_Params.
+type Conmon_servePortForwardContainer_Params_List = capnp.StructList[Conmon_servePortForwardContainer_Params]
+
+// NewConmon_servePortForwardContainer_Params creates a new list of Conmon_servePortForwardContainer_Params.
+func NewConmon_servePortForwardContainer_Params_List(s *capnp.Segment, sz int32) (Conmon_servePortForwardContainer_Params_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	return capnp.StructList[Conmon_servePortForwardContainer_Params](l), err
+}
+
+// Conmon_servePortForwardContainer_Params_Future is a wrapper for a Conmon_servePortForwardContainer_Params promised by a client call.
+type Conmon_servePortForwardContainer_Params_Future struct{ *capnp.Future }
+
+func (f Conmon_servePortForwardContainer_Params_Future) Struct() (Conmon_servePortForwardContainer_Params, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_servePortForwardContainer_Params(p.Struct()), err
+}
+func (p Conmon_servePortForwardContainer_Params_Future) Request() Conmon_ServePortForwardContainerRequest_Future {
+	return Conmon_ServePortForwardContainerRequest_Future{Future: p.Future.Field(0, nil)}
+}
+
+type Conmon_servePortForwardContainer_Results capnp.Struct
+
+// Conmon_servePortForwardContainer_Results_TypeID is the unique identifier for the type Conmon_servePortForwardContainer_Results.
+const Conmon_servePortForwardContainer_Results_TypeID = 0xae5e0ae5001ebdfe
+
+func NewConmon_servePortForwardContainer_Results(s *capnp.Segment) (Conmon_servePortForwardContainer_Results, error) {
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_servePortForwardContainer_Results(st), err
+}
+
+func NewRootConmon_servePortForwardContainer_Results(s *capnp.Segment) (Conmon_servePortForwardContainer_Results, error) {
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	return Conmon_servePortForwardContainer_Results(st), err
+}
+
+func ReadRootConmon_servePortForwardContainer_Results(msg *capnp.Message) (Conmon_servePortForwardContainer_Results, error) {
+	root, err := msg.Root()
+	return Conmon_servePortForwardContainer_Results(root.Struct()), err
+}
+
+func (s Conmon_servePortForwardContainer_Results) String() string {
+	str, _ := text.Marshal(0xae5e0ae5001ebdfe, capnp.Struct(s))
+	return str
+}
+
+func (s Conmon_servePortForwardContainer_Results) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
+	return capnp.Struct(s).EncodeAsPtr(seg)
+}
+
+func (Conmon_servePortForwardContainer_Results) DecodeFromPtr(p capnp.Ptr) Conmon_servePortForwardContainer_Results {
+	return Conmon_servePortForwardContainer_Results(capnp.Struct{}.DecodeFromPtr(p))
+}
+
+func (s Conmon_servePortForwardContainer_Results) ToPtr() capnp.Ptr {
+	return capnp.Struct(s).ToPtr()
+}
+func (s Conmon_servePortForwardContainer_Results) IsValid() bool {
+	return capnp.Struct(s).IsValid()
+}
+
+func (s Conmon_servePortForwardContainer_Results) Message() *capnp.Message {
+	return capnp.Struct(s).Message()
+}
+
+func (s Conmon_servePortForwardContainer_Results) Segment() *capnp.Segment {
+	return capnp.Struct(s).Segment()
+}
+func (s Conmon_servePortForwardContainer_Results) Response() (Conmon_ServePortForwardContainerResponse, error) {
+	p, err := capnp.Struct(s).Ptr(0)
+	return Conmon_ServePortForwardContainerResponse(p.Struct()), err
+}
+
+func (s Conmon_servePortForwardContainer_Results) HasResponse() bool {
+	return capnp.Struct(s).HasPtr(0)
+}
+
+func (s Conmon_servePortForwardContainer_Results) SetResponse(v Conmon_ServePortForwardContainerResponse) error {
+	return capnp.Struct(s).SetPtr(0, capnp.Struct(v).ToPtr())
+}
+
+// NewResponse sets the response field to a newly
+// allocated Conmon_ServePortForwardContainerResponse struct, preferring placement in s's segment.
+func (s Conmon_servePortForwardContainer_Results) NewResponse() (Conmon_ServePortForwardContainerResponse, error) {
+	ss, err := NewConmon_ServePortForwardContainerResponse(capnp.Struct(s).Segment())
+	if err != nil {
+		return Conmon_ServePortForwardContainerResponse{}, err
+	}
+	err = capnp.Struct(s).SetPtr(0, capnp.Struct(ss).ToPtr())
+	return ss, err
+}
+
+// Conmon_servePortForwardContainer_Results_List is a list of Conmon_servePortForwardContainer_Results.
+type Conmon_servePortForwardContainer_Results_List = capnp.StructList[Conmon_servePortForwardContainer_Results]
+
+// NewConmon_servePortForwardContainer_Results creates a new list of Conmon_servePortForwardContainer_Results.
+func NewConmon_servePortForwardContainer_Results_List(s *capnp.Segment, sz int32) (Conmon_servePortForwardContainer_Results_List, error) {
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	return capnp.StructList[Conmon_servePortForwardContainer_Results](l), err
+}
+
+// Conmon_servePortForwardContainer_Results_Future is a wrapper for a Conmon_servePortForwardContainer_Results promised by a client call.
+type Conmon_servePortForwardContainer_Results_Future struct{ *capnp.Future }
+
+func (f Conmon_servePortForwardContainer_Results_Future) Struct() (Conmon_servePortForwardContainer_Results, error) {
+	p, err := f.Future.Ptr()
+	return Conmon_servePortForwardContainer_Results(p.Struct()), err
+}
+func (p Conmon_servePortForwardContainer_Results_Future) Response() Conmon_ServePortForwardContainerResponse_Future {
+	return Conmon_ServePortForwardContainerResponse_Future{Future: p.Future.Field(0, nil)}
+}
+
+const schema_ffaaf7385bc4adad = "x\xda\xc4z}t\x14e\x96\xf7\xbdUI*\x09\xe9" +
+	"t\x8a\xea\xcc\x8b11\x04\x02o\x92!\xc3G`\x05" +
+	"\x0e\x1c\x12 \xb20\xa0\xa94\xea\x0a3.Ew\x11" +
+	"\x1a:\xddMU5\x10\xd4E\x9deu\xf0c\x84\xc5" +
+	"\xa3p\x86s\xc4o\x18P\x9c\x19\x1cE\x99#\x8c\x1e" +
+	"\x11u\xd7\xb0\x8b\xab\x1eqQ`\x14\x8e\xa88z\x04" +
+	"\x0eX{\xee\xd3]\x1f]i\xa1;rv\xff\xc8I" +
+	"\xf7\xad[\xf7>\xcf}\xee\xe7\xef\xe9Q{\xcaZ\x0b" +
+	"F\xfb\xbe\x1c\x08\x9c\xfcaa\x91\xa9\x7f\xdc\xa3=\xb9" +
+	"y\xc6\xaf@\x1c\x8a\x00\x85(\x00\xb4\xfc\xb2\xe4\x13\x04" +
+	"\x94\x96\x95L\x014\xbf}|\xff\xe4\x87\xd6}\xb9\xd6" +
+	"\xcd\xb0.\xc5\xf0\x04c\xf8p|\xd3\xa2G\xf8\xd9\xf7" +
+	"\xb8\x19\xde(\xf9\x80\x18\x0e3\x86\x7fZ\xe0\xdf\xf0\xaf" +
+	"?\x99\xcf\x18\xcc\xd3-\x8b\x0eo\xfc\xec\xea?A\xa1" +
+	"@\x8c\x17J>@\xe9\x8aR\xfaXY\xfa\x1b\x044" +
+	"\xef\xf9i\x9b\\\xfa\xe0c\x0f\xb8\xc5};\xe0$\x89" +
+	"+)#q\xa36\xbd9bS\xf3S\x1b<\xe2\x18" +
+	"cc\x19\xc7I\xede\x02\x80\xd4\xc6\x98\xdf\xbcj\xd5" +
+	"\x8d\xfe'\xefz8\x1b\xb3R\xf6\x09J\xb71\xe6\x1e" +
+	"\xc6\xdc9p\xcd\xdc\x87:\xef\xdc\xecV\xbd\xa3l\x08" +
+	"\x07(\xbd\xc6\x18\xd6\x9c\xb8\xf6\xf9\xeb\x7f\xf5\xe5#n" +
+	"\x86\xe3e_\xd3\xda\xce2\x86\x8d\xf3?[\xda>\xd3" +
+	"\xffh\xa6\xba\x02\xe2\xab\xf1mCi\x9cO\x00\xde|" +
+	"\xee@sg\xb4\xf5\xcd\xc7\xdcbD\xdf9\x123\xcc" +
+	"Gb~r\xee\xe8\xe3\xef\x06\xc7o\x05y(\xf6Y" +
+	"v;\x09\xfa\xa5\x8f\x96}\x93o\x05\xa09n\xc5s" +
+	"\x8b\xbf\x9etbk\xb6=\xee\xf2}\x8dR/c~" +
+	"\x9b\x89\xae\x7f\xf6/\xbdk'\x8d\xdc\xe6\xd6}\xcaw" +
+	"\x90tc91\xac}J\xfd\xff{w\xff\x9c\x188" +
+	"G\x1a`K]\xf9Z\x94&\x94\x93\xa8q\xe5W\x03" +
+	"\x9a+\x16\xec\x7fv\x95||{\x96\xcdN._\x8f" +
+	"\xd2\xf5\xe5\xb4Yi\xfa\xa8\x17\xdfmi\xda\xe1\xdd\x0b" +
+	"G|\xa3\x89o&\x93\xd9^\xfe,\xe0w\xdf\xef\xb9" +
+	"\xeax\xe9\xcd\xcf\xb8\xcf\xbe\xbc\x89\x0e\xc0\xe7\xa7\xc5\x8d" +
+	"\xdd\xf2\x87\xe7\xef\xffb\xe53$\x8c\xf3\xeeu\xb4\x7f" +
+	"\x09J\xed\xfe\xff\x07 \xcd\xf1?\x0bh\xde\xd2{\xf2" +
+	"\xe9\xfb\xefi\xdb\xe5U\xcd\xb3s\xf3\xefC\xe9\x82\x9f" +
+	">\x9e\xf5\xd7\x92\xe7\xf1G\x8e\x95\xde\xdf6\xf2\xf9l" +
+	"v\xac\x13\x0f\xa04Y\xa4\x85N\x10i%\xf6s\xb1" +
+	"\x9a7w\xecxu\xfe\xf8\xef\xb6\x99d\xa6\x9b\xc4*" +
+	"l\x89\x88\x7fB\x8a\x13\xe9uNZW)\x00\x98\x8d" +
+	"\x9f\xdf\xfd\xe4]\xbf\x0b\xee\xce&\xbc\xa7r\x1f\xa6\xd8" +
+	"\xa4\xfb*I\xf8\x81\xe7\xb7N<wt\xc5n\xef\xc2" +
+	"\xe9\x1c[\xf6V\x1eD\xe90q\xb7\xbc_y\x17\x0f" +
+	"hV\xcc\xff\xf7\xc9\x9f\xdf\xfc\xd7\xd7\xdcg:\xa7\x8a" +
+	"E\xa0RE\xf2>U^\xe2\xda\xdf\x8e\xbe\xeefX" +
+	"SUJv\xdd\xcc\x18^\x1b?x\xe0\x96\xf7\xd4\xfd" +
+	"\x9e\xd5\xb13\xdaS5\x84\x93\x0eW\xd1\xea\xde\xaf\"" +
+	"\x7f\xfb\x97g\x86\xaf\xf4\xdd\x7f\xef\x81\xac':\xe7\xca" +
+	"s(E\xae\xa4\x8f\xea\x95\xcc\xac\x9f\x1e\xfb~IW" +
+	"b\xe4[n\xe5\xbf\xae^O\xab\xdbXM\xca\x97\x0e" +
+	"\xd8\x1f(\x99\xa2\xff\x9b\x9b\xe1\xc5\xea}\xc4\xf0\x06c" +
+	"8S\xf9\xe7\x87\xaa&\xed\xce`8Q\xcd\xf6w\x81" +
+	"1\xd4U\xff\xf5\x0e-R\xfdN\xd6\x83\xae\xab9\x89" +
+	"\xd2\xe4\x1a\xfa8\xa1\xe6uZQU[\xefX\x7fl" +
+	"\xc6;\x9e\xdd2\xeea\xb5\x8f\xa24\xb9\x96\x1dt-" +
+	"9\xd1c\x7f{z\xc1\xaeu\x81w\xfb\xc4\xc3\x89\xda" +
+	"%(]`\x9cgkW\x03\x9a\xe7\xd7L\xba\xbd\xa6" +
+	"\xe6\xdd\xf7\xb3\xda\xa5y\xf0I\x94f\x0ef\x9e>\xf8" +
+	"S@s\xd3OW$n^8\xf1#\x0f7\x0b\x9f" +
+	"\xba\xba\x0fP\x9a\\\xc7\x16QG\x1b\xbc}\xfb\x9dO" +
+	"\x1d\xfcb\xf7G\x19Y\xba\x8e%\x9ee\x8c\xe1\xfc\xc4" +
+	"\xf3\x7f~dR\xe2\xbf\xbd\xba\x0b\x89\xf3\xc1\xba\xb5(" +
+	"\xed q-[\xebn$\x0b\\\x9f\x98!\x0e\xef," +
+	"?\xe2\x96W3t 9\xc4\xb8\xa1,\xc9\xde2c" +
+	"\xeb\xcd\x11\xe9\xa8\x9b\xe1\xa6\xa1\x9bHa\x841\xfc\x9d" +
+	"\xf4\x97\x9d\xb1u'\x8f\xbb\x19\xee\x1b\xca\xd2\xf4\x16\xc6" +
+	"\xf0\xd2-\xa7\x07\xed<~\xf0\x94\x9ba\xefP\x8eT" +
+	"\x1cb\x0c{\xe7\xb7t\xfc\xd7\xd1\xe1_\x81\xd8\xcc9" +
+	"\x81\x0d\xd8rv\xe8z\x94\xc4z\xda\xbd\xaf\xfe:@" +
+	"\xb3\xf7\x8b\xda\xedo\x1e\xff\xf9\xdf\xbc\x9b+aQ_" +
+	"\xbf\x09\xa5\x99\xf5,3\xd6_\xcd\x01\x9aO.{\xec" +
+	"\x813C\xc4o\xbcI\x82\xd9b\xe3\xf0OP\xda5" +
+	"\x9c>>7\x9cy\xc3\x0b\x9b6\xfc\xe6\xd513\xbe" +
+	"\xc9p\xbf\x06\x96\x11\xdfn\xa0\x85V\xfe\xe3\x1dG\x9a" +
+	"N\x1c\xcd`8\xd5p\x80\xa5\xccFb86\xf6\xd3" +
+	"i\x83n\xeb\xf8.[l\x0fkl\xe2\xa4\xf6FV" +
+	"\x91\x18\xf3\xcb\xb8m\xc0/\x96|v\xc6-Mid" +
+	"\x86K2\x863[~\xd7r\xfb\xdb\x7f8\x9b%\xad" +
+	"nl<\x80\xd2\xaeFJ\xab\xeb\xffcV\xf7G\x17" +
+	"^:\x97-b\xd75>\x8a\xd2V\xa6\xf3\x89\xc6\x15" +
+	"\xd0lFb\x86\xaa\xc5\x94h\xd1\xc8\x84\x167\xe2#" +
+	"C\xf1Xw<\xf6\xb3\x90\x92\x88%&NK}Q" +
+	"W\xaa\xa1`O,4-\x1e3\x94HL\xd5\xea;" +
+	"\x14MP\xbau\xb9\x80/\x00(@\x00\xd17\x15@" +
+	".\xe6Q\x0ep\xb8ZS\x97%U\xdd\xc0\x0a\xc7\xe0" +
+	"\x80X\x01\x98\x93\xba\x90\xa6*\x86z\xad\xd2\xad\xea\x09" +
+	"%\xa4\xea\xf5\x9d\xaa\x9e\x14\xa2F\x86\xbaY\x00r\x19" +
+	"\x8f\xf2 \x0eMM\xd5\x13\xf1\x98\xae\x02\x00V8u" +
+	"\xfd\xc7\xa8\xecP4\x85\xcfe\x83v\x07\x93\x87\xb6i" +
+	"\x1em\x9d$\x8d\xd7\x8d\x0eD\xb9\xdaV\xb8k!\x80" +
+	"\xfcG\x1e\xe5W8\x14\x11\x03H\xc4=\xf3\x00\xe4\x97" +
+	"y\x94\xdf\xe3P\xe4\xb8\x00r\x00\xe2!\xe2\xfcO\x1e" +
+	"\xe5\xaf8\x14y>\x80<\x80x\x8a\x88\x9f\xf3\x18," +
+	"F\x0e\xc5\x82\x82\x00\x16\x00H\x858\x0b X\x80<" +
+	"\x06+\x88^X\x18\xc0B\x8a&\x1c\x03\x10,&z" +
+	"\x80\xe8EE\x01,\x02\x90D\xc6_A\xf4\x11\xc8\xa1" +
+	"\xd9\xad\x1aJX1\x14\x10\xae\x8b\x86\xd1\x07\x1c\xfa\x00" +
+	"\xcdXz+\xc0\xab:\x96\x03v\xf0\x88~'=\x02" +
+	"\x12\xd1LF\xc2s\x94D\"\x02B\xac\xcbf+\x03" +
+	"\x8e=\xec\xba\xd8\xc3\x85\x8a\xaev(\xc6b:`\xa2" +
+	"\x95\x01\xd6&\xe2\xe1\x99a\xeb\x9b\xb3.\x00\xeb\xe5\x0a" +
+	"'\x10\xd2\x0b\xc8\xe5ltU[\xae\xb6\xafT3\x9c" +
+	"\xdd\xaf\xe5\xe4\xecv\xad\xf1\xf8\x82p\x11}A\xd2\xd7" +
+	"f\x18Jh\xb1\xad\xb1\xd3\xf2gr\x08\x97\xd6!\x8e" +
+	"V!\xa9E\xed\xcd\xf7\xcf\xe7\xf4D\\\x88\xe9\xaaG" +
+	"\xc7\xbct\\5p\xd9\x8f\xb5\xc2\xe9@=V\x15." +
+	"e\xd5\x8e\xb8f\\\x13\xd7V(Z\xb8\x1f\x99\xc4\xee" +
+	"C\xf2\x084M\x8d'\xd4\xd8\xecx\x97\xa3\xafS\xad" +
+	"\xd5\x939\xe7\x12\xbbi\xf7(-\xbc\x88\xd2NK)" +
+	"\x99\xd8\x1fO\x998w\xdf\xf3\xf8B\xfd\x14JE\xb9" +
+	"\x18\xc8\xee\xbd\xf2X\xab\xed\x0f\xee\xb5\xca\xc5\xb6\xaa\xc6" +
+	"&\x00\xb9\x9eGy\x14\x87V\x0aj&Z\x03\x8f\xf2" +
+	"X\x0e\xfdFOB\xf5\x84\xba\x1f\xd0\x9fP\x8c\xc5y" +
+	"\xb9g\xb0O\xd8u\xaazm\"\xde\xd7A\x7fL\x10" +
+	"(\x1e\xdb2\xd3b\x0e\xb6\xb5{\xa8<l;\xadK" +
+	"\x8b'\x13s\x94\x98\xd2\xa5j\xc0b\xb9\x98\xa5kq" +
+	"*\x89\x11Kf\x01\xac\xd6{tC\xed\x0e\x9b!\xc6" +
+	"\xbcH\x07\x80\x9c\x84\xa7\xbc$\x9d(0\xc3\xc3.\xf6" +
+	"\xda\x0d\xaa\xa6G\xe21Vptd\x05\xa7\xcc\xde{" +
+	";\xed\xbd\x95Gy\xb6s\xd83\xa9\x8a\xfc=\x8f\xf2" +
+	"\\\xaa7\x98\xaa72\x05L\x07\x8fr\x94\xc3\xd5\xcb" +
+	"Uma\\W\x11\x81C\x84\x1f\xaa\x10y\xe5\xe7\xfe" +
+	"e\x92NU\xf7\xe7\x1e\xd9vc\xe69\xd1\x82\x8b\xe8" +
+	"\x9e\x1d\xef\x9a\xae\xf9#\xcbUM.@w\x97\x8aM" +
+	"\xfe\xb9=\x09\xd5m\xcb\xa6,\xb6$\xdat\x1e\xe5\x0e" +
+	"\x97-\xe7Lu\x0clE\x93-8K4\xad\xeeV" +
+	"V\x06#\xabT,\x01\x0eKr\x8e.\xe3\xc6H," +
+	"\x1c_Ao\xa6\x0e\xdf`\x0e\x19\xb0\x17|[\x15\x80" +
+	"\xbc\x92G\xf9\x9f\x9d\x05\xdf1\x06@\xbe\x95G\xf9n" +
+	"\xd7\x82\xd7L\x04\x90o\xe7Q\xbe\x97\x9a\x0dL5\x1b" +
+	"\xbf&7\xb9\x9bGy\x03\xf5\x1a\x1c\xeb5\xc4ud" +
+	"\xfd\x07x\x94\xb7s\xc8G\xecZ]\xbb\"\x126\x16" +
+	"\xa3\x00\x1c\x0a\x80S\x16\xab\x91\xae\xc5\x86\xf5\xf5r\xb8" +
+	"\xcfE-a(\x9aqM8\x18\x0f-U\x0d\xbb\xce" +
+	"z\x0bm\x93\x93\x04\xb2\xa72\xfe\x87T\xf0\xf1\x98\x1c" +
+	"Et\xa0\x0d\xb1w\x953\xa4\x88\xbdw:\x03\xbc\xd8" +
+	"\xbb\xdb\x99m\xc4C\x9d.x\xe5\x90\xe6\xcc\x80\xe2\xa1" +
+	"}N\x17-\xbe\x7f\xc0\x99%\xc5\x8f\x0f:\x89I<" +
+	"\xa1\xb9P\x97\x13\xab\\\x93\xec\x89\xb5.\xf0\xe9\xd4z" +
+	"\x07\xfb\x10Oos\x8d\x14\xdf\xfe\xde\x05\xc7\x9d\xdd\xe7" +
+	"\x9an/t\xba\xc0\xb2\x0b\x07\x9c\x0e@*\xc4\xf5\x0e" +
+	"|!\x95\xe06\x07)\x91|\xf8{\xe7\x88$\x11\xd7" +
+	":\xfd\x91T\x89\x07\x1dlJ\xaa\xc1\x0f\x9c\xea%\x0d" +
+	"\xc3O\x1c Oj\xc6\x93N\xe9o\x19\x87\xa5\xae\x99" +
+	"\xaa\xa5\x0d\x07\xa2i\xe54\x98\x92rl\x9b\xc0[\xc7" +
+	"\x9b\xea}\x9c\xcab1\xb2x\x8e,W\x015\xd3\xca" +
+	"\xd6P\xcb\xf2\xb5i\xbdS\xe8\xed\xc9\xda\xbd\xc3\x90\x15" +
+	"O`Z\x8f8o'\x87\xaai%l\xa8M\xe9\xb6" +
+	"\xbfOI\xc95\xad\xb6\x01\xbb\x1c\x81n\x9a%\xc8\x8a" +
+	"e\xb4\x82\xd9\xcf\xe4y\xc9\xe9\xe2iZ}\x1f\x9f1" +
+	"l\xe8\x06X\xa5\x1f\x1d\x1e.\xa39d\x81a:l" +
+	"\xae%\xa4\x83\x08\xd3Qd-\xc1C\xb6\x960W]" +
+	"i\xd0\x1f\xceQ\x12\xed1C\xeb\x010\xadz\xcfy" +
+	"\xed\x88F\xf6g\xa4\x9b\xd7U\xd3\xea\x97\xb9\xcc\x86y" +
+	"YRHY!\xeb\xd3to\x93z\xdc\x11\xd7\xf8>" +
+	"\xd5\xc3\xb1\xf9\xc5x\xd2\x06\x90G\xf0\x85\x006z\x85" +
+	"\x16\"\"\xc98\x158\xa9\x1d\x05t\xb0\x03\xb4 *" +
+	"i\x02\xde\x09\x9c4\x1a\x05\xe4ll\x1d\xad\x99_\x1a" +
+	"\x86\xeb\x81\x93\xeaP@\xdeFb\xd1\x82\xef\xa4J\xf6" +
+	"\xae\x0f\x05,\xb0\xf1\x15\xb40g\x09q\x13p\xe2\x05" +
+	"\x01\x0bm<\x0f-\x1cG<\xbd\x1b8\xf1\x94\x80E" +
+	"6\x1c\x8f\x16p/~\xbc\x168\xf1\xb0\x80\x82\x8d\xb4" +
+	"\xa1\x05i\x88\xbd\x1ap\xe2\x1b\x02\x16\xdb\xb8;ZX" +
+	"\x93\xb8\x87\xf4\xbd(`\x89\x0dX\xa3\x05\xea\x88;\xb6" +
+	"\x01'n\x15\xb0\xd4\x06\xcd\xf1\xfb=W\x01\xc3n7" +
+	"\x1f\x04N\xdc,P\xd3@!\xda\x8af(\x1dg\x98" +
+	"62\xb4\xa2i\xe1\x0dh\x99\x1e\xb5V4\xad\xe6\xcd" +
+	"\xcd\xa9\xd9\x01\x92f\xe5Ub\xd53\x82aZ<6" +
+	"%\xf5\x8a\xad\xefZ\x05-_\x07\x92\xa3\xa7]\x17j" +
+	"\x99\xef2\x11)'\xc4\x90Gr\xca\xc1\xd0r0\x7f" +
+	"Z\xae\xd5\x97p^\xb7\xa1\xb5\xe7:\x00x\xaa\x93S" +
+	"\xa7\xb3\xb44\x0d\xdce,\x8b\xde\x0c\xe9\xea\x0f[-" +
+	"\xd5\xd2sX\x05\x10\xdc\x8e<\x06_@\x07\x93\x90v" +
+	"\xe1<\x80\xe0\x1f\x89\xfe\x0ar\x88)TB\xda\xc3\xa0" +
+	"\x83\x97\x89\xbc\x1f\x9d^Az\x8dA\x0d\xaf\x10\xfd-" +
+	"t\xda\x05\xe9\x0d\xec\x04\x08\xee'\xfa1\x06M\xf0)" +
+	"h\xe2c\\\x02\x10<B\xf4\xf3\x0c\x9a(HA\x13" +
+	"g\x99\xda3\x0c\xb2\xe08\x14\x85\xc2\x00\x0a\x00\x92\xc8" +
+	"\x11\xbd\x82\xe318\x82\xe8\xc5E\x01,\x06\x90\x1a\x19" +
+	"\xbd\x81\xe8\xd3\x89^\"\x04\xb0\x04@j\xe3\x16\x02\x04" +
+	"[\x89\xfe\x0b\xa2\x97\x16\x07\xb0\x14@\xba\x89\xd1\xff\x81" +
+	"\xe8a\xa2\x0f(\x09\xe0\x00\x00I\xe1h_\x0b\x88~" +
+	"+\xd1\xcbJ\x03X\x06 \xf5pS\x01\x82\x06\xd1\x1f" +
+	" \xba\x0f\x03\xe8\x03\x90\xee\xe34\x80\xe0\xbdD\x7f\x98" +
+	"\xe8\xe5\x03\x02X\x0e =\xc8\xe8\x1b\x88\xbe\x93\xe8\xfe" +
+	"\xb2\x00\xfa\x01\xa4\x1dL\xce\xd3D\x7f\x95\xcb\xe8\x9c\xcc" +
+	"\x85\xc9X8\xaav(\xc0\xbbz\x12C\xd5\xba#1" +
+	"%JN\x90n\xc2ku#\x1c\x89\xd9-\xb9\xba2" +
+	"b0\xf8\x04\xfb +\xf1xw;=\x05\xbfb," +
+	"\xee\xf34j\x15H^s\x01\x00.@\x96q\x85\xa2" +
+	"\xaa\x12K&\xa6\x01\xdf\x1d\xee\x03\xebD\xe3\x0b\x95h" +
+	"\x9b\x06|_T'\x14\xef\xeeVb\xe16\x10\xb4\xbe" +
+	"\x0f\xfb\xdf\x07\xaeVc\xcboP\xdc\x0b\xf6FD(" +
+	"\xb3\xd6\xa3\xdfi\xbdR\x1d\xb7\xa9\x84\xc3\x11#\x12\x8f" +
+	"A\xad\x12\xbd&l\x8b*I-nuTU\x96\xf6" +
+	"%\xf7k\x04\xedT\xf5d\x94\xcfuj\xb1;\xbc<" +
+	"\x10&\xdd\xdd\xfc{f_\x1d\xe0\xd2\xc3\xaf\xdd/\xe6" +
+	"\x0bke\x1b\xd3\xacR\xed\xc1\x19f\xa51\x85\xe9." +
+	"\xac\xb3\xad\xd3\x99\xa1rKu1\xd5\xb8V\xefP\x0c" +
+	"\xc0~\xa0\x0f^\x10.\xdd%z\xc6\xa4Y\xe9\x91\xe8" +
+	"a\xd7B\x1f\xacJ\x0f:\xbf\xb5\xb3\x9f\xb8\x91f\xa7" +
+	"\x0d<\xca\x8f\xb8\xc6\xa4\xcd4;=\xcc\xa3\xfc\xb8k" +
+	"L\xdaB\xc4\xdf\xf2(?\x9d\xe36\xdd\xb3TF\xa0" +
+	"O\xd1\x8dp<i\xb8\xbf\xaa\x9af\xa7\x81\\\x00\x82" +
+	"ta\xce\x1d\x19\xb1\x07\x9d<`9\xdd]\xe6,G" +
+	"\xbc\xb4*{\xd0\xc8\x1b\xd8\xefo\xb8\xd9CX\x1e\x1a" +
+	"\xb3!Y\xa9\x06\x99<i\xb0\xad\xb6\x97\xd4\xbe\xc3\xa3" +
+	"\xfc\xb9\xcb\x93N\x90'\x1dK#\xf9\x16\xbc\x7f\x8a\xcc" +
+	"\xf1\x19\x8f\xc1\x02\xaa\xae)x_B\x1c\x02 \x9f\xb7" +
+	"\xf1}\xb4\xf0\xfd1\x00\x9dT\x13\xcbX\x0d\xe5R5" +
+	"\xb4\x04'f\xc0\xfeE|\xaa\x86\xfa\x18\xdd\x81\xfd\x05" +
+	"L\xd7P\xd4,\xd8\xbf\x1a\xf3w\xcb\xd5\xe9\xd4\xeeI" +
+	"\xea\x82a\xf4d/Q\x97\xf0\xdcK'\xec<\x81Y" +
+	"'\x07\xb9 \x9b*'\xdd\x88\xd9\xf1/\xae/\xfe\xe5" +
+	".\xcf\x97\x01\xbb(\xb8\x14X\xeb\xa7\xa6\x95\xe5$\xb6" +
+	"\x94qC\x18\x96\xd8L\xff8q\x18\xfd\xe3\xc5\x9a&" +
+	"\x00,\x10+\x87\x00\x08\x91DH\x88\xa9\x86\x90\x88\x84" +
+	"\xfdI]\xd5\x84\xa4\xa1\xe7\xe4\xc7Y\xe6\\\x17D\\" +
+	"a\x9bM!c,H\x19\xc3\xb2Z\x84RZ\x98G" +
+	"9\xe1\x02\x8e\xba\x89\xb8\x98G\xd9\xa0\x8c88\x95\x11" +
+	"\x97\xd1\xdb\x09\x1e\xe5[\xb9T\x9f2-\x1ef\xc1W" +
+	"\x00\x1c\x168\x8e\x916\xa6\xe5\x18\x96m\x8dH\xb7\x1a" +
+	"\xbe.i\xb8z\x9f\xfe\xf5\xbb\xe9\xf1\xd2\xd3k/q" +
+	"e\x86P\x9a\x19\xfcZG$\x8c\xc5\xc0aq\xff\xef" +
+	"\x94\xf2\xbb\x86\xb0\xa1\x92<\xe0g\x0b`H\xcf\xb5\xb4" +
+	"\xb3A\xb6\xae\x8dU\xae\xead\x9d\xda\xe6yN!\xb2" +
+	"}\xfd\x09\x0d@~\x9cGy\xa7\x9d{\xc4\x1d\xeb\x01" +
+	"\xe4\x9d<\xca/S\xe6\xe1Se\xecE\x8a\x94\x17x" +
+	"\x94_\xa5\xbcS\xc0\xf2\x8e\xb8\x97\xf6\xf4\x0a\x8f\xf2\x87" +
+	"\x99\x91\xa2\xb3\xd4\xefid\xd9\xd8\xa7\xea:\xd4F\xe2" +
+	"1\xd7\xdd\x9en\xc4\x13m\x8b\x0c\x15\xb5 \xe5\x8c\xf6" +
+	"8.\xfa\xdfC\x9b\xb3\xf6N\xac\x8a\x18\x98\xe3\xe9\xd9" +
+	"\x10[\x1e\xa7g\xd5\xe1\xfc\xea\x95\x0d4\xfe\xb8;\xb2" +
+	"\x9c/<m\x8c1\xafv4\xcb%W\xca\xa0\x99M" +
+	"\xc0\x0fo\xd3F\x07\xf30\xa8\x85\xf5i?\x9b\xdb\x93" +
+	"`\x17&r\x19s\xf0\x9a\x83,\x83\xd65\xb1\x0cz" +
+	"\xc5,\x00;\xd49\xad3\x19\xa3\x143\x93\x14,R" +
+	"B\xa8\xfa\x97\xe8\xf1\x98\xb9$\x9e$}\xe1\\ok" +
+	"\xeck\x17W\x9ai\xb0\xe7\xea\x126\xf8\xdaE\xd8\x1a" +
+	"\xabE\xa49\xb0\x8c\xc8\x83\xd0\xc9\xa3R%U~\xa7" +
+	"6\x8b<\x97\xea\x08\xae`\xb5<@\xf4\xc1\xe8\x04\xa6" +
+	"T\xc3\xc4W\x13\xbd\x01\x9d\xd8\x94\x861\xfe\xc1\xd6\xd5" +
+	"\xbeXT\x98\xea\x09\x1a\x91\xe6\xde\x06\xa2\x8fe=A" +
+	"Q\xaa'\x18\xcd\xe6\xf0QD\x9fD\xf4b!5W" +
+	"O`\xf2\xc7\x13}:\xd1K\x8a\xd3s5\x9b\xff[" +
+	"\x89>\x9bz\x88\x84\x16\x0f\xa9\xba>\x13\xd0\xce\x9e\x16" +
+	"\x0ed\x85\xba`(]\xd6\xe7)\xd4CD\x0c\xd7\xec" +
+	"\x1b\x89\x86\xa7So\xaf\xda,\x86\xa2u\xa9\x0e\x8b\x96" +
+	"\xd4\x0d25\x08.\x99fH\xd1\xba\xe27\xa8\x1a\xf8" +
+	"\xf5>\xe4\xb9\x9a\xea\x92\x97\x917\xac\\\xd2\xcfZ\xe9" +
+	"t\x18\xae\x96\x8f\xb2\xee[\xa9\x1foXI\xf7\xd0\xbc" +
+	"\xf4o7\x8e\xb8J\xe5a\x0a\xb7\xf7x\x94\xbf\xa1\xf3" +
+	"mMe\xdd\xd3\x14\x10_\xf1(\x9fw\x0d\x0fg)" +
+	"\xeb\x9eI\xf7\x866d\x82d\xfaN\xdbC,\xc4\xe4" +
+	"\x0a\xe6Q\xccCF\xa1\x0b1if\xdd\xde\x08\xa2\x8f" +
+	"\xc7\xccDM\xde\x1fO\x1aA\xe0\xd5\x90u\xe5\xf4\x03" +
+	"\xdd]6 \xe2\xffx\x8c\xef\xcf\x84\x90\xf3\xe4c_" +
+	"\xe4\xf4{\xf2\xb1\xb2^\x8ei\xcf\xbeZ\xb9<s\xb8" +
+	"\xab\x9b\xbbL\xd7\xeb}\x7f'\x96\xdf\x9d\xac}\xb3\x95" +
+	"\xd7\xb8\x95q\xb5\xe9\xba\xd0\xcb)3[w\x13\xecj" +
+	"B0\xb4\x1e\x0f.1\xc4\xf9\xfd\x83\xdd'5\x8fq" +
+	"~\x00!,U{\xeca|\xb9\x12M\xda\xc9\xe4\x7f" +
+	"\x02\x00\x00\xff\xff^\xc3g\x98"
 
 func RegisterSchema(reg *schemas.Registry) {
 	reg.Register(&schemas.Schema{
@@ -4793,14 +6193,20 @@ func RegisterSchema(reg *schemas.Registry) {
 			0x8aef91973dc8a4f5,
 			0x8b4c03a0662a38dc,
 			0x8b5b1693940f607e,
+			0x90a3950a51412b8b,
+			0x94a72d9a2ccb9a30,
 			0x9887a60f577a1ecb,
+			0x9d82529754851252,
 			0xa0ef8355b64ee985,
 			0xa20f49456be85b99,
+			0xa3cb406c522dcab1,
 			0xa93853d6a4e3fa16,
+			0xa9e93cf268b17735,
 			0xaa2f3c8ad1c3af24,
 			0xaa4bbac12765a78a,
 			0xace5517aafc86077,
 			0xad2a33d6b9304413,
+			0xae5e0ae5001ebdfe,
 			0xae78ee8eb6b3a134,
 			0xb5418b8ea8ead17b,
 			0xb62f418e0ae4e003,
@@ -4809,22 +6215,28 @@ func RegisterSchema(reg *schemas.Registry) {
 			0xba77e3fa3aa9b6ca,
 			0xc5e65eec3dcf5b10,
 			0xc76ccd4502bb61e7,
+			0xc865d8a1122038c5,
+			0xca8c8e0d7826ae86,
 			0xcc2f70676afee4e7,
 			0xce733f0914c80b6b,
 			0xceba3c1a97be15f8,
+			0xd01c697281e61c21,
 			0xd0476e0f34d1411a,
 			0xd61491b560a8f3a3,
 			0xd9d61d1d803c85fc,
 			0xde3a625e70772b9a,
+			0xdebaeed2a782ac80,
 			0xdf703ca0befc3afc,
 			0xe00e522611477055,
 			0xe313695ea9477b30,
 			0xe5ea916eb0c31336,
+			0xedd2e5b018f17bbb,
 			0xf026e3d750335bc1,
 			0xf34be5cbac1feed1,
 			0xf41122f890a371a6,
 			0xf44732c48f949ab8,
 			0xf4e3e92ae0815f15,
+			0xf7507d1843e734e4,
 			0xf8e86a5c0baa01bc,
 			0xf9b3cd8033aba1f8,
 			0xfabbfdde6d4ad392,

--- a/vendor/github.com/containers/conmon-rs/pkg/client/capnp_util.go
+++ b/vendor/github.com/containers/conmon-rs/pkg/client/capnp_util.go
@@ -50,9 +50,11 @@ func stringStringMapToMapEntryList(
 		if err := entry.SetKey(key); err != nil {
 			return fmt.Errorf("set map key: %w", err)
 		}
+
 		if err := entry.SetValue(value); err != nil {
 			return fmt.Errorf("set map value: %w", err)
 		}
+
 		i++
 	}
 
@@ -64,10 +66,12 @@ func remoteFDSliceToUInt64List(src []RemoteFD, newFunc func(int32) (capnp.UInt64
 	if l == 0 {
 		return nil
 	}
+
 	list, err := newFunc(l)
 	if err != nil {
 		return err
 	}
+
 	for i := range src {
 		list.Set(i, uint64(src[i]))
 	}

--- a/vendor/github.com/containers/conmon-rs/pkg/client/client.go
+++ b/vendor/github.com/containers/conmon-rs/pkg/client/client.go
@@ -177,6 +177,7 @@ func New(config *ConmonServerConfig) (client *ConmonClient, retErr error) {
 
 		return cl, nil
 	}
+
 	if err := cl.startServer(config); err != nil {
 		return nil, fmt.Errorf("start server: %w", err)
 	}
@@ -197,9 +198,11 @@ func New(config *ConmonServerConfig) (client *ConmonClient, retErr error) {
 			}
 		}
 	}()
+
 	if err := cl.waitUntilServerUp(); err != nil {
 		return nil, fmt.Errorf("wait until server is up: %w", err)
 	}
+
 	if err := os.Remove(cl.pidFile()); err != nil {
 		return nil, fmt.Errorf("remove pid file: %w", err)
 	}
@@ -236,6 +239,7 @@ func (c *ConmonClient) startSpan(ctx context.Context, name string) (context.Cont
 	if c.tracer == nil {
 		return ctx, nil
 	}
+
 	const prefix = "conmonrs-client: "
 
 	//nolint:spancheck // https://github.com/jjti/go-spancheck/issues/7
@@ -252,6 +256,7 @@ func (c *ConmonClient) startServer(config *ConmonServerConfig) error {
 	if err != nil {
 		return fmt.Errorf("convert config to args: %w", err)
 	}
+
 	cmd := exec.Command(entrypoint, args...)
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -261,9 +266,11 @@ func (c *ConmonClient) startServer(config *ConmonServerConfig) error {
 	if config.LogDriver == LogDriverStdout {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+
 		if config.Stdout != nil {
 			cmd.Stdout = config.Stdout
 		}
+
 		if config.Stderr != nil {
 			cmd.Stderr = config.Stderr
 		}
@@ -280,22 +287,27 @@ func (c *ConmonClient) toArgs(config *ConmonServerConfig) (entrypoint string, ar
 	if c == nil {
 		return "", args, nil
 	}
+
 	entrypoint = config.ConmonServerPath
 	if entrypoint == "" {
 		path, err := exec.LookPath(binaryName)
 		if err != nil {
 			return "", args, fmt.Errorf("finding path: %w", err)
 		}
+
 		entrypoint = path
 	}
+
 	if config.Runtime == "" {
 		return "", args, errRuntimeUnspecified
 	}
+
 	args = append(args, "--runtime", config.Runtime)
 
 	if config.ServerRunDir == "" {
 		return "", args, errRunDirUnspecified
 	}
+
 	args = append(args, "--runtime-dir", config.ServerRunDir)
 
 	if config.RuntimeRoot != "" {
@@ -306,6 +318,7 @@ func (c *ConmonClient) toArgs(config *ConmonServerConfig) (entrypoint string, ar
 		if err := validateLogLevel(config.LogLevel); err != nil {
 			return "", args, fmt.Errorf("validate log level: %w", err)
 		}
+
 		args = append(args, "--log-level", string(config.LogLevel))
 	}
 
@@ -313,10 +326,12 @@ func (c *ConmonClient) toArgs(config *ConmonServerConfig) (entrypoint string, ar
 		if err := validateLogDriver(config.LogDriver); err != nil {
 			return "", args, fmt.Errorf("validate log driver: %w", err)
 		}
+
 		args = append(args, "--log-driver", string(config.LogDriver))
 	}
 
 	const cgroupManagerFlag = "--cgroup-manager"
+
 	switch config.CgroupManager {
 	case CgroupManagerSystemd:
 		args = append(args, cgroupManagerFlag, "systemd")
@@ -333,6 +348,7 @@ func (c *ConmonClient) toArgs(config *ConmonServerConfig) (entrypoint string, ar
 
 	if config.Tracing != nil && config.Tracing.Enabled {
 		c.tracingEnabled = true
+
 		args = append(args, "--enable-tracing")
 
 		if config.Tracing.Endpoint != "" {
@@ -380,10 +396,12 @@ func pidGivenFile(file string) (uint32, error) {
 	if err != nil {
 		return 0, fmt.Errorf("reading pid bytes: %w", err)
 	}
+
 	const (
 		base    = 10
 		bitSize = 32
 	)
+
 	pidU64, err := strconv.ParseUint(string(pidBytes), base, bitSize)
 	if err != nil {
 		return 0, fmt.Errorf("parsing pid: %w", err)
@@ -436,10 +454,12 @@ func (c *ConmonClient) newRPCConn() (*rpc.Conn, error) {
 // It assumes a valid path, as well as a file name that doesn't exceed the unix max socket length.
 func DialLongSocket(network, path string) (*net.UnixConn, error) {
 	parent := filepath.Dir(path)
+
 	f, err := os.Open(parent)
 	if err != nil {
 		return nil, fmt.Errorf("open socket parent: %w", err)
 	}
+
 	defer f.Close()
 
 	socketName := filepath.Base(path)
@@ -507,6 +527,7 @@ func (c *ConmonClient) Version(
 	if err != nil {
 		return nil, fmt.Errorf("create RPC connection: %w", err)
 	}
+
 	defer conn.Close()
 	client := proto.Conmon(conn.Bootstrap(ctx))
 
@@ -524,6 +545,7 @@ func (c *ConmonClient) Version(
 		if cfg != nil {
 			verbose = cfg.Verbose
 		}
+
 		req.SetVerbose(verbose)
 
 		return nil
@@ -549,6 +571,7 @@ func (c *ConmonClient) Version(
 	if err != nil {
 		return nil, fmt.Errorf("parse server version to semver: %w", err)
 	}
+
 	c.serverVersion = semverVersion
 
 	tag, err := response.Tag()
@@ -613,6 +636,7 @@ func (c *ConmonClient) setCgroupManager(
 			"cgroup manager specified in per command config, but global cgroup manager is not set to CgroupManagerPerCommand",
 		)
 	}
+
 	req.SetCgroupManager(proto.Conmon_CgroupManager(cgroupManager))
 }
 
@@ -687,6 +711,7 @@ const (
 	// type.
 	LogDriverTypeContainerRuntimeInterface LogDriverType = iota
 	LogDriverTypeJSONLogger                LogDriverType = iota
+	LogDriverTypeJournald                  LogDriverType = iota
 )
 
 // CreateContainerResponse is the response of the CreateContainer method.
@@ -711,6 +736,7 @@ func (c *ConmonClient) CreateContainer(
 	if err != nil {
 		return nil, fmt.Errorf("create RPC connection: %w", err)
 	}
+
 	defer conn.Close()
 	client := proto.Conmon(conn.Bootstrap(ctx))
 
@@ -719,20 +745,26 @@ func (c *ConmonClient) CreateContainer(
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
 		}
+
 		if err := c.setMetadata(ctx, req); err != nil {
 			return err
 		}
+
 		if err := req.SetId(cfg.ID); err != nil {
 			return fmt.Errorf("set ID: %w", err)
 		}
+
 		if err := req.SetBundlePath(cfg.BundlePath); err != nil {
 			return fmt.Errorf("set bundle path: %w", err)
 		}
+
 		req.SetTerminal(cfg.Terminal)
 		req.SetStdin(cfg.Stdin)
+
 		if err := stringSliceToTextList(cfg.ExitPaths, req.NewExitPaths); err != nil {
 			return fmt.Errorf("convert exit paths string slice to text list: %w", err)
 		}
+
 		if err := stringSliceToTextList(cfg.OOMExitPaths, req.NewOomExitPaths); err != nil {
 			return fmt.Errorf("convert oom exit paths string slice to text list: %w", err)
 		}
@@ -840,25 +872,33 @@ func (c *ConmonClient) ExecSyncContainer(ctx context.Context, cfg *ExecSyncConfi
 	defer conn.Close()
 
 	client := proto.Conmon(conn.Bootstrap(ctx))
+
 	future, free := client.ExecSyncContainer(ctx, func(p proto.Conmon_execSyncContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
 		}
+
 		if err := c.setMetadata(ctx, req); err != nil {
 			return err
 		}
+
 		if err := req.SetId(cfg.ID); err != nil {
 			return fmt.Errorf("set ID: %w", err)
 		}
+
 		req.SetTimeoutSec(cfg.Timeout)
+
 		if err := stringSliceToTextList(cfg.Command, req.NewCommand); err != nil {
 			return err
 		}
+
 		req.SetTerminal(cfg.Terminal)
+
 		if err := stringStringMapToMapEntryList(cfg.EnvVars, req.NewEnvVars); err != nil {
 			return err
 		}
+
 		c.setCgroupManager(cfg.CgroupManager, req)
 
 		return nil
@@ -902,17 +942,25 @@ func (c *ConmonClient) initLogDrivers(req *proto.Conmon_CreateContainerRequest, 
 	if err != nil {
 		return fmt.Errorf("create log drivers: %w", err)
 	}
+
 	for i, logDriver := range logDrivers {
 		n := newLogDrivers.At(i)
 		if logDriver.Type == LogDriverTypeContainerRuntimeInterface {
 			n.SetType(proto.Conmon_LogDriver_Type_containerRuntimeInterface)
 		}
+
 		if logDriver.Type == LogDriverTypeJSONLogger {
 			n.SetType(proto.Conmon_LogDriver_Type_json)
 		}
+
+		if logDriver.Type == LogDriverTypeJournald {
+			n.SetType(proto.Conmon_LogDriver_Type_journald)
+		}
+
 		if err := n.SetPath(logDriver.Path); err != nil {
 			return fmt.Errorf("set log driver path: %w", err)
 		}
+
 		n.SetMaxSize(logDriver.MaxSize)
 	}
 
@@ -952,6 +1000,7 @@ func (c *ConmonClient) Shutdown() error {
 		waitInterval = 100 * time.Millisecond
 		waitCount    = 100
 	)
+
 	for range waitCount {
 		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
 			return nil
@@ -990,6 +1039,7 @@ func (c *ConmonClient) ReopenLogContainer(ctx context.Context, cfg *ReopenLogCon
 	if err != nil {
 		return fmt.Errorf("create RPC connection: %w", err)
 	}
+
 	defer conn.Close()
 	client := proto.Conmon(conn.Bootstrap(ctx))
 
@@ -1053,6 +1103,7 @@ func (c *ConmonClient) setMetadata(ctx context.Context, req RequestWithMetadata)
 
 	span := trace.SpanFromContext(ctx)
 	m := make(map[string]string)
+
 	if span.SpanContext().HasSpanID() {
 		c.logger.Tracef("Injecting tracing span ID %v", span.SpanContext().SpanID())
 		otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(m))
@@ -1129,6 +1180,7 @@ func (c *ConmonClient) CreateNamespaces(
 
 	// Feature not supported pre v0.5.0
 	const minMinor = 5
+
 	minVersion := semver.Version{Minor: minMinor}
 	if c.serverVersion.LT(minVersion) {
 		return nil, fmt.Errorf("requires at least %v: %w", minVersion, ErrUnsupported)
@@ -1138,6 +1190,7 @@ func (c *ConmonClient) CreateNamespaces(
 	if err != nil {
 		return nil, fmt.Errorf("create RPC connection: %w", err)
 	}
+
 	defer conn.Close()
 	client := proto.Conmon(conn.Bootstrap(ctx))
 
@@ -1231,10 +1284,12 @@ func (c *ConmonClient) CreateNamespaces(
 	}
 
 	namespacesResponse := []*NamespacesResponse{}
+
 	for i := range namespaces.Len() {
 		namespace := namespaces.At(i)
 
 		var typ Namespace
+
 		switch namespace.Type() {
 		case proto.Conmon_Namespace_ipc:
 			typ = NamespaceIPC
@@ -1276,4 +1331,253 @@ func mappingsToSlice(mappings []idtools.IDMap) (res []string) {
 	}
 
 	return res
+}
+
+// ServeExecContainerConfig is the configuration for calling the ServeExecContainer method.
+type ServeExecContainerConfig struct {
+	// ID is the container identifier.
+	ID string
+
+	// Command is the command to be run.
+	Command []string
+
+	// Tty indicates if a tty should be used or not.
+	Tty bool
+
+	// Stdin indicates if stdin should be available or not.
+	Stdin bool
+
+	// Stdout indicates if stdout should be available or not.
+	Stdout bool
+
+	// Stderr indicates if stderr should be available or not.
+	Stderr bool
+
+	// CgroupManager can be use to select the cgroup manager.
+	//
+	// To use this option set `ConmonServerConfig.CgroupManager` to
+	// `CgroupManagerPerCommand`.
+	CgroupManager CgroupManager
+}
+
+// ServeExecContainerResult is the result for calling the ServeExecContainer method.
+type ServeExecContainerResult struct {
+	// URL specifies the returned URL.
+	URL string
+}
+
+// ServeExecContainer can be used to execute a command within a running container.
+func (c *ConmonClient) ServeExecContainer(
+	ctx context.Context,
+	cfg *ServeExecContainerConfig,
+) (*ServeExecContainerResult, error) {
+	ctx, span := c.startSpan(ctx, "ServeExecContainer")
+	if span != nil {
+		defer span.End()
+	}
+
+	conn, err := c.newRPCConn()
+	if err != nil {
+		return nil, fmt.Errorf("create RPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := proto.Conmon(conn.Bootstrap(ctx))
+
+	future, free := client.ServeExecContainer(ctx, func(p proto.Conmon_serveExecContainer_Params) error {
+		req, err := p.NewRequest()
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+
+		if err := c.setMetadata(ctx, req); err != nil {
+			return err
+		}
+
+		if err := req.SetId(cfg.ID); err != nil {
+			return fmt.Errorf("set ID: %w", err)
+		}
+
+		if err := stringSliceToTextList(cfg.Command, req.NewCommand); err != nil {
+			return fmt.Errorf("convert command to text list: %w", err)
+		}
+
+		req.SetTty(cfg.Tty)
+		req.SetStdin(cfg.Stdin)
+		req.SetStdout(cfg.Stdout)
+		req.SetStderr(cfg.Stderr)
+
+		c.setCgroupManager(cfg.CgroupManager, req)
+
+		return nil
+	})
+	defer free()
+
+	result, err := future.Struct()
+	if err != nil {
+		return nil, fmt.Errorf("create result: %w", err)
+	}
+
+	resp, err := result.Response()
+	if err != nil {
+		return nil, fmt.Errorf("set response: %w", err)
+	}
+
+	url, err := resp.Url()
+	if err != nil {
+		return nil, fmt.Errorf("get url: %w", err)
+	}
+
+	return &ServeExecContainerResult{URL: url}, nil
+}
+
+// ServeAttachContainerConfig is the configuration for calling the ServeAttachContainer method.
+type ServeAttachContainerConfig struct {
+	// ID is the container identifier.
+	ID string
+
+	// Stdin indicates if stdin should be available or not.
+	Stdin bool
+
+	// Stdout indicates if stdout should be available or not.
+	Stdout bool
+
+	// Stderr indicates if stderr should be available or not.
+	Stderr bool
+
+	// CgroupManager can be use to select the cgroup manager.
+	//
+	// To use this option set `ConmonServerConfig.CgroupManager` to
+	// `CgroupManagerPerCommand`.
+	CgroupManager CgroupManager
+}
+
+// ServeAttachContainerResult is the result for calling the ServeAttachContainer method.
+type ServeAttachContainerResult struct {
+	// URL specifies the returned URL.
+	URL string
+}
+
+// ServeAttachContainer can be used to attach to a running container.
+func (c *ConmonClient) ServeAttachContainer(
+	ctx context.Context,
+	cfg *ServeAttachContainerConfig,
+) (*ServeAttachContainerResult, error) {
+	ctx, span := c.startSpan(ctx, "ServeAttachContainer")
+	if span != nil {
+		defer span.End()
+	}
+
+	conn, err := c.newRPCConn()
+	if err != nil {
+		return nil, fmt.Errorf("create RPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := proto.Conmon(conn.Bootstrap(ctx))
+
+	future, free := client.ServeAttachContainer(ctx, func(p proto.Conmon_serveAttachContainer_Params) error {
+		req, err := p.NewRequest()
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+
+		if err := c.setMetadata(ctx, req); err != nil {
+			return err
+		}
+
+		if err := req.SetId(cfg.ID); err != nil {
+			return fmt.Errorf("set ID: %w", err)
+		}
+
+		req.SetStdin(cfg.Stdin)
+		req.SetStdout(cfg.Stdout)
+		req.SetStderr(cfg.Stderr)
+
+		return nil
+	})
+	defer free()
+
+	result, err := future.Struct()
+	if err != nil {
+		return nil, fmt.Errorf("create result: %w", err)
+	}
+
+	resp, err := result.Response()
+	if err != nil {
+		return nil, fmt.Errorf("set response: %w", err)
+	}
+
+	url, err := resp.Url()
+	if err != nil {
+		return nil, fmt.Errorf("get url: %w", err)
+	}
+
+	return &ServeAttachContainerResult{URL: url}, nil
+}
+
+// ServePortForwardContainerConfig is the configuration for calling the ServePortForwardContainer method.
+type ServePortForwardContainerConfig struct {
+	// NetNsPath is the path to the network namespace of the container.
+	NetNsPath string
+}
+
+// ServePortForwardContainerResult is the result for calling the ServePortForwardContainer method.
+type ServePortForwardContainerResult struct {
+	// URL specifies the returned URL.
+	URL string
+}
+
+// ServePortForwardContainer can be used to forward ports to a running container.
+func (c *ConmonClient) ServePortForwardContainer(
+	ctx context.Context,
+	cfg *ServePortForwardContainerConfig,
+) (*ServePortForwardContainerResult, error) {
+	ctx, span := c.startSpan(ctx, "ServePortForwardContainer")
+	if span != nil {
+		defer span.End()
+	}
+
+	conn, err := c.newRPCConn()
+	if err != nil {
+		return nil, fmt.Errorf("create RPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := proto.Conmon(conn.Bootstrap(ctx))
+
+	future, free := client.ServePortForwardContainer(ctx, func(p proto.Conmon_servePortForwardContainer_Params) error {
+		req, err := p.NewRequest()
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+
+		if err := c.setMetadata(ctx, req); err != nil {
+			return err
+		}
+
+		if err := req.SetNetNsPath(cfg.NetNsPath); err != nil {
+			return fmt.Errorf("set ID: %w", err)
+		}
+
+		return nil
+	})
+	defer free()
+
+	result, err := future.Struct()
+	if err != nil {
+		return nil, fmt.Errorf("create result: %w", err)
+	}
+
+	resp, err := result.Response()
+	if err != nil {
+		return nil, fmt.Errorf("set response: %w", err)
+	}
+
+	url, err := resp.Url()
+	if err != nil {
+		return nil, fmt.Errorf("get url: %w", err)
+	}
+
+	return &ServePortForwardContainerResult{URL: url}, nil
 }

--- a/vendor/github.com/containers/conmon-rs/pkg/client/remote_fds.go
+++ b/vendor/github.com/containers/conmon-rs/pkg/client/remote_fds.go
@@ -74,16 +74,19 @@ func (r *RemoteFDs) Send(fds ...int) ([]RemoteFD, error) {
 
 	b := binary.LittleEndian.AppendUint64(nil, uint64(reqID)<<numFDsBits|uint64(len(fds)))
 	oob := syscall.UnixRights(fds...)
+
 	_, _, err := r.conn.WriteMsgUnix(b, oob, nil)
 	if err != nil {
 		return nil, fmt.Errorf("send request: %w", err)
 	}
 
 	buf := make([]byte, msgBufferSize)
+
 	n, err := r.conn.Read(buf)
 	if err != nil {
 		return nil, fmt.Errorf("receviree reaponse: %w", err)
 	}
+
 	buf = buf[:n]
 
 	if len(buf) < uint64Bytes {
@@ -138,6 +141,7 @@ func (c *ConmonClient) RemoteFDs(ctx context.Context) (*RemoteFDs, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create RPC connection: %w", err)
 	}
+
 	defer func() {
 		if err := conn.Close(); err != nil {
 			c.logger.Errorf("Unable to close connection: %v", err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# capnproto.org/go/capnp/v3 v3.0.1-alpha.2
+# capnproto.org/go/capnp/v3 v3.1.0-alpha.1
 ## explicit; go 1.19
 capnproto.org/go/capnp/v3
 capnproto.org/go/capnp/v3/encoding/text
@@ -285,8 +285,8 @@ github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit
 github.com/containers/conmon/runner/config
-# github.com/containers/conmon-rs v0.6.6
-## explicit; go 1.23
+# github.com/containers/conmon-rs v0.6.7-0.20250626143653-25c2ef8b3da5
+## explicit; go 1.24.0
 github.com/containers/conmon-rs/internal/proto
 github.com/containers/conmon-rs/pkg/client
 # github.com/containers/image/v5 v5.35.0


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Add support for websocket exec and attach using conmon-rs. This means that those sessions will survive a CRI-O restart. Drawback is that we cannot know if spdy or a websocket connection is being used on setup. Therefore we cannot support spdy through conmon-rs anymore. The whole feature is gated through the `stream_websockets` runtime handler configuration.
#### Which issue(s) this PR fixes:

Refers to #7826, https://github.com/kubernetes/enhancements/issues/4006

#### Special notes for your reviewer:
Requires https://github.com/cri-o/cri-o/pull/9290
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added support for conmon-rs streaming server on `Exec` and `Attach`. To enable it, set
`stream_websockets = true` as part of the runtime handler configuration.
```
