### PR TITLE
tutorials/CRI-O in kind: fix bash syntax error

### DIFF
--- a/tutorials/crio-in-kind.md
+++ b/tutorials/crio-in-kind.md
@@ -119,7 +119,7 @@ echo "Building final image $TARGET ..."
 # Run the intermediate image in the background
 docker run --privileged --rm -d --name crio-builder --entrypoint sleep $INTERMEDIATE infinity
 
-func cleanup {
+function cleanup {
   docker kill crio-builder
 }
 # Remove the crio-builder container on exit


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
Fixes a syntax error in a tutorial bash script.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bash script syntax in the installation tutorial for improved consistency.

* **Style**
  * Refined code example formatting in tutorial documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->