### PR TITLE
Allow containers to use both host network and user namespace

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -792,7 +792,12 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		}
 	}()
 
-	addSysfsMounts(ctr, containerConfig, hostNet)
+	containerMappings, err := s.getSandboxIDMappings(ctx, sb)
+	if err != nil {
+		return nil, err
+	}
+
+	addSysfsMounts(ctr, containerConfig, hostNet, sb, containerMappings)
 
 	containerImageConfig := containerInfo.Config
 	if containerImageConfig == nil {

--- a/server/container_create_freebsd.go
+++ b/server/container_create_freebsd.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"strings"
 
-	"go.podman.io/storage/pkg/idtools"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
+	"go.podman.io/storage/pkg/idtools"
 	"golang.org/x/net/context"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -39,7 +39,7 @@ func disableFipsForContainer(ctr ctrfactory.Container, containerDir string) erro
 	return nil
 }
 
-func addSysfsMounts(ctr ctrfactory.Container, containerConfig *types.ContainerConfig, hostNet bool) {
+func addSysfsMounts(ctr ctrfactory.Container, containerConfig *types.ContainerConfig, hostNet bool, sb *sandbox.Sandbox, containerIDMappings *idtools.IDMappings) {
 }
 
 func setOCIBindMountsPrivileged(g *generate.Generator) {

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -867,22 +867,35 @@ func (s *Server) specSetDevices(ctr ctrfactory.Container, sb *sandbox.Sandbox) e
 	return ctr.SpecAddDevices(configuredDevices, annotationDevices, privilegedWithoutHostDevices, s.config.DeviceOwnershipFromSecurityContext)
 }
 
-func addSysfsMounts(ctr ctrfactory.Container, containerConfig *types.ContainerConfig, hostNet bool) {
+func addSysfsMounts(ctr ctrfactory.Container, containerConfig *types.ContainerConfig, hostNet bool, sb *sandbox.Sandbox, containerIDMappings *idtools.IDMappings) {
+	usernsEnabled := containerIDMappings != nil
+
 	// If the sandbox is configured to run in the host network, do not create a new network namespace
 	if hostNet {
 		if !isInCRIMounts("/sys", containerConfig.GetMounts()) {
-			ctr.SpecAddMount(rspec.Mount{
-				Destination: "/sys",
-				Type:        "sysfs",
-				Source:      "sysfs",
-				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
-			})
-			ctr.SpecAddMount(rspec.Mount{
-				Destination: cgroupSysFsPath,
-				Type:        "cgroup",
-				Source:      "cgroup",
-				Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
-			})
+			// When using both host network and user namespace, use bind mount for /sys
+			// to avoid sysfs mounting failures in this configuration
+			if usernsEnabled {
+				ctr.SpecAddMount(rspec.Mount{
+					Destination: "/sys",
+					Type:        "bind",
+					Source:      "/sys",
+					Options:     []string{"nosuid", "noexec", "nodev", "ro", "rbind"},
+				})
+			} else {
+				ctr.SpecAddMount(rspec.Mount{
+					Destination: "/sys",
+					Type:        "sysfs",
+					Source:      "sysfs",
+					Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+				})
+				ctr.SpecAddMount(rspec.Mount{
+					Destination: cgroupSysFsPath,
+					Type:        "cgroup",
+					Source:      "cgroup",
+					Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature

#### What this PR does / why we need it:
This is the implementation of [KEP-5607](https://github.com/kubernetes/enhancements/issues/5607) in cri-o.

In KEP-5607, we allow containers to use both user namespace and host network simultaneously. This requires us to change the sys mount to a bind mount when the user employs both user namespace and host network, because mounting sys in the standard way is a privileged operation, which would prevent the container from using the standard /sys mount.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow containers to use both host network and user namespace.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * System filesystem mounts inside containers now respect user-namespace settings, improving isolation and compatibility when host networking is used.
  * Sandbox ID mappings are consulted during container filesystem setup to ensure consistent ownership and access behavior across environments.
  * Container startup now fails early on mapping retrieval errors, adding clearer error handling for more reliable cross-platform initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->