### PR TITLE
OCPBUGS-78585: [1.35] Return image ID from PullImage instead of repo digest

### DIFF
--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -123,17 +123,18 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 		return nil, storage.WrapSignatureCRIErrorIfNeeded(pullOp.err)
 	}
 
-	log.Infof(ctx, "Pulled image: %v", pullOp.imageRef)
+	log.Infof(ctx, "Pulled image: %s", pullOp.imageRef)
 
 	return &types.PullImageResponse{
-		ImageRef: pullOp.imageRef.StringForOutOfProcessConsumptionOnly(),
+		ImageRef: pullOp.imageRef,
 	}, nil
 }
 
 // pullImage performs the actual pull operation of PullImage. Used to separate
 // the pull implementation from the pullCache logic in PullImage and improve
 // readability and maintainability.
-func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storage.RegistryImageReference, error) {
+// It returns the image ID string suitable for PullImageResponse.ImageRef.
+func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string, error) {
 	var err error
 
 	ctx, span := log.StartSpan(ctx)
@@ -141,7 +142,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storag
 
 	sourceCtx, err := s.contextForNamespace(pullArgs.namespace)
 	if err != nil {
-		return storage.RegistryImageReference{}, fmt.Errorf("get context for namespace: %w", err)
+		return "", fmt.Errorf("get context for namespace: %w", err)
 	}
 
 	log.Debugf(ctx, "Using pull policy path for image %s: %q", pullArgs.image, sourceCtx.SignaturePolicyPath)
@@ -149,7 +150,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storag
 	if pullArgs.namespace != "" {
 		authCleanup, err := s.prepareTempAuthFile(ctx, &sourceCtx, pullArgs.image, pullArgs.namespace)
 		if err != nil {
-			return storage.RegistryImageReference{}, fmt.Errorf("prepare temp auth file: %w", err)
+			return "", fmt.Errorf("prepare temp auth file: %w", err)
 		}
 		defer authCleanup()
 	}
@@ -161,14 +162,14 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storag
 
 	decryptConfig, err := getDecryptionKeys(s.config.DecryptionKeysPath)
 	if err != nil {
-		return storage.RegistryImageReference{}, err
+		return "", err
 	}
 
 	cgroup := ""
 
 	if s.config.SeparatePullCgroup != "" {
 		if !s.config.CgroupManager().IsSystemd() {
-			return storage.RegistryImageReference{}, errors.New("--separate-pull-cgroup is supported only with systemd")
+			return "", errors.New("--separate-pull-cgroup is supported only with systemd")
 		}
 
 		if s.config.SeparatePullCgroup == utils.PodCgroupName {
@@ -176,32 +177,32 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (storag
 		} else {
 			cgroup = s.config.SeparatePullCgroup
 			if !strings.Contains(cgroup, ".slice") {
-				return storage.RegistryImageReference{}, fmt.Errorf("invalid systemd cgroup %q", cgroup)
+				return "", fmt.Errorf("invalid systemd cgroup %q", cgroup)
 			}
 		}
 	}
 
 	remoteCandidates, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
 	if err != nil {
-		return storage.RegistryImageReference{}, err
+		return "", err
 	}
 	// CandidatesForPotentiallyShortImageName is defined never to return an empty slice on success, so if the loop considers all candidates
 	// and they all fail, this error value should be overwritten by a real failure.
 	lastErr := errors.New("internal error: pullImage failed but reported no error reason")
 
 	for _, remoteCandidateName := range remoteCandidates {
-		repoDigest, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup)
+		imageRef, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup)
 		if err == nil {
 			// Update metric for successful image pulls
 			metrics.Instance().MetricImagePullsSuccessesInc(remoteCandidateName)
 
-			return repoDigest, nil
+			return s.resolveImageRefToID(ctx, imageRef)
 		}
 
 		lastErr = err
 	}
 
-	return storage.RegistryImageReference{}, lastErr
+	return "", lastErr
 }
 
 // contextForNamespace takes the provided namespace and returns a modifiable
