### PR TITLE
Replace v1 annotation references with v2

### DIFF
--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -385,7 +385,7 @@ var _ = t.Describe("Container", func() {
 			}
 
 			differentContainerName := "bar"
-			annotationKey := fmt.Sprintf("%s.%s", v2.UnifiedCgroup, differentContainerName)
+			annotationKey := fmt.Sprintf("%s/%s", v2.UnifiedCgroup, differentContainerName)
 			annotationsMap := map[string]string{
 				annotationKey: "memory.max=1000000;memory.min=MTAwMDA=;memory.low=20000",
 			}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -1,8 +1,6 @@
 package annotations
 
 import (
-	"github.com/intel/goresctrl/pkg/rdt"
-
 	v2 "github.com/cri-o/cri-o/pkg/annotations/v2"
 )
 
@@ -132,29 +130,6 @@ const (
 	StopSignalAnnotation = v2.StopSignal
 )
 
-var AllAllowedAnnotations = append(
-	append(
-		[]string{
-			// External annotations
-			rdt.RdtContainerAnnotation,
-
-			// Keep in sync with
-			// https://github.com/opencontainers/runc/blob/3db0871f1cf25c7025861ba0d51d25794cb21623/features.go#L67
-			// Once runc 1.2 is released, we can use the `runc features` command to get this programmatically,
-			// but we should hardcode these for now to prevent misuse.
-			"bundle",
-			"org.systemd.property.",
-			"org.criu.config",
-
-			// Similarly, keep in sync with
-			// https://github.com/containers/crun/blob/475a3fd0be/src/libcrun/container.c#L362-L366
-			"module.wasm.image/variant",
-			"io.kubernetes.cri.container-type",
-			"run.oci.",
-		},
-		// V2 annotations (recommended)
-		v2.AllAnnotations...,
-	),
-	// V1 annotations (deprecated, kept for backwards compatibility)
-	v2.AllV1Annotations...,
-)
+// Deprecated: Use v2.AllAllowedAnnotations instead.
+// AllAllowedAnnotations lists all annotations that CRI-O allows, including both V2, V1, and external annotations.
+var AllAllowedAnnotations = v2.AllAllowedAnnotations

--- a/pkg/annotations/v2/annotations.go
+++ b/pkg/annotations/v2/annotations.go
@@ -1,6 +1,12 @@
 package v2
 
 const (
+	// External annotations (not part of CRI-O's *.crio.io namespace).
+
+	// RdtContainerAnnotation is the CRI level container annotation for setting
+	// the RDT class of a container.
+	RdtContainerAnnotation = "io.kubernetes.cri.rdt-class"
+
 	// V2 annotations (recommended format: *.crio.io).
 
 	// Cgroup2MountHierarchyRW specifies mounting v2 cgroups as an rw filesystem.
@@ -300,3 +306,31 @@ var AllV1Annotations = []string{
 	V1UnifiedCgroup,
 	V1UsernsMode,
 }
+
+// AllAllowedAnnotations lists all annotations that CRI-O allows, including both V2, V1, and external annotations.
+var AllAllowedAnnotations = append(
+	append(
+		[]string{
+			// External annotations
+			RdtContainerAnnotation,
+
+			// Keep in sync with
+			// https://github.com/opencontainers/runc/blob/3db0871f1cf25c7025861ba0d51d25794cb21623/features.go#L67
+			// Once runc 1.2 is released, we can use the `runc features` command to get this programmatically,
+			// but we should hardcode these for now to prevent misuse.
+			"bundle",
+			"org.systemd.property.",
+			"org.criu.config",
+
+			// Similarly, keep in sync with
+			// https://github.com/containers/crun/blob/475a3fd0be/src/libcrun/container.c#L362-L366
+			"module.wasm.image/variant",
+			"io.kubernetes.cri.container-type",
+			"run.oci.",
+		},
+		// V2 annotations (recommended)
+		AllAnnotations...,
+	),
+	// V1 annotations (deprecated, kept for backwards compatibility)
+	AllV1Annotations...,
+)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,6 @@ import (
 	"github.com/cri-o/cri-o/internal/config/ulimits"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/storage/references"
-	extannotations "github.com/cri-o/cri-o/pkg/annotations"
 	v2 "github.com/cri-o/cri-o/pkg/annotations/v2"
 	"github.com/cri-o/cri-o/server/metrics/collectors"
 	"github.com/cri-o/cri-o/server/useragent"
@@ -2146,7 +2145,7 @@ func (r *RuntimeHandler) validateRuntimeSeccompProfile() error {
 
 func validateAllowedAndGenerateDisallowedAnnotations(allowed []string) (disallowed []string, _ error) {
 	disallowedMap := make(map[string]bool)
-	for _, ann := range extannotations.AllAllowedAnnotations {
+	for _, ann := range v2.AllAllowedAnnotations {
 		disallowedMap[ann] = false
 	}
 

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cri-o/cri-o/internal/memorystore"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/resourcestore"
-	extannotations "github.com/cri-o/cri-o/pkg/annotations"
 	v2 "github.com/cri-o/cri-o/pkg/annotations/v2"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/utils"
@@ -291,7 +290,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	g.AddAnnotation(annotations.HostNetwork, fmt.Sprintf("%v", hostNetwork))
 	g.AddAnnotation(annotations.ContainerManager, constants.ContainerManagerCRIO)
 	if podContainer.Config.Config.StopSignal != "" {
-		g.AddAnnotation(extannotations.StopSignalAnnotation, podContainer.Config.Config.StopSignal)
+		g.AddAnnotation(v2.StopSignal, podContainer.Config.Config.StopSignal)
 	}
 
 	if s.config.CgroupManager().IsSystemd() && node.SystemdHasCollectMode() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Move `AllAllowedAnnotations` to v2 package and use v2 annotations directly instead of the deprecated v1 package.

Changes:
- Move `AllAllowedAnnotations` from v1 to v2 package
- Deprecate v1 `AllAllowedAnnotations` to reference v2
- Use `v2.AllAllowedAnnotations` in `pkg/config/config.go`
- Use `v2.StopSignal` in `server/sandbox_run_freebsd.go`
- Fix annotation key separator from `.` to `/` in tests
- Remove unused v1 annotation imports

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Follow-up to address review comments from bitoku on #9537.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Annotation keys now use a new delimiter format, affecting how unified memory annotations are recognized.
  * Allowed annotation sources consolidated and expanded, improving consistency and compatibility with additional external annotations.
  * FreeBSD pod stop-signal handling streamlined for clearer stop-signal annotation usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->