### PR TITLE
server: add real-time memory validation for limit updates

### DIFF
--- a/internal/config/cgmgr/cgmgr_linux.go
+++ b/internal/config/cgmgr/cgmgr_linux.go
@@ -29,9 +29,9 @@ const (
 
 	// these constants define the path and name of the memory max file
 	// for v1 and v2 respectively.
-	cgroupMemoryPathV1    = "/sys/fs/cgroup/memory"
+	CgroupMemoryPathV1    = "/sys/fs/cgroup/memory"
 	cgroupMemoryMaxFileV1 = "memory.limit_in_bytes"
-	cgroupMemoryPathV2    = "/sys/fs/cgroup"
+	CgroupMemoryPathV2    = "/sys/fs/cgroup"
 	cgroupMemoryMaxFileV2 = "memory.max"
 )
 
@@ -105,13 +105,13 @@ func SetCgroupManager(cgroupManager string) (CgroupManager, error) {
 	case cgroupfsCgroupManager:
 		if node.CgroupIsV2() {
 			return &CgroupfsManager{
-				memoryPath:    cgroupMemoryPathV2,
+				memoryPath:    CgroupMemoryPathV2,
 				memoryMaxFile: cgroupMemoryMaxFileV2,
 			}, nil
 		}
 
 		return &CgroupfsManager{
-			memoryPath:    cgroupMemoryPathV1,
+			memoryPath:    CgroupMemoryPathV1,
 			memoryMaxFile: cgroupMemoryMaxFileV1,
 			v1CtrCgMgr:    make(map[string]cgroups.Manager),
 			v1SbCgMgr:     make(map[string]cgroups.Manager),

--- a/internal/config/cgmgr/systemd_linux.go
+++ b/internal/config/cgmgr/systemd_linux.go
@@ -42,10 +42,10 @@ type SystemdManager struct {
 func NewSystemdManager() *SystemdManager {
 	systemdMgr := SystemdManager{}
 	if node.CgroupIsV2() {
-		systemdMgr.memoryPath = cgroupMemoryPathV2
+		systemdMgr.memoryPath = CgroupMemoryPathV2
 		systemdMgr.memoryMaxFile = cgroupMemoryMaxFileV2
 	} else {
-		systemdMgr.memoryPath = cgroupMemoryPathV1
+		systemdMgr.memoryPath = CgroupMemoryPathV1
 		systemdMgr.memoryMaxFile = cgroupMemoryMaxFileV1
 		systemdMgr.v1CtrCgMgr = make(map[string]cgroups.Manager)
 		systemdMgr.v1SbCgMgr = make(map[string]cgroups.Manager)

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -44,6 +44,11 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *types.Update
 			updated = req.GetLinux()
 		}
 
+		// Validate memory update before applying it.
+		if err := s.validateMemoryUpdate(ctx, c, updated.GetMemoryLimitInBytes()); err != nil {
+			return nil, fmt.Errorf("memory validation failed: %w", err)
+		}
+
 		resources := toOCIResources(updated)
 		if err := s.ContainerServer.Runtime().UpdateContainer(ctx, c, resources); err != nil {
 			return nil, err

--- a/server/container_update_resources_linux.go
+++ b/server/container_update_resources_linux.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/internal/oci"
+)
+
+// validateMemoryUpdate checks if the new memory limit is safe to apply by getting current usage from CRI-O's stats server.
+// This ensures real-time accuracy and prevents decreasing memory limits below current usage.
+func (s *Server) validateMemoryUpdate(ctx context.Context, c *oci.Container, newMemoryLimit int64) error {
+	// Negative memory limits are invalid
+	if newMemoryLimit < 0 {
+		return fmt.Errorf("invalid memory limit: %d bytes (cannot be negative)", newMemoryLimit)
+	}
+
+	// Zero means unlimited memory, no validation needed.
+	if newMemoryLimit == 0 {
+		return nil
+	}
+
+	sb := s.GetSandbox(c.Sandbox())
+	if sb == nil {
+		log.Warnf(ctx, "Could not get sandbox %s for container %s", c.Sandbox(), c.ID())
+
+		return nil
+	}
+
+	containerStats := s.StatsForContainer(c, sb)
+	if containerStats == nil {
+		log.Warnf(ctx, "No memory stats available for container %s", c.ID())
+
+		return nil
+	}
+
+	usageBytes := containerStats.GetMemory().GetUsageBytes()
+	if usageBytes == nil {
+		log.Warnf(ctx, "Memory usage not available for container %s", c.ID())
+
+		return nil
+	}
+
+	currentUsage := int64(usageBytes.GetValue())
+
+	// Check if new limit is below current usage.
+	if newMemoryLimit < currentUsage {
+		return fmt.Errorf("cannot decrease memory limit to %d bytes: current usage is %d bytes",
+			newMemoryLimit, currentUsage)
+	}
+
+	log.Debugf(ctx, "Memory validation passed: new limit %d >= current usage %d",
+		newMemoryLimit, currentUsage)
+
+	return nil
+}

--- a/server/container_update_resources_unsupported.go
+++ b/server/container_update_resources_unsupported.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cri-o/cri-o/internal/oci"
+)
+
+// validateMemoryUpdate is a no-op on non-Linux platforms since cgroups don't exist.
+// However, we still validate basic input constraints.
+func (s *Server) validateMemoryUpdate(ctx context.Context, c *oci.Container, newMemoryLimit int64) error {
+	// Negative memory limits are invalid
+	if newMemoryLimit < 0 {
+		return fmt.Errorf("invalid memory limit: %d bytes (cannot be negative)", newMemoryLimit)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This change validates memory limits against current usage from cgroup files instead of stale cAdvisor cache.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
server: add real-time memory validation for limit updates
```
