### PR TITLE
fix: ensure CRI container event ordering

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -94,6 +94,11 @@ type Container struct {
 	// When set, the exec process will spawn on this cgroup.
 	// If this is used, InfraCtrCPUSet will be ignored for the exec operation.
 	execCgroupPath string
+	// eventMu serializes CRI event emission so that handleExit cannot
+	// emit CONTAINER_STOPPED_EVENT before CONTAINER_STARTED_EVENT.
+	// Held by StartContainer across the runtime start + STARTED event,
+	// and by handleExit around the STOPPED event.
+	eventMu sync.Mutex
 }
 
 func (c *Container) CRIAttributes() *types.ContainerAttributes {
@@ -211,6 +216,7 @@ func NewSpoofedContainer(id, name string, labels map[string]string, sandbox stri
 	state := &ContainerState{}
 	state.Created = created
 	state.Started = created
+
 	c := &Container{
 		criContainer: &types.Container{
 			Id:           id,
@@ -729,6 +735,18 @@ func (c *Container) SetAsDoneStopping() {
 	c.stopWatchers = make([]chan struct{}, 0)
 	close(c.stopTimeoutChan)
 	c.stopLock.Unlock()
+}
+
+// LockEventOrder acquires the event-ordering mutex.
+// It is held by StartContainer across the runtime start + STARTED event
+// emission, ensuring handleExit cannot emit STOPPED before STARTED.
+func (c *Container) LockEventOrder() {
+	c.eventMu.Lock()
+}
+
+// UnlockEventOrder releases the event-ordering mutex.
+func (c *Container) UnlockEventOrder() {
+	c.eventMu.Unlock()
 }
 
 func (c *Container) AddManagedPIDNamespace(ns nsmgr.Namespace) {

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -1055,6 +1055,38 @@ var _ = t.Describe("Container", func() {
 			}).To(Panic())
 		})
 	})
+
+	t.Describe("EventOrderMutex", func() {
+		It("should serialize LockEventOrder callers", func() {
+			done := make(chan struct{})
+
+			sut.LockEventOrder()
+
+			go func() {
+				sut.LockEventOrder()
+				sut.UnlockEventOrder()
+				close(done)
+			}()
+
+			Consistently(done, 100*time.Millisecond).ShouldNot(BeClosed())
+
+			sut.UnlockEventOrder()
+
+			Eventually(done, 100*time.Millisecond).Should(BeClosed())
+		})
+
+		It("should not block when mutex is not held", func() {
+			done := make(chan struct{})
+
+			go func() {
+				sut.LockEventOrder()
+				sut.UnlockEventOrder()
+				close(done)
+			}()
+
+			Eventually(done, 100*time.Millisecond).Should(BeClosed())
+		})
+	})
 })
 
 var _ = t.Describe("SpoofedContainer", func() {

--- a/server/container_events_test.go
+++ b/server/container_events_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -63,7 +64,13 @@ var _ = t.Describe("ContainerEvents", func() {
 				client2.EXPECT().Send(&events[i]).Return(nil)
 			}
 
+			var wg sync.WaitGroup
+			wg.Add(2)
+
 			recv := func(ces types.RuntimeService_GetContainerEventsServer) {
+				defer GinkgoRecover()
+				defer wg.Done()
+
 				err := sut.GetContainerEvents(nil, ces)
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -79,6 +86,8 @@ var _ = t.Describe("ContainerEvents", func() {
 			for _, event := range events {
 				sut.ContainerEventsChan <- event
 			}
+
+			wg.Wait()
 		})
 	})
 })

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -27,6 +27,9 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 	}
 
 	if c.Restore() {
+		c.LockEventOrder()
+		defer c.UnlockEventOrder()
+
 		// If the create command found a checkpoint image, the container
 		// has the restore flag set to true. At this point we need to jump
 		// into the restore code.
@@ -74,6 +77,9 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 	if err := s.nri.startContainer(ctx, sandbox, c); err != nil {
 		log.Warnf(ctx, "NRI start failed for container %q: %v", c.ID(), err)
 	}
+
+	c.LockEventOrder()
+	defer c.UnlockEventOrder()
 
 	defer func() {
 		// if the call to StartContainer fails below we still want to fill

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -539,6 +539,8 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	}
 
 	s.generateCRIEvent(ctx, sb.InfraContainer(), types.ContainerEventType_CONTAINER_CREATED_EVENT)
+	container.LockEventOrder()
+	defer container.UnlockEventOrder()
 	if err := s.ContainerServer.Runtime().StartContainer(ctx, container); err != nil {
 		return nil, err
 	}

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -744,6 +744,9 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
+	container.LockEventOrder()
+	defer container.UnlockEventOrder()
+
 	if err := s.createAndStartInfraContainer(ctx, sb, container, sandboxIDMappings, sboxName, resourceCleaner); err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -897,7 +897,9 @@ func (s *Server) handleExit(ctx context.Context, event fsnotify.Event) {
 
 	s.postStopCleanup(ctx, c, sb, s.hooksRetriever.Get(ctx, sb.RuntimeHandler(), sb.Annotations()))
 
+	c.LockEventOrder()
 	s.generateCRIEvent(ctx, c, types.ContainerEventType_CONTAINER_STOPPED_EVENT)
+	c.UnlockEventOrder()
 
 	if err := os.Remove(event.Name); err != nil {
 		log.Warnf(ctx, "Failed to remove exit file: %v", err)

--- a/test/ctr_events.bats
+++ b/test/ctr_events.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_test
+	newconfig="$TESTDIR/config.json"
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "ctr events ordering for short-lived container" {
+	ENABLE_POD_EVENTS=true start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '.command = ["echo", "HELLO"]' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	ctr_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+	wait_for_log "Container event CONTAINER_CREATED_EVENT generated"
+
+	crictl start "$ctr_id"
+	wait_until_exit "$ctr_id"
+
+	wait_for_log "Container event CONTAINER_STARTED_EVENT generated for $ctr_id"
+	wait_for_log "Container event CONTAINER_STOPPED_EVENT generated for $ctr_id"
+
+	# Extract line numbers from the CRI-O log to verify ordering.
+	# STARTED must appear before STOPPED for the same container.
+	started_line=$(grep -n "Container event CONTAINER_STARTED_EVENT generated for $ctr_id" "$CRIO_LOG" | head -1 | cut -d: -f1)
+	stopped_line=$(grep -n "Container event CONTAINER_STOPPED_EVENT generated for $ctr_id" "$CRIO_LOG" | head -1 | cut -d: -f1)
+
+	echo "STARTED at line $started_line, STOPPED at line $stopped_line"
+	[ -n "$started_line" ]
+	[ -n "$stopped_line" ]
+	[ "$started_line" -lt "$stopped_line" ]
+
+	crictl rm "$ctr_id"
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+}
+
+@test "ctr events ordering for multiple short-lived containers" {
+	ENABLE_POD_EVENTS=true start_crio
+
+	for i in $(seq 1 5); do
+		pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+		jq '.command = ["echo", "RUN'"$i"'"]' \
+			"$TESTDATA"/container_config.json > "$newconfig"
+		ctr_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+
+		crictl start "$ctr_id"
+		wait_until_exit "$ctr_id"
+
+		wait_for_log "Container event CONTAINER_STOPPED_EVENT generated for $ctr_id"
+
+		started_line=$(grep -n "Container event CONTAINER_STARTED_EVENT generated for $ctr_id" "$CRIO_LOG" | head -1 | cut -d: -f1)
+		stopped_line=$(grep -n "Container event CONTAINER_STOPPED_EVENT generated for $ctr_id" "$CRIO_LOG" | head -1 | cut -d: -f1)
+
+		echo "Run $i: ctr=$ctr_id STARTED at line $started_line, STOPPED at line $stopped_line"
+		[ -n "$started_line" ]
+		[ -n "$stopped_line" ]
+		[ "$started_line" -lt "$stopped_line" ]
+
+		crictl rm "$ctr_id"
+		crictl stopp "$pod_id"
+		crictl rmp "$pod_id"
+	done
+}
+
+@test "ctr events ordering for immediate-exit container" {
+	ENABLE_POD_EVENTS=true start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	jq '.command = ["true"]' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+	ctr_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
+
+	crictl start "$ctr_id"
+	wait_until_exit "$ctr_id"
+
+	wait_for_log "Container event CONTAINER_STOPPED_EVENT generated for $ctr_id"
+
+	started_line=$(grep -n "Container event CONTAINER_STARTED_EVENT generated for $ctr_id" "$CRIO_LOG" | head -1 | cut -d: -f1)
+	stopped_line=$(grep -n "Container event CONTAINER_STOPPED_EVENT generated for $ctr_id" "$CRIO_LOG" | head -1 | cut -d: -f1)
+
+	echo "STARTED at line $started_line, STOPPED at line $stopped_line"
+	[ -n "$started_line" ]
+	[ -n "$stopped_line" ]
+	[ "$started_line" -lt "$stopped_line" ]
+
+	crictl rm "$ctr_id"
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

There is a race condition in the CRI container event delivery path. When a
short-lived container exits before the `StartContainer` gRPC handler finishes
generating the `CONTAINER_STARTED_EVENT`, the exit-file watcher (`handleExit`)
can emit `CONTAINER_STOPPED_EVENT` first because it runs in an independent
goroutine with no ordering guarantee.

The sequence is:
1. `StartContainer` -> `Runtime().StartContainer()` starts the process, **sets `state.Started`**, releases `opLock`
2. Container exits immediately, conmon writes exit file
3. `handleExit` goroutine spawns -> calls `generateCRIEvent(STOPPED)`
4. `StartContainer` handler calls `generateCRIEvent(STARTED)` concurrently
5. `STOPPED` can reach `ContainerEventsChan` before `STARTED`

This adds a per-container `startedEvtDone` channel barrier. `handleExit` waits
on it before emitting `CONTAINER_STOPPED_EVENT`, and `StartContainer` closes
it after `CONTAINER_STARTED_EVENT` is sent.

For containers restored after a CRI-O restart, the barrier is signaled during
`LoadContainer` and `LoadSandbox` so that `handleExit` does not block
indefinitely. The same applies to the checkpoint/restore path.

Additionally, this fixes a panic in `NewSpoofedContainer` (used when
`drop_infra_ctr = true`) where the `startedEvtDone` channel was manually
closed at construction time without consuming the `sync.Once`. When
`finalizeSandboxCreation` later called `SignalStartedEventDone()`,
`sync.Once.Do` fired and tried to close an already-closed channel, causing
`panic: close of closed channel`. The fix uses `SignalStartedEventDone()`
in the constructor instead, which atomically consumes the `Once` and closes
the channel.

A defensive `SignalStartedEventDone()` is also added on the `StartContainer`
error path so `handleExit` can never block indefinitely if the start fails
after the OCI runtime has launched the process.

#### Which issue(s) this PR fixes:

Fixes #9738

#### Special notes for reviewer:

Same pattern as the existing `stopWatchers`/`stopDone`/`SetAsDoneStopping`
in the `Container` struct -- just a channel + `sync.Once` barrier.

An earlier revision used `state.Started.IsZero()` to skip the wait on
restart, but `runtimeOCI.StartContainer()` sets `state.Started` before
returning to the gRPC handler, so `handleExit` always bypassed the barrier.
Removed that and signal from `LoadContainer`/`LoadSandbox` instead.

The `NewSpoofedContainer` panic (`close of closed channel`) was caught
while running `ctr_events.bats` locally -- the channel was closed manually
at construction without going through `sync.Once`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed out-of-order CRI container event delivery for short-lived containers where STOPPED could arrive before STARTED.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure container "started" signaling is always completed across normal, restore, and failure paths; the server now waits for that completion before emitting CONTAINER_STOPPED events to prevent out-of-order start/stop events.

* **Tests**
  * Added unit and integration tests validating start-event synchronization and CRI event ordering for short-lived, multiple, and immediate-exit containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->