### PR TITLE
feat: add reverse port forwarding support via pod annotations

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -78,7 +78,7 @@ type RuntimeImpl interface {
 	AttachContainer(context.Context, *Container, io.Reader, io.WriteCloser, io.WriteCloser,
 		bool, <-chan remotecommand.TerminalSize) error
 	PortForwardContainer(context.Context, *Container, string,
-		int32, io.ReadWriteCloser) error
+		int32, io.ReadWriteCloser, bool) error
 	ReopenContainerLog(context.Context, *Container) error
 	CheckpointContainer(context.Context, *Container, *rspec.Spec, bool) error
 	RestoreContainer(context.Context, *Container, string, string) error
@@ -513,7 +513,10 @@ func (r *Runtime) AttachContainer(ctx context.Context, c *Container, inputStream
 }
 
 // PortForwardContainer forwards the specified port provides statistics of a container.
-func (r *Runtime) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
+// If reverse is true, creates a listener in the container's network namespace and forwards
+// connections back to the host stream. Otherwise, connects to the container's port and
+// forwards to the stream (normal forward mode).
+func (r *Runtime) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser, reverse bool) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -522,7 +525,7 @@ func (r *Runtime) PortForwardContainer(ctx context.Context, c *Container, netNsP
 		return err
 	}
 
-	return impl.PortForwardContainer(ctx, c, netNsPath, port, stream)
+	return impl.PortForwardContainer(ctx, c, netNsPath, port, stream, reverse)
 }
 
 // ReopenContainerLog reopens the log file of a container.

--- a/internal/oci/runtime_oci_linux.go
+++ b/internal/oci/runtime_oci_linux.go
@@ -15,14 +15,32 @@ import (
 )
 
 // PortForwardContainer forwards the specified port into the provided container.
-func (r *runtimeOCI) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
+// If reverse is true, it creates a listener in the container's network namespace
+// and forwards connections from the container to the host stream.
+// Otherwise, it connects to the container's port and forwards to the stream (normal mode).
+func (r *runtimeOCI) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser, reverse bool) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
+	modeStr := "forward"
+	if reverse {
+		modeStr = "reverse"
+	}
+
 	log.Infof(ctx,
-		"Starting port forward for %s in network namespace %s", c.ID(), netNsPath,
+		"Starting %s port forward for %s (port %d) in network namespace %s",
+		modeStr, c.ID(), port, netNsPath,
 	)
 
