### PR TITLE
[release-1.35]: Skip OCI artifact fallback on transient network errors

### DIFF
--- a/internal/storage/image_test.go
+++ b/internal/storage/image_test.go
@@ -569,11 +569,6 @@ var _ = t.Describe("Image", func() {
 	})
 
 	t.Describe("PullImage", func() {
-		var graphRoot string
-		BeforeEach(func() {
-			graphRoot = t.MustTempDir("ociartifact")
-		})
-
 		It("should fail on invalid policy path", func() {
 			// Given
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox:latest")
@@ -591,9 +586,6 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail on copy image", func() {
 			// Given
-			mockutils.InOrder(
-				storeMock.EXPECT().GraphRoot().Return(graphRoot),
-			)
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox:latest")
 			Expect(err).ToNot(HaveOccurred())
 
@@ -609,9 +601,6 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail on canonical copy image", func() {
 			// Given
-			mockutils.InOrder(
-				storeMock.EXPECT().GraphRoot().Return(graphRoot),
-			)
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox@sha256:" + testSHA256)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -627,9 +616,6 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail on cancelled context", func() {
 			// Given
-			mockutils.InOrder(
-				storeMock.EXPECT().GraphRoot().Return(graphRoot),
-			)
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox:latest")
 			Expect(err).ToNot(HaveOccurred())
 
@@ -648,9 +634,6 @@ var _ = t.Describe("Image", func() {
 
 		It("should fail on timed out context", func() {
 			// Given
-			mockutils.InOrder(
-				storeMock.EXPECT().GraphRoot().Return(graphRoot),
-			)
 			imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData("localhost/busybox:latest")
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/image.bats
+++ b/test/image.bats
@@ -413,3 +413,13 @@ EOF
 	# There should be many nginx images
 	crictl pull nginx
 }
+
+@test "image pull should not fall back to OCI artifact on network error" {
+	start_crio
+
+	# 192.0.2.1 is TEST-NET-1 (RFC 5737), guaranteed unreachable
+	run ! crictl pull 192.0.2.1/test/image:latest
+
+	# Network errors should not trigger the OCI artifact fallback
+	run ! grep -q "Falling back" "$CRIO_LOG"
+}


### PR DESCRIPTION
Use net.Error timeout detection to skip the OCI artifact fallback for transient network timeouts that should be retried as image pulls instead. For all other errors, optimistically fall back to an artifact pull since the image reference may actually be an artifact.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partially fix https://issues.redhat.com/browse/OCPBUGS-77165 and https://issues.redhat.com/browse/OCPBUGS-76599
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Skip the OCI artifact pull fallback when the initial image pull fails due to a retryable error
```
