### PR TITLE
[release-1.33] [cherry-pick #9271] test/ctr.bats: fix wrt new CPU units to weight conversion

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -869,8 +869,10 @@ function assert_log_linking() {
 		[[ "$output" == *"20000 10000"* ]]
 
 		output=$(crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.weight")
-		# 512 shares are converted to cpu.weight 20
-		[[ "$output" == *"20"* ]]
+		# CPU shares of 512 is converted to cpu.weight of either 20 or 59,
+		# depending on crun/runc version (see https://github.com/kubernetes/kubernetes/issues/131216).
+		echo "got cpu.weight $output, want 20 or 59"
+		[ "$output" = "20" ] || [ "$output" = "59" ]
 	else
 		output=$(crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.shares")
 		[[ "$output" == *"512"* ]]
@@ -897,8 +899,10 @@ function assert_log_linking() {
 		[[ "$output" == *"10000 20000"* ]]
 
 		output=$(crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu.weight")
-		# 256 shares are converted to cpu.weight 10
-		[[ "$output" == *"10"* ]]
+		# CPU shares of 256 is converted to cpu.weight of either 10 or 35,
+		# depending on crun/runc version (see https://github.com/kubernetes/kubernetes/issues/131216).
+		echo "got cpu.weight $output, want 10 or 35"
+		[ "$output" = "10" ] || [ "$output" = "35" ]
 	else
 		output=$(crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpu/cpu.shares")
 		[[ "$output" == *"256"* ]]


### PR DESCRIPTION

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

From the original PR #9271:

```
It's a long story (see [1], [2], [3], [4]) but both runc and crun is changing the formula to convert cgroup v1 CPU shares to cgroup v2 CPU weight, and it causes a failure in "ctr update resources" test, because it relies on the old conversion formula.

Let's modify it so it works either the old or the new conversion.

(Ultimately, with cgroup v2 we should switch to setting unified.cpu.weight directly).

[1]: https://github.com/kubernetes/kubernetes/issues/131216
[2]: https://github.com/opencontainers/runc/issues/4772
[3]: https://github.com/opencontainers/cgroups/pull/20
[4]: https://github.com/containers/crun/pull/1767
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is a cherry-pick of #9271 to the 1.33 release branch.

#### Does this PR introduce a user-facing change?


```release-note
None
```
