### PR TITLE
fix: correct typos found by codespell

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -281,7 +281,7 @@ more than one organization.
 
 - CRI-O cuts releases in line with Kubernetes minor releases (1.x bump). The CRI-O
   community attempts to release a minor version of CRI-O
-  _within three days ofthe corresponding Kubernetes release_.
+  _within three days of the corresponding Kubernetes release_.
 - For Patch releases (1.1.z bump), releases are cut intermittently, when there
   are sufficient bug fixes backported to the branch. End-users can request
   releases be cut, and approvers can choose to accept that request at their discretion.

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -972,7 +972,7 @@ func RemoveStorageDirectory(config *libconfig.Config, store cstorage.Store, forc
 		// with a storage wipe.
 		//
 		// The storage directory removal can also be forced, which will
-		// then delete everything irregardless of whether there are any
+		// then delete everything regardless of whether there are any
 		// containers running at the moment.
 		if !force && errors.Is(err, cstorage.ErrLayerUsedByContainer) {
 			return fmt.Errorf("failed to shutdown storage: %w", err)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -81,7 +81,7 @@ func shouldCrioWipe(versionFileName, versionString string) (bool, error) {
 	}
 
 	// in every case that the minor and major version are out of sync,
-	// we want to preform a {down,up}grade. The common case here is newVersion > oldVersion,
+	// we want to perform a {down,up}grade. The common case here is newVersion > oldVersion,
 	// but even in the opposite case, images are out of date and could be wiped
 	return newVersion.Major != oldVersion.Major || newVersion.Minor != oldVersion.Minor, nil
 }

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -89,7 +89,7 @@ var _ = t.Describe("Watchdog", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should abort if systemd doest not acknowledge", func() {
+	It("should abort if systemd does not acknowledge", func() {
 		// Given
 		gomock.InOrder(
 			systemdMock.EXPECT().WatchdogEnabled().Return(validTimeout, nil),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -622,7 +622,7 @@ type ImageConfig struct {
 	// Note that image name provided to the credential provider does not
 	// contain any specific tag or digest, only the normalized repository
 	// as well as the image name, which can cause races if the same image
-	// prefix get's pulled on a single node.
+	// prefix gets pulled on a single node.
 	// This temporary auth file will be used instead of any configured GlobalAuthFile.
 	// If no pod namespace is being provided on image pull (via the sandbox
 	// config), or the concatenated path is non existent, then the system wide

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -274,7 +274,7 @@ var _ = t.Describe("Utils", func() {
 			Expect(groupPath).ToNot(BeEmpty())
 		})
 
-		It("should fail with username that desn't exist in /etc/passwd", func() {
+		It("should fail with username that doesn't exist in /etc/passwd", func() {
 			dir := createEtcFiles()
 			defer os.RemoveAll(dir)
 


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fix several typos across source code, tests, and documentation found by codespell.

Changes:
- `preform` → `perform` in internal/version/version.go
- `desn't` → `doesn't` in utils/utils_test.go
- `doest` → `does` in internal/watchdog/watchdog_test.go
- `get's` → `gets` in pkg/config/config.go
- `irregardless` → `regardless` in internal/lib/container_server.go
- `ofthe` → `of the` in GOVERNANCE.md

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Pure typo fixes, no functional changes.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple grammar and spelling errors across governance documentation and code comments for improved accuracy and clarity.

* **Tests**
  * Fixed spelling errors in test descriptions and names to enhance readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->