### PR TITLE
WIP: Add storage deduplication support using reflinks

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -161,6 +161,7 @@ func main() {
 	app.Commands = append(app.Commands,
 		criocli.CheckCommand,
 		criocli.ConfigCommand,
+		criocli.DedupCommand,
 		criocli.PublishCommand,
 		criocli.StatusCommand,
 		criocli.VersionCommand,

--- a/completions/bash/crio
+++ b/completions/bash/crio
@@ -6,6 +6,7 @@ _cli_bash_autocomplete() {
 complete
 completion
 config
+dedup
 man
 markdown
 md
@@ -56,6 +57,7 @@ h
 --enable-nri
 --enable-pod-events
 --enable-profile-unix-socket
+--enable-storage-dedup
 --enable-tracing
 --gid-mappings
 --global-auth-file

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -2,7 +2,7 @@
 
 function __fish_crio_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i check complete completion help h config man markdown md status config c containers container cs s info i goroutines g heap hp version wipe help h
+        if contains -- $i check complete completion help h config dedup man markdown md status config c containers container cs s info i goroutines g heap hp version wipe help h
             return 1
         end
     end
@@ -59,6 +59,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-metrics -d 'Enable 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-nri -d 'Enable NRI (Node Resource Interface) support.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-pod-events -d 'If true, CRI-O starts sending the container events to the kubelet'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-profile-unix-socket -d 'Enable pprof profiler on crio unix domain socket.'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-storage-dedup -d 'Enable background storage deduplication using reflinks on startup.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-tracing -d 'Enable OpenTelemetry trace data exporting.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l gid-mappings -r -d 'Specify the GID mappings to use for the user namespace. This option is deprecated, and will be replaced with Kubernetes user namespace (KEP-127) support in the future.'
 complete -c crio -n '__fish_crio_no_subcommand' -l global-auth-file -r -d 'Path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.'
@@ -222,6 +223,8 @@ complete -r -c crio -n '__fish_crio_no_subcommand' -a 'config' -d 'Outputs a com
 by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.'
 complete -c crio -n '__fish_seen_subcommand_from config' -f -l default -d 'Output the default configuration (without taking into account any configuration options).'
+complete -c crio -n '__fish_seen_subcommand_from dedup' -f -l help -s h -d 'show help'
+complete -r -c crio -n '__fish_crio_no_subcommand' -a 'dedup' -d 'deduplicate image storage using reflinks'
 complete -c crio -n '__fish_seen_subcommand_from man' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'man' -d 'Generate the man page documentation.'
 complete -c crio -n '__fish_seen_subcommand_from markdown md' -f -l help -s h -d 'show help'

--- a/completions/zsh/_crio
+++ b/completions/zsh/_crio
@@ -26,6 +26,7 @@ best if CRI-O and any currently running containers are stopped."
         'config:Outputs a commented version of the configuration file that could be used
 by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.'
+        'dedup:deduplicate image storage using reflinks'
         'man:Generate the man page documentation.'
         'markdown:Generate the markdown documentation.'
         'md:Generate the markdown documentation.'
@@ -81,6 +82,7 @@ it later with **--config**. Global options will modify the output.'
         '--enable-nri'
         '--enable-pod-events'
         '--enable-profile-unix-socket'
+        '--enable-storage-dedup'
         '--enable-tracing'
         '--gid-mappings'
         '--global-auth-file'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -52,6 +52,7 @@ crio
 [--enable-nri]
 [--enable-pod-events]
 [--enable-profile-unix-socket]
+[--enable-storage-dedup]
 [--enable-tracing]
 [--gid-mappings]=[value]
 [--global-auth-file]=[value]
@@ -261,6 +262,8 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 **--enable-pod-events**: If true, CRI-O starts sending the container events to the kubelet
 
 **--enable-profile-unix-socket**: Enable pprof profiler on crio unix domain socket.
+
+**--enable-storage-dedup**: Enable background storage deduplication using reflinks on startup.
 
 **--enable-tracing**: Enable OpenTelemetry trace data exporting.
 
@@ -527,6 +530,10 @@ by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.
 
 **--default**: Output the default configuration (without taking into account any configuration options).
+
+## dedup
+
+deduplicate image storage using reflinks
 
 ## man
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -531,6 +531,13 @@ The valid values are "enforcing" and "disabled", and the default is "enforcing".
 If "enforcing", an image pull will fail if a short name is used, but the results are ambiguous.
 If "disabled", the first result will be chosen.
 
+**enable_storage_dedup**=false
+Enable background storage deduplication using reflinks on startup. Identical
+files across image layers are deduplicated at the filesystem level using
+copy-on-write clones, reducing disk usage without the drawbacks of hard links.
+Deduplication can also be triggered manually via `crio dedup`.
+Requires filesystem support (e.g., XFS with reflink=1 or Btrfs).
+
 ## CRIO.NETWORK TABLE
 
 The `crio.network` table containers settings pertaining to the management of CNI plugins.

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -213,6 +213,10 @@ func mergeImageConfig(config *libconfig.Config, ctx *cli.Context) {
 	if ctx.IsSet("oci-artifact-mount-support") {
 		config.OCIArtifactMountSupport = ctx.Bool("oci-artifact-mount-support")
 	}
+
+	if ctx.IsSet("enable-storage-dedup") {
+		config.EnableStorageDedup = ctx.Bool("enable-storage-dedup")
+	}
 }
 
 // mergeRuntimeConfig merges RuntimeConfig-related CLI flags into the config, including runtime paths,
@@ -1472,6 +1476,12 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 			Usage:   "If true, CRI-O can mount OCI artifacts as volumes.",
 			EnvVars: []string{"CONTAINER_OCI_ARTIFACT_SUPPORT"},
 			Value:   defConf.OCIArtifactMountSupport,
+		},
+		&cli.BoolFlag{
+			Name:    "enable-storage-dedup",
+			Usage:   "Enable background storage deduplication using reflinks on startup.",
+			EnvVars: []string{"CONTAINER_ENABLE_STORAGE_DEDUP"},
+			Value:   defConf.EnableStorageDedup,
 		},
 		&cli.StringFlag{
 			Name:    "infra-ctr-cpuset",

--- a/internal/criocli/dedup.go
+++ b/internal/criocli/dedup.go
@@ -1,0 +1,50 @@
+package criocli
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+
+	"github.com/cri-o/cri-o/server"
+)
+
+// DedupCommand is the `crio dedup` subcommand for running storage
+// deduplication on demand. It opens the storage, runs deduplication
+// using reflinks, and reports the result. This should be run while
+// CRI-O is stopped to avoid lock contention with image pulls.
+var DedupCommand = &cli.Command{
+	Name:  "dedup",
+	Usage: "deduplicate image storage using reflinks",
+	Description: `Deduplicate identical files across container image layers using
+filesystem-level reflinks (copy-on-write clones). This reduces disk
+usage without the drawbacks of hard links, as modifying one copy does
+not affect others.
+
+Requires a filesystem that supports reflinks (e.g., XFS with reflink=1
+or Btrfs). On unsupported filesystems, the command exits with an error.
+
+This command should be run while CRI-O is stopped to avoid lock
+contention with image pull operations.`,
+	Action: crioDedup,
+}
+
+func crioDedup(c *cli.Context) error {
+	config, err := GetConfigFromContext(c)
+	if err != nil {
+		return fmt.Errorf("unable to load configuration: %w", err)
+	}
+
+	store, err := config.GetStore()
+	if err != nil {
+		return fmt.Errorf("unable to open storage: %w", err)
+	}
+
+	defer func() {
+		if _, err := store.Shutdown(true); err != nil {
+			logrus.Errorf("Unable to shutdown storage: %v", err)
+		}
+	}()
+
+	return server.RunDedup(c.Context, store)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -684,6 +684,14 @@ type ImageConfig struct {
 	// If "enforcing", an image pull will fail if a short name is used, but the results are ambiguous.
 	// If "disabled", the first result will be chosen.
 	ShortNameMode string `toml:"short_name_mode"`
+	// EnableStorageDedup enables background storage deduplication using
+	// reflinks on startup. Identical files across image layers are
+	// deduplicated at the filesystem level using copy-on-write clones,
+	// reducing disk usage without the drawbacks of hard links.
+	// Deduplication can also be triggered manually via `crio dedup`.
+	// Requires filesystem support (e.g., XFS with reflink=1 or Btrfs).
+	// Default: false.
+	EnableStorageDedup bool `toml:"enable_storage_dedup"`
 }
 
 // NetworkConfig represents the "crio.network" TOML config table.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -578,6 +578,11 @@ func initCrioTemplateConfig(c *Config) ([]*templateConfigValue, error) {
 			isDefaultValue: simpleEqual(dc.OCIArtifactMountSupport, c.OCIArtifactMountSupport),
 		},
 		{
+			templateString: templateStringCrioImageEnableStorageDedup,
+			group:          crioImageConfig,
+			isDefaultValue: simpleEqual(dc.EnableStorageDedup, c.EnableStorageDedup),
+		},
+		{
 			templateString: templateStringCrioNetworkCniDefaultNetwork,
 			group:          crioNetworkConfig,
 			isDefaultValue: simpleEqual(dc.CNIDefaultNetwork, c.CNIDefaultNetwork),
@@ -836,6 +841,17 @@ const templateStringCrioInternalRepair = `# InternalRepair is whether CRI-O shou
 const templateStringOCIArtifactMountSupport = `# OCIArtifactMountSupport is whether CRI-O should support OCI artifacts.
 # If set to false, mounting OCI Artifacts will result in an error.
 {{ $.Comment }}oci_artifact_mount_support = {{ .OCIArtifactMountSupport }}
+`
+
+const templateStringCrioImageEnableStorageDedup = `# EnableStorageDedup enables background storage deduplication using
+# reflinks on startup. Identical files across image layers are
+# deduplicated at the filesystem level using copy-on-write clones,
+# reducing disk usage without the drawbacks of hard links.
+# Deduplication can also be triggered manually via "crio dedup".
+# Requires filesystem support (e.g., XFS with reflink=1 or Btrfs).
+# Default: false.
+{{ $.Comment }}enable_storage_dedup = {{ .EnableStorageDedup }}
+
 `
 
 const templateStringCrioAPI = `# The crio.api table contains settings for the kubelet/gRPC interface.

--- a/server/dedup.go
+++ b/server/dedup.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/docker/go-units"
+	"go.podman.io/storage"
+	"golang.org/x/sys/unix"
+
+	"github.com/cri-o/cri-o/internal/log"
+)
+
+// RunDedup runs a single storage deduplication pass using reflinks.
+// It calls store.Dedup with SHA256 hashing and logs the result.
+func RunDedup(ctx context.Context, store storage.Store) error {
+	log.Infof(ctx, "Starting storage deduplication")
+
+	result, err := store.Dedup(storage.DedupArgs{
+		Options: storage.DedupOptions{
+			HashMethod: storage.DedupHashSHA256,
+		},
+	})
+	if err != nil {
+		if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.EOPNOTSUPP) {
+			return fmt.Errorf("storage deduplication not supported on current filesystem: %w", err)
+		}
+
+		return fmt.Errorf("storage deduplication failed: %w", err)
+	}
+
+	if result.Deduped == 0 {
+		log.Infof(ctx, "Storage deduplication complete: no savings")
+	} else {
+		log.Infof(ctx, "Storage deduplication complete: %s saved", units.BytesSize(float64(result.Deduped)))
+	}
+
+	return nil
+}

--- a/server/dedup_test.go
+++ b/server/dedup_test.go
@@ -1,0 +1,116 @@
+package server_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	graphdriver "go.podman.io/storage/drivers"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/sys/unix"
+
+	"github.com/cri-o/cri-o/server"
+)
+
+var _ = t.Describe("Dedup", func() {
+	// Prepare the sut
+	BeforeEach(beforeEach)
+	AfterEach(afterEach)
+
+	t.Describe("RunDedup", func() {
+		It("should succeed when dedup saves bytes", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{Deduped: 1024}, nil)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed when dedup has no savings", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{Deduped: 0}, nil)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error on ENOTSUP", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{}, unix.ENOTSUP)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not supported"))
+		})
+
+		It("should return error on EOPNOTSUPP", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{}, unix.EOPNOTSUPP)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not supported"))
+		})
+
+		It("should return error on other failures", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{}, t.TestError)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed"))
+		})
+	})
+
+	t.Describe("Server with dedup enabled", func() {
+		It("should succeed creating server with dedup enabled", func() {
+			// Given
+			serverConfig.EnableStorageDedup = true
+
+			graphroot := t.MustTempDir("graphroot")
+			gomock.InOrder(
+				cniPluginMock.EXPECT().Status().Return(nil),
+				libMock.EXPECT().GetData().Times(2).Return(serverConfig),
+				libMock.EXPECT().GetStore().Return(storeMock, nil),
+				libMock.EXPECT().GetData().Return(serverConfig),
+				storeMock.EXPECT().GraphRoot().Return(graphroot),
+				storeMock.EXPECT().Containers().Return(nil, nil),
+				cniPluginMock.EXPECT().GC(gomock.Any(), gomock.Any()).
+					Return(nil).AnyTimes(),
+			)
+			Expect(serverConfig.SetCNIPlugin(cniPluginMock)).To(Succeed())
+
+			// Expect dedup to be called for startup trigger
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{Deduped: 0}, nil).
+				AnyTimes()
+
+			// When
+			srv, err := server.New(context.Background(), libMock)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(srv).NotTo(BeNil())
+		})
+	})
+})

