### PR TITLE
Add tests for OCI image volume mount options

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -534,6 +534,9 @@ func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, im
 
 	log.Debugf(ctx, "Image ID to mount: %v", imageID)
 
+	// These options apply to the host-level storage mount, not the overlay
+	// mount inside the container. The container-facing overlay mount has its
+	// own options set separately below.
 	options := []string{"ro", "noexec", "nosuid", "nodev"}
 
 	mountPoint, err := s.ContainerServer.Store().MountImage(imageID, options, "")


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Verify that image volumes are mounted readonly and document the current behavior where noexec is missing from the overlay mount.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OCI image volume mounts now include enhanced security restrictions: read-only access and disabled execution permissions at the host level.

* **Tests**
  * Added test coverage for OCI image volume mount security properties, including read-only enforcement and execution restriction verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->