### PR TITLE
Refactor mount and selinux codes in container creation.

### DIFF
--- a/server/container_create_freebsd.go
+++ b/server/container_create_freebsd.go
@@ -153,7 +153,8 @@ func (s *Server) addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container,
 func addShmMount(ctr ctrfactory.Container, sb *sandbox.Sandbox) {
 }
 
-func setupSystemd(mounts []rspec.Mount, g generate.Generator) {
+// setupSystemdMounts is a no-op on FreeBSD as systemd is not supported.
+func setupSystemdMounts(g *generate.Generator) {
 }
 
 // Returns the spec Generator for the container, with some values set.

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -656,8 +656,9 @@ func mountExists(specMounts []rspec.Mount, dest string) bool {
 
 // systemd expects to have /run, /run/lock and /tmp on tmpfs
 // It also expects to be able to write to /sys/fs/cgroup/systemd and /var/log/journal.
-func setupSystemd(mounts []rspec.Mount, g generate.Generator) {
+func setupSystemdMounts(g *generate.Generator) {
 	options := []string{"rw", "rprivate", "noexec", "nosuid", "nodev"}
+	mounts := g.Mounts()
 
 	for _, dest := range []string{"/run", "/run/lock"} {
 		if mountExists(mounts, dest) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

It decouples selinux code and mount code, and decouple some unrelated codes.
Also it removes some arguments which should be the same as `ctr`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized container mount and initialization flow for clearer behavior and maintainability.
* **Bug Fixes / Reliability**
  * Improved error propagation during container setup for more robust container creation.
  * Applied host-network decisions earlier so mounts and setup respect network mode consistently.
* **Platform behavior**
  * Systemd-related mount handling applied only when applicable; treated as no-op on unsupported platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->