### PR TITLE
Bump go-chi to v5.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/go-chi/chi/v5 v5.2.1
+	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-logr/logr v1.4.2
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
-github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
-github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=

--- a/vendor/github.com/go-chi/chi/v5/README.md
+++ b/vendor/github.com/go-chi/chi/v5/README.md
@@ -20,7 +20,9 @@ and [docgen](https://github.com/go-chi/docgen). We hope you enjoy it too!
 
 ## Install
 
-`go get -u github.com/go-chi/chi/v5`
+```sh
+go get -u github.com/go-chi/chi/v5
+```
 
 
 ## Features
@@ -194,7 +196,7 @@ type Router interface {
 	// path, with a fresh middleware stack for the inline-Router.
 	Group(fn func(r Router)) Router
 
-	// Route mounts a sub-Router along a `pattern`` string.
+	// Route mounts a sub-Router along a `pattern` string.
 	Route(pattern string, fn func(r Router)) Router
 
 	// Mount attaches another http.Handler along ./pattern/*

--- a/vendor/github.com/go-chi/chi/v5/chi.go
+++ b/vendor/github.com/go-chi/chi/v5/chi.go
@@ -37,8 +37,7 @@
 //
 // A placeholder with a name followed by a colon allows a regular
 // expression match, for example {number:\\d+}. The regular expression
-// syntax is Go's normal regexp RE2 syntax, except that regular expressions
-// including { or } are not supported, and / will never be
+// syntax is Go's normal regexp RE2 syntax, except that / will never be
 // matched. An anonymous regexp pattern is allowed, using an empty string
 // before the colon in the placeholder, such as {:\\d+}
 //

--- a/vendor/github.com/go-chi/chi/v5/mux.go
+++ b/vendor/github.com/go-chi/chi/v5/mux.go
@@ -107,9 +107,8 @@ func (mx *Mux) Use(middlewares ...func(http.Handler) http.Handler) {
 // Handle adds the route `pattern` that matches any http method to
 // execute the `handler` http.Handler.
 func (mx *Mux) Handle(pattern string, handler http.Handler) {
-	parts := strings.SplitN(pattern, " ", 2)
-	if len(parts) == 2 {
-		mx.Method(parts[0], parts[1], handler)
+	if method, rest, found := strings.Cut(pattern, " "); found {
+		mx.Method(method, rest, handler)
 		return
 	}
 
@@ -119,9 +118,8 @@ func (mx *Mux) Handle(pattern string, handler http.Handler) {
 // HandleFunc adds the route `pattern` that matches any http method to
 // execute the `handlerFn` http.HandlerFunc.
 func (mx *Mux) HandleFunc(pattern string, handlerFn http.HandlerFunc) {
-	parts := strings.SplitN(pattern, " ", 2)
-	if len(parts) == 2 {
-		mx.Method(parts[0], parts[1], handlerFn)
+	if method, rest, found := strings.Cut(pattern, " "); found {
+		mx.Method(method, rest, handlerFn)
 		return
 	}
 

--- a/vendor/github.com/go-chi/chi/v5/path_value.go
+++ b/vendor/github.com/go-chi/chi/v5/path_value.go
@@ -1,5 +1,6 @@
-//go:build go1.22
-// +build go1.22
+//go:build go1.22 && !tinygo
+// +build go1.22,!tinygo
+
 
 package chi
 

--- a/vendor/github.com/go-chi/chi/v5/path_value_fallback.go
+++ b/vendor/github.com/go-chi/chi/v5/path_value_fallback.go
@@ -1,5 +1,5 @@
-//go:build !go1.22
-// +build !go1.22
+//go:build !go1.22 || tinygo
+// +build !go1.22 tinygo
 
 package chi
 

--- a/vendor/github.com/go-chi/chi/v5/tree.go
+++ b/vendor/github.com/go-chi/chi/v5/tree.go
@@ -730,11 +730,9 @@ func patNextSegment(pattern string) (nodeTyp, string, string, byte, int, int) {
 			tail = pattern[pe]
 		}
 
-		var rexpat string
-		if idx := strings.Index(key, ":"); idx >= 0 {
+		key, rexpat, isRegexp := strings.Cut(key, ":")
+		if isRegexp {
 			nt = ntRegexp
-			rexpat = key[idx+1:]
-			key = key[:idx]
 		}
 
 		if len(rexpat) > 0 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -526,7 +526,7 @@ github.com/fsnotify/fsnotify/internal
 # github.com/fxamacker/cbor/v2 v2.7.0
 ## explicit; go 1.17
 github.com/fxamacker/cbor/v2
-# github.com/go-chi/chi/v5 v5.2.1
+# github.com/go-chi/chi/v5 v5.2.2
 ## explicit; go 1.20
 github.com/go-chi/chi/v5
 # github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind dependency-change

#### What this PR does / why we need it:

This fixes [GHSA-vrw8-fxc6-2r93](https://github.com/advisories/GHSA-vrw8-fxc6-2r93).

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

Discussed on slack here: https://kubernetes.slack.com/archives/CAZH62UR1/p1753170348596769
I get that this is a low priority issue but we would like to get it fixed and included in a release. This is why I am pushing it to release-1.33. It is already fixed on main and release-1.34 but not included in any release.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
