### PR TITLE
Test Case: Ensure container stopping and creating can happen in parallel

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -111,3 +111,11 @@ function teardown() {
   crictl runtimeversion
 }
 ```
+
+## CI Test Logs
+
+For the `ci/prow/ci-cgroupv2-integration` CI run, BATS test output can be found at:
+
+```text
+artifacts/cgroupv2-integration/cri-o-gather/artifacts/testout.txt
+```

--- a/test/sandbox_stop_locking.bats
+++ b/test/sandbox_stop_locking.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# vim: set syntax=sh:
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+# Helper function to create container config that ignores SIGTERM
+# This simulates a container that won't terminate gracefully, forcing
+# CRI-O to wait through the full timeout period before sending SIGKILL
+function create_nonterminating_container_config() {
+	local output_path="$1"
+	# This forces CRI-O to wait through full timeout before SIGKILL
+	jq '.command = ["sh", "-c", "trap '"'"''"'"' TERM; while true; do sleep 1; done"]' \
+		"$TESTDATA"/container_sleep.json > "$output_path"
+}
+
+@test "locking CreateContainer blocks when StopPodSandbox holds exclusive lock" {
+	start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	create_nonterminating_container_config "$TESTDIR/container_noterminate.json"
+	ctr_id=$(crictl create "$pod_id" "$TESTDIR/container_noterminate.json" "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	# Container stopping in background
+	crictl stopp "$pod_id" &
+	stop_pid=$!
+
+	# Wait for stop operation to acquire the lock
+	sleep 1
+
+	# Attempt to create another container while stop holds lock
+	start_create=$(date +%s)
+	timeout 5s crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json &
+	create_pid=$!
+
+	# Monitor for 3 seconds to show blocking
+	for i in {1..3}; do
+		sleep 1
+		if ps -p "$create_pid" > /dev/null 2>&1; then
+			echo "CreateContainer is BLOCKED (waiting ${i}s so far)" >&3
+		else
+			break
+		fi
+	done
+
+	# Verify it was NOT blocked for 2+ seconds
+	end_create=$(date +%s)
+	blocked_time=$((end_create - start_create))
+	echo "CreateContainer took $blocked_time seconds" >&3
+
+	# The test will fail if its blocked for 2 seconds or more
+	[ "$blocked_time" -lt 2 ]
+
+	if ps -p "$create_pid" > /dev/null 2>&1; then
+		kill -9 "$create_pid" 2> /dev/null || true
+	fi
+
+	wait "$stop_pid" || true
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind ci

#### What this PR does / why we need it:
An attempt to recreate the locking issue discussed here: https://kubernetes.slack.com/archives/CAZH62UR1/p1772497739779279

Basically I made an attempt to create containers while there are other containers stopping in parallel.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
@klihub This didn't recreate the problem but I thought its worth having this test case. I have a few more test cases which I can add on the same line which tests the code around this with more load.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "CI Test Logs" section documenting where CI test output is stored.

* **Tests**
  * Added a new integration test validating that stopping a sandbox obtains an exclusive lock that blocks concurrent container creation, with timing and cleanup checks to ensure correct lock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->