### PR TITLE
Fix `patch-release` job by adding dependencies.yaml

### DIFF
--- a/scripts/release/release.go
+++ b/scripts/release/release.go
@@ -117,8 +117,10 @@ func updateVersionAndCreatePR(
 
 	logrus.Info("Committing changes")
 
-	if err := repo.Add(utils.VersionFile); err != nil {
-		return fmt.Errorf("unable to add file %q to repo: %w", utils.VersionFile, err)
+	for _, file := range []string{utils.VersionFile, utils.DependenciesYAMLFile} {
+		if err := repo.Add(file); err != nil {
+			return fmt.Errorf("unable to add file %q to repo: %w", file, err)
+		}
 	}
 
 	if err := repo.UserCommit(
@@ -176,20 +178,18 @@ func modifyVersionFile(filePath, oldVersion, newVersion string) error {
 }
 
 func updateDependenciesYAML(oldVersion, newVersion string) error {
-	const fileName = "dependencies.yaml"
-
-	content, err := os.ReadFile(fileName)
+	content, err := os.ReadFile(utils.DependenciesYAMLFile)
 	if err != nil {
-		return fmt.Errorf("read file %s: %w", fileName, err)
+		return fmt.Errorf("read file %s: %w", utils.DependenciesYAMLFile, err)
 	}
 
 	const developmentVersion = "name: development version\n    version: "
 
 	modifiedContent := bytes.ReplaceAll(content, []byte(developmentVersion+oldVersion), []byte(developmentVersion+newVersion))
 
-	err = os.WriteFile(fileName, modifiedContent, 0o644)
+	err = os.WriteFile(utils.DependenciesYAMLFile, modifiedContent, 0o644)
 	if err != nil {
-		return fmt.Errorf("update file %s: %w", fileName, err)
+		return fmt.Errorf("update file %s: %w", utils.DependenciesYAMLFile, err)
 	}
 
 	return nil

--- a/scripts/utils/utils.go
+++ b/scripts/utils/utils.go
@@ -13,13 +13,14 @@ import (
 )
 
 const (
-	GithubTokenEnvKey = "GITHUB_TOKEN"
-	GitRemoteEnvKey   = "REMOTE"
-	OrgEnvKey         = "ORG"
-	VersionFile       = "internal/version/version.go"
-	BranchPrefix      = "release-"
-	VersionPrefix     = "v"
-	CrioOrgRepo       = "cri-o"
+	GithubTokenEnvKey    = "GITHUB_TOKEN"
+	GitRemoteEnvKey      = "REMOTE"
+	OrgEnvKey            = "ORG"
+	VersionFile          = "internal/version/version.go"
+	DependenciesYAMLFile = "dependencies.yaml"
+	BranchPrefix         = "release-"
+	VersionPrefix        = "v"
+	CrioOrgRepo          = "cri-o"
 )
 
 func GetCurrentVersionFromReleaseBranch(repo *git.Repo, baseBranchName string) (res semver.Version, err error) {


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
This should fix the failing CI
https://github.com/cri-o/cri-o/actions/runs/18988468445/job/54236873693 and let the patch release job work correctly.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
