### PR TITLE
ci: refactor runtime configuration into a single container_runtime variable

### DIFF
--- a/contrib/test/ci/build/cri-o.yml
+++ b/contrib/test/ci/build/cri-o.yml
@@ -65,16 +65,6 @@
     target: install
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o"
 
-- name: use crun
-  copy:
-    dest: /etc/crio/crio.conf.d/01-crun.conf
-    content: |
-      [crio.runtime]
-      default_runtime = "crun"
-      [crio.runtime.runtimes.crun]
-      runtime_root = "/run/crun"
-  when: "build_crun | default(False) | bool"
-
 - name: use conmon-rs
   copy:
     dest: /etc/crio/crio.conf.d/99-conmonrs.conf

--- a/contrib/test/ci/critest-main.yml
+++ b/contrib/test/ci/critest-main.yml
@@ -7,6 +7,9 @@
   vars_files:
     - "{{ playbook_dir }}/vars.yml"
   tasks:
+    - name: set up container runtime
+      include_tasks: "util/integration-configure-runtime.yml"
+
     - name: run critest validation and benchmarks
       include_tasks: "critest.yml"
 

--- a/contrib/test/ci/e2e-main.yml
+++ b/contrib/test/ci/e2e-main.yml
@@ -8,6 +8,9 @@
   tags:
     - e2e
   tasks:
+    - name: set up container runtime
+      include_tasks: "util/e2e-configure-runtime.yml"
+
     - name: run k8s e2e tests
       include_tasks: "e2e.yml"
       args:

--- a/contrib/test/ci/integration-main.yml
+++ b/contrib/test/ci/integration-main.yml
@@ -8,12 +8,16 @@
   vars_files:
     - "{{ playbook_dir }}/vars.yml"
   tasks:
+    # TODO: remove build_kata guard once all pipelines have migrated to container_runtime.
     - name: install kata
       include_tasks: "build/kata.yml"
-      when: "build_kata | default(False) | bool"
+      when: "build_kata | default(False) | bool or container_runtime == 'kata'"
 
     - name: build and install cri-o
       include_tasks: "build/cri-o.yml"
+
+    - name: set up container runtime
+      include_tasks: "util/integration-configure-runtime.yml"
 
     - name: enable and start CRI-O
       become: yes

--- a/contrib/test/ci/integration.yml
+++ b/contrib/test/ci/integration.yml
@@ -33,18 +33,8 @@
     path: "{{ artifacts }}"
     state: directory
 
-- name: set crun runtime if enabled
-  set_fact:
-    int_test_env: "{{ int_test_env | combine(crun_test_env) }}"
-  when: "build_crun | bool"
-
 - name: kata configuration
   block:
-    - name: configure integration test suite for kata
-      set_fact:
-        int_test_env: "{{ int_test_env | combine(kata_int_test_env) }}"
-        userns_int_test_skip: True
-
     - name: skip tests not working in kata
       lineinfile:
         dest: "{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/test/{{ item.0 }}"
@@ -69,7 +59,8 @@
       ansible.posix.selinux:
         state: disabled
 
-  when: "build_kata | bool"
+  # TODO: remove build_kata guard once all pipelines have migrated to container_runtime.
+  when: "build_kata | bool or container_runtime == 'kata'"
 
 - block:
     - name: run integration tests

--- a/contrib/test/ci/util/e2e-configure-runtime.yml
+++ b/contrib/test/ci/util/e2e-configure-runtime.yml
@@ -1,0 +1,25 @@
+---
+- name: validate container_runtime
+  assert:
+    that:
+      - container_runtime in ['crun', 'runc']
+    fail_msg: "Invalid container_runtime '{{ container_runtime }}'. Accepted values: crun, runc"
+
+# crun is the default runtime in cri-o, no additional configuration needed.
+
+- name: runc configuration
+  block:
+    - name: configure cri-o to use runc for e2e
+      copy:
+        dest: /etc/crio/crio.conf.d/01-runc-runtime.conf
+        content: |
+          [crio.runtime]
+          default_runtime = "runc"
+
+          [crio.runtime.runtimes.runc]
+          runtime_path = "/usr/bin/runc"
+          runtime_type = "oci"
+          runtime_root = "/run/runc"
+  when: "container_runtime == 'runc'"
+
+# It is not supposed to run e2e with kata

