### PR TITLE
checkpoint: allow callers to specify work and image paths

### DIFF
--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -92,7 +92,7 @@ func (c *ContainerServer) ContainerCheckpoint(
 		}
 	}
 
-	if err := c.runtime.CheckpointContainer(ctx, ctr, specgen.Config, opts.KeepRunning); err != nil {
+	if err := c.runtime.CheckpointContainer(ctx, ctr, specgen.Config, opts.KeepRunning, ctr.Dir(), ctr.CheckpointPath()); err != nil {
 		// in the case of an error, clean up any leftover CRIU images
 		if err := os.RemoveAll(ctr.CheckpointPath()); err != nil {
 			log.Warnf(ctx, "Unable to remove checkpoint directory %s: %v", ctr.CheckpointPath(), err)

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -76,7 +76,7 @@ type RuntimeImpl interface {
 	PortForwardContainer(context.Context, *Container, string,
 		int32, io.ReadWriteCloser) error
 	ReopenContainerLog(context.Context, *Container) error
-	CheckpointContainer(context.Context, *Container, *rspec.Spec, bool) error
+	CheckpointContainer(context.Context, *Container, *rspec.Spec, bool, string, string) error
 	RestoreContainer(context.Context, *Container, string, string) error
 	IsContainerAlive(*Container) bool
 	// ProbeMonitor is used to check the liveness of the container monitor process.
@@ -534,13 +534,13 @@ func (e *ExecSyncError) Error() string {
 }
 
 // CheckpointContainer checkpoints a container.
-func (r *Runtime) CheckpointContainer(ctx context.Context, c *Container, specgen *rspec.Spec, leaveRunning bool) error {
+func (r *Runtime) CheckpointContainer(ctx context.Context, c *Container, specgen *rspec.Spec, leaveRunning bool, workPath, imagePath string) error {
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return err
 	}
 
-	return impl.CheckpointContainer(ctx, c, specgen, leaveRunning)
+	return impl.CheckpointContainer(ctx, c, specgen, leaveRunning, workPath, imagePath)
 }
 
 // RestoreContainer restores a container.

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -3,6 +3,7 @@ package oci_test
 import (
 	"context"
 	"os"
+	"time"
 
 	criu "github.com/checkpoint-restore/go-criu/v8/utils"
 	. "github.com/onsi/ginkgo/v2"
@@ -220,7 +221,7 @@ var _ = t.Describe("Oci", func() {
 				},
 			}
 			// When
-			err := sut.CheckpointContainer(context.Background(), myContainer, specgen, false)
+			err := sut.CheckpointContainer(context.Background(), myContainer, specgen, false, myContainer.Dir(), myContainer.CheckpointPath())
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())
@@ -248,11 +249,57 @@ var _ = t.Describe("Oci", func() {
 				},
 			}
 			// When
-			err := sut.CheckpointContainer(context.Background(), myContainer, specgen, true)
+			err := sut.CheckpointContainer(context.Background(), myContainer, specgen, true, myContainer.Dir(), myContainer.CheckpointPath())
 
 			// Then
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("configured runtime does not support checkpoint/restore"))
+		})
+		It("CheckpointContainer should fail with invalid workPath", func() {
+			if err := criu.CheckForCriu(criu.PodCriuVersion); err != nil {
+				Skip("Check CRIU: " + err.Error())
+			}
+			// Given
+			beforeEach()
+
+			config.Runtimes["runc"] = &libconfig.RuntimeHandler{
+				RuntimePath: "/bin/true",
+			}
+
+			specgen := &specs.Spec{
+				Version: "1.0.0",
+				Process: &specs.Process{
+					SelinuxLabel: "",
+				},
+				Linux: &specs.Linux{
+					MountLabel: "",
+				},
+			}
+			// When — pass a non-existent directory as workPath so that
+			// CRCreateFileWithLabel fails when trying to create dump.log
+			err := sut.CheckpointContainer(context.Background(), myContainer, specgen, false, "/nonexistent/path", myContainer.CheckpointPath())
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create file"))
+		})
+		It("CheckpointContainer should fail with invalid runtime handler", func() {
+			// Given — create a container with a runtime handler that
+			// doesn't exist in the configured runtimes, so RuntimeImpl
+			// returns an error before reaching the checkpoint logic.
+			ctr, err := oci.NewContainer("ctr-bad-handler", "", "", "",
+				make(map[string]string), make(map[string]string),
+				make(map[string]string), "", nil, nil, "",
+				nil, sandboxID, false,
+				false, false, "nonexistent-runtime", "", time.Now(), "")
+			Expect(err).ToNot(HaveOccurred())
+
+			// When
+			err = sut.CheckpointContainer(context.Background(), ctr, &specs.Spec{}, false, "", "")
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to find runtime handler"))
 		})
 		It("RestoreContainer should fail with destination sandbox detection", func() {
 			if err := criu.CheckForCriu(criu.PodCriuVersion); err != nil {

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1660,7 +1660,7 @@ func (r *runtimeOCI) defaultRuntimeArgs() []string {
 }
 
 // CheckpointContainer checkpoints a container.
-func (r *runtimeOCI) CheckpointContainer(ctx context.Context, c *Container, specgen *rspec.Spec, leaveRunning bool) error {
+func (r *runtimeOCI) CheckpointContainer(ctx context.Context, c *Container, specgen *rspec.Spec, leaveRunning bool, workPath, imagePath string) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
@@ -1674,17 +1674,12 @@ func (r *runtimeOCI) CheckpointContainer(ctx context.Context, c *Container, spec
 	// file which is outside of the container. Giving the log file
 	// the label of the container enables logging for the parasite.
 	if err := crutils.CRCreateFileWithLabel(
-		c.Dir(),
+		workPath,
 		metadata.DumpLogFile,
 		specgen.Linux.MountLabel,
 	); err != nil {
 		return err
 	}
-
-	// workPath will be used to store dump.log and stats-dump
-	workPath := c.Dir()
-	// imagePath is used by CRIU to store the actual checkpoint files
-	imagePath := c.CheckpointPath()
 
 	log.Debugf(ctx, "Writing checkpoint to %s", imagePath)
 	log.Debugf(ctx, "Writing checkpoint logs to %s", workPath)

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -213,8 +213,10 @@ func (r *runtimePod) CheckpointContainer(
 	c *Container,
 	specgen *rspec.Spec,
 	leaveRunning bool,
+	workPath string,
+	imagePath string,
 ) error {
-	return r.oci.CheckpointContainer(ctx, c, specgen, leaveRunning)
+	return r.oci.CheckpointContainer(ctx, c, specgen, leaveRunning, workPath, imagePath)
 }
 
 func (r *runtimePod) RestoreContainer(

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -1197,7 +1197,7 @@ func (r *runtimeVM) closeIO(ctrID, execID string) error {
 }
 
 // CheckpointContainer not implemented for runtimeVM.
-func (r *runtimeVM) CheckpointContainer(ctx context.Context, c *Container, specgen *rspec.Spec, leaveRunning bool) error {
+func (r *runtimeVM) CheckpointContainer(ctx context.Context, c *Container, specgen *rspec.Spec, leaveRunning bool, workPath, imagePath string) error {
 	log.Debugf(ctx, "RuntimeVM.CheckpointContainer() start")
 	defer log.Debugf(ctx, "RuntimeVM.CheckpointContainer() end")
 

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -76,17 +76,17 @@ func (mr *MockRuntimeImplMockRecorder) CgroupStats(arg0, arg1, arg2 any) *gomock
 }
 
 // CheckpointContainer mocks base method.
-func (m *MockRuntimeImpl) CheckpointContainer(arg0 context.Context, arg1 *oci.Container, arg2 *specs.Spec, arg3 bool) error {
+func (m *MockRuntimeImpl) CheckpointContainer(arg0 context.Context, arg1 *oci.Container, arg2 *specs.Spec, arg3 bool, arg4, arg5 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckpointContainer", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "CheckpointContainer", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CheckpointContainer indicates an expected call of CheckpointContainer.
-func (mr *MockRuntimeImplMockRecorder) CheckpointContainer(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) CheckpointContainer(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckpointContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).CheckpointContainer), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckpointContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).CheckpointContainer), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // CreateContainer mocks base method.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add workPath and imagePath parameters to the CheckpointContainer interface and all implementations (runtimeOCI, runtimePod, runtimeVM).

Previously these paths were derived internally from the container object.  Making them explicit enables callers to direct CRIU output to a location of their choice.

The main motivation for this change is pod-level checkpointing. When creating a pod checkpoint every container checkpoint needs to be included in a single checkpoint archive (or image).  If the checkpoint data is always written to the container's default directory first, it has to be copied into the archive afterwards. For large checkpoints this copying step can be very expensive. By letting the caller specify the target paths directly, the checkpoint data can be written straight into the archive's directory structure, avoiding the extra copy entirely.

The existing single-container checkpoint path continues to pass `ctr.Dir()` and `ctr.CheckpointPath()`, so its behaviour is unchanged.

Generated with Claude Code (https://claude.ai/code)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

No functional changes. Just additional parameters. Trying to add as a simple change early to reduce review size

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved container checkpoint handling to support explicit working and checkpoint path usage for more reliable checkpoint operations.

* **Bug Fixes**
  * Better error detection and cleanup when checkpoint paths are invalid or inaccessible, reducing leftover artifacts on failure.

* **Tests**
  * Expanded tests to cover new path-related failure modes and ensure robust checkpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->