### PR TITLE
server: clear default seccomp filter for privileged containers

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1110,6 +1110,13 @@ func (s *Server) setupSeccomp(ctx context.Context, ctr container.Container, sb *
 		}
 
 		seccompRef = ref
+	} else {
+		// Privileged container without a custom seccomp profile: clear the default
+		// seccomp filter that the OCI spec generator populates automatically.
+		// Privileged containers must run unconfined per the CRI specification.
+		if specgen.Config.Linux != nil {
+			specgen.Config.Linux.Seccomp = nil
+		}
 	}
 
 	return seccompRef, nil

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1119,6 +1119,13 @@ func (s *Server) setupSandboxSeccomp(ctx context.Context, g *generate.Generator,
 		}
 
 		seccompRef = ref
+	} else {
+		// Privileged sandbox without a custom seccomp profile: clear the default
+		// seccomp filter that the OCI spec generator populates automatically.
+		// Privileged containers must run unconfined per the CRI specification.
+		if g.Config.Linux != nil {
+			g.Config.Linux.Seccomp = nil
+		}
 	}
 
 	return seccompRef, nil


### PR DESCRIPTION
/kind bug

## What this PR does / why we need it

`generate.New()` auto-populates a default seccomp filter into every OCI spec.
For privileged sandboxes and containers, `setupSandboxSeccomp` and `setupSeccomp`
skip calling `seccompConfig.Setup()` — but neither function explicitly removes
that default filter. The result is that privileged containers silently run under
the OCI spec generator's default allowlist rather than with an unconfined profile.

This causes a concrete failure with runc 1.3.3 (issue #4007 in opencontainers/runc):
`runc` calls `close_range()` and `openat2()` during container init. Both syscalls
are absent from the default seccomp allowlist, so runc fails with:

```
error closing exec fds: get handle to /proc/thread-self/fd: unsafe procfs detected:
openat2 fsmount:fscontext:proc/thread-self/fd/: operation not permitted
```

Any pod sandbox that uses host network (which CRI-O treats as privileged) hits this
when `PrivilegedSeccompProfile` is not configured.

## Which issue(s) this PR fixes

Fixes #9675

## How the fix works

Add an `else` branch to both `setupSandboxSeccomp` (sandbox) and `setupSeccomp`
(container): when the container is privileged and no custom `PrivilegedSeccompProfile`
is set, explicitly set `Config.Linux.Seccomp = nil`. This mirrors exactly what
`seccompConfig.Setup()` does when it receives an `Unconfined` profile type.

## Testing

The existing seccomp unit tests cover the non-privileged path. A new integration
test creating a privileged sandbox without `PrivilegedSeccompProfile` set and
verifying the generated OCI spec has no seccomp stanza would be the ideal addition,
but the behaviour is straightforward to verify by inspecting the bundle's `config.json`.

## Release note

```release-note
Fixed a bug where privileged containers ran with the OCI spec generator's default
seccomp allowlist instead of unconfined, causing runc 1.3.3+ to fail on syscalls
such as close_range and openat2.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Privileged containers without custom seccomp profiles now run unconfined, aligning with CRI specification. Default seccomp filters are cleared for privileged sandboxes without custom profiles, ensuring consistent security policy handling across sandbox and container creation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->