### PR TITLE
Add OpenVEX report generation via govulncheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -312,5 +312,31 @@ jobs:
           go-version-file: go.mod
       - name: Run govulncheck
         run: make verify-govulncheck
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        if: always()
+        with:
+          name: vex
+          path: build/cri-o.openvex.json
+          if-no-files-found: ignore
       - name: Run gosec
         run: make verify-gosec
+
+  vex-upload:
+    if: |
+      !cancelled() &&
+      (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags'))
+    runs-on: ubuntu-latest
+    needs:
+      - security-checks
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: vex
+          path: ${{ github.sha }}
+      - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
+        with:
+          credentials_json: ${{ secrets.GCS_CRIO_SA }}
+      - uses: google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0 # v2.2.1
+        with:
+          path: ${{ github.sha }}
+          destination: cri-o/artifacts

--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,10 @@ verify-gosec: ${GOSEC} ## Run gosec on the project.
 verify-govulncheck: ## Check common vulnerabilities.
 	./hack/govulncheck.sh
 
+.PHONY: vex
+vex: ## Generate an OpenVEX report.
+	VEX_ONLY=true ./hack/govulncheck.sh
+
 .PHONY: verify-mdtoc
 verify-mdtoc: ${MDTOC} ## Verify the table of contents for the docs.
 	git grep --name-only '<!-- toc -->' | grep -v Makefile | xargs ${MDTOC} -i -m=5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,3 +41,24 @@ being incorporated into the repository without breaking the embargo.
 - You need help tuning CRI-O components for security
 - You need help applying security related updates
 - Your issue is not security related
+
+## OpenVEX
+
+CRI-O publishes [OpenVEX](https://openvex.dev) documents with each release to
+communicate the exploitability of known vulnerabilities in our dependency tree.
+These documents are generated using
+[govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) and indicate
+which vulnerabilities are actually reachable in CRI-O's code paths versus those
+that exist in dependencies but are not called.
+
+The VEX report for each release is available as a signed artifact alongside the
+release bundles. See the release notes for download and verification
+instructions.
+
+To generate a VEX report locally:
+
+```console
+make vex
+```
+
+This produces `build/cri-o.openvex.json`.

--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -147,6 +147,10 @@ Download one of our static release bundles via our Google Cloud Bucket:
   - [cri-o.s390x.%s.tar.gz.spdx](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.spdx)
   - [cri-o.s390x.%s.tar.gz.spdx.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.s390x.%s.tar.gz.spdx.bundle)
 
+The [OpenVEX](https://openvex.dev) report for this release is available at:
+
+- [cri-o.%s.openvex.json](https://storage.googleapis.com/cri-o/artifacts/cri-o.%s.openvex.json)
+
 To verify the artifact signatures via [cosign](https://github.com/sigstore/cosign), run:
 
 `+"```"+`console
@@ -164,6 +168,17 @@ To verify the bill of materials (SBOM) in [SPDX](https://spdx.org) format using 
 `+"```"+`console
 > tar xfz cri-o.amd64.%s.tar.gz
 > bom validate -e cri-o.amd64.%s.tar.gz.spdx -d cri-o
+`+"```"+`
+
+To verify the [OpenVEX](https://openvex.dev) vulnerability report, run:
+
+`+"```"+`console
+> cosign verify-blob cri-o.%s.openvex.json \
+    --certificate-identity https://github.com/cri-o/packaging/.github/workflows/obs.yml@refs/heads/main \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-github-workflow-repository cri-o/packaging \
+    --certificate-github-workflow-ref refs/heads/main \
+    --bundle cri-o.%s.openvex.json.bundle
 `+"```"+`
 
 ## Changelog since %s
@@ -186,6 +201,8 @@ To verify the bill of materials (SBOM) in [SPDX](https://spdx.org) format using 
 		startTag, shortHead,
 		startTag, endRev,
 		time.Now().Format(time.RFC1123),
+		bundleVersion, bundleVersion,
+		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds project-level VEX (Vulnerability Exploitability eXchange) support:
- Extends `hack/govulncheck.sh` to generate an OpenVEX document
- Adds `make vex` target
- Adds VEX download link and verification instructions to release notes
- Documents VEX in `SECURITY.md`

#### Which issue(s) this PR fixes:

Fixes #9104

#### Special notes for your reviewer:

Requires a companion PR in cri-o/packaging to generate, sign, and
upload the VEX file during the release process:
https://github.com/cri-o/packaging/pull/339

#### Does this PR introduce a user-facing change?

```release-note
Add OpenVEX vulnerability report generation for releases
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a build target to generate OpenVEX reports so users can produce VEX artifacts locally.

* **Documentation**
  * Expanded security docs with OpenVEX details, generation and verification guidance.
  * Updated release notes templates to include OpenVEX sections and verification instructions.

* **Chores**
  * CI now preserves and uploads generated OpenVEX artifacts as part of security workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->