### PR TITLE
Added container_file_descriptors metrics

### DIFF
--- a/internal/lib/stats/descriptors.go
+++ b/internal/lib/stats/descriptors.go
@@ -149,3 +149,12 @@ var (
 		LabelKeys: baseLabelKeys,
 	}
 )
+
+// Process metrics
+var (
+	containerFileDescriptors = &types.MetricDescriptor{
+		Name:      "container_file_descriptors",
+		Help:      "Number of open file descriptors for the container",
+		LabelKeys: baseLabelKeys,
+	}
+)

--- a/internal/lib/stats/metrics.go
+++ b/internal/lib/stats/metrics.go
@@ -15,6 +15,7 @@ const (
 	MemoryMetrics  = "memory"
 	NetworkMetrics = "network"
 	OOMMetrics     = "oom"
+	ProcessMetrics = "process"
 )
 
 type metricValue struct {
@@ -84,6 +85,9 @@ func (ss *StatsServer) PopulateMetricDescriptors(includedKeys []string) map[stri
 		},
 		OOMMetrics: {
 			containerOomEventsTotal,
+		},
+		ProcessMetrics: {
+			containerFileDescriptors,
 		},
 	}
 

--- a/internal/lib/stats/process_metrics.go
+++ b/internal/lib/stats/process_metrics.go
@@ -1,0 +1,32 @@
+package statsserver
+
+import (
+	"os"
+	"fmt"
+
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+)
+
+func generateSandboxProcessMetrics(sb *sandbox.Sandbox, pid int) []*types.Metric {
+	processMetrics := []*containerMetric{
+		{
+			desc: containerFileDescriptors,
+			valueFunc: func() metricValues {
+				fdDir := fmt.Sprintf("/proc/%d/fd", pid)
+				entries, err := os.ReadDir(fdDir)
+				if err != nil {
+					return metricValues{}
+				}
+
+				return metricValues{{
+					value: uint64(len(entries)),
+					metricType: types.MetricType_GAUGE,
+				}}
+			},
+		},
+	}
+
+	return computeSandboxMetrics(sb, processMetrics, "process")
+}

--- a/internal/lib/stats/stats_server_linux.go
+++ b/internal/lib/stats/stats_server_linux.go
@@ -263,6 +263,16 @@ func (ss *StatsServer) containerMetricsFromCgStats(sb *sandbox.Sandbox, c *oci.C
 			metrics = append(metrics, oomMetrics...)
 		case NetworkMetrics:
 			continue // Network metrics are collected at the pod level only.
+		case ProcessMetrics:
+			pid, err := c.Pid()
+			if err != nil {
+				log.Errorf(ss.ctx, "Unable to fetch process ID for container %s: %v", c.ID(), err)
+
+				continue
+			}
+			if processMetrics := generateSandboxProcessMetrics(sb, pid); processMetrics != nil {
+				metrics = append(metrics, processMetrics...)
+			}
 		default:
 			log.Warnf(ss.ctx, "Unknown metric: %s", m)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind feature

#### What this PR does / why we need it:

This PR adds the `container_file_descriptors` metric to CRI-O which reports the number of open file descriptors for each container. 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Part of https://github.com/cri-o/cri-o/issues/9125.

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

I've created `internal/lib/stats/process_metrics.go` and added a new metric descriptor for process metrics. I was able to test this locally. I still need work on the tests, but if this is in the right direction, I'd like to work on the rest of the process metrics as well.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added new metric container_file_descriptors to expose the number of open file descriptors for each container from CRI-O metrics
```
