### PR TITLE
[docs] fix dead nixos link in install.md

### DIFF
--- a/install.md
+++ b/install.md
@@ -366,7 +366,7 @@ libc (for `s390x`)](https://www.musl-libc.org/). These binaries are integration 
 - selinux
 
 To build the binaries locally either [install the nix package
-manager](https://nixos.org/nix/download.html) or use the `make build-static`
+manager](https://nixos.org/download) or use the `make build-static`
 target which relies on the nixos/nix container image.
 
 The overall build process can take a tremendous amount of CPU time depending on


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:

This PR addresses a dead link to the nixos downloads page and points readers to the up-to-date working link.

<img width="1464" height="385" alt="Screenshot 2026-03-05 at 12 38 15 AM" src="https://github.com/user-attachments/assets/47947006-7114-440a-9741-bbdc7f158e67" />

#### Does this PR introduce a user-facing change?
No

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Nix package manager download link in the installation instructions to reflect the current official source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->