### PR TITLE
Pre-check streaming websockets on config validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containernetworking/plugins v1.7.1
 	github.com/containers/common v0.63.1
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/conmon-rs v0.6.7-0.20250626143653-25c2ef8b3da5
+	github.com/containers/conmon-rs v0.6.7-0.20250708125850-5449cc50f844
 	github.com/containers/image/v5 v5.35.0
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/containers/common v0.63.1 h1:6g02gbW34PaRVH4Heb2Pk11x0SdbQ+8AfeKKeQGq
 github.com/containers/common v0.63.1/go.mod h1:+3GCotSqNdIqM3sPs152VvW7m5+Mg8Kk+PExT3G9hZw=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/conmon-rs v0.6.7-0.20250626143653-25c2ef8b3da5 h1:74v2Kt+6Lv6K8s2CkZTLrJn4i04bGcuqCXH857w2X+w=
-github.com/containers/conmon-rs v0.6.7-0.20250626143653-25c2ef8b3da5/go.mod h1:F2fvsYBN5uO966WmWqr2oZHe/nQ4WY519HNmmCLungA=
+github.com/containers/conmon-rs v0.6.7-0.20250708125850-5449cc50f844 h1:oyQuiHPo9/3SJjIfqf/oum06OR3tIQmcjchrnjL65WE=
+github.com/containers/conmon-rs v0.6.7-0.20250708125850-5449cc50f844/go.mod h1:F2fvsYBN5uO966WmWqr2oZHe/nQ4WY519HNmmCLungA=
 github.com/containers/image/v5 v5.35.0 h1:T1OeyWp3GjObt47bchwD9cqiaAm/u4O4R9hIWdrdrP8=
 github.com/containers/image/v5 v5.35.0/go.mod h1:8vTsgb+1gKcBL7cnjyNOInhJQfTUQjJoO2WWkKDoebM=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/containers/common/pkg/resize"
@@ -328,10 +327,6 @@ func (r *runtimePod) ServeExecContainer(ctx context.Context, c *Container, cmd [
 		Stderr:  stderr,
 	})
 	if err != nil {
-		if isUnimplementedRPCErr(err) {
-			return "", nil
-		}
-
 		return "", fmt.Errorf("call ServeExecContainer RPC: %w", err)
 	}
 
@@ -346,18 +341,8 @@ func (r *runtimePod) ServeAttachContainer(ctx context.Context, c *Container, std
 		Stderr: stderr,
 	})
 	if err != nil {
-		if isUnimplementedRPCErr(err) {
-			return "", nil
-		}
-
 		return "", fmt.Errorf("call ServeAttachContainer RPC: %w", err)
 	}
 
 	return res.URL, nil
-}
-
-func isUnimplementedRPCErr(err error) bool {
-	const errUnimplementedString = "Method not implemented."
-
-	return strings.Contains(err.Error(), errUnimplementedString)
 }

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -31,13 +31,9 @@ func (s *Server) Attach(ctx context.Context, req *types.AttachRequest) (*types.A
 			return nil, fmt.Errorf("could not serve attach for container %q: %w", req.ContainerId, err)
 		}
 
-		if url != "" {
-			log.Infof(ctx, "Using attach URL from container monitor")
+		log.Infof(ctx, "Using attach URL from container monitor")
 
-			return &types.AttachResponse{Url: url}, nil
-		}
-
-		log.Debugf(ctx, "Runtime %q does not support websocket streaming, falling back to SPDY", runtimeHandler)
+		return &types.AttachResponse{Url: url}, nil
 	}
 
 	resp, err := s.getAttach(req)

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -31,13 +31,9 @@ func (s *Server) Exec(ctx context.Context, req *types.ExecRequest) (*types.ExecR
 			return nil, fmt.Errorf("could not serve exec for container %q: %w", req.ContainerId, err)
 		}
 
-		if url != "" {
-			log.Infof(ctx, "Using exec URL from container monitor")
+		log.Infof(ctx, "Using exec URL from container monitor")
 
-			return &types.ExecResponse{Url: url}, nil
-		}
-
-		log.Debugf(ctx, "Runtime %q does not support websocket streaming, falling back to SPDY", runtimeHandler)
+		return &types.ExecResponse{Url: url}, nil
 	}
 
 	resp, err := s.getExec(req)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -285,7 +285,7 @@ github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit
 github.com/containers/conmon/runner/config
-# github.com/containers/conmon-rs v0.6.7-0.20250626143653-25c2ef8b3da5
+# github.com/containers/conmon-rs v0.6.7-0.20250708125850-5449cc50f844
 ## explicit; go 1.24.0
 github.com/containers/conmon-rs/internal/proto
 github.com/containers/conmon-rs/pkg/client


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Use the new conmon-rs API to pre-validate the version requirements.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Early pre-validate the configured pod runtime (`conmon-rs`) on config validation.
```
