### PR TITLE
Reduce log noise from monitor prober

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -1010,7 +1010,7 @@ func (c *ContainerServer) probeMonitorProcesses(ctx context.Context) {
 			return
 		case <-timer.C:
 		}
-		log.Debugf(ctx, "Probe monitor processes")
+		log.Tracef(ctx, "Probe monitor processes")
 
 		for _, ctr := range c.listContainers() {
 			err := c.runtime.ProbeMonitor(ctx, ctr)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -14,6 +14,10 @@ type (
 	Name struct{}
 )
 
+func Tracef(ctx context.Context, format string, args ...any) {
+	entry(ctx).Tracef(format, args...)
+}
+
 func Debugf(ctx context.Context, format string, args ...any) {
 	entry(ctx).Debugf(format, args...)
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
The message is printed periodically to the logs which can be noisy. To reduce the verbosity we now print it only when the log level is set to trace.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
