### PR TITLE
fix: avoid fully numeric usernames in generated passwd files

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -203,6 +203,19 @@ func GetUserInfo(rootfs, userName string) (uid, gid uint32, additionalGids []uin
 	return uid, gid, additionalGids, nil
 }
 
+// IsFullyNumeric checks if a string contains only digits
+func IsFullyNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // GeneratePasswd generates a container specific passwd file,
 // iff uid is not defined in the containers /etc/passwd.
 func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir string) (string, error) {
@@ -226,6 +239,12 @@ func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir st
 
 	if username == "" {
 		username = "default"
+	}
+
+	// Ensure username is not fully numeric to avoid issues on Fedora and Fedora Based systems
+	// See: https://github.com/shadow-maint/shadow/issues/1339
+	if IsFullyNumeric(username) {
+		username = "user" + username
 	}
 
 	if homedir == "" {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR fixes a compatibility issue where CRI-O generates fully numeric usernames (e.g., "1234") that are rejected by systems derived from Fedora and RHEL. The shadow utilities on these systems do not support purely numeric usernames, causing container creation failures. (https://github.com/shadow-maint/shadow/issues/1339)

The fix modifies the `GeneratePasswd` function in `utils/utils.go` to detect fully numeric usernames and prefix them with "user" (e.g., "1234" becomes "user1234"). This ensures compatibility with shadow utilities while maintaining the original numeric identifier for clarity.

#### Which issue(s) this PR fixes:

Fixes #9432 

#### Special notes for your reviewer:
- The fix only affects usernames that are purely numeric (all digits)
- Non-numeric usernames remain unchanged to preserve existing behavior
- Added comprehensive test coverage for the new functionality
- The solution is minimal and maintains backward compatibility
```
[root@a3elp75 cri-o]# ./build/bin/ginkgo run --focus "numeric username" -v utils/
2025/09/01 15:18:16 maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined
Running Suite: Utils - /tmp/cri-o/utils
=======================================
Random Seed: 1756732696

Will run 1 of 39 specs
------------------------------
[BeforeSuite] 
/tmp/cri-o/utils/suite_test.go:20
[BeforeSuite] PASSED [0.000 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
cri-o: Utils cri-o: GetUserInfo and GeneratePasswd should prefix numeric username to avoid issues on Fedora and its derived OS
/tmp/cri-o/utils/utils_test.go:395
• [0.001 seconds]
------------------------------
SSSSSSSSSSS
------------------------------
[AfterSuite] 
/tmp/cri-o/utils/suite_test.go:25
[AfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 1 of 39 Specs in 0.003 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 38 Skipped
PASS
```
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed compatibility issue with Fedora/RHEL-based systems where fully numeric usernames generated by CRI-O were rejected by shadow utilities. Numeric usernames are now automatically prefixed with "user" (e.g., "1234" becomes "user1234").
```
