### PR TITLE
Fix the bug where the ContainersStatuses.Image fields returned by the GetContainerEvents is nil

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -933,9 +933,9 @@ func (s *Server) getContainerStatuses(ctx context.Context, sandboxUID string) ([
 		return []*types.ContainerStatus{}, err
 	}
 
-	containerStatuses := make([]*types.ContainerStatus, len(containers.GetContainers()))
+	containerStatuses := make([]*types.ContainerStatus, 0, len(containers.GetContainers()))
 
-	for i, cc := range containers.GetContainers() {
+	for _, cc := range containers.GetContainers() {
 		containerStatusRequest := &types.ContainerStatusRequest{ContainerId: cc.GetId()}
 
 		resp, err := s.ContainerStatus(ctx, containerStatusRequest)
@@ -947,7 +947,7 @@ func (s *Server) getContainerStatuses(ctx context.Context, sandboxUID string) ([
 			return []*types.ContainerStatus{}, err
 		}
 
-		containerStatuses[i] = resp.GetStatus()
+		containerStatuses = append(containerStatuses, resp.GetStatus())
 	}
 
 	return containerStatuses, nil
@@ -961,9 +961,9 @@ func (s *Server) getContainerStatusesFromSandboxID(ctx context.Context, sandboxI
 		return []*types.ContainerStatus{}, err
 	}
 
-	containerStatuses := make([]*types.ContainerStatus, len(containers.GetContainers()))
+	containerStatuses := make([]*types.ContainerStatus, 0, len(containers.GetContainers()))
 
-	for i, cc := range containers.GetContainers() {
+	for _, cc := range containers.GetContainers() {
 		containerStatusRequest := &types.ContainerStatusRequest{ContainerId: cc.GetId(), Verbose: false}
 
 		resp, err := s.ContainerStatus(ctx, containerStatusRequest)
@@ -975,7 +975,7 @@ func (s *Server) getContainerStatusesFromSandboxID(ctx context.Context, sandboxI
 			return []*types.ContainerStatus{}, err
 		}
 
-		containerStatuses[i] = resp.GetStatus()
+		containerStatuses = append(containerStatuses, resp.GetStatus())
 	}
 
 	return containerStatuses, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
If `s.ContainerStatus()` returns a **NotFound** error, the element at the corresponding index in `containerStatuses` will be nil, because we initially initialized the list with all elements set to nil.

When a list containing nil pointers is serialized and sent to the client via grpc, the protocol handling mechanism typically does not allow _null_ values in the list.

To preserve the list structure, the serialization layer usually treats this nil pointer as a _default empty message_.

After the receiving end deserializes the data, this empty message will be converted into a non-nil `ContainerStatus` struct, but all fields of this struct will be in a zero value state.

*  `ContainerStatus` is a valid struct pointer.

*  In the `ContainerStatus` definition, `Image` is a pointer type. The zero value of a pointer is nil.

*  Ultimately, this causes kubelet to panic when directly accessing the value of `ContainerStatus.Image` due to a nil pointer.

Code path in kubelet that directly uses this field:
https://github.com/kubernetes/kubernetes/blob/c180d6762d7ac5059d9b50457cafb0d7f4cf74a9/pkg/kubelet/kuberuntime/kuberuntime_container.go#L715-L724

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
Test code:
```
func TestNilSerialization(t *testing.T) {
	statuses := []*ContainerStatus{
		{Image: &ImageSpec{Id: "image1"}},
		nil, // This is the nil pointer
		{Image: &ImageSpec{Id: "image3"}},
	}
	resp := &Response{Statuses: statuses}

	data, err := proto.Marshal(resp)
	if err != nil {
		t.Fatalf("Marshal failed: %v", err)
	}

	var received Response
	if err := proto.Unmarshal(data, &received); err != nil {
		t.Fatalf("Unmarshal failed: %v", err)
	}

	middle := received.Statuses[1]
	if middle == nil {
		t.Error("Expected middle status to be non-nil, but it is nil")
	} else {
		fmt.Printf("Middle status is non-nil: %+v\n", middle)
		if middle.Image != nil {
			t.Errorf("Expected Image to be nil, but got %+v", middle.Image)
		} else {
			fmt.Println("Image field is nil, as expected")
		}
	}
}
```
Output:
```
Middle status is non-nil: 
Image field is nil, as expected
```

It can be demonstrated that during serialization and deserialization, protobuf will convert nil pointer elements in a list into an empty/default value.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix the bug where the `ContainersStatuses.Image` returned by the `GetContainerEvents` is nil.
```
