### PR TITLE
test: enable checkpoint/restore tests for crun

### DIFF
--- a/test/checkpoint.bats
+++ b/test/checkpoint.bats
@@ -17,10 +17,6 @@ function teardown() {
 }
 
 @test "checkpoint and restore one container into a new pod (drop infra:true)" {
-	if is_using_crun; then
-		skip "not supported by crun: https://github.com/containers/crun/issues/1207"
-	fi
-
 	CONTAINER_DROP_INFRA_CTR=true CONTAINER_ENABLE_CRIU_SUPPORT=true start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	BIND_MOUNT_FILE=$(mktemp)

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -686,8 +686,8 @@ function has_criu() {
         skip "Cannot run CRIU tests in user namespace."
     fi
 
-    if [[ "$CONTAINER_DEFAULT_RUNTIME" != "runc" ]]; then
-        skip "Checkpoint/Restore with pods only works in runc."
+    if [[ "$CONTAINER_DEFAULT_RUNTIME" != "runc" ]] && [[ "$CONTAINER_DEFAULT_RUNTIME" != "crun" ]]; then
+        skip "Checkpoint/Restore with pods only works with runc or crun."
     fi
 
     if ! "$CHECKCRIU_BINARY"; then


### PR DESCRIPTION
#### What type of PR is this?

/kind ci
/kind cleanup

#### What this PR does / why we need it:

crun now has all the features needed for CRI checkpoint and restore. Remove the skip for crun in the checkpoint test and extend the runtime check in has_criu() to accept both runc and crun.

#### Which issue(s) this PR fixes:

`Fixes None`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Checkpoint and restore functionality tests now execute on crun runtime in addition to runc
  * Broadened compatibility testing to validate container checkpoint operations across both supported runtimes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->