### PR TITLE
Fix incomplete config validation on sandbox restoration

### DIFF
--- a/internal/lib/suite_test.go
+++ b/internal/lib/suite_test.go
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 			"io.kubernetes.cri-o.PortMappings": "[]",
 			"io.kubernetes.cri-o.Labels": "{}",
 			"io.kubernetes.cri-o.LogPath": "{}",
-			"io.kubernetes.cri-o.Metadata": "{}",
+			"io.kubernetes.cri-o.Metadata": "{\"name\":\"testpod\",\"namespace\":\"default\",\"uid\":\"test-uid-123\",\"attempt\":0}",
 			"io.kubernetes.cri-o.Name": "name",
 			"io.kubernetes.cri-o.Namespace": "default",
 			"io.kubernetes.cri-o.PrivilegedRuntime": "{}",

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -249,7 +249,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	logPath := filepath.Join(logDir, sboxId+".log")
 
 	sbox.SetNamespace(namespace)
-	sbox.SetName(sboxName)
 	sbox.SetKubeName(kubeName)
 	sbox.SetLogDir(logDir)
 	sbox.SetContainers(memorystore.New[*oci.Container]())

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -436,8 +436,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	sboxID := sbox.ID()
 	sboxName := sbox.Name()
 
-	sbox.SetName(sboxName)
-
 	resourceCleaner := resourcestore.NewResourceCleaner()
 	// in some cases, it is still necessary to reserve container resources when an error occurs (such as just a request context timeout error)
 	storeResource := false

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -109,7 +109,7 @@ var beforeEach = func() {
 			"io.kubernetes.cri-o.PortMappings": "[]",
 			"io.kubernetes.cri-o.Labels": "{}",
 			"io.kubernetes.cri-o.LogPath": "{}",
-			"io.kubernetes.cri-o.Metadata": "{}",
+			"io.kubernetes.cri-o.Metadata": "{\"name\":\"testpod\",\"namespace\":\"default\",\"uid\":\"test-uid-123\",\"attempt\":0}",
 			"io.kubernetes.cri-o.Name": "name",
 			"io.kubernetes.cri-o.Namespace": "default",
 			"io.kubernetes.cri-o.PrivilegedRuntime": "{}",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds validation for critical metadata fields during sandbox restoration from disk.

During normal sandbox creation, `GenerateNameAndID()` validates that metadata fields (name, namespace, uid) are not empty. However, `LoadSandbox()` loads these values directly from config.json without validation, allowing corrupt configs to restore invalid sandboxes.

This PR adds validation to ensure:
- Metadata name, namespace, and uid are not empty
- Annotation-level name and namespace are not empty

Also removes redundant `SetName()` calls after `GenerateNameAndID()`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Without these validations, modified config.json files could bypass namespace-scoped image signature policies, network policies, and RBAC enforcement.

All validation occurs early in LoadSandbox before any sandbox state is created, ensuring clean error handling.

#### Does this PR introduce a user-facing change?

```release-note
LoadSandbox now validates critical metadata fields (name, namespace, uid) to prevent restoring sandboxes with corrupt configurations.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to ensure sandbox configuration fields (name, namespace, uid) are properly populated and non-empty, preventing malformed sandbox creation.

* **Tests**
  * Expanded test coverage for edge cases including empty metadata fields and malformed sandbox configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->