### PR TITLE
Fix the bug where cri-o doesn't emit any metrics when all is set.

### DIFF
--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -612,6 +612,7 @@ func mergeMetricsConfig(config *libconfig.Config, ctx *cli.Context) {
 	}
 
 	if ctx.IsSet("included-pod-metrics") {
+		//nolint:staticcheck // Needs to use the user input config.
 		config.IncludedPodMetrics = StringSliceTrySplit(ctx, "included-pod-metrics")
 	}
 }
@@ -1516,6 +1517,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 				"CONTAINER_INCLUDED_POD_METRCIS", // TODO: This typo'ed variable is deprecated and can be removed in a future release.
 				"CONTAINER_INCLUDED_POD_METRICS",
 			},
+			//nolint:staticcheck // Needs to use the user input config.
 			Value: cli.NewStringSlice(defConf.IncludedPodMetrics...),
 		},
 		&cli.BoolFlag{

--- a/internal/lib/statsserver/metrics.go
+++ b/internal/lib/statsserver/metrics.go
@@ -128,11 +128,6 @@ var availableMetricDescriptors = map[string][]*types.MetricDescriptor{
 
 // PopulateMetricDescriptors stores metricdescriptors statically at startup and populates the list.
 func (ss *StatsServer) PopulateMetricDescriptors(includedKeys []string) map[string][]*types.MetricDescriptor {
-	// It's guaranteed in config validation that if all is specified, it's the only one element in the slice.
-	if len(includedKeys) == 1 && includedKeys[0] == config.AllMetrics {
-		return availableMetricDescriptors
-	}
-
 	descriptorsMap := map[string][]*types.MetricDescriptor{
 		"": alwaysOnMetrics,
 	}

--- a/internal/lib/statsserver/stats_server_linux.go
+++ b/internal/lib/statsserver/stats_server_linux.go
@@ -46,7 +46,7 @@ func (ss *StatsServer) updateSandbox(sb *sandbox.Sandbox) *types.PodSandboxStats
 	}
 
 	// Network metrics are collected at pod level only.
-	if slices.Contains(ss.Config().IncludedPodMetrics, config.NetworkMetrics) {
+	if slices.Contains(ss.Config().EnabledPodMetrics(), config.NetworkMetrics) {
 		podMetrics := ss.GenerateNetworkMetrics(sb)
 		sandboxMetrics.metric.Metrics = podMetrics
 	}
@@ -208,7 +208,7 @@ func (ss *StatsServer) updatePodSandboxMetrics(sb *sandbox.Sandbox) *SandboxMetr
 		sm = NewSandboxMetrics(sb)
 	}
 	// Network metrics are collected at the pod level.
-	if slices.Contains(ss.Config().IncludedPodMetrics, config.NetworkMetrics) {
+	if slices.Contains(ss.Config().EnabledPodMetrics(), config.NetworkMetrics) {
 		podMetrics := ss.GenerateNetworkMetrics(sb)
 		sm.metric.Metrics = podMetrics
 	}
@@ -264,7 +264,7 @@ func (ss *StatsServer) containerMetricsFromContainerStats(sb *sandbox.Sandbox, c
 		},
 	}}, "")
 
-	for _, m := range ss.Config().IncludedPodMetrics {
+	for _, m := range ss.Config().EnabledPodMetrics() {
 		switch m {
 		case config.CPUMetrics:
 			if cpuMetrics := generateContainerCPUMetrics(c, &cgroupStats.CpuStats); cpuMetrics != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,8 +92,9 @@ const (
 	PressureMetrics = "pressure"
 )
 
+// AvailableMetrics is a list of all available metrics that can be included in stats.
+// It excludes the "all" metric, which is a special value that includes all other metrics.
 var AvailableMetrics = []string{
-	AllMetrics,
 	CPUMetrics,
 	DiskMetrics,
 	DiskIOMetrics,
@@ -804,7 +805,14 @@ type StatsConfig struct {
 
 	// IncludedPodMetrics specifies the list of metrics to include when collecting pod metrics.
 	// If "all" is specified, all metrics are included. In that case, "all" should be the only element.
+	//
+	// Deprecated: Use this field only when the user input config is needed because it's not formalized.
+	// Use EnabledPodMetrics() instead.
 	IncludedPodMetrics []string `toml:"included_pod_metrics"`
+
+	// includedPodMetrics is an internal representation of IncludedPodMetrics.
+	// It doesn't contain "all".
+	includedPodMetrics []string
 }
 
 // tomlConfig is another way of looking at a Config, which is
@@ -2260,8 +2268,14 @@ func (c *Config) SetSingleConfigPath(singleConfigPath string) {
 }
 
 func (c *StatsConfig) Validate() error {
+	if len(c.IncludedPodMetrics) == 1 && c.IncludedPodMetrics[0] == AllMetrics {
+		c.includedPodMetrics = AvailableMetrics
+
+		return nil
+	}
+
 	for _, metrics := range c.IncludedPodMetrics {
-		if metrics == AllMetrics && len(c.IncludedPodMetrics) != 1 {
+		if metrics == AllMetrics {
 			return errors.New("'all' should be only one element in included_pod_metrics")
 		}
 
@@ -2270,7 +2284,13 @@ func (c *StatsConfig) Validate() error {
 		}
 	}
 
+	c.includedPodMetrics = c.IncludedPodMetrics
+
 	return nil
+}
+
+func (c *StatsConfig) EnabledPodMetrics() []string {
+	return c.includedPodMetrics
 }
 
 // DefaultTLSMinVersion is the default minimum TLS version.

--- a/server/metric_descriptors_list.go
+++ b/server/metric_descriptors_list.go
@@ -8,7 +8,7 @@ import (
 
 // ListMetricDescriptors lists all metric descriptors.
 func (s *Server) ListMetricDescriptors(ctx context.Context, req *types.ListMetricDescriptorsRequest) (*types.ListMetricDescriptorsResponse, error) {
-	includedKeys := s.config.IncludedPodMetrics
+	includedKeys := s.config.EnabledPodMetrics()
 	descriptorsMap := s.PopulateMetricDescriptors(includedKeys)
 
 	// Flatten the map of descriptors to a slice.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR fixes a bug where CRI-O didn't return all metrics when "all" is set.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where CRI-O didn't return all metrics when "all" is set.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable handling of the special "all" metric setting to prevent unexpected gaps.
  * Fixed inconsistent selection so pod- and container-level network/metric collection align.

* **Changes**
  * Metric selection is unified across the system via a stable enabled-metrics accessor.
  * A canonical list of available metrics was added; descriptor output and collected metrics may change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->