### PR TITLE
Fix metric label cardinality mismatches in CRI stats

### DIFF
--- a/internal/lib/statsserver/cpu_metrics_linux.go
+++ b/internal/lib/statsserver/cpu_metrics_linux.go
@@ -83,5 +83,5 @@ func generateContainerCPUMetrics(ctr *oci.Container, cpu *cgroups.CpuStats) []*t
 		},
 	}
 
-	return computeContainerMetrics(ctr, cpuMetrics, "cpu")
+	return computeContainerMetrics(ctr, cpuMetrics)
 }

--- a/internal/lib/statsserver/disk_metrics_linux.go
+++ b/internal/lib/statsserver/disk_metrics_linux.go
@@ -47,7 +47,7 @@ func generateContainerDiskMetrics(ctr *oci.Container, diskStats *stats.Filesyste
 		},
 	}
 
-	return computeContainerMetrics(ctr, diskMetrics, "disk")
+	return computeContainerMetrics(ctr, diskMetrics)
 }
 
 // generateContainerDiskIOMetrics computes filesystem disk metrics from DiskStats for a container sandbox.
@@ -111,5 +111,5 @@ func generateContainerDiskIOMetrics(ctr *oci.Container, ioStats *cgroups.BlkioSt
 		}
 	}
 
-	return computeContainerMetrics(ctr, diskMetrics, "diskIO")
+	return computeContainerMetrics(ctr, diskMetrics)
 }

--- a/internal/lib/statsserver/hugetlb_metrics_linux.go
+++ b/internal/lib/statsserver/hugetlb_metrics_linux.go
@@ -40,5 +40,5 @@ func generateContainerHugetlbMetrics(ctr *oci.Container, hugetlb map[string]cgro
 		},
 	}
 
-	return computeContainerMetrics(ctr, hugetlbMetrics, "hugetlb")
+	return computeContainerMetrics(ctr, hugetlbMetrics)
 }

--- a/internal/lib/statsserver/memory_metrics_linux.go
+++ b/internal/lib/statsserver/memory_metrics_linux.go
@@ -114,7 +114,7 @@ func generateContainerMemoryMetrics(ctr *oci.Container, mem *cgroups.MemoryStats
 		},
 	}
 
-	return computeContainerMetrics(ctr, memoryMetrics, "memory")
+	return computeContainerMetrics(ctr, memoryMetrics)
 }
 
 // computeMemoryMetricValues computes derived memory statistics for metrics.
@@ -181,5 +181,5 @@ func GenerateContainerOOMMetrics(ctr *oci.Container, oomCount uint64) []*types.M
 		},
 	}
 
-	return computeContainerMetrics(ctr, oomMetrics, "oom")
+	return computeContainerMetrics(ctr, oomMetrics)
 }

--- a/internal/lib/statsserver/metrics.go
+++ b/internal/lib/statsserver/metrics.go
@@ -140,8 +140,8 @@ func (ss *StatsServer) PopulateMetricDescriptors(includedKeys []string) map[stri
 }
 
 // ComputeSandboxMetrics computes the metrics for both pod and container sandbox.
