### PR TITLE
Update log formatting in interceptors to use %+v

### DIFF
--- a/internal/log/interceptors/interceptors.go
+++ b/internal/log/interceptors/interceptors.go
@@ -61,7 +61,7 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 		operationStart := time.Now()
 		operation := filepath.Base(info.FullMethod)
 		newCtx, span := opentelemetry.Tracer().Start(AddRequestNameAndID(ctx, info.FullMethod), info.FullMethod)
-		log.Debugf(newCtx, "Request: %#v", req)
+		log.Debugf(newCtx, "Request: %T: %+v", req, req)
 
 		resp, err := handler(newCtx, req)
 		// record the operation
@@ -73,7 +73,7 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 			log.Debugf(newCtx, "Response error: %+v", err)
 			metrics.Instance().MetricOperationsErrorsInc(operation)
 		} else {
-			log.Debugf(newCtx, "Response: %#v", resp)
+			log.Debugf(newCtx, "Response: %T: %+v", resp, resp)
 		}
 
 		span.End()

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -166,6 +166,9 @@ function assert_log_linking() {
 	[[ "$output" == "$pod_id" ]]
 
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
+	# Make sure the GRPC debug log includes the container config.
+	# https://github.com/cri-o/cri-o/pull/9501.
+	wait_for_log "v1\\.CreateContainerRequest.*podsandbox1-redis"
 	output=$(crictl ps --quiet --state created)
 	[[ "$output" == "$ctr_id" ]]
 

--- a/test/logs.bats
+++ b/test/logs.bats
@@ -46,7 +46,7 @@ function teardown() {
 	sleep 5
 
 	crictl stop -t 10 "$ctr_id" &
-	wait_for_log "Request: &v1.StopContainerRequest"
+	wait_for_log "v1\\.StopContainerRequest"
 	crictl logs -r "$ctr_id"
 	output=$(crictl inspect "$ctr_id" | jq -r ".status.state")
 	[[ "$output" == "CONTAINER_RUNNING" ]]


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

The log format has changed since https://github.com/cri-o/cri-o/pull/9334 .

We changed the format from `%+v` to `%#v` because we thought it sometimes failed to print structs, but it was actually because the structs didn't have values.
For example, VersionRequest is sometimes like `&VersionRequest{Version:,}`:

In [1.33](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/cri-o_cri-o/9194/pull-ci-cri-o-cri-o-main-ci-cgroupv2-e2e-features/1923039946097037312/artifacts/cgroupv2-e2e-features/cri-o-gather/artifacts/journal.log), it's printed with `%+v` as
```
May 15 15:51:45 ci-op-fi2q3184-9d9a4-buildhost crio[9683]: time="2025-05-15T15:51:45.812030634Z" level=debug msg="Request: &VersionRequest{Version:,}" file="interceptors/interceptors.go:64" id=29ca6d2c-933d-4916-a16e-4bf01d1ea977 name=/runtime.v1.RuntimeService/Version
```
but since 1.34 (protobuf dependency change), it's printed `%+v` as
```
time="2025-10-06T11:25:36.83281109Z" level=debug msg="Request: " file="interceptors/interceptors.go:64" id=99be283b-8114-49ae-abab-d6d3b15eefcc name=/runtime.v1.RuntimeService/Version
```
It was not that `%+v` failed to print the struct, but it's just there's no fields to print.

---

After the change from `%+v` to `%#v`, some information was removed, For example, ContainerCreateRequest is printed with `%#v`:
```
time="2025-10-06T11:29:39.511274359Z" level=debug msg="Request: &v1.CreateContainerRequest{state:impl.MessageState{NoUnkeyedLiterals:pragma.NoUnkeyedLiterals{}, DoNotCompare:pragma.DoNotCompare{}, DoNotCopy:pragma.DoNotCopy{}, atomicMessageInfo:(*impl.MessageInfo)(0xc0007afe38)}, PodSandboxId:\"edf07957cd365dc1751e1250cefb1701c8b72f769656261d31ad5851980352f4\", Config:(*v1.ContainerConfig)(0xc00094b560), SandboxConfig:(*v1.PodSandboxConfig)(0xc000a986c0), unknownFields:[]uint8(nil), sizeCache:0}" file="interceptors/interceptors.go:64" id=f9244e40-b6d6-418d-a666-d81605f2fee0 name=/runtime.v1.RuntimeService/CreateContainer
```
but with `%+v`:
```
time="2025-10-06T11:31:26.492458734Z" level=debug msg="Request: pod_sandbox_id:\"c30f8a8d25835a21ff5dcfede7a12200799f70625cd06663cc692dcd70fab685\" config:{metadata:{name:\"trap\" attempt:1} image:{image:\"quay.io/crio/fedora-crio-ci:latest\" user_specified_image:\"quay.io/crio/fedora-crio-ci:latest\"} command:\"/bin/sh\" command:\"-c\" command:\"trap \\\"sleep 600\\\" TERM && sleep 600\" working_dir:\"/\" envs:{key:\"PATH\" value:\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"} envs:{key:\"TERM\" value:\"xterm\"} envs:{key:\"GLIBC_TUNABLES\" value:\"glibc.pthread.rseq=0\"} envs:{key:\"TESTDIR\" value:\"test/dir1\"} envs:{key:\"TESTFILE\" value:\"test/file1\"} labels:{key:\"batch\" value:\"no\"} labels:{key:\"type\" value:\"small\"} annotations:{key:\"daemon\" value:\"crio\"} annotations:{key:\"owner\" value:\"dragon\"} linux:{resources:{cpu_period:10000 cpu_quota:20000 cpu_shares:512 memory_limit_in_bytes:268435456 oom_score_adj:30} security_context:{capabilities:{add_capabilities:\"setuid\" add_capabilities:\"setgid\"} namespace_options:{pid:CONTAINER} selinux_options:{user:\"system_u\" role:\"system_r\" type:\"svirt_lxc_net_t\" level:\"s0:c4,c5\"} run_as_user:{}}}} sandbox_config:{metadata:{name:\"podsandbox1\" uid:\"redhat-test-crio\" namespace:\"redhat.test.crio\" attempt:1} hostname:\"crictl_host\" dns_config:{servers:\"8.8.8.8\"} labels:{key:\"group\" value:\"test\"} annotations:{key:\"com.example.test\" value:\"sandbox annotation\"} annotations:{key:\"owner\" value:\"hmeng\"} annotations:{key:\"security.alpha.kubernetes.io/seccomp/pod\" value:\"unconfined\"} linux:{cgroup_parent:\"pod_123-456.slice\" security_context:{namespace_options:{pid:CONTAINER} selinux_options:{user:\"system_u\" role:\"system_r\" type:\"svirt_lxc_net_t\" level:\"s0:c4,c5\"}}}}" file="interceptors/interceptors.go:64" id=d2b976ef-cfaa-4c2f-b0b1-7819f4a62a70 name=/runtime.v1.RuntimeService/CreateContainer
```

So with `%#v`, `Config` and `SandboxConfig` are hidden. This will make it harder to debug.

This PR changes the format to `%+v` again, and added removed information about the type of request/response.
You can compare how the logs changed by comparing at the ci-cgroupv2-e2e-features CI journal logs.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed GRPC debug log format to be more informative
```
