### PR TITLE
refactor: Reduce cyclomatic complexity in sandbox_run

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,7 +137,7 @@ linters:
         - filepathJoin
         - whyNoLint
     gocyclo:
-      min-complexity: 177
+      min-complexity: 60
     nakedret:
       max-func-lines: 15
     revive:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor server/sandbox_run_linux.go to reduce cyclomatic complexity by
decomposing large functions into smaller, focused helpers.

Changes:
- Break down complex sandbox runtime logic into separate functions
- Simplify control flow and conditional logic
- Extract complex conditional blocks into dedicated helper functions
- Split functions with multiple responsibilities into single-purpose functions:
  * Split setupPortMappingsAndCgroupPath into setupSandboxPortMappings and setupSandboxCgroupPath
  * Split setupSandboxIDMappingsAndResources into setupSandboxIDMappings and setupSandboxResources
  * Split setupSandboxShmAndMounts into setupSandboxShmMount, setupSandboxLogLinking, and setupSandboxContainerIDIndex
  * Split setupStorageAndFinalize into setupSandboxStorage, setupSandboxInfraContainerResources, setupSandboxHostnameAndMounts, and finalizeSandboxSpec
  * Keep setupNamespacesAndNetwork as-is since network setup depends on namespace setup and their cleanup is coupled

This is the largest file in the refactor with ~1481 lines modified. The
refactoring makes the sandbox creation and runtime logic easier to
understand, test, and maintain.

This is part of splitting #9533 into smaller, reviewable PRs per maintainer
request.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is part of a series of PRs split from #9533. The refactoring improves
code maintainability without changing any functional behavior.

The function splits address the review feedback about the `*And*` naming pattern,
ensuring each function has a single, clear responsibility.

#### Does this PR introduce a user-facing change?

```release-note
None
```