### PR TITLE
OCPBUGS-69402: Ensure `InitLabel` only sets process label when unset

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1015,9 +1015,14 @@ func (s *Server) setupContainerMountsAndSystemd(ctr container.Container, sb *san
 	if ctr.WillRunSystemd() {
 		var err error
 
-		processLabel, err = InitLabel(processLabel)
-		if err != nil {
-			return "", err
+		// Don't override the process label if it was already set.
+		// Otherwise, it should be set container_init_t to run the init process
+		// in a container.
+		if processLabel == "" {
+			processLabel, err = InitLabel(processLabel)
+			if err != nil {
+				return "", err
+			}
 		}
 
 		setupSystemd(specgen.Mounts(), *specgen)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

When systemd runs in a container, process label will be container_init_t, even if a user specify selinux type explicitly.
This PR fixes the process label of systemd.

ref: https://github.com/cri-o/cri-o/pull/3754

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

We need an image which can run systemd to write integration tests.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Respect user specified selinux label for systemd or init container. 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Process label initialization in container creation now conditionally preserves pre-existing labels instead of unconditionally reinitializing them. The initialization only occurs when the label is empty, allowing existing labels to persist while maintaining error handling during container setup and system configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->