### PR TITLE
Updated version of criocli.go with log.Warnf

### DIFF
--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"log"
 
 	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
@@ -575,7 +576,7 @@ func GetFlagsAndMetadata() ([]cli.Flag, map[string]any, error) {
 	}
 
 	if val, ok := os.LookupEnv("CONTAINER_INCLUDED_POD_METRCIS") ; ok {
-		logrus.Warn("Environment variable CONTAINER_INCLUDED_POD_METRCIS is deprecated (typo). Use CONTAINER_INCLUDED_POD_METRICS instead.")
+		log.Warnf("Environment variable CONTAINER_INCLUDED_POD_METRCIS is deprecated (typo). Use CONTAINER_INCLUDED_POD_METRICS instead.")
 
 		if _, exists := os.LookupEnv("CONTAINER_INCLUDED_POD_METRICS") ; !exists {
 			os.Setenv("CONTAINER_INCLUDED_POD_METRICS", val)

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -574,6 +574,15 @@ func GetFlagsAndMetadata() ([]cli.Flag, map[string]any, error) {
 		return nil, nil, fmt.Errorf("error loading server config: %w", err)
 	}
 
+	if val, ok := os.LookupEnv("CONTAINER_INCLUDED_POD_METRCIS") ; ok {
+		logrus.Warn("Environment variable CONTAINER_INCLUDED_POD_METRCIS is deprecated (typo). Use CONTAINER_INCLUDED_POD_METRICS instead.")
+
+		if _, exists := os.LookupEnv("CONTAINER_INCLUDED_POD_METRICS") ; !exists {
+			os.Setenv("CONTAINER_INCLUDED_POD_METRICS", val)
+		}
+
+	}
+
 	// TODO FIXME should be crio wipe flags
 	flags := getCrioFlags(config)
 


### PR DESCRIPTION
#### What type of PR is this?

This PR Logs warning when CONTAINER_INCLUDED_POD_METRCIS(typo) is used. Updated GetFlagsAndMetadata() in internal/criocli/criocli.go

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
It Logs warning when CONTAINER_INCLUDED_POD_METRCIS(typo) is used. instead of CONTAINER_INCLUDED_POD_METRICS.

#### Which issue(s) this PR fixes:
It fixes #9300 and Warns when CONTAINER_INCLUDED_POD_METRCIS is used.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #9315

-->

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

```release-note
- Logs Warning for using CONTAINER_INCLUDED_POD_METRCIS(typo).
```
