### PR TITLE
Disable runc integration tests due to AppArmor issue

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,15 +59,19 @@ jobs:
       fail-fast: false
       matrix:
         run:
-          - name: critest / conmon / runc / amd64
-            arch: amd64
-            runner: ubuntu-latest
-            defaultRuntime: runc
-            runtimeType: oci
-            critest: 1
-            userns: 0
-            jobs: 1
-            timeout: 20
+          # TODO: Re-enable runc integration tests when mitigation is found
+          # Disabled due to AppArmor issue in nested environments
+          # See: https://github.com/cri-o/cri-o/issues/9573
+          # See: https://github.com/opencontainers/runc/issues/4968
+          # - name: critest / conmon / runc / amd64
+          #   arch: amd64
+          #   runner: ubuntu-latest
+          #   defaultRuntime: runc
+          #   runtimeType: oci
+          #   critest: 1
+          #   userns: 0
+          #   jobs: 1
+          #   timeout: 20
 
           - name: critest / conmon / crun / amd64
             arch: amd64
@@ -79,15 +83,15 @@ jobs:
             jobs: 1
             timeout: 20
 
-          - name: critest / conmon-rs / runc / amd64
-            arch: amd64
-            runner: ubuntu-latest
-            defaultRuntime: runc
-            runtimeType: pod
-            critest: 1
-            userns: 0
-            jobs: 1
-            timeout: 20
+          # - name: critest / conmon-rs / runc / amd64
+          #   arch: amd64
+          #   runner: ubuntu-latest
+          #   defaultRuntime: runc
+          #   runtimeType: pod
+          #   critest: 1
+          #   userns: 0
+          #   jobs: 1
+          #   timeout: 20
 
           - name: critest / conmon-rs / crun / amd64
             arch: amd64
@@ -99,15 +103,15 @@ jobs:
             jobs: 1
             timeout: 20
 
-          - name: critest / conmon / runc / arm64
-            arch: arm64
-            runner: ubuntu-24.04-arm
-            defaultRuntime: runc
-            runtimeType: oci
-            critest: 1
-            userns: 0
-            jobs: 1
-            timeout: 20
+          # - name: critest / conmon / runc / arm64
+          #   arch: arm64
+          #   runner: ubuntu-24.04-arm
+          #   defaultRuntime: runc
+          #   runtimeType: oci
+          #   critest: 1
+          #   userns: 0
+          #   jobs: 1
+          #   timeout: 20
 
           - name: critest / conmon / crun / arm64
             arch: arm64
@@ -119,15 +123,15 @@ jobs:
             jobs: 1
             timeout: 20
 
-          - name: critest / conmon-rs / runc / arm64
-            arch: arm64
-            runner: ubuntu-24.04-arm
-            defaultRuntime: runc
-            runtimeType: pod
-            critest: 1
-            userns: 0
-            jobs: 1
-            timeout: 20
+          # - name: critest / conmon-rs / runc / arm64
+          #   arch: arm64
+          #   runner: ubuntu-24.04-arm
+          #   defaultRuntime: runc
+          #   runtimeType: pod
+          #   critest: 1
+          #   userns: 0
+          #   jobs: 1
+          #   timeout: 20
 
           - name: critest / conmon-rs / crun / arm64
             arch: arm64
@@ -139,15 +143,15 @@ jobs:
             jobs: 1
             timeout: 20
 
-          - name: integration / conmon / runc / amd64
-            arch: amd64
-            runner: ubuntu-latest
-            defaultRuntime: runc
-            runtimeType: oci
-            critest: 0
-            userns: 0
-            jobs: 2
-            timeout: 120
+          # - name: integration / conmon / runc / amd64
+          #   arch: amd64
+          #   runner: ubuntu-latest
+          #   defaultRuntime: runc
+          #   runtimeType: oci
+          #   critest: 0
+          #   userns: 0
+          #   jobs: 2
+          #   timeout: 120
 
           - name: integration / conmon / crun / amd64
             arch: amd64
@@ -159,25 +163,25 @@ jobs:
             jobs: 2
             timeout: 120
 
-          - name: integration / conmon-rs / runc / amd64
-            arch: amd64
-            runner: ubuntu-latest
-            defaultRuntime: runc
-            runtimeType: pod
-            critest: 0
-            userns: 0
-            jobs: 2
-            timeout: 120
+          # - name: integration / conmon-rs / runc / amd64
+          #   arch: amd64
+          #   runner: ubuntu-latest
+          #   defaultRuntime: runc
+          #   runtimeType: pod
+          #   critest: 0
+          #   userns: 0
+          #   jobs: 2
+          #   timeout: 120
 
-          - name: integration / userns / runc / amd64
-            arch: amd64
-            runner: ubuntu-latest
-            defaultRuntime: runc
-            runtimeType: oci
-            critest: 0
-            userns: 1
-            jobs: 2
-            timeout: 120
+          # - name: integration / userns / runc / amd64
+          #   arch: amd64
+          #   runner: ubuntu-latest
+          #   defaultRuntime: runc
+          #   runtimeType: oci
+          #   critest: 0
+          #   userns: 1
+          #   jobs: 2
+          #   timeout: 120
     env:
       GOCOVERDIR: ${{ github.workspace }}/build/coverage/bats # It's used to make coverage profiles. https://go.dev/doc/build-cover
     name: ${{ matrix.run.name }}


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:

All runc integration tests are failing in CI due to an AppArmor issue in nested environments. The error occurs when runc tries to access /proc/sys/net/ipv4/ip_unprivileged_port_start, which AppArmor incorrectly interprets as trying to access /sys/... in detached mounts.

This is a known issue in runc that affects various container platforms. The maintainers advise against downgrading as the current version fixes multiple container escape vulnerabilities.

Disabled tests:
- critest / conmon / runc / amd64
- critest / conmon-rs / runc / amd64
- critest / conmon / runc / arm64
- critest / conmon-rs / runc / arm64
- integration / conmon / runc / amd64
- integration / conmon-rs / runc / amd64
- integration / userns / runc / amd64


#### Which issue(s) this PR fixes:

Fixes: https://github.com/cri-o/cri-o/issues/9573



#### Special notes for your reviewer:
Refers to: https://github.com/opencontainers/runc/issues/4968

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