@@ -329,6 +330,27 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 	}
 
 	return repoDigest, nil
+}
+
+// resolveImageRefToID converts a pulled image reference (repo@digest) to a
+// storage image ID suitable for PullImageResponse.ImageRef. For regular
+// container images the ID is looked up via ImageStatusByName. For OCI artifacts
+// (which are not stored in container storage) it falls back to the artifact
+// store.
+func (s *Server) resolveImageRefToID(ctx context.Context, imageRef storage.RegistryImageReference) (string, error) {
+	// Try resolving as a regular container image first.
+	imageResult, err := s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, imageRef)
+	if err == nil {
+		return imageResult.ID.IDStringForOutOfProcessConsumptionOnly(), nil
+	}
+
+	// Fall back to the artifact store for OCI artifacts.
+	artifact, artifactErr := s.ArtifactStore().Status(ctx, imageRef.StringForOutOfProcessConsumptionOnly())
+	if artifactErr != nil {
+		return "", fmt.Errorf("resolve pulled image %s: not found in container storage (%w) or artifact store (%w)", imageRef, err, artifactErr)
+	}
+
+	return artifact.CRIImage().GetId(), nil
 }
 
 // consumeImagePullProgress consumes progress and turns it into metrics updates.

--- a/server/server.go
+++ b/server/server.go
@@ -118,9 +118,8 @@ type pullOperation struct {
 	// wg allows for Goroutines trying to pull the same image to wait until the
 	// currently running pull operation has finished.
 	wg sync.WaitGroup
-	// imageRef is the reference of the actually pulled image; it is always
-	// in a full repo@digest format, resolving short names and tags
-	imageRef storage.RegistryImageReference
+	// imageRef is the resolved image ID to return in the CRI PullImageResponse
+	imageRef string
 	// err is the error indicating if the pull operation has succeeded or not.
 	err error
 }

--- a/test/image.bats
+++ b/test/image.bats
@@ -414,12 +414,32 @@ EOF
 	crictl pull nginx
 }
 
-@test "image pull should not fall back to OCI artifact on network error" {
+@test "image pull returns image ID not repo digest" {
 	start_crio
 
-	# 192.0.2.1 is TEST-NET-1 (RFC 5737), guaranteed unreachable
-	run ! crictl pull 192.0.2.1/test/image:latest
+	# Pull an image and capture the returned image reference
+	pulled_ref=$(crictl pull "$IMAGE")
 
-	# Network errors should not trigger the OCI artifact fallback
-	run ! grep -q "Falling back" "$CRIO_LOG"
+	# Extract the image ID from crictl output
+	# crictl may output "Image is up to date for <id>" or just "<id>"
+	# We want just the ID part (the last word)
+	pulled_id=$(echo "$pulled_ref" | awk '{print $NF}')
+
+	# Ensure we actually got an ID back (format is storage-defined)
+	[ "$pulled_id" != "" ]
+
+	# Get the image status for the same image
+	imageid=$(crictl images --quiet "$IMAGE")
+	[ "$imageid" != "" ]
+
+	# The pulled reference should match the image ID from ImageStatus
+	# Both PullImage and GetImageRef (via ImageStatus) should return the same value
+	# to ensure Kubernetes credential verification works correctly
+	[ "$pulled_id" = "$imageid" ]
+
+	# Verify we can use the image ID to inspect the image
+	output=$(crictl inspecti "$imageid")
+	[[ "$output" == *"$IMAGE"* ]]
+
+	cleanup_images
 }


### PR DESCRIPTION
Resolve the pulled image reference to a storage image ID in the server layer (server/image_pull.go) rather than changing the storage layer's PullImage return type. This keeps the storage layer's contract unchanged while the server resolves references to IDs via ImageStatusByName, with a fallback to the artifact store for OCI artifacts.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
cherry-pick of https://github.com/cri-o/cri-o/pull/9728/
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
PullImage now returns the image ID directly, ensuring compatibility with Kubernetes credential verification for image pulls.
```
