### PR TITLE
Add EnsureNotContainerImage to prevent container images in artifact store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,7 @@ mockgen: \
 	mock-image-types \
 	mock-ocicni-types \
 	mock-seccompociartifact-types \
+	mock-ociartifact-types \
 	mock-ociartifact-datastore-types \
 	mock-systemd \
 	mock-cgmgr
@@ -524,6 +525,13 @@ mock-seccompociartifact-types: ${MOCKGEN}
 		-package seccompociartifactmock \
 		-destination ${MOCK_PATH}/seccompociartifact/seccompociartifact.go \
 		github.com/cri-o/cri-o/internal/config/seccomp/seccompociartifact Impl
+
+.PHONY: mock-ociartifact-types
+mock-ociartifact-types: ${MOCKGEN}
+	${BUILD_BIN_PATH}/mockgen \
+		-package ociartifactmock \
+		-destination ${MOCK_PATH}/ociartifact/ociartifact.go \
+		github.com/cri-o/cri-o/internal/ociartifact Impl,LibartifactStore
 
 .PHONY: mock-ociartifact-datastore-types
 mock-ociartifact-datastore-types: ${MOCKGEN}

--- a/internal/ociartifact/impl.go
+++ b/internal/ociartifact/impl.go
@@ -1,0 +1,42 @@
+package ociartifact
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opencontainers/go-digest"
+	"go.podman.io/image/v5/manifest"
+	"go.podman.io/image/v5/types"
+)
+
+// Impl is the main interface for OCI artifact manifest operations.
+// It abstracts manifest retrieval and platform resolution so that the
+// Store can be tested with mock implementations.
+type Impl interface {
+	// ChooseInstance selects the platform-specific manifest digest from a
+	// multi-architecture manifest list based on the provided system context
+	// (OS, architecture, variant).
+	ChooseInstance(manifest.List, *types.SystemContext) (digest.Digest, error)
+
+	// GetManifestFromRef fetches the raw manifest bytes and its MIME type
+	// from the given image reference. If instanceDigest is non-nil, it
+	// retrieves that specific manifest instance rather than the root manifest.
+	GetManifestFromRef(context.Context, types.ImageReference, *types.SystemContext, *digest.Digest) ([]byte, string, error)
+}
+
+// defaultImpl is the default implementation for the OCI artifact handling.
+type defaultImpl struct{}
+
+func (*defaultImpl) ChooseInstance(list manifest.List, sys *types.SystemContext) (digest.Digest, error) {
+	return list.ChooseInstance(sys)
+}
+
+func (*defaultImpl) GetManifestFromRef(ctx context.Context, ref types.ImageReference, sys *types.SystemContext, instanceDigest *digest.Digest) (manifestBlob []byte, mimeType string, err error) {
+	src, err := ref.NewImageSource(ctx, sys)
+	if err != nil {
+		return nil, "", fmt.Errorf("create image source: %w", err)
+	}
+	defer src.Close()
+
+	return src.GetManifest(ctx, instanceDigest)
+}

--- a/internal/ociartifact/libartifact_store.go
+++ b/internal/ociartifact/libartifact_store.go
@@ -6,11 +6,26 @@ import (
 	"github.com/opencontainers/go-digest"
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/pkg/libartifact"
+	"go.podman.io/image/v5/types"
 )
 
+// LibartifactStore abstracts the libartifact storage operations so that
+// the Store can be tested with mock implementations.
 type LibartifactStore interface {
 	Remove(ctx context.Context, asr libartifact.ArtifactStoreReference) (*digest.Digest, error)
 	List(ctx context.Context) (libartifact.ArtifactList, error)
 	Pull(ctx context.Context, ref libartifact.ArtifactReference, opts libimage.CopyOptions) (digest.Digest, error)
 	Inspect(ctx context.Context, asr libartifact.ArtifactStoreReference) (*libartifact.Artifact, error)
+	SystemContext() *types.SystemContext
+}
+
+// artifactStore wraps *libartifact.ArtifactStore to satisfy
+// the LibartifactStore interface by exposing the SystemContext field
+// as a method.
+type artifactStore struct {
+	*libartifact.ArtifactStore
+}
+
+func (s *artifactStore) SystemContext() *types.SystemContext {
+	return s.ArtifactStore.SystemContext
 }

