### PR TITLE
[1.33] Pin cri-tools to v1.33.0 and add libpathrs for runc

### DIFF
--- a/contrib/test/ci/build/libpathrs.yml
+++ b/contrib/test/ci/build/libpathrs.yml
@@ -1,0 +1,38 @@
+---
+# Download the build-libpathrs.sh script directly
+- name: download libpathrs build script
+  get_url:
+    url: "https://raw.githubusercontent.com/opencontainers/runc/496b68a3050547ff8365fb1231b81ff8153f4359/script/build-libpathrs.sh"
+    dest: "/tmp/build-libpathrs.sh"
+    mode: "0755"
+    checksum: "sha256:3685397177e21430ce17b0e063c7d127ee437b64078ef9e5ce0fb816b9ac1d85"
+
+# Download the lib.sh helper script required by build-libpathrs.sh
+- name: download lib.sh helper script
+  get_url:
+    url: "https://raw.githubusercontent.com/opencontainers/runc/496b68a3050547ff8365fb1231b81ff8153f4359/script/lib.sh"
+    dest: "/tmp/lib.sh"
+    mode: "0644"
+    checksum: "sha256:ae80403a66c1b94e9d984cd790cf0226efe3df6e16c76244464d3ac215237124"
+
+# Build and install libpathrs using the runc build script
+- name: build libpathrs
+  become: yes
+  shell: |
+    cd /tmp
+    ./build-libpathrs.sh 0.2.4 /usr
+  environment:
+    PATH: "/usr/local/bin:/usr/bin:/bin"
+    CARGO_HOME: "{{ ansible_env.HOME }}/.cargo"
+
+# Clean up libpathrs build artifacts
+- name: cleanup libpathrs build artifacts
+  become: yes
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "/tmp/libpathrs-0.2.4.tar.xz"
+    - "/tmp/libpathrs-0.2.4.tar.xz.asc"
+    - "/tmp/build-libpathrs.sh"
+    - "/tmp/lib.sh"

--- a/contrib/test/ci/setup.yml
+++ b/contrib/test/ci/setup.yml
@@ -16,6 +16,10 @@
   vars:
     force_clone: true
 
+- name: build and install libpathrs
+  include_tasks: "build/libpathrs.yml"
+  when: ansible_distribution in ['Fedora']
+
 - name: clone build and install runc
   include_tasks: "build/runc.yml"
 

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -13,7 +13,7 @@ use_conmonrs: "{{ USE_CONMONRS | default(False) | bool }}"
 evented_pleg_fg: "{{ EVENTED_PLEG | default(False) | bool }}"
 
 critest_mirror_repo: quay.io/crio
-cri_tools_git_version: master
+cri_tools_git_version: v1.33.0
 
 # For results.yml Paths use rsync 'source' conventions
 artifacts: "/tmp/artifacts" # Base-directory for collection

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -53,7 +53,7 @@ dependencies:
         match: conmon
 
   - name: cri-tools
-    version: master
+    version: v1.33.0
     refPaths:
       - path: contrib/test/ci/vars.yml
         match: cri_tools_git_version
@@ -63,6 +63,14 @@ dependencies:
     refPaths:
       - path: scripts/versions
         match: buildah
+
+  - name: libpathrs
+    version: 0.2.4
+    refPaths:
+      - path: scripts/versions
+        match: libpathrs
+      - path: contrib/test/ci/build/libpathrs.yml
+        match: build-libpathrs.sh
 
   - name: runc
     version: main

--- a/scripts/github-actions-packages
+++ b/scripts/github-actions-packages
@@ -11,6 +11,7 @@ sudo apt update
 sudo apt install -y \
     autoconf \
     automake \
+    cargo \
     conmon \
     criu \
     libaio-dev \
@@ -29,6 +30,10 @@ sudo apt install -y \
     libtool \
     libudev-dev \
     libyajl-dev \
+    lld \
+    make \
+    rustc \
     sed \
     socat \
-    uuid-dev
+    uuid-dev \
+    wget

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -16,6 +16,7 @@ main() {
     install_conmonrs
     install_critools
     install_crun
+    install_libpathrs
     install_runc
     install_ginkgo
     install_cni_plugins
@@ -94,7 +95,7 @@ install_critools() {
     install_from_github_org_repo \
         kubernetes-sigs \
         cri-tools \
-        master \
+        v1.33.0 \
         sudo -E PATH="$PATH" make BINDIR=/usr/bin install
 
     sudo critest --version
@@ -121,6 +122,43 @@ install_crun() {
     popd
     sudo rm -rf crun
     crun --version
+}
+
+# Installs libpathrs as required by runc
+# Refer: https://github.com/opencontainers/runc/pull/5103
+install_libpathrs() {
+    RUNC_COMMIT="496b68a3050547ff8365fb1231b81ff8153f4359"
+    LIBPATHRS_VERSION="${VERSIONS["libpathrs"]}"
+    BUILD_SCRIPT_SHA256="3685397177e21430ce17b0e063c7d127ee437b64078ef9e5ce0fb816b9ac1d85"
+    LIB_SH_SHA256="ae80403a66c1b94e9d984cd790cf0226efe3df6e16c76244464d3ac215237124"
+
+    # Download build-libpathrs.sh script
+    curl_retry "https://raw.githubusercontent.com/opencontainers/runc/$RUNC_COMMIT/script/build-libpathrs.sh" \
+        -o /tmp/build-libpathrs.sh
+
+    # Verify checksum for build-libpathrs.sh
+    echo "$BUILD_SCRIPT_SHA256  /tmp/build-libpathrs.sh" | sha256sum --check --strict
+
+    # Download lib.sh helper script
+    curl_retry "https://raw.githubusercontent.com/opencontainers/runc/$RUNC_COMMIT/script/lib.sh" \
+        -o /tmp/lib.sh
+
+    # Verify checksum for lib.sh
+    echo "$LIB_SH_SHA256  /tmp/lib.sh" | sha256sum --check --strict
+
+    # Make build script executable
+    sudo chmod +x /tmp/build-libpathrs.sh
+
+    # Build and install libpathrs
+    pushd /tmp
+    sudo ./build-libpathrs.sh "$LIBPATHRS_VERSION" /usr
+    popd
+
+    # Clean up
+    sudo rm -f /tmp/libpathrs-"$LIBPATHRS_VERSION".tar.xz \
+        /tmp/libpathrs-"$LIBPATHRS_VERSION".tar.xz.asc \
+        /tmp/build-libpathrs.sh \
+        /tmp/lib.sh
 }
 
 install_runc() {

--- a/scripts/versions
+++ b/scripts/versions
@@ -5,4 +5,5 @@ declare -A VERSIONS=(
     ["runc"]=main
     ["bats"]=v1.11.1
     ["buildah"]=v1.38.0
+    ["libpathrs"]=0.2.4
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Cherry-pick of #9813 to release-1.33. Pin cri-tools to v1.33.0 to avoid test regressions from master. Add libpathrs as a build dependency required by runc.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```