### PR TITLE
server,nri: pass any POSIX rlimits to plugins.

### DIFF
--- a/internal/nri/container.go
+++ b/internal/nri/container.go
@@ -21,6 +21,7 @@ type Container interface {
 	GetHooks() *nri.Hooks
 	GetLinuxContainer() LinuxContainer
 	GetUser() *nri.User
+	GetRlimits() []*nri.POSIXRlimit
 
 	GetSpec() *specs.Spec
 }
@@ -51,6 +52,7 @@ func containerToNRI(ctr Container) *nri.Container {
 		Hooks:        ctr.GetHooks(),
 		Linux:        linuxContainerToNRI(ctr),
 		User:         ctr.GetUser(),
+		Rlimits:      ctr.GetRlimits(),
 	}
 }
 

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -826,6 +826,25 @@ func (c *criContainer) GetUser() *api.User {
 	}
 }
 
+func (c *criContainer) GetRlimits() []*api.POSIXRlimit {
+	spec := c.GetSpec()
+	if spec.Process == nil {
+		return nil
+	}
+
+	rlimits := make([]*api.POSIXRlimit, 0, len(spec.Process.Rlimits))
+
+	for _, l := range spec.Process.Rlimits {
+		rlimits = append(rlimits, &api.POSIXRlimit{
+			Type: l.Type,
+			Hard: l.Hard,
+			Soft: l.Soft,
+		})
+	}
+
+	return rlimits
+}
+
 func (c *criContainer) GetSpec() *rspec.Spec {
 	if c.spec != nil {
 		return c.spec


### PR DESCRIPTION

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Add missing support for passing any container POSIX rlimits to NRI plugins as input.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- nri: pass any container POSIX rlimits to NRI plugins as input. 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Containers now surface POSIX resource limits through the NRI interface, with NRI container records populated with configured rlimit values for improved visibility into runtime constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->