### PR TITLE
[release-1.33] Backport kata logrotate fix

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -942,29 +942,10 @@ func (r *runtimeVM) createContainerIO(ctx context.Context, c *Container, cioOpts
 		}
 	}()
 
-	f, err := os.OpenFile(c.LogPath(), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	stdout, stderr, err := r.createContainerLoggers(ctx, c.LogPath())
 	if err != nil {
 		return nil, err
 	}
-
-	var stdoutCh, stderrCh <-chan struct{}
-
-	wc := cioutil.NewSerialWriteCloser(f)
-	stdout, stdoutCh := cio.NewCRILogger(c.LogPath(), wc, cio.Stdout, -1)
-	stderr, stderrCh := cio.NewCRILogger(c.LogPath(), wc, cio.Stderr, -1)
-
-	go func() {
-		if stdoutCh != nil {
-			<-stdoutCh
-		}
-
-		if stderrCh != nil {
-			<-stderrCh
-		}
-
-		log.Debugf(ctx, "Finish redirecting log file %q, closing it", c.LogPath())
-		f.Close()
-	}()
 
 	containerIO.AddOutput(c.LogPath(), stdout, stderr)
 	containerIO.Pipe()
@@ -976,6 +957,35 @@ func (r *runtimeVM) createContainerIO(ctx context.Context, c *Container, cioOpts
 	r.Unlock()
 
 	return containerIO, nil
+}
+
+// createContainerLoggers creates container loggers and return write closer for stdout and stderr.
+func (r *runtimeVM) createContainerLoggers(ctx context.Context, logPath string) (stdout, stderr io.WriteCloser, err error) {
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var stdoutCh, stderrCh <-chan struct{}
+
+	wc := cioutil.NewSerialWriteCloser(f)
+	stdout, stdoutCh = cio.NewCRILogger(logPath, wc, cio.Stdout, -1)
+	stderr, stderrCh = cio.NewCRILogger(logPath, wc, cio.Stderr, -1)
+
+	go func() {
+		if stdoutCh != nil {
+			<-stdoutCh
+		}
+
+		if stderrCh != nil {
+			<-stderrCh
+		}
+
+		log.Debugf(ctx, "Finish redirecting log file %q, closing it", logPath)
+		f.Close()
+	}()
+
+	return stdout, stderr, nil
 }
 
 // PauseContainer pauses a container.
@@ -1227,6 +1237,29 @@ func (r *runtimeVM) PortForwardContainer(ctx context.Context, c *Container, netN
 func (r *runtimeVM) ReopenContainerLog(ctx context.Context, c *Container) error {
 	log.Debugf(ctx, "RuntimeVM.ReopenContainerLog() start")
 	defer log.Debugf(ctx, "RuntimeVM.ReopenContainerLog() end")
+
+	r.Lock()
+	cInfo, ok := r.ctrs[c.ID()]
+	r.Unlock()
+
+	if !ok {
+		return errors.New("could not retrieve container information")
+	}
+
+	// Create new container logger and replace the existing ones.
+	stdoutWC, stderrWC, err := r.createContainerLoggers(ctx, c.LogPath())
+	if err != nil {
+		return err
+	}
+
+	oldStdoutWC, oldStderrWC := cInfo.cio.AddOutput(c.LogPath(), stdoutWC, stderrWC)
+	if oldStdoutWC != nil {
+		oldStdoutWC.Close()
+	}
+
+	if oldStderrWC != nil {
+		oldStderrWC.Close()
+	}
 
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is a cherry-pick of https://github.com/cri-o/cri-o/pull/9433

This commit implements the ReopenContainerLog function. This fixes an issue where kata container logs could not be rotated.

This required duplicating part of the createContainerIO function, so I am moving this in its own subfunction for reuse.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix log rotation not working for containers running with the kata-containers runtime
```
