### PR TITLE
Remove support for `InsecureRegistries` in favor of `registries.conf`

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -495,7 +495,7 @@ Controls how image volumes are handled. The valid values are mkdir, bind and ign
 
 **insecure_registries**=[]
 List of registries to skip TLS verification for pulling images.
-This option is deprecated. Use registries.conf instead.
+This option is deprecated and no longer effective. Use registries.conf instead.
 
 **big_files_temporary_dir**=""
 Path to the temporary directory to use for storing big files, used to store image blobs and data streams related to containers image management.

--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -67,8 +67,7 @@ var _ = t.Describe("Image", func() {
 				SystemRegistriesConfPath: t.MustTempFile("registries"),
 			},
 			ImageConfig: config.ImageConfig{
-				DefaultTransport:   "docker://",
-				InsecureRegistries: []string{},
+				DefaultTransport: "docker://",
 			},
 		}
 
@@ -104,8 +103,7 @@ var _ = t.Describe("Image", func() {
 					SystemRegistriesConfPath: "../../test/registries.conf",
 				},
 				ImageConfig: config.ImageConfig{
-					DefaultTransport:   "",
-					InsecureRegistries: []string{},
+					DefaultTransport: "",
 				},
 			}
 			imageService, err := storage.GetImageService(
@@ -283,8 +281,7 @@ var _ = t.Describe("Image", func() {
 			config := &config.Config{
 				SystemContext: ctx,
 				ImageConfig: config.ImageConfig{
-					DefaultTransport:   "",
-					InsecureRegistries: []string{},
+					DefaultTransport: "",
 				},
 			}
 			// Create an empty file for the registries config path

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -617,7 +617,7 @@ type ImageConfig struct {
 	SignaturePolicyDir string `toml:"signature_policy_dir"`
 	// InsecureRegistries is a list of registries that must be contacted w/o
 	// TLS verification.
-	// Deprecated: use `insecure` in `registries.conf` instead.
+	// Deprecated: it's no longer effective. Please use `insecure` in `registries.conf` instead.
 	InsecureRegistries []string `toml:"insecure_registries"`
 	// ImageVolumes controls how volumes specified in image config are handled
 	ImageVolumes ImageVolumesType `toml:"image_volumes"`

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1509,7 +1509,7 @@ const templateStringCrioImageSignaturePolicyDir = `# Root path for pod namespace
 const templateStringCrioImageInsecureRegistries = `# List of registries to skip TLS verification for pulling images. Please
 # consider configuring the registries via /etc/containers/registries.conf before
 # changing them here.
-# This option is deprecated. Use registries.conf file instead.
+# This option is deprecated and no longer effective. Use registries.conf file instead.
 {{ $.Comment }}insecure_registries = [
 {{ range $opt := .InsecureRegistries }}{{ $.Comment }}{{ printf "\t%q,\n" $opt }}{{ end }}{{ $.Comment }}]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind deprecation
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR makes `insecureRegistries` no effective.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
part of #9278 
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

I left the option for now.
Let me know if you think it's too early to make it ineffective, or if you think we can remove it completely right now.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Deprecated --insecure-registries option, and made it ineffective.
```