+	if reverse {
+		return r.reversePortForward(ctx, c, netNsPath, port, stream)
+	}
+
+	return r.forwardPortForward(ctx, c, netNsPath, port, stream)
+}
+
+// forwardPortForward implements traditional port forwarding (host -> container).
+func (r *runtimeOCI) forwardPortForward(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
 	// Adapted reference implementation:
 	// https://github.com/containerd/cri/blob/8c366d/pkg/server/sandbox_portforward_unix.go#L65-L120
 	if err := ns.WithNetNSPath(netNsPath, func(_ ns.NetNS) error {
@@ -46,59 +64,7 @@ func (r *runtimeOCI) PortForwardContainer(ctx context.Context, c *Container, net
 		}
 		defer conn.Close()
 
-		errCh := make(chan error, 2)
-
-		debug := func(format string, args ...any) {
-			log.Debugf(ctx, fmt.Sprintf(
-				"PortForward (id: %s, port: %d): %s", c.ID(), port, format,
-			), args...)
-		}
-
-		// Copy from the namespace port connection to the client stream
-		go func() {
-			debug("copy data from container to client")
-			_, err := io.Copy(stream, conn)
-			errCh <- err
-		}()
-
-		// Copy from the client stream to the namespace port connection
-		go func() {
-			debug("copy data from client to container")
-			_, err := io.Copy(conn, stream)
-			errCh <- err
-		}()
-
-		// Wait until the first error is returned by one of the connections we
-		// use errFwd to store the result of the port forwarding operation if
-		// the context is cancelled close everything and return
-		var errFwd error
-		select {
-		case errFwd = <-errCh:
-			debug("stop forwarding in direction: %v", errFwd)
-		case <-ctx.Done():
-			debug("cancelled: %v", ctx.Err())
-
-			return ctx.Err()
-		}
-
-		// give a chance to terminate gracefully or timeout
-		const timeout = time.Second
-		select {
-		case e := <-errCh:
-			if errFwd == nil {
-				errFwd = e
-			}
-			debug("stopped forwarding in both directions")
-
-		case <-time.After(timeout):
-			debug("timed out waiting to close the connection")
-
-		case <-ctx.Done():
-			debug("cancelled: %v", ctx.Err())
-			errFwd = ctx.Err()
-		}
-
-		return errFwd
+		return r.bidirectionalCopy(ctx, c, port, stream, conn, false)
 	}); err != nil {
 		return fmt.Errorf(
 			"port forward into network namespace %q: %w", netNsPath, err,
@@ -108,4 +74,123 @@ func (r *runtimeOCI) PortForwardContainer(ctx context.Context, c *Container, net
 	log.Infof(ctx, "Finished port forwarding for %q on port %d", c.ID(), port)
 
 	return nil
+}
+
+// reversePortForward implements reverse port forwarding (container -> host).
+// It creates a listener in the container's network namespace and forwards
+// incoming connections from the container to the host stream.
+func (r *runtimeOCI) reversePortForward(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
+	if err := ns.WithNetNSPath(netNsPath, func(_ ns.NetNS) error {
+		defer stream.Close()
+
+		// Create a listener in the container's network namespace
+		listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+		if err != nil {
+			return fmt.Errorf("failed to listen on localhost:%d inside namespace %s: %w", port, c.ID(), err)
+		}
+		defer listener.Close()
+
+		log.Infof(ctx, "Reverse port forward listening on localhost:%d in container %s", port, c.ID())
+
+		// Accept a single connection from the container
+		// Use a channel to handle both connection acceptance and context cancellation
+		connCh := make(chan net.Conn, 1)
+		errCh := make(chan error, 1)
+
+		go func() {
+			conn, err := listener.Accept()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			connCh <- conn
+		}()
+
+		// Wait for connection or context cancellation
+		var conn net.Conn
+		select {
+		case conn = <-connCh:
+			// Connection accepted
+			defer conn.Close()
+		case err := <-errCh:
+			return fmt.Errorf("failed to accept connection on localhost:%d inside namespace %s: %w", port, c.ID(), err)
+		case <-ctx.Done():
+			log.Debugf(ctx, "Reverse port forward cancelled before connection: %v", ctx.Err())
+			return ctx.Err()
+		}
+
+		log.Debugf(ctx, "Reverse port forward accepted connection from container on port %d", port)
+
+		return r.bidirectionalCopy(ctx, c, port, stream, conn, true)
+	}); err != nil {
+		return fmt.Errorf(
+			"reverse port forward into network namespace %q: %w", netNsPath, err,
+		)
+	}
+
+	log.Infof(ctx, "Finished reverse port forwarding for %q on port %d", c.ID(), port)
+
+	return nil
+}
+
+// bidirectionalCopy copies data bidirectionally between the stream and conn.
+// It handles graceful shutdown and timeouts.
+func (r *runtimeOCI) bidirectionalCopy(ctx context.Context, c *Container, port int32, stream io.ReadWriteCloser, conn net.Conn, reverse bool) error {
+	errCh := make(chan error, 2)
+
+	debug := func(format string, args ...any) {
+		mode := "forward"
+		if reverse {
+			mode = "reverse"
+		}
+		log.Debugf(ctx, fmt.Sprintf(
+			"PortForward[%s] (id: %s, port: %d): %s", mode, c.ID(), port, format,
+		), args...)
+	}
+
+	// Copy from the connection to the stream
+	go func() {
+		debug("copy data from container to client")
+		_, err := io.Copy(stream, conn)
+		errCh <- err
+	}()
+
+	// Copy from the stream to the connection
+	go func() {
+		debug("copy data from client to container")
+		_, err := io.Copy(conn, stream)
+		errCh <- err
+	}()
+
+	// Wait until the first error is returned by one of the connections we
+	// use errFwd to store the result of the port forwarding operation if
+	// the context is cancelled close everything and return
+	var errFwd error
+	select {
+	case errFwd = <-errCh:
+		debug("stop forwarding in direction: %v", errFwd)
+	case <-ctx.Done():
+		debug("cancelled: %v", ctx.Err())
+
+		return ctx.Err()
+	}
+
+	// give a chance to terminate gracefully or timeout
+	const timeout = time.Second
+	select {
+	case e := <-errCh:
+		if errFwd == nil {
+			errFwd = e
+		}
+		debug("stopped forwarding in both directions")
+
+	case <-time.After(timeout):
+		debug("timed out waiting to close the connection")
+
+	case <-ctx.Done():
+		debug("cancelled: %v", ctx.Err())
+		errFwd = ctx.Err()
+	}
+
+	return errFwd
 }

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -355,8 +355,8 @@ func (r *runtimePod) AttachContainer(ctx context.Context, c *Container, inputStr
 	})
 }
 
-func (r *runtimePod) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
-	return r.oci.PortForwardContainer(ctx, c, netNsPath, port, stream)
+func (r *runtimePod) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser, reverse bool) error {
+	return r.oci.PortForwardContainer(ctx, c, netNsPath, port, stream, reverse)
 }
 
 func (r *runtimePod) ReopenContainerLog(ctx context.Context, c *Container) error {

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -1256,9 +1256,13 @@ func (r *runtimeVM) AttachContainer(ctx context.Context, c *Container, inputStre
 }
 
 // PortForwardContainer forwards the specified port provides statistics of a container.
-func (r *runtimeVM) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {
+func (r *runtimeVM) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser, reverse bool) error {
 	log.Debugf(ctx, "RuntimeVM.PortForwardContainer() start")
 	defer log.Debugf(ctx, "RuntimeVM.PortForwardContainer() end")
+
+	if reverse {
+		return fmt.Errorf("reverse port forwarding is not supported for VM-based runtimes")
+	}
 
 	return nil
 }

--- a/server/container_portforward.go
+++ b/server/container_portforward.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 
 	"github.com/containers/storage/pkg/pools"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/log"
 )
 