--- a/server/server.go
+++ b/server/server.go
@@ -501,6 +501,14 @@ func New(
 	deletedImages := s.restore(ctx)
 	s.wipeIfAppropriate(ctx, deletedImages)
 
+	if config.EnableStorageDedup {
+		go func() {
+			if err := RunDedup(ctx, s.Store()); err != nil {
+				log.Warnf(ctx, "%v", err)
+			}
+		}()
+	}
+
 	var bindAddressStr string
 
 	bindAddress := net.ParseIP(config.StreamAddress)

--- a/test/dedup.bats
+++ b/test/dedup.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "dedup: startup dedup runs when enabled" {
+	cat << EOF > "$CRIO_CONFIG_DIR/01-dedup.conf"
+[crio.image]
+enable_storage_dedup = true
+EOF
+
+	start_crio
+
+	# Verify dedup was triggered at startup
+	wait_for_log "Starting storage deduplication"
+
+	# It should complete (either with savings or no savings)
+	wait_for_log "Storage deduplication complete"
+}
+
+@test "dedup: no dedup when disabled" {
+	cat << EOF > "$CRIO_CONFIG_DIR/01-dedup.conf"
+[crio.image]
+enable_storage_dedup = false
+EOF
+
+	start_crio
+
+	# Give it a moment to start
+	sleep 2
+
+	# Verify dedup was NOT triggered
+	run ! grep -q "Starting storage deduplication" "$CRIO_LOG"
+}
+
+@test "dedup: crio dedup command succeeds with expected output" {
+	setup_crio
+
+	run "$CRIO_BINARY_PATH" \
+		-c "$CRIO_CONFIG" \
+		-d "$CRIO_CONFIG_DIR" \
+		dedup
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Starting storage deduplication"* ]]
+	[[ "$output" == *"Storage deduplication complete"* ]]
+}
+
+@test "dedup: server remains functional after startup dedup" {
+	cat << EOF > "$CRIO_CONFIG_DIR/01-dedup.conf"
+[crio.image]
+enable_storage_dedup = true
+EOF
+
+	start_crio
+
+	wait_for_log "Starting storage deduplication"
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+}
+
+@test "dedup: config option appears in generated config" {
+	output=$("$CRIO_BINARY_PATH" config --default 2> /dev/null)
+	[[ "$output" == *"enable_storage_dedup"* ]]
+}


### PR DESCRIPTION
/kind feature

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds storage deduplication support to CRI-O using filesystem-level reflinks (copy-on-write clones). Identical files across container image layers are deduplicated at the filesystem level, reducing disk usage. Since reflinks are copy-on-write, modifying one copy does not affect others.

This is useful for storage-constrained environments (SNO, edge, small clusters) where multiple images share common base layers or files.

**Two ways to trigger dedup:**

| Trigger | When | Details |
|---------|------|---------|
| Startup | `enable_storage_dedup = true` in config | Runs in background goroutine during server startup |
| On-demand | `crio dedup` CLI command | Run while CRI-O is stopped; admin controls timing |

#### Changes

- `pkg/config/config.go`: `EnableStorageDedup` field on `ImageConfig`
- `pkg/config/template.go`: Config template for `crio config --default`
- `internal/criocli/criocli.go`: `--enable-storage-dedup` CLI flag
- `internal/criocli/dedup.go`: `crio dedup` subcommand
- `server/dedup.go`: `RunDedup()` — calls `store.Dedup()` with SHA256 hashing
- `server/server.go`: Startup dedup goroutine when enabled
- `cmd/crio/main.go`: Register `DedupCommand`
- `docs/crio.conf.5.md`: Man page documentation

<details>
<summary><b>E2E test: 26% storage reduction on XFS with reflinks</b></summary>

**Setup:** 3 container images built with podman on an XFS filesystem (`reflink=1`). Each image has a **different** layer (different digest) containing the **same** 10 MB file (`shared.dat`), plus a unique file to force distinct layers.

```
Images in storage:
  localhost/image-a:latest  10.5 MB
  localhost/image-b:latest  10.5 MB
  localhost/image-c:latest  10.5 MB

Copies of shared.dat across layers: 3
```

**Before dedup** — 3 separate copies of `shared.dat`, each with its own inode:

```
XFS block usage: 76 MB

Copies of shared.dat (each 10 MB, different inodes):
  layer 0862f10c3d23  10M  inode=1048726
  layer cd87f17f7901  10M  inode=3145870
  layer ee6668357256  10M  inode=2117776
```

**Running `crio dedup`:**

```
Starting storage deduplication
Storage deduplication complete: 20MiB saved
```

**After dedup:**

```
XFS block usage: 56 MB
```

**Results:**

```
  Disk usage before dedup:       76 MB
  Disk usage after dedup:        56 MB
  Space saved:                   20 MB (20484 KB)
  Reduction:                     26%
```

The 3 copies of `shared.dat` still appear as separate files (separate inodes), but at the filesystem level they now share physical blocks via copy-on-write. Writing to any copy triggers a transparent clone — no data corruption risk.

</details>

<details>
<summary><b>Unit tests (Ginkgo)</b></summary>

`server/dedup_test.go` covers:
- Successful dedup with savings
- Successful dedup with no savings (empty storage)
- `ENOTSUP` error → returns error indicating unsupported filesystem
- `EOPNOTSUPP` error → same behavior
- Other errors → returns wrapped error
- Server creation with `EnableStorageDedup = true`

</details>

<details>
<summary><b>Integration tests (BATS)</b></summary>

`test/dedup.bats` covers:
- Startup dedup runs when `enable_storage_dedup = true`
- No dedup when `enable_storage_dedup = false`
- `crio dedup` CLI command succeeds
- Config option appears in `crio config --default`

</details>

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- Requires filesystem support for reflinks (XFS with `reflink=1` or Btrfs). On unsupported filesystems, dedup returns an error and logs a warning.
- The `crio dedup` command should be run while CRI-O is stopped to avoid lock contention — `store.Dedup()` acquires an exclusive write lock on the layer store.
- Startup dedup runs before kubelet connects, so no pull contention in practice.

#### Does this PR introduce a user-facing change?

```release-note
Add storage deduplication support using filesystem reflinks. Enable via
`enable_storage_dedup = true` in crio.conf for automatic dedup on startup,
or run `crio dedup` manually. Reduces disk usage by deduplicating identical
files across image layers using copy-on-write clones. Requires XFS with
reflink=1 or Btrfs.
```