### PR TITLE
Update golangci-lint to v2.6.2

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ on:
       - update-nixpkgs-*
   pull_request:
 env:
-  GOLANGCI_LINT_VERSION: v2.5.0
+  GOLANGCI_LINT_VERSION: v2.6.2
 permissions:
   contents: read
 concurrency:
@@ -32,16 +32,6 @@ jobs:
       - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-
-  gopls-modernize:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-        with:
-          go-version-file: go.mod
-      - run: scripts/github-actions-packages
-      - run: make gopls-modernize
 
   lint-markdown:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - dupl
     - dupword
     - durationcheck
+    - embeddedstructfieldcheck
     - errcheck
     - errchkjson
     - errorlint
@@ -55,6 +56,7 @@ linters:
     - makezero
     - mirror
     - misspell
+    - modernize
     - musttag
     - nakedret
     - nilnesserr
@@ -87,7 +89,6 @@ linters:
     # - contextcheck
     # - cyclop
     # - depguard
-    # - embeddedstructfieldcheck
     # - err113
     # - errname
     # - exhaustive

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ GO_MD2MAN ?= ${BUILD_BIN_PATH}/go-md2man
 GINKGO := ${BUILD_BIN_PATH}/ginkgo
 MOCKGEN := ${BUILD_BIN_PATH}/mockgen
 GOLANGCI_LINT := ${BUILD_BIN_PATH}/golangci-lint
-GOLANGCI_LINT_VERSION := v2.5.0
+GOLANGCI_LINT_VERSION := v2.6.2
 GO_MOD_OUTDATED := ${BUILD_BIN_PATH}/go-mod-outdated
 GO_MOD_OUTDATED_VERSION := 0.9.0
 GOSEC := ${BUILD_BIN_PATH}/gosec
@@ -314,16 +314,10 @@ uninstall: ## Uninstall all files.
 ##@ Verify targets:
 
 .PHONY: lint
-lint: ${GOLANGCI_LINT} gopls-modernize ## Run the golang linter, supposed to not run on CI.
+lint: ${GOLANGCI_LINT} ## Run the golang linter, supposed to not run on CI.
 	${GOLANGCI_LINT} version
 	${GOLANGCI_LINT} linters
 	GL_DEBUG=gocritic ${GOLANGCI_LINT} run --fix
-
-.PHONY: gopls-modernize
-gopls-modernize: ## Run the gopls modernize linter and report any diff, supposed to not run on CI.
-	export GOFLAGS=-tags="test,$(shell echo $(BUILDTAGS) | sed -r 's/\s+/,/g')" && \
-		$(GO_RUN) golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix ./...
-	./hack/tree_status.sh
 
 .PHONY: check-log-lines
 check-log-lines: ## Verify that all log lines start with a capitalized letter.

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -249,6 +249,7 @@ func main() {
 
 				return fmt.Errorf("could not start CPU profiling: %w", err)
 			}
+
 			defer pprof.StopCPUProfile()
 		}
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -25,7 +25,7 @@ dependencies:
         match: ReleaseMinorVersions
 
   - name: golangci-lint
-    version: v2.5.0
+    version: v2.6.2
     refPaths:
       - path: .github/workflows/verify.yml
         match: GOLANGCI_LINT_VERSION