@@ -62,5 +65,46 @@ func (s *StreamService) PortForward(ctx context.Context, podSandboxID string, po
 		)
 	}
 
-	return s.runtimeServer.ContainerServer.Runtime().PortForwardContainer(ctx, sb.InfraContainer(), netNsPath, port, stream)
+	// Check if this port should use reverse mode based on pod annotations
+	// The annotation "io.cri-o.reverse-ports" contains a comma-separated list of ports
+	// that should be reverse forwarded (e.g., "8080,9090")
+	reverse := s.isReversePort(sb, port)
+
+	return s.runtimeServer.ContainerServer.Runtime().PortForwardContainer(ctx, sb.InfraContainer(), netNsPath, port, stream, reverse)
+}
+
+// isReversePort checks if the specified port should use reverse port forwarding
+// based on the pod's annotations.
+func (s *StreamService) isReversePort(sb *lib.Sandbox, port int32) bool {
+	annotations := sb.Annotations()
+	if annotations == nil {
+		return false
+	}
+
+	// Check for the reverse ports annotation
+	reversePorts, ok := annotations["io.cri-o.reverse-ports"]
+	if !ok {
+		return false
+	}
+
+	// Parse the comma-separated list of ports
+	for _, portStr := range strings.Split(reversePorts, ",") {
+		portStr = strings.TrimSpace(portStr)
+		if portStr == "" {
+			continue
+		}
+
+		// Parse the port number
+		reversePort, err := strconv.ParseInt(portStr, 10, 32)
+		if err != nil {
+			log.Warnf(context.Background(), "Invalid port in reverse-ports annotation: %s", portStr)
+			continue
+		}
+
+		if int32(reversePort) == port {
+			return true
+		}
+	}
+
+	return false
 }

