### PR TITLE
[WIP] OCPBUGS-61220: internal/cgmgr: fix CPU weight setting for cgroup v2

### DIFF
--- a/internal/config/cgmgr/systemd_linux.go
+++ b/internal/config/cgmgr/systemd_linux.go
@@ -192,10 +192,23 @@ func (m *SystemdManager) MoveConmonToCgroup(cid, cgroupParent, conmonCgroup stri
 		}
 
 		if resources.CPU.Shares != nil {
-			props = append(props, systemdDbus.Property{
-				Name:  "CPUShares",
-				Value: dbus.MakeVariant(resources.CPU.Shares),
-			})
+			// For cgroup v2, systemd should automatically convert CPUShares to CPUWeight,
+			// but there are cases where this conversion doesn't work properly.
+			// To ensure compatibility, we explicitly set CPUWeight for cgroup v2 systems.
+			if node.CgroupIsV2() {
+				cpuWeight := cgroups.ConvertCPUSharesToCgroupV2Value(*resources.CPU.Shares)
+				if cpuWeight > 0 {
+					props = append(props, systemdDbus.Property{
+						Name:  "CPUWeight",
+						Value: dbus.MakeVariant(cpuWeight),
+					})
+				}
+			} else {
+				props = append(props, systemdDbus.Property{
+					Name:  "CPUShares",
+					Value: dbus.MakeVariant(resources.CPU.Shares),
+				})
+			}
 		}
 
 		if resources.CPU.Quota != nil {


### PR DESCRIPTION
It resolves Pod InPlace Resize Container test failure where cpu.weight file was empty for Guaranteed QoS pods with restartable init containers. Sometimes, systemd fails to convert CPUShares → CPUWeight for this specific scenario, likely due to how it handles complex pod hierarchies with concurrent containers, but the exact internal mechanism is unclear. This acts more as a safeguard in case systemd doesn’t set the value.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://issues.redhat.com/browse/OCPBUGS-61220

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use systemd property as fallback for cpu weight
```
