### PR TITLE
go.{mod,sum}: bump CDI deps to v1.1.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	sigs.k8s.io/release-sdk v0.12.5
 	sigs.k8s.io/release-utils v0.12.2
 	sigs.k8s.io/yaml v1.6.0
-	tags.cncf.io/container-device-interface v1.0.2-0.20251126141844-16a1328247ae
+	tags.cncf.io/container-device-interface v1.1.0
 )
 
 require (
@@ -256,7 +256,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-	tags.cncf.io/container-device-interface/specs-go v1.0.1-0.20251126141844-16a1328247ae // indirect
+	tags.cncf.io/container-device-interface/specs-go v1.1.0 // indirect
 )
 
 replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -766,7 +766,7 @@ sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
-tags.cncf.io/container-device-interface v1.0.2-0.20251126141844-16a1328247ae h1:JQnGGIghGlYSQKmPmIsVCj/L3P7UKt3qPAMvvuIuKNU=
-tags.cncf.io/container-device-interface v1.0.2-0.20251126141844-16a1328247ae/go.mod h1:kIlIMADdgOVbyLj4ZvEtCvHXqFXqxfbVKKKgBZt8NgQ=
-tags.cncf.io/container-device-interface/specs-go v1.0.1-0.20251126141844-16a1328247ae h1:1Xvl+PS2mK2NXkmNCFisIbgCdIiRdAW6gyZzykpsIxY=
-tags.cncf.io/container-device-interface/specs-go v1.0.1-0.20251126141844-16a1328247ae/go.mod h1:u86hoFWqnh3hWz3esofRFKbI261bUlvUfLKGrDhJkgQ=
+tags.cncf.io/container-device-interface v1.1.0 h1:RnxNhxF1JOu6CJUVpetTYvrXHdxw9j9jFYgZpI+anSY=
+tags.cncf.io/container-device-interface v1.1.0/go.mod h1:76Oj0Yqp9FwTx/pySDc8Bxjpg+VqXfDb50cKAXVJ34Q=
+tags.cncf.io/container-device-interface/specs-go v1.1.0 h1:QRZVeAceQM+zTZe12eyfuJuuzp524EKYwhmvLd+h+yQ=
+tags.cncf.io/container-device-interface/specs-go v1.1.0/go.mod h1:u86hoFWqnh3hWz3esofRFKbI261bUlvUfLKGrDhJkgQ=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1799,13 +1799,13 @@ sigs.k8s.io/structured-merge-diff/v6/value
 # sigs.k8s.io/yaml v1.6.0
 ## explicit; go 1.22
 sigs.k8s.io/yaml
-# tags.cncf.io/container-device-interface v1.0.2-0.20251126141844-16a1328247ae
+# tags.cncf.io/container-device-interface v1.1.0
 ## explicit; go 1.21
 tags.cncf.io/container-device-interface/internal/validation
 tags.cncf.io/container-device-interface/internal/validation/k8s
 tags.cncf.io/container-device-interface/pkg/cdi
 tags.cncf.io/container-device-interface/pkg/parser
-# tags.cncf.io/container-device-interface/specs-go v1.0.1-0.20251126141844-16a1328247ae
+# tags.cncf.io/container-device-interface/specs-go v1.1.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
 # github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.4.1

--- a/vendor/tags.cncf.io/container-device-interface/pkg/cdi/container-edits.go
+++ b/vendor/tags.cncf.io/container-device-interface/pkg/cdi/container-edits.go
@@ -113,6 +113,14 @@ func (e *ContainerEdits) Apply(spec *oci.Spec) error {
 		}
 	}
 