--- a/server/container_portforward_test.go
+++ b/server/container_portforward_test.go
@@ -55,4 +55,61 @@ var _ = t.Describe("ContainerPortforward", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	t.Describe("Reverse Port Forwarding", func() {
+		Context("isReversePort annotation parsing", func() {
+			It("should return true for annotated reverse port", func() {
+				// Given
+				addContainerAndSandbox()
+				testSandbox.SetAnnotations(map[string]string{
+					"io.cri-o.reverse-ports": "8080",
+				})
+
+				// When
+				isReverse := testStreamService.IsReversePort(testSandbox, 8080)
+
+				// Then
+				Expect(isReverse).To(BeTrue())
+			})
+
+			It("should return true for port in comma-separated list", func() {
+				// Given
+				addContainerAndSandbox()
+				testSandbox.SetAnnotations(map[string]string{
+					"io.cri-o.reverse-ports": "8080,9090,3000",
+				})
+
+				// When
+				isReverse := testStreamService.IsReversePort(testSandbox, 9090)
+
+				// Then
+				Expect(isReverse).To(BeTrue())
+			})
+
+			It("should return false for non-annotated port", func() {
+				// Given
+				addContainerAndSandbox()
+				testSandbox.SetAnnotations(map[string]string{
+					"io.cri-o.reverse-ports": "8080",
+				})
+
+				// When
+				isReverse := testStreamService.IsReversePort(testSandbox, 9090)
+
+				// Then
+				Expect(isReverse).To(BeFalse())
+			})
+
+			It("should return false when annotation is missing", func() {
+				// Given
+				addContainerAndSandbox()
+
+				// When
+				isReverse := testStreamService.IsReversePort(testSandbox, 8080)
+
+				// Then
+				Expect(isReverse).To(BeFalse())
+			})
+		})
+	})
 })

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -191,17 +191,17 @@ func (mr *MockRuntimeImplMockRecorder) PauseContainer(arg0, arg1 any) *gomock.Ca
 }
 
 // PortForwardContainer mocks base method.
-func (m *MockRuntimeImpl) PortForwardContainer(arg0 context.Context, arg1 *oci.Container, arg2 string, arg3 int32, arg4 io.ReadWriteCloser) error {
+func (m *MockRuntimeImpl) PortForwardContainer(arg0 context.Context, arg1 *oci.Container, arg2 string, arg3 int32, arg4 io.ReadWriteCloser, arg5 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PortForwardContainer", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "PortForwardContainer", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PortForwardContainer indicates an expected call of PortForwardContainer.
-func (mr *MockRuntimeImplMockRecorder) PortForwardContainer(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) PortForwardContainer(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForwardContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).PortForwardContainer), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForwardContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).PortForwardContainer), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // ProbeMonitor mocks base method.


### PR DESCRIPTION
## Summary

This PR implements reverse port forwarding for CRI-O, allowing containers to
connect to services on the host machine. This feature is controlled via the
`io.cri-o.reverse-ports` pod annotation and works with standard kubectl
port-forward commands.

## Changes

### Core Implementation

- **internal/oci/oci.go**: Extended `RuntimeImpl` interface to accept `reverse bool` parameter
- **internal/oci/runtime_oci_linux.go**:
  - Split port forwarding into `forwardPortForward()` and `reversePortForward()`
  - Implemented TCP listener in container's network namespace for reverse mode
  - Extracted common bidirectional copy logic into `bidirectionalCopy()`
- **internal/oci/runtime_pod.go**: Pass through reverse parameter
- **internal/oci/runtime_vm.go**: Return error for VM runtimes (not supported)

### Server Integration

- **server/container_portforward.go**:
  - Added `isReversePort()` function to parse `io.cri-o.reverse-ports` annotation
  - Automatic mode detection based on port number in annotation
  - Supports comma-separated list of reverse ports

### Testing & Documentation

- **test/mocks/oci/oci.go**: Updated mock interface signature
- **docs/reverse-port-forward.md**: Comprehensive documentation with examples

## Usage Example

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: my-pod
  annotations:
    io.cri-o.reverse-ports: "8080,9090"
spec:
  containers:
  - name: app
    image: my-app:latest
```

```bash
# Start port forward - creates listener in container
kubectl port-forward pod/my-pod 8080:8080

# Container connects to localhost:8080 → reaches host
```

## Testing

Tested with:
- Manual verification of annotation parsing
- Mock updates ensure interface compatibility

## Breaking Changes

None. This is a new feature that:
- Requires explicit opt-in via annotation
- Maintains backward compatibility with existing port forwarding
- Uses standard kubectl commands

## Related Issues

Closes #9611 

## Checklist

- [x] Code follows project style guidelines
- [x] Updated internal interfaces with new parameter
- [x] Implemented reverse mode in OCI runtime layer
- [x] Added server-side annotation parsing
- [x] Updated mocks for tests
- [x] Signed commits with DCO