### PR TITLE
Add support for conmon-rs log driver and heaptrack config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containernetworking/plugins v1.7.1
 	github.com/containers/common v0.64.1
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/conmon-rs v0.7.1
+	github.com/containers/conmon-rs v0.7.2
 	github.com/containers/image/v5 v5.36.1
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/containers/common v0.64.1 h1:E8vSiL+B84/UCsyVSb70GoxY9cu+0bseLujm4EKF
 github.com/containers/common v0.64.1/go.mod h1:CtfQNHoCAZqWeXMwdShcsxmMJSeGRgKKMqAwRKmWrHE=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/conmon-rs v0.7.1 h1:moyLfCU6tmu7hDAxJXLp225HXLLN0jPa/9ZyOB+mC1k=
-github.com/containers/conmon-rs v0.7.1/go.mod h1:htNM9ZwmApnrxCDfX6EdCQG1G1pZTTAvEm9sY2+FiOo=
+github.com/containers/conmon-rs v0.7.2 h1:FwBHa0v3Cb6WvrXqiLmQ67WGcDY8SaFlhSKck4g2eKU=
+github.com/containers/conmon-rs v0.7.2/go.mod h1:KphPSdEB/4XnEAaNMJavrGYg0+KHX9hx50LeKm4QaSY=
 github.com/containers/image/v5 v5.36.1 h1:6zpXBqR59UcAzoKpa/By5XekeqFV+htWYfr65+Cgjqo=
 github.com/containers/image/v5 v5.36.1/go.mod h1:b4GMKH2z/5t6/09utbse2ZiLK/c72GuGLFdp7K69eA4=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1290,6 +1290,11 @@ const templateStringCrioRuntimeRuntimesRuntimeHandler = `# The "crio.runtime.run
 #   should be moved to the container's cgroup
 # - monitor_env (optional, array of strings): Environment variables to pass to the monitor.
 #   Replaces deprecated option "conmon_env".
+#   When using the pod runtime and conmon-rs, then the monitor_env can be used to further configure
+#   conmon-rs by using:
+#     - LOG_DRIVER=[none,systemd,stdout] - Enable logging to the configured target, defaults to none.
+#     - HEAPTRACK_OUTPUT_PATH=/path/to/dir - Enable heaptrack profiling and save the files to the set directory.
+#     - HEAPTRACK_BINARY_PATH=/path/to/heaptrack - Enable heaptrack profiling and use set heaptrack binary.
 # - platform_runtime_paths (optional, map): A mapping of platforms to the corresponding
 #   runtime executable paths for the runtime handler.
 # - container_min_memory (optional, string): The minimum memory that must be set for a container.

--- a/vendor/github.com/containers/conmon-rs/pkg/client/consts.go
+++ b/vendor/github.com/containers/conmon-rs/pkg/client/consts.go
@@ -29,6 +29,9 @@ const (
 type LogDriver string
 
 const (
+	// LogDriverNone disables logging.
+	LogDriverNone LogDriver = "none"
+
 	// LogDriverStdout is the log driver printing to stdio.
 	LogDriverStdout LogDriver = "stdout"
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -286,7 +286,7 @@ github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit
 github.com/containers/conmon/runner/config
-# github.com/containers/conmon-rs v0.7.1
+# github.com/containers/conmon-rs v0.7.2
 ## explicit; go 1.24.0
 github.com/containers/conmon-rs/internal/proto
 github.com/containers/conmon-rs/pkg/client


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:

Reuse `monitor_env` to pass down the options to the pod runtime (conmon-rs).

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added support for conmon-rs log driver and heaptrack config by using the `monitor_env` runtime configuration.
```
