### PR TITLE
[1.33][4.20] OCPBUGS-59321: HighPerformanceHooks: Fix IRQ SMP affinity race conditions

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -63,9 +63,12 @@ const (
 
 // HighPerformanceHooks used to run additional hooks that will configure a system for the latency sensitive workloads.
 type HighPerformanceHooks struct {
-	irqBalanceConfigFile string
-	cpusetLock           sync.Mutex
-	sharedCPUs           string
+	irqBalanceConfigFile     string
+	cpusetLock               sync.Mutex
+	irqSMPAffinityFileLock   sync.Mutex
+	irqBalanceConfigFileLock sync.Mutex
+	sharedCPUs               string
+	irqSMPAffinityFile       string
 }
 
 func (h *HighPerformanceHooks) PreCreate(ctx context.Context, specgen *generate.Generator, s *sandbox.Sandbox, c *oci.Container) error {
@@ -142,7 +145,7 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 	if shouldIRQLoadBalancingBeDisabled(ctx, s.Annotations()) {
 		log.Infof(ctx, "Disable irq smp balancing for container %q", c.ID())
 
-		if err := setIRQLoadBalancing(ctx, c, false, IrqSmpAffinityProcFile, h.irqBalanceConfigFile); err != nil {
+		if err := h.setIRQLoadBalancing(ctx, c, false); err != nil {
 			return fmt.Errorf("set IRQ load balancing: %w", err)
 		}
 	}
@@ -196,7 +199,7 @@ func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s 
 
 	// enable the IRQ smp balancing for the container CPUs
 	if shouldIRQLoadBalancingBeDisabled(ctx, s.Annotations()) {
-		if err := setIRQLoadBalancing(ctx, c, true, IrqSmpAffinityProcFile, h.irqBalanceConfigFile); err != nil {
+		if err := h.setIRQLoadBalancing(ctx, c, true); err != nil {
 			return fmt.Errorf("set IRQ load balancing: %w", err)
 		}
 	}
@@ -569,7 +572,7 @@ func disableCPULoadBalancingV1(containerManagers []cgroups.Manager) error {
 	return nil
 }
 
-func setIRQLoadBalancing(ctx context.Context, c *oci.Container, enable bool, irqSmpAffinityFile, irqBalanceConfigFile string) error {
+func (h *HighPerformanceHooks) setIRQLoadBalancing(ctx context.Context, c *oci.Container, enable bool) error {
 	lspec := c.Spec().Linux
 	if lspec == nil ||
 		lspec.Resources == nil ||
@@ -578,26 +581,15 @@ func setIRQLoadBalancing(ctx context.Context, c *oci.Container, enable bool, irq
 		return fmt.Errorf("find container %s CPUs", c.ID())
 	}
 
-	content, err := os.ReadFile(irqSmpAffinityFile)
+	newIRQBalanceSetting, err := h.updateNewIRQSMPAffinityMask(lspec.Resources.CPU.Cpus, enable)
 	if err != nil {
 		return err
 	}
 
-	currentIRQSMPSetting := strings.TrimSpace(string(content))
-
-	newIRQSMPSetting, newIRQBalanceSetting, err := UpdateIRQSmpAffinityMask(lspec.Resources.CPU.Cpus, currentIRQSMPSetting, enable)
-	if err != nil {
-		return err
-	}
-
-	if err := os.WriteFile(irqSmpAffinityFile, []byte(newIRQSMPSetting), 0o644); err != nil {
-		return err
-	}
-
-	isIrqConfigExists := fileExists(irqBalanceConfigFile)
+	isIrqConfigExists := fileExists(h.irqBalanceConfigFile)
 
 	if isIrqConfigExists {
-		if err := updateIrqBalanceConfigFile(irqBalanceConfigFile, newIRQBalanceSetting); err != nil {
+		if err := h.updateIrqBalanceConfigFile(newIRQBalanceSetting); err != nil {
 			return err
 		}
 	}
@@ -622,6 +614,36 @@ func setIRQLoadBalancing(ctx context.Context, c *oci.Container, enable bool, irq
 	}
 
 	return nil
+}
+
+func (h *HighPerformanceHooks) updateNewIRQSMPAffinityMask(cpus string, enable bool) (string, error) {
+	h.irqSMPAffinityFileLock.Lock()
+	defer h.irqSMPAffinityFileLock.Unlock()
+
+	content, err := os.ReadFile(h.irqSMPAffinityFile)
+	if err != nil {
+		return "", err
+	}
+
+	currentIRQSMPSetting := strings.TrimSpace(string(content))
+
+	newIRQSMPSetting, newIRQBalanceSetting, err := calcIRQSMPAffinityMask(cpus, currentIRQSMPSetting, enable)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(h.irqSMPAffinityFile, []byte(newIRQSMPSetting), 0o644); err != nil {
+		return "", err
+	}
+
+	return newIRQBalanceSetting, nil
+}
+
+func (h *HighPerformanceHooks) updateIrqBalanceConfigFile(newIRQBalanceSetting string) error {
+	h.irqBalanceConfigFileLock.Lock()
+	defer h.irqBalanceConfigFileLock.Unlock()
+
+	return updateIrqBalanceConfigFile(h.irqBalanceConfigFile, newIRQBalanceSetting)
 }
 
 func setCPUQuota(podManager cgroups.Manager, containerManagers []cgroups.Manager) error {
@@ -1032,19 +1054,6 @@ func RestoreIrqBalanceConfig(ctx context.Context, irqBalanceConfigFile, irqBanne
 	}
 
 	return nil
-}
-
-func ShouldCPUQuotaBeDisabled(ctx context.Context, cid string, cSpec *specs.Spec, s *sandbox.Sandbox, annotations fields.Set) bool {
-	if !shouldRunHooks(ctx, cid, cSpec, s) {
-		return false
-	}
-
-	if annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue {
-		log.Warnf(ctx, "%s", annotationValueDeprecationWarning(crioannotations.CPUQuotaAnnotation))
-	}
-
-	return annotations[crioannotations.CPUQuotaAnnotation] == annotationTrue ||
-		annotations[crioannotations.CPUQuotaAnnotation] == annotationDisable
 }
 
 func shouldRunHooks(ctx context.Context, id string, cSpec *specs.Spec, s *sandbox.Sandbox) bool {

--- a/internal/runtimehandlerhooks/runtime_handler_hooks.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
+	libconfig "github.com/cri-o/cri-o/pkg/config"
 )
 
 var (
@@ -26,4 +27,10 @@ type RuntimeHandlerHooks interface {
 //nolint:iface // interface duplication is intentional
 type HighPerformanceHook interface {
 	RuntimeHandlerHooks
+}
+
+// HooksRetriever allows retrieving the runtime hooks for a given sandbox.
+type HooksRetriever struct {
+	config               *libconfig.Config
+	highPerformanceHooks RuntimeHandlerHooks
 }

--- a/internal/runtimehandlerhooks/runtime_handler_hooks_unsupported.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks_unsupported.go
@@ -13,11 +13,22 @@ const (
 	IrqSmpAffinityProcFile = ""
 )
 
-// GetRuntimeHandlerHooks returns RuntimeHandlerHooks implementation by the runtime handler name
-func GetRuntimeHandlerHooks(ctx context.Context, config *libconfig.Config, handler string, annotations map[string]string) (RuntimeHandlerHooks, error) {
+// NewHooksRetriever returns a pointer to a new retriever.
+func NewHooksRetriever(ctx context.Context, config *libconfig.Config) *HooksRetriever {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
-	return &DefaultCPULoadBalanceHooks{}, nil
+
+	rhh := &HooksRetriever{
+		config:               config,
+		highPerformanceHooks: nil,
+	}
+
+	return rhh
+}
+
+// Get always returns DefaultCPULoadBalanceHooks for non-linux architectures.
+func (hr *HooksRetriever) Get(runtimeName string, sandboxAnnotations map[string]string) RuntimeHandlerHooks {
+	return &DefaultCPULoadBalanceHooks{}
 }
 
 // RestoreIrqBalanceConfig restores irqbalance service with original banned cpu mask settings

--- a/internal/runtimehandlerhooks/utils_linux.go
+++ b/internal/runtimehandlerhooks/utils_linux.go
@@ -103,10 +103,10 @@ func isAllBitSet(in []byte) bool {
 	return true
 }
 
-// UpdateIRQSmpAffinityMask take input cpus that need to change irq affinity mask and
+// calcIRQSMPAffinityMask take input cpus that need to change irq affinity mask and
 // the current mask string, return an update mask string and inverted mask, with those cpus
 // enabled or disable in the mask.
-func UpdateIRQSmpAffinityMask(cpus, current string, set bool) (cpuMask, bannedCPUMask string, err error) {
+func calcIRQSMPAffinityMask(cpus, current string, set bool) (cpuMask, bannedCPUMask string, err error) {
 	podcpuset, err := cpuset.Parse(cpus)
 	if err != nil {
 		return cpus, "", err

--- a/internal/runtimehandlerhooks/utils_test.go
+++ b/internal/runtimehandlerhooks/utils_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Utils", func() {
 
 		DescribeTable("testing cpu mask",
 			func(c TestData) {
-				mask, invMask, err := UpdateIRQSmpAffinityMask(c.input.cpus, c.input.mask, c.input.set)
+				mask, invMask, err := calcIRQSMPAffinityMask(c.input.cpus, c.input.mask, c.input.set)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(mask).To(Equal(c.expected.mask))
 				Expect(invMask).To(Equal(c.expected.invMask))

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/resourcestore"
-	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
 	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/internal/storage/references"
 	crioann "github.com/cri-o/cri-o/pkg/annotations"
@@ -1315,10 +1314,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		makeOCIConfigurationRootless(specgen)
 	}
 
-	hooks, err := runtimehandlerhooks.GetRuntimeHandlerHooks(ctx, &s.config, sb.RuntimeHandler(), sb.Annotations())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get runtime handler %q hooks", sb.RuntimeHandler())
-	}
+	hooks := s.hooksRetriever.Get(sb.RuntimeHandler(), sb.Annotations())
 
 	if err := s.nri.createContainer(ctx, specgen, sb, ociContainer); err != nil {
 		return nil, err

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
-	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
 )
 
 // StartContainer starts the container.
@@ -70,10 +69,7 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 
 	sandbox := s.getSandbox(ctx, c.Sandbox())
 
-	hooks, err := runtimehandlerhooks.GetRuntimeHandlerHooks(ctx, &s.config, sandbox.RuntimeHandler(), sandbox.Annotations())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get runtime handler %q hooks", sandbox.RuntimeHandler())
-	}
+	hooks := s.hooksRetriever.Get(sandbox.RuntimeHandler(), sandbox.Annotations())
 
 	if err := s.nri.startContainer(ctx, sandbox, c); err != nil {
 		log.Warnf(ctx, "NRI start failed for container %q: %v", c.ID(), err)

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
 )
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
@@ -49,11 +48,7 @@ func (s *Server) stopContainer(ctx context.Context, ctr *oci.Container, timeout 
 
 	sb := s.getSandbox(ctx, ctr.Sandbox())
 
-	hooks, err := runtimehandlerhooks.GetRuntimeHandlerHooks(ctx, &s.config, sb.RuntimeHandler(), sb.Annotations())
-	if err != nil {
-		return fmt.Errorf("failed to get runtime handler %q hooks", sb.RuntimeHandler())
-	}
-
+	hooks := s.hooksRetriever.Get(sb.RuntimeHandler(), sb.Annotations())
 	if hooks != nil {
 		if err := hooks.PreStop(ctx, ctr, sb); err != nil {
 			return fmt.Errorf("failed to run pre-stop hook for container %q: %w", ctr.ID(), err)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cri-o/cri-o/internal/memorystore"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/resourcestore"
-	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
 	"github.com/cri-o/cri-o/pkg/annotations"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/utils"
@@ -1174,12 +1173,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
-	hooks, err := runtimehandlerhooks.GetRuntimeHandlerHooks(ctx, &s.config, sb.RuntimeHandler(), sb.Annotations())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get runtime handler %q hooks", sb.RuntimeHandler())
-	}
-
-	if hooks != nil {
+	if hooks := s.hooksRetriever.Get(sb.RuntimeHandler(), sb.Annotations()); hooks != nil {
 		if err := hooks.PreStart(ctx, container, sb); err != nil {
 			return nil, fmt.Errorf("failed to run pre-stop hook for container %q: %w", sb.ID(), err)
 		}


### PR DESCRIPTION
Cherry-pick of:
- Merge pull request #9228 from andreaskaris/issue9227 The original 6 commits merged but were not squashed together, therefore doing this here on the downstream cherry-pick.

(cherry picked from commit 3dce7d856a218e5b674eeab3cbd96422507bb69e)


Reported-at: https://issues.redhat.com/browse/OCPBUGS-59321

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

The same as for the change to `main`, I ran a smoke test for sanity checking:

I ran my smoke test on a VM with 14 CPUs where I first installed the entire stack with kubeadm.

Dependencies:
```
# rpm -qa | grep kubelet
kubelet-1.33.1-150500.1.1.x86_64
# rpm -qa | grep kubeadm
kubeadm-1.33.1-150500.1.1.x86_64
# rpm -qa | grep crun
crun-1.21-1.el9.x86_64
# rpm -qa | grep conmon
conmon-2.1.13-1.el9.x86_64
```

/etc/crio/crio.conf.d/99-runtimes.conf
```
[crio.runtime]
infra_ctr_cpuset = "0-3"




# The CRI-O will check the allowed_annotations under the runtime handler and apply high-performance hooks when one of
# high-performance annotations presents under it.
# We should provide the runtime_path because we need to inform that we want to re-use runc binary and we
# do not have high-performance binary under the $PATH that will point to it.
[crio.runtime.runtimes.high-performance]
inherit_default_runtime = true
allowed_annotations = ["cpu-load-balancing.crio.io", "cpu-quota.crio.io", "irq-load-balancing.crio.io", "cpu-c-states.crio.io", "cpu-freq-governor.crio.io"]
```

```
# tail -n 5 /var/lib/kubelet/config.yaml
cpuManagerPolicy: static
cpuManagerPolicyOptions:
  full-pcpus-only: "true"
cpuManagerReconcilePeriod: 5s
reservedSystemCPUs: 0-3
```

I then stopped the crio service, started the compiled crio in foreground `make binaries && bin/crio`, and ran this smoke test:

smoke.sh
```
#!/bin/bash

set -x

affinity_file="/proc/irq/default_smp_affinity"
expected_reset_affinity="3fff"
expected_mask="3e0f"

echo $expected_reset_affinity > $affinity_file
cat $affinity_file

for i in {0..20}; do
	set +x
	echo "========"
	echo "Run ${i}"
	echo "========"
	set -x
	kubectl apply -f pod.yaml
	kubectl wait --for=condition=Ready pod/qos-demo --timeout=180s
	mask=$(cat ${affinity_file} | tr -d '\n')
        echo "Got mask: $mask, expected mask: $expected_mask"
        if [ "${mask}" != "${expected_mask}" ]; then
            exit 1
        fi
        kubectl delete pod qos-demo
        kubectl wait --for=delete pod/qos-demo --timeout=180s
	mask=$(cat ${affinity_file} | tr -d '\n')
	echo "After reset --- Got mask: $mask, expected mask: $expected_reset_affinity"
	if [ "${mask}" != "${expected_reset_affinity}" ]; then
	    exit 1
	fi
done
```

pod.yaml
```
apiVersion: v1
kind: Pod
metadata:
  name: qos-demo
  annotations:
    irq-load-balancing.crio.io: "disable"
spec:
  hostNetwork: true
  runtimeClassName: performance-performance
  containers:
  - name: qos-demo-ctr-1
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
  - name: qos-demo-ctr-2
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
  - name: qos-demo-ctr-3
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
  - name: qos-demo-ctr-4
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
  - name: qos-demo-ctr-5
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
```


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