+	if len(e.NetDevices) > 0 {
+		// specgen is currently missing functionality to set Linux NetDevices,
+		// so we use a locally rolled function for now.
+		for _, dev := range e.NetDevices {
+			specgenAddLinuxNetDevice(&specgen, dev.HostInterfaceName, (&LinuxNetDevice{dev}).toOCI())
+		}
+	}
+
 	if len(e.Mounts) > 0 {
 		for _, m := range e.Mounts {
 			specgen.RemoveMount(m.ContainerPath)
@@ -162,6 +170,24 @@ func (e *ContainerEdits) Apply(spec *oci.Spec) error {
 	return nil
 }
 
+func specgenAddLinuxNetDevice(specgen *ocigen.Generator, hostIf string, netDev *oci.LinuxNetDevice) {
+	if specgen == nil || netDev == nil {
+		return
+	}
+	ensureLinuxNetDevices(specgen.Config)
+	specgen.Config.Linux.NetDevices[hostIf] = *netDev
+}
+
+// Ensure OCI Spec Linux NetDevices map is not nil.
+func ensureLinuxNetDevices(spec *oci.Spec) {
+	if spec.Linux == nil {
+		spec.Linux = &oci.Linux{}
+	}
+	if spec.Linux.NetDevices == nil {
+		spec.Linux.NetDevices = map[string]oci.LinuxNetDevice{}
+	}
+}
+
 // Validate container edits.
 func (e *ContainerEdits) Validate() error {
 	if e == nil || e.ContainerEdits == nil {
@@ -191,6 +217,9 @@ func (e *ContainerEdits) Validate() error {
 			return err
 		}
 	}
+	if err := ValidateNetDevices(e.NetDevices); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -210,6 +239,7 @@ func (e *ContainerEdits) Append(o *ContainerEdits) *ContainerEdits {
 
 	e.Env = append(e.Env, o.Env...)
 	e.DeviceNodes = append(e.DeviceNodes, o.DeviceNodes...)
+	e.NetDevices = append(e.NetDevices, o.NetDevices...)
 	e.Hooks = append(e.Hooks, o.Hooks...)
 	e.Mounts = append(e.Mounts, o.Mounts...)
 	if o.IntelRdt != nil {
@@ -244,6 +274,9 @@ func (e *ContainerEdits) isEmpty() bool {
 	if e.IntelRdt != nil {
 		return false
 	}
+	if len(e.NetDevices) > 0 {
+		return false
+	}
 	return true
 }
 
@@ -253,6 +286,49 @@ func ValidateEnv(env []string) error {
 		if strings.IndexByte(v, byte('=')) <= 0 {
 			return fmt.Errorf("invalid environment variable %q", v)
 		}
+	}
+	return nil
+}
+
+// ValidateNetDevices validates the given net devices.
+func ValidateNetDevices(devices []*cdi.LinuxNetDevice) error {
+	var (
+		hostSeen = map[string]string{}
+		nameSeen = map[string]string{}
+	)
+
+	for _, dev := range devices {
+		if err := (&LinuxNetDevice{dev}).Validate(); err != nil {
+			return err
+		}
+		if other, ok := hostSeen[dev.HostInterfaceName]; ok {
+			return fmt.Errorf("invalid linux net device, duplicate HostInterfaceName %q with names %q and %q",
+				dev.HostInterfaceName, dev.Name, other)
+		}
+		hostSeen[dev.HostInterfaceName] = dev.Name
+
+		if other, ok := nameSeen[dev.Name]; ok {
+			return fmt.Errorf("invalid linux net device, duplicate Name %q with HostInterfaceName %q and %q",
+				dev.Name, dev.HostInterfaceName, other)
+		}
+		nameSeen[dev.Name] = dev.HostInterfaceName
+	}
+
+	return nil
+}
+
+// LinuxNetDevice is a CDI Spec LinuxNetDevice wrapper, used for OCI conversion and validating.
+type LinuxNetDevice struct {
+	*cdi.LinuxNetDevice
+}
+
+// Validate LinuxNetDevice.
+func (d *LinuxNetDevice) Validate() error {
+	if d.HostInterfaceName == "" {
+		return errors.New("invalid linux net device, empty HostInterfaceName")
+	}
+	if d.Name == "" {
+		return errors.New("invalid linux net device, empty Name")
 	}
 	return nil
 }

--- a/vendor/tags.cncf.io/container-device-interface/pkg/cdi/oci.go
+++ b/vendor/tags.cncf.io/container-device-interface/pkg/cdi/oci.go
@@ -63,3 +63,10 @@ func (i *IntelRdt) toOCI() *spec.LinuxIntelRdt {
 		EnableMonitoring: i.EnableMonitoring,
 	}
 }
+
+// toOCI returns the opencontainers runtime Spec LinuxNetDevice for this LinuxNetDevice.
+func (d *LinuxNetDevice) toOCI() *spec.LinuxNetDevice {
+	return &spec.LinuxNetDevice{
+		Name: d.Name,
+	}
+}

--- a/vendor/tags.cncf.io/container-device-interface/specs-go/config.go
+++ b/vendor/tags.cncf.io/container-device-interface/specs-go/config.go
@@ -24,12 +24,13 @@ type Device struct {
 
 // ContainerEdits are edits a container runtime must make to the OCI spec to expose the device.
 type ContainerEdits struct {
-	Env            []string      `json:"env,omitempty"            yaml:"env,omitempty"`
-	DeviceNodes    []*DeviceNode `json:"deviceNodes,omitempty"    yaml:"deviceNodes,omitempty"`
-	Hooks          []*Hook       `json:"hooks,omitempty"          yaml:"hooks,omitempty"`
-	Mounts         []*Mount      `json:"mounts,omitempty"         yaml:"mounts,omitempty"`
-	IntelRdt       *IntelRdt     `json:"intelRdt,omitempty"       yaml:"intelRdt,omitempty"`       // Added in v0.7.0
-	AdditionalGIDs []uint32      `json:"additionalGids,omitempty" yaml:"additionalGids,omitempty"` // Added in v0.7.0
+	Env            []string          `json:"env,omitempty"            yaml:"env,omitempty"`
+	DeviceNodes    []*DeviceNode     `json:"deviceNodes,omitempty"    yaml:"deviceNodes,omitempty"`
+	NetDevices     []*LinuxNetDevice `json:"netDevices,omitempty"     yaml:"netDevices,omitempty"` // Added in v1.1.0
+	Hooks          []*Hook           `json:"hooks,omitempty"          yaml:"hooks,omitempty"`
+	Mounts         []*Mount          `json:"mounts,omitempty"         yaml:"mounts,omitempty"`
+	IntelRdt       *IntelRdt         `json:"intelRdt,omitempty"       yaml:"intelRdt,omitempty"`       // Added in v0.7.0
+	AdditionalGIDs []uint32          `json:"additionalGids,omitempty" yaml:"additionalGids,omitempty"` // Added in v0.7.0
 }
 
 // DeviceNode represents a device node that needs to be added to the OCI spec.
@@ -67,6 +68,12 @@ type IntelRdt struct {
 	ClosID           string   `json:"closID,omitempty"           yaml:"closID,omitempty"`
 	L3CacheSchema    string   `json:"l3CacheSchema,omitempty"    yaml:"l3CacheSchema,omitempty"`
 	MemBwSchema      string   `json:"memBwSchema,omitempty"      yaml:"memBwSchema,omitempty"`
-	Schemata         []string `json:"schemata,omitempty"         yaml:"schemata,omitempty"`
-	EnableMonitoring bool     `json:"enableMonitoring,omitempty" yaml:"enableMonitoring,omitempty"`
+	Schemata         []string `json:"schemata,omitempty"         yaml:"schemata,omitempty"`         // Added in v1.1.0.
+	EnableMonitoring bool     `json:"enableMonitoring,omitempty" yaml:"enableMonitoring,omitempty"` // Added in v1.1.0.
+}
+
+// LinuxNetDevice represents an OCI LinuxNetDevice to be added to the OCI Spec.
+type LinuxNetDevice struct {
+	HostInterfaceName string `json:"hostInterfaceName" yaml:"hostInterfaceName"`
+	Name              string `json:"name"   yaml:"name"`
 }

--- a/vendor/tags.cncf.io/container-device-interface/specs-go/version.go
+++ b/vendor/tags.cncf.io/container-device-interface/specs-go/version.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// CurrentVersion is the current version of the Spec.
-	CurrentVersion = "1.0.0"
+	CurrentVersion = "1.1.0"
 
 	// vCurrent is the current version as a semver-comparable type
 	vCurrent version = "v" + CurrentVersion
@@ -150,11 +150,19 @@ func requiresV110(spec *Spec) bool {
 		}
 	}
 
+	if len(spec.ContainerEdits.NetDevices) > 0 {
+		return true
+	}
+
 	for _, dev := range spec.Devices {
 		if i := dev.ContainerEdits.IntelRdt; i != nil {
 			if i.Schemata != nil || i.EnableMonitoring {
 				return true
 			}
+		}
+
+		if len(dev.ContainerEdits.NetDevices) > 0 {
+			return true
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:

Bump our container-device-interface dependencies to the latest tagged v1.1.0 version.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- CDI: bump CDI dependencies to v1.1.0.
```
