### PR TITLE
nri: fix a deadlock and a livelock, block plugin sync during other event processing.

### DIFF
--- a/internal/nri/domain.go
+++ b/internal/nri/domain.go
@@ -3,7 +3,6 @@ package nri
 import (
 	"context"
 	"errors"
-	"sync"
 
 	nri "github.com/containerd/nri/pkg/adaptation"
 	"github.com/sirupsen/logrus"
@@ -44,28 +43,18 @@ func SetDomain(d Domain) {
 }
 
 type domainTable struct {
-	sync.Mutex
 	domain Domain
 }
 
 func (t *domainTable) set(d Domain) {
-	t.Lock()
-	defer t.Unlock()
-
 	t.domain = d
 }
 
 func (t *domainTable) listPodSandboxes(ctx context.Context) []PodSandbox {
-	t.Lock()
-	defer t.Unlock()
-
 	return t.domain.ListPodSandboxes(ctx)
 }
 
 func (t *domainTable) listContainers() []Container {
-	t.Lock()
-	defer t.Unlock()
-
 	return t.domain.ListContainers()
 }
 

--- a/internal/nri/nri.go
+++ b/internal/nri/nri.go
@@ -71,6 +71,9 @@ type API interface {
 
 	// StopContainer relays container removal events to NRI.
 	RemoveContainer(context.Context, PodSandbox, Container) error
+
+	// BlockPluginSync blocks plugin synchronization until it is Unblock()ed.
+	BlockPluginSync() *PluginSyncBlock
 }
 
 type State int
@@ -424,6 +427,16 @@ func (l *local) RemoveContainer(ctx context.Context, pod PodSandbox, ctr Contain
 	l.setState(request.GetContainer().GetId(), Removed)
 
 	return err
+}
+
+type PluginSyncBlock = nri.PluginSyncBlock
+
+func (l *local) BlockPluginSync() *PluginSyncBlock {
+	if !l.IsEnabled() {
+		return nil
+	}
+
+	return l.nri.BlockPluginSync()
 }
 
 func (l *local) IsEnabled() bool {

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1330,15 +1330,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 
 	hooks := s.hooksRetriever.Get(ctx, sb.RuntimeHandler(), sb.Annotations())
 
-	if err := s.nri.createContainer(ctx, specgen, sb, ociContainer); err != nil {
-		return nil, err
-	}
-
 	defer func() {
 		if retErr != nil {
 			s.nri.undoCreateContainer(ctx, specgen, sb, ociContainer)
 		}
 	}()
+
+	if err := s.nri.createContainer(ctx, specgen, sb, ociContainer); err != nil {
+		return nil, err
+	}
 
 	if hooks != nil {
 		if err := hooks.PreCreate(ctx, specgen, sb, ociContainer); err != nil {

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -466,6 +466,8 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 		return nil, fmt.Errorf("CreateContainer failed as the sandbox was stopped: %s", sb.ID())
 	}
 
+	defer s.nri.BlockPluginSync().Unblock()
+
 	ctr, err := container.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container: %w", err)

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -62,10 +62,14 @@ func (s *Server) removeContainerInPod(ctx context.Context, sb *sandbox.Sandbox, 
 		}
 	}
 
+	blk := s.nri.BlockPluginSync()
+
 	if err := s.nri.removeContainer(ctx, sb, c); err != nil {
 		log.Warnf(ctx, "NRI container removal failed for container %s of pod %s: %v",
 			c.ID(), sb.ID(), err)
 	}
+
+	blk.Unblock()
 
 	if err := s.ContainerServer.Runtime().DeleteContainer(ctx, c); err != nil {
 		return fmt.Errorf("failed to delete container %s in pod sandbox %s: %w", c.Name(), sb.ID(), err)

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -67,6 +67,8 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 		return nil, fmt.Errorf("container %s is not in created state: %s", c.ID(), state.Status)
 	}
 
+	blk := s.nri.BlockPluginSync()
+
 	sandbox := s.getSandbox(ctx, c.Sandbox())
 
 	hooks := s.hooksRetriever.Get(ctx, sandbox.RuntimeHandler(), sandbox.Annotations())
@@ -74,6 +76,8 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 	if err := s.nri.startContainer(ctx, sandbox, c); err != nil {
 		log.Warnf(ctx, "NRI start failed for container %q: %v", c.ID(), err)
 	}
+
+	blk.Unblock()
 
 	defer func() {
 		// if the call to StartContainer fails below we still want to fill

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -79,9 +79,14 @@ func (s *Server) postStopCleanup(ctx context.Context, ctr *oci.Container, sb *sa
 		}
 	}
 
+	blk := s.nri.BlockPluginSync()
+
 	if err := s.nri.stopContainer(ctx, sb, ctr); err != nil {
 		log.Warnf(ctx, "NRI stop container request of %s failed: %v", ctr.ID(), err)
 	}
+
+	blk.Unblock()
+
 	// persist container state at the end, so there's no window where CRI-O reports the container
 	// as stopped, but hasn't run post stop hooks.
 	if err := s.ContainerStateToDisk(ctx, ctr); err != nil {

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -35,6 +35,8 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *types.Update
 			return nil, err
 		}
 
+		defer s.nri.BlockPluginSync().Unblock()
+
 		updated, err := s.nri.updateContainer(ctx, c, req.GetLinux())
 		if err != nil {
 			return nil, err

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/containerd/nri/pkg/api"
@@ -22,6 +23,10 @@ import (
 	"github.com/cri-o/cri-o/internal/nri"
 	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/pkg/annotations"
+)
+
+const (
+	nonRunningContainerError = "container not running"
 )
 
 type nriAPI struct {
@@ -467,6 +472,10 @@ func (a *nriAPI) UpdateContainer(ctx context.Context, u *api.ContainerUpdate) er
 
 	resources := u.GetLinux().GetResources().ToOCI()
 	if err = a.cri.ContainerServer.Runtime().UpdateContainer(ctx, ctr, resources); err != nil {
+		if strings.Contains(err.Error(), nonRunningContainerError) {
+			return nil
+		}
+
 		log.Errorf(ctx, "Failed to update CRI container %q: %v", u.GetContainerId(), err)
 
 		if u.GetIgnoreFailure() {

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -354,6 +354,16 @@ func (a *nriAPI) undoCreateContainer(ctx context.Context, specgen *generate.Gene
 	}
 }
 
+type PluginSyncBlock = nri.PluginSyncBlock
+
+func (a *nriAPI) BlockPluginSync() *PluginSyncBlock {
+	if !a.isEnabled() {
+		return nil
+	}
+
+	return a.nri.BlockPluginSync()
+}
+
 //
 // CRI 'upward' interface for NRI
 //

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/containerd/nri/pkg/api"
 	nrigen "github.com/containerd/nri/pkg/runtime-tools/generate"
@@ -401,8 +402,10 @@ func (a *nriAPI) ListContainers() []nri.Container {
 	}
 
 	for _, ctr := range ctrList {
-		switch ctr.State().Status {
-		case oci.ContainerStateCreated, oci.ContainerStateRunning, oci.ContainerStatePaused:
+		if s := asyncGetState(ctr); s != nil &&
+			(s.Status == oci.ContainerStateCreated ||
+				s.Status == oci.ContainerStateRunning ||
+				s.Status == oci.ContainerStatePaused) {
 			containers = append(containers, &criContainer{
 				api: a,
 				ctr: ctr,
@@ -448,7 +451,17 @@ func (a *nriAPI) UpdateContainer(ctx context.Context, u *api.ContainerUpdate) er
 		return nil
 	}
 
-	if s := ctr.State().Status; s != oci.ContainerStateRunning && s != oci.ContainerStateCreated {
+	s := asyncGetState(ctr)
+	if s == nil {
+		log.Errorf(ctx, "Failed to get container state %q (timeout)",
+			u.GetContainerId())
+
+		return nil
+	}
+
+	if s.Status != oci.ContainerStateCreated &&
+		s.Status != oci.ContainerStateRunning &&
+		s.Status != oci.ContainerStatePaused {
 		return nil
 	}
 
@@ -677,8 +690,10 @@ func (c *criContainer) GetName() string {
 }
 
 func (c *criContainer) GetState() api.ContainerState {
-	if c.ctr != nil {
-		switch c.ctr.State().Status {
+	state := asyncGetState(c.ctr)
+
+	if state != nil {
+		switch state.Status {
 		case oci.ContainerStateCreated:
 			return api.ContainerState_CONTAINER_CREATED
 		case oci.ContainerStatePaused:
@@ -691,6 +706,45 @@ func (c *criContainer) GetState() api.ContainerState {
 	}
 
 	return api.ContainerState_CONTAINER_UNKNOWN
+}
+
+func asyncGetState(ctr *oci.Container) *oci.ContainerState {
+	// Try to acquire container state asynchronously.
+	//
+	// Notes/TODO(klihub):
+	// This is currently necessary because if a container's init process
+	// is stuck in an unkillable state runtimeOCI.StopLoopForContainer tries
+	// to kill it holding the same c.ctr.opLock, which c.ctr.State() tries to
+	// take causing it to be stuck indefinitely.
+	const timeout = 200 * time.Millisecond
+
+	if ctr == nil {
+		return nil
+	}
+
+	stateCh := make(chan *oci.ContainerState, 1)
+
+	go func() {
+		stateCh <- ctr.State()
+	}()
+
+	var state *oci.ContainerState
+
+	select {
+	case state = <-stateCh:
+	case <-time.After(timeout):
+		log.Errorf(context.TODO(), "failed to get state for container %q (timed out)",
+			ctr.ID())
+		state = ctr.StateNoLock()
+	}
+
+	if state != nil {
+		cpy := *state
+
+		return &cpy
+	}
+
+	return nil
 }
 
 func (c *criContainer) GetLabels() map[string]string {

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -67,6 +67,8 @@ func (s *Server) removePodSandbox(ctx context.Context, sb *sandbox.Sandbox) erro
 		return err
 	}
 
+	defer s.nri.BlockPluginSync().Unblock()
+
 	if sb.InfraContainer().Spoofed() {
 		if err := s.config.CgroupManager().RemoveSandboxCgroup(sb.CgroupParent(), sb.ID()); err != nil {
 			return err

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1212,6 +1212,8 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil
 	})
 
+	defer s.nri.BlockPluginSync().Unblock()
+
 	if err := s.ContainerStateToDisk(ctx, container); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", container.ID(), err)
 	}

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -66,6 +66,8 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		return fmt.Errorf("failed to stop infra container for pod sandbox %s: %w", sb.ID(), err)
 	}
 
+	defer s.nri.BlockPluginSync().Unblock()
+
 	if err := sb.RemoveManagedNamespaces(); err != nil {
 		return fmt.Errorf("unable to remove managed namespaces: %w", err)
 	}

--- a/server/sandbox_update_resources.go
+++ b/server/sandbox_update_resources.go
@@ -20,6 +20,8 @@ func (s *Server) UpdatePodSandboxResources(ctx context.Context, req *types.Updat
 		return nil, status.Errorf(codes.NotFound, "could not find pod %q: %v", req.GetPodSandboxId(), err)
 	}
 
+	defer s.nri.BlockPluginSync().Unblock()
+
 	err = s.nri.updatePodSandbox(ctx, sb, req.GetOverhead(), req.GetResources())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Recent long-running conformance tests have uncovered a deadlock in NRI event processing. Fix a deadlock by lock inversion on 2 different code paths (and eliminate an unnecessary lock). Acquire state of container with a timeout to avoid an indefinite livelock if a container (shutdown) is stuck (probably with the container's init process being in an unkillable state). Also, block plugin synchronization during other event processing.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

```release-note
Fix NRI event processing deadlock.
```