--- a/internal/ociartifact/store_test.go
+++ b/internal/ociartifact/store_test.go
@@ -1,0 +1,353 @@
+package ociartifact_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+	"go.podman.io/image/v5/manifest"
+	"go.uber.org/mock/gomock"
+
+	"github.com/cri-o/cri-o/internal/ociartifact"
+	ociartifactmock "github.com/cri-o/cri-o/test/mocks/ociartifact"
+)
+
+var errTest = errors.New("test")
+
+const testDigest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func makeOCIManifest(configMediaType, artifactType string) []byte {
+	m := map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     specs.MediaTypeImageManifest,
+		"config": map[string]any{
+			"mediaType": configMediaType,
+			"digest":    testDigest,
+			"size":      0,
+		},
+		"layers": []any{},
+	}
+	if artifactType != "" {
+		m["artifactType"] = artifactType
+	}
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+func makeDockerV2S2Manifest() []byte {
+	b, err := json.Marshal(map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     manifest.DockerV2Schema2MediaType,
+		"config": map[string]any{
+			"mediaType": manifest.DockerV2Schema2ConfigMediaType,
+			"digest":    testDigest,
+			"size":      0,
+		},
+		"layers": []any{},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+func makeDockerV2S1SignedManifest() []byte {
+	b, err := json.Marshal(map[string]any{
+		"schemaVersion": 1,
+		"name":          "test",
+		"tag":           "latest",
+		"architecture":  "amd64",
+		"fsLayers": []any{
+			map[string]any{"blobSum": testDigest},
+		},
+		"history": []any{
+			map[string]any{"v1Compatibility": `{"id":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+func makeOCIIndex() []byte {
+	b, err := json.Marshal(map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     specs.MediaTypeImageIndex,
+		"manifests": []any{
+			map[string]any{
+				"mediaType": specs.MediaTypeImageManifest,
+				"digest":    testDigest,
+				"size":      100,
+				"platform": map[string]any{
+					"os":           "linux",
+					"architecture": "amd64",
+				},
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+// The actual test suite.
+var _ = t.Describe("Store", func() {
+	t.Describe("EnsureNotContainerImage", func() {
+		var (
+			implMock *ociartifactmock.MockImpl
+			mockCtrl *gomock.Controller
+			store    *ociartifact.Store
+		)
+
+		BeforeEach(func() {
+			logrus.SetOutput(io.Discard)
+
+			mockCtrl = gomock.NewController(GinkgoT())
+			implMock = ociartifactmock.NewMockImpl(mockCtrl)
+
+			var err error
+
+			store, err = ociartifact.NewStore(t.MustTempDir("artifact"), nil)
+			Expect(err).NotTo(HaveOccurred())
+			store.SetFakeImpl(implMock)
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		It("should fail when GetManifestFromRef fails", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, "", errTest)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("get manifest from ref"))
+		})
+
+		It("should return ErrIsAnImage for OCI manifest with OCI image config", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(makeOCIManifest(specs.MediaTypeImageConfig, ""), specs.MediaTypeImageManifest, nil)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ociartifact.ErrIsAnImage)).To(BeTrue())
+		})
+
+		It("should return ErrIsAnImage for OCI manifest with empty config media type", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(makeOCIManifest("", ""), specs.MediaTypeImageManifest, nil)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ociartifact.ErrIsAnImage)).To(BeTrue())
+		})
+
+		It("should return ErrIsAnImage for Docker v2 schema 2 manifest", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(makeDockerV2S2Manifest(), manifest.DockerV2Schema2MediaType, nil)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ociartifact.ErrIsAnImage)).To(BeTrue())
+		})
+
+		It("should return ErrIsAnImage for Docker v2 schema 1 signed manifest", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(makeDockerV2S1SignedManifest(), manifest.DockerV2Schema1SignedMediaType, nil)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ociartifact.ErrIsAnImage)).To(BeTrue())
+		})
+
+		It("should succeed for OCI manifest with artifactType set", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(
+					makeOCIManifest(specs.MediaTypeImageConfig, "application/vnd.example.artifact"),
+					specs.MediaTypeImageManifest,
+					nil,
+				)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should succeed for non-container-image config media type", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(
+					makeOCIManifest("application/vnd.custom.config", ""),
+					specs.MediaTypeImageManifest,
+					nil,
+				)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail when manifest bytes are unparsable", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return([]byte("invalid"), specs.MediaTypeImageManifest, nil)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parse manifest"))
+		})
+
+		It("should fail when manifest list bytes are unparsable", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return([]byte("invalid"), specs.MediaTypeImageIndex, nil)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parse manifest list"))
+		})
+
+		It("should fail when ChooseInstance fails", func() {
+			// Given
+			implMock.EXPECT().
+				GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(makeOCIIndex(), specs.MediaTypeImageIndex, nil)
+			implMock.EXPECT().
+				ChooseInstance(gomock.Any(), gomock.Any()).
+				Return(digest.Digest(""), errTest)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("choose manifest instance"))
+		})
+
+		It("should fail when getting instance manifest fails", func() {
+			// Given
+			gomock.InOrder(
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(makeOCIIndex(), specs.MediaTypeImageIndex, nil),
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, "", errTest),
+			)
+			implMock.EXPECT().
+				ChooseInstance(gomock.Any(), gomock.Any()).
+				Return(digest.Digest(testDigest), nil)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("get instance manifest"))
+		})
+
+		It("should return ErrIsAnImage for multi-arch image resolving to container image", func() {
+			// Given
+			gomock.InOrder(
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(makeOCIIndex(), specs.MediaTypeImageIndex, nil),
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(makeOCIManifest(specs.MediaTypeImageConfig, ""), specs.MediaTypeImageManifest, nil),
+			)
+			implMock.EXPECT().
+				ChooseInstance(gomock.Any(), gomock.Any()).
+				Return(digest.Digest(testDigest), nil)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ociartifact.ErrIsAnImage)).To(BeTrue())
+		})
+
+		It("should succeed for multi-arch artifact with artifactType", func() {
+			// Given
+			gomock.InOrder(
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(makeOCIIndex(), specs.MediaTypeImageIndex, nil),
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(
+						makeOCIManifest(specs.MediaTypeImageConfig, "application/vnd.example.artifact"),
+						specs.MediaTypeImageManifest,
+						nil,
+					),
+			)
+			implMock.EXPECT().
+				ChooseInstance(gomock.Any(), gomock.Any()).
+				Return(digest.Digest(testDigest), nil)
+
+			// When
+			err := store.EnsureNotContainerImage(context.Background(), nil)
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/internal/ociartifact/store_test_inject.go
+++ b/internal/ociartifact/store_test_inject.go
@@ -13,6 +13,10 @@ func (s *Store) SetFakeStore(l LibartifactStore) {
 	s.libartifactStore = l
 }
 
+func (s *Store) SetFakeImpl(impl Impl) {
+	s.impl = impl
+}
+
 type FakeLibartifactStore struct {
 	*ociartifactmock.MockLibartifactStore
 }

--- a/test/mocks/ociartifact/ociartifact.go
+++ b/test/mocks/ociartifact/ociartifact.go
@@ -11,13 +11,11 @@ package ociartifactmock
 
 import (
 	context "context"
-	io "io"
 	reflect "reflect"
 
 	digest "github.com/opencontainers/go-digest"
 	libimage "go.podman.io/common/libimage"
 	libartifact "go.podman.io/common/pkg/libartifact"
-	reference "go.podman.io/image/v5/docker/reference"
 	manifest "go.podman.io/image/v5/manifest"
 	types "go.podman.io/image/v5/types"
 	gomock "go.uber.org/mock/gomock"
@@ -47,138 +45,35 @@ func (m *MockImpl) EXPECT() *MockImplMockRecorder {
 	return m.recorder
 }
 
-// CandidatesForPotentiallyShortImageName mocks base method.
-func (m *MockImpl) CandidatesForPotentiallyShortImageName(systemContext *types.SystemContext, imageName string) ([]reference.Named, error) {
+// ChooseInstance mocks base method.
+func (m *MockImpl) ChooseInstance(arg0 manifest.List, arg1 *types.SystemContext) (digest.Digest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CandidatesForPotentiallyShortImageName", systemContext, imageName)
-	ret0, _ := ret[0].([]reference.Named)
+	ret := m.ctrl.Call(m, "ChooseInstance", arg0, arg1)
+	ret0, _ := ret[0].(digest.Digest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CandidatesForPotentiallyShortImageName indicates an expected call of CandidatesForPotentiallyShortImageName.
-func (mr *MockImplMockRecorder) CandidatesForPotentiallyShortImageName(systemContext, imageName any) *gomock.Call {
+// ChooseInstance indicates an expected call of ChooseInstance.
+func (mr *MockImplMockRecorder) ChooseInstance(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidatesForPotentiallyShortImageName", reflect.TypeOf((*MockImpl)(nil).CandidatesForPotentiallyShortImageName), systemContext, imageName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChooseInstance", reflect.TypeOf((*MockImpl)(nil).ChooseInstance), arg0, arg1)
 }
 
-// CloseImageSource mocks base method.
-func (m *MockImpl) CloseImageSource(arg0 types.ImageSource) error {
+// GetManifestFromRef mocks base method.
+func (m *MockImpl) GetManifestFromRef(arg0 context.Context, arg1 types.ImageReference, arg2 *types.SystemContext, arg3 *digest.Digest) ([]byte, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloseImageSource", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CloseImageSource indicates an expected call of CloseImageSource.
-func (mr *MockImplMockRecorder) CloseImageSource(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseImageSource", reflect.TypeOf((*MockImpl)(nil).CloseImageSource), arg0)
-}
-
-// DockerNewReference mocks base method.
-func (m *MockImpl) DockerNewReference(arg0 reference.Named) (types.ImageReference, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DockerNewReference", arg0)
-	ret0, _ := ret[0].(types.ImageReference)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DockerNewReference indicates an expected call of DockerNewReference.
-func (mr *MockImplMockRecorder) DockerNewReference(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DockerNewReference", reflect.TypeOf((*MockImpl)(nil).DockerNewReference), arg0)
-}
-
-// GetBlob mocks base method.
-func (m *MockImpl) GetBlob(arg0 context.Context, arg1 types.ImageSource, arg2 types.BlobInfo, arg3 types.BlobInfoCache) (io.ReadCloser, int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBlob", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(io.ReadCloser)
-	ret1, _ := ret[1].(int64)
+	ret := m.ctrl.Call(m, "GetManifestFromRef", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetBlob indicates an expected call of GetBlob.
-func (mr *MockImplMockRecorder) GetBlob(arg0, arg1, arg2, arg3 any) *gomock.Call {
+// GetManifestFromRef indicates an expected call of GetManifestFromRef.
+func (mr *MockImplMockRecorder) GetManifestFromRef(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlob", reflect.TypeOf((*MockImpl)(nil).GetBlob), arg0, arg1, arg2, arg3)
-}
-
-// LayerInfos mocks base method.
-func (m *MockImpl) LayerInfos(arg0 manifest.Manifest) []manifest.LayerInfo {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LayerInfos", arg0)
-	ret0, _ := ret[0].([]manifest.LayerInfo)
-	return ret0
-}
-
-// LayerInfos indicates an expected call of LayerInfos.
-func (mr *MockImplMockRecorder) LayerInfos(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LayerInfos", reflect.TypeOf((*MockImpl)(nil).LayerInfos), arg0)
-}
-
-// LayoutNewReference mocks base method.
-func (m *MockImpl) LayoutNewReference(arg0, arg1 string) (types.ImageReference, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LayoutNewReference", arg0, arg1)
-	ret0, _ := ret[0].(types.ImageReference)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LayoutNewReference indicates an expected call of LayoutNewReference.
-func (mr *MockImplMockRecorder) LayoutNewReference(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LayoutNewReference", reflect.TypeOf((*MockImpl)(nil).LayoutNewReference), arg0, arg1)
-}
-
-// NewImageSource mocks base method.
-func (m *MockImpl) NewImageSource(arg0 context.Context, arg1 types.ImageReference, arg2 *types.SystemContext) (types.ImageSource, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewImageSource", arg0, arg1, arg2)
-	ret0, _ := ret[0].(types.ImageSource)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewImageSource indicates an expected call of NewImageSource.
-func (mr *MockImplMockRecorder) NewImageSource(arg0, arg1, arg2 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewImageSource", reflect.TypeOf((*MockImpl)(nil).NewImageSource), arg0, arg1, arg2)
-}
-
-// ParseNormalizedNamed mocks base method.
-func (m *MockImpl) ParseNormalizedNamed(arg0 string) (reference.Named, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ParseNormalizedNamed", arg0)
-	ret0, _ := ret[0].(reference.Named)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ParseNormalizedNamed indicates an expected call of ParseNormalizedNamed.
-func (mr *MockImplMockRecorder) ParseNormalizedNamed(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseNormalizedNamed", reflect.TypeOf((*MockImpl)(nil).ParseNormalizedNamed), arg0)
-}
-
-// ReadAll mocks base method.
-func (m *MockImpl) ReadAll(arg0 io.Reader) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadAll", arg0)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadAll indicates an expected call of ReadAll.
-func (mr *MockImplMockRecorder) ReadAll(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAll", reflect.TypeOf((*MockImpl)(nil).ReadAll), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManifestFromRef", reflect.TypeOf((*MockImpl)(nil).GetManifestFromRef), arg0, arg1, arg2, arg3)
 }
 
 // MockLibartifactStore is a mock of LibartifactStore interface.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Fix cases where regular container images could accidentally be pulled into the OCI artifact store by validating manifest and config media types, including multi-arch manifest resolution and artifact type detection. Includes unit tests and updated mocks.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed cases where regular container images could accidentally be pulled into the OCI artifact store
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rejects container images when pulling OCI artifacts (early validation) and surfaces a clear error
  * Adds access to SystemContext for artifact handling

* **Bug Fixes**
  * Pull flow now validates references earlier to avoid misclassifying images as artifacts

* **Tests**
  * Added comprehensive tests for manifest parsing and multi-arch resolution; test helpers to inject implementations

* **Chores**
  * Expanded mock generation to include OCI artifact interfaces and updated mock surfaces
<!-- end of auto-generated comment: release notes by coderabbit.ai -->