### PR TITLE
refactor: Reduce cyclomatic complexity from 177 to 60

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -136,7 +136,7 @@ linters:
         - filepathJoin
         - whyNoLint
     gocyclo:
-      min-complexity: 177
+      min-complexity: 60
     nakedret:
       max-func-lines: 15
     revive:

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -98,6 +98,15 @@ func (m criOrderedMounts) parts(i int) int {
 	return strings.Count(filepath.Clean(m[i].GetContainerPath()), string(os.PathSeparator))
 }
 
+// containerImageResult holds the image resolution and verification results.
+type containerImageResult struct {
+	userRequestedImage string
+	imgResult          *storage.ImageResult
+	someNameOfTheImage *references.RegistryImageReference
+	imageID            storage.StorageImageID
+	someRepoDigest     string
+}
+
 // Ensure mount point on which path is mounted, is shared.
 func ensureShared(path string, mountInfos []*mount.Info) error {
 	sourceMount, optionalOpts, err := getSourceMount(path, mountInfos)
@@ -620,7 +629,6 @@ func isInCRIMounts(dst string, mounts []*types.Mount) bool {
 func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Container, sb *sandbox.Sandbox) (cntr *oci.Container, retErr error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
-	// TODO: simplify this function (cyclomatic complexity here is high)
 	// TODO: factor generating/updating the spec into something other projects can vendor
 
 	// eventually, we'd like to access all of these variables through the interface themselves, and do most
@@ -645,93 +653,17 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 
 	specgen := s.getSpecGen(ctr, containerConfig)
 
-	// userRequestedImage is the way to locate the image.
-	// When called by Kubelet, it is either the ImageRef as returned by PullImage
-	// (for us, always a RegistryImageReference using a repo@digest), or an ImageID as returned by ImageStatus (a full StorageImageID).
-	// We accept other inputs, like short names and digest prefixes, because previous CRI-O versions did, just to be conservative against breakage.
-	userRequestedImage, err := ctr.UserRequestedImage()
+	imgInfo, err := s.resolveAndVerifyContainerImage(ctx, ctr, sb)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get imageName and imageID that are later requested in container status
-	var imgResult *storage.ImageResult
-	if id := s.ContainerServer.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
-		imgResult, err = s.ContainerServer.StorageImageServer().ImageStatusByID(s.config.SystemContext, *id)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		potentialMatches, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, userRequestedImage)
-		if err != nil {
-			return nil, err
-		}
-
-		var imgResultErr error
-		for _, name := range potentialMatches {
-			imgResult, imgResultErr = s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, name)
-			if imgResultErr == nil {
-				break
-			}
-		}
-
-		if imgResultErr != nil {
-			return nil, imgResultErr
-		}
-	}
-	// At this point we know userRequestedImage is not empty; "" is accepted by neither HeuristicallyTryResolvingStringAsIDPrefix
-	// nor CandidatesForPotentiallyShortImageName. Just to be sure:
-	if userRequestedImage == "" {
-		return nil, errors.New("internal error: successfully found an image, but userRequestedImage is empty")
-	}
-
-	someNameOfTheImage := imgResult.SomeNameOfThisImage
-	imageID := imgResult.ID
-
-	someRepoDigest := ""
-	if len(imgResult.RepoDigests) > 0 {
-		someRepoDigest = imgResult.RepoDigests[0]
-	}
-	// == Image lookup done.
-	// == NEVER USE userRequestedImage (or even someNameOfTheImage) for anything but diagnostic logging past this point; it might
-	// resolve to a different image.
-
-	if err := s.verifyImageSignature(ctx, sb.Metadata().GetNamespace(), ctr.Config().GetImage().GetUserSpecifiedImage(), imgResult); err != nil {
-		return nil, err
-	}
-
-	labelOptions, err := ctr.SelinuxLabel(sb.ProcessLabel())
+	containerInfo, containerIDMappings, err := s.createStorageContainer(ctx, ctr, sb, imgInfo.userRequestedImage, imgInfo.imageID, containerName, containerID)
 	if err != nil {
 		return nil, err
-	}
-
-	containerIDMappings, err := s.getSandboxIDMappings(ctx, sb)
-	if err != nil {
-		return nil, err
-	}
-
-	var idMappingOptions *cstorage.IDMappingOptions
-	if containerIDMappings != nil {
-		idMappingOptions = &cstorage.IDMappingOptions{UIDMap: containerIDMappings.UIDs(), GIDMap: containerIDMappings.GIDs()}
 	}
 
 	metadata := containerConfig.GetMetadata()
-
-	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage creation")
-
-	containerInfo, err := s.ContainerServer.StorageRuntimeServer().CreateContainer(s.config.SystemContext,
-		sb.Name(), sb.ID(),
-		userRequestedImage, imageID,
-		containerName, containerID,
-		metadata.GetName(),
-		metadata.GetAttempt(),
-		idMappingOptions,
-		labelOptions,
-		ctr.Privileged(),
-	)
-	if err != nil {
-		return nil, err
-	}
 
 	defer func() {
 		if retErr != nil {
@@ -743,43 +675,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		}
 	}()
 
-	mountLabel := containerInfo.MountLabel
-
-	var processLabel string
-	if !ctr.Privileged() {
-		processLabel = containerInfo.ProcessLabel
-	}
-
-	hostIPC := securityContext.GetNamespaceOptions().GetIpc() == types.NamespaceMode_NODE
-	hostPID := securityContext.GetNamespaceOptions().GetPid() == types.NamespaceMode_NODE
-	hostNet := securityContext.GetNamespaceOptions().GetNetwork() == types.NamespaceMode_NODE
-
-	// Don't use SELinux separation with Host Pid or IPC Namespace or privileged.
-	if hostPID || hostIPC {
-		processLabel, mountLabel = "", ""
-	}
-
-	if hostNet && s.config.HostNetworkDisableSELinux {
-		processLabel = ""
-	}
-
-	maybeRelabel := false
-	if val, present := sb.Annotations()[crioann.TrySkipVolumeSELinuxLabelAnnotation]; present && val == "true" {
-		maybeRelabel = true
-	}
-
-	skipRelabel := false
-
-	const superPrivilegedType = "spc_t"
-
-	if securityContext.GetSelinuxOptions().GetType() == superPrivilegedType || // super privileged container
-		(ctr.SandboxConfig().GetLinux() != nil &&
-			ctr.SandboxConfig().GetLinux().GetSecurityContext() != nil &&
-			ctr.SandboxConfig().GetLinux().GetSecurityContext().GetSelinuxOptions() != nil &&
-			ctr.SandboxConfig().GetLinux().GetSecurityContext().GetSelinuxOptions().GetType() == superPrivilegedType && // super privileged pod
-			securityContext.GetSelinuxOptions().GetType() == "") {
-		skipRelabel = true
-	}
+	mountLabel, processLabel, hostNet, maybeRelabel, skipRelabel := s.configureSELinuxLabels(ctr, sb, containerInfo, securityContext)
 
 	cgroup2RW := node.CgroupIsV2() && sb.Annotations()[crioann.Cgroup2RWAnnotation] == "true"
 
@@ -805,7 +701,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		}
 	}()
 
-	containerVolumes, ociMounts, safeMounts, err := s.addOCIBindMounts(ctx, ctr, &containerInfo, maybeRelabel, skipRelabel, cgroup2RW, idMapSupport, rroSupport)
+	containerVolumes, ociMounts, safeMounts, err := s.addOCIBindMounts(ctx, ctr, containerInfo, maybeRelabel, skipRelabel, cgroup2RW, idMapSupport, rroSupport)
 	if err != nil {
 		return nil, err
 	}
@@ -866,31 +762,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 	}
 
 	linux := containerConfig.GetLinux()
