### PR TITLE
include workload allowed_annotations in crio config output

### DIFF
--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1408,6 +1408,9 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 {{ $.Comment }}[crio.runtime.workloads.{{ $workload_type }}]
 {{ $.Comment }}activation_annotation = "{{ $workload_config.ActivationAnnotation }}"
 {{ $.Comment }}annotation_prefix = "{{ $workload_config.AnnotationPrefix }}"
+{{ if gt (len $workload_config.AllowedAnnotations) 0 }}{{ $.Comment }}allowed_annotations = [
+{{ range $opt := $workload_config.AllowedAnnotations }}{{ $.Comment }}{{ printf "\t%q," $opt }}
+{{ end }}{{ $.Comment }}]{{ end }}
 {{ if $workload_config.Resources }}{{ $.Comment }}[crio.runtime.workloads.{{ $workload_type }}.resources]
 {{ $.Comment }}cpuset = "{{ $workload_config.Resources.CPUSet }}"
 {{ $.Comment }}cpuquota = {{ $workload_config.Resources.CPUQuota }}

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1408,9 +1408,9 @@ const templateStringCrioRuntimeWorkloads = `# The workloads table defines ways t
 {{ $.Comment }}[crio.runtime.workloads.{{ $workload_type }}]
 {{ $.Comment }}activation_annotation = "{{ $workload_config.ActivationAnnotation }}"
 {{ $.Comment }}annotation_prefix = "{{ $workload_config.AnnotationPrefix }}"
-{{ if gt (len $workload_config.AllowedAnnotations) 0 }}{{ $.Comment }}allowed_annotations = [
-{{ range $opt := $workload_config.AllowedAnnotations }}{{ $.Comment }}{{ printf "\t%q," $opt }}
-{{ end }}{{ $.Comment }}]{{ end }}
+{{ $.Comment }}allowed_annotations = [
+{{ range $opt := $workload_config.AllowedAnnotations }}{{ $.Comment }}{{ printf "\t%q,\n" $opt }}
+{{ end }}{{ $.Comment }}]
 {{ if $workload_config.Resources }}{{ $.Comment }}[crio.runtime.workloads.{{ $workload_type }}.resources]
 {{ $.Comment }}cpuset = "{{ $workload_config.Resources.CPUSet }}"
 {{ $.Comment }}cpuquota = {{ $workload_config.Resources.CPUQuota }}

--- a/pkg/config/template_test.go
+++ b/pkg/config/template_test.go
@@ -46,10 +46,12 @@ var _ = t.Describe("Config", func() {
 			// Then
 			Expect(err).ToNot(HaveOccurred())
 			output := wr.String()
-			Expect(output).To(ContainSubstring("allowed_annotations = ["))
-			Expect(output).To(ContainSubstring(`"io.kubernetes.cri-o.userns-mode",`))
-			Expect(output).To(ContainSubstring(`"io.kubernetes.cri-o.umask",`))
-			Expect(output).To(ContainSubstring(`"io.kubernetes.cri-o.Devices",`))
+			expected := `allowed_annotations = [
+						"io.kubernetes.cri-o.userns-mode",
+						"io.kubernetes.cri-o.umask",
+						"io.kubernetes.cri-o.Devices",
+						]`
+			Expect(output).To(ContainSubstring(expected))
 		})
 
 		It("should not include workload allowed_annotations when empty", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind bug

#### What this PR does / why we need it:

This PR updates `pkg/config/template.go` to include `allowed_annotations` in the generated `crio config` output for each workload.  
Previously, even if `allowed_annotations` were set in `crio.conf`, they were missing from the printed configuration, making it hard for users to verify workload configuration.  

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes https://github.com/cri-o/cri-o/issues/9467

#### Special notes for your reviewer:

- Added template logic to print `allowed_annotations` when non-empty  
- Added unit tests to verify both presence (when set) and absence (when empty)  
- Verified manually that `bin/crio config` now shows `allowed_annotations` as expected 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
crio config` now includes workload `allowed_annotations` when defined in `crio.conf.
```