### PR TITLE
OCPBUGS-76451: fix: prevent panic on closed stopTimeoutChan in StopContainer

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -70,6 +70,7 @@ type Container struct {
 	created            bool
 	spoofed            bool
 	stopping           bool
+	stopDone           bool
 	stopLock           sync.Mutex
 	// stopTimeoutChan is used to update the stop timeout.
 	// After the container goes into the kill loop, the channel must not be used
@@ -689,7 +690,7 @@ func (c *Container) SetStopKillLoopBegun() {
 func (c *Container) WaitOnStopTimeout(ctx context.Context, timeout int64) {
 	c.stopLock.Lock()
 
-	if !c.stopping {
+	if !c.stopping || c.stopDone {
 		c.stopLock.Unlock()
 
 		return
@@ -718,6 +719,8 @@ func (c *Container) WaitOnStopTimeout(ctx context.Context, timeout int64) {
 
 func (c *Container) SetAsDoneStopping() {
 	c.stopLock.Lock()
+
+	c.stopDone = true
 
 	for _, watcher := range c.stopWatchers {
 		close(watcher)

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -1008,6 +1008,23 @@ var _ = t.Describe("Container", func() {
 			}
 		})
 
+		// Regression test for a race between concurrent StopContainer calls.
+		// When a second StopContainer arrives after the first has already
+		// completed (SetAsDoneStopping closed stopTimeoutChan),
+		// WaitOnStopTimeout used to panic on the closed channel.
+		// The stopDone guard ensures it returns early instead.
+		It("should not panic when WaitOnStopTimeout is called after SetAsDoneStopping", func() {
+			ctx := context.Background()
+
+			sut.SetAsStopping()
+
+			sut.SetAsDoneStopping()
+
+			Expect(func() {
+				sut.WaitOnStopTimeout(ctx, 1000)
+			}).ToNot(Panic())
+		})
+
 		It("should clear the watchers slice", func() {
 			// Given
 			ctx := context.Background()


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

There is a race condition in the container stop path. When a second `StopContainer` call
comes in after the first one has already finished (i.e. `SetAsDoneStopping` has
run), `WaitOnStopTimeout` still gets called. At that point `stopTimeoutChan`
is already closed, so we panic.

The sequence is:

1. First `StopContainer` -> starts the stop loop, waits via `WaitOnStopTimeout`
2. Stop loop finishes -> `SetAsDoneStopping` closes `stopTimeoutChan` and watchers
3. Second `StopContainer` -> `SetAsStopping` returns false (already stopping),
   falls through to `WaitOnStopTimeout` which tries to use the closed channel

This adds a `stopDone` bool (guarded by the existing `stopLock`) that gets set
in `SetAsDoneStopping`. `WaitOnStopTimeout` checks it and returns early if
the stop lifecycle is already done.

#### Which issue(s) this PR fixes:

Addresses: [OCPBUGS-76451](https://issues.redhat.com/browse/OCPBUGS-76451)

#### Special notes for your reviewer:

The change is small : one new bool field, one assignment, one extra condition
check. All under the existing `stopLock` so no new synchronization concerns.

Added a unit test that exercises the exact crash sequence:
`SetAsStopping -> SetAsDoneStopping -> WaitOnStopTimeout` and confirms it
doesn't panic.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a panic when concurrent StopContainer calls race against the stop lifecycle completing.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rare panics during container shutdown by improving coordination between stop and timeout handling, making shutdown sequences more reliable and resilient.

* **Tests**
  * Added regression tests to ensure stop/wait operations do not panic when invoked after shutdown completion, reducing regressions and increasing stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->