### PR TITLE
Explicitly use websocket critest for conmon-rs based tests

### DIFF
--- a/test/conmonrs.bats
+++ b/test/conmonrs.bats
@@ -14,24 +14,6 @@ function teardown() {
 	cleanup_test
 }
 
-function prepare_stream_server() {
-	setup_crio
-
-	cat << EOF > "$CRIO_CONFIG_DIR/99-websocket.conf"
-[crio.runtime]
-default_runtime = "websocket"
-[crio.runtime.runtimes.websocket]
-runtime_path = "$RUNTIME_BINARY_PATH"
-runtime_type = "pod"
-monitor_path = ""
-stream_websockets = true
-EOF
-	unset CONTAINER_DEFAULT_RUNTIME
-	unset CONTAINER_RUNTIMES
-
-	start_crio_no_setup
-}
-
 @test "conmonrs is used" {
 	start_crio
 
@@ -42,7 +24,7 @@ EOF
 }
 
 @test "conmonrs streaming server for exec" {
-	prepare_stream_server
+	start_crio_with_websocket_stream_server
 	POD=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	CTR=$(crictl create "$POD" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$CTR"
@@ -53,7 +35,7 @@ EOF
 }
 
 @test "conmonrs streaming server for attach" {
-	prepare_stream_server
+	start_crio_with_websocket_stream_server
 	POD=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	CTR=$(crictl create "$POD" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$CTR"

--- a/test/critest.bats
+++ b/test/critest.bats
@@ -8,7 +8,6 @@ function setup() {
 	fi
 
 	setup_test
-	start_crio
 }
 
 function teardown() {
@@ -16,6 +15,14 @@ function teardown() {
 }
 
 @test "run the critest suite" {
+	WEBSOCKET_ARGS=()
+	if [[ $RUNTIME_TYPE == pod ]]; then
+		start_crio_with_websocket_stream_server
+		WEBSOCKET_ARGS=(-websocket-attach -websocket-exec)
+	else
+		start_crio
+	fi
+
 	critest \
 		--runtime-endpoint "unix://${CRIO_SOCKET}" \
 		--image-endpoint "unix://${CRIO_SOCKET}" \
@@ -24,7 +31,8 @@ function teardown() {
 		--ginkgo.timeout 5m \
 		--ginkgo.trace \
 		--ginkgo.vv \
-		--ginkgo.flake-attempts 3 >&3
+		--ginkgo.flake-attempts 3 \
+		"${WEBSOCKET_ARGS[@]}" >&3
 
 	if [[ $RUNTIME_TYPE == pod ]]; then
 		# Validate that we actually used conmonrs

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -800,3 +800,21 @@ function remove_random_storage_layer() {
 function is_using_crun() {
     runtime --version | grep -q crun
 }
+
+function start_crio_with_websocket_stream_server() {
+    setup_crio
+
+    cat <<EOF >"$CRIO_CONFIG_DIR/99-websocket.conf"
+[crio.runtime]
+default_runtime = "websocket"
+[crio.runtime.runtimes.websocket]
+runtime_path = "$RUNTIME_BINARY_PATH"
+runtime_type = "pod"
+monitor_path = ""
+stream_websockets = true
+EOF
+    unset CONTAINER_DEFAULT_RUNTIME
+    unset CONTAINER_RUNTIMES
+
+    start_crio_no_setup
+}


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Use the new websocket flags for critest when using conmon-rs.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
