### PR TITLE
Disable swap setup on GitHub actions and fix critest

### DIFF
--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -31,15 +31,6 @@ prepare_system() {
     sudo systemctl stop docker || true
     sudo ufw disable || true
 
-    if [[ "$GOARCH" == amd64 ]]; then
-        # Setup swap for integration tests
-        sudo fallocate -l 1G /swapfile
-        sudo chmod 600 /swapfile
-        sudo mkswap /swapfile
-        sudo swapon /swapfile
-    fi
-    sudo swapon --show
-
     # enable necessary kernel modules
     sudo modprobe br_netfilter
     sudo sysctl -p /etc/sysctl.conf

--- a/test/critest.bats
+++ b/test/critest.bats
@@ -30,7 +30,6 @@ function teardown() {
 		--ginkgo.randomize-all \
 		--ginkgo.timeout 5m \
 		--ginkgo.trace \
-		--ginkgo.vv \
 		--ginkgo.flake-attempts 3 \
 		"${WEBSOCKET_ARGS[@]}" >&3
 


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
- Disable the dedicated swap setup, because it looks like they already have swap enabled now.
- Removed --ginkgo.vv from the critest invocation to fix up the test.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI environment by removing AMD64-specific swap initialization steps.
* **Tests**
  * Reduced test run verbosity by disabling an overly verbose output flag during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->