--- a/internal/config/nsmgr/types_linux.go
+++ b/internal/config/nsmgr/types_linux.go
@@ -35,6 +35,7 @@ type PodNamespaceConfig struct {
 // namespace is the internal implementation of the Namespace interface.
 type namespace struct {
 	sync.Mutex
+
 	ns     NS
 	closed bool
 	nsType NSType

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -178,6 +178,7 @@ func mergeImageConfig(config *libconfig.Config, ctx *cli.Context) {
 	}
 
 	if ctx.IsSet("insecure-registry") {
+		//nolint:staticcheck // SA1019: InsecureRegistries is deprecated but still supported for backward compatibility
 		config.InsecureRegistries = StringSliceTrySplit(ctx, "insecure-registry")
 	}
 
@@ -873,7 +874,8 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 			EnvVars: []string{"CONTAINER_STORAGE_OPT"},
 		},
 		&cli.StringSliceFlag{
-			Name:  "insecure-registry",
+			Name: "insecure-registry",
+			//nolint:staticcheck // SA1019: InsecureRegistries is deprecated but still supported for backward compatibility
 			Value: cli.NewStringSlice(defConf.InsecureRegistries...),
 			Usage: "Enable insecure registry communication, i.e., enable un-encrypted and/or untrusted communication." + `
     This option is deprecated. Please use "insecure" in registries.conf instead.

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -42,6 +42,8 @@ const (
 
 // ContainerServer implements the ImageServer.
 type ContainerServer struct {
+	*statsserver.StatsServer
+
 	runtime              *oci.Runtime
 	store                cstorage.Store
 	storageImageServer   storage.ImageServer
@@ -51,7 +53,6 @@ type ContainerServer struct {
 	podNameIndex         *registrar.Registrar
 	podIDIndex           *truncindex.TruncIndex
 	Hooks                *hooks.Manager
-	*statsserver.StatsServer
 
 	stateLock sync.Locker
 	state     *containerServerState

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -824,13 +824,11 @@ var _ = t.Describe("ContainerServer", func() {
 
 			// When
 			sandboxes := sut.ListSandboxes()
-			containers, err := sut.ListContainers(
-				func(container *oci.Container) bool {
-					return true
-				},
-				func(container *oci.Container) bool {
-					return true
-				})
+			returnTrue := func(container *oci.Container) bool {
+				return true
+			}
+			//nolint:gocritic // dupOption is expected here as both filters are intentionally the same in this test
+			containers, err := sut.ListContainers(returnTrue, returnTrue)
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/lib/stats/stats_server.go
+++ b/internal/lib/stats/stats_server.go
@@ -19,6 +19,8 @@ import (
 // If collectionPeriod is > 0, it maintains this list by updating the stats on collectionPeriod frequency.
 // Otherwise, it only updates the stats as they're requested.
 type StatsServer struct {
+	parentServerIface
+
 	shutdown         chan struct{}
 	alreadyShutdown  bool
 	collectionPeriod time.Duration
@@ -26,8 +28,7 @@ type StatsServer struct {
 	ctrStats         map[string]*types.ContainerStats
 	sboxMetrics      map[string]*SandboxMetrics
 	ctx              context.Context
-	parentServerIface
-	mutex sync.Mutex
+	mutex            sync.Mutex
 }
 
 // parentServerIface is an interface for requesting information from the parent ContainerServer.

--- a/internal/log/interceptors/interceptors.go
+++ b/internal/log/interceptors/interceptors.go
@@ -15,6 +15,7 @@ import (
 
 type ServerStream struct {
 	grpc.ServerStream
+
 	NewContext context.Context
 }
 

--- a/internal/mockutils/mockutils.go
+++ b/internal/mockutils/mockutils.go
@@ -17,6 +17,7 @@ func InOrder(calls ...any) MockSequence {
 	// This implementation does a few more assignments and checks than strictly necessary, but it is O(N) and reasonably easy to read, so, whatever.
 	for i := range calls {
 		var elem MockSequence
+
 		switch e := calls[i].(type) {
 		case MockSequence:
 			elem = e

--- a/internal/nri/domain.go
+++ b/internal/nri/domain.go
@@ -45,6 +45,7 @@ func SetDomain(d Domain) {
 
 type domainTable struct {
 	sync.Mutex
+
 	domain Domain
 }
 

--- a/internal/nri/nri.go
+++ b/internal/nri/nri.go
@@ -84,6 +84,7 @@ const (
 
 type local struct {
 	sync.Mutex
+
 	cfg *config.Config
 	nri *nri.Adaptation
 

--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -114,6 +114,7 @@ type ContainerVolume struct {
 // ContainerState represents the status of a container.
 type ContainerState struct {
 	specs.State
+
 	Created       time.Time `json:"created"`
 	Started       time.Time `json:"started"`
 	Finished      time.Time `json:"finished"`

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -53,6 +53,8 @@ import (
 // runtimeVM is the Runtime interface implementation that is more appropriate
 // for VM based container runtimes.
 type runtimeVM struct {
+	sync.Mutex
+
 	path       string
 	fifoDir    string
 	configPath string
@@ -62,7 +64,6 @@ type runtimeVM struct {
 	client     *ttrpc.Client
 	task       task.TaskService
 
-	sync.Mutex
 	ctrs map[string]containerInfo
 }
 

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -1033,6 +1033,7 @@ func GetImageService(ctx context.Context, store storage.Store, storageTransport 
 		regexForPinnedImages: CompileRegexpsForPinnedImages(serverConfig.PinnedImages),
 	}
 
+	//nolint:staticcheck // SA1019: InsecureRegistries is deprecated but still supported for backward compatibility
 	if len(serverConfig.InsecureRegistries) > 0 {
 		log.Errorf(ctx, "Insecure registries option is deprecated and no longer effective. Please use `insecure` in `registries.conf` instead.")
 	}

--- a/internal/watchdog/watchdog_test_inject.go
+++ b/internal/watchdog/watchdog_test_inject.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 // All *_inject.go files are meant to be used by tests only. Purpose of this
 // files is to provide a way to inject mocked data into the current setup.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,10 +74,6 @@ const (
 // Config represents the entire set of configuration values that can be set for
 // the server. This is intended to be loaded from a toml-encoded config file.
 type Config struct {
-	Comment          string
-	singleConfigPath string // Path to the single config file
-	dropInConfigDir  string // Path to the drop-in config files
-
 	RootConfig
 	APIConfig
 	RuntimeConfig
@@ -86,6 +82,11 @@ type Config struct {
 	MetricsConfig
 	TracingConfig
 	StatsConfig
+
+	Comment          string
+	singleConfigPath string // Path to the single config file
+	dropInConfigDir  string // Path to the drop-in config files
+
 	NRI           *nri.Config
 	SystemContext *types.SystemContext
 }
@@ -203,8 +204,9 @@ func (c *RootConfig) GetStore() (storage.Store, error) {
 
 // runtimeHandlerFeatures represents the supported features of the runtime.
 type runtimeHandlerFeatures struct {
-	RecursiveReadOnlyMounts bool `json:"-"` // Internal use only.
 	features.Features
+
+	RecursiveReadOnlyMounts bool `json:"-"` // Internal use only.
 }
 
 // RuntimeHandler represents each item of the "crio.runtime.runtimes" TOML
@@ -617,6 +619,7 @@ type ImageConfig struct {
 	SignaturePolicyDir string `toml:"signature_policy_dir"`
 	// InsecureRegistries is a list of registries that must be contacted w/o
 	// TLS verification.
+	//
 	// Deprecated: it's no longer effective. Please use `insecure` in `registries.conf` instead.
 	InsecureRegistries []string `toml:"insecure_registries"`
 	// ImageVolumes controls how volumes specified in image config are handled
@@ -755,6 +758,7 @@ type StatsConfig struct {
 type tomlConfig struct {
 	Crio struct {
 		RootConfig
+
 		API     struct{ APIConfig }     `toml:"api"`
 		Runtime struct{ RuntimeConfig } `toml:"runtime"`
 		Image   struct{ ImageConfig }   `toml:"image"`

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -64,15 +64,19 @@ func assembleTemplateString(displayAllConfig bool, c *Config) string {
 func crioTemplateString(group templateGroup, prefix string, displayAll bool, crioTemplateConfig []*templateConfigValue) string {
 	templateString := ""
 
+	var sb strings.Builder
+
 	for _, configItem := range crioTemplateConfig {
 		if group == configItem.group {
 			if !configItem.isDefaultValue || displayAll {
-				templateString += strings.ReplaceAll(configItem.templateString, "{{ $.Comment }}", "")
+				sb.WriteString(strings.ReplaceAll(configItem.templateString, "{{ $.Comment }}", ""))
 			} else {
-				templateString += configItem.templateString
+				sb.WriteString(configItem.templateString)
 			}
 		}
 	}
+
+	templateString += sb.String()
 
 	if templateString != "" {
 		templateString = prefix + templateString

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -483,6 +483,7 @@ func (a *nriAPI) EvictContainer(ctx context.Context, e *api.ContainerEviction) e
 
 type criPodSandbox struct {
 	*sandbox.Sandbox
+
 	spec *rspec.Spec
 	pid  int
 }

--- a/server/rootless_unsupported.go
+++ b/server/rootless_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package server
 

--- a/server/sandbox_network_freebsd.go
+++ b/server/sandbox_network_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package server
 

--- a/server/sandbox_network_linux.go
+++ b/server/sandbox_network_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package server
 

--- a/server/sandbox_network_unsupported.go
+++ b/server/sandbox_network_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package server
 

--- a/server/server.go
+++ b/server/server.go
@@ -56,20 +56,24 @@ var errSandboxNotCreated = errors.New("sandbox not created")
 
 // StreamService implements streaming.Runtime.
 type StreamService struct {
+	streaming.Runtime
+
 	ctx                 context.Context
 	runtimeServer       *Server // needed by Exec() endpoint
 	streamServer        streaming.Server
 	streamServerCloseCh chan struct{}
-	streaming.Runtime
 }
 
 // Server implements the RuntimeService and ImageService.
 type Server struct {
+	*lib.ContainerServer
+	types.UnsafeImageServiceServer
+	types.UnsafeRuntimeServiceServer
+
 	config          libconfig.Config
 	stream          *StreamService
 	hostportManager hostport.HostPortManager
 
-	*lib.ContainerServer
 	monitorsChan        chan struct{}
 	defaultIDMappings   *idtools.IDMappings
 	ContainerEventsChan chan types.ContainerEventResponse
@@ -94,9 +98,6 @@ type Server struct {
 	nri *nriAPI
 	// hooksRetriever allows getting the runtime hooks for the sandboxes.
 	hooksRetriever *runtimehandlerhooks.HooksRetriever
-
-	types.UnsafeImageServiceServer
-	types.UnsafeRuntimeServiceServer
 }
 
 // pullArguments are used to identify a pullOperation via an input image name and

--- a/test/docs-validation/main.go
+++ b/test/docs-validation/main.go
@@ -287,7 +287,7 @@ func recursiveEntries(
 
 			if !stringInSlice(tag, excludedTagsValue) {
 				switch {
-				case field.Type.Implements(reflect.TypeOf((*stringer)(nil)).Elem()):
+				case field.Type.Implements(reflect.TypeFor[stringer]()):
 					// We need a checked type assertion to make golangci-lint happy...
 					if str, ok := vv.MethodByName("String").Interface().(func() string); ok {
 						// if the field is a pointer and nil, skip validation

--- a/test/nri/nri_suite_test.go
+++ b/test/nri/nri_suite_test.go
@@ -86,6 +86,7 @@ func setupLogging() {
 
 type nriTest struct {
 	*testing.T
+
 	namespace string
 	plugins   []*plugin
 	options   [][]PluginOption

--- a/test/nri/nri_test.go
+++ b/test/nri/nri_test.go
@@ -498,6 +498,7 @@ func skipTestForCondition(t *testing.T, skipChecks ...map[string]bool) {
 
 type idgen struct {
 	sync.Mutex
+
 	uid int
 	pod int
 	ctr int

--- a/test/nri/plugin.go
+++ b/test/nri/plugin.go
@@ -16,6 +16,7 @@ type PluginOption func(*plugin)
 
 type plugin struct {
 	sync.Mutex
+
 	namespace string
 	options   []stub.Option
 	stub      stub.Stub

--- a/test/nri/runtime.go
+++ b/test/nri/runtime.go
@@ -23,6 +23,7 @@ const (
 
 type runtime struct {
 	sync.Mutex
+
 	cc         *grpc.ClientConn
 	runtime    cri.RuntimeServiceClient
 	image      cri.ImageServiceClient


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency-change
/kind cleanup

#### What this PR does / why we need it:

This PR updates golangci-lint from v2.5.0 to v2.6.2 and modernizes the linter configuration.

**Changes:**
- Update golangci-lint from v2.5.0 to v2.6.2 in dependencies.yaml, Makefile, and CI workflows
- Add new linters: `modernize` and `embeddedstructfieldcheck`
- Remove the separate `gopls-modernize` CI job in favor of the built-in `modernize` linter (introduced in v2.6.0)
- Update `.golangci.yml` to include all available linters (enabled or commented out)
- Fix all `embeddedstructfieldcheck` issues by moving embedded fields to the beginning of structs
- Fix deprecated comment formatting issues
- Add nolint directives for backward-compatible deprecated code
- Apply auto-fixes from `golangci-lint run --fix`

None

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```