### PR TITLE
log warning when CONTAINER_INCLUDED_POD_METRCIS(typo) is used

### DIFF
--- a/internal/criocli/config.go
+++ b/internal/criocli/config.go
@@ -21,6 +21,19 @@ it later with **--config**. Global options will modify the output.`,
 		},
 	},
 	Action: func(c *cli.Context) error {
+
+		if val, ok := os.LookupEnv("CONTAINER_INCLUDED_POD_METRCIS") ; ok {
+
+			logrus.Warn("Environment variable CONTAINER_INCLUDED_POD_METRCIS is deprecated (typo). Use CONTAINER_INCLUDED_POD_METRICS instead.")
+
+			if _, exists := os.LookupEnv("CONTAINER_INCLUDED_POD_METRICS") ; !exists {
+				os.Setenv("CONTAINER_INCLUDED_POD_METRICS", val)
+			}
+
+		}
+
+
+
 		logrus.SetFormatter(&logrus.TextFormatter{
 			DisableTimestamp: true,
 		})


### PR DESCRIPTION
What type of PR is this?
This PR Logs warning when CONTAINER_INCLUDED_POD_METRCIS(typo) is used.

What this PR does / why we need it:
It Log warning when  CONTAINER_INCLUDED_POD_METRCIS(typo) is used. instead of CONTAINER_INCLUDED_POD_METRICS.

Which issue this PR fixes:
Warn when CONTAINER_INCLUDED_POD_METRCIS is used #9300 

Fixes #9300 

Special notes for your reviewer:
None

Does this PR introduce a user-facing change?
```release-note
Logs Warning for using CONTAINER_INCLUDED_POD_METRCIS(typo).
```