### PR TITLE
OCPBUGS-58229: server: handle missing network namespace gracefully during networkStop

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -154,6 +154,7 @@ kata_skip_network_tests:
   - 'test "Connect to pod hostport from the host"'
   - 'test "Clean up network if pod sandbox fails"'
   - 'test "Clean up network if pod sandbox gets killed"'
+  - 'test "Network recovery after reboot with destroyed netns"'
 kata_skip_pod_tests:
   - 'test "pass pod sysctls to runtime"'
   - 'test "pass pod sysctls to runtime when in userns"'

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -29,7 +29,6 @@ var _ = t.Describe("Image", func() {
 		testDockerRegistry                  = "docker.io"
 		testQuayRegistry                    = "quay.io"
 		testRedHatRegistry                  = "registry.access.redhat.com"
-		testFedoraRegistry                  = "registry.fedoraproject.org"
 		testImageName                       = "image"
 		testImageAlias                      = "image-for-testing"
 		testImageAliasResolved              = "registry.crio.test.com/repo"
@@ -193,7 +192,6 @@ var _ = t.Describe("Image", func() {
 			Expect(refsToNames(refs)).To(Equal([]string{
 				testQuayRegistry + "/" + testImageName + ":latest",
 				testRedHatRegistry + "/" + testImageName + ":latest",
-				testFedoraRegistry + "/" + testImageName + ":latest",
 				testDockerRegistry + "/library/" + testImageName + ":latest",
 			}))
 		})
@@ -247,7 +245,6 @@ var _ = t.Describe("Image", func() {
 			Expect(refsToNames(refs)).To(Equal([]string{
 				testQuayRegistry + "/" + testImageName + "@sha256:" + testSHA256,
 				testRedHatRegistry + "/" + testImageName + "@sha256:" + testSHA256,
-				testFedoraRegistry + "/" + testImageName + "@sha256:" + testSHA256,
 				testDockerRegistry + "/library/" + testImageName + "@sha256:" + testSHA256,
 			}))
 		})

--- a/server/sandbox_network_freebsd.go
+++ b/server/sandbox_network_freebsd.go
@@ -1,0 +1,24 @@
+//go:build freebsd
+// +build freebsd
+
+package server
+
+import (
+	"context"
+
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/log"
+)
+
+// validateNetworkNamespace checks if the given path is a valid network namespace
+// On FreeBSD, this is a no-op since network namespaces are Linux-specific.
+func (s *Server) validateNetworkNamespace(netnsPath string) error {
+	// Network namespaces are Linux-specific, so on FreeBSD we assume it's valid
+	return nil
+}
+
+// cleanupNetns removes a network namespace file and logs the action
+// On FreeBSD, this is a no-op since network namespaces are Linux-specific.
+func (s *Server) cleanupNetns(ctx context.Context, netnsPath string, sb *sandbox.Sandbox) {
+	log.Debugf(ctx, "Network namespace cleanup not supported on this platform")
+}

--- a/server/sandbox_network_linux.go
+++ b/server/sandbox_network_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+// +build linux
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/log"
+)
+
+// validateNetworkNamespace checks if the given path is a valid network namespace.
+func (s *Server) validateNetworkNamespace(netnsPath string) error {
+	netns, err := ns.GetNS(netnsPath)
+	if err != nil {
+		return fmt.Errorf("invalid network namespace: %w", err)
+	}
+
+	defer netns.Close()
+
+	return nil
+}
+
+// cleanupNetns removes a network namespace file and logs the action.
+func (s *Server) cleanupNetns(ctx context.Context, netnsPath string, sb *sandbox.Sandbox) {
+	if rmErr := os.RemoveAll(netnsPath); rmErr != nil {
+		log.Warnf(ctx, "Failed to remove netns path %s: %v", netnsPath, rmErr)
+	} else {
+		log.Infof(ctx, "Removed netns path %s from pod sandbox %s(%s)", netnsPath, sb.Name(), sb.ID())
+	}
+}

--- a/server/sandbox_network_unsupported.go
+++ b/server/sandbox_network_unsupported.go
@@ -1,0 +1,23 @@
+//go:build !linux && !freebsd
+// +build !linux,!freebsd
+
+package server
+
+import (
+	"context"
+
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/log"
+)
+
+// validateNetworkNamespace checks if the given path is a valid network namespace
+// On unsupported platforms, this is a no-op since network namespaces are Linux-specific.
+func (s *Server) validateNetworkNamespace(netnsPath string) error {
+	return nil
+}
+
+// cleanupNetns removes a network namespace file and logs the action
+// On unsupported platforms, this is a no-op since network namespaces are Linux-specific.
+func (s *Server) cleanupNetns(ctx context.Context, netnsPath string, sb *sandbox.Sandbox) {
+	log.Debugf(ctx, "Network namespace cleanup not supported on this platform")
+}

--- a/test/image.bats
+++ b/test/image.bats
@@ -104,7 +104,9 @@ function teardown() {
 	mkdir -p "$TESTDIR/imagestore"
 	CONTAINER_IMAGESTORE="$TESTDIR/imagestore" start_crio
 
-	FEDORA="registry.fedoraproject.org/fedora"
+	# registry.fedoraproject.org is pretty flaky
+	# Moving to the stable quay.io
+	FEDORA="quay.io/fedora/fedora"
 	crictl pull $FEDORA
 	imageid=$(crictl images --quiet "$FEDORA")
 	[ "$imageid" != "" ]

--- a/test/network.bats
+++ b/test/network.bats
@@ -187,3 +187,40 @@ function check_networking() {
 	crictl rmp -f "$POD"
 	grep -q "Removed netns path $NETNS_PATH$NS from pod sandbox" "$CRIO_LOG"
 }
+
+@test "Network recovery after reboot with destroyed netns" {
+	# This test simulates a reboot scenario where network namespaces are destroyed
+	# but CRI-O needs to clean up pod network resources gracefully.
+
+	start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	# Get the network namespace path
+	NETNS_PATH=/var/run/netns/
+	NS=$(crictl inspectp "$pod_id" |
+		jq -er '.info.runtimeSpec.linux.namespaces[] | select(.type == "network").path | sub("'$NETNS_PATH'"; "")')
+
+	# Remove the network namespace.
+	ip netns del "$NS"
+
+	# Create a fake netns file.
+	touch "$NETNS_PATH$NS"
+
+	restart_crio
+
+	# Try to remove the pod.
+	crictl rmp -f "$pod_id" 2> /dev/null || true
+
+	grep -q "Successfully cleaned up network for pod" "$CRIO_LOG"
+
+	new_pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	# Verify the new pod is running.
+	output=$(crictl inspectp "$new_pod_id" | jq -r '.status.state')
+	[[ "$output" == "SANDBOX_READY" ]]
+
+	# Clean up the new pod
+	crictl stopp "$new_pod_id"
+	crictl rmp "$new_pod_id"
+}

--- a/test/network.bats
+++ b/test/network.bats
@@ -185,5 +185,5 @@ function check_networking() {
 
 	# be able to remove the sandbox
 	crictl rmp -f "$POD"
-	grep -q "Removed invalid netns path $NETNS_PATH$NS from pod sandbox" "$CRIO_LOG"
+	grep -q "Removed netns path $NETNS_PATH$NS from pod sandbox" "$CRIO_LOG"
 }

--- a/test/registries.conf
+++ b/test/registries.conf
@@ -1,4 +1,4 @@
-unqualified-search-registries = ['quay.io' ,'registry.access.redhat.com', 'registry.fedoraproject.org', 'docker.io']
+unqualified-search-registries = ['quay.io', 'registry.access.redhat.com', 'docker.io']
 
 [aliases]
 "image-for-testing" = "registry.crio.test.com/repo"

--- a/test/testdata/Dockerfile
+++ b/test/testdata/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:38
+FROM quay.io/fedora/fedora-minimal:38
 RUN microdnf install -y coreutils \
 		gcc \
 		gzip \


### PR DESCRIPTION
After host reboot, network namespaces are destroyed but CRI-O attempts to clean them up during pod sandbox destruction, causing CNI plugin failures and preventing pods from restarting properly. The fix ensures pods can restart normally after host reboots.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
[Link to journal logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-microshift-release-4.20-periodics-e2e-aws-tests-bootc-nightly/1939504337394864128/artifacts/e2e-aws-tests-bootc-nightly/openshift-microshift-e2e-metal-tests/artifacts/scenario-info/el96-src@ai-model-serving-offline/vms/host1/sos/journal_2025-06-30_03:38:43.log)
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Handle missing network namespace gracefully during networkStop
```
