### PR TITLE
[release-1.32] server,factory/container: delay CDI device injection later.

### DIFF
--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -112,6 +112,9 @@ type Container interface {
 	// SpecAddDevices adds devices from the server config, and container CRI config
 	SpecAddDevices([]device.Device, []device.Device, bool, bool) error
 
+	// SpecInjectCDIDevices injects any requested CDI devices to the container's Spec.
+	SpecInjectCDIDevices() error
+
 	// AddUnifiedResourcesFromAnnotations adds the cgroup-v2 resources specified in the io.kubernetes.cri-o.UnifiedCgroup annotation
 	AddUnifiedResourcesFromAnnotations(annotationsMap map[string]string) error
 

--- a/internal/factory/container/device_linux.go
+++ b/internal/factory/container/device_linux.go
@@ -49,8 +49,7 @@ func (c *container) SpecAddDevices(configuredDevices, annotationDevices []device
 		return err
 	}
 
-	// Finally, inject CDI devices
-	return c.specInjectCDIDevices()
+	return nil
 }
 
 func (c *container) specAddHostDevicesIfPrivileged(privilegedWithoutHostDevices bool) error {
@@ -171,7 +170,7 @@ func (c *container) specAddContainerConfigDevices(enableDeviceOwnershipFromSecur
 	return nil
 }
 
-func (c *container) specInjectCDIDevices() error {
+func (c *container) SpecInjectCDIDevices() error {
 	var (
 		cdiDevices = c.Config().CDIDevices
 		fromCRI    = map[string]struct{}{}

--- a/internal/factory/container/device_test.go
+++ b/internal/factory/container/device_test.go
@@ -185,7 +185,7 @@ var _ = t.Describe("Container", func() {
 		}
 	})
 
-	t.Describe("SpecAdd(CDI)Devices", func() {
+	t.Describe("SpecInjectCDIDevices", func() {
 		writeCDISpecFiles := func(content []string) error {
 			if len(content) == 0 {
 				return nil
@@ -419,7 +419,7 @@ containerEdits:
 				Expect(writeCDISpecFiles(test.cdiSpecFiles)).To(Succeed())
 
 				// When
-				err := sut.SpecAddDevices(nil, nil, false, false)
+				err := sut.SpecInjectCDIDevices()
 
 				// Then
 				Expect(err != nil).To(Equal(test.expectError))

--- a/internal/factory/container/device_unsupported.go
+++ b/internal/factory/container/device_unsupported.go
@@ -12,3 +12,10 @@ import (
 func (c *container) SpecAddDevices(configuredDevices, annotationDevices []devicecfg.Device, privilegedWithoutHostDevices, enableDeviceOwnershipFromSecurityContext bool) error {
 	return fmt.Errorf("(*container).SpecAddDevices not supported on %s", runtime.GOOS)
 }
+
+func (c *container) SpecInjectCDIDevices() error {
+	if len(c.Config().CDIDevices) > 0 {
+		return fmt.Errorf("(*container).SpecInjectCDIDevices not supported on %s", runtime.GOOS)
+	}
+	return nil
+}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -687,6 +687,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr ctrfactory.Cont
 		}
 	}
 
+	if err := ctr.SpecInjectCDIDevices(); err != nil {
+		return nil, err
+	}
+
 	// Set up pids limit if pids cgroup is mounted
 	if node.CgroupHasPid() {
 		specgen.SetLinuxResourcesPidsLimit(s.config.PidsLimit)

--- a/test/cdi.bats
+++ b/test/cdi.bats
@@ -111,7 +111,7 @@ function annotate_ctr_with_unknown_cdidev {
 }
 
 function prepare_ctr_with_cdidev {
-	jq ".CDI_Devices |= . + [ { \"Name\": \"vendor0.com/device=loop8\" }, { \"Name\": \"vendor0.com/device=loop9\" } ]" \
+	jq ".CDI_Devices |= . + [ { \"Name\": \"vendor0.com/device=loop8\" }, { \"Name\": \"vendor0.com/device=loop9\" } ] | .envs |= . + [ { \"key\": \"VENDOR0\", \"value\": \"unset\" }, { \"key\": \"LOOP8\", \"value\": \"unset\" } ]" \
 		"$TESTDATA/container_sleep.json" > "$ctr_config"
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently CDI device injection is performed right after injecting other devices into the container. This is problematic because CDI device injection might alter, among other things, the environment. However setting up the final environment happens only later during container creation and it involves setting environment variables from the image and the Pod Spec. If the same environment variable is injected both from an image or a container, and from a CDI Spec, now the former take precedence of the latter. This is unintentional and wrong.

This patch moves CDI device injection much later during container creation.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
server: delay CDI device injection, to ensure that CDI Spec edits take precedence over image defaults and the Pod Spec.
```
