### PR TITLE
Update dependencies.yaml if required on release cut

### DIFF
--- a/scripts/release/release.go
+++ b/scripts/release/release.go
@@ -111,6 +111,10 @@ func updateVersionAndCreatePR(
 		return fmt.Errorf("unable to update version file: %w", err)
 	}
 
+	if err := updateDependenciesYAML(oldVersion, newVersion); err != nil {
+		return fmt.Errorf("unable to update dependencies YAML file: %w", err)
+	}
+
 	logrus.Info("Committing changes")
 
 	if err := repo.Add(utils.VersionFile); err != nil {
@@ -166,6 +170,26 @@ func modifyVersionFile(filePath, oldVersion, newVersion string) error {
 	err = os.WriteFile(filePath, modifiedContent, 0o644)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func updateDependenciesYAML(oldVersion, newVersion string) error {
+	const fileName = "dependencies.yaml"
+
+	content, err := os.ReadFile(fileName)
+	if err != nil {
+		return fmt.Errorf("read file %s: %w", fileName, err)
+	}
+
+	const developmentVersion = "name: development version\n    version: "
+
+	modifiedContent := bytes.ReplaceAll(content, []byte(developmentVersion+oldVersion), []byte(developmentVersion+newVersion))
+
+	err = os.WriteFile(fileName, modifiedContent, 0o644)
+	if err != nil {
+		return fmt.Errorf("update file %s: %w", fileName, err)
 	}
 
 	return nil


### PR DESCRIPTION


#### What type of PR is this?


/kind ci

#### What this PR does / why we need it:
This allows to update the dependencies.yaml file if it contains the 'development version' (from 1.33). This will cause not to break CI for those branches anymore. Previous branches should be unaffected by this change.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
