### PR TITLE
oci: prevent nil pointer panic in runtimeVM.kill after restart

### DIFF
--- a/internal/oci/runtime_vm_test.go
+++ b/internal/oci/runtime_vm_test.go
@@ -1,0 +1,132 @@
+package oci_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/oci"
+	libconfig "github.com/cri-o/cri-o/pkg/config"
+	"github.com/cri-o/cri-o/utils/errdefs"
+)
+
+func newTestRuntimeVM() oci.RuntimeVM {
+	return oci.NewRuntimeVM(&libconfig.RuntimeHandler{
+		RuntimeRoot: t.MustTempDir("runtime-vm-root"),
+	})
+}
+
+func newContainerWithBundle(bundleDir string) *oci.Container {
+	ctr, err := oci.NewContainer(
+		"vm-ctr-id", "vm-ctr-name", bundleDir, "",
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"", nil, nil, "", &types.ContainerMetadata{}, "sandbox-id",
+		false, false, false, "", "", time.Now(), "",
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	return ctr
+}
+
+func setContainerStatus(ctr *oci.Container, status rspec.ContainerState) {
+	state := &oci.ContainerState{}
+	state.Status = status
+	ctr.SetState(state)
+}
+
+var _ = t.Describe("RuntimeVM", func() {
+	Context("kill() nil-task guard", func() {
+		It("returns ErrNotFound instead of panicking when task is nil", func() {
+			// Given: runtimeVM reconstructed after restart — task connection not yet established
+			sut := newTestRuntimeVM()
+			Expect(sut.HasTask()).To(BeFalse())
+
+			// When: kill is called with signal 0 (liveness probe)
+			err := sut.Kill("ctr-id", "", syscall.Signal(0))
+
+			// Then: must not panic and must report ErrNotFound
+			Expect(err).To(MatchError(errdefs.ErrNotFound))
+		})
+
+		It("returns ErrNotFound for SIGTERM when task is nil", func() {
+			sut := newTestRuntimeVM()
+
+			err := sut.Kill("ctr-id", "", syscall.SIGTERM)
+
+			Expect(err).To(MatchError(errdefs.ErrNotFound))
+		})
+
+		It("returns ErrNotFound for exec-scoped SIGKILL when task is nil", func() {
+			sut := newTestRuntimeVM()
+
+			err := sut.Kill("ctr-id", "exec-id", syscall.SIGKILL)
+
+			Expect(err).To(MatchError(errdefs.ErrNotFound))
+		})
+	})
+
+	Context("connectTask()", func() {
+		var ctx = context.Background()
+
+		It("returns nil without connecting for a stopped container with no address file", func() {
+			// Given: task is nil, container is Stopped, and the shim address file is absent
+			// This is the expected state when CRI-O restarts and the container was already done.
+			sut := newTestRuntimeVM()
+			bundleDir := t.MustTempDir("bundle-stopped")
+			ctr := newContainerWithBundle(bundleDir)
+			setContainerStatus(ctr, rspec.ContainerState(oci.ContainerStateStopped))
+
+			// When
+			err := sut.ConnectTask(ctx, ctr)
+
+			// Then: graceful no-op — a stopped container needs no shim connection
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sut.HasTask()).To(BeFalse())
+		})
+
+		It("returns an error for a running container when the address file is missing", func() {
+			// Given: task is nil, container is Running, shim address file absent
+			sut := newTestRuntimeVM()
+			bundleDir := t.MustTempDir("bundle-running-no-addr")
+			ctr := newContainerWithBundle(bundleDir)
+			setContainerStatus(ctr, rspec.ContainerState(oci.ContainerStateRunning))
+
+			// When
+			err := sut.ConnectTask(ctx, ctr)
+
+			// Then: error surfaced — the address file must exist for a running container
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("read shim address"))
+		})
+
+		It("returns an error when the address file points to a non-existent socket", func() {
+			// Given: task is nil, container is Running, address file present but
+			// references a socket path with no listening shim
+			sut := newTestRuntimeVM()
+			bundleDir := t.MustTempDir("bundle-bad-addr")
+			ctr := newContainerWithBundle(bundleDir)
+			setContainerStatus(ctr, rspec.ContainerState(oci.ContainerStateRunning))
+
+			bogusAddr := filepath.Join(bundleDir, "nonexistent.sock")
+			Expect(os.WriteFile(
+				filepath.Join(bundleDir, "address"),
+				[]byte(bogusAddr+"\n"),
+				0o644,
+			)).To(Succeed())
+
+			// When
+			err := sut.ConnectTask(ctx, ctr)
+
+			// Then: connection must fail — no shim is listening at that address
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("connect to shim"))
+		})
+	})
+})

