### PR TITLE
Preserve knownRepoDigests order in ImageStatus

### DIFF
--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -324,12 +324,43 @@ func (svc *imageService) buildImageResult(image *storage.Image, cacheItem imageC
 
 	sort.Strings(repoTagStrings)
 
+	// Build repo digest strings with stable ordering:
+	// - Keep knownRepoDigests (from image's stored names) in original order
+	// - Sort additional computed digests alphabetically
+	// This ensures the PullImage digest appears first, allowing Kubernetes to rely on
+	// the first RepoDigest for credential tracking (kubernetes/kubernetes#135369).
+
+	// Convert known digests to strings (preserve order)
+	// `digests` contains canonical references from the image's stored names - these are
+	// the "known" digests that should appear first in RepoDigests in their original order.
+	// `repoDigests` (returned from makeRepoDigests earlier) contains the union of:
+	// - known digests from the image's stored names
+	// - computed digests from combining the image digest with repository names from tags
 	repoDigestStrings := make([]string, 0, len(repoDigests))
-	for _, d := range repoDigests {
+	for _, d := range digests {
 		repoDigestStrings = append(repoDigestStrings, d.String())
 	}
 
-	sort.Strings(repoDigestStrings)
+	// Collect additional (computed) digests
+	knownSet := make(map[string]bool, len(digests))
+	for _, d := range repoDigestStrings {
+		knownSet[d] = true
+	}
+
+	additionalDigests := make([]string, 0)
+
+	for _, d := range repoDigests {
+		digestString := d.String()
+		if !knownSet[digestString] {
+			additionalDigests = append(additionalDigests, digestString)
+		}
+	}
+
+	// Sort only the additional digests
+	sort.Strings(additionalDigests)
+
+	// Combine: known (in original order) + additional (sorted)
+	repoDigestStrings = append(repoDigestStrings, additionalDigests...)
 
 	previousName := ""
 
@@ -868,6 +899,8 @@ func pullImageImplementation(ctx context.Context, lookup *imageLookupService, st
 		ProgressInterval: options.ProgressInterval,
 		Progress:         options.Progress,
 	})
+	isOCIArtifact := false
+
 	if err != nil {
 		artifactManifestBytes, artifactErr := ociartifact.NewStore(store.GraphRoot(), &srcSystemContext).PullManifest(ctx, srcRef, &ociartifact.PullOptions{CopyOptions: &libimage.CopyOptions{
 			OciDecryptConfig: options.OciDecryptConfig,
@@ -879,6 +912,7 @@ func pullImageImplementation(ctx context.Context, lookup *imageLookupService, st
 		}
 
 		manifestBytes = artifactManifestBytes
+		isOCIArtifact = true
 	}
 
 	manifestDigest, err := manifest.Digest(manifestBytes)
@@ -889,6 +923,33 @@ func pullImageImplementation(ctx context.Context, lookup *imageLookupService, st
 	canonicalRef, err := reference.WithDigest(reference.TrimNamed(imageName.Raw()), manifestDigest)
 	if err != nil {
 		return RegistryImageReference{}, fmt.Errorf("create canonical reference: %w", err)
+	}
+
+	// The manifestDigest may differ from the requested reference for multi-arch images
+	// (platform-specific vs manifest list digest) or pull-by-tag (tag -> digest form).
+	// Ensure the pulled digest appears first in image names so Kubernetes can find it
+	// in ImageStatus RepoDigests for credential tracking (kubernetes/kubernetes#135369).
+	// Note: This only applies to regular container images, not OCI artifacts.
+	canonicalRefString := canonicalRef.String()
+	if !isOCIArtifact && canonicalRefString != imageName.Raw().String() {
+		// The pulled digest differs from the requested reference
+		// Look up the image to reorder its names (reuse destRef from above)
+		_, img, err := istorage.ResolveReference(destRef)
+		if err != nil {
+			return RegistryImageReference{}, fmt.Errorf("looking up pulled image: %w", err)
+		}
+
+		// Reorder names to put the platform-specific digest first
+		reorderedNames := []string{canonicalRefString}
+		for _, name := range img.Names {
+			if name != canonicalRefString {
+				reorderedNames = append(reorderedNames, name)
+			}
+		}
+
+		if err := store.SetNames(img.ID, reorderedNames); err != nil {
+			return RegistryImageReference{}, fmt.Errorf("reordering image names: %w", err)
+		}
 	}
 
 	return references.RegistryImageReferenceFromRaw(canonicalRef), nil

--- a/test/image.bats
+++ b/test/image.bats
@@ -413,3 +413,59 @@ EOF
 	# There should be many nginx images
 	crictl pull nginx
 }
+
+@test "image status preserves pulled digest order for multi-arch images" {
+	start_crio
+
+	# Pull a multi-arch image by its manifest list digest
+	crictl pull "$IMAGE_LIST_DIGEST"
+
+	# Get image status as JSON
+	output=$(crictl inspecti -o json "$IMAGE_LIST_DIGEST")
+
+	# On amd64, the platform-specific digest should appear FIRST in RepoDigests
+	# because it's the one that was actually pulled (stored in knownRepoDigests).
+	# The manifest list digest should also be present, but should come AFTER the
+	# platform-specific digest.
+	case $ARCH in
+	x86_64)
+		# Verify the first digest is the platform-specific one (what was actually pulled)
+		firstDigest=$(jq -r '.status.repoDigests[0]' <<< "$output")
+		[[ "$firstDigest" == "$IMAGE_LIST_DIGEST_AMD64" ]]
+
+		# Verify the manifest list digest appears somewhere in the array
+		manifestListIndex=$(jq '.status.repoDigests | index("'"$IMAGE_LIST_DIGEST"'")' <<< "$output")
+		[[ -n "$manifestListIndex" ]] && [[ "$manifestListIndex" != "null" ]]
+
+		# Verify the manifest list digest comes AFTER the platform-specific digest (index > 0)
+		[[ "$manifestListIndex" -gt 0 ]]
+		;;
+	esac
+
+	cleanup_images
+}
+
+@test "image status preserves pulled digest order for single-arch images" {
+	start_crio
+
+	# Pull a single-arch image by tag to verify tag-to-digest conversion works
+	crictl pull "$IMAGE"
+
+	# Get image status as JSON
+	output=$(crictl inspecti -o json "$IMAGE")
+
+	# Extract the first RepoDigest
+	firstDigest=$(jq -r '.status.repoDigests[0]' <<< "$output")
+
+	# Verify we got at least one digest
+	[[ -n "$firstDigest" ]] && [[ "$firstDigest" != "null" ]]
+
+	# The first digest should reference the correct image repository
+	[[ "$firstDigest" == quay.io/crio/pause@sha256:* ]]
+
+	# Verify RepoDigests is not empty and is deterministically ordered
+	repoDigestsCount=$(jq '.status.repoDigests | length' <<< "$output")
+	[[ "$repoDigestsCount" -gt 0 ]]
+
+	cleanup_images
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For multi-arch images, RepoDigests are currently sorted alphabetically, which can place the manifest list digest before the platform-specific digest that was actually pulled.

This causes issues for consumers like Kubernetes that store the digest from PullImage and expect to find it in RepoDigests (ideally first).

**This PR fixes the issue in two ways:**
1. During image pull: reorder the image's stored names to place the actual pulled digest first
2. During ImageStatus: preserve the order of knownRepoDigests (from image's stored names) and only sort additional computed digests

This ensures the pulled digest appears first while maintaining deterministic ordering for consistency.

#### Special notes for your reviewer:

The alphabetical sort was originally added in commit 061e6d52d for test consistency. This PR maintains that consistency while ensuring meaningful ordering.

I found this issue during the serial test debugging as part of https://github.com/kubernetes/kubernetes/pull/135369. Vendoring that change into test-infra should make the `KubeletEnsureSecretPulledImages` serial tests green.

#### Does this PR introduce a user-facing change?

```release-note
None
```