### PR TITLE
Fix pod stop timeout allocation for containers and infra

### DIFF
--- a/server/sandbox_stop_freebsd.go
+++ b/server/sandbox_stop_freebsd.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 
 	"go.podman.io/storage"
+	"golang.org/x/sync/errgroup"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
-	"golang.org/x/sync/errgroup"
-	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error {
@@ -30,6 +31,24 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		return nil
 	}
 
+	// Calculate the timeout once. Regular containers get most of the timeout,
+	// reserving a small amount for infra container shutdown. The infra container
+	// will use the full totalTimeout, allowing it to use any time saved from
+	// containers stopping earlier than their allocated timeout.
+	totalTimeout := stopTimeoutFromContext(ctx)
+
+	const infraReservedTimeout int64 = 1 // 1 second reserved for infra container
+
+	var containerTimeout int64
+
+	if totalTimeout < infraReservedTimeout*2 {
+		// If total timeout is too small, split evenly
+		containerTimeout = totalTimeout / 2
+	} else {
+		// Reserve fixed time for infra, give rest to containers
+		containerTimeout = totalTimeout - infraReservedTimeout
+	}
+
 	errorGroup := &errgroup.Group{}
 
 	for _, ctr := range sb.Containers().List() {
@@ -37,8 +56,13 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 			continue
 		}
 
+		// Because ctr is reused across iterations, all goroutines can end up
+		// calling stopContainer on the last container in the list instead of
+		// their respective one. We fix that by:
+		stopCtr := ctr
+
 		errorGroup.Go(func() error {
-			return s.stopContainer(ctx, ctr, stopTimeoutFromContext(ctx))
+			return s.stopContainer(ctx, stopCtr, containerTimeout)
 		})
 	}
 	if err := errorGroup.Wait(); err != nil {
@@ -46,8 +70,8 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 	}
 
 	podInfraContainer := sb.InfraContainer()
-	if err := s.stopContainer(ctx, podInfraContainer, stopTimeoutFromContext(ctx)); err != nil && !errors.Is(err, storage.ErrContainerUnknown) && !errors.Is(err, oci.ErrContainerStopped) {
-		return fmt.Errorf("failed to stop infra container for pod sandbox %s: %v", sb.ID(), err)
+	if err := s.stopContainer(ctx, podInfraContainer, totalTimeout); err != nil && !errors.Is(err, storage.ErrContainerUnknown) && !errors.Is(err, oci.ErrContainerStopped) {
+		return fmt.Errorf("failed to stop infra container for pod sandbox %s: %w", sb.ID(), err)
 	}
 
 	if err := sb.RemoveManagedNamespaces(); err != nil {

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -45,6 +45,24 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		return nil
 	}
 
+	// Calculate the timeout once. Regular containers get most of the timeout,
+	// reserving a small amount for infra container shutdown. The infra container
+	// will use the full totalTimeout, allowing it to use any time saved from
+	// containers stopping earlier than their allocated timeout.
+	totalTimeout := stopTimeoutFromContext(ctx)
+
+	const infraReservedTimeout int64 = 1 // 1 second reserved for infra container
+
+	var containerTimeout int64
+
+	if totalTimeout < infraReservedTimeout*2 {
+		// If total timeout is too small, split evenly
+		containerTimeout = totalTimeout / 2
+	} else {
+		// Reserve fixed time for infra, give rest to containers
+		containerTimeout = totalTimeout - infraReservedTimeout
+	}
+
 	errorGroup := &errgroup.Group{}
 
 	for _, ctr := range sb.Containers().List() {
@@ -52,8 +70,13 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 			continue
 		}
 
+		// Because ctr is reused across iterations, all goroutines can end up
+		// calling stopContainer on the last container in the list instead of
+		// their respective one. We fix that by:
+		stopCtr := ctr
+
 		errorGroup.Go(func() error {
-			return s.stopContainer(ctx, ctr, stopTimeoutFromContext(ctx))
+			return s.stopContainer(ctx, stopCtr, containerTimeout)
 		})
 	}
 
@@ -62,7 +85,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 	}
 
 	podInfraContainer := sb.InfraContainer()
-	if err := s.stopContainer(ctx, podInfraContainer, stopTimeoutFromContext(ctx)); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
+	if err := s.stopContainer(ctx, podInfraContainer, totalTimeout); err != nil && !errors.Is(err, storage.ErrContainerUnknown) && !errors.Is(err, oci.ErrContainerStopped) {
 		return fmt.Errorf("failed to stop infra container for pod sandbox %s: %w", sb.ID(), err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

When stopping a pod sandbox with a deadline set via context, the stopTimeoutFromContext() function was called twice:
1. Once for regular containers
2. Once for the infra container

Both calls would attempt to use all remaining time from the deadline. This caused issues when the first phase consumed most/all of the timeout, leaving 0 seconds for the infra container stop.

Fix this by calculating the timeout once and allocating it to regular containers after reserving a small amount (1 second) for the infra container. The infra container stop then uses the full totalTimeout, allowing it to benefit from any time saved when regular containers stop earlier than their allocation. For very small timeouts (less than 2 seconds), regular containers get half the timeout.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This was particularly problematic on slower systems (e.g., arm64 CI runners) where operations took longer. For example, with a 5s deadline:
- CNI teardown: ~127ms
- Container stop: 4s (used all remaining time)
- Infra stop + cleanup: needed ~300ms but got 0s
- Result: DeadlineExceeded error

Fixes the flaky "pod remove with timeout from context" test on arm64.

#### Does this PR introduce a user-facing change?

```release-note
Fixed pod sandbox stop timeout allocation to properly distribute deadline between container and infra container stops, preventing timeout failures on slower systems.
```