### PR TITLE
Return image ID from PullImage instead of repo digest

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -118,9 +118,8 @@ type pullOperation struct {
 	// wg allows for Goroutines trying to pull the same image to wait until the
 	// currently running pull operation has finished.
 	wg sync.WaitGroup
-	// imageRef is the reference of the actually pulled image; it is always
-	// in a full repo@digest format, resolving short names and tags
-	imageRef storage.RegistryImageReference
+	// imageRef is the resolved image ID to return in the CRI PullImageResponse
+	imageRef string
 	// err is the error indicating if the pull operation has succeeded or not.
 	err error
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR changes `PullImage` to return the storage image ID instead of the repo digest, fixing a compatibility issue with Kubernetes credential verification which expects `PullImage` and `GetImageRef` to return compatible values for pull record lookups.

The ref-to-ID resolution happens in the server layer (`server/image_pull.go`) via a new `resolveImageRefToID` method, keeping the storage layer's `PullImage` contract unchanged. For OCI artifacts (not stored in container storage), it falls back to the artifact store.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
PullImage now returns the image ID directly, ensuring compatibility with Kubernetes credential verification for image pulls.
```