-func computeSandboxMetrics(sb *sandbox.Sandbox, metrics []*containerMetric, metricName string) []*types.Metric {
-	return computeMetrics(sandboxBaseLabelValues(sb), metrics, metricName)
+func computeSandboxMetrics(sb *sandbox.Sandbox, metrics []*containerMetric) []*types.Metric {
+	return computeMetrics(sandboxBaseLabelValues(sb), metrics)
 }
 
 func sandboxBaseLabelValues(sb *sandbox.Sandbox) []string {
@@ -150,8 +150,8 @@ func sandboxBaseLabelValues(sb *sandbox.Sandbox) []string {
 }
 
 // computeContainerMetrics computes the metrics for container.
-func computeContainerMetrics(ctr *oci.Container, metrics []*containerMetric, metricName string) []*types.Metric {
-	return computeMetrics(containerBaseLabelValues(ctr), metrics, metricName)
+func computeContainerMetrics(ctr *oci.Container, metrics []*containerMetric) []*types.Metric {
+	return computeMetrics(containerBaseLabelValues(ctr), metrics)
 }
 
 func containerBaseLabelValues(ctr *oci.Container) []string {
@@ -163,11 +163,7 @@ func containerBaseLabelValues(ctr *oci.Container) []string {
 	return []string{ctr.ID(), ctr.Name(), image}
 }
 
-func computeMetrics(baseLabels []string, metrics []*containerMetric, metricName string) []*types.Metric {
-	if metricName != "" {
-		baseLabels = append(baseLabels, metricName)
-	}
-
+func computeMetrics(baseLabels []string, metrics []*containerMetric) []*types.Metric {
 	calculatedMetrics := make([]*types.Metric, 0, len(metrics))
 
 	for _, m := range metrics {

--- a/internal/lib/statsserver/metrics_test.go
+++ b/internal/lib/statsserver/metrics_test.go
@@ -1,0 +1,225 @@
+package statsserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opencontainers/cgroups"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/lib/stats"
+	"github.com/cri-o/cri-o/internal/oci"
+)
+
+// TestMetricLabelCardinality verifies that every metric produced by each
+// generate function has exactly as many label values as its descriptor
+// declares label keys. A mismatch causes the kubelet's prometheus client
+// to reject the metric with "inconsistent label cardinality".
+func TestMetricLabelCardinality(t *testing.T) {
+	t.Parallel()
+
+	descLabelCount := descriptorLabelCounts()
+	ctr := newTestContainer(t)
+
+	cpuStats := testCPUStats()
+	memStats := testMemoryStats()
+	blkioStats := testBlkioStats()
+	pidsStats := cgroups.PidsStats{Current: 10}
+	processStats := stats.ProcessStats{
+		FileDescriptors: 50,
+		Sockets:         5,
+		Threads:         10,
+		ThreadsMax:      1000,
+		UlimitsSoft:     1024,
+	}
+	diskStats := stats.FilesystemStats{
+		UsageBytes:  1024 * 1024,
+		LimitBytes:  10 * 1024 * 1024,
+		InodesFree:  1000,
+		InodesTotal: 2000,
+	}
+	hugetlbStats := map[string]cgroups.HugetlbStats{
+		"2MB": {Usage: 1024, MaxUsage: 2048},
+	}
+	networkMetrics := testNetworkMetrics()
+
+	tests := []struct {
+		name    string
+		metrics []*types.Metric
+	}{
+		{"cpu", generateContainerCPUMetrics(ctr, &cpuStats)},
+		{"disk", generateContainerDiskMetrics(ctr, &diskStats)},
+		{"diskIO", generateContainerDiskIOMetrics(ctr, &blkioStats)},
+		{"hugetlb", generateContainerHugetlbMetrics(ctr, hugetlbStats)},
+		{"memory", generateContainerMemoryMetrics(ctr, &memStats)},
+		{"network", networkMetrics},
+		{"oom", GenerateContainerOOMMetrics(ctr, 3)},
+		{"process", generateContainerProcessMetrics(ctr, &pidsStats, &processStats)},
+		{"spec", generateContainerSpecMetrics(ctr)},
+		{"pressure", generateContainerPressureMetrics(ctr, &cpuStats, &memStats, &blkioStats)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if len(tt.metrics) == 0 {
+				t.Fatal("no metrics generated")
+			}
+
+			for _, m := range tt.metrics {
+				expected, ok := descLabelCount[m.GetName()]
+				if !ok {
+					t.Errorf("metric %q not found in availableMetricDescriptors", m.GetName())
+
+					continue
+				}
+
+				if got := len(m.GetLabelValues()); got != expected {
+					t.Errorf("metric %q: got %d label values, want %d (descriptor label keys: %d)",
+						m.GetName(), got, expected, expected)
+				}
+			}
+		})
+	}
+}
+
+// descriptorLabelCounts builds a lookup from metric name to expected label count.
+func descriptorLabelCounts() map[string]int {
+	m := make(map[string]int)
+
+	for _, descs := range availableMetricDescriptors {
+		for _, d := range descs {
+			m[d.GetName()] = len(d.GetLabelKeys())
+		}
+	}
+
+	return m
+}
+
+func newTestContainer(t *testing.T) *oci.Container {
+	t.Helper()
+
+	ctr, err := oci.NewContainer(
+		"test-id", "test-name", "", "", nil, nil, nil,
+		"", nil, nil, "", &types.ContainerMetadata{}, "",
+		false, false, false, "", "", time.Now(), "",
+	)
+	if err != nil {
+		t.Fatalf("failed to create test container: %v", err)
+	}
+
+	cpuPeriod := uint64(100000)
+	cpuQuota := int64(50000)
+	cpuShares := uint64(1024)
+	memLimit := int64(256 * 1024 * 1024)
+
+	ctr.SetResources(&specs.Spec{
+		Linux: &specs.Linux{
+			Resources: &specs.LinuxResources{
+				CPU: &specs.LinuxCPU{
+					Period: &cpuPeriod,
+					Quota:  &cpuQuota,
+					Shares: &cpuShares,
+				},
+				Memory: &specs.LinuxMemory{
+					Limit: &memLimit,
+				},
+			},
+		},
+	})
+
+	return ctr
+}
+
+func testCPUStats() cgroups.CpuStats {
+	return cgroups.CpuStats{
+		CpuUsage: cgroups.CpuUsage{
+			TotalUsage:        1000000000,
+			UsageInUsermode:   500000000,
+			UsageInKernelmode: 500000000,
+			PercpuUsage:       []uint64{500000000, 500000000},
+		},
+		ThrottlingData: cgroups.ThrottlingData{
+			Periods:          10,
+			ThrottledPeriods: 2,
+			ThrottledTime:    100000000,
+		},
+		PSI: &cgroups.PSIStats{
+			Full: cgroups.PSIData{Total: 1000000},
+			Some: cgroups.PSIData{Total: 2000000},
+		},
+	}
+}
+
+func testMemoryStats() cgroups.MemoryStats {
+	return cgroups.MemoryStats{
+		Usage:       cgroups.MemoryData{Usage: 1024 * 1024, MaxUsage: 2 * 1024 * 1024, Failcnt: 1},
+		SwapUsage:   cgroups.MemoryData{Usage: 512 * 1024},
+		KernelUsage: cgroups.MemoryData{Usage: 256 * 1024},
+		Cache:       128 * 1024,
+		Stats: map[string]uint64{
+			"total_rss":           512 * 1024,
+			"total_inactive_file": 64 * 1024,
+			"total_mapped_file":   32 * 1024,
+			"pgfault":             100,
+			"pgmajfault":          5,
+		},
+		PSI: &cgroups.PSIStats{
+			Full: cgroups.PSIData{Total: 500000},
+			Some: cgroups.PSIData{Total: 1000000},
+		},
+	}
+}
+
+// testNetworkMetrics builds network metrics using computeMetrics directly,
+// mirroring what generateSandboxNetworkMetrics does but without requiring a
+// real sandbox.Sandbox or netlink.LinkAttrs.
+func testNetworkMetrics() []*types.Metric {
+	sandboxBaseLabels := []string{"test-sandbox-id", "POD", ""}
+
+	networkDescs := []*types.MetricDescriptor{
+		containerNetworkReceiveBytesTotal,
+		containerNetworkReceivePacketsTotal,
+		containerNetworkReceivePacketsDroppedTotal,
+		containerNetworkReceiveErrorsTotal,
+		containerNetworkTransmitBytesTotal,
+		containerNetworkTransmitPacketsTotal,
+		containerNetworkTransmitPacketsDroppedTotal,
+		containerNetworkTransmitErrorsTotal,
+	}
+
+	cms := make([]*containerMetric, 0, len(networkDescs))
+	for _, desc := range networkDescs {
+		cms = append(cms, &containerMetric{
+			desc: desc,
+			valueFunc: func() metricValues {
+				return metricValues{{
+					value:      1,
+					labels:     []string{"eth0"},
+					metricType: types.MetricType_COUNTER,
+				}}
+			},
+		})
+	}
+
+	return computeMetrics(sandboxBaseLabels, cms)
+}
+
+func testBlkioStats() cgroups.BlkioStats {
+	return cgroups.BlkioStats{
+		IoServicedRecursive: []cgroups.BlkioStatEntry{
+			{Major: 8, Minor: 0, Op: "Read", Value: 100},
+			{Major: 8, Minor: 0, Op: "Write", Value: 200},
+		},
+		IoServiceBytesRecursive: []cgroups.BlkioStatEntry{
+			{Major: 8, Minor: 0, Op: "Read", Value: 4096},
+			{Major: 8, Minor: 0, Op: "Write", Value: 8192},
+		},
+		PSI: &cgroups.PSIStats{
+			Full: cgroups.PSIData{Total: 300000},
+			Some: cgroups.PSIData{Total: 600000},
+		},
+	}
+}

--- a/internal/lib/statsserver/network_metrics_linux.go
+++ b/internal/lib/statsserver/network_metrics_linux.go
@@ -45,6 +45,7 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			valueFunc: func() metricValues {
 				return metricValues{{
 					value:      attr.Statistics.RxBytes,
+					labels:     []string{attr.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -53,6 +54,7 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			valueFunc: func() metricValues {
 				return metricValues{{
 					value:      attr.Statistics.RxPackets,
+					labels:     []string{attr.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -61,6 +63,7 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			valueFunc: func() metricValues {
 				return metricValues{{
 					value:      attr.Statistics.RxDropped,
+					labels:     []string{attr.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -69,6 +72,7 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			valueFunc: func() metricValues {
 				return metricValues{{
 					value:      attr.Statistics.RxErrors,
+					labels:     []string{attr.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -77,6 +81,7 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			valueFunc: func() metricValues {
 				return metricValues{{
 					value:      attr.Statistics.TxBytes,
+					labels:     []string{attr.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -85,6 +90,7 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			valueFunc: func() metricValues {
 				return metricValues{{
 					value:      attr.Statistics.TxPackets,
+					labels:     []string{attr.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -93,6 +99,7 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			valueFunc: func() metricValues {
 				return metricValues{{
 					value:      attr.Statistics.TxDropped,
+					labels:     []string{attr.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -101,11 +108,12 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			valueFunc: func() metricValues {
 				return metricValues{{
 					value:      attr.Statistics.TxErrors,
+					labels:     []string{attr.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
 		},
 	}
 
-	return computeSandboxMetrics(sb, networkMetrics, "network")
+	return computeSandboxMetrics(sb, networkMetrics)
 }

--- a/internal/lib/statsserver/pressure_metrics_linux.go
+++ b/internal/lib/statsserver/pressure_metrics_linux.go
@@ -88,5 +88,5 @@ func generateContainerPressureMetrics(ctr *oci.Container, cpu *cgroups.CpuStats,
 		)
 	}
 
-	return computeContainerMetrics(ctr, metrics, "cpu")
+	return computeContainerMetrics(ctr, metrics)
 }

--- a/internal/lib/statsserver/process_metrics_linux.go
+++ b/internal/lib/statsserver/process_metrics_linux.go
@@ -64,11 +64,12 @@ func generateContainerProcessMetrics(ctr *oci.Container, pids *cgroups.PidsStats
 			valueFunc: func() metricValues {
 				return metricValues{{
 					value:      process.UlimitsSoft,
+					labels:     []string{"max_open_files"},
 					metricType: types.MetricType_GAUGE,
 				}}
 			},
 		},
 	}
 
-	return computeContainerMetrics(ctr, processMetrics, "process")
+	return computeContainerMetrics(ctr, processMetrics)
 }

--- a/internal/lib/statsserver/spec_metrics_linux.go
+++ b/internal/lib/statsserver/spec_metrics_linux.go
@@ -74,7 +74,7 @@ func generateContainerSpecMetrics(ctr *oci.Container) []*types.Metric {
 		})
 	}
 
-	return computeContainerMetrics(ctr, specMetrics, "spec")
+	return computeContainerMetrics(ctr, specMetrics)
 }
 
 func specMemoryValue(limit int64) uint64 {

--- a/internal/lib/statsserver/stats_server_linux.go
+++ b/internal/lib/statsserver/stats_server_linux.go
@@ -262,7 +262,7 @@ func (ss *StatsServer) containerMetricsFromContainerStats(sb *sandbox.Sandbox, c
 				metricType: types.MetricType_GAUGE,
 			}}
 		},
-	}}, "")
+	}})
 
 	for _, m := range ss.Config().EnabledPodMetrics() {
 		switch m {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind bug

#### What this PR does / why we need it:

When `PodAndContainerStatsFromCRI` is enabled, the kubelet rejects all CRI metrics from CRI-O with "inconsistent label cardinality" errors because the number of label values doesn't match the number of label keys declared in the metric descriptors.

While testing I ran into two separate label inconsistency issues:

1. The container_ulimits_soft and container_network_* metrics were missing one label when they were generated
```
E0226 13:44:29.365916 cri_metrics.go:118] "Error getting CRI prometheus metric" err="inconsistent label cardinality: expected 4 label values but got 3 in []string{"06b2e3a8...", "k8s_coredns_coredns-...", "registry.k8s.io/coredns/coredns:v1.14.1"}" descriptor="Desc{fqName: "container_ulimits_soft", variableLabels: {id,name,image,ulimit}}"
```

2. For all metrics, cri-o was generating a metric name (cpu, memory, process, ...) label which wasn't defined in the metric descriptor
```
got 4 in []string{"da989c2aa...", "k8s_coredns...", "registry.k8s.io/coredns/coredns:v1.14.1", "process"}
```

In this PR, I added the missing labels and removed the metric name as a label as I don't think adding it is intended.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network metrics now include per-network name labels for clearer identification.
  * Process metrics include a "max_open_files" label for ulimits.
  * Metric label handling simplified and made consistent across CPU, disk, memory, hugetlb, spec, pressure, and others to prevent inconsistent label outputs.

* **Tests**
  * Added unit tests validating metric label cardinality to ensure reliable Prometheus metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->