### PR TITLE
dependencies.yaml: bump/sync internal version.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,7 +13,7 @@ dependencies:
   # tag the .0 release if it does not already exist. If the .0 release is done,
   # increase the development version to the next minor (1.x.0).
   - name: development version
-    version: 1.33.0
+    version: 1.33.1
     refPaths:
       - path: internal/version/version.go
         match: Version


### PR DESCRIPTION

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Bump the checked internal version in `dependencies.yaml` to match the latest internal version bumped in ce6f724d73ed492e114d7df35b71610ff6113916, to let `make verify-dependencies` to pass/exit with a 0 status. 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None
