### PR TITLE
extract the JSON substring from the state command's output

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1159,8 +1159,18 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 			return nil, true, nil
 		}
 
+		// only extract the JSON substring from the state command output
+		var outJSON string
+
+		startIdx := strings.Index(out, "{")
+
+		endIdx := strings.LastIndex(out, "}") + 1
+		if startIdx >= 0 && (endIdx-startIdx) > 0 {
+			outJSON = out[startIdx:endIdx]
+		}
+
 		state := *c.state
-		if err := json.NewDecoder(strings.NewReader(out)).Decode(&state); err != nil {
+		if err := json.NewDecoder(strings.NewReader(outJSON)).Decode(&state); err != nil {
 			return &state, false, fmt.Errorf("failed to decode container status for %s: %w", c.ID(), err)
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR makes the execution of `UpdateContainerStatus` more robust. CRI-O, when running this method, runs the `state <container-id>` command to retrieve the current state of the container in JSON format. Currently, this method expects the command output to only contain JSON. This causes failures when we supply our own custom wrapper binaries which print additional information apart from calling `crun` under the hood. 

I believe this is a safe change to make, as the method call below is the only instance where the output of the command is actually consumed in the cri-o codebase

```
out, err := r.runtimeCmd("state", c.ID())
```
Since the method only anticipates valid JSON to proceed, it should be sufficient to just grab the substring between the first occurrence of the "{" and the last occurrence of "}"

#### Which issue(s) this PR fixes:

Fixes #9541 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

```release-note
Extract the JSON substring before decoding the state command output
```
