### PR TITLE
[1.34] Update release notes to use cosign bundle format

### DIFF
--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -128,32 +128,24 @@ Download one of our static release bundles via our Google Cloud Bucket:
 
 - [cri-o.amd64.%s.tar.gz](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz)
   - [cri-o.amd64.%s.tar.gz.sha256sum](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz.sha256sum)
-  - [cri-o.amd64.%s.tar.gz.sig](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz.sig)
-  - [cri-o.amd64.%s.tar.gz.cert](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz.cert)
+  - [cri-o.amd64.%s.tar.gz.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz.bundle)
   - [cri-o.amd64.%s.tar.gz.spdx](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz.spdx)
-  - [cri-o.amd64.%s.tar.gz.spdx.sig](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz.spdx.sig)
-  - [cri-o.amd64.%s.tar.gz.spdx.cert](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz.spdx.cert)
+  - [cri-o.amd64.%s.tar.gz.spdx.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.%s.tar.gz.spdx.bundle)
 - [cri-o.arm64.%s.tar.gz](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz)
   - [cri-o.arm64.%s.tar.gz.sha256sum](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz.sha256sum)
-  - [cri-o.arm64.%s.tar.gz.sig](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz.sig)
-  - [cri-o.arm64.%s.tar.gz.cert](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz.cert)
+  - [cri-o.arm64.%s.tar.gz.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz.bundle)
   - [cri-o.arm64.%s.tar.gz.spdx](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz.spdx)
-  - [cri-o.arm64.%s.tar.gz.spdx.sig](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz.spdx.sig)
-  - [cri-o.arm64.%s.tar.gz.spdx.cert](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz.spdx.cert)
+  - [cri-o.arm64.%s.tar.gz.spdx.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.arm64.%s.tar.gz.spdx.bundle)
 - [cri-o.ppc64le.%s.tar.gz](https://storage.googleapis.com/cri-o/artifacts/cri-o.ppc64le.%s.tar.gz)
   - [cri-o.ppc64le.%s.tar.gz.sha256sum](https://storage.googleapis.com/cri-o/artifacts/cri-o.ppc64le.%s.tar.gz.sha256sum)
-  - [cri-o.ppc64le.%s.tar.gz.sig](https://storage.googleapis.com/cri-o/artifacts/cri-o.ppc64le.%s.tar.gz.sig)
-  - [cri-o.ppc64le.%s.tar.gz.cert](https://storage.googleapis.com/cri-o/artifacts/cri-o.ppc64le.%s.tar.gz.cert)
+  - [cri-o.ppc64le.%s.tar.gz.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.ppc64le.%s.tar.gz.bundle)
   - [cri-o.ppc64le.%s.tar.gz.spdx](https://storage.googleapis.com/cri-o/artifacts/cri-o.ppc64le.%s.tar.gz.spdx)
-  - [cri-o.ppc64le.%s.tar.gz.spdx.sig](https://storage.googleapis.com/cri-o/artifacts/cri-o.ppc64le.%s.tar.gz.spdx.sig)
-  - [cri-o.ppc64le.%s.tar.gz.spdx.cert](https://storage.googleapis.com/cri-o/artifacts/cri-o.ppc64le.%s.tar.gz.spdx.cert)
+  - [cri-o.ppc64le.%s.tar.gz.spdx.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.ppc64le.%s.tar.gz.spdx.bundle)
 - [cri-o.s390x.%s.tar.gz](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz)
   - [cri-o.s390x.%s.tar.gz.sha256sum](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.sha256sum)
-  - [cri-o.s390x.%s.tar.gz.sig](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.sig)
-  - [cri-o.s390x.%s.tar.gz.cert](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.cert)
+  - [cri-o.s390x.%s.tar.gz.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.bundle)
   - [cri-o.s390x.%s.tar.gz.spdx](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.spdx)
-  - [cri-o.s390x.%s.tar.gz.spdx.sig](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.spdx.sig)
-  - [cri-o.s390x.%s.tar.gz.spdx.cert](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.spdx.cert)
+  - [cri-o.s390x.%s.tar.gz.spdx.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.spdx.bundle)
 
 To verify the artifact signatures via [cosign](https://github.com/sigstore/cosign), run:
 
@@ -164,8 +156,7 @@ To verify the artifact signatures via [cosign](https://github.com/sigstore/cosig
     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
     --certificate-github-workflow-repository cri-o/packaging \
     --certificate-github-workflow-ref refs/heads/main \
-    --signature cri-o.amd64.%s.tar.gz.sig \
-    --certificate cri-o.amd64.%s.tar.gz.cert
+    --bundle cri-o.amd64.%s.tar.gz.bundle
 `+"```"+`
 
 To verify the bill of materials (SBOM) in [SPDX](https://spdx.org) format using the [bom](https://sigs.k8s.io/bom) tool, run:
@@ -217,14 +208,6 @@ To verify the bill of materials (SBOM) in [SPDX](https://spdx.org) format using 
 		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,
-		bundleVersion, bundleVersion,
-		bundleVersion, bundleVersion,
-		bundleVersion, bundleVersion,
-		bundleVersion, bundleVersion,
-		bundleVersion, bundleVersion,
-		bundleVersion, bundleVersion,
-		bundleVersion, bundleVersion,
-		bundleVersion, bundleVersion, bundleVersion,
 		startTag,
 	); err != nil {
 		return fmt.Errorf("writing template to file: %w", err)


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
The packaging repository now uses --bundle flag for cosign instead of separate .sig and .cert files. This updates the release notes template to reference .bundle files and updates the verification instructions.

#### Which issue(s) this PR fixes:
Fixes https://github.com/cri-o/cri-o/issues/9653
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed release description to use cosigns new bundle format.
```