### PR TITLE
version: bump cri-o.spec during version bumps

### DIFF
--- a/contrib/test/ci/cri-o.spec
+++ b/contrib/test/ci/cri-o.spec
@@ -26,7 +26,7 @@
 %global service_name crio
 
 Name: %{repo}
-Version: 1.32.0
+Version: 1.36.0
 Release: 1.ci%{?dist}
 Summary: Kubernetes Container Runtime Interface for OCI-based containers
 License: ASL 2.0

--- a/contrib/test/ci/cri-o.spec
+++ b/contrib/test/ci/cri-o.spec
@@ -21,13 +21,14 @@
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path %{provider_prefix}
 %global git0 https://%{import_path}
-#%%global commit0 ee2e7485ffe9c6d8932ec6acb0adcb7a0a55c253
+# Requires a git checkout; this spec is only used in CI (see line 1).
+%global shortcommit0 %(git rev-parse --short HEAD)
 
 %global service_name crio
 
 Name: %{repo}
 Version: 1.36.0
-Release: 1.ci%{?dist}
+Release: 1.ci.git%{shortcommit0}%{?dist}
 Summary: Kubernetes Container Runtime Interface for OCI-based containers
 License: ASL 2.0
 URL: %{git0}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,3 +1,5 @@
+# Dependency tracking configuration for zeitgeist.
+# It verifies that the versions specified here match across all referenced files.
 dependencies:
   - name: go
     version: 1.25
@@ -16,6 +18,8 @@ dependencies:
     version: 1.36.0
     refPaths:
       - path: internal/version/version.go
+        match: Version
+      - path: contrib/test/ci/cri-o.spec
         match: Version
 
   - name: supported versions

--- a/scripts/release/release.go
+++ b/scripts/release/release.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/release-sdk/git"
@@ -115,9 +116,15 @@ func updateVersionAndCreatePR(
 		return fmt.Errorf("unable to update dependencies YAML file: %w", err)
 	}
 
+	logrus.Infof("Updating version in spec file %s", utils.SpecFile)
+
+	if err := updateSpecFile(oldVersion, newVersion); err != nil {
+		return fmt.Errorf("unable to update spec file: %w", err)
+	}
+
 	logrus.Info("Committing changes")
 
-	for _, file := range []string{utils.VersionFile, utils.DependenciesYAMLFile} {
+	for _, file := range []string{utils.VersionFile, utils.DependenciesYAMLFile, utils.SpecFile} {
 		if err := repo.Add(file); err != nil {
 			return fmt.Errorf("unable to add file %q to repo: %w", file, err)
 		}
@@ -172,6 +179,27 @@ func modifyVersionFile(filePath, oldVersion, newVersion string) error {
 	err = os.WriteFile(filePath, modifiedContent, 0o644)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func updateSpecFile(oldVersion, newVersion string) error {
+	content, err := os.ReadFile(utils.SpecFile)
+	if err != nil {
+		return fmt.Errorf("read file %s: %w", utils.SpecFile, err)
+	}
+
+	re := regexp.MustCompile(`(?m)^Version:\s+` + regexp.QuoteMeta(oldVersion) + `\s*$`)
+	if !re.Match(content) {
+		return fmt.Errorf("version string %q not found in %s", "Version: "+oldVersion, utils.SpecFile)
+	}
+
+	modifiedContent := re.ReplaceAll(content, []byte("Version: "+newVersion))
+
+	err = os.WriteFile(utils.SpecFile, modifiedContent, 0o644)
+	if err != nil {
+		return fmt.Errorf("update file %s: %w", utils.SpecFile, err)
 	}
 
 	return nil

--- a/scripts/utils/utils.go
+++ b/scripts/utils/utils.go
@@ -18,6 +18,7 @@ const (
 	OrgEnvKey            = "ORG"
 	VersionFile          = "internal/version/version.go"
 	DependenciesYAMLFile = "dependencies.yaml"
+	SpecFile             = "contrib/test/ci/cri-o.spec"
 	BranchPrefix         = "release-"
 	VersionPrefix        = "v"
 	CrioOrgRepo          = "cri-o"

--- a/scripts/version_bump.go
+++ b/scripts/version_bump.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
@@ -14,9 +15,12 @@ func main() {
 
 	var versionFile string
 
+	var specFile string
+
 	// Define command-line flags for bump type and version file
 	flag.StringVar(&bumpType, "bump", "", "Version bump type: major, minor, or patch")
 	flag.StringVar(&versionFile, "f", "../internal/version/version.go", "Path to the version file")
+	flag.StringVar(&specFile, "spec", "../contrib/test/ci/cri-o.spec", "Path to the spec file")
 	flag.Parse()
 
 	// Read the current version from the version.go file
@@ -32,6 +36,12 @@ func main() {
 	// Update the version in the version.go file
 	if err := updateVersion(versionFile, newVersion); err != nil {
 		fmt.Printf("Error updating version: %q\n", err)
+		os.Exit(1)
+	}
+
+	// Update the version in the spec file
+	if err := updateSpecVersion(specFile, currentVersion, newVersion); err != nil {
+		fmt.Printf("Error updating spec version: %q\n", err)
 		os.Exit(1)
 	}
 
@@ -88,6 +98,22 @@ func incrementVersionPart(part string) string {
 	num++
 
 	return strconv.Itoa(num)
+}
+
+func updateSpecVersion(specFile, oldVersion, newVersion string) error {
+	content, err := os.ReadFile(specFile)
+	if err != nil {
+		return err
+	}
+
+	old := []byte("Version: " + oldVersion)
+	if !bytes.Contains(content, old) {
+		return fmt.Errorf("version %s not found in %s", oldVersion, specFile)
+	}
+
+	newContent := bytes.Replace(content, old, []byte("Version: "+newVersion), 1)
+
+	return os.WriteFile(specFile, newContent, 0o644)
 }
 
 func updateVersion(versionFile, newVersion string) error {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Update the version bump and release scripts to also update the Version field in contrib/test/ci/cri-o.spec. Add the spec file to the zeitgeist dependency tracking in dependencies.yaml to keep it in sync.

This will make CI show the intended version `1.36.0-1.ci.git<hash>`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release tooling can update package spec/version entries automatically and accepts a configurable spec file path.

* **Chores**
  * Bumped packaged metadata version (1.32.0 → 1.36.0) and adjusted CI release identifier to include a short git reference.
  * Extended development-version tracking for Go dependency in CI metadata.
  * Ensured release flow stages and commits updated package metadata for consistent versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->