### PR TITLE
WIP: Add OCI artifact support to copyimg binary

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -111,6 +111,7 @@ IMAGES=(
     registry.k8s.io/pause:3.10.1
     quay.io/crio/fedora-crio-ci:latest
     quay.io/crio/hello-wasm:latest
+    quay.io/crio/seccomp:v2
 )
 
 function img2dir() {

--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -344,7 +344,13 @@ function start_crio_with_stopped_pod() {
 
 	# Since one of the layers was removed, the image would be corrupted, so we expect
 	# one to have been removed.
-	num_images=${#IMAGES[@]}
+	# Count only regular images (not OCI artifacts) since artifacts don't appear in crictl images
+	num_images=0
+	for img in "${IMAGES[@]}"; do
+		if ! is_artifact "$img"; then
+			((num_images++))
+		fi
+	done
 
 	# We start with $num_images images, and remove one with the layer removal above.
 	# `crictl images` adds one additional row for the table header.

--- a/test/seccomp_oci_artifacts.bats
+++ b/test/seccomp_oci_artifacts.bats
@@ -18,7 +18,7 @@ function teardown() {
 ARTIFACT_IMAGE_WITH_ANNOTATION=quay.io/crio/nginx-seccomp:v2
 ARTIFACT_IMAGE_WITH_POD_ANNOTATION=$ARTIFACT_IMAGE_WITH_ANNOTATION-pod
 ARTIFACT_IMAGE_WITH_CONTAINER_ANNOTATION=$ARTIFACT_IMAGE_WITH_ANNOTATION-container
-ARTIFACT_IMAGE=quay.io/crio/seccomp:v2
+ARTIFACT_IMAGE=${IMAGES[3]}
 CONTAINER_NAME=container1
 ANNOTATION=seccomp-profile.kubernetes.cri-o.io
 POD_ANNOTATION=seccomp-profile.kubernetes.cri-o.io/POD
@@ -167,7 +167,8 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	create_runtime_with_allowed_annotation seccomp $ANNOTATION
 	start_crio_no_setup
 
-	jq '.annotations += { "'$POD_ANNOTATION'": "'$ARTIFACT_IMAGE'" }' \
+	jq --arg ARTIFACT "$ARTIFACT_IMAGE" \
+		'.annotations += { "'$POD_ANNOTATION'": $ARTIFACT }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
 	CTR=$(crictl run "$TESTDATA/container_config.json" "$TESTDIR/sandbox.json")
@@ -184,7 +185,8 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	create_runtime_with_allowed_annotation seccomp $ANNOTATION
 	start_crio_no_setup
 
-	jq '.annotations += { "'$ANNOTATION'/'$CONTAINER_NAME'": "'$ARTIFACT_IMAGE'" }' \
+	jq --arg ARTIFACT "$ARTIFACT_IMAGE" \
+		'.annotations += { "'$ANNOTATION'/'$CONTAINER_NAME'": $ARTIFACT }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
 	CTR=$(crictl run "$TESTDATA/container_config.json" "$TESTDIR/sandbox.json")
@@ -201,7 +203,8 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 	create_runtime_with_allowed_annotation seccomp $ANNOTATION
 	start_crio_no_setup
 
-	jq '.annotations += { "'$ANNOTATION'/container2": "'$ARTIFACT_IMAGE'" }' \
+	jq --arg ARTIFACT "$ARTIFACT_IMAGE" \
+		'.annotations += { "'$ANNOTATION'/container2": $ARTIFACT }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
 	CTR=$(crictl run "$TESTDATA/container_config.json" "$TESTDIR/sandbox.json")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds OCI artifact support to the `copyimg` binary used in tests. The main changes are:

- **Migrated copyimg to use libimage**: Replaced the low-level `containers/image/v5/copy` package with `containers/common/libimage`, which properly handles OCI artifacts
- **Removed unused policyContext code**: The `libimage.Copier` handles signature policy internally via `SystemContext`, so the explicit policy and policyContext creation/teardown was removed
- **Added artifact to IMAGES array**: Added `quay.io/crio/seccomp:v2` to the `IMAGES` array in `test/common.sh` to ensure the artifact is cached before running tests
- **Updated test references**: Changed `test/seccomp_oci_artifacts.bats` to reference `${IMAGES[3]}` instead of hardcoding the artifact image
- **Fixed shellcheck warnings**: Updated jq commands to use `--arg` for proper variable handling instead of string interpolation

OCI artifacts differ from container images in that they may use `application/vnd.oci.empty.v1+json` as their config media type and rely on the `artifactType` field. The `libimage.Copier` handles these cases properly, whereas the lower-level `copy.Image` function does not.

#### Which issue(s) this PR fixes:

Fixes #9041

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```