### PR TITLE
Switch to go 1.25

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -220,7 +220,9 @@ jobs:
           TEST_USERNS: ${{ matrix.run.userns }}
           CONTAINER_DEFAULT_RUNTIME: ${{ matrix.run.defaultRuntime }}
       # Codecov
-      - run: sudo go tool covdata textfmt -i="$GOCOVERDIR" -o build/coverage/coverprofile
+      - run: |
+          sudo chown -R $(id -u):$(id -g) build
+          go tool covdata textfmt -i="$GOCOVERDIR" -o build/coverage/coverprofile
       - uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e # v5.1.1
         with:
           files: build/coverage/coverprofile

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: go
-    version: 1.24
+    version: 1.25
     refPaths:
       - path: nix/derivation.nix
-        match: buildGo124Module
+        match: buildGo125Module
       - path: go.mod
         match: go
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.24.6
+go 1.25
 
 module github.com/cri-o/cri-o
 

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,7 +1,7 @@
 { stdenv
 , pkgs
 }:
-with pkgs; buildGo124Module /* use go 1.24 */ {
+with pkgs; buildGo125Module /* use go 1.25 */ {
   name = "cri-o";
   # Use Pure to avoid exuding the .git directory
   src = nix-gitignore.gitignoreSourcePure [ ../.gitignore ] ./..;


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Switch to go1.25 because it will be required for the next k8s release.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Require go 1.25 for building CRI-O.
```
