### PR TITLE
Support PSI metrics

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -589,7 +589,7 @@ The number of seconds between collecting pod/container stats and pod sandbox met
 **included_pod_metrics**=[]
 A list of pod metrics to include. Specify the names of the metrics to include in this list.
 If empty, only always-on metrics are included.
-Available values are "cpu", "hugetlb", "memory", "network", "oom", "process", "spec", "disk", and "diskIO".
+Available values are "cpu", "hugetlb", "memory", "network", "oom", "process", "spec", "disk", "diskIO", "pressure".
 You can also specify "all" to include all available metrics. If you specify "all", it should be the only item in the list.
 
 ## CRIO.NRI TABLE

--- a/internal/lib/stats/descriptors.go
+++ b/internal/lib/stats/descriptors.go
@@ -294,3 +294,37 @@ var (
 		LabelKeys: baseLabelKeys,
 	}
 )
+
+// Pressure metrics.
+var (
+	containerPressureCPUStalledSecondsTotal = &types.MetricDescriptor{
+		Name:      "container_pressure_cpu_stalled_seconds_total",
+		Help:      "Total time duration no tasks in the container could make progress due to CPU congestion.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureCPUWaitingSecondsTotal = &types.MetricDescriptor{
+		Name:      "container_pressure_cpu_waiting_seconds_total",
+		Help:      "Total time duration tasks in the container have waited due to CPU congestion.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureMemoryStalledSecondsTotal = &types.MetricDescriptor{
+		Name:      "container_pressure_memory_stalled_seconds_total",
+		Help:      "Total time duration no tasks in the container could make progress due to memory congestion.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureMemoryWaitingSecondsTotal = &types.MetricDescriptor{
+		Name:      "container_pressure_memory_waiting_seconds_total",
+		Help:      "Total time duration tasks in the container have waited due to memory congestion.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureIOStalledSecondsTotal = &types.MetricDescriptor{
+		Name:      "container_pressure_io_stalled_seconds_total",
+		Help:      "Total time duration no tasks in the container could make progress due to IO congestion.",
+		LabelKeys: baseLabelKeys,
+	}
+	containerPressureIOWaitingSecondsTotal = &types.MetricDescriptor{
+		Name:      "container_pressure_io_waiting_seconds_total",
+		Help:      "Total time duration tasks in the container have waited due to IO congestion.",
+		LabelKeys: baseLabelKeys,
+	}
+)

--- a/internal/lib/stats/metrics.go
+++ b/internal/lib/stats/metrics.go
@@ -116,6 +116,14 @@ var availableMetricDescriptors = map[string][]*types.MetricDescriptor{
 		containerSpecMemorySwapLimitBytes,
 		containerStartTimeSeconds,
 	},
+	config.PressureMetrics: {
+		containerPressureCPUStalledSecondsTotal,
+		containerPressureCPUWaitingSecondsTotal,
+		containerPressureMemoryStalledSecondsTotal,
+		containerPressureMemoryWaitingSecondsTotal,
+		containerPressureIOStalledSecondsTotal,
+		containerPressureIOWaitingSecondsTotal,
+	},
 }
 
 // PopulateMetricDescriptors stores metricdescriptors statically at startup and populates the list.

--- a/internal/lib/stats/pressure_metrics_linux.go
+++ b/internal/lib/stats/pressure_metrics_linux.go
@@ -1,0 +1,92 @@
+package statsserver
+
+import (
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/config/cgmgr"
+	"github.com/cri-o/cri-o/internal/oci"
+)
+
+func microSecondsToSeconds(microSeconds uint64) uint64 {
+	return microSeconds / 1e6
+}
+
+// generateContainerPressureMetrics generates metrics for pressure stalling events
+// It returns PSI Total time in seconds for each pressure type.
+// Because cAdvisor returns in seconds, we convert to seconds here, though we can't
+// return float64 because of the CRI API spec.
+// https://github.com/google/cadvisor/pull/3649/files#diff-583dd1a38478c42e7ee4f90a9c3dfb5fd8a07b82f57d4ed24fa6a98a5951a4e7R1754
+func generateContainerPressureMetrics(ctr *oci.Container, cpu *cgmgr.CPUStats, memory *cgmgr.MemoryStats, blkio *cgmgr.DiskIOStats) []*types.Metric {
+	var metrics []*containerMetric
+
+	if cpu != nil && cpu.PSI != nil {
+		metrics = append(metrics,
+			&containerMetric{
+				desc: containerPressureCPUStalledSecondsTotal,
+				valueFunc: func() metricValues {
+					return metricValues{{
+						value:      microSecondsToSeconds(cpu.PSI.Full.Total),
+						metricType: types.MetricType_COUNTER,
+					}}
+				},
+			},
+			&containerMetric{
+				desc: containerPressureCPUWaitingSecondsTotal,
+				valueFunc: func() metricValues {
+					return metricValues{{
+						value:      microSecondsToSeconds(cpu.PSI.Some.Total),
+						metricType: types.MetricType_COUNTER,
+					}}
+				},
+			},
+		)
+	}
+
+	if memory != nil && memory.PSI != nil {
+		metrics = append(metrics,
+			&containerMetric{
+				desc: containerPressureMemoryStalledSecondsTotal,
+				valueFunc: func() metricValues {
+					return metricValues{{
+						value:      microSecondsToSeconds(memory.PSI.Full.Total),
+						metricType: types.MetricType_COUNTER,
+					}}
+				},
+			},
+			&containerMetric{
+				desc: containerPressureMemoryWaitingSecondsTotal,
+				valueFunc: func() metricValues {
+					return metricValues{{
+						value:      microSecondsToSeconds(memory.PSI.Some.Total),
+						metricType: types.MetricType_COUNTER,
+					}}
+				},
+			},
+		)
+	}
+
+	if blkio != nil && blkio.PSI != nil {
+		metrics = append(metrics,
+			&containerMetric{
+				desc: containerPressureIOStalledSecondsTotal,
+				valueFunc: func() metricValues {
+					return metricValues{{
+						value:      microSecondsToSeconds(blkio.PSI.Full.Total),
+						metricType: types.MetricType_COUNTER,
+					}}
+				},
+			},
+			&containerMetric{
+				desc: containerPressureIOWaitingSecondsTotal,
+				valueFunc: func() metricValues {
+					return metricValues{{
+						value:      microSecondsToSeconds(blkio.PSI.Some.Total),
+						metricType: types.MetricType_COUNTER,
+					}}
+				},
+			},
+		)
+	}
+
+	return computeContainerMetrics(ctr, metrics, "cpu")
+}