-	if linux != nil {
-		resources := linux.GetResources()
-		if resources != nil {
-			containerMinMemory, err := s.ContainerServer.Runtime().GetContainerMinMemory(sb.RuntimeHandler())
-			if err != nil {
-				return nil, err
-			}
 
-			err = ctr.SpecSetLinuxContainerResources(resources, containerMinMemory)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		specgen.SetLinuxCgroupsPath(s.config.CgroupManager().ContainerCgroupPath(sb.CgroupParent(), containerID))
-
-		if len(securityContext.GetMaskedPaths()) != 0 {
-			securityContext.MaskedPaths = appendDefaultMaskedPaths(securityContext.GetMaskedPaths())
-			log.Debugf(ctx, "Using masked paths: %v", strings.Join(securityContext.GetMaskedPaths(), ", "))
-		}
-
-		err = ctr.SpecSetPrivileges(ctx, securityContext, &s.config)
-		if err != nil {
-			return nil, err
-		}
+	if err := s.setupLinuxResources(ctx, ctr, sb, containerID, containerConfig, securityContext, specgen); err != nil {
+		return nil, err
 	}
 
 	if err := ctr.AddUnifiedResourcesFromAnnotations(sb.Annotations()); err != nil {
@@ -920,7 +794,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 
 	containerImageConfig := containerInfo.Config
 	if containerImageConfig == nil {
-		err = fmt.Errorf("empty image config for %s", userRequestedImage)
+		err = fmt.Errorf("empty image config for %s", imgInfo.userRequestedImage)
 
 		return nil, err
 	}
@@ -929,71 +803,14 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		return nil, err
 	}
 
-	// When running on cgroupv2, automatically add a cgroup namespace for not privileged containers.
-	if !ctr.Privileged() && node.CgroupIsV2() {
-		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.CgroupNamespace), ""); err != nil {
-			return nil, err
-		}
+	if err := s.setupCgroupNamespace(ctr, specgen); err != nil {
+		return nil, err
 	}
 
 	addShmMount(ctr, sb)
 
-	options := []string{"rw"}
-	if ctr.ReadOnly(s.config.ReadOnly) {
-		options = []string{"ro"}
-	}
-
-	if sb.ResolvPath() != "" {
-		if err := securityLabel(sb.ResolvPath(), mountLabel, false, false); err != nil {
-			return nil, err
-		}
-
-		ctr.SpecAddMount(rspec.Mount{
-			Destination: "/etc/resolv.conf",
-			Type:        "bind",
-			Source:      sb.ResolvPath(),
-			Options:     append(options, []string{"bind", "nodev", "nosuid", "noexec"}...),
-		})
-	}
-
-	if sb.HostnamePath() != "" {
-		if err := securityLabel(sb.HostnamePath(), mountLabel, false, false); err != nil {
-			return nil, err
-		}
-
-		ctr.SpecAddMount(rspec.Mount{
-			Destination: "/etc/hostname",
-			Type:        "bind",
-			Source:      sb.HostnamePath(),
-			Options:     append(options, "bind"),
-		})
-	}
-
-	if sb.ContainerEnvPath() != "" {
-		if err := securityLabel(sb.ContainerEnvPath(), mountLabel, false, false); err != nil {
-			return nil, err
-		}
-
-		ctr.SpecAddMount(rspec.Mount{
-			Destination: "/run/.containerenv",
-			Type:        "bind",
-			Source:      sb.ContainerEnvPath(),
-			Options:     append(options, "bind"),
-		})
-	}
-
-	if !isInCRIMounts("/etc/hosts", containerConfig.GetMounts()) && hostNet {
-		// Only bind mount for host netns and when CRI does not give us any hosts file
-		ctr.SpecAddMount(rspec.Mount{
-			Destination: "/etc/hosts",
-			Type:        "bind",
-			Source:      "/etc/hosts",
-			Options:     append(options, "bind"),
-		})
-	}
-
-	if ctr.Privileged() {
-		setOCIBindMountsPrivileged(specgen)
+	if err := s.setupContainerMounts(ctr, sb, containerConfig, mountLabel, hostNet, specgen); err != nil {
+		return nil, err
 	}
 
 	// Set hostname and add env for hostname
@@ -1001,86 +818,22 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 	specgen.AddProcessEnv("HOSTNAME", sb.Hostname())
 
 	created := time.Now()
-	seccompRef := types.SecurityProfile_Unconfined.String()
 
-	if err := s.FilterDisallowedAnnotations(sb.Annotations(), imgResult.Annotations, sb.RuntimeHandler()); err != nil {
+	if err := s.FilterDisallowedAnnotations(sb.Annotations(), imgInfo.imgResult.Annotations, sb.RuntimeHandler()); err != nil {
 		return nil, fmt.Errorf("filter image annotations: %w", err)
 	}
 
-	if s.config.Seccomp().IsDisabled() && specgen.Config.Linux != nil {
-		specgen.Config.Linux.Seccomp = nil
-	}
-
-	setupSeccompForPrivCtr := (ctr.Privileged() && s.config.PrivilegedSeccompProfile != "")
-
-	if !ctr.Privileged() || setupSeccompForPrivCtr {
-		if setupSeccompForPrivCtr {
-			// Inject a custom seccomp profile for a privileged container
-			securityContext.Seccomp = &types.SecurityProfile{
-				ProfileType:  types.SecurityProfile_Localhost,
-				LocalhostRef: s.config.PrivilegedSeccompProfile,
-			}
-		}
-
-		seccompConfig, err := s.ContainerServer.Runtime().Seccomp(sb.RuntimeHandler())
-		if err != nil {
-			return nil, err
-		}
-
-		notifier, ref, err := seccompConfig.Setup(
-			ctx,
-			s.config.SystemContext,
-			s.seccompNotifierChan,
-			containerID,
-			ctr.Config().GetMetadata().GetName(),
-			sb.Annotations(),
-			imgResult.Annotations,
-			specgen,
-			securityContext.GetSeccomp(),
-			s.Store().GraphRoot(),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("setup seccomp: %w", err)
-		}
-
-		if notifier != nil {
-			s.seccompNotifiers.Store(containerID, notifier)
-		}
-
-		seccompRef = ref
-	}
-
-	// Get RDT class
-	rdtClass, err := s.ContainerServer.Config().Rdt().ContainerClassFromAnnotations(metadata.GetName(), containerConfig.GetAnnotations(), sb.Annotations())
+	seccompRef, err := s.setupSeccomp(ctx, ctr, sb, containerID, imgInfo.imgResult, securityContext, specgen)
 	if err != nil {
 		return nil, err
 	}
 
-	if rdtClass != "" {
-		log.Debugf(ctx, "Setting RDT ClosID of container %s to %q", containerID, rdt.ResctrlPrefix+rdtClass)
-		// TODO: patch runtime-tools to support setting ClosID via a helper func similar to SetLinuxIntelRdtL3CacheSchema()
-		specgen.Config.Linux.IntelRdt = &rspec.LinuxIntelRdt{ClosID: rdt.ResctrlPrefix + rdtClass}
-	}
-	// compute the runtime path for a given container
-	platform := containerInfo.Config.OS + "/" + containerInfo.Config.Architecture
-
-	runtimePath, err := s.ContainerServer.Runtime().PlatformRuntimePath(sb.RuntimeHandler(), platform)
+	runtimePath, stopSignal, err := s.setupContainerRuntimeAndStopSignal(ctx, ctr, sb, containerID, containerInfo, containerConfig, containerImageConfig, metadata, specgen)
 	if err != nil {
 		return nil, err
 	}
 
-	// Determine the stop signal for the container. If a custom stop signal is provided
-	// via CRI API, use it. Otherwise, fall back to the image's default stop signal as
-	// defined in its configuration.
-	// https://github.com/kubernetes/enhancements/issues/4960
-	stopSignal := containerImageConfig.Config.StopSignal
-
-	if signal := ctr.Config().GetStopSignal(); signal != types.Signal_RUNTIME_DEFAULT {
-		log.Debugf(ctx, "Override stop signal to %s", signal)
-		stopSignal = signal.String()
-	}
-
-	err = ctr.SpecAddAnnotations(ctx, sb, containerVolumes, mountPoint, stopSignal, imgResult, s.config.CgroupManager().IsSystemd(), seccompRef, runtimePath)
+	err = ctr.SpecAddAnnotations(ctx, sb, containerVolumes, mountPoint, stopSignal, imgInfo.imgResult, s.config.CgroupManager().IsSystemd(), seccompRef, runtimePath)
 	if err != nil {
 		return nil, err
 	}
@@ -1089,101 +842,14 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		return nil, err
 	}
 
-	// First add any configured environment variables from crio config.
-	// They will get overridden if specified in the image or container config.
-	specgen.AddMultipleProcessEnv(s.ContainerServer.Config().DefaultEnv)
-
-	// Add environment variables from image the CRI configuration
-	envs := mergeEnvs(containerImageConfig, containerConfig.GetEnvs())
-	for _, e := range envs {
-		parts := strings.SplitN(e, "=", 2)
-		specgen.AddProcessEnv(parts[0], parts[1])
-	}
-
-	// Setup user and groups
-	if linux != nil {
-		if err := setupContainerUser(ctx, specgen, mountPoint, mountLabel, containerInfo.RunDir, securityContext, containerImageConfig); err != nil {
-			return nil, err
-		}
-	}
-
-	// Add image volumes
-	volumeMounts, err := addImageVolumes(ctx, mountPoint, s, &containerInfo, mountLabel, specgen)
+	volumeMounts, err := s.setupContainerEnvironmentAndWorkdir(ctx, specgen, containerConfig, containerImageConfig, containerInfo, mountPoint, mountLabel, linux, securityContext)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set working directory
-	// Pick it up from image config first and override if specified in CRI
-	containerCwd := "/"
-	imageCwd := containerImageConfig.Config.WorkingDir
-
-	if imageCwd != "" {
-		containerCwd = imageCwd
-	}
-
-	runtimeCwd := containerConfig.GetWorkingDir()
-	if runtimeCwd != "" {
-		containerCwd = runtimeCwd
-	}
-
-	specgen.SetProcessCwd(containerCwd)
-
-	if err := setupWorkingDirectory(mountPoint, mountLabel, containerCwd); err != nil {
+	processLabel, err = s.setupContainerMountsAndSystemd(ctr, sb, containerInfo, containerIDMappings, mountPoint, mountLabel, processLabel, ociMounts, volumeMounts, specgen)
+	if err != nil {
 		return nil, err
-	}
-
-	rootUID, rootGID := 0, 0
-
-	if containerIDMappings != nil {
-		rootPair := containerIDMappings.RootPair()
-		rootUID, rootGID = rootPair.UID, rootPair.GID
-	}
-
-	// Add secrets from the default and override mounts.conf files
-	secretMounts := subscriptions.MountsWithUIDGID(
-		mountLabel,
-		containerInfo.RunDir,
-		s.config.DefaultMountsFile,
-		mountPoint,
-		rootUID,
-		rootGID,
-		unshare.IsRootless(),
-		ctr.DisableFips(),
-	)
-
-	if ctr.DisableFips() && sb.Annotations()[crioann.DisableFIPSAnnotation] == "true" {
-		if err := disableFipsForContainer(ctr, containerInfo.RunDir); err != nil {
-			return nil, fmt.Errorf("failed to disable FIPS for container %s: %w", containerID, err)
-		}
-	}
-
-	mounts := []rspec.Mount{}
-	mounts = append(mounts, ociMounts...)
-	mounts = append(mounts, volumeMounts...)
-	mounts = append(mounts, secretMounts...)
-
-	sort.Sort(orderedMounts(mounts))
-
-	for _, m := range mounts {
-		rspecMount := rspec.Mount{
-			Type:        "bind",
-			Options:     append(m.Options, "bind"),
-			Destination: m.Destination,
-			Source:      m.Source,
-			UIDMappings: m.UIDMappings,
-			GIDMappings: m.GIDMappings,
-		}
-		ctr.SpecAddMount(rspecMount)
-	}
-
-	if ctr.WillRunSystemd() {
-		processLabel, err = InitLabel(processLabel)
-		if err != nil {
-			return nil, err
-		}
-
-		setupSystemd(specgen.Mounts(), *specgen)
 	}
 
 	if s.Hooks != nil {
@@ -1220,7 +886,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		Attempt: metadata.GetAttempt(),
 	}
 
-	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().GetAnnotations(), userRequestedImage, someNameOfTheImage, &imageID, someRepoDigest, criMetadata, sb.ID(), containerConfig.GetTty(), containerConfig.GetStdin(), containerConfig.GetStdinOnce(), sb.RuntimeHandler(), containerInfo.Dir, created, stopSignal)
+	ociContainer, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, labels, crioAnnotations, ctr.Config().GetAnnotations(), imgInfo.userRequestedImage, imgInfo.someNameOfTheImage, &imgInfo.imageID, imgInfo.someRepoDigest, criMetadata, sb.ID(), containerConfig.GetTty(), containerConfig.GetStdin(), containerConfig.GetStdinOnce(), sb.RuntimeHandler(), containerInfo.Dir, created, stopSignal)
 	if err != nil {
 		return nil, err
 	}
@@ -1232,89 +898,16 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 
 	ociContainer.SetIDMappings(containerIDMappings)
 
-	if containerIDMappings != nil {
-		s.finalizeUserMapping(sb, specgen, containerIDMappings)
-
-		for _, uidmap := range containerIDMappings.UIDs() {
-			specgen.AddLinuxUIDMapping(uint32(uidmap.HostID), uint32(uidmap.ContainerID), uint32(uidmap.Size))
-		}
-
-		for _, gidmap := range containerIDMappings.GIDs() {
-			specgen.AddLinuxGIDMapping(uint32(gidmap.HostID), uint32(gidmap.ContainerID), uint32(gidmap.Size))
-		}
-
-		for _, path := range []string{mountPoint, containerInfo.RunDir} {
-			if err := makeAccessible(path, rootUID, rootGID); err != nil {
-				return nil, fmt.Errorf("cannot make %s accessible to %d:%d: %w", path, rootUID, rootGID, err)
-			}
-		}
-	} else if err := specgen.RemoveLinuxNamespace(string(rspec.UserNamespace)); err != nil {
+	if err := s.setupContainerIDMappings(sb, specgen, containerIDMappings, mountPoint, containerInfo.RunDir); err != nil {
 		return nil, err
 	}
 
-	if v := sb.Annotations()[crioann.UmaskAnnotation]; v != "" {
-		umaskRegexp := regexp.MustCompile(`^[0-7]{1,4}$`)
-		if !umaskRegexp.MatchString(v) {
-			return nil, fmt.Errorf("invalid umask string %s", v)
-		}
-
-		decVal, err := strconv.ParseUint(sb.Annotations()[crioann.UmaskAnnotation], 8, 32)
-		if err != nil {
-			return nil, err
-		}
-
-		umask := uint32(decVal)
-		specgen.Config.Process.User.Umask = &umask
-	}
-
-	etcPath := filepath.Join(mountPoint, "/etc")
-
-	// Warn users if the container /etc directory path points to a location
-	// that is not a regular directory. This could indicate that something
-	// might be afoot.
-	etc, err := os.Lstat(etcPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err := s.setupContainerUmask(sb, specgen); err != nil {
 		return nil, err
 	}
 
-	if err == nil && !etc.IsDir() {
-		log.Warnf(ctx, "Detected /etc path for container %s is not a directory", ctr.ID())
-	}
-
-	// The /etc directory can be subjected to various attempts on the path (directory)
-	// traversal attacks. As such, we need to ensure that its path will be relative to
-	// the base (or root, if you wish) of the container to mitigate a container escape.
-	etcPath, err = securejoin.SecureJoin(mountPoint, "/etc")
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve container /etc directory path: %w", err)
-	}
-
-	// Create the /etc directory only when it doesn't exist.
-	if _, err := os.Stat(etcPath); err != nil && os.IsNotExist(err) {
-		rootPair := idtools.IDPair{UID: 0, GID: 0}
-		if containerIDMappings != nil {
-			rootPair = containerIDMappings.RootPair()
-		}
-
-		if err := idtools.MkdirAllAndChown(etcPath, 0o755, rootPair); err != nil {
-			return nil, fmt.Errorf("failed to create container /etc directory: %w", err)
-		}
-	}
-
-	// Add a symbolic link from /proc/mounts to /etc/mtab to keep compatibility with legacy
-	// Linux distributions and Docker.
-	//
-	// We cannot use SecureJoin here, as the /etc/mtab can already be symlinked from somewhere
-	// else in some cases, and doing so would resolve an existing mtab path to the symbolic
-	// link target location, for example, the /etc/proc/self/mounts, which breaks container
-	// creation.
-	if err := os.Symlink("/proc/mounts", filepath.Join(etcPath, "mtab")); err != nil && !os.IsExist(err) {
+	if err := s.setupContainerEtcDirectory(ctx, ctr, ociContainer, mountPoint, mountLabel, containerIDMappings); err != nil {
 		return nil, err
-	}
-
-	// Configure timezone for the container if it is set.
-	if err := configureTimezone(s.ContainerServer.Runtime().Timezone(), ociContainer.BundlePath(), mountPoint, mountLabel, etcPath, ociContainer.ID(), options, ctr); err != nil {
-		return nil, fmt.Errorf("failed to configure timezone for container %s: %w", ociContainer.ID(), err)
 	}
 
 	if os.Getenv(rootlessEnvName) != "" {
@@ -1367,6 +960,364 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 	}
 
 	return ociContainer, nil
+}
+
+func (s *Server) setupContainerMountsAndSystemd(ctr container.Container, sb *sandbox.Sandbox, containerInfo *storage.ContainerInfo, containerIDMappings *idtools.IDMappings, mountPoint, mountLabel, processLabel string, ociMounts, volumeMounts []rspec.Mount, specgen *generate.Generator) (string, error) {
+	rootUID, rootGID := 0, 0
+
+	if containerIDMappings != nil {
+		rootPair := containerIDMappings.RootPair()
+		rootUID, rootGID = rootPair.UID, rootPair.GID
+	}
+
+	// Add secrets from the default and override mounts.conf files
+	secretMounts := subscriptions.MountsWithUIDGID(
+		mountLabel,
+		containerInfo.RunDir,
+		s.config.DefaultMountsFile,
+		mountPoint,
+		rootUID,
+		rootGID,
+		unshare.IsRootless(),
+		ctr.DisableFips(),
+	)
+
+	if ctr.DisableFips() && sb.Annotations()[crioann.DisableFIPSAnnotation] == "true" {
+		if err := disableFipsForContainer(ctr, containerInfo.RunDir); err != nil {
+			return "", fmt.Errorf("failed to disable FIPS for container %s: %w", ctr.ID(), err)
+		}
+	}
+
+	mounts := []rspec.Mount{}
+	mounts = append(mounts, ociMounts...)
+	mounts = append(mounts, volumeMounts...)
+	mounts = append(mounts, secretMounts...)
+
+	sort.Sort(orderedMounts(mounts))
+
+	for _, m := range mounts {
+		rspecMount := rspec.Mount{
+			Type:        "bind",
+			Options:     append(m.Options, "bind"),
+			Destination: m.Destination,
+			Source:      m.Source,
+			UIDMappings: m.UIDMappings,
+			GIDMappings: m.GIDMappings,
+		}
+		ctr.SpecAddMount(rspecMount)
+	}
+
+	if ctr.WillRunSystemd() {
+		var err error
+
+		processLabel, err = InitLabel(processLabel)
+		if err != nil {
+			return "", err
+		}
+
+		setupSystemd(specgen.Mounts(), *specgen)
+	}
+
+	return processLabel, nil
+}
+
+func (s *Server) setupContainerEnvironmentAndWorkdir(ctx context.Context, specgen *generate.Generator, containerConfig *types.ContainerConfig, containerImageConfig *v1.Image, containerInfo *storage.ContainerInfo, mountPoint, mountLabel string, linux *types.LinuxContainerConfig, securityContext *types.LinuxContainerSecurityContext) ([]rspec.Mount, error) {
+	// First add any configured environment variables from crio config.
+	// They will get overridden if specified in the image or container config.
+	specgen.AddMultipleProcessEnv(s.ContainerServer.Config().DefaultEnv)
+
+	// Add environment variables from image the CRI configuration
+	envs := mergeEnvs(containerImageConfig, containerConfig.GetEnvs())
+	for _, e := range envs {
+		parts := strings.SplitN(e, "=", 2)
+		specgen.AddProcessEnv(parts[0], parts[1])
+	}
+
+	// Setup user and groups
+	if linux != nil {
+		if err := setupContainerUser(ctx, specgen, mountPoint, mountLabel, containerInfo.RunDir, securityContext, containerImageConfig); err != nil {
+			return nil, err
+		}
+	}
+
+	// Add image volumes
+	volumeMounts, err := addImageVolumes(ctx, mountPoint, s, containerInfo, mountLabel, specgen)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set working directory
+	// Pick it up from image config first and override if specified in CRI
+	containerCwd := "/"
+	imageCwd := containerImageConfig.Config.WorkingDir
+
+	if imageCwd != "" {
+		containerCwd = imageCwd
+	}
+
+	runtimeCwd := containerConfig.GetWorkingDir()
+	if runtimeCwd != "" {
+		containerCwd = runtimeCwd
+	}
+
+	specgen.SetProcessCwd(containerCwd)
+
+	if err := setupWorkingDirectory(mountPoint, mountLabel, containerCwd); err != nil {
+		return nil, err
+	}
+
+	return volumeMounts, nil
+}
+
+func (s *Server) setupSeccomp(ctx context.Context, ctr container.Container, sb *sandbox.Sandbox, containerID string, imgResult *storage.ImageResult, securityContext *types.LinuxContainerSecurityContext, specgen *generate.Generator) (string, error) {
+	seccompRef := types.SecurityProfile_Unconfined.String()
+
+	if s.config.Seccomp().IsDisabled() && specgen.Config.Linux != nil {
+		specgen.Config.Linux.Seccomp = nil
+
+		return seccompRef, nil
+	}
+
+	setupSeccompForPrivCtr := (ctr.Privileged() && s.config.PrivilegedSeccompProfile != "")
+
+	if !ctr.Privileged() || setupSeccompForPrivCtr {
+		if setupSeccompForPrivCtr {
+			// Inject a custom seccomp profile for a privileged container
+			securityContext.Seccomp = &types.SecurityProfile{
+				ProfileType:  types.SecurityProfile_Localhost,
+				LocalhostRef: s.config.PrivilegedSeccompProfile,
+			}
+		}
+
+		seccompConfig, err := s.ContainerServer.Runtime().Seccomp(sb.RuntimeHandler())
+		if err != nil {
+			return "", err
+		}
+
+		notifier, ref, err := seccompConfig.Setup(
+			ctx,
+			s.config.SystemContext,
+			s.seccompNotifierChan,
+			containerID,
+			ctr.Config().GetMetadata().GetName(),
+			sb.Annotations(),
+			imgResult.Annotations,
+			specgen,
+			securityContext.GetSeccomp(),
+			s.Store().GraphRoot(),
+		)
+		if err != nil {
+			return "", fmt.Errorf("setup seccomp: %w", err)
+		}
+
+		if notifier != nil {
+			s.seccompNotifiers.Store(containerID, notifier)
+		}
+
+		seccompRef = ref
+	}
+
+	return seccompRef, nil
+}
+
+func (s *Server) setupContainerMounts(ctr container.Container, sb *sandbox.Sandbox, containerConfig *types.ContainerConfig, mountLabel string, hostNet bool, specgen *generate.Generator) error {
+	options := []string{"rw"}
+	if ctr.ReadOnly(s.config.ReadOnly) {
+		options = []string{"ro"}
+	}
+
+	if sb.ResolvPath() != "" {
+		if err := securityLabel(sb.ResolvPath(), mountLabel, false, false); err != nil {
+			return err
+		}
+
+		ctr.SpecAddMount(rspec.Mount{
+			Destination: "/etc/resolv.conf",
+			Type:        "bind",
+			Source:      sb.ResolvPath(),
+			Options:     append(options, []string{"bind", "nodev", "nosuid", "noexec"}...),
+		})
+	}
+
+	if sb.HostnamePath() != "" {
+		if err := securityLabel(sb.HostnamePath(), mountLabel, false, false); err != nil {
+			return err
+		}
+
+		ctr.SpecAddMount(rspec.Mount{
+			Destination: "/etc/hostname",
+			Type:        "bind",
+			Source:      sb.HostnamePath(),
+			Options:     append(options, "bind"),
+		})
+	}
+
+	if sb.ContainerEnvPath() != "" {
+		if err := securityLabel(sb.ContainerEnvPath(), mountLabel, false, false); err != nil {
+			return err
+		}
+
+		ctr.SpecAddMount(rspec.Mount{
+			Destination: "/run/.containerenv",
+			Type:        "bind",
+			Source:      sb.ContainerEnvPath(),
+			Options:     append(options, "bind"),
+		})
+	}
+
+	if !isInCRIMounts("/etc/hosts", containerConfig.GetMounts()) && hostNet {
+		// Only bind mount for host netns and when CRI does not give us any hosts file
+		ctr.SpecAddMount(rspec.Mount{
+			Destination: "/etc/hosts",
+			Type:        "bind",
+			Source:      "/etc/hosts",
+			Options:     append(options, "bind"),
+		})
+	}
+
+	if ctr.Privileged() {
+		setOCIBindMountsPrivileged(specgen)
+	}
+
+	return nil
+}
+
+// configureSELinuxLabels determines the appropriate SELinux labels for a container based on its
+// security context and namespace configuration. It returns the mount and process labels, along with
+// flags indicating network mode and whether volume relabeling should be skipped or made optional.
+func (s *Server) configureSELinuxLabels(ctr container.Container, sb *sandbox.Sandbox, containerInfo *storage.ContainerInfo, securityContext *types.LinuxContainerSecurityContext) (mountLabel, processLabel string, hostNet, maybeRelabel, skipRelabel bool) {
+	mountLabel = containerInfo.MountLabel
+
+	if !ctr.Privileged() {
+		processLabel = containerInfo.ProcessLabel
+	}
+
+	hostIPC := securityContext.GetNamespaceOptions().GetIpc() == types.NamespaceMode_NODE
+	hostPID := securityContext.GetNamespaceOptions().GetPid() == types.NamespaceMode_NODE
+	hostNet = securityContext.GetNamespaceOptions().GetNetwork() == types.NamespaceMode_NODE
+
+	// Don't use SELinux separation with Host Pid or IPC Namespace or privileged.
+	if hostPID || hostIPC {
+		processLabel, mountLabel = "", ""
+	}
+
+	if hostNet && s.config.HostNetworkDisableSELinux {
+		processLabel = ""
+	}
+
+	if val, present := sb.Annotations()[crioann.TrySkipVolumeSELinuxLabelAnnotation]; present && val == "true" {
+		maybeRelabel = true
+	}
+
+	const superPrivilegedType = "spc_t"
+
+	if securityContext.GetSelinuxOptions().GetType() == superPrivilegedType || // super privileged container
+		(ctr.SandboxConfig().GetLinux() != nil &&
+			ctr.SandboxConfig().GetLinux().GetSecurityContext() != nil &&
+			ctr.SandboxConfig().GetLinux().GetSecurityContext().GetSelinuxOptions() != nil &&
+			ctr.SandboxConfig().GetLinux().GetSecurityContext().GetSelinuxOptions().GetType() == superPrivilegedType && // super privileged pod
+			securityContext.GetSelinuxOptions().GetType() == "") {
+		skipRelabel = true
+	}
+
+	return mountLabel, processLabel, hostNet, maybeRelabel, skipRelabel
+}
+
+// createStorageContainer creates the storage layer container with the specified image and ID mappings.
+// It configures SELinux labels and user namespace mappings as needed for the container.
+func (s *Server) createStorageContainer(ctx context.Context, ctr container.Container, sb *sandbox.Sandbox, userRequestedImage string, imageID storage.StorageImageID, containerName, containerID string) (*storage.ContainerInfo, *idtools.IDMappings, error) {
+	labelOptions, err := ctr.SelinuxLabel(sb.ProcessLabel())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	containerIDMappings, err := s.getSandboxIDMappings(ctx, sb)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var idMappingOptions *cstorage.IDMappingOptions
+	if containerIDMappings != nil {
+		idMappingOptions = &cstorage.IDMappingOptions{UIDMap: containerIDMappings.UIDs(), GIDMap: containerIDMappings.GIDs()}
+	}
+
+	metadata := ctr.Config().GetMetadata()
+
+	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage creation")
+
+	containerInfo, err := s.ContainerServer.StorageRuntimeServer().CreateContainer(s.config.SystemContext,
+		sb.Name(), sb.ID(),
+		userRequestedImage, imageID,
+		containerName, containerID,
+		metadata.GetName(),
+		metadata.GetAttempt(),
+		idMappingOptions,
+		labelOptions,
+		ctr.Privileged(),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &containerInfo, containerIDMappings, nil
+}
+
+// resolveAndVerifyContainerImage resolves the user-requested image reference to a concrete image,
+// verifies its signature policy, and returns detailed image metadata including image ID, names, and digests.
+func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr container.Container, sb *sandbox.Sandbox) (*containerImageResult, error) {
+	userRequestedImage, err := ctr.UserRequestedImage()
+	if err != nil {
+		return nil, err
+	}
+
+	var imgResult *storage.ImageResult
+	if id := s.ContainerServer.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
+		imgResult, err = s.ContainerServer.StorageImageServer().ImageStatusByID(s.config.SystemContext, *id)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		potentialMatches, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, userRequestedImage)
+		if err != nil {
+			return nil, err
+		}
+
+		var imgResultErr error
+		for _, name := range potentialMatches {
+			imgResult, imgResultErr = s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, name)
+			if imgResultErr == nil {
+				break
+			}
+		}
+
+		if imgResultErr != nil {
+			return nil, imgResultErr
+		}
+	}
+
+	if userRequestedImage == "" {
+		return nil, errors.New("internal error: successfully found an image, but userRequestedImage is empty")
+	}
+
+	someNameOfTheImage := imgResult.SomeNameOfThisImage
+	imageID := imgResult.ID
+
+	someRepoDigest := ""
+	if len(imgResult.RepoDigests) > 0 {
+		someRepoDigest = imgResult.RepoDigests[0]
+	}
+
+	if err := s.verifyImageSignature(ctx, sb.Metadata().GetNamespace(), ctr.Config().GetImage().GetUserSpecifiedImage(), imgResult); err != nil {
+		return nil, err
+	}
+
+	return &containerImageResult{
+		userRequestedImage: userRequestedImage,
+		imgResult:          imgResult,
+		someNameOfTheImage: someNameOfTheImage,
+		imageID:            imageID,
+		someRepoDigest:     someRepoDigest,
+	}, nil
 }
 
 func setupWorkingDirectory(rootfs, mountLabel, containerCwd string) error {
@@ -1483,6 +1434,192 @@ func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecif
 		}
 
 		if err := s.ContainerServer.StorageImageServer().IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *Server) setupContainerIDMappings(sb *sandbox.Sandbox, specgen *generate.Generator, containerIDMappings *idtools.IDMappings, mountPoint, containerRunDir string) error {
+	if containerIDMappings != nil {
+		s.finalizeUserMapping(sb, specgen, containerIDMappings)
+
+		for _, uidmap := range containerIDMappings.UIDs() {
+			specgen.AddLinuxUIDMapping(uint32(uidmap.HostID), uint32(uidmap.ContainerID), uint32(uidmap.Size))
+		}
+
+		for _, gidmap := range containerIDMappings.GIDs() {
+			specgen.AddLinuxGIDMapping(uint32(gidmap.HostID), uint32(gidmap.ContainerID), uint32(gidmap.Size))
+		}
+
+		rootPair := containerIDMappings.RootPair()
+		rootUID, rootGID := rootPair.UID, rootPair.GID
+
+		for _, path := range []string{mountPoint, containerRunDir} {
+			if err := makeAccessible(path, rootUID, rootGID); err != nil {
+				return fmt.Errorf("cannot make %s accessible to %d:%d: %w", path, rootUID, rootGID, err)
+			}
+		}
+	} else if err := specgen.RemoveLinuxNamespace(string(rspec.UserNamespace)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Server) setupContainerUmask(sb *sandbox.Sandbox, specgen *generate.Generator) error {
+	if v := sb.Annotations()[crioann.UmaskAnnotation]; v != "" {
+		umaskRegexp := regexp.MustCompile(`^[0-7]{1,4}$`)
+		if !umaskRegexp.MatchString(v) {
+			return fmt.Errorf("invalid umask string %s", v)
+		}
+
+		decVal, err := strconv.ParseUint(sb.Annotations()[crioann.UmaskAnnotation], 8, 32)
+		if err != nil {
+			return err
+		}
+
+		umask := uint32(decVal)
+		specgen.Config.Process.User.Umask = &umask
+	}
+
+	return nil
+}
+
+func (s *Server) setupContainerEtcDirectory(ctx context.Context, ctr container.Container, ociContainer *oci.Container, mountPoint, mountLabel string, containerIDMappings *idtools.IDMappings) error {
+	etcPath := filepath.Join(mountPoint, "/etc")
+
+	// Warn users if the container /etc directory path points to a location
+	// that is not a regular directory. This could indicate that something
+	// might be afoot.
+	etc, err := os.Lstat(etcPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if err == nil && !etc.IsDir() {
+		log.Warnf(ctx, "Detected /etc path for container %s is not a directory", ctr.ID())
+	}
+
+	// The /etc directory can be subjected to various attempts on the path (directory)
+	// traversal attacks. As such, we need to ensure that its path will be relative to
+	// the base (or root, if you wish) of the container to mitigate a container escape.
+	etcPath, err = securejoin.SecureJoin(mountPoint, "/etc")
+	if err != nil {
+		return fmt.Errorf("failed to resolve container /etc directory path: %w", err)
+	}
+
+	// Create the /etc directory only when it doesn't exist.
+	if _, err := os.Stat(etcPath); err != nil && os.IsNotExist(err) {
+		rootPair := idtools.IDPair{UID: 0, GID: 0}
+		if containerIDMappings != nil {
+			rootPair = containerIDMappings.RootPair()
+		}
+
+		if err := idtools.MkdirAllAndChown(etcPath, 0o755, rootPair); err != nil {
+			return fmt.Errorf("failed to create container /etc directory: %w", err)
+		}
+	}
+
+	// Add a symbolic link from /proc/mounts to /etc/mtab to keep compatibility with legacy
+	// Linux distributions and Docker.
+	//
+	// We cannot use SecureJoin here, as the /etc/mtab can already be symlinked from somewhere
+	// else in some cases, and doing so would resolve an existing mtab path to the symbolic
+	// link target location, for example, the /etc/proc/self/mounts, which breaks container
+	// creation.
+	if err := os.Symlink("/proc/mounts", filepath.Join(etcPath, "mtab")); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	// Configure timezone for the container if it is set.
+	options := []string{"rw"}
+	if ctr.ReadOnly(s.config.ReadOnly) {
+		options = []string{"ro"}
+	}
+
+	if err := configureTimezone(s.ContainerServer.Runtime().Timezone(), ociContainer.BundlePath(), mountPoint, mountLabel, etcPath, ociContainer.ID(), options, ctr); err != nil {
+		return fmt.Errorf("failed to configure timezone for container %s: %w", ociContainer.ID(), err)
+	}
+
+	return nil
+}
+
+func (s *Server) setupContainerRuntimeAndStopSignal(ctx context.Context, ctr container.Container, sb *sandbox.Sandbox, containerID string, containerInfo *storage.ContainerInfo, containerConfig *types.ContainerConfig, containerImageConfig *v1.Image, metadata *types.ContainerMetadata, specgen *generate.Generator) (runtimePath, stopSignal string, err error) {
+	// Get RDT class
+	var rdtClass string
+
+	rdtClass, err = s.ContainerServer.Config().Rdt().ContainerClassFromAnnotations(metadata.GetName(), containerConfig.GetAnnotations(), sb.Annotations())
+	if err != nil {
+		return "", "", err
+	}
+
+	if rdtClass != "" {
+		log.Debugf(ctx, "Setting RDT ClosID of container %s to %q", containerID, rdt.ResctrlPrefix+rdtClass)
+		// TODO: patch runtime-tools to support setting ClosID via a helper func similar to SetLinuxIntelRdtL3CacheSchema()
+		specgen.Config.Linux.IntelRdt = &rspec.LinuxIntelRdt{ClosID: rdt.ResctrlPrefix + rdtClass}
+	}
+	// compute the runtime path for a given container
+	platform := containerInfo.Config.OS + "/" + containerInfo.Config.Architecture
+
+	runtimePath, err = s.ContainerServer.Runtime().PlatformRuntimePath(sb.RuntimeHandler(), platform)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Determine the stop signal for the container. If a custom stop signal is provided
+	// via CRI API, use it. Otherwise, fall back to the image's default stop signal as
+	// defined in its configuration.
+	// https://github.com/kubernetes/enhancements/issues/4960
+	stopSignal = containerImageConfig.Config.StopSignal
+
+	if signal := ctr.Config().GetStopSignal(); signal != types.Signal_RUNTIME_DEFAULT {
+		log.Debugf(ctx, "Override stop signal to %s", signal)
+		stopSignal = signal.String()
+	}
+
+	return runtimePath, stopSignal, nil
+}
+
+// setupLinuxResources configures Linux-specific resources and security settings for the container,
+// including resource limits, cgroup paths, masked paths, and privilege settings.
+func (s *Server) setupLinuxResources(ctx context.Context, ctr container.Container, sb *sandbox.Sandbox, containerID string, containerConfig *types.ContainerConfig, securityContext *types.LinuxContainerSecurityContext, specgen *generate.Generator) error {
+	linux := containerConfig.GetLinux()
+	if linux != nil {
+		resources := linux.GetResources()
+		if resources != nil {
+			containerMinMemory, err := s.ContainerServer.Runtime().GetContainerMinMemory(sb.RuntimeHandler())
+			if err != nil {
+				return err
+			}
+
+			err = ctr.SpecSetLinuxContainerResources(resources, containerMinMemory)
+			if err != nil {
+				return err
+			}
+		}
+
+		specgen.SetLinuxCgroupsPath(s.config.CgroupManager().ContainerCgroupPath(sb.CgroupParent(), containerID))
+
+		if len(securityContext.GetMaskedPaths()) != 0 {
+			securityContext.MaskedPaths = appendDefaultMaskedPaths(securityContext.GetMaskedPaths())
+			log.Debugf(ctx, "Using masked paths: %v", strings.Join(securityContext.GetMaskedPaths(), ", "))
+		}
+
+		err := ctr.SpecSetPrivileges(ctx, securityContext, &s.config)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *Server) setupCgroupNamespace(ctr container.Container, specgen *generate.Generator) error {
+	// When running on cgroupv2, automatically add a cgroup namespace for not privileged containers.
+	if !ctr.Privileged() && node.CgroupIsV2() {
+		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.CgroupNamespace), ""); err != nil {
 			return err
 		}
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -33,6 +33,8 @@ import (
 	"github.com/cri-o/cri-o/internal/memorystore"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/resourcestore"
+	istorage "github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	"github.com/cri-o/cri-o/pkg/annotations"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/utils"
@@ -40,6 +42,20 @@ import (
 
 // DefaultUserNSSize is the default size for the user namespace created.
 const DefaultUserNSSize = 65536
+
+// sandboxMetadataResult holds the metadata, labels, and related configuration for a sandbox.
+type sandboxMetadataResult struct {
+	metadata            *types.PodSandboxMetadata
+	labels              map[string]string
+	metadataJSON        []byte
+	labelsJSON          []byte
+	kubeAnnotationsJSON []byte
+	nsOptsJSON          []byte
+	hostIPC             bool
+	hostPID             bool
+	processLabel        string
+	mountLabel          string
+}
 
 // addToMappingsIfMissing ensures the specified id is mapped from the host.
 func addToMappingsIfMissing(ids []idtools.IDMap, id int64) []idtools.IDMap {
@@ -132,192 +148,201 @@ func (s *Server) configureSandboxIDMappings(mode string, sc *types.LinuxSandboxS
 
 	switch parts[0] {
 	case "auto":
-		const t = "true"
-
-		ret := &storage.IDMappingOptions{
-			AutoUserNs: true,
-		}
-		// If keep-id=true then the UID:GID won't be changed inside of the user namespace and it
-		// will map to the same value on the host.
-		keepID := values["keep-id"] == t
-		// If map-to-root=true then the UID:GID will be mapped to root inside of the user namespace.
-		mapToRoot := values["map-to-root"] == t
-		if keepID && mapToRoot {
-			return nil, fmt.Errorf("cannot use both keep-id and map-to-root: %q", mode)
-		}
-
-		if v, ok := values["size"]; ok {
-			s, err := strconv.ParseUint(v, 10, 32)
-			if err != nil {
-				return nil, err
-			}
-
-			ret.AutoUserNsOpts.Size = uint32(s)
-		} else {
-			ret.AutoUserNsOpts.Size = DefaultUserNSSize
-		}
-
-		if v, ok := values["uidmapping"]; ok {
-			uids, err := idtools.ParseIDMap(strings.Split(v, ","), "UID")
-			if err != nil {
-				return nil, err
-			}
-
-			ret.AutoUserNsOpts.AdditionalUIDMappings = append(ret.AutoUserNsOpts.AdditionalUIDMappings, uids...)
-		}
-
-		if v, ok := values["gidmapping"]; ok {
-			gids, err := idtools.ParseIDMap(strings.Split(v, ","), "GID")
-			if err != nil {
-				return nil, err
-			}
-
-			ret.AutoUserNsOpts.AdditionalGIDMappings = append(ret.AutoUserNsOpts.AdditionalGIDMappings, gids...)
-		}
-
-		if sc.GetRunAsUser() != nil {
-			if keepID || mapToRoot {
-				id := 0
-				if keepID {
-					id = int(sc.GetRunAsUser().GetValue())
-				}
-
-				ret.AutoUserNsOpts.AdditionalUIDMappings = append(
-					ret.AutoUserNsOpts.AdditionalUIDMappings,
-					idtools.IDMap{
-						ContainerID: id,
-						HostID:      int(sc.GetRunAsUser().GetValue()),
-						Size:        1,
-					})
-			} else {
-				m := addToMappingsIfMissing(ret.AutoUserNsOpts.AdditionalUIDMappings, sc.GetRunAsUser().GetValue())
-				ret.AutoUserNsOpts.AdditionalUIDMappings = m
-			}
-		}
-
-		if sc.GetRunAsGroup() != nil {
-			if keepID || mapToRoot {
-				id := 0
-				if keepID {
-					id = int(sc.GetRunAsGroup().GetValue())
-				}
-
-				ret.AutoUserNsOpts.AdditionalGIDMappings = append(
-					ret.AutoUserNsOpts.AdditionalGIDMappings,
-					idtools.IDMap{
-						ContainerID: id,
-						HostID:      int(sc.GetRunAsGroup().GetValue()),
-						Size:        1,
-					})
-			} else {
-				m := addToMappingsIfMissing(ret.AutoUserNsOpts.AdditionalGIDMappings, sc.GetRunAsGroup().GetValue())
-				ret.AutoUserNsOpts.AdditionalGIDMappings = m
-			}
-		}
-
-		for _, g := range sc.GetSupplementalGroups() {
-			if keepID {
-				ret.AutoUserNsOpts.AdditionalGIDMappings = append(
-					ret.AutoUserNsOpts.AdditionalGIDMappings,
-					idtools.IDMap{
-						ContainerID: int(g),
-						HostID:      int(g),
-						Size:        1,
-					})
-			} else {
-				m := addToMappingsIfMissing(ret.AutoUserNsOpts.AdditionalGIDMappings, g)
-				ret.AutoUserNsOpts.AdditionalGIDMappings = m
-			}
-		}
-		// make sure we haven't asked to map any sensitive and/or privileged IDs
-		if minimumMappableUID >= 0 {
-			for _, uidSlice := range ret.AutoUserNsOpts.AdditionalUIDMappings {
-				if int64(uidSlice.HostID) < minimumMappableUID {
-					return nil, fmt.Errorf("not allowed to map UID range (%d-%d), below minimum mappable UID %d", uidSlice.HostID, uidSlice.HostID+uidSlice.Size-1, minimumMappableUID)
-				}
-			}
-		}
-
-		if minimumMappableGID >= 0 {
-			for _, gidSlice := range ret.AutoUserNsOpts.AdditionalGIDMappings {
-				if int64(gidSlice.HostID) < minimumMappableGID {
-					return nil, fmt.Errorf("not allowed to map GID range (%d-%d), below minimum mappable GID %d", gidSlice.HostID, gidSlice.HostID+gidSlice.Size-1, minimumMappableGID)
-				}
-			}
-		}
-
-		return ret, nil
+		return s.configureAutoUserNS(mode, values, sc, minimumMappableUID, minimumMappableGID)
 	case "private":
-		var err error
-
-		var uids, gids []idtools.IDMap
-
-		if v, ok := values["uidmapping"]; ok {
-			uids, err = idtools.ParseIDMap(strings.Split(v, ","), "UID")
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if v, ok := values["gidmapping"]; ok {
-			// both gidmapping and uidmapping are specified
-			gids, err = idtools.ParseIDMap(strings.Split(v, ","), "GID")
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if uids == nil && gids == nil {
-			if s.defaultIDMappings == nil {
-				// no configuration and no global mappings
-				return nil, errors.New("userns requested but no userns mappings configured")
-			}
-
-			// no configuration specified, so use the global mappings
-			uids = s.defaultIDMappings.UIDs()
-			gids = s.defaultIDMappings.GIDs()
-		} else {
-			// one between uids and gids is set, use the same range
-			if uids == nil && gids != nil {
-				uids = gids
-			} else if gids == nil && uids != nil {
-				gids = uids
-			}
-		}
-		// make sure the specified users are part of the namespace
-		if sc.GetRunAsUser() != nil {
-			uids = addToMappingsIfMissing(uids, sc.GetRunAsUser().GetValue())
-		}
-
-		if sc.GetRunAsGroup() != nil {
-			gids = addToMappingsIfMissing(gids, sc.GetRunAsGroup().GetValue())
-		}
-
-		for _, g := range sc.GetSupplementalGroups() {
-			gids = addToMappingsIfMissing(gids, g)
-		}
-
-		// make sure we haven't mapped any sensitive and/or privileged IDs
-		if minimumMappableUID >= 0 {
-			for _, uidSlice := range uids {
-				if int64(uidSlice.HostID) < minimumMappableUID {
-					return nil, fmt.Errorf("not allowed to map UID range (%d-%d), below minimum mappable UID %d", uidSlice.HostID, uidSlice.HostID+uidSlice.Size-1, minimumMappableUID)
-				}
-			}
-		}
-
-		if minimumMappableGID >= 0 {
-			for _, gidSlice := range gids {
-				if int64(gidSlice.HostID) < minimumMappableGID {
-					return nil, fmt.Errorf("not allowed to map GID range (%d-%d), below minimum mappable GID %d", gidSlice.HostID, gidSlice.HostID+gidSlice.Size-1, minimumMappableGID)
-				}
-			}
-		}
-
-		return &storage.IDMappingOptions{UIDMap: uids, GIDMap: gids}, nil
+		return s.configurePrivateUserNS(values, sc, minimumMappableUID, minimumMappableGID)
 	}
 
 	return nil, fmt.Errorf("invalid userns mode: %q", mode)
+}
+
+func (s *Server) configureAutoUserNS(mode string, values map[string]string, sc *types.LinuxSandboxSecurityContext, minimumMappableUID, minimumMappableGID int64) (*storage.IDMappingOptions, error) {
+	const t = "true"
+
+	ret := &storage.IDMappingOptions{
+		AutoUserNs: true,
+	}
+
+	keepID := values["keep-id"] == t
+
+	mapToRoot := values["map-to-root"] == t
+	if keepID && mapToRoot {
+		return nil, fmt.Errorf("cannot use both keep-id and map-to-root: %q", mode)
+	}
+
+	if v, ok := values["size"]; ok {
+		s, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		ret.AutoUserNsOpts.Size = uint32(s)
+	} else {
+		ret.AutoUserNsOpts.Size = DefaultUserNSSize
+	}
+
+	if v, ok := values["uidmapping"]; ok {
+		uids, err := idtools.ParseIDMap(strings.Split(v, ","), "UID")
+		if err != nil {
+			return nil, err
+		}
+
+		ret.AutoUserNsOpts.AdditionalUIDMappings = append(ret.AutoUserNsOpts.AdditionalUIDMappings, uids...)
+	}
+
+	if v, ok := values["gidmapping"]; ok {
+		gids, err := idtools.ParseIDMap(strings.Split(v, ","), "GID")
+		if err != nil {
+			return nil, err
+		}
+
+		ret.AutoUserNsOpts.AdditionalGIDMappings = append(ret.AutoUserNsOpts.AdditionalGIDMappings, gids...)
+	}
+
+	s.addAutoUserNSRunAsUserMapping(ret, sc, keepID, mapToRoot)
+	s.addAutoUserNSRunAsGroupMapping(ret, sc, keepID, mapToRoot)
+	s.addAutoUserNSSupplementalGroupsMappings(ret, sc, keepID)
+
+	if err := s.validateIDMappings(ret.AutoUserNsOpts.AdditionalUIDMappings, ret.AutoUserNsOpts.AdditionalGIDMappings, minimumMappableUID, minimumMappableGID); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (s *Server) addAutoUserNSRunAsUserMapping(ret *storage.IDMappingOptions, sc *types.LinuxSandboxSecurityContext, keepID, mapToRoot bool) {
+	if sc.GetRunAsUser() != nil {
+		if keepID || mapToRoot {
+			id := 0
+			if keepID {
+				id = int(sc.GetRunAsUser().GetValue())
+			}
+
+			ret.AutoUserNsOpts.AdditionalUIDMappings = append(
+				ret.AutoUserNsOpts.AdditionalUIDMappings,
+				idtools.IDMap{
+					ContainerID: id,
+					HostID:      int(sc.GetRunAsUser().GetValue()),
+					Size:        1,
+				})
+		} else {
+			m := addToMappingsIfMissing(ret.AutoUserNsOpts.AdditionalUIDMappings, sc.GetRunAsUser().GetValue())
+			ret.AutoUserNsOpts.AdditionalUIDMappings = m
+		}
+	}
+}
+
+func (s *Server) addAutoUserNSRunAsGroupMapping(ret *storage.IDMappingOptions, sc *types.LinuxSandboxSecurityContext, keepID, mapToRoot bool) {
+	if sc.GetRunAsGroup() != nil {
+		if keepID || mapToRoot {
+			id := 0
+			if keepID {
+				id = int(sc.GetRunAsGroup().GetValue())
+			}
+
+			ret.AutoUserNsOpts.AdditionalGIDMappings = append(
+				ret.AutoUserNsOpts.AdditionalGIDMappings,
+				idtools.IDMap{
+					ContainerID: id,
+					HostID:      int(sc.GetRunAsGroup().GetValue()),
+					Size:        1,
+				})
+		} else {
+			m := addToMappingsIfMissing(ret.AutoUserNsOpts.AdditionalGIDMappings, sc.GetRunAsGroup().GetValue())
+			ret.AutoUserNsOpts.AdditionalGIDMappings = m
+		}
+	}
+}
+
+func (s *Server) addAutoUserNSSupplementalGroupsMappings(ret *storage.IDMappingOptions, sc *types.LinuxSandboxSecurityContext, keepID bool) {
+	for _, g := range sc.GetSupplementalGroups() {
+		if keepID {
+			ret.AutoUserNsOpts.AdditionalGIDMappings = append(
+				ret.AutoUserNsOpts.AdditionalGIDMappings,
+				idtools.IDMap{
+					ContainerID: int(g),
+					HostID:      int(g),
+					Size:        1,
+				})
+		} else {
+			m := addToMappingsIfMissing(ret.AutoUserNsOpts.AdditionalGIDMappings, g)
+			ret.AutoUserNsOpts.AdditionalGIDMappings = m
+		}
+	}
+}
+
+func (s *Server) validateIDMappings(uidMappings, gidMappings []idtools.IDMap, minimumMappableUID, minimumMappableGID int64) error {
+	if minimumMappableUID >= 0 {
+		for _, uidSlice := range uidMappings {
+			if int64(uidSlice.HostID) < minimumMappableUID {
+				return fmt.Errorf("not allowed to map UID range (%d-%d), below minimum mappable UID %d", uidSlice.HostID, uidSlice.HostID+uidSlice.Size-1, minimumMappableUID)
+			}
+		}
+	}
+
+	if minimumMappableGID >= 0 {
+		for _, gidSlice := range gidMappings {
+			if int64(gidSlice.HostID) < minimumMappableGID {
+				return fmt.Errorf("not allowed to map GID range (%d-%d), below minimum mappable GID %d", gidSlice.HostID, gidSlice.HostID+gidSlice.Size-1, minimumMappableGID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *Server) configurePrivateUserNS(values map[string]string, sc *types.LinuxSandboxSecurityContext, minimumMappableUID, minimumMappableGID int64) (*storage.IDMappingOptions, error) {
+	var (
+		uids, gids []idtools.IDMap
+		err        error
+	)
+
+	if v, ok := values["uidmapping"]; ok {
+		uids, err = idtools.ParseIDMap(strings.Split(v, ","), "UID")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if v, ok := values["gidmapping"]; ok {
+		gids, err = idtools.ParseIDMap(strings.Split(v, ","), "GID")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if uids == nil && gids == nil {
+		if s.defaultIDMappings == nil {
+			return nil, errors.New("userns requested but no userns mappings configured")
+		}
+
+		uids = s.defaultIDMappings.UIDs()
+		gids = s.defaultIDMappings.GIDs()
+	} else {
+		if uids == nil && gids != nil {
+			uids = gids
+		} else if gids == nil && uids != nil {
+			gids = uids
+		}
+	}
+
+	if sc.GetRunAsUser() != nil {
+		uids = addToMappingsIfMissing(uids, sc.GetRunAsUser().GetValue())
+	}
+
+	if sc.GetRunAsGroup() != nil {
+		gids = addToMappingsIfMissing(gids, sc.GetRunAsGroup().GetValue())
+	}
+
+	for _, g := range sc.GetSupplementalGroups() {
+		gids = addToMappingsIfMissing(gids, g)
+	}
+
+	if err := s.validateIDMappings(uids, gids, minimumMappableUID, minimumMappableGID); err != nil {
+		return nil, err
+	}
+
+	return &storage.IDMappingOptions{UIDMap: uids, GIDMap: gids}, nil
 }
 
 func convertToStorageIDMap(mappings []*types.IDMapping) []idtools.IDMap {
@@ -602,134 +627,19 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
-	// add metadata
-	metadata := sbox.Config().GetMetadata()
-
-	metadataJSON, err := json.Marshal(metadata)
+	result, err := s.prepareSandboxMetadataAndLabels(sbox, kubeAnnotations, securityContext, processLabel, mountLabel)
 	if err != nil {
 		return nil, err
-	}
-
-	// add labels
-	labels := sbox.Config().GetLabels()
-
-	if err := validateLabels(labels); err != nil {
-		return nil, err
-	}
-
-	// Add special container name label for the infra container
-	if labels != nil {
-		labels[kubeletTypes.KubernetesContainerNameLabel] = oci.InfraContainerName
-	}
-
-	labelsJSON, err := json.Marshal(labels)
-	if err != nil {
-		return nil, err
-	}
-
-	// add annotations
-	kubeAnnotationsJSON, err := json.Marshal(kubeAnnotations)
-	if err != nil {
-		return nil, err
-	}
-
-	nsOptsJSON, err := json.Marshal(securityContext.GetNamespaceOptions())
-	if err != nil {
-		return nil, err
-	}
-
-	hostIPC := securityContext.GetNamespaceOptions().GetIpc() == types.NamespaceMode_NODE
-	hostPID := securityContext.GetNamespaceOptions().GetPid() == types.NamespaceMode_NODE
-
-	// Don't use SELinux separation with Host Pid or IPC Namespace or privileged.
-	if hostPID || hostIPC {
-		processLabel, mountLabel = "", ""
 	}
 
 	g := sbox.Spec()
-	g.SetProcessSelinuxLabel(processLabel)
-	g.SetLinuxMountLabel(mountLabel)
+	g.SetProcessSelinuxLabel(result.processLabel)
+	g.SetLinuxMountLabel(result.mountLabel)
 
-	// Remove the default /dev/shm mount to ensure we overwrite it
-	g.RemoveMount(libsandbox.DevShmPath)
-
-	// create shm mount for the pod containers.
-	// TODO: Pass interface instead of individual field.
-	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox shm creation")
-
-	var shmPath string
-	if hostIPC {
-		shmPath = libsandbox.DevShmPath
-	} else {
-		shmSize := int64(libsandbox.DefaultShmSize)
-
-		if shmSizeStr, ok := kubeAnnotations[annotations.ShmSizeAnnotation]; ok {
-			quantity, err := resource.ParseQuantity(shmSizeStr)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse shm size '%s': %w", shmSizeStr, err)
-			}
-
-			shmSize = quantity.Value()
-		}
-
-		shmPath, err = libsandbox.SetupShm(podContainer.RunDir, mountLabel, shmSize)
-		if err != nil {
-			return nil, err
-		}
-
-		if sandboxIDMappings != nil {
-			rootPair := sandboxIDMappings.RootPair()
-			if err := os.Chown(shmPath, rootPair.UID, rootPair.GID); err != nil {
-				return nil, fmt.Errorf("cannot chown %s to %d:%d: %w", shmPath, rootPair.UID, rootPair.GID, err)
-			}
-		}
-
-		resourceCleaner.Add(ctx, "runSandbox: unmounting shmPath for sandbox "+sboxID, func() error {
-			if err := unix.Unmount(shmPath, unix.MNT_DETACH); err != nil {
-				return fmt.Errorf("failed to unmount shm for sandbox: %w", err)
-			}
-
-			return nil
-		})
-	}
-
-	sbox.SetShmPath(shmPath)
-
-	// Link logs if requested
-	if emptyDirVolName, ok := kubeAnnotations[annotations.LinkLogsAnnotation]; ok {
-		if err = linklogs.MountPodLogs(ctx, kubePodUID, emptyDirVolName, namespace, kubeName, mountLabel); err != nil {
-			log.Warnf(ctx, "Failed to link logs: %v", err)
-		}
-	}
-
-	// TODO: Pass interface instead of individual field.
-	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox spec configuration")
-
-	mnt := spec.Mount{
-		Type:        "bind",
-		Source:      shmPath,
-		Destination: libsandbox.DevShmPath,
-		Options:     []string{"rw", "bind"},
-	}
-	// bind mount the pod shm
-	g.AddMount(mnt)
-
-	err = s.setPodSandboxMountLabel(ctx, sboxID, mountLabel)
+	shmPath, err := s.setupSandboxShmAndMounts(ctx, sbox, g, sboxName, sboxID, namespace, kubeName, kubePodUID, result.hostIPC, podContainer.RunDir, result.mountLabel, kubeAnnotations, sandboxIDMappings, resourceCleaner)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := s.ContainerServer.CtrIDIndex().Add(sboxID); err != nil {
-		return nil, err
-	}
-
-	resourceCleaner.Add(ctx, "runSandbox: deleting container ID from idIndex for sandbox "+sboxID, func() error {
-		if err := s.ContainerServer.CtrIDIndex().Delete(sboxID); err != nil && !strings.Contains(err.Error(), noSuchID) {
-			return fmt.Errorf("could not delete ctr id %s from idIndex: %w", sboxID, err)
-		}
-
-		return nil
-	})
 
 	// set log path inside log directory
 	logPath := filepath.Join(logDir, sboxID+".log")
@@ -747,139 +657,23 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	sbox.SetHostname(hostname)
 	g.SetHostname(hostname)
 
-	g.AddAnnotation(annotations.Metadata, string(metadataJSON))
-	g.AddAnnotation(annotations.Labels, string(labelsJSON))
-	g.AddAnnotation(annotations.Annotations, string(kubeAnnotationsJSON))
-	g.AddAnnotation(annotations.LogPath, logPath)
-	g.AddAnnotation(annotations.Name, sboxName)
-	g.AddAnnotation(annotations.SandboxName, sboxName)
-	g.AddAnnotation(annotations.Namespace, namespace)
-	g.AddAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox)
-	g.AddAnnotation(annotations.SandboxID, sboxID)
-	g.AddAnnotation(annotations.UserRequestedImage, pauseImage.StringForOutOfProcessConsumptionOnly())
-	g.AddAnnotation(annotations.SomeNameOfTheImage, pauseImage.StringForOutOfProcessConsumptionOnly())
-	g.AddAnnotation(annotations.ContainerName, containerName)
-	g.AddAnnotation(annotations.ContainerID, sboxID)
-	g.AddAnnotation(annotations.ShmPath, shmPath)
-	g.AddAnnotation(annotations.PrivilegedRuntime, strconv.FormatBool(privileged))
-	g.AddAnnotation(annotations.RuntimeHandler, runtimeHandler)
-	g.AddAnnotation(annotations.ResolvPath, sbox.ResolvPath())
-	g.AddAnnotation(annotations.HostName, hostname)
-	g.AddAnnotation(annotations.NamespaceOptions, string(nsOptsJSON))
-	g.AddAnnotation(annotations.KubeName, kubeName)
-	g.AddAnnotation(annotations.HostNetwork, strconv.FormatBool(hostNetwork))
-	g.AddAnnotation(annotations.ContainerManager, constants.ContainerManagerCRIO)
-
-	if podContainer.Config.Config.StopSignal != "" {
-		g.AddAnnotation(annotations.StopSignalAnnotation, podContainer.Config.Config.StopSignal)
-	}
-
-	created := time.Now()
-	sbox.SetCreatedAt(created)
-
-	err = sbox.SetCRISandbox(sboxID, labels, kubeAnnotations, metadata)
+	created, err := s.setupSandboxAnnotations(sbox, g, sboxID, sboxName, namespace, containerName, runtimeHandler, kubeName, hostname, pauseImage, &podContainer, result.metadataJSON, result.labelsJSON, result.kubeAnnotationsJSON, result.nsOptsJSON, logPath, shmPath, privileged, hostNetwork, result.labels, kubeAnnotations, result.metadata)
 	if err != nil {
 		return nil, err
 	}
 
-	g.AddAnnotation(annotations.Created, created.Format(time.RFC3339Nano))
-
-	portMappings := convertPortMappings(sbox.Config().GetPortMappings())
-
-	portMappingsJSON, err := json.Marshal(portMappings)
+	cgroupParent, err := s.setupPortMappingsAndCgroupPath(sbox, g, sboxID, runtimeHandler)
 	if err != nil {
 		return nil, err
 	}
 
-	sbox.SetPortMappings(portMappings)
-
-	g.AddAnnotation(annotations.PortMappings, string(portMappingsJSON))
-
-	containerMinMemory, err := s.ContainerServer.Runtime().GetContainerMinMemory(runtimeHandler)
-	if err != nil {
+	if err := s.setupSandboxIDMappingsAndResources(sbox, g, sandboxIDMappings); err != nil {
 		return nil, err
 	}
 
-	cgroupParent, cgroupPath, err := s.config.CgroupManager().SandboxCgroupPath(sbox.Config().GetLinux().GetCgroupParent(), sboxID, containerMinMemory)
+	seccompRef, err := s.setupSandboxSeccomp(ctx, g, runtimeHandler, privileged, securityContext)
 	if err != nil {
 		return nil, err
-	}
-
-	if cgroupPath != "" {
-		g.SetLinuxCgroupsPath(cgroupPath)
-	}
-
-	sbox.SetCgroupParent(cgroupParent)
-	g.AddAnnotation(annotations.CgroupParent, cgroupParent)
-
-	if sandboxIDMappings != nil {
-		if err := g.AddOrReplaceLinuxNamespace(string(spec.UserNamespace), ""); err != nil {
-			return nil, fmt.Errorf("add or replace linux namespace: %w", err)
-		}
-
-		for _, uidmap := range sandboxIDMappings.UIDs() {
-			g.AddLinuxUIDMapping(uint32(uidmap.HostID), uint32(uidmap.ContainerID), uint32(uidmap.Size))
-		}
-
-		for _, gidmap := range sandboxIDMappings.GIDs() {
-			g.AddLinuxGIDMapping(uint32(gidmap.HostID), uint32(gidmap.ContainerID), uint32(gidmap.Size))
-		}
-	}
-
-	overhead := sbox.Config().GetLinux().GetOverhead()
-
-	overheadJSON, err := json.Marshal(overhead)
-	if err != nil {
-		return nil, err
-	}
-
-	sbox.SetPodLinuxOverhead(overhead)
-	g.AddAnnotation(annotations.PodLinuxOverhead, string(overheadJSON))
-
-	resources := sbox.Config().GetLinux().GetResources()
-
-	resourcesJSON, err := json.Marshal(resources)
-	if err != nil {
-		return nil, err
-	}
-
-	sbox.SetPodLinuxResources(resources)
-	g.AddAnnotation(annotations.PodLinuxResources, string(resourcesJSON))
-
-	seccompRef := types.SecurityProfile_Unconfined.String()
-	setupSeccompForPrivCtr := (privileged && s.config.PrivilegedSeccompProfile != "")
-
-	if !privileged || setupSeccompForPrivCtr {
-		if setupSeccompForPrivCtr {
-			// Inject a custom seccomp profile for a privileged container
-			securityContext.Seccomp = &types.SecurityProfile{
-				ProfileType:  types.SecurityProfile_Localhost,
-				LocalhostRef: s.config.PrivilegedSeccompProfile,
-			}
-		}
-
-		seccompConfig, err := s.ContainerServer.Runtime().Seccomp(runtimeHandler)
-		if err != nil {
-			return nil, err
-		}
-
-		_, ref, err := seccompConfig.Setup(
-			ctx,
-			s.config.SystemContext,
-			nil,
-			"",
-			"",
-			nil,
-			nil,
-			g,
-			securityContext.GetSeccomp(),
-			s.Store().GraphRoot(),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("setup seccomp: %w", err)
-		}
-
-		seccompRef = ref
 	}
 
 	hostnamePath := podContainer.RunDir + "/hostname"
@@ -923,297 +717,36 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		g.AddAnnotation(k, v)
 	}
 
-	for k, v := range labels {
+	for k, v := range result.labels {
 		g.AddAnnotation(k, v)
 	}
 
 	// Add default sysctls given in crio.conf
-	sysctls := s.configureGeneratorForSysctls(ctx, g, hostNetwork, hostIPC, sandboxIDMappings, req.GetConfig().GetLinux().GetSysctls())
+	sysctls := s.configureGeneratorForSysctls(ctx, g, hostNetwork, result.hostIPC, sandboxIDMappings, req.GetConfig().GetLinux().GetSysctls())
 
-	// set up namespaces
-	// TODO: Pass interface instead of individual field.
-	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox namespace creation")
-	nsCleanupFuncs, err := s.configureGeneratorForSandboxNamespaces(ctx, hostNetwork, hostIPC, hostPID, sandboxIDMappings, sysctls, sb, g)
-	// We want to cleanup after ourselves if we are managing any namespaces and fail in this function.
-	// However, we don't immediately register this func with resourceCleaner because we need to pair the
-	// ns cleanup with networkStop. Otherwise, we could try to cleanup the namespace before the network stop runs,
-	// which could put us in a weird state.
-	nsCleanupDescription := "runSandbox: cleaning up namespaces after failing to run sandbox " + sboxID
-	nsCleanupFunc := func() error {
-		for idx := range nsCleanupFuncs {
-			if err := nsCleanupFuncs[idx](); err != nil {
-				return fmt.Errorf("RunSandbox: failed to cleanup namespace %w", err)
-			}
-		}
-
-		return nil
-	}
-
+	ips, err := s.setupNamespacesAndNetwork(ctx, sb, g, sboxID, sboxName, hostNetwork, result.hostIPC, result.hostPID, sandboxIDMappings, sysctls, resourceCleaner)
 	if err != nil {
-		resourceCleaner.Add(ctx, nsCleanupDescription, nsCleanupFunc)
-
 		return nil, err
 	}
 
-	// now that we have the namespaces, we should create the network if we're managing namespace Lifecycle
-	var ips []string
-
-	var result cnitypes.Result
-
-	// TODO: Pass interface instead of individual field.
-	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox network creation")
-
-	ips, result, err = s.networkStart(ctx, sb)
+	mountPoint, err := s.setupStorageAndFinalize(ctx, sb, g, sboxID, sboxName, containerName, hostnamePath, hostname, hostNetwork, result.mountLabel, sandboxIDMappings, securityContext, resourceCleaner)
 	if err != nil {
-		resourceCleaner.Add(ctx, nsCleanupDescription, nsCleanupFunc)
-
 		return nil, err
-	}
-
-	resourceCleaner.Add(ctx, "runSandbox: stopping network for sandbox"+sb.ID(), func() error {
-		// use a new context to prevent an expired context from preventing a stop
-		if err := s.networkStop(context.Background(), sb); err != nil {
-			return fmt.Errorf("error stopping network on cleanup: %w", err)
-		}
-
-		// Now that we've succeeded in stopping the network, cleanup namespaces
-		log.Infof(ctx, "%s", nsCleanupDescription)
-
-		return nsCleanupFunc()
-	})
-
-	if result != nil {
-		resultCurrent, err := current.NewResultFromResult(result)
-		if err != nil {
-			return nil, err
-		}
-
-		cniResultJSON, err := json.Marshal(resultCurrent)
-		if err != nil {
-			return nil, err
-		}
-
-		g.AddAnnotation(annotations.CNIResult, string(cniResultJSON))
-	}
-	// TODO: Pass interface instead of individual field.
-	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox storage start")
-
-	mountPoint, err := s.ContainerServer.StorageRuntimeServer().StartContainer(sboxID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %w", containerName, sb.Name(), sboxID, err)
-	}
-
-	resourceCleaner.Add(ctx, "runSandbox: stopping storage container for sandbox "+sboxID, func() error {
-		if err := s.ContainerServer.StorageRuntimeServer().StopContainer(ctx, sboxID); err != nil {
-			return fmt.Errorf("could not stop storage container: %s: %w", sboxID, err)
-		}
-
-		return nil
-	})
-
-	// Set OOM score adjust of the infra container to be very low
-	// so it doesn't get killed.
-	g.SetProcessOOMScoreAdj(PodInfraOOMAdj)
-
-	g.SetLinuxResourcesCPUShares(PodInfraCPUshares)
-
-	// When infra-ctr-cpuset specified, set the infra container CPU set
-	if s.config.InfraCtrCPUSet != "" {
-		log.Debugf(ctx, "Set the infra container cpuset to %q", s.config.InfraCtrCPUSet)
-		g.SetLinuxResourcesCPUCpus(s.config.InfraCtrCPUSet)
-	}
-
-	saveOptions := generate.ExportOptions{}
-
-	g.AddAnnotation(annotations.MountPoint, mountPoint)
-
-	if err := os.WriteFile(hostnamePath, []byte(hostname+"\n"), 0o644); err != nil {
-		return nil, err
-	}
-
-	if err := label.Relabel(hostnamePath, mountLabel, false); err != nil && !errors.Is(err, unix.ENOTSUP) {
-		return nil, err
-	}
-
-	if sandboxIDMappings != nil {
-		rootPair := sandboxIDMappings.RootPair()
-		if err := os.Chown(hostnamePath, rootPair.UID, rootPair.GID); err != nil {
-			return nil, fmt.Errorf("cannot chown %s to %d:%d: %w", hostnamePath, rootPair.UID, rootPair.GID, err)
-		}
-	}
-
-	mnt = spec.Mount{
-		Type:        "bind",
-		Source:      hostnamePath,
-		Destination: "/etc/hostname",
-		Options:     []string{"ro", "bind", "nodev", "nosuid", "noexec"},
-	}
-	g.AddMount(mnt)
-	g.AddAnnotation(annotations.HostnamePath, hostnamePath)
-
-	if sandboxIDMappings != nil {
-		if securityContext.GetNamespaceOptions().GetIpc() == types.NamespaceMode_NODE {
-			g.RemoveMount("/dev/mqueue")
-
-			mqueue := spec.Mount{
-				Type:        "bind",
-				Source:      "/dev/mqueue",
-				Destination: "/dev/mqueue",
-				Options:     []string{"rw", "rbind", "nodev", "nosuid", "noexec"},
-			}
-			g.AddMount(mqueue)
-		}
-
-		if hostNetwork {
-			g.RemoveMount("/sys")
-			g.RemoveMount("/sys/cgroup")
-
-			sysMnt := spec.Mount{
-				Destination: "/sys",
-				Type:        "bind",
-				Source:      "/sys",
-				Options:     []string{"nosuid", "noexec", "nodev", "ro", "rbind"},
-			}
-			g.AddMount(sysMnt)
-		}
-
-		if securityContext.GetNamespaceOptions().GetPid() == types.NamespaceMode_NODE {
-			g.RemoveMount("/proc")
-
-			proc := spec.Mount{
-				Type:        "bind",
-				Source:      "/proc",
-				Destination: "/proc",
-				Options:     []string{"rw", "rbind", "nodev", "nosuid", "noexec"},
-			}
-			g.AddMount(proc)
-		}
-	}
-
-	g.SetRootPath(mountPoint)
-
-	if os.Getenv(rootlessEnvName) != "" {
-		makeOCIConfigurationRootless(g)
-	}
-
-	sb.SetNamespaceOptions(securityContext.GetNamespaceOptions())
-
-	if s.config.Seccomp().IsDisabled() {
-		g.Config.Linux.Seccomp = nil
 	}
 
 	g.AddAnnotation(annotations.SeccompProfilePath, seccompRef)
 
-	runtimeType, err := s.ContainerServer.Runtime().RuntimeType(runtimeHandler)
+	container, _, err := s.setupInfraContainer(ctx, sb, g, sboxID, containerName, runtimeHandler, cgroupParent, &podContainer, logPath, result.labels, kubeAnnotations, pauseImage, created, result.processLabel)
 	if err != nil {
 		return nil, err
 	}
 
-	// A container is kernel separated if we're using shimv2, or we're using a kata v1 binary
-	podIsKernelSeparated := runtimeType == libconfig.RuntimeTypeVM ||
-		strings.Contains(strings.ToLower(runtimeHandler), "kata") ||
-		(runtimeHandler == "" && strings.Contains(strings.ToLower(s.config.DefaultRuntime), "kata"))
-
-	var container *oci.Container
-	// In the case of kernel separated containers, we need the infra container to create the VM for the pod
-	if sb.NeedsInfra(s.config.DropInfraCtr) || podIsKernelSeparated {
-		log.Debugf(ctx, "Keeping infra container for pod %s", sboxID)
-		// pauseImage, as the userRequestedImage parameter, only shows up in CRI values we return.
-		container, err = oci.NewContainer(sboxID, containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, "", nil, sboxID, false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
-		if err != nil {
-			return nil, err
-		}
-		// If using a kernel separated container runtime, the process label should be set to container_kvm_t
-		// Keep in mind that kata does *not* apply any process label to containers within the VM
-		if podIsKernelSeparated {
-			processLabel, err = KVMLabel(processLabel)
-			if err != nil {
-				return nil, err
-			}
-
-			g.SetProcessSelinuxLabel(processLabel)
-		}
-	} else {
-		log.Debugf(ctx, "Dropping infra container for pod %s", sboxID)
-		container = oci.NewSpoofedContainer(sboxID, containerName, labels, sboxID, created, podContainer.RunDir)
-
-		g.AddAnnotation(annotations.SpoofedContainer, "true")
-
-		if err := s.config.CgroupManager().CreateSandboxCgroup(cgroupParent, sboxID); err != nil {
-			return nil, fmt.Errorf("create dropped infra %s cgroup: %w", sboxID, err)
-		}
-	}
-
-	container.SetMountPoint(mountPoint)
-	container.SetSpec(g.Config)
-
-	// needed for getSandboxIDMappings()
-	container.SetIDMappings(sandboxIDMappings)
-
-	if err := sb.SetInfraContainer(container); err != nil {
+	if err := s.configureAndSaveInfraContainer(ctx, sb, container, g, mountPoint, sandboxIDMappings, &podContainer, sboxID); err != nil {
 		return nil, err
 	}
 
-	if err := sb.SetContainerEnvFile(ctx); err != nil {
+	if err := s.createAndStartInfraContainer(ctx, sb, container, sandboxIDMappings, sboxName, resourceCleaner); err != nil {
 		return nil, err
-	}
-
-	if err = g.SaveToFile(filepath.Join(podContainer.Dir, "config.json"), saveOptions); err != nil {
-		return nil, fmt.Errorf("failed to save template configuration for pod sandbox %s(%s): %w", sb.Name(), sboxID, err)
-	}
-
-	if err = g.SaveToFile(filepath.Join(podContainer.RunDir, "config.json"), saveOptions); err != nil {
-		return nil, fmt.Errorf("failed to write runtime configuration for pod sandbox %s(%s): %w", sb.Name(), sboxID, err)
-	}
-
-	s.addInfraContainer(ctx, container)
-	resourceCleaner.Add(ctx, "runSandbox: removing infra container "+container.ID(), func() error {
-		s.removeInfraContainer(ctx, container)
-
-		return nil
-	})
-	// TODO: Pass interface instead of individual field.
-	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox container runtime creation")
-
-	if err := s.createContainerPlatform(ctx, container, sb.CgroupParent(), sandboxIDMappings); err != nil {
-		return nil, err
-	}
-
-	if hooks := s.hooksRetriever.Get(ctx, sb.RuntimeHandler(), sb.Annotations()); hooks != nil {
-		if err := hooks.PreStart(ctx, container, sb); err != nil {
-			return nil, fmt.Errorf("failed to run pre-stop hook for container %q: %w", sb.ID(), err)
-		}
-	}
-
-	s.generateCRIEvent(ctx, sb.InfraContainer(), types.ContainerEventType_CONTAINER_CREATED_EVENT)
-
-	if err := s.ContainerServer.Runtime().StartContainer(ctx, container); err != nil {
-		return nil, err
-	}
-
-	resourceCleaner.Add(ctx, "runSandbox: stopping container "+container.ID(), func() error {
-		// Clean-up steps from RemovePodSandbox
-		if err := s.stopContainer(ctx, container, stopTimeoutFromContext(ctx)); err != nil {
-			return errors.New("failed to stop container for removal")
-		}
-
-		log.Infof(ctx, "RunSandbox: deleting container %s", container.ID())
-
-		if err := s.ContainerServer.Runtime().DeleteContainer(ctx, container); err != nil {
-			return fmt.Errorf("failed to delete container %s in pod sandbox %s: %w", container.Name(), sb.ID(), err)
-		}
-
-		log.Infof(ctx, "RunSandbox: writing container %s state to disk", container.ID())
-
-		if err := s.ContainerStateToDisk(ctx, container); err != nil {
-			return fmt.Errorf("failed to write container state %s in pod sandbox %s: %w", container.Name(), sb.ID(), err)
-		}
-
-		return nil
-	})
-
-	if err := s.ContainerStateToDisk(ctx, container); err != nil {
-		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", container.ID(), err)
 	}
 
 	for idx, ip := range ips {
@@ -1401,4 +934,627 @@ func (s *Server) configureGeneratorForSandboxNamespaces(ctx context.Context, hos
 	}
 
 	return cleanupFuncs, nil
+}
+
+func (s *Server) setupSandboxShm(ctx context.Context, sboxName, sboxID string, hostIPC bool, containerRunDir, mountLabel string, kubeAnnotations map[string]string, sandboxIDMappings *idtools.IDMappings, resourceCleaner *resourcestore.ResourceCleaner) (string, error) {
+	// create shm mount for the pod containers.
+	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox shm creation")
+
+	var shmPath string
+	if hostIPC {
+		shmPath = libsandbox.DevShmPath
+	} else {
+		shmSize := int64(libsandbox.DefaultShmSize)
+
+		if shmSizeStr, ok := kubeAnnotations[annotations.ShmSizeAnnotation]; ok {
+			quantity, err := resource.ParseQuantity(shmSizeStr)
+			if err != nil {
+				return "", fmt.Errorf("failed to parse shm size '%s': %w", shmSizeStr, err)
+			}
+
+			shmSize = quantity.Value()
+		}
+
+		var err error
+
+		shmPath, err = libsandbox.SetupShm(containerRunDir, mountLabel, shmSize)
+		if err != nil {
+			return "", err
+		}
+
+		if sandboxIDMappings != nil {
+			rootPair := sandboxIDMappings.RootPair()
+			if err := os.Chown(shmPath, rootPair.UID, rootPair.GID); err != nil {
+				return "", fmt.Errorf("cannot chown %s to %d:%d: %w", shmPath, rootPair.UID, rootPair.GID, err)
+			}
+		}
+
+		resourceCleaner.Add(ctx, "runSandbox: unmounting shmPath for sandbox "+sboxID, func() error {
+			if err := unix.Unmount(shmPath, unix.MNT_DETACH); err != nil {
+				return fmt.Errorf("failed to unmount shm for sandbox: %w", err)
+			}
+
+			return nil
+		})
+	}
+
+	return shmPath, nil
+}
+
+func (s *Server) setupSandboxAnnotations(sbox libsandbox.Builder, g *generate.Generator, sboxID, sboxName, namespace, containerName, runtimeHandler, kubeName, hostname string, pauseImage references.RegistryImageReference, podContainer *istorage.ContainerInfo, metadataJSON, labelsJSON, kubeAnnotationsJSON, nsOptsJSON []byte, logPath, shmPath string, privileged, hostNetwork bool, labels, kubeAnnotations map[string]string, metadata *types.PodSandboxMetadata) (time.Time, error) {
+	g.AddAnnotation(annotations.Metadata, string(metadataJSON))
+	g.AddAnnotation(annotations.Labels, string(labelsJSON))
+	g.AddAnnotation(annotations.Annotations, string(kubeAnnotationsJSON))
+	g.AddAnnotation(annotations.LogPath, logPath)
+	g.AddAnnotation(annotations.Name, sboxName)
+	g.AddAnnotation(annotations.SandboxName, sboxName)
+	g.AddAnnotation(annotations.Namespace, namespace)
+	g.AddAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox)
+	g.AddAnnotation(annotations.SandboxID, sboxID)
+	g.AddAnnotation(annotations.UserRequestedImage, pauseImage.StringForOutOfProcessConsumptionOnly())
+	g.AddAnnotation(annotations.SomeNameOfTheImage, pauseImage.StringForOutOfProcessConsumptionOnly())
+	g.AddAnnotation(annotations.ContainerName, containerName)
+	g.AddAnnotation(annotations.ContainerID, sboxID)
+	g.AddAnnotation(annotations.ShmPath, shmPath)
+	g.AddAnnotation(annotations.PrivilegedRuntime, strconv.FormatBool(privileged))
+	g.AddAnnotation(annotations.RuntimeHandler, runtimeHandler)
+	g.AddAnnotation(annotations.ResolvPath, sbox.ResolvPath())
+	g.AddAnnotation(annotations.HostName, hostname)
+	g.AddAnnotation(annotations.NamespaceOptions, string(nsOptsJSON))
+	g.AddAnnotation(annotations.KubeName, kubeName)
+	g.AddAnnotation(annotations.HostNetwork, strconv.FormatBool(hostNetwork))
+	g.AddAnnotation(annotations.ContainerManager, constants.ContainerManagerCRIO)
+
+	if podContainer.Config.Config.StopSignal != "" {
+		g.AddAnnotation(annotations.StopSignalAnnotation, podContainer.Config.Config.StopSignal)
+	}
+
+	created := time.Now()
+	sbox.SetCreatedAt(created)
+
+	if err := sbox.SetCRISandbox(sboxID, labels, kubeAnnotations, metadata); err != nil {
+		return time.Time{}, err
+	}
+
+	g.AddAnnotation(annotations.Created, created.Format(time.RFC3339Nano))
+
+	return created, nil
+}
+
+func (s *Server) setupSandboxSeccomp(ctx context.Context, g *generate.Generator, runtimeHandler string, privileged bool, securityContext *types.LinuxSandboxSecurityContext) (string, error) {
+	seccompRef := types.SecurityProfile_Unconfined.String()
+	setupSeccompForPrivCtr := (privileged && s.config.PrivilegedSeccompProfile != "")
+
+	if !privileged || setupSeccompForPrivCtr {
+		if setupSeccompForPrivCtr {
+			// Inject a custom seccomp profile for a privileged container
+			securityContext.Seccomp = &types.SecurityProfile{
+				ProfileType:  types.SecurityProfile_Localhost,
+				LocalhostRef: s.config.PrivilegedSeccompProfile,
+			}
+		}
+
+		seccompConfig, err := s.ContainerServer.Runtime().Seccomp(runtimeHandler)
+		if err != nil {
+			return "", err
+		}
+
+		_, ref, err := seccompConfig.Setup(
+			ctx,
+			s.config.SystemContext,
+			nil,
+			"",
+			"",
+			nil,
+			nil,
+			g,
+			securityContext.GetSeccomp(),
+			s.Store().GraphRoot(),
+		)
+		if err != nil {
+			return "", fmt.Errorf("setup seccomp: %w", err)
+		}
+
+		seccompRef = ref
+	}
+
+	return seccompRef, nil
+}
+
+func (s *Server) setupPortMappingsAndCgroupPath(sbox libsandbox.Builder, g *generate.Generator, sboxID, runtimeHandler string) (string, error) {
+	portMappings := convertPortMappings(sbox.Config().GetPortMappings())
+
+	portMappingsJSON, err := json.Marshal(portMappings)
+	if err != nil {
+		return "", err
+	}
+
+	sbox.SetPortMappings(portMappings)
+
+	g.AddAnnotation(annotations.PortMappings, string(portMappingsJSON))
+
+	containerMinMemory, err := s.ContainerServer.Runtime().GetContainerMinMemory(runtimeHandler)
+	if err != nil {
+		return "", err
+	}
+
+	cgroupParent, cgroupPath, err := s.config.CgroupManager().SandboxCgroupPath(sbox.Config().GetLinux().GetCgroupParent(), sboxID, containerMinMemory)
+	if err != nil {
+		return "", err
+	}
+
+	if cgroupPath != "" {
+		g.SetLinuxCgroupsPath(cgroupPath)
+	}
+
+	sbox.SetCgroupParent(cgroupParent)
+	g.AddAnnotation(annotations.CgroupParent, cgroupParent)
+
+	return cgroupParent, nil
+}
+
+func (s *Server) setupSandboxIDMappingsAndResources(sbox libsandbox.Builder, g *generate.Generator, sandboxIDMappings *idtools.IDMappings) error {
+	if sandboxIDMappings != nil {
+		if err := g.AddOrReplaceLinuxNamespace(string(spec.UserNamespace), ""); err != nil {
+			return fmt.Errorf("add or replace linux namespace: %w", err)
+		}
+
+		for _, uidmap := range sandboxIDMappings.UIDs() {
+			g.AddLinuxUIDMapping(uint32(uidmap.HostID), uint32(uidmap.ContainerID), uint32(uidmap.Size))
+		}
+
+		for _, gidmap := range sandboxIDMappings.GIDs() {
+			g.AddLinuxGIDMapping(uint32(gidmap.HostID), uint32(gidmap.ContainerID), uint32(gidmap.Size))
+		}
+	}
+
+	overhead := sbox.Config().GetLinux().GetOverhead()
+
+	overheadJSON, err := json.Marshal(overhead)
+	if err != nil {
+		return err
+	}
+
+	sbox.SetPodLinuxOverhead(overhead)
+	g.AddAnnotation(annotations.PodLinuxOverhead, string(overheadJSON))
+
+	resources := sbox.Config().GetLinux().GetResources()
+
+	resourcesJSON, err := json.Marshal(resources)
+	if err != nil {
+		return err
+	}
+
+	sbox.SetPodLinuxResources(resources)
+	g.AddAnnotation(annotations.PodLinuxResources, string(resourcesJSON))
+
+	return nil
+}
+
+func (s *Server) setupHostnameFile(g *generate.Generator, hostnamePath, hostname, mountLabel string, sandboxIDMappings *idtools.IDMappings) error {
+	if err := os.WriteFile(hostnamePath, []byte(hostname+"\n"), 0o644); err != nil {
+		return err
+	}
+
+	if err := label.Relabel(hostnamePath, mountLabel, false); err != nil && !errors.Is(err, unix.ENOTSUP) {
+		return err
+	}
+
+	if sandboxIDMappings != nil {
+		rootPair := sandboxIDMappings.RootPair()
+		if err := os.Chown(hostnamePath, rootPair.UID, rootPair.GID); err != nil {
+			return fmt.Errorf("cannot chown %s to %d:%d: %w", hostnamePath, rootPair.UID, rootPair.GID, err)
+		}
+	}
+
+	mnt := spec.Mount{
+		Type:        "bind",
+		Source:      hostnamePath,
+		Destination: "/etc/hostname",
+		Options:     []string{"ro", "bind", "nodev", "nosuid", "noexec"},
+	}
+	g.AddMount(mnt)
+	g.AddAnnotation(annotations.HostnamePath, hostnamePath)
+
+	return nil
+}
+
+func (s *Server) setupUserNamespaceMounts(g *generate.Generator, sandboxIDMappings *idtools.IDMappings, hostNetwork bool, securityContext *types.LinuxSandboxSecurityContext) {
+	if sandboxIDMappings == nil {
+		return
+	}
+
+	if securityContext.GetNamespaceOptions().GetIpc() == types.NamespaceMode_NODE {
+		g.RemoveMount("/dev/mqueue")
+
+		mqueue := spec.Mount{
+			Type:        "bind",
+			Source:      "/dev/mqueue",
+			Destination: "/dev/mqueue",
+			Options:     []string{"rw", "rbind", "nodev", "nosuid", "noexec"},
+		}
+		g.AddMount(mqueue)
+	}
+
+	if hostNetwork {
+		g.RemoveMount("/sys")
+		g.RemoveMount("/sys/cgroup")
+
+		sysMnt := spec.Mount{
+			Destination: "/sys",
+			Type:        "bind",
+			Source:      "/sys",
+			Options:     []string{"nosuid", "noexec", "nodev", "ro", "rbind"},
+		}
+		g.AddMount(sysMnt)
+	}
+
+	if securityContext.GetNamespaceOptions().GetPid() == types.NamespaceMode_NODE {
+		g.RemoveMount("/proc")
+
+		proc := spec.Mount{
+			Type:        "bind",
+			Source:      "/proc",
+			Destination: "/proc",
+			Options:     []string{"rw", "rbind", "nodev", "nosuid", "noexec"},
+		}
+		g.AddMount(proc)
+	}
+}
+
+func (s *Server) setupInfraContainer(ctx context.Context, sb *libsandbox.Sandbox, g *generate.Generator, sboxID, containerName, runtimeHandler, cgroupParent string, podContainer *istorage.ContainerInfo, logPath string, labels, kubeAnnotations map[string]string, pauseImage references.RegistryImageReference, created time.Time, processLabel string) (*oci.Container, string, error) {
+	runtimeType, err := s.ContainerServer.Runtime().RuntimeType(runtimeHandler)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// A container is kernel separated if we're using shimv2, or we're using a kata v1 binary
+	podIsKernelSeparated := runtimeType == libconfig.RuntimeTypeVM ||
+		strings.Contains(strings.ToLower(runtimeHandler), "kata") ||
+		(runtimeHandler == "" && strings.Contains(strings.ToLower(s.config.DefaultRuntime), "kata"))
+
+	var container *oci.Container
+	// In the case of kernel separated containers, we need the infra container to create the VM for the pod
+	if sb.NeedsInfra(s.config.DropInfraCtr) || podIsKernelSeparated {
+		log.Debugf(ctx, "Keeping infra container for pod %s", sboxID)
+		// pauseImage, as the userRequestedImage parameter, only shows up in CRI values we return.
+		container, err = oci.NewContainer(sboxID, containerName, podContainer.RunDir, logPath, labels, g.Config.Annotations, kubeAnnotations, pauseImage.StringForOutOfProcessConsumptionOnly(), nil, nil, "", nil, sboxID, false, false, false, runtimeHandler, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+		if err != nil {
+			return nil, "", err
+		}
+		// If using a kernel separated container runtime, the process label should be set to container_kvm_t
+		// Keep in mind that kata does *not* apply any process label to containers within the VM
+		if podIsKernelSeparated {
+			processLabel, err = KVMLabel(processLabel)
+			if err != nil {
+				return nil, "", err
+			}
+
+			g.SetProcessSelinuxLabel(processLabel)
+		}
+	} else {
+		log.Debugf(ctx, "Dropping infra container for pod %s", sboxID)
+		container = oci.NewSpoofedContainer(sboxID, containerName, labels, sboxID, created, podContainer.RunDir)
+
+		g.AddAnnotation(annotations.SpoofedContainer, "true")
+
+		if err := s.config.CgroupManager().CreateSandboxCgroup(cgroupParent, sboxID); err != nil {
+			return nil, "", fmt.Errorf("create dropped infra %s cgroup: %w", sboxID, err)
+		}
+	}
+
+	return container, processLabel, nil
+}
+
+func (s *Server) configureAndSaveInfraContainer(ctx context.Context, sb *libsandbox.Sandbox, container *oci.Container, g *generate.Generator, mountPoint string, sandboxIDMappings *idtools.IDMappings, podContainer *istorage.ContainerInfo, sboxID string) error {
+	container.SetMountPoint(mountPoint)
+	container.SetSpec(g.Config)
+
+	// needed for getSandboxIDMappings()
+	container.SetIDMappings(sandboxIDMappings)
+
+	if err := sb.SetInfraContainer(container); err != nil {
+		return err
+	}
+
+	if err := sb.SetContainerEnvFile(ctx); err != nil {
+		return err
+	}
+
+	saveOptions := generate.ExportOptions{}
+
+	if err := g.SaveToFile(filepath.Join(podContainer.Dir, "config.json"), saveOptions); err != nil {
+		return fmt.Errorf("failed to save template configuration for pod sandbox %s(%s): %w", sb.Name(), sboxID, err)
+	}
+
+	if err := g.SaveToFile(filepath.Join(podContainer.RunDir, "config.json"), saveOptions); err != nil {
+		return fmt.Errorf("failed to write runtime configuration for pod sandbox %s(%s): %w", sb.Name(), sboxID, err)
+	}
+
+	return nil
+}
+
+func (s *Server) createAndStartInfraContainer(ctx context.Context, sb *libsandbox.Sandbox, container *oci.Container, sandboxIDMappings *idtools.IDMappings, sboxName string, resourceCleaner *resourcestore.ResourceCleaner) error {
+	s.addInfraContainer(ctx, container)
+	resourceCleaner.Add(ctx, "runSandbox: removing infra container "+container.ID(), func() error {
+		s.removeInfraContainer(ctx, container)
+
+		return nil
+	})
+	// TODO: Pass interface instead of individual field.
+	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox container runtime creation")
+
+	if err := s.createContainerPlatform(ctx, container, sb.CgroupParent(), sandboxIDMappings); err != nil {
+		return err
+	}
+
+	if hooks := s.hooksRetriever.Get(ctx, sb.RuntimeHandler(), sb.Annotations()); hooks != nil {
+		if err := hooks.PreStart(ctx, container, sb); err != nil {
+			return fmt.Errorf("failed to run pre-stop hook for container %q: %w", sb.ID(), err)
+		}
+	}
+
+	s.generateCRIEvent(ctx, sb.InfraContainer(), types.ContainerEventType_CONTAINER_CREATED_EVENT)
+
+	if err := s.ContainerServer.Runtime().StartContainer(ctx, container); err != nil {
+		return err
+	}
+
+	resourceCleaner.Add(ctx, "runSandbox: stopping container "+container.ID(), func() error {
+		// Clean-up steps from RemovePodSandbox
+		if err := s.stopContainer(ctx, container, stopTimeoutFromContext(ctx)); err != nil {
+			return errors.New("failed to stop container for removal")
+		}
+
+		log.Infof(ctx, "RunSandbox: deleting container %s", container.ID())
+
+		if err := s.ContainerServer.Runtime().DeleteContainer(ctx, container); err != nil {
+			return fmt.Errorf("failed to delete container %s in pod sandbox %s: %w", container.Name(), sb.ID(), err)
+		}
+
+		log.Infof(ctx, "RunSandbox: writing container %s state to disk", container.ID())
+
+		if err := s.ContainerStateToDisk(ctx, container); err != nil {
+			return fmt.Errorf("failed to write container state %s in pod sandbox %s: %w", container.Name(), sb.ID(), err)
+		}
+
+		return nil
+	})
+
+	if err := s.ContainerStateToDisk(ctx, container); err != nil {
+		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", container.ID(), err)
+	}
+
+	return nil
+}
+
+func (s *Server) setupSandboxShmAndMounts(ctx context.Context, sbox libsandbox.Builder, g *generate.Generator, sboxName, sboxID, namespace, kubeName, kubePodUID string, hostIPC bool, containerRunDir, mountLabel string, kubeAnnotations map[string]string, sandboxIDMappings *idtools.IDMappings, resourceCleaner *resourcestore.ResourceCleaner) (string, error) {
+	// Remove the default /dev/shm mount to ensure we overwrite it
+	g.RemoveMount(libsandbox.DevShmPath)
+
+	shmPath, err := s.setupSandboxShm(ctx, sboxName, sboxID, hostIPC, containerRunDir, mountLabel, kubeAnnotations, sandboxIDMappings, resourceCleaner)
+	if err != nil {
+		return "", err
+	}
+
+	sbox.SetShmPath(shmPath)
+
+	// Link logs if requested
+	if emptyDirVolName, ok := kubeAnnotations[annotations.LinkLogsAnnotation]; ok {
+		if err = linklogs.MountPodLogs(ctx, kubePodUID, emptyDirVolName, namespace, kubeName, mountLabel); err != nil {
+			log.Warnf(ctx, "Failed to link logs: %v", err)
+		}
+	}
+
+	// TODO: Pass interface instead of individual field.
+	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox spec configuration")
+
+	mnt := spec.Mount{
+		Type:        "bind",
+		Source:      shmPath,
+		Destination: libsandbox.DevShmPath,
+		Options:     []string{"rw", "bind"},
+	}
+	// bind mount the pod shm
+	g.AddMount(mnt)
+
+	err = s.setPodSandboxMountLabel(ctx, sboxID, mountLabel)
+	if err != nil {
+		return "", err
+	}
+
+	if err := s.ContainerServer.CtrIDIndex().Add(sboxID); err != nil {
+		return "", err
+	}
+
+	resourceCleaner.Add(ctx, "runSandbox: deleting container ID from idIndex for sandbox "+sboxID, func() error {
+		if err := s.ContainerServer.CtrIDIndex().Delete(sboxID); err != nil && !strings.Contains(err.Error(), noSuchID) {
+			return fmt.Errorf("could not delete ctr id %s from idIndex: %w", sboxID, err)
+		}
+
+		return nil
+	})
+
+	return shmPath, nil
+}
+
+func (s *Server) setupNamespacesAndNetwork(ctx context.Context, sb *libsandbox.Sandbox, g *generate.Generator, sboxID, sboxName string, hostNetwork, hostIPC, hostPID bool, sandboxIDMappings *idtools.IDMappings, sysctls map[string]string, resourceCleaner *resourcestore.ResourceCleaner) ([]string, error) {
+	// set up namespaces
+	// TODO: Pass interface instead of individual field.
+	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox namespace creation")
+	nsCleanupFuncs, err := s.configureGeneratorForSandboxNamespaces(ctx, hostNetwork, hostIPC, hostPID, sandboxIDMappings, sysctls, sb, g)
+	// We want to cleanup after ourselves if we are managing any namespaces and fail in this function.
+	// However, we don't immediately register this func with resourceCleaner because we need to pair the
+	// ns cleanup with networkStop. Otherwise, we could try to cleanup the namespace before the network stop runs,
+	// which could put us in a weird state.
+	nsCleanupDescription := "runSandbox: cleaning up namespaces after failing to run sandbox " + sboxID
+	nsCleanupFunc := func() error {
+		for idx := range nsCleanupFuncs {
+			if err := nsCleanupFuncs[idx](); err != nil {
+				return fmt.Errorf("RunSandbox: failed to cleanup namespace %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		resourceCleaner.Add(ctx, nsCleanupDescription, nsCleanupFunc)
+
+		return nil, err
+	}
+
+	// now that we have the namespaces, we should create the network if we're managing namespace Lifecycle
+	var ips []string
+
+	var result cnitypes.Result
+
+	// TODO: Pass interface instead of individual field.
+	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox network creation")
+
+	ips, result, err = s.networkStart(ctx, sb)
+	if err != nil {
+		resourceCleaner.Add(ctx, nsCleanupDescription, nsCleanupFunc)
+
+		return nil, err
+	}
+
+	resourceCleaner.Add(ctx, "runSandbox: stopping network for sandbox"+sb.ID(), func() error {
+		// use a new context to prevent an expired context from preventing a stop
+		if err := s.networkStop(context.Background(), sb); err != nil {
+			return fmt.Errorf("error stopping network on cleanup: %w", err)
+		}
+
+		// Now that we've succeeded in stopping the network, cleanup namespaces
+		log.Infof(ctx, "%s", nsCleanupDescription)
+
+		return nsCleanupFunc()
+	})
+
+	if result != nil {
+		resultCurrent, err := current.NewResultFromResult(result)
+		if err != nil {
+			return nil, err
+		}
+
+		cniResultJSON, err := json.Marshal(resultCurrent)
+		if err != nil {
+			return nil, err
+		}
+
+		g.AddAnnotation(annotations.CNIResult, string(cniResultJSON))
+	}
+
+	return ips, nil
+}
+
+func (s *Server) prepareSandboxMetadataAndLabels(sbox libsandbox.Builder, kubeAnnotations map[string]string, securityContext *types.LinuxSandboxSecurityContext, processLabel, mountLabel string) (*sandboxMetadataResult, error) {
+	// add metadata
+	metadata := sbox.Config().GetMetadata()
+
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	// add labels
+	labels := sbox.Config().GetLabels()
+
+	if err := validateLabels(labels); err != nil {
+		return nil, err
+	}
+
+	// Add special container name label for the infra container
+	if labels != nil {
+		labels[kubeletTypes.KubernetesContainerNameLabel] = oci.InfraContainerName
+	}
+
+	labelsJSON, err := json.Marshal(labels)
+	if err != nil {
+		return nil, err
+	}
+
+	// add annotations
+	kubeAnnotationsJSON, err := json.Marshal(kubeAnnotations)
+	if err != nil {
+		return nil, err
+	}
+
+	nsOptsJSON, err := json.Marshal(securityContext.GetNamespaceOptions())
+	if err != nil {
+		return nil, err
+	}
+
+	hostIPC := securityContext.GetNamespaceOptions().GetIpc() == types.NamespaceMode_NODE
+	hostPID := securityContext.GetNamespaceOptions().GetPid() == types.NamespaceMode_NODE
+
+	// Don't use SELinux separation with Host Pid or IPC Namespace or privileged.
+	if hostPID || hostIPC {
+		processLabel, mountLabel = "", ""
+	}
+
+	return &sandboxMetadataResult{
+		metadata:            metadata,
+		labels:              labels,
+		metadataJSON:        metadataJSON,
+		labelsJSON:          labelsJSON,
+		kubeAnnotationsJSON: kubeAnnotationsJSON,
+		nsOptsJSON:          nsOptsJSON,
+		hostIPC:             hostIPC,
+		hostPID:             hostPID,
+		processLabel:        processLabel,
+		mountLabel:          mountLabel,
+	}, nil
+}
+
+func (s *Server) setupStorageAndFinalize(ctx context.Context, sb *libsandbox.Sandbox, g *generate.Generator, sboxID, sboxName, containerName, hostnamePath, hostname string, hostNetwork bool, mountLabel string, sandboxIDMappings *idtools.IDMappings, securityContext *types.LinuxSandboxSecurityContext, resourceCleaner *resourcestore.ResourceCleaner) (string, error) {
+	// TODO: Pass interface instead of individual field.
+	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox storage start")
+
+	mountPoint, err := s.ContainerServer.StorageRuntimeServer().StartContainer(sboxID)
+	if err != nil {
+		return "", fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %w", containerName, sb.Name(), sboxID, err)
+	}
+
+	resourceCleaner.Add(ctx, "runSandbox: stopping storage container for sandbox "+sboxID, func() error {
+		if err := s.ContainerServer.StorageRuntimeServer().StopContainer(ctx, sboxID); err != nil {
+			return fmt.Errorf("could not stop storage container: %s: %w", sboxID, err)
+		}
+
+		return nil
+	})
+
+	// Set OOM score adjust of the infra container to be very low
+	// so it doesn't get killed.
+	g.SetProcessOOMScoreAdj(PodInfraOOMAdj)
+
+	g.SetLinuxResourcesCPUShares(PodInfraCPUshares)
+
+	// When infra-ctr-cpuset specified, set the infra container CPU set
+	if s.config.InfraCtrCPUSet != "" {
+		log.Debugf(ctx, "Set the infra container cpuset to %q", s.config.InfraCtrCPUSet)
+		g.SetLinuxResourcesCPUCpus(s.config.InfraCtrCPUSet)
+	}
+
+	g.AddAnnotation(annotations.MountPoint, mountPoint)
+
+	if err := s.setupHostnameFile(g, hostnamePath, hostname, mountLabel, sandboxIDMappings); err != nil {
+		return "", err
+	}
+
+	s.setupUserNamespaceMounts(g, sandboxIDMappings, hostNetwork, securityContext)
+
+	g.SetRootPath(mountPoint)
+
+	if os.Getenv(rootlessEnvName) != "" {
+		makeOCIConfigurationRootless(g)
+	}
+
+	sb.SetNamespaceOptions(securityContext.GetNamespaceOptions())
+
+	if s.config.Seccomp().IsDisabled() {
+		g.Config.Linux.Seccomp = nil
+	}
+
+	return mountPoint, nil
 }


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

Refactor core CRI-O components to improve code maintainability and
readability by significantly reducing cyclomatic complexity.

Changes:
- Decompose large monolithic functions into smaller, focused helpers
- Extract config merging logic in criocli.go into domain-specific
  functions (mergeImageConfig, mergeRuntimeConfig, etc.)
- Simplify control flow in container_create.go and sandbox_run_linux.go
  by extracting complex conditional blocks into separate functions
- Update golangci-lint gocyclo threshold from 177 to 60

This refactoring reduces the maximum cyclomatic complexity by ~66%,
making the codebase easier to understand, test, and maintain without
changing any functional behavior.

Files modified:
- internal/criocli/criocli.go: Config merging logic decomposed
- server/container_create.go: Container creation flow simplified
- server/sandbox_run_linux.go: Sandbox runtime logic restructured
- .golangci.yml: Enforce max complexity of 60


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
