### PR TITLE
Remove temporary auth files if used

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1459,7 +1459,7 @@ func configureTimezone(tz, containerRunDir, mountPoint, mountLabel, etcPath, con
 
 // verifyImageSignature verifies the signature of a container image.
 func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecifiedImage string, status *storage.ImageResult) error {
-	systemCtx, err := s.contextForNamespace(ctx, userSpecifiedImage, namespace)
+	systemCtx, err := s.contextForNamespace(namespace)
 	if err != nil {
 		return fmt.Errorf("get context for namespace: %w", err)
 	}

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -81,7 +81,7 @@ func (s *Server) CRImportCheckpoint(
 	var restoreArchivePath string
 
 	if restoreStorageImageID != nil {
-		systemCtx, err := s.contextForNamespace(ctx, inputImage, sb.Metadata().GetNamespace())
+		systemCtx, err := s.contextForNamespace(sb.Metadata().GetNamespace())
 		if err != nil {
 			return "", fmt.Errorf("get context for namespace: %w", err)
 		}

--- a/server/image_pull_test.go
+++ b/server/image_pull_test.go
@@ -87,11 +87,6 @@ var _ = t.Describe("ImagePull", func() {
 
 		It("should fail when resolve names errors", func() {
 			// Given
-			gomock.InOrder(
-				imageServerMock.EXPECT().CandidatesForPotentiallyShortImageName(
-					gomock.Any(), "").
-					Return(nil, t.TestError),
-			)
 			// When
 			response, err := sut.PullImage(context.Background(),
 				&types.PullImageRequest{})


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
We now move the namespaced auth files to a unique location for singular usage. This means that CRI-O can also remove the file afterwards, while other parallel pulls can re-use the previous file location for parallel pulls.

#### Which issue(s) this PR fixes:


Follow-up on https://github.com/cri-o/cri-o/pull/9463

#### Special notes for your reviewer:
cc @QiWang19 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
