### PR TITLE
handle ErrNotAnImage in RemoveImage for concurrent deletion idempotency

### DIFF
--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -46,7 +46,7 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 		}
 
 		if err := s.ContainerServer.StorageImageServer().DeleteImage(s.config.SystemContext, *id); err != nil {
-			if errors.Is(err, storagetypes.ErrImageUnknown) {
+			if errors.Is(err, storagetypes.ErrImageUnknown) || errors.Is(err, storagetypes.ErrNotAnImage) {
 				// The RemoveImage RPC is idempotent, and must not return an
 				// error if the image has already been removed. Ref:
 				// https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto#L156-L157
@@ -96,6 +96,10 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 	}
 
 	if !deleted && untagErr != nil {
+		if errors.Is(untagErr, storagetypes.ErrImageUnknown) || errors.Is(untagErr, storagetypes.ErrNotAnImage) {
+			return nil
+		}
+
 		return untagErr
 	}
 

--- a/server/image_remove_test.go
+++ b/server/image_remove_test.go
@@ -140,5 +140,47 @@ var _ = t.Describe("ImageRemove", func() {
 			// Then
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		// https://github.com/cri-o/cri-o/issues/9796
+		It("should succeed if image was concurrently deleted (ErrNotAnImage)", func() {
+			// Given
+			parsedTestSHA256, err := storage.ParseStorageImageIDFromOutOfProcessData(testSHA256)
+			Expect(err).ToNot(HaveOccurred())
+			gomock.InOrder(
+				imageServerMock.EXPECT().HeuristicallyTryResolvingStringAsIDPrefix(testSHA256).
+					Return(&parsedTestSHA256),
+				imageServerMock.EXPECT().DeleteImage(
+					gomock.Any(), parsedTestSHA256).
+					Return(fmt.Errorf("delete image: %w", storagetypes.ErrNotAnImage)),
+			)
+
+			// When
+			_, err = sut.RemoveImage(context.Background(),
+				&types.RemoveImageRequest{Image: &types.ImageSpec{Image: testSHA256}})
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed if image was concurrently deleted during untag", func() {
+			// Given
+			gomock.InOrder(
+				imageServerMock.EXPECT().HeuristicallyTryResolvingStringAsIDPrefix("image").
+					Return(nil),
+				imageServerMock.EXPECT().CandidatesForPotentiallyShortImageName(
+					gomock.Any(), "image").
+					Return([]storage.RegistryImageReference{resolvedImageName}, nil),
+				imageServerMock.EXPECT().ImageStatusByName(gomock.Any(), gomock.Any()).
+					Return(&storage.ImageResult{ID: storageID}, nil),
+				imageServerMock.EXPECT().UntagImage(gomock.Any(),
+					resolvedImageName).Return(fmt.Errorf("untag: %w", storagetypes.ErrNotAnImage)),
+			)
+			// When
+			_, err := sut.RemoveImage(context.Background(),
+				&types.RemoveImageRequest{Image: &types.ImageSpec{Image: "image"}})
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
When multiple concurrent RemoveImage calls race on the same image, the first call succeeds but subsequent calls fail with "identifier is not an image" (ErrNotAnImage). This happens because the image is already gone from storage by the time the other goroutines attempt deletion.

The existing idempotency check only handled ErrImageUnknown but not ErrNotAnImage, which is the error returned by containers/storage when the image ID no longer resolves. Add ErrNotAnImage to the idempotency checks in both the ID-based and name-based deletion paths.

Fixes #9796

#### What type of PR is this?                                                                                                                                              
 
/kind bug                                                                                                                                                                  
                                                                
#### What this PR does / why we need it:

When multiple concurrent `RemoveImage` calls race on the same image, the first call succeeds but subsequent calls fail with "identifier is not an image" (`ErrNotAnImage`). This happens because the image is already gone from storage by the time the other goroutines attempt deletion.

The existing idempotency check only handled `ErrImageUnknown` but not `ErrNotAnImage`, which is the error returned by `containers/storage` when the image ID no longer resolves. This PR adds `ErrNotAnImage` to the idempotency checks in both the ID-based and name-based deletion paths.

#### Which issue(s) this PR fixes:

Fixes #9796

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fix concurrent RemoveImage race condition by handling ErrNotAnImage as an idempotent deletion result.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Image removal operations are now idempotent. Attempting to remove an image that is not found no longer returns an error, allowing safe repeated removal attempts.
  * Improved handling of concurrent deletion scenarios in both direct and indirect image removal paths for more robust operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->