### PR TITLE
Bump development version to v1.36.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,13 +13,13 @@ dependencies:
   # tag the .0 release if it does not already exist. If the .0 release is done,
   # increase the development version to the next minor (1.x.0).
   - name: development version
-    version: 1.35.0
+    version: 1.36.0
     refPaths:
       - path: internal/version/version.go
         match: Version
 
   - name: supported versions
-    version: '{"1.34", "1.33"}'
+    version: '{"1.35", "1.34", "1.33"}'
     refPaths:
       - path: internal/version/version.go
         match: ReleaseMinorVersions

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 // Version is the version of the build.
-const Version = "1.35.0"
+const Version = "1.36.0"
 
 // ReleaseMinorVersions are the currently supported minor versions.
-var ReleaseMinorVersions = []string{"1.34", "1.33"}
+var ReleaseMinorVersions = []string{"1.35", "1.34", "1.33"}
 
 // Variables injected during build-time.
 var (


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Add v1.36.0 as the new development version and move v1.35 to the supported versions list.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Refers to https://github.com/cri-o/packaging/pull/338
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release version 1.36.0
  * Extended compatibility to support version 1.35

<!-- end of auto-generated comment: release notes by coderabbit.ai -->