### PR TITLE
Implement getDeviceFileMode function to retrieve file mode for devices and update device specifications to include FileMode.

### DIFF
--- a/internal/factory/container/device_linux.go
+++ b/internal/factory/container/device_linux.go
@@ -24,7 +24,9 @@ func getDeviceFileMode(devicePath string) *os.FileMode {
 	if err != nil {
 		return nil
 	}
+
 	mode := stat.Mode()
+
 	return &mode
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind bug

#### What this PR does / why we need it:

Populate the `fileMode` field for devices in the generated OCI spec so that container device permissions match host device permissions. This prevents containers from getting overly permissive (0666) access to devices when using runtimes like crun, improving security and respecting host configuration.

#### Which issue(s) this PR fixes:

Resolves https://github.com/cri-o/cri-o/issues/9358

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

Minimal change: retrieves device file permissions via `os.Stat` and sets `fileMode` in `spec.LinuxDevice`. Falls back to current behavior if stat fails.

#### Does this PR introduce a user-facing change?

Device permissions inside containers now reflect the host device permissions (instead of defaulting to 0666) when using CRI-O with runtimes that support `fileMode` (e.g., crun).

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Device permissions inside containers now reflect the host device permissions (instead of defaulting to 0666) when using CRI-O with runtimes that support `fileMode` (e.g., crun).
```