### PR TITLE
[release-1.32] fix GitHub action CI test setup, failing tests.

### DIFF
--- a/install.md
+++ b/install.md
@@ -80,7 +80,6 @@ To install CRI-O on Flatcar Container Linux with sysexts, follow these steps:
 - Step 1: Download the installation script:
 
   Sample extension script for installing CRI-O using sysext is [here](https://github.com/flatcar/sysext-bakery/blob/main/create_crio_sysext.sh).
-
   - Using curl:
 
     ```bash
@@ -106,7 +105,6 @@ chmod +x create_crio_sysext.sh
 - Step 2: Run the installation script:
 
   Execute the script with the required arguments:
-
   - The version of CRI-O you wish to install. [(Find a specific version of
     CRI-O here)](https://github.com/cri-o/cri-o/releases)
   - The name you wish to give to the sysext image.
@@ -123,7 +121,6 @@ chmod +x create_crio_sysext.sh
   ```
 
 - Step 3: Deploy the system extension:
-
   - Once the script completes, you will have a `.raw` sysext image file named as
     per your `SYSEXTNAME` argument.
   - To deploy the system extension, move the `.raw` file to the
@@ -137,7 +134,6 @@ chmod +x create_crio_sysext.sh
   ```
 
 - Step 4: Verify the installation:
-
   - Verify that the CRI-O service is running correctly.
 
     ```bash

--- a/roadmap.md
+++ b/roadmap.md
@@ -87,7 +87,6 @@ Some of these features can be seen below:
 ## Known Risks
 
 - Relying on different SIGs for CRI-O features:
-
   - We have a need to discuss our enhancements with different SIGs to get all
     required information and drive the change. This can lead into helpful, but maybe
     not expected input and delay the deliverable.

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -869,8 +869,10 @@ function assert_log_linking() {
 		[[ "$output" == *"20000 10000"* ]]
 
 		output=$(crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.weight")
-		# 512 shares are converted to cpu.weight 20
-		[[ "$output" == *"20"* ]]
+		# CPU shares of 512 is converted to cpu.weight of either 20 or 59,
+		# depending on crun/runc version (see https://github.com/kubernetes/kubernetes/issues/131216).
+		echo "got cpu.weight $output, want 20 or 59"
+		[ "$output" = "20" ] || [ "$output" = "59" ]
 	else
 		output=$(crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.shares")
 		[[ "$output" == *"512"* ]]
@@ -897,8 +899,10 @@ function assert_log_linking() {
 		[[ "$output" == *"10000 20000"* ]]
 
 		output=$(crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.weight")
-		# 256 shares are converted to cpu.weight 10
-		[[ "$output" == *"10"* ]]
+		# CPU shares of 256 is converted to cpu.weight of either 10 or 35,
+		# depending on crun/runc version (see https://github.com/kubernetes/kubernetes/issues/131216).
+		echo "got cpu.weight $output, want 10 or 35"
+		[ "$output" = "10" ] || [ "$output" = "35" ]
 	else
 		output=$(crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.shares")
 		[[ "$output" == *"256"* ]]

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1508,7 +1508,7 @@ EOF
 	CRICTL_TIMEOUT=10m crictl stop -t 10 "$ctr_id"
 	crictl rmp -f "$pod_id"
 
-	grep -q "Stopping container ${ctr_id} with stop signal timed out." "$CRIO_LOG"
+	grep -q "Stopping container ${ctr_id} with stop signal(15) timed out." "$CRIO_LOG"
 
 	readarray -t attempts < "$FAKE_RUNTIME_ATTEMPTS_LOG"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Fix GitHub action CI test setup (missing br_netfilter).
Cherry-pick #9271 for failing  container update test in `test/ctr.bats`.
Fix failing test due to a mismatching test pattern altered in 438d5281862801c370ef3bed5994d79d872f1a2c.
Fix markdown to make docs pass the prettier-verification in CI.  

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
