### PR TITLE
OCPBUGS-62150: server: ignore /etc/passwd mount

### DIFF
--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -272,6 +272,8 @@ func (s *Server) CRImportCheckpoint(
 		"/dev/shm":           true,
 		"/etc/resolv.conf":   true,
 		"/etc/hostname":      true,
+		"/etc/passwd":        true,
+		"/etc/group":         true,
 		"/run/secrets":       true,
 		"/run/.containerenv": true,
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Ignore /etc/passwd when checking for mounts. Always rely on the mount as defined from Kubernetes. This follows existing practice like for /etc/hosts or /etc/resolv.conf

#### Which issue(s) this PR fixes:

OCPBUGS-62150

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container checkpoint and restore operations to properly preserve system authentication files and user identity settings, ensuring user credentials and access permissions remain consistent when containers are restored from checkpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->