### PR TITLE
Update install.md - Add Dep for Ubuntu 24

### DIFF
--- a/install.md
+++ b/install.md
@@ -236,6 +236,7 @@ apt-get update -qq && apt-get install -y \
 ```shell
 apt update -qq && apt install -y \
   libbtrfs-dev \
+  golang-go \
   golang-github-containers-common \
   git \
   libassuan-dev \


### PR DESCRIPTION
I added "golang-go" explicitly to the apt install Ubuntu 24 section, it might be something odd/interesting on my end but when I ran the install list as currently given I got "go not found", which explicitly installing golang-go fixed, so I thought I'd add it here.

To show the steps I took with editing, I ran:
```
root@ubuntu-linux-2404:~# apt update -qq && apt install -y \
  libbtrfs-dev \
  golang-github-containers-common \
  git \
  libassuan-dev \
  libglib2.0-dev \
  libc6-dev \
  libgpgme-dev \
  libgpg-error-dev \
  libseccomp-dev \
  libsystemd-dev \
  libselinux1-dev \
  pkg-config \
  go-md2man \
  crun \
  libudev-dev \
  software-properties-common \
  gcc \
  make
7 packages can be upgraded. Run 'apt list --upgradable' to see them.
etc
```

Clone cri-o, cd in, then

```
root@ubuntu-linux-2404:~/cri-o# make
hack/libsubid_tag.sh: line 2: go: command not found
go build -trimpath  -ldflags '-s -w -X github.com/cri-o/cri-o/internal/version.buildDate='2025-08-02T18:13:27Z' ' -tags "containers_image_ostree_stub     seccomp selinux "  -o bin/crio ./cmd/crio
/bin/sh: 1: go: not found
make: *** [Makefile:213: bin/crio] Error 127
```

Then:
```
root@ubuntu-linux-2404:~/cri-o# apt install golang-go
Reading package lists... Done
Building dependency tree... Done
etc
```
Then make succeeds:
```
root@ubuntu-linux-2404:~/cri-o# make
go: downloading go1.24.3 (linux/arm64)
etc
root@ubuntu-linux-2404:~/cri-o# echo $?
0
```

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Documentation
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
Possibly make someone else's install path on Ubuntu 24 easier.
#### Which issue(s) this PR fixes:
None, didn't open an issue.
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
