### PR TITLE
OCPBUGS-5_9_4_0_3: HighPerformanceHooks: Implement idempotent IRQ SMP affinity management with atomic locking

### DIFF
--- a/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_linux.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opencontainers/runtime-tools/generate"
 
 	"github.com/cri-o/cri-o/internal/config/node"
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 )
@@ -24,12 +25,12 @@ func (*DefaultCPULoadBalanceHooks) PreCreate(context.Context, *generate.Generato
 }
 
 // No-op.
-func (*DefaultCPULoadBalanceHooks) PreStart(context.Context, *oci.Container, *sandbox.Sandbox) error {
+func (*DefaultCPULoadBalanceHooks) PreStart(context.Context, *lib.ContainerServer, *oci.Container, *sandbox.Sandbox) error {
 	return nil
 }
 
 // No-op.
-func (*DefaultCPULoadBalanceHooks) PreStop(context.Context, *oci.Container, *sandbox.Sandbox) error {
+func (*DefaultCPULoadBalanceHooks) PreStop(context.Context, *lib.ContainerServer, *oci.Container, *sandbox.Sandbox) error {
 	return nil
 }
 

--- a/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_unsupported.go
+++ b/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_unsupported.go
@@ -5,6 +5,7 @@ package runtimehandlerhooks
 import (
 	"context"
 
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -24,12 +25,12 @@ func (*DefaultCPULoadBalanceHooks) PreCreate(context.Context, *generate.Generato
 }
 
 // No-op
-func (*DefaultCPULoadBalanceHooks) PreStart(context.Context, *oci.Container, *sandbox.Sandbox) error {
+func (*DefaultCPULoadBalanceHooks) PreStart(context.Context, *lib.ContainerServer, *oci.Container, *sandbox.Sandbox) error {
 	return nil
 }
 
 // No-op
-func (*DefaultCPULoadBalanceHooks) PreStop(context.Context, *oci.Container, *sandbox.Sandbox) error {
+func (*DefaultCPULoadBalanceHooks) PreStop(context.Context, *lib.ContainerServer, *oci.Container, *sandbox.Sandbox) error {
 	return nil
 }
 

--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/config/cgmgr"
 	"github.com/cri-o/cri-o/internal/config/node"
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
@@ -50,6 +51,7 @@ const (
 	sysCPUDir            = "/sys/devices/system/cpu"
 	sysCPUSaveDir        = "/var/run/crio/cpu"
 	milliCPUToCPU        = 1000
+	preStoppingMaxLen    = 100
 )
 
 const (
@@ -113,6 +115,7 @@ type HighPerformanceHooks struct {
 	sharedCPUs               string
 	execCPUAffinity          config.ExecCPUAffinityType
 	irqSMPAffinityFile       string
+	preStoppingContainers    map[string]bool
 }
 
 func (h *HighPerformanceHooks) PreCreate(ctx context.Context, specgen *generate.Generator, s *sandbox.Sandbox, c *oci.Container) error {
@@ -199,7 +202,7 @@ func (h *HighPerformanceHooks) setExecCPUAffinity(ctx context.Context, specgen *
 	return nil
 }
 
-func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error {
+func (h *HighPerformanceHooks) PreStart(ctx context.Context, containerServer *lib.ContainerServer, c *oci.Container, s *sandbox.Sandbox) error {
 	log.Infof(ctx, "Run %q runtime handler pre-start hook for the container %q", HighPerformance, c.ID())
 
 	cSpec := c.Spec()
@@ -237,7 +240,7 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 	if shouldIRQLoadBalancingBeDisabled(ctx, s.Annotations()) {
 		log.Infof(ctx, "Disable irq smp balancing for container %q", c.ID())
 
-		if err := h.setIRQLoadBalancing(ctx, c, false); err != nil {
+		if err := h.setIRQLoadBalancing(ctx, containerServer, c, false); err != nil {
 			return fmt.Errorf("set IRQ load balancing: %w", err)
 		}
 	}
@@ -279,11 +282,14 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 	return nil
 }
 
-func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error {
+func (h *HighPerformanceHooks) PreStop(ctx context.Context, containerServer *lib.ContainerServer, c *oci.Container, s *sandbox.Sandbox) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
 	log.Infof(ctx, "Run %q runtime handler pre-stop hook for the container %q", HighPerformance, c.ID())
+
+	// Update prestopping list with current container and cleanup stale entries
+	h.updatePreStopping(ctx, containerServer, c)
 
 	cSpec := c.Spec()
 	if !shouldRunHooks(ctx, c.ID(), &cSpec, s) {
@@ -292,7 +298,7 @@ func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s 
 
 	// enable the IRQ smp balancing for the container CPUs
 	if shouldIRQLoadBalancingBeDisabled(ctx, s.Annotations()) {
-		if err := h.setIRQLoadBalancing(ctx, c, true); err != nil {
+		if err := h.setIRQLoadBalancing(ctx, containerServer, c, true); err != nil {
 			return fmt.Errorf("set IRQ load balancing: %w", err)
 		}
 	}
@@ -330,6 +336,50 @@ func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s 
 	}
 
 	return nil
+}
+
+// updatePreStopping adds the current container to the prestopping list and cleans up
+// stale entries by removing containers that are no longer present in the container list.
+// Uses the IRQ affinity lock to ensure atomic access with IRQ calculations.
+func (h *HighPerformanceHooks) updatePreStopping(ctx context.Context, containerServer *lib.ContainerServer, c *oci.Container) {
+	h.updateIRQSMPAffinityLock.Lock()
+	defer h.updateIRQSMPAffinityLock.Unlock()
+
+	// Initialize map if needed
+	if h.preStoppingContainers == nil {
+		h.preStoppingContainers = make(map[string]bool)
+	}
+
+	// Add current container to prestopping list
+	h.preStoppingContainers[c.ID()] = true
+
+	// Do not clean up if we haven't passed a threshold, yet.
+	if len(h.preStoppingContainers) < preStoppingMaxLen {
+		return
+	}
+
+	log.Debugf(ctx, "Running prestopping cleanup since %d above threshold (%d)", len(h.preStoppingContainers), preStoppingMaxLen)
+
+	// Clean up stale entries by getting current container list
+	containers, err := containerServer.ListContainers()
+	if err != nil {
+		log.Warnf(ctx, "Failed to list containers for prestopping cleanup: %v", err)
+
+		return
+	}
+
+	// Create a set of current container IDs for efficient lookup
+	currentContainerIDs := make(map[string]bool)
+	for _, container := range containers {
+		currentContainerIDs[container.ID()] = true
+	}
+
+	// Remove prestopping entries for containers that no longer exist
+	for containerID := range h.preStoppingContainers {
+		if !currentContainerIDs[containerID] {
+			delete(h.preStoppingContainers, containerID)
+		}
+	}
 }
 
 // If CPU load balancing is enabled, then *all* containers must run this PostStop hook.
@@ -665,21 +715,114 @@ func disableCPULoadBalancingV1(containerManagers []cgroups.Manager) error {
 	return nil
 }
 
-func (h *HighPerformanceHooks) setIRQLoadBalancing(ctx context.Context, c *oci.Container, enable bool) error {
-	lspec := c.Spec().Linux
-	if lspec == nil ||
-		lspec.Resources == nil ||
-		lspec.Resources.CPU == nil ||
-		lspec.Resources.CPU.Cpus == "" {
-		return fmt.Errorf("find container %s CPUs", c.ID())
-	}
-
-	if err := h.updateNewIRQSMPAffinityMask(ctx, c.Name(), lspec.Resources.CPU.Cpus, enable); err != nil {
-		return err
+// setIRQLoadBalancing manages IRQ SMP affinity configuration using an idempotent approach.
+// Changes are made only for the CPUs of the current container. For container start (isDelete=false),
+// disables IRQ on container CPUs. For container stop, recalculates complete IRQ affinity state
+// from all running containers excluding the current one.
+func (h *HighPerformanceHooks) setIRQLoadBalancing(ctx context.Context, containerServer *lib.ContainerServer,
+	container *oci.Container, isDelete bool,
+) error {
+	// updateNewIRQSMPAffinityMask runs under mutex lock to calculate and write new IRQ masks.
+	if err := h.updateNewIRQSMPAffinityMask(ctx, containerServer, container, isDelete); err != nil {
+		return fmt.Errorf("failed to update IRQ SMP affinity mask: %w", err)
 	}
 	// Outside of the lock section, we can restart the irqbalance service or run irqbalance --oneshot command.
 	// handleIRQBalanceRestart will log errors but will not return them, as it is not critical for the pod to start.
-	h.handleIRQBalanceRestart(ctx, c.Name())
+	h.handleIRQBalanceRestart(ctx)
+
+	return nil
+}
+
+// calcIRQSMPAffinityCPUs computes which CPUs should have IRQ SMP affinity enabled or disabled.
+// For container start: returns empty enabled set and current container CPUs as disabled set.
+// For container stop: scans all running containers (excluding current one) to determine
+// which CPUs still need IRQ disabled, enabling IRQ on the remaining CPUs.
+func (h *HighPerformanceHooks) calcIRQSMPAffinityCPUs(ctx context.Context, containerServer *lib.ContainerServer,
+	c *oci.Container, isDelete bool,
+) (enabled, disabled cpuset.CPUSet, err error) {
+	// CPUs that are eligible for a change are all CPUs of container c.
+	eligibleCPUSet, err := getContainerCPUSet(c)
+	if err != nil {
+		return cpuset.CPUSet{}, cpuset.CPUSet{}, err
+	}
+
+	// Container start: disable IRQ on all container CPUs.
+	if !isDelete {
+		enabledCPUSet := cpuset.CPUSet{}
+		disabledCPUSet := eligibleCPUSet
+
+		return enabledCPUSet, disabledCPUSet, nil
+	}
+
+	// Container stop: check if other containers still need IRQ disabled.
+	// Kubelet may add replacement containers before deletion completes.
+	containers, err := containerServer.ListContainers()
+	if err != nil {
+		return cpuset.CPUSet{}, cpuset.CPUSet{}, fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	// Start with the assumption that IRQ load balancing must be enabled on all eligible CPUs.
+	enabledCPUSet := eligibleCPUSet
+
+	for _, container := range containers {
+		// Skip the container being deleted since we are in prestop - the container must be deleted
+		// but here in prestop this hasn't happened yet.
+		if container.ID() == c.ID() {
+			continue
+		}
+
+		// Skip if container was already marked as prestopping. We must do this as cri-o doesn't otherwise
+		// keep track that containers have already entered prestop.
+		if h.preStoppingContainers != nil && h.preStoppingContainers[container.ID()] {
+			continue
+		}
+
+		// Skip if container is not a static IRQ SMP affinity container.
+		if !isIRQSMPStaticContainer(ctx, containerServer, container) {
+			continue
+		}
+
+		containerSet, err := getContainerCPUSet(container)
+		if err != nil {
+			return cpuset.CPUSet{}, cpuset.CPUSet{}, fmt.Errorf(
+				"failed to parse container %q CPUs %q: %w",
+				container.ID(), container.Spec().Linux.Resources.CPU.Cpus, err)
+		}
+
+		enabledCPUSet = enabledCPUSet.Difference(containerSet)
+		// We can only disable, so once this is empty, exit early.
+		if enabledCPUSet.IsEmpty() {
+			break
+		}
+	}
+
+	// disabledCPUSet = container CPUs - enabled CPUs.
+	disabledCPUSet := eligibleCPUSet.Difference(enabledCPUSet)
+
+	return enabledCPUSet, disabledCPUSet, nil
+}
+
+// writeIRQAffinityFiles writes IRQ SMP affinity and balance config files with rollback on failure.
+func (h *HighPerformanceHooks) writeIRQAffinityFiles(ctx context.Context, newSMPSetting, newBalanceSetting,
+	originalSMPSetting string,
+) error {
+	if err := os.WriteFile(h.irqSMPAffinityFile, []byte(newSMPSetting), 0o644); err != nil {
+		return fmt.Errorf("failed to write IRQ SMP affinity file %q: %w", h.irqSMPAffinityFile, err)
+	}
+
+	// Skip if IRQ balance config file doesn't exist.
+	if !fileExists(h.irqBalanceConfigFile) {
+		return nil
+	}
+
+	if err := updateIrqBalanceConfigFile(h.irqBalanceConfigFile, newBalanceSetting); err != nil {
+		// Rollback IRQ SMP affinity file to maintain consistency
+		if rollbackErr := os.WriteFile(h.irqSMPAffinityFile, []byte(originalSMPSetting), 0o644); rollbackErr != nil {
+			log.Errorf(ctx, "Failed to rollback IRQ SMP affinity file after config update failure: %v", rollbackErr)
+		}
+
+		return fmt.Errorf("failed to update IRQ balance config file %q: %w", h.irqBalanceConfigFile, err)
+	}
 
 	return nil
 }
@@ -688,7 +831,7 @@ func (h *HighPerformanceHooks) setIRQLoadBalancing(ctx context.Context, c *oci.C
 // irqbalance --oneshot command if the service is not enabled. The environment variable for irqbalance oneshot
 // is read from h.irqBalanceConfigFile (/etc/sysconfig/irqbalance) which is guaranteed to be in a consistent state
 // after the lock section in updateNewIRQSMPAffinityMask.
-func (h *HighPerformanceHooks) handleIRQBalanceRestart(ctx context.Context, cName string) {
+func (h *HighPerformanceHooks) handleIRQBalanceRestart(ctx context.Context) {
 	// Nothing else to do if irq balance config file does not exist.
 	if !fileExists(h.irqBalanceConfigFile) {
 		return
@@ -700,7 +843,7 @@ func (h *HighPerformanceHooks) handleIRQBalanceRestart(ctx context.Context, cNam
 	// See:
 	// https://github.com/cri-o/cri-o/pull/8834/commits/b96928dcbb7956e0ebde42238e88955831411216
 	if serviceManager.IsServiceEnabled(irqBalancedName) {
-		log.Debugf(ctx, "Container %q restarting irqbalance service", cName)
+		log.Debugf(ctx, "Restarting irqbalance service")
 
 		if err := serviceManager.RestartService(irqBalancedName); err != nil {
 			log.Warnf(ctx, "Irqbalance service restart failed: %v", err)
@@ -737,15 +880,15 @@ func (h *HighPerformanceHooks) handleIRQBalanceRestart(ctx context.Context, cNam
 		text = strings.Trim(text, "\"'")
 		env := fmt.Sprintf("%s=%s", irqBalanceBannedCpus, text)
 
-		log.Debugf(ctx, "Container %q running '%s %s %s'", cName, env, irqBalanceFullPath, "--oneshot")
+		log.Debugf(ctx, "Running '%s %s %s'", env, irqBalanceFullPath, "--oneshot")
 
 		if err := commandRunner.RunCommand(
 			irqBalanceFullPath,
 			[]string{env},
 			"--oneshot",
 		); err != nil {
-			log.Warnf(ctx, "Container %q failed to run '%s %s %s', err: %q",
-				cName, env, irqBalanceFullPath, "--oneshot", err)
+			log.Warnf(ctx, "Failed to run '%s %s %s', err: %q",
+				env, irqBalanceFullPath, "--oneshot", err)
 		}
 
 		return
@@ -758,53 +901,48 @@ func (h *HighPerformanceHooks) handleIRQBalanceRestart(ctx context.Context, cNam
 	log.Warnf(ctx, "Failed to find %q in irq balance config file %q", irqBalanceBannedCpus, h.irqBalanceConfigFile)
 }
 
-// updateNewIRQSMPAffinityMask updates SMP IRQ affinity and IRQ balance configuration files.
-// The entire function must be wrapped inside a single lock to avoid race conditions.
-// The reason for this is that once we read from the SMP IRQ affinity file, we have to calculate new masks and
-// write those masks to /proc/irq/default_smp_affinity and /etc/sysconfig/irqbalance
-// Without this lock, 2 threads could read from the file and calculate the new mask but overwrite the
-// results of each other.
-func (h *HighPerformanceHooks) updateNewIRQSMPAffinityMask(ctx context.Context, cName, cpus string, enable bool) error {
+// updateNewIRQSMPAffinityMask updates IRQ SMP affinity and balance configuration files atomically.
+// Runs under mutex lock to prevent race conditions during concurrent container operations.
+// Calculates new IRQ affinity masks and updates both /proc/irq/default_smp_affinity and
+// /etc/sysconfig/irqbalance files.
+func (h *HighPerformanceHooks) updateNewIRQSMPAffinityMask(ctx context.Context, containerServer *lib.ContainerServer,
+	container *oci.Container, isDelete bool,
+) error {
+	if container == nil {
+		return errors.New("container cannot be nil")
+	}
+
 	h.updateIRQSMPAffinityLock.Lock()
 	defer h.updateIRQSMPAffinityLock.Unlock()
 
-	content, err := os.ReadFile(h.irqSMPAffinityFile)
+	// Determine which CPUs should have IRQ SMP load balancing enabled or disabled.
+	enabledCPUSet, disabledCPUSet, err := h.calcIRQSMPAffinityCPUs(ctx, containerServer, container, isDelete)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to calculate IRQ SMP affinity CPUs: %w", err)
 	}
 
-	originalIRQSMPSetting := strings.TrimSpace(string(content))
-
-	newIRQSMPSetting, newIRQBalanceSetting, err := calcIRQSMPAffinityMask(cpus, originalIRQSMPSetting, enable)
+	// Next, calculate the new masks for IRQ SMP affinity file and for irqbalance configuration.
+	originalIRQSMPSettingRaw, err := os.ReadFile(h.irqSMPAffinityFile)
 	if err != nil {
+		return fmt.Errorf("failed to read IRQ SMP affinity file %q: %w", h.irqSMPAffinityFile, err)
+	}
+
+	originalIRQSMPSetting := strings.TrimSpace(string(originalIRQSMPSettingRaw))
+
+	newIRQSMPSetting, newIRQBalanceSetting, err := calcIRQSMPAffinityMask(originalIRQSMPSetting,
+		enabledCPUSet, disabledCPUSet)
+	if err != nil {
+		return fmt.Errorf("failed to calculate IRQ SMP affinity mask: %w", err)
+	}
+
+	log.Debugf(ctx, "New IRQ masks are - %q: %q; %q: %q", h.irqSMPAffinityFile, newIRQSMPSetting, h.irqBalanceConfigFile, newIRQBalanceSetting)
+
+	// Last, write the changes to IRQ SMP affinity file and to IRQ Balance config file.
+	if err := h.writeIRQAffinityFiles(ctx, newIRQSMPSetting, newIRQBalanceSetting, originalIRQSMPSetting); err != nil {
 		return err
 	}
 
-	log.Debugf(ctx, "Container %q set %q: %q; %q: %q", cName,
-		h.irqSMPAffinityFile, newIRQSMPSetting,
-		h.irqBalanceConfigFile, newIRQBalanceSetting,
-	)
-
-	if err := os.WriteFile(h.irqSMPAffinityFile, []byte(newIRQSMPSetting), 0o644); err != nil {
-		return err
-	}
-
-	// Nothing else to do if irq balance config file does not exist.
-	if !fileExists(h.irqBalanceConfigFile) {
-		return nil
-	}
-
-	if err := updateIrqBalanceConfigFile(h.irqBalanceConfigFile, newIRQBalanceSetting); err != nil {
-		// Rollback IRQ SMP affinity file to maintain consistency
-		if rollbackErr := os.WriteFile(h.irqSMPAffinityFile, []byte(originalIRQSMPSetting), 0o644); rollbackErr != nil {
-			log.Errorf(ctx, "Failed to rollback IRQ SMP affinity file after config update failure: %v", rollbackErr)
-		}
-
-		return err
-	}
-
-	// Nothing else to do here inside the lock section. irqbalance --oneshot or
-	// service restart will be handled outside of the lock in setIRQLoadBalancing.
+	// IRQ balance restart handled outside lock in setIRQLoadBalancing.
 	return nil
 }
 
@@ -952,15 +1090,7 @@ func setCPUPMQOSResumeLatency(c *oci.Container, latency string) error {
 
 // doSetCPUPMQOSResumeLatency facilitates unit testing by allowing the directories to be specified as parameters.
 func doSetCPUPMQOSResumeLatency(c *oci.Container, latency, cpuDir, cpuSaveDir string) error {
-	lspec := c.Spec().Linux
-	if lspec == nil ||
-		lspec.Resources == nil ||
-		lspec.Resources.CPU == nil ||
-		lspec.Resources.CPU.Cpus == "" {
-		return fmt.Errorf("find container %s CPUs", c.ID())
-	}
-
-	cpus, err := cpuset.Parse(lspec.Resources.CPU.Cpus)
+	cpus, err := getContainerCPUSet(c)
 	if err != nil {
 		return err
 	}
@@ -1057,15 +1187,7 @@ func setCPUFreqGovernor(c *oci.Container, governor string) error {
 
 // doSetCPUFreqGovernor facilitates unit testing by allowing the directories to be specified as parameters.
 func doSetCPUFreqGovernor(c *oci.Container, governor, cpuDir, cpuSaveDir string) error {
-	lspec := c.Spec().Linux
-	if lspec == nil ||
-		lspec.Resources == nil ||
-		lspec.Resources.CPU == nil ||
-		lspec.Resources.CPU.Cpus == "" {
-		return fmt.Errorf("find container %s CPUs", c.ID())
-	}
-
-	cpus, err := cpuset.Parse(lspec.Resources.CPU.Cpus)
+	cpus, err := getContainerCPUSet(c)
 	if err != nil {
 		return err
 	}
@@ -1291,16 +1413,9 @@ func convertAnnotationToLatency(annotation string) (maxLatency string, err error
 }
 
 func setSharedCPUs(c *oci.Container, containerManagers []cgroups.Manager, sharedCPUs string) ([]cgroups.Manager, error) {
-	cSpec := c.Spec()
-	if isContainerCPUsSpecEmpty(&cSpec) {
-		return nil, fmt.Errorf("no cpus found for container %q", c.Name())
-	}
-
-	cpusString := cSpec.Linux.Resources.CPU.Cpus
-
-	exclusiveCPUs, err := cpuset.Parse(cpusString)
+	exclusiveCPUs, err := getContainerCPUSet(c)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse container %q cpus: %w", c.Name(), err)
+		return nil, err
 	}
 
 	if sharedCPUs == "" {
@@ -1357,10 +1472,30 @@ func setSharedCPUs(c *oci.Container, containerManagers []cgroups.Manager, shared
 }
 
 func isContainerCPUsSpecEmpty(spec *specs.Spec) bool {
-	return spec.Linux == nil ||
+	return spec == nil ||
+		spec.Linux == nil ||
 		spec.Linux.Resources == nil ||
 		spec.Linux.Resources.CPU == nil ||
 		spec.Linux.Resources.CPU.Cpus == ""
+}
+
+// getContainerCPUSet extracts and parses the CPU set from a container, handling common error cases.
+func getContainerCPUSet(c *oci.Container) (cpuset.CPUSet, error) {
+	if c == nil {
+		return cpuset.CPUSet{}, errors.New("getContainerCPUSet called with nil pointer")
+	}
+
+	cSpec := c.Spec()
+	if isContainerCPUsSpecEmpty(&cSpec) {
+		return cpuset.CPUSet{}, fmt.Errorf("find container %q CPUs", c.ID())
+	}
+
+	cpus, err := cpuset.Parse(cSpec.Linux.Resources.CPU.Cpus)
+	if err != nil {
+		return cpuset.CPUSet{}, fmt.Errorf("failed to parse container %q CPUs: %w", c.ID(), err)
+	}
+
+	return cpus, nil
 }
 
 func injectQuotaGivenSharedCPUs(c *oci.Container, podManager cgroups.Manager, containerManagers []cgroups.Manager, sharedCPUs string) error {
@@ -1481,9 +1616,32 @@ func getPodQuotaV2(mng cgroups.Manager) (string, error) {
 	return cpuQuota, nil
 }
 
+func isIRQSMPStaticContainer(ctx context.Context, containerServer *lib.ContainerServer, c *oci.Container) bool {
+	sb := containerServer.GetSandbox(c.Sandbox())
+
+	if sb == nil {
+		return false
+	}
+
+	cSpec := c.Spec()
+
+	return c.State().Status != specs.StateStopped &&
+		shouldIRQLoadBalancingBeDisabled(ctx, sb.Annotations()) &&
+		isHighPerformanceRuntime(sb.RuntimeHandler(), sb.Annotations()) &&
+		!isContainerCPUsSpecEmpty(&cSpec) &&
+		shouldRunHooks(ctx, c.ID(), &cSpec, sb)
+}
+
 func injectCpusetEnv(specgen *generate.Generator, isolated, shared *cpuset.CPUSet) {
 	spec := specgen.Config
 	spec.Process.Env = append(spec.Process.Env,
 		fmt.Sprintf("%s=%s", IsolatedCPUsEnvVar, isolated.String()),
 		fmt.Sprintf("%s=%s", SharedCPUsEnvVar, shared.String()))
+}
+
+// isHighPerformanceRuntime checks if the runtime name or annotations indicate high-performance usage.
+// It returns true if the runtime name contains "high-performance" or if high-performance annotations are present.
+func isHighPerformanceRuntime(runtimeName string, annotations map[string]string) bool {
+	return strings.Contains(runtimeName, HighPerformance) ||
+		highPerformanceAnnotationsSpecified(annotations)
 }

--- a/internal/runtimehandlerhooks/runtime_handler_hooks.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opencontainers/runtime-tools/generate"
 
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
@@ -19,8 +20,8 @@ var (
 //nolint:iface // interface duplication is intentional
 type RuntimeHandlerHooks interface {
 	PreCreate(ctx context.Context, specgen *generate.Generator, s *sandbox.Sandbox, c *oci.Container) error
-	PreStart(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error
-	PreStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error
+	PreStart(ctx context.Context, containerServer *lib.ContainerServer, c *oci.Container, s *sandbox.Sandbox) error
+	PreStop(ctx context.Context, containerServer *lib.ContainerServer, c *oci.Container, s *sandbox.Sandbox) error
 	PostStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error
 }
 

--- a/internal/runtimehandlerhooks/runtime_handler_hooks_linux.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks_linux.go
@@ -41,7 +41,7 @@ func NewHooksRetriever(ctx context.Context, config *libconfig.Config) *HooksRetr
 // Otherwise, if crio's config allows CPU load balancing anywhere, return a DefaultCPULoadBalanceHooks.
 // Otherwise, return nil.
 func (hr *HooksRetriever) Get(ctx context.Context, runtimeName string, sandboxAnnotations map[string]string) RuntimeHandlerHooks {
-	if strings.Contains(runtimeName, HighPerformance) || highPerformanceAnnotationsSpecified(sandboxAnnotations) {
+	if isHighPerformanceRuntime(runtimeName, sandboxAnnotations) {
 		runtimeConfig, ok := hr.config.Runtimes[runtimeName]
 		if !ok {
 			// This shouldn't happen because runtime is already validated

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -84,7 +84,7 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 			c.SetStartFailed(retErr)
 
 			if hooks != nil {
-				if err := hooks.PreStop(ctx, c, sandbox); err != nil {
+				if err := hooks.PreStop(ctx, s.ContainerServer, c, sandbox); err != nil {
 					log.Warnf(ctx, "Failed to run pre-stop hook for container %q: %v", c.ID(), err)
 				}
 			}
@@ -104,7 +104,7 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 	}()
 
 	if hooks != nil {
-		if err := hooks.PreStart(ctx, c, sandbox); err != nil {
+		if err := hooks.PreStart(ctx, s.ContainerServer, c, sandbox); err != nil {
 			return nil, fmt.Errorf("failed to run pre-start hook for container %q: %w", c.ID(), err)
 		}
 	}

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -51,7 +51,7 @@ func (s *Server) stopContainer(ctx context.Context, ctr *oci.Container, timeout 
 
 	hooks := s.hooksRetriever.Get(ctx, sb.RuntimeHandler(), sb.Annotations())
 	if hooks != nil {
-		if err := hooks.PreStop(ctx, ctr, sb); err != nil {
+		if err := hooks.PreStop(ctx, s.ContainerServer, ctr, sb); err != nil {
 			return fmt.Errorf("failed to run pre-stop hook for container %q: %w", ctr.ID(), err)
 		}
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1175,7 +1175,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	}
 
 	if hooks := s.hooksRetriever.Get(ctx, sb.RuntimeHandler(), sb.Annotations()); hooks != nil {
-		if err := hooks.PreStart(ctx, container, sb); err != nil {
+		if err := hooks.PreStart(ctx, s.ContainerServer, container, sb); err != nil {
 			return nil, fmt.Errorf("failed to run pre-stop hook for container %q: %w", sb.ID(), err)
 		}
 	}


### PR DESCRIPTION
Addresses race conditions issues IRQ SMP affinity management for high-performance hooks.

1. Race conditions from dual locking: The prior patch used separate locks for IRQ SMP affinity and irqbalance configuration files, creating a window where concurrent operations could corrupt system state. This fix consolidates to a single atomic lock protecting the entire read-calculate-write cycle for both /proc/irq/default_smp_affinity and /etc/sysconfig/irqbalance.
2. Kubelet container replacement timing: Addresses scenarios where kubelet starts replacement containers before deleting old ones, leading to incorrect IRQ affinity calculations. The new idempotent approach recalculates complete state from all running containers rather than incremental updates, ensuring consistent results regardless of container lifecycle timing. In order to achieve this, it keeps a list of containers which passed PreStop, as crio doesn't do that.
3. systemctl restart limitations: While adding reference to PR8834's systemd StartLimitBurst workaround, the implementation recognizes that rapid systemctl restarts are inherently problematic (concurrent restarts are ignored while service is  restarting).

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug

#### What this PR does / why we need it:

Fix race condition in IRQ balance configuration

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

This is a follow-up to https://github.com/cri-o/cri-o/pull/9228 which did not fix all race conditions

#### Special notes for your reviewer:

##### One big fat lock 

The current approach assumes that we cannot rely on optimistic concurrency.

The section under mutex lock is pretty large and a bit too complex for my taste. No matter how much I think about it, I cannot remove the containerServer.ListContainers() operations from within the lock.

```
	// Moving ListContainers outside of the lock instead of inside calcIRQSMPAffinityCPUs under the lock.
	// a) On add operations, we don't list at all --> it's o.k. for add
	// b) On delete operations, the following potential race scenario should be ok thanks to the prestopping list.
	// 	  The potential race scenario without putting the list operation under a lock. Assuming X and Y share same
	//    static set:
	//    1. Thread A: Lock -> Container X enters prestopping -> Unlock
	//    2. Thread A: ListContainers() outside lock → sees container Y
	//    3. Thread B: Lock -> Container Y enters prestop, adds itself to in-prestopping -> Unlock
	//    4. Thread B: Lock -> updates IRQ files (without X, without Y) -> Unlock
	//    5. Thread B: container Y is deleted from cri-o
	//    6. Thread A: Lock -> calculates based on stale list including Y; however, prestopping contains Y,
	//                 updates IRQ files (without X, without Y) -> Unlock
        //   c) But on delete, the following races:
	// 	  The race scenario:
	//    1. Thread A: Lock -> Container X enters prestopping -> Unlock
	//    2. Thread A: ListContainers() outside lock → container Y not yet started
	//    3. Thread B: Container Y starts, locks, updates IRQ files, sets IRQs correctly, unlocks
	//    6. Thread A: Lock -> calculates based on stale list without Y;
	//                 updates IRQ files (without X, without Y) -> Unlock
	//    ---> RACE
```

The alternative is having crio manage all IRQ SMP CPUs and having it recalculate the entire set based on a timer. I.e., running a go func() when the highperformancehook is first initialized that checks and corrects want vs have affinity every second (?). That way, we could use optimistic concurrency on container prestart / prestop. But that would mean that crio manages all IRQ SMP CPUs and resets them to what it wants, using infra_ctr_cpuset to mark the unmanaged CPU set.

##### how to reproduce / smoke test

Here's a deployment which reproduces the race conditions:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    app: qos-demo
  name: qos-demo
spec:
  replicas: 3
  selector:
    matchLabels:
      app: qos-demo
  strategy: {}
  template:
    metadata:
      name: qos-demo
      labels:
        app: qos-demo
      annotations:
        irq-load-balancing.crio.io: "disable"
    spec:
      hostNetwork: true
      runtimeClassName: performance-sno-pp
      containers:
      - name: qos-demo-ctr-1
        image: quay.io/akaris/nice-test
        command:
        - "/bin/sleep"
        - "infinity"
        resources:
          limits:
            memory: "100Mi"
            cpu: "2"
          requests:
            memory: "100Mi"
            cpu: "2"
        livenessProbe:
          exec:
            command:
            - cat
            - /tmp/healthy
          initialDelaySeconds: 5
          periodSeconds: 5
      - name: qos-demo-ctr-2
        image: quay.io/akaris/nice-test
        command:
        - "/bin/sleep"
        - "infinity"
        resources:
          limits:
            memory: "100Mi"
            cpu: "2"
          requests:
            memory: "100Mi"
            cpu: "2"
        livenessProbe:
          exec:
            command:
            - cat
            - /tmp/healthy
          initialDelaySeconds: 1
          periodSeconds: 1
      - name: qos-demo-ctr-3
        image: quay.io/akaris/nice-test
        command:
        - "/bin/sleep"
        - "infinity"
        resources:
          limits:
            memory: "100Mi"
            cpu: "2"
          requests:
            memory: "100Mi"
            cpu: "2"
      - name: qos-demo-ctr-4
        image: quay.io/akaris/nice-test
        command:
        - "/bin/sleep"
        - "infinity"
        resources:
          limits:
            memory: "100Mi"
            cpu: "2"
          requests:
            memory: "100Mi"
            cpu: "2"
      - name: qos-demo-ctr-5
        image: quay.io/akaris/nice-test
        command:
        - "/bin/sleep"
        - "infinity"
        resources:
          limits:
            memory: "100Mi"
            cpu: "2"
          requests:
            memory: "100Mi"
            cpu: "2"
```

Smoke test:
```
mkdir -p /etc/systemd/system/irqbalance.service.d
cat <<'EOF' > /etc/systemd/system/irqbalance.service.d/restart-limits.conf
# cri-o high performance runtime handler reconfigures and restarts irqbalance
# after every container with pinned cpus and moved interrupts is created.
# Systemd does not like this and will block further restarts when the
# StartLimitBurst (default 5) is crossed within the default timeout (10s).
# That is too strict as during system startup many such containers might
# be launched.
# Install this to /etc/systemd/system/irqbalance.service.d/restart-limits.conf
# to prevent systemd from blocking the necessary restarts.
[Unit]
StartLimitBurst=100
EOF
systemctl daemon-reload
```

```
mv /usr/sbin/irqbalance{,.back}
cat <<'EOF' > /usr/sbin/irqbalance
# cat /usr/sbin/irqbalance
#!/bin/bash

log_file=/tmp/irqbalance.mock.log

echo "$(env | tr '\n' ' ') $@" >> $log_file
/usr/sbin/irqbalance.back "$@"
EOF
chmod +x /usr/sbin/irqbalance.back
```

```
cat <<'EOF' > smoke.sh
#!/bin/bash

set -x

affinity_file="/proc/irq/default_smp_affinity"
banned_file="/etc/sysconfig/irqbalance"
expected_reset_affinity="3fff"
expected_affinity="3e0f"
expected_reset_banned="IRQBALANCE_BANNED_CPUS=\"0000c000\""
expected_banned="IRQBALANCE_BANNED_CPUS=\"0000c1f0\""
expected_irqbalance_oneshots=10
# The delete runs systemctl restart in such quick succession that it shows only once (or more).
expected_irqbalance_restarts=6

echo $expected_reset_affinity > $affinity_file
cat $affinity_file

check() {
	expected_a="$1"
	expected_b="$2"

	affinity=$(cat ${affinity_file} | tr -d '\n')
        echo "Got affinity: $affinity, expected affinity: $expected_a"
        if [ "${affinity}" != "${expected_a}" ]; then
            exit 1
        fi
	banned=$(grep -E "^IRQBALANCE_BANNED_CPUS=" ${banned_file} | tr -d '\n')
        echo "Got banned: '$banned', expected banned: '$expected_b'"
        if [ "${banned}" != "${expected_b}" ]; then
            exit 1
        fi
}

# irqbalance --oneshot
systemctl disable --now irqbalance
for i in {0..5}; do
	set +x
	echo "========"
	echo "Run ${i}"
	echo "========"
	set -x
	irqbalance_restarts_start=$(grep "oneshot" /tmp/irqbalance.mock.log | wc -l)

	kubectl apply -f pod.yaml
	kubectl wait --for=condition=Ready pod/qos-demo --timeout=180s
	echo "After set:"
	check "$expected_affinity" "$expected_banned"
        kubectl delete pod qos-demo
        kubectl wait --for=delete pod/qos-demo --timeout=180s
	echo "After reset:"
	check "$expected_reset_affinity" "$expected_reset_banned"

	irqbalance_restarts_end=$(grep "oneshot" /tmp/irqbalance.mock.log | wc -l)
	irqbalance_restarts=$((irqbalance_restarts_end - irqbalance_restarts_start))
	echo "Got $irqbalance_restarts irqbalance --oneshot runs"
	if [ "$irqbalance_restarts" != "$expected_irqbalance_oneshots" ]; then
	    exit 1
	fi
done

# systemctl restart irqbalance
systemctl enable --now irqbalance
for i in {0..5}; do
	set +x
	echo "========"
	echo "Run ${i}"
	echo "========"
	set -x
	irqbalance_restarts_start=$(journalctl -u irqbalance --boot | grep "Started irqbalance daemon" | wc -l)

	kubectl apply -f pod.yaml
	kubectl wait --for=condition=Ready pod/qos-demo --timeout=180s
	echo "After set:"
	check "$expected_affinity" "$expected_banned"
        kubectl delete pod qos-demo
        kubectl wait --for=delete pod/qos-demo --timeout=180s
	echo "After reset:"
	check "$expected_reset_affinity" "$expected_reset_banned"

	irqbalance_restarts_end=$(journalctl -u irqbalance --boot | grep "Started irqbalance daemon" | wc -l)
	irqbalance_restarts=$((irqbalance_restarts_end - irqbalance_restarts_start))
	echo "Got $irqbalance_restarts irqbalance restarts"
	if [ "$irqbalance_restarts" -lt "$expected_irqbalance_restarts" ]; then
	    exit 1
	fi
done
EOF
chmod +x smoke.sh
```

```
cat <<'EOF' > pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: qos-demo
  annotations:
    irq-load-balancing.crio.io: "disable"
spec:
  hostNetwork: true
  runtimeClassName: performance-performance
  containers:
  - name: qos-demo-ctr-1
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
  - name: qos-demo-ctr-2
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
  - name: qos-demo-ctr-3
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
  - name: qos-demo-ctr-4
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
  - name: qos-demo-ctr-5
    image: quay.io/akaris/nice-test
    command:
    - "/bin/sleep"
    - "infinity"
    resources:
      limits:
        memory: "100Mi"
        cpu: "1"
      requests:
        memory: "100Mi"
        cpu: "1"
EOF
```

```
smoke.sh
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
