### PR TITLE
OCPBUGS-62150: [release-1.31] server: ignore /etc/passwd mount

### DIFF
--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -278,6 +278,8 @@ func (s *Server) CRImportCheckpoint(
 		"/dev/shm":           true,
 		"/etc/resolv.conf":   true,
 		"/etc/hostname":      true,
+		"/etc/passwd":        true,
+		"/etc/group":         true,
 		"/run/secrets":       true,
 		"/run/.containerenv": true,
 	}

--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -154,3 +154,44 @@ function teardown() {
 	[[ "$container_name" == "restored-sleep-container" ]]
 	[[ "$pod_name" == "restoresandbox2" ]]
 }
+
+@test "checkpoint and restore: /etc/passwd uses Kubernetes run_as_user on restore" {
+	CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	# Create container with run_as_user=1001
+	START_JSON=$(mktemp)
+	jq '.linux.security_context.run_as_user.value = 1001
+		| .command=["/bin/sh"]
+		| .args=["-c","sleep inf"]' \
+		"$TESTDATA"/container_sleep.json > "$START_JSON"
+	ctr_id=$(crictl create "$pod_id" "$START_JSON" "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	# Verify the UID of the running process
+	run crictl exec "$ctr_id" id
+	[[ "$output" == *"uid=1001"* ]]
+	# Verify /etc/passwd contains entry for UID 1001
+	run crictl exec "$ctr_id" cat /etc/passwd
+	[[ "$output" == *"1001"* ]]
+	# Checkpoint the container
+	crictl checkpoint --export="$TESTDIR"/cp.tar "$ctr_id"
+	crictl rm -f "$ctr_id"
+	crictl rmp -f "$pod_id"
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	RESTORE_JSON=$(mktemp)
+	jq '.image.image="'"$TESTDIR"'/cp.tar"
+		| .linux.security_context.run_as_user.value = 1001' \
+		"$TESTDATA"/container_sleep.json > "$RESTORE_JSON"
+	ctr_id=$(crictl create "$pod_id" "$RESTORE_JSON" "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	# Verify that the container was restored
+	restored=$(crictl inspect --output go-template --template "{{(index .info.restored)}}" "$ctr_id")
+	[[ "$restored" == "true" ]]
+	# Verify the UID is still 1001
+	run crictl exec "$ctr_id" id
+	[[ "$output" == *"uid=1001"* ]]
+	run crictl exec "$ctr_id" cat /etc/passwd
+	[[ "$output" == *"1001"* ]]
+	# Cleanup
+	rm -f "$START_JSON"
+	rm -f "$RESTORE_JSON"
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Ignore /etc/passwd when checking for mounts. Always rely on the mount as defined from Kubernetes. This follows existing practice like for /etc/hosts or /etc/resolv.conf

(cherry picked from commit 9d7aa99d0defb26213d45164e1309649c3bf18ec)

As requested in https://github.com/cri-o/cri-o/pull/9563#issuecomment-3646717979

#### Which issue(s) this PR fixes:

OCPBUGS-62150

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

OCPBUGS-62150

```release-note
None
```
