### PR TITLE
Cleanup container user log message and trivial code

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -252,7 +252,7 @@ func setupContainerUser(ctx context.Context, specgen *generate.Generator, rootfs
 		imageUser,
 		sc.GetRunAsUser(),
 	)
-	log.Debugf(ctx, "CONTAINER USER: %+v", containerUser)
+	log.Debugf(ctx, "Container user: %q", containerUser)
 
 	// Add uid, gid and groups from user
 	uid, gid, addGroups, err := utils.GetUserInfo(rootfs, containerUser)
@@ -374,10 +374,6 @@ func generateUserString(username, imageUser string, uid *types.Int64Value) strin
 	// We use the user from the image config if nothing is provided
 	if userstr == "" {
 		userstr = imageUser
-	}
-
-	if userstr == "" {
-		return ""
 	}
 
 	return userstr


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
The log message is pretty old, but we should keep the information around by stating the user even when it's an empty string.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/issues/9416
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed `CONTAINER USER: …` debug log message to become `Container user: "…"`.
```
