### PR TITLE
Fix inconsistent imageRef when there are two images that are identical but have different names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -597,3 +597,12 @@ upload-artifacts: ## Upload the built artifacts.
 .PHONY: push-oci-artifacts
 push-oci-artifacts: ## Push OCI Artifacts to quay.io/crio
 	./test/testdata/artifacts/push-oci-artifacts
+
+.PHONY: push-mirror-image
+push-mirror-image: ## Push mirror image of fedora-crio-ci
+	./test/testdata/mirror-fedora-crio-ci-image.sh
+
+.PHONY: push-test-images ## Push Images and OCI Artifacts to quay.io/crio for tests
+push-test-images: \
+	push-oci-artifacts \
+	push-mirror-image

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -707,9 +707,9 @@ var _ = t.Describe("Container", func() {
 			pid1 := 12345
 			pid2 := 12346
 			pid3 := 12347
-			Expect(addTestExecPID(sut,pid1, true)).To(Succeed())
-			Expect(addTestExecPID(sut,pid2, false)).To(Succeed())
-			Expect(addTestExecPID(sut,pid3, true)).To(Succeed())
+			Expect(addTestExecPID(sut, pid1, true)).To(Succeed())
+			Expect(addTestExecPID(sut, pid2, false)).To(Succeed())
+			Expect(addTestExecPID(sut, pid3, true)).To(Succeed())
 
 			// When
 			sut.DeleteExecPID(pid2)
@@ -726,7 +726,7 @@ var _ = t.Describe("Container", func() {
 		It("should be safe to delete same PID multiple times", func() {
 			// Given
 			testPID := 12345
-			Expect(addTestExecPID(sut,testPID, true)).To(Succeed())
+			Expect(addTestExecPID(sut, testPID, true)).To(Succeed())
 
 			// When/Then - Multiple deletes should not panic
 			Expect(func() {
@@ -765,7 +765,7 @@ var _ = t.Describe("Container", func() {
 			// Given - Add a PID that doesn't exist
 			// KillExecPIDs will try to kill this PID, get ESRCH error, and should handle it
 			nonExistentPID := neverRunningPid
-			Expect(addTestExecPID(sut,nonExistentPID, true)).To(Succeed())
+			Expect(addTestExecPID(sut, nonExistentPID, true)).To(Succeed())
 
 			// When/Then - Should handle ESRCH error and complete without panic
 			Expect(func() {
@@ -778,9 +778,9 @@ var _ = t.Describe("Container", func() {
 			pid1 := neverRunningPid
 			pid2 := neverRunningPid - 1
 			pid3 := neverRunningPid - 2
-			Expect(addTestExecPID(sut,pid1, true)).To(Succeed())
-			Expect(addTestExecPID(sut,pid2, false)).To(Succeed())
-			Expect(addTestExecPID(sut,pid3, true)).To(Succeed())
+			Expect(addTestExecPID(sut, pid1, true)).To(Succeed())
+			Expect(addTestExecPID(sut, pid2, false)).To(Succeed())
+			Expect(addTestExecPID(sut, pid3, true)).To(Succeed())
 
 			// When/Then - Should attempt to kill all PIDs
 			Expect(func() {
@@ -794,8 +794,8 @@ var _ = t.Describe("Container", func() {
 			// but we can verify the function completes without error
 			pid1 := neverRunningPid
 			pid2 := neverRunningPid - 1
-			Expect(addTestExecPID(sut,pid1, true)).To(Succeed())  // Should use SIGKILL
-			Expect(addTestExecPID(sut,pid2, false)).To(Succeed()) // Should use SIGINT
+			Expect(addTestExecPID(sut, pid1, true)).To(Succeed())  // Should use SIGKILL
+			Expect(addTestExecPID(sut, pid2, false)).To(Succeed()) // Should use SIGINT
 
 			// When/Then - Should complete successfully
 			Expect(func() {
@@ -806,13 +806,13 @@ var _ = t.Describe("Container", func() {
 		It("should clear exec PIDs map after killing", func() {
 			// Given
 			pid1 := neverRunningPid
-			Expect(addTestExecPID(sut,pid1, true)).To(Succeed())
+			Expect(addTestExecPID(sut, pid1, true)).To(Succeed())
 
 			// When
 			sut.KillExecPIDs()
 
 			// Then - Should be able to add the same PID again (map was cleared)
-			Expect(addTestExecPID(sut,pid1, false)).To(Succeed())
+			Expect(addTestExecPID(sut, pid1, false)).To(Succeed())
 		})
 	})
 
@@ -1048,6 +1048,7 @@ type mockExecStarter struct {
 
 func (m *mockExecStarter) Start() error {
 	m.startCalled = true
+
 	return m.startFunc()
 }
 
@@ -1062,5 +1063,6 @@ func addTestExecPID(c *oci.Container, pid int, shouldKill bool) error {
 		pid:       pid,
 	}
 	_, err := c.StartExecCmd(mock, shouldKill)
+
 	return err
 }

--- a/internal/oci/oci_unix.go
+++ b/internal/oci/oci_unix.go
@@ -27,7 +27,9 @@ type ptyStarter struct {
 
 func (p *ptyStarter) Start() error {
 	var err error
+
 	p.pty, err = pty.Start(p.cmd)
+
 	return err
 }
 
@@ -56,6 +58,7 @@ func setSize(fd uintptr, size remotecommand.TerminalSize) error {
 
 func ttyCmd(execCmd *exec.Cmd, stdin io.Reader, stdout io.WriteCloser, resizeChan <-chan remotecommand.TerminalSize, c *Container) error {
 	starter := &ptyStarter{cmd: execCmd}
+
 	pid, err := c.StartExecCmd(starter, true)
 	if err != nil {
 		return err

--- a/server/container_create_test.go
+++ b/server/container_create_test.go
@@ -6,7 +6,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.podman.io/image/v5/docker/reference"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/server"
 )
 
 // The actual test suite.
@@ -218,5 +221,109 @@ var _ = t.Describe("ContainerCreate", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(response).To(BeNil())
 		})
+	})
+})
+
+var _ = t.Describe("FindRepoDigestForImage", func() {
+	// Helper to create canonical reference
+	mustCanonical := func(s string) reference.Canonical {
+		GinkgoHelper()
+		ref, err := reference.ParseNormalizedNamed(s)
+		Expect(err).ToNot(HaveOccurred())
+		canonical, ok := ref.(reference.Canonical)
+		Expect(ok).To(BeTrue(), "expected canonical reference for %s", s)
+
+		return canonical
+	}
+
+	const (
+		digest1 = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		digest2 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		digest3 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	)
+
+	It("should return empty string when repoDigests is empty", func() {
+		result := server.FindRepoDigestForImage(nil, "docker.io/library/nginx:latest")
+		Expect(result).To(Equal(""))
+
+		result = server.FindRepoDigestForImage([]reference.Canonical{}, "docker.io/library/nginx:latest")
+		Expect(result).To(Equal(""))
+	})
+
+	It("should return exact match when userRequestedImage matches a repo digest", func() {
+		exactMatch := "docker.io/library/nginx@" + digest1
+		repoDigests := []reference.Canonical{
+			mustCanonical("docker.io/library/alpine@" + digest2),
+			mustCanonical(exactMatch),
+			mustCanonical("docker.io/library/busybox@" + digest3),
+		}
+
+		result := server.FindRepoDigestForImage(repoDigests, exactMatch)
+		Expect(result).To(Equal(exactMatch))
+	})
+
+	It("should return matching repository digest when repo name matches", func() {
+		repoDigests := []reference.Canonical{
+			mustCanonical("docker.io/library/alpine@" + digest1),
+			mustCanonical("docker.io/library/nginx@" + digest2),
+			mustCanonical("docker.io/library/busybox@" + digest3),
+		}
+
+		// User requested nginx:latest, should match docker.io/library/nginx@digest2
+		result := server.FindRepoDigestForImage(repoDigests, "nginx:latest")
+		Expect(result).To(Equal("docker.io/library/nginx@" + digest2))
+
+		// User requested docker.io/library/nginx:v1, should match docker.io/library/nginx@digest2
+		result = server.FindRepoDigestForImage(repoDigests, "docker.io/library/nginx:v1")
+		Expect(result).To(Equal("docker.io/library/nginx@" + digest2))
+	})
+
+	It("should return first digest when no match is found", func() {
+		repoDigests := []reference.Canonical{
+			mustCanonical("docker.io/library/alpine@" + digest1),
+			mustCanonical("docker.io/library/nginx@" + digest2),
+		}
+
+		// User requested an image that doesn't match any repository
+		result := server.FindRepoDigestForImage(repoDigests, "redis:latest")
+		Expect(result).To(Equal("docker.io/library/alpine@" + digest1))
+	})
+
+	It("should return first digest when userRequestedImage is invalid", func() {
+		repoDigests := []reference.Canonical{
+			mustCanonical("docker.io/library/alpine@" + digest1),
+			mustCanonical("docker.io/library/nginx@" + digest2),
+		}
+
+		// Invalid image reference
+		result := server.FindRepoDigestForImage(repoDigests, ":::invalid:::")
+		Expect(result).To(Equal("docker.io/library/alpine@" + digest1))
+	})
+
+	It("should handle fully qualified registry names", func() {
+		repoDigests := []reference.Canonical{
+			mustCanonical("gcr.io/project/image@" + digest1),
+			mustCanonical("quay.io/namespace/image@" + digest2),
+		}
+
+		// User requested gcr.io/project/image:v1
+		result := server.FindRepoDigestForImage(repoDigests, "gcr.io/project/image:v1")
+		Expect(result).To(Equal("gcr.io/project/image@" + digest1))
+
+		// User requested quay.io/namespace/image:latest
+		result = server.FindRepoDigestForImage(repoDigests, "quay.io/namespace/image:latest")
+		Expect(result).To(Equal("quay.io/namespace/image@" + digest2))
+	})
+
+	It("should prefer exact match over repository match", func() {
+		exactMatch := "docker.io/library/nginx@" + digest2
+		repoDigests := []reference.Canonical{
+			mustCanonical("docker.io/library/nginx@" + digest1),
+			mustCanonical(exactMatch),
+		}
+
+		// When user requested the exact digest, return it even though there's another nginx digest
+		result := server.FindRepoDigestForImage(repoDigests, exactMatch)
+		Expect(result).To(Equal(exactMatch))
 	})
 })

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"go.podman.io/image/v5/docker/reference"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/log"
@@ -83,7 +84,7 @@ func ConvertImage(from *storage.ImageResult) *types.Image {
 	}
 
 	if len(from.RepoDigests) > 0 {
-		repoDigests = from.RepoDigests
+		repoDigests = repoDigestsToStrings(from.RepoDigests)
 	} else if from.PreviousName != "" && from.Digest != "" {
 		repoDigests = []string{from.PreviousName + "@" + string(from.Digest)}
 	}
@@ -107,4 +108,14 @@ func ConvertImage(from *storage.ImageResult) *types.Image {
 	}
 
 	return to
+}
+
+// repoDigestsToStrings converts a slice of reference.Canonical to a slice of strings.
+func repoDigestsToStrings(digests []reference.Canonical) []string {
+	result := make([]string, 0, len(digests))
+	for _, d := range digests {
+		result = append(result, d.String())
+	}
+
+	return result
 }

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -64,7 +64,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 		Image: &types.Image{
 			Id:          status.ID.IDStringForOutOfProcessConsumptionOnly(),
 			RepoTags:    status.RepoTags,
-			RepoDigests: status.RepoDigests,
+			RepoDigests: repoDigestsToStrings(status.RepoDigests),
 			Size:        size,
 			Spec: &types.ImageSpec{
 				Annotations: status.Annotations,

--- a/test/testdata/mirror-fedora-crio-ci-image.sh
+++ b/test/testdata/mirror-fedora-crio-ci-image.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_IMAGE="quay.io/crio/fedora-crio-ci:latest"
+TARGET_IMAGE="quay.io/crio/fedora-crio-ci-mirror:latest"
+
+echo "Pulling $SOURCE_IMAGE..."
+skopeo copy --all "docker://$SOURCE_IMAGE" "docker://$TARGET_IMAGE"
+
+echo "Successfully mirrored $SOURCE_IMAGE to $TARGET_IMAGE"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Currently when image status is requested, imageRef is just a first element of repoDigests returned from images package.
When there are some images that are identical but have different names, the name of imageRef sometimes doesn't match the name of the userRequested image.
This PR prioritizes the repoDigest that has the same name as userRequested, so that imageRef has a consistent name with userRequestedImage.

#### Which issue(s) this PR fixes:

Partially addressed https://issues.redhat.com/browse/OCPBUGS-69675

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix inconsistent imageRef when there are two images that are identical but have different names
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced image digest selection with repository matching logic for improved container creation.
  * Added support for mirrored image repositories in CI/CD pipeline.

* **Tests**
  * Added comprehensive test coverage for image digest selection and repository matching scenarios.
  * Added new tests validating correct image repository reference when using mirrored images.

* **Chores**
  * Updated build orchestration with new image artifact push targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->