### PR TITLE
Re-add the `--enable-fixed-path` removal for gpgme

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -3,7 +3,11 @@ let
 in
 self: super:
 {
-  gpgme = (static super.gpgme);
+  gpgme = (static super.gpgme).overrideAttrs (x: {
+    # Drop the --enable-fixed-path:
+    # https://github.com/nixos/nixpkgs/blob/9a79bc99/pkgs/development/libraries/gpgme/default.nix#L94
+    configureFlags = self.lib.lists.remove "--enable-fixed-path=${self.gnupg}/bin" x.configureFlags;
+  });
   libassuan = (static super.libassuan);
   libgpg-error = (static super.libgpg-error);
   libseccomp = (static super.libseccomp);


### PR DESCRIPTION


#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
We still need to drop that to make gpgme work on various systems.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Should fix https://github.com/cri-o/cri-o/issues/9478
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed static build gpgme issue resulting in an "Invalid crypto engine" error on various platforms.
```