--- a/internal/oci/runtime_vm_test_inject.go
+++ b/internal/oci/runtime_vm_test_inject.go
@@ -1,0 +1,46 @@
+//go:build test
+
+// All *_inject.go files are meant to be used by tests only. Purpose of this
+// files is to provide a way to inject mocked data into the current setup.
+
+package oci
+
+import (
+	"context"
+	"syscall"
+
+	"github.com/cri-o/cri-o/pkg/config"
+)
+
+// RuntimeVM wraps the unexported runtimeVM for use in unit tests.
+type RuntimeVM struct {
+	*runtimeVM
+}
+
+// NewRuntimeVM creates a RuntimeVM with a nil task, simulating a post-restart
+// state where the shim connection has not yet been re-established.
+func NewRuntimeVM(handler *config.RuntimeHandler) RuntimeVM {
+	return RuntimeVM{
+		runtimeVM: &runtimeVM{
+			ctx:     context.Background(),
+			handler: handler,
+			ctrs:    make(map[string]containerInfo),
+		},
+	}
+}
+
+// HasTask reports whether the underlying task connection is non-nil.
+func (r RuntimeVM) HasTask() bool {
+	return r.task != nil
+}
+
+// Kill calls the unexported kill() method so tests can verify the nil-task guard.
+func (r RuntimeVM) Kill(ctrID, execID string, signal syscall.Signal) error {
+	return r.kill(ctrID, execID, signal)
+}
+
+// ConnectTask calls the unexported connectTask() method so tests can verify
+// the reconnect logic without a real shim.
+func (r RuntimeVM) ConnectTask(ctx context.Context, c *Container) error {
+	return r.connectTask(ctx, c)
+}


### PR DESCRIPTION
/kind bug

## What this PR does / why we need it

When CRI-O restarts, `runtimeVM` is reconstructed with `r.task == nil`.
The task client is only assigned later — either when `CreateContainer` connects
to a newly spawned shim, or when `updateContainerStatus` reconnects to an
existing one via the `address` file in the container bundle.

If kubelet immediately drives a VM container to termination after the restart
(before `ContainerStatus` has been called to trigger reconnection), the call chain

```
StopContainer → kill → r.task.Kill(...)   ← panic: nil pointer dereference
```

crashes CRI-O, as reported in #9772. The goroutine dump from that report shows
a container that had been in the `StopContainer` path for 837 minutes.

## Which issue(s) this PR fixes

Fixes #9772

## How the fix works

**`connectTask()` helper** — extracts the reconnect-to-shim logic already present
in `updateContainerStatus` into a reusable method. It is a no-op when `r.task` is
already set. If the shim `address` file is missing and the container is already in
stopped state, it returns `nil` with `r.task` still `nil` (caller should bail out).
Otherwise it reads the address, connects, and sets `r.task`/`r.client`.

**`StopContainer`** — calls `connectTask()` before the first `kill()` call. If
reconnection fails the error is returned (no panic). If the shim is gone and the
container is already stopped, returns `nil` cleanly.

**`kill()` nil guard** — defence-in-depth: returns `errdefs.ErrNotFound` instead
of panicking when `r.task` is nil. Protects `IsContainerAlive` and any other
caller.

`updateContainerStatus` is refactored to use `connectTask()` while preserving its
original error handling and log messages.

## Release note

```release-note
Fixed a nil pointer panic in runtimeVM.kill (Kata Containers / VM runtime) that
could crash CRI-O when kubelet restarts and immediately terminates VM containers
before their shim connection is re-established.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes by guarding container operations when no runtime connection exists.
  * Kill/stop now return clear "not found" behavior for stopped containers and avoid nil-pointer errors.
  * Improved handling and error messages for containers whose runtime/shim is missing, and removed duplicated connection logic.
* **Tests**
  * Added unit tests covering reconnect behavior, missing shim/address cases, and nil-task guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->