--- a/internal/lib/stats/pressure_metrics_unsupported.go
+++ b/internal/lib/stats/pressure_metrics_unsupported.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package statsserver
+
+import (
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/config/cgmgr"
+	"github.com/cri-o/cri-o/internal/oci"
+)
+
+func generateContainerPressureMetrics(ctr *oci.Container, cpu *cgmgr.CPUStats, memory *cgmgr.MemoryStats, blkio *cgmgr.DiskIOStats) []*types.Metric {
+	// pressure metrics are not supported on non-linux platforms
+	return nil
+}

--- a/internal/lib/stats/stats_server_linux.go
+++ b/internal/lib/stats/stats_server_linux.go
@@ -310,6 +310,10 @@ func (ss *StatsServer) containerMetricsFromContainerStats(sb *sandbox.Sandbox, c
 			if specMetrics := generateContainerSpecMetrics(c); specMetrics != nil {
 				metrics = append(metrics, specMetrics...)
 			}
+		case config.PressureMetrics:
+			if pressureMetrics := generateContainerPressureMetrics(c, containerStats.CPU, containerStats.Memory, containerStats.DiskIO); pressureMetrics != nil {
+				metrics = append(metrics, pressureMetrics...)
+			}
 		default:
 			log.Warnf(ss.ctx, "Unknown metric: %s", m)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,22 +75,33 @@ const (
 	MonitorExecCgroupContainer    = "container"
 )
 
-// When updating metrics, don't forget to update the document as well.
+// When updating metrics, remember to update the document as well.
 const (
-	AllMetrics     = "all"
-	CPUMetrics     = "cpu"
-	DiskMetrics    = "disk"
-	DiskIOMetrics  = "diskIO"
-	HugetlbMetrics = "hugetlb"
-	MemoryMetrics  = "memory"
-	NetworkMetrics = "network"
-	OOMMetrics     = "oom"
-	ProcessMetrics = "process"
-	SpecMetrics    = "spec"
+	AllMetrics      = "all"
+	CPUMetrics      = "cpu"
+	DiskMetrics     = "disk"
+	DiskIOMetrics   = "diskIO"
+	HugetlbMetrics  = "hugetlb"
+	MemoryMetrics   = "memory"
+	NetworkMetrics  = "network"
+	OOMMetrics      = "oom"
+	ProcessMetrics  = "process"
+	SpecMetrics     = "spec"
+	PressureMetrics = "pressure"
 )
 
 var AvailableMetrics = []string{
-	AllMetrics, CPUMetrics, DiskMetrics, DiskIOMetrics, HugetlbMetrics, MemoryMetrics, NetworkMetrics, OOMMetrics, ProcessMetrics, SpecMetrics,
+	AllMetrics,
+	CPUMetrics,
+	DiskMetrics,
+	DiskIOMetrics,
+	HugetlbMetrics,
+	MemoryMetrics,
+	NetworkMetrics,
+	OOMMetrics,
+	ProcessMetrics,
+	SpecMetrics,
+	PressureMetrics,
 }
 
 // Config represents the entire set of configuration values that can be set for


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind feature
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

building on #9565 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes #9073 

#### Special notes for your reviewer:

Apparently only uint64 is supported in CRI stats.
In cAdvisor, it emits in float64 (converted to microseconds to seconds).
Do we have a way to do in the same way as cAdvisor? In this implementation it converts it in seconds, but the value below the decimal point is ignored.

ref: https://github.com/google/cadvisor/pull/3649/files#diff-583dd1a38478c42e7ee4f90a9c3dfb5fd8a07b82f57d4ed24fa6a98a5951a4e7R1754

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added PSI metrics for containers
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds six container pressure metrics (CPU/Memory/IO stalled & waiting) and a "pressure" config option to enable them.
  * Resource stats now include PSI-based pressure telemetry so pressure metrics can be reported on supported platforms.

* **Platform**
  * Pressure metrics implemented on Linux; non-Linux platforms return no pressure metrics.

* **Tests**
  * New automated test validating presence of the six pressure metrics.

* **Documentation**
  * Configuration docs updated to list "pressure" as a valid metric.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->