--- a/contrib/test/ci/util/integration-configure-runtime.yml
+++ b/contrib/test/ci/util/integration-configure-runtime.yml
@@ -1,0 +1,43 @@
+---
+- name: validate container_runtime
+  assert:
+    that:
+      - container_runtime in ['crun', 'runc', 'kata']
+    fail_msg: "Invalid container_runtime '{{ container_runtime }}'. Accepted values: crun, runc, kata"
+
+# crun is the default runtime in cri-o, no additional configuration needed.
+
+- name: configure cri-o to use runc for integration
+  set_fact:
+    int_test_env: "{{ int_test_env | combine(runc_int_test_env) }}"
+  vars:
+    runc_int_test_env:
+      CONTAINER_RUNTIMES: "runc:/usr/bin/runc:/run/runc:oci:false:"
+      CONTAINER_RUNTIME: "runc"
+      CONTAINER_DEFAULT_RUNTIME: "runc"
+      RUNTIME_NAME: "runc"
+      RUNTIME_ROOT: "/run/runc"
+      RUNTIME_TYPE: "oci"
+  when: "container_runtime == 'runc'"
+
+- name: configure cri-o to use kata for integration
+  set_fact:
+    int_test_env: "{{ int_test_env | combine(kata_int_test_env) }}"
+    userns_int_test_skip: True
+  vars:
+    kata_int_test_env:
+      CONTAINER_RUNTIMES: "containerd-shim-kata-v2:/opt/kata/bin/containerd-shim-kata-v2:/run/vc:vm:true:/opt/kata/share/defaults/kata-containers/configuration.toml"
+      CONTAINER_RUNTIME: "containerd-shim-kata-v2"
+      CONTAINER_DEFAULT_RUNTIME: "containerd-shim-kata-v2"
+      RUNTIME_NAME: "containerd-shim-kata-v2"
+      RUNTIME_ROOT: "/run/vc"
+      RUNTIME_TYPE: "vm"
+      TESTFLAGS:
+        "{{ lookup('fileglob', '{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/test/*.bats', wantlist=True) \
+        | map('basename') | difference(kata_skip_files) | join(' ') }}"
+      JOBS: "1" # TODO: add support to parallelization in kata (causes failures in the integration tests)
+      PRIVILEGED_WITHOUT_HOST_DEVICES: true
+      RUNTIME_CONFIG_PATH: "/opt/kata/share/defaults/kata-containers/configuration.toml"
+      PATH: "/opt/kata/bin:{{ ansible_env.PATH }}"
+      CONTAINER_STORAGE_OPT: "overlay.skip_mount_home=true"
+  when: "container_runtime == 'kata'"

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -1,14 +1,12 @@
 ---
-# When False, disable SELinux on the system during specific tests
-integration_selinux_enabled: True
-e2e_selinux_enabled: False
-node_e2e_selinux_enabled: False
-manage_ns_lifecycle: True
-
+# TODO: remove build_* once all pipeline configurations have migrated to container_runtime.
+# Deprecated: use container_runtime instead.
 build_runc: True
 build_crun: False
 build_kata: False
 cgroupv2: False
+# Accepted values: crun, runc, kata
+container_runtime: "{{ container_runtime | default('crun') }}"
 use_conmonrs: "{{ USE_CONMONRS | default(False) | bool }}"
 evented_pleg_fg: "{{ EVENTED_PLEG | default(False) | bool }}"
 
@@ -31,11 +29,6 @@ int_test_env:
   CGROUP_MANAGER: "systemd"
   STORAGE_OPTIONS: >
     --storage-driver=overlay
-
-# Environment variables to set when executing integration tests with crun (mixed with int_test_env)
-crun_test_env:
-  CONTAINER_DEFAULT_RUNTIME: "crun"
-  CONTAINER_RUNTIMES: "crun::/run/crun:oci"
 
 # for ssh ID generation
 ssh_user: "{{ lookup('env','USER') }}"
@@ -74,22 +67,6 @@ kata_skip_files:
   - "version.bats"
   - "workloads.bats"
   - "cri-metrics.bats"
-
-kata_int_test_env:
-  CONTAINER_RUNTIMES: "containerd-shim-kata-v2:/opt/kata/bin/containerd-shim-kata-v2:/run/vc:vm:true:/opt/kata/share/defaults/kata-containers/configuration.toml"
-  CONTAINER_RUNTIME: "containerd-shim-kata-v2"
-  CONTAINER_DEFAULT_RUNTIME: "containerd-shim-kata-v2"
-  RUNTIME_NAME: "containerd-shim-kata-v2"
-  RUNTIME_ROOT: "/run/vc"
-  RUNTIME_TYPE: "vm"
-  TESTFLAGS:
-    "{{ lookup('fileglob', '{{ ansible_env.GOPATH }}/src/github.com/cri-o/cri-o/test/*.bats', wantlist=True) \
-    | map('basename') | difference(kata_skip_files) | join(' ') }}"
-  JOBS: "1" # TODO: add support to parallelization in kata (causes failures in the integration tests)
-  PRIVILEGED_WITHOUT_HOST_DEVICES: true
-  RUNTIME_CONFIG_PATH: "/opt/kata/share/defaults/kata-containers/configuration.toml"
-  PATH: "/opt/kata/bin:{{ ansible_env.PATH }}"
-  CONTAINER_STORAGE_OPT: "overlay.skip_mount_home=true"
 
 kata_skip_cgroups_tests:
   - 'test "pids limit"'


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Replace scattered build_crun/build_runc boolean flags with a unified container_runtime variable and extract runtime configuration into dedicated task files under contrib/test/ci/util/. This prevents contradictory runtime states and centralizes configuration logic.

Actually, we haven't run tests with runc probably since we migrate the default container runtime from crun to runc.
This is a first step to remove duplicate tests, and enable runc tests in prow.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
