### PR TITLE
Skip OCI artifact fallback on retryable errors

### DIFF
--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -581,12 +581,6 @@ var _ = t.Describe("Image", func() {
 	})
 
 	t.Describe("PullImage", func() {
-		var graphRoot string
-
-		BeforeEach(func() {
-			graphRoot = t.MustTempDir("ociartifact")
-		})
-
 		It("should fail on invalid policy path", func() {
 			// Given
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox:latest")
@@ -604,10 +598,6 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail on copy image", func() {
 			// Given
-			mockutils.InOrder(
-				storeMock.EXPECT().GraphRoot().Return(graphRoot),
-			)
-
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox:latest")
 			Expect(err).ToNot(HaveOccurred())
 
@@ -623,10 +613,6 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail on canonical copy image", func() {
 			// Given
-			mockutils.InOrder(
-				storeMock.EXPECT().GraphRoot().Return(graphRoot),
-			)
-
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox@sha256:" + testSHA256)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -642,10 +628,6 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail on cancelled context", func() {
 			// Given
-			mockutils.InOrder(
-				storeMock.EXPECT().GraphRoot().Return(graphRoot),
-			)
-
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox:latest")
 			Expect(err).ToNot(HaveOccurred())
 
@@ -665,10 +647,6 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail on timed out context", func() {
 			// Given
-			mockutils.InOrder(
-				storeMock.EXPECT().GraphRoot().Return(graphRoot),
-			)
-
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox:latest")
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/image.bats
+++ b/test/image.bats
@@ -443,3 +443,13 @@ EOF
 
 	cleanup_images
 }
+
+@test "image pull should not fall back to OCI artifact on network error" {
+	start_crio
+
+	# 192.0.2.1 is TEST-NET-1 (RFC 5737), guaranteed unreachable
+	run ! crictl pull 192.0.2.1/test/image:latest
+
+	# Network errors should not trigger the OCI artifact fallback
+	run ! grep -q "Falling back" "$CRIO_LOG"
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Avoid falling back to an OCI artifact pull when the initial image pull fails due to a network error, since the artifact pull would fail the same way. This prevents blocking pod operations for an extra timeout cycle on unreachable registries. Also disable retries on the artifact pull path to further reduce latency on failures.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Skip the OCI artifact pull fallback when the initial image pull fails due to a retryable error
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OCI-artifact fallback for image pulls when primary pulls fail, with debug logging and final image reference construction from artifact digest; artifact pulls use zero retries to avoid blocking.

* **Bug Fixes**
  * Returns clearer combined errors when primary and artifact pull attempts fail.
  * Detects network-related failures and avoids artifact fallback to prevent delays.

* **Tests**
  * Added a test ensuring network errors do not trigger artifact fallback and cleaned up related test scaffolding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->