### PR TITLE
Implement missing metrics 9215 - container_spec_memory_reservation_li…

### DIFF
--- a/internal/lib/stats/descriptors.go
+++ b/internal/lib/stats/descriptors.go
@@ -93,6 +93,11 @@ var (
 		Help:      "Cumulative count of memory allocation failures.",
 		LabelKeys: append(baseLabelKeys, "failure_type", "scope"),
 	}
+	containerSpecMemoryReservationLimitBytes = &types.MetricDescriptor{
+		Name:      "container_spec_memory_reservation_limit_bytes",
+		Help:      "Memory reservation limit for the container in bytes.",
+		LabelKeys: baseLabelKeys,
+	}
 )
 
 var networkLabelKeys = append(baseLabelKeys, "interface")

--- a/internal/lib/stats/memory_metrics.go
+++ b/internal/lib/stats/memory_metrics.go
@@ -59,6 +59,17 @@ func generateSandboxMemoryMetrics(sb *sandbox.Sandbox, mem *cgmgr.MemoryStats) [
 			},
 		},
 		{
+			desc: containerSpecMemoryReservationLimitBytes, // New metric for reservation limit
+			valueFunc: func() metricValues {
+				// Report reservation limit as 0 if above maxMemorySize (unlimited)
+				reservation := mem.Reservation
+				if reservation > maxMemorySize {
+					return metricValues{{value: 0, metricType: types.MetricType_GAUGE}}
+				}
+				return metricValues{{value: reservation, metricType: types.MetricType_GAUGE}}
+			},
+		},
+		{
 			desc: containerMemoryFailcnt,
 			valueFunc: func() metricValues {
 				return metricValues{{value: mem.Failcnt, metricType: types.MetricType_COUNTER}}

--- a/internal/lib/stats/metrics.go
+++ b/internal/lib/stats/metrics.go
@@ -71,6 +71,7 @@ func (ss *StatsServer) PopulateMetricDescriptors(includedKeys []string) map[stri
 			containerMemoryMaxUsageBytes,
 			containerMemoryWorkingSetBytes,
 			containerMemoryFailuresTotal,
+			containerSpecMemoryReservationLimitBytes,
 		},
 		NetworkMetrics: {
 			containerNetworkReceiveBytesTotal,


### PR DESCRIPTION
This pull request introduces a new memory metric, container_spec_memory_reservation_limit_bytes, to track the memory reservation limit for containers. The changes include adding the metric descriptor, implementing logic to calculate its values, and ensuring it is included in the list of metrics exposed by the stats server.

Addition of the new memory metric:
[internal/lib/stats/descriptors.go](https://github.com/Fidelity-External-Staging/cri-o-cri-o/pull/16/files#diff-07606cd64e85f126c4d30b9f04740c082f599978aa4d71ab2ed48421cb7f3413R96-R100): Added the containerSpecMemoryReservationLimitBytes descriptor to define the new metric, including its name, help text, and associated label keys.
Implementation of metric value calculation:
[internal/lib/stats/memory_metrics.go](https://github.com/Fidelity-External-Staging/cri-o-cri-o/pull/16/files#diff-c7b3f7155f817b2a994a414832a960cd6d3dbb7a9b0b585bd669e0de2d859d9aR61-R71): Added logic to calculate the value of containerSpecMemoryReservationLimitBytes. If the reservation exceeds maxMemorySize (unlimited), it reports a value of 0; otherwise, it reports the reservation value as a gauge metric.
Integration with stats server:
[internal/lib/stats/metrics.go](https://github.com/Fidelity-External-Staging/cri-o-cri-o/pull/16/files#diff-a3a5454db4bfe98e024685b1d6cf8fc8b7b2ef3c0d8fad564edc1b3fb837a242R74): Included containerSpecMemoryReservationLimitBytes in the list of metrics exposed by the stats server to ensure it is available for monitoring.