### PR TITLE
Update pause image to 3.10.1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -131,7 +131,7 @@ dependencies:
         match: MDTOC_VERSION
 
   - name: pause
-    version: 3.10
+    version: 3.10.1
     refPaths:
       - path: docs/crio.8.md
         match: "registry.k8s.io/pause:"

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -370,7 +370,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--pause-command**="": Path to the pause executable in the pause image. (default: "/pause")
 
-**--pause-image**="": Image which contains the pause executable. (default: "registry.k8s.io/pause:3.10")
+**--pause-image**="": Image which contains the pause executable. (default: "registry.k8s.io/pause:3.10.1")
 
 **--pause-image-auth-file**="": Path to a config file containing credentials for --pause-image.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -466,7 +466,7 @@ Default transport for pulling images from a remote container storage.
 **global_auth_file**=""
 The path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.
 
-**pause_image**="registry.k8s.io/pause:3.10"
+**pause_image**="registry.k8s.io/pause:3.10.1"
 The on-registry image used to instantiate infra containers.
 The value should start with a registry host name.
 This option supports live configuration reload.

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -665,12 +665,12 @@ var _ = t.Describe("Image", func() {
 
 	t.Describe("CompileRegexpsForPinnedImages", func() {
 		It("should return regexps for exact patterns", func() {
-			patterns := []string{"quay.io/crio/pause:latest", "docker.io/crio/sandbox:latest", "registry.k8s.io/pause:3.10"}
+			patterns := []string{"quay.io/crio/pause:latest", "docker.io/crio/sandbox:latest", "registry.k8s.io/pause:3.10.1"}
 			regexps := storage.CompileRegexpsForPinnedImages(patterns)
 			Expect(regexps).To(HaveLen(len(patterns)))
 			Expect(regexps[0].MatchString("quay.io/crio/pause:latest")).To(BeTrue())
 			Expect(regexps[1].MatchString("docker.io/crio/sandbox:latest")).To(BeTrue())
-			Expect(regexps[2].MatchString("registry.k8s.io/pause:3.10")).To(BeTrue())
+			Expect(regexps[2].MatchString("registry.k8s.io/pause:3.10.1")).To(BeTrue())
 		})
 
 		It("should return regexps for keyword patterns", func() {

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -21,7 +21,7 @@ const (
 	// ImageVolumesBind option is for using bind mounted volumes.
 	ImageVolumesBind ImageVolumesType = "bind"
 	// DefaultPauseImage is default pause image.
-	DefaultPauseImage string = "registry.k8s.io/pause:3.10"
+	DefaultPauseImage string = "registry.k8s.io/pause:3.10.1"
 )
 
 var (

--- a/pkg/config/config_unsupported.go
+++ b/pkg/config/config_unsupported.go
@@ -14,7 +14,7 @@ const (
 	// ImageVolumesBind option is for using bind mounted volumes
 	ImageVolumesBind ImageVolumesType = "invalid ImageVolumesBind"
 	// DefaultPauseImage is default pause image
-	DefaultPauseImage string = "registry.k8s.io/pause:3.10"
+	DefaultPauseImage string = "registry.k8s.io/pause:3.10.1"
 )
 
 func selinuxEnabled() bool {

--- a/test/common.sh
+++ b/test/common.sh
@@ -108,7 +108,7 @@ ARCH=$(uname -m)
 ARCH_X86_64=x86_64
 
 IMAGES=(
-    registry.k8s.io/pause:3.10
+    registry.k8s.io/pause:3.10.1
     quay.io/crio/fedora-crio-ci:latest
     quay.io/crio/hello-wasm:latest
 )


### PR DESCRIPTION

#### What type of PR is this?


/kind dependency-change


#### What this PR does / why we need it:
Update the pause image to the latest version.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/kubernetes/kubernetes/pull/130713

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated pause image to 3.10.1.
```
