### PR TITLE
Make artifact pinned status respect pinned_images configuration

### DIFF
--- a/internal/ociartifact/artifact.go
+++ b/internal/ociartifact/artifact.go
@@ -28,10 +28,14 @@ type Artifact struct {
 
 	rootPath string
 	namedRef reference.Named
+
+	// pinned indicates whether this artifact should be excluded from
+	// garbage collection, based on the pinned_images configuration.
+	pinned bool
 }
 
-// NewArtifact creates a new Artifact from a libartifact.Artifact.
-func NewArtifact(art *libartifact.Artifact, rootPath string) *Artifact {
+// newArtifact creates a new Artifact from a libartifact.Artifact.
+func (s *Store) newArtifact(art *libartifact.Artifact, rootPath string, pinned bool) *Artifact {
 	artifact := &Artifact{
 		Artifact: art,
 		rootPath: rootPath,
@@ -48,6 +52,8 @@ func NewArtifact(art *libartifact.Artifact, rootPath string) *Artifact {
 
 		artifact.namedRef = namedRef
 	}
+
+	artifact.pinned = pinned || s.isArtifactPinned(artifact)
 
 	return artifact
 }
@@ -83,6 +89,6 @@ func (a *Artifact) CRIImage() *critypes.Image {
 		Size:        uint64(a.TotalSizeBytes()),
 		RepoTags:    repoTags,
 		RepoDigests: []string{a.CanonicalName()},
-		Pinned:      true,
+		Pinned:      a.pinned,
 	}
 }

--- a/internal/ociartifact/datastore/store.go
+++ b/internal/ociartifact/datastore/store.go
@@ -47,7 +47,7 @@ func New(rootPath string, systemContext *types.SystemContext) (*Store, error) {
 	// Additional read-only stores are not threaded through here (we pass
 	// nil for additionalPaths) since the datastore is used for in-memory
 	// artifact data managed by the main CRI-O lifecycle.
-	ociStore, err := ociartifact.NewStore(rootPath, nil, systemContext)
+	ociStore, err := ociartifact.NewStore(rootPath, nil, systemContext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create OCI artifact store: %w", err)
 	}

--- a/internal/ociartifact/store.go
+++ b/internal/ociartifact/store.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"slices"
+	"sync/atomic"
 
 	modelSpec "github.com/modelpack/model-spec/specs-go/v1"
 	"github.com/opencontainers/go-digest"
@@ -58,10 +60,15 @@ type Store struct {
 	// rootPath is required for BlobMountPaths.
 	rootPath         string
 	additionalStores []additionalStore
+
+	// pinnedImageRegexps holds compiled regexps from the pinned_images config.
+	// Access is via atomic.Pointer to allow concurrent reads during listing
+	// while the reload watcher updates the regexps.
+	pinnedImageRegexps atomic.Pointer[[]*regexp.Regexp]
 }
 
 // NewStore creates a new OCI artifact store.
-func NewStore(rootPath string, additionalPaths []string, systemContext *types.SystemContext) (*Store, error) {
+func NewStore(rootPath string, additionalPaths []string, systemContext *types.SystemContext, pinnedImageRegexps []*regexp.Regexp) (*Store, error) {
 	storePath := filepath.Join(rootPath, "artifacts")
 
 	store, err := libart.NewArtifactStore(storePath, systemContext)
@@ -88,12 +95,15 @@ func NewStore(rootPath string, additionalPaths []string, systemContext *types.Sy
 		})
 	}
 
-	return &Store{
+	s := &Store{
 		libartifactStore: &artifactStore{store},
-		impl:             &defaultImpl{},
 		rootPath:         storePath,
+		impl:             &defaultImpl{},
 		additionalStores: additional,
-	}, nil
+	}
+	s.SetPinnedImageRegexps(pinnedImageRegexps)
+
+	return s, nil
 }
 
 // Pull tries to pull the artifact and returns the manifest bytes if the
@@ -121,7 +131,8 @@ func (s *Store) Pull(
 			for _, add := range s.additionalStores {
 				if art, err := add.store.Inspect(ctx, artRef); err == nil {
 					log.Infof(ctx, "Artifact %s already exists in additional store %s, skipping pull", strRef, add.path)
-					dgst := NewArtifact(art, add.path).Digest()
+					// Force-pinned: additional stores are read-only and not subject to GC.
+					dgst := s.newArtifact(art, add.path, true).Digest()
 
 					return &dgst, nil
 				}
@@ -229,7 +240,8 @@ func (s *Store) List(ctx context.Context) (res []*Artifact, err error) {
 		}
 
 		for _, art := range addArts {
-			arts = append(arts, NewArtifact(art, add.path))
+			// Force-pinned: additional stores are read-only and not subject to GC.
+			arts = append(arts, s.newArtifact(art, add.path, true))
 		}
 	}
 
@@ -240,7 +252,7 @@ func (s *Store) List(ctx context.Context) (res []*Artifact, err error) {
 	}
 
 	for _, art := range mainArts {
-		arts = append(arts, NewArtifact(art, s.rootPath))
+		arts = append(arts, s.newArtifact(art, s.rootPath, false))
 	}
 
 	// Deduplicate by reference, preserving priority (additional stores
@@ -274,7 +286,8 @@ func (s *Store) Status(ctx context.Context, nameOrDigest string) (*Artifact, err
 	for _, add := range s.additionalStores {
 		artifact, err := add.store.Inspect(ctx, artRef)
 		if err == nil {
-			return NewArtifact(artifact, add.path), nil
+			// Force-pinned: additional stores are read-only and not subject to GC.
+			return s.newArtifact(artifact, add.path, true), nil
 		}
 
 		if errors.Is(err, ErrNotFound) {
@@ -287,7 +300,7 @@ func (s *Store) Status(ctx context.Context, nameOrDigest string) (*Artifact, err
 	// Check main store
 	artifact, err := s.libartifactStore.Inspect(ctx, artRef)
 	if err == nil {
-		return NewArtifact(artifact, s.rootPath), nil
+		return s.newArtifact(artifact, s.rootPath, false), nil
 	}
 
 	return nil, fmt.Errorf("inspect artifact: %w", err)
@@ -360,6 +373,34 @@ func artifactName(annotations map[string]string) string {
 	}
 
 	return ""
+}
+
+// SetPinnedImageRegexps updates the compiled regular expressions used to
+// determine whether an artifact should be pinned.
+func (s *Store) SetPinnedImageRegexps(regexps []*regexp.Regexp) {
+	if regexps == nil {
+		regexps = []*regexp.Regexp{}
+	}
+
+	s.pinnedImageRegexps.Store(&regexps)
+}
+
+// isArtifactPinned checks if the artifact's reference or canonical name
+// matches any of the configured pinned image patterns.
+// TODO: We should reuse storage.FilterPinnedImage, but we can't due to cyclic dependency.
+func (s *Store) isArtifactPinned(artifact *Artifact) bool {
+	regexps := s.pinnedImageRegexps.Load()
+	if regexps == nil {
+		return false
+	}
+
+	for _, re := range *regexps {
+		if re.MatchString(artifact.Reference()) || re.MatchString(artifact.CanonicalName()) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // RootPath returns the root path of the store.

--- a/internal/ociartifact/store_test.go
+++ b/internal/ociartifact/store_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"regexp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/common/pkg/libartifact"
 	"go.podman.io/image/v5/manifest"
 	"go.uber.org/mock/gomock"
 
@@ -123,7 +125,7 @@ var _ = t.Describe("Store", func() {
 
 			var err error
 
-			store, err = ociartifact.NewStore(t.MustTempDir("artifact"), nil, nil)
+			store, err = ociartifact.NewStore(t.MustTempDir("artifact"), nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			store.SetFakeImpl(implMock)
 		})
@@ -348,6 +350,186 @@ var _ = t.Describe("Store", func() {
 
 			// Then
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	t.Describe("Artifact pinning", func() {
+		var (
+			storeMock *ociartifactmock.MockLibartifactStore
+			mockCtrl  *gomock.Controller
+			store     *ociartifact.Store
+		)
+
+		makeLibArtifact := func(name string) *libartifact.Artifact {
+			return &libartifact.Artifact{
+				Name:     name,
+				Digest:   testDigest,
+				Manifest: &manifest.OCI1{},
+			}
+		}
+
+		BeforeEach(func() {
+			logrus.SetOutput(io.Discard)
+
+			mockCtrl = gomock.NewController(GinkgoT())
+			storeMock = ociartifactmock.NewMockLibartifactStore(mockCtrl)
+
+			var err error
+
+			store, err = ociartifact.NewStore(t.MustTempDir("artifact"), nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			store.SetFakeStore(&ociartifact.FakeLibartifactStore{storeMock})
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		It("should not pin artifacts when no pinned regexps are configured", func() {
+			// Given
+			storeMock.EXPECT().
+				List(gomock.Any()).
+				Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+
+			// When
+			arts, err := store.List(context.Background())
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts).To(HaveLen(1))
+			Expect(arts[0].CRIImage().GetPinned()).To(BeFalse())
+		})
+
+		It("should pin artifacts matching a pinned image regexp", func() {
+			// Given
+			store.SetPinnedImageRegexps([]*regexp.Regexp{
+				regexp.MustCompile(`nginx`),
+			})
+			storeMock.EXPECT().
+				List(gomock.Any()).
+				Return(libartifact.ArtifactList{makeLibArtifact("registry.example.com/nginx:latest")}, nil)
+
+			// When
+			arts, err := store.List(context.Background())
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts).To(HaveLen(1))
+			Expect(arts[0].CRIImage().GetPinned()).To(BeTrue())
+		})
+
+		It("should not pin artifacts that do not match any pinned image regexp", func() {
+			// Given
+			store.SetPinnedImageRegexps([]*regexp.Regexp{
+				regexp.MustCompile(`redis`),
+			})
+			storeMock.EXPECT().
+				List(gomock.Any()).
+				Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+
+			// When
+			arts, err := store.List(context.Background())
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts).To(HaveLen(1))
+			Expect(arts[0].CRIImage().GetPinned()).To(BeFalse())
+		})
+
+		It("should pin artifacts passed through NewStore constructor regexps", func() {
+			// Given
+			var err error
+
+			store, err = ociartifact.NewStore(t.MustTempDir("artifact"), nil, nil, []*regexp.Regexp{
+				regexp.MustCompile(`nginx`),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			store.SetFakeStore(&ociartifact.FakeLibartifactStore{storeMock})
+
+			storeMock.EXPECT().
+				List(gomock.Any()).
+				Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+
+			// When
+			arts, err := store.List(context.Background())
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts).To(HaveLen(1))
+			Expect(arts[0].CRIImage().GetPinned()).To(BeTrue())
+		})
+
+		It("should pin artifact matching by canonical name", func() {
+			// Given
+			store.SetPinnedImageRegexps([]*regexp.Regexp{
+				regexp.MustCompile(testDigest),
+			})
+			storeMock.EXPECT().
+				List(gomock.Any()).
+				Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+
+			// When
+			arts, err := store.List(context.Background())
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts).To(HaveLen(1))
+			Expect(arts[0].CRIImage().GetPinned()).To(BeTrue())
+		})
+
+		It("should pin Status result when matching", func() {
+			// Given
+			store.SetPinnedImageRegexps([]*regexp.Regexp{
+				regexp.MustCompile(`nginx`),
+			})
+			storeMock.EXPECT().
+				Inspect(gomock.Any(), gomock.Any()).
+				Return(makeLibArtifact("docker.io/library/nginx:latest"), nil)
+
+			// When
+			art, err := store.Status(context.Background(), testDigest)
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(art.CRIImage().GetPinned()).To(BeTrue())
+		})
+
+		It("should not pin Status result when not matching", func() {
+			// Given
+			storeMock.EXPECT().
+				Inspect(gomock.Any(), gomock.Any()).
+				Return(makeLibArtifact("docker.io/library/nginx:latest"), nil)
+
+			// When
+			art, err := store.Status(context.Background(), testDigest)
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(art.CRIImage().GetPinned()).To(BeFalse())
+		})
+
+		It("should reflect updated regexps after SetPinnedImageRegexps", func() {
+			// Given
+			storeMock.EXPECT().
+				List(gomock.Any()).
+				Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil).
+				Times(2)
+
+			// Initially no pinning
+			arts, err := store.List(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts[0].CRIImage().GetPinned()).To(BeFalse())
+
+			// When - update regexps
+			store.SetPinnedImageRegexps([]*regexp.Regexp{
+				regexp.MustCompile(`nginx`),
+			})
+
+			arts, err = store.List(context.Background())
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts[0].CRIImage().GetPinned()).To(BeTrue())
 		})
 	})
 })

--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -172,6 +172,9 @@ type ImageServer interface {
 	// UpdatePinnedImagesList updates pinned and pause images list in imageService.
 	UpdatePinnedImagesList(imageList []string)
 
+	// PinnedImageRegexps returns the compiled regular expressions for pinned images.
+	PinnedImageRegexps() []*regexp.Regexp
+
 	// IsRunningImageAllowed verifies if running of the container image is allowed.
 	//
 	// Arguments:
@@ -873,7 +876,11 @@ func pullImageImplementation(ctx context.Context, lookup *imageLookupService, st
 	if shouldTryArtifact(err) {
 		log.Infof(ctx, "Falling back to pull %s as an OCI artifact: %v", imageName, err)
 
-		artifactStore, artifactErr := ociartifact.NewStore(store.GraphRoot(), options.AdditionalArtifactStores, &srcSystemContext)
+		// TODO: pinnedImageRegexps is nil here because the image lookup service
+		//   does not have access to the compiled regexps. The pull result is not
+		//   used for image GC, but the store should ideally be configured at a
+		//   higher level where the regexps are available.
+		artifactStore, artifactErr := ociartifact.NewStore(store.GraphRoot(), options.AdditionalArtifactStores, &srcSystemContext, nil)
 		if artifactErr != nil {
 			return RegistryImageReference{}, fmt.Errorf("unable to pull image or OCI artifact: create store err: %w", artifactErr)
 		}
@@ -1096,6 +1103,10 @@ func (st nativeStorageTransport) ResolveReference(ref types.ImageReference) (typ
 // UpdatePinnedImagesList updates pinned images list in imageService.
 func (svc *imageService) UpdatePinnedImagesList(pinnedImages []string) {
 	svc.regexForPinnedImages = CompileRegexpsForPinnedImages(pinnedImages)
+}
+
+func (svc *imageService) PinnedImageRegexps() []*regexp.Regexp {
+	return svc.regexForPinnedImages
 }
 
 // FilterPinnedImage checks if the given image needs to be pinned

--- a/server/server.go
+++ b/server/server.go
@@ -457,7 +457,7 @@ func New(
 		os.Unsetenv("DBUS_SESSION_BUS_ADDRESS")
 	}
 
-	artifactStore, err := ociartifact.NewStore(containerServer.Store().GraphRoot(), config.AdditionalArtifactStores, config.SystemContext)
+	artifactStore, err := ociartifact.NewStore(containerServer.Store().GraphRoot(), config.AdditionalArtifactStores, config.SystemContext, containerServer.StorageImageServer().PinnedImageRegexps())
 	if err != nil {
 		return nil, err
 	}
@@ -634,6 +634,7 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			// ImageServer compiles the list with regex for both
 			// pinned and sandbox/pause images, we need to update them
 			s.ContainerServer.StorageImageServer().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
+			s.artifactStore.SetPinnedImageRegexps(s.ContainerServer.StorageImageServer().PinnedImageRegexps())
 			log.Infof(ctx, "Configuration reload completed")
 			// Print the current configuration.
 			tomlConfig, err := s.config.ToString()

--- a/test/mocks/criostorage/criostorage.go
+++ b/test/mocks/criostorage/criostorage.go
@@ -12,6 +12,7 @@ package criostoragemock
 import (
 	context "context"
 	reflect "reflect"
+	regexp "regexp"
 
 	storage "github.com/cri-o/cri-o/internal/storage"
 	types "go.podman.io/image/v5/types"
@@ -157,6 +158,20 @@ func (m *MockImageServer) ListImages(systemContext *types.SystemContext) ([]stor
 func (mr *MockImageServerMockRecorder) ListImages(systemContext any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockImageServer)(nil).ListImages), systemContext)
+}
+
+// PinnedImageRegexps mocks base method.
+func (m *MockImageServer) PinnedImageRegexps() []*regexp.Regexp {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PinnedImageRegexps")
+	ret0, _ := ret[0].([]*regexp.Regexp)
+	return ret0
+}
+
+// PinnedImageRegexps indicates an expected call of PinnedImageRegexps.
+func (mr *MockImageServerMockRecorder) PinnedImageRegexps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinnedImageRegexps", reflect.TypeOf((*MockImageServer)(nil).PinnedImageRegexps))
 }
 
 // PullImage mocks base method.

--- a/test/oci_artifacts.bats
+++ b/test/oci_artifacts.bats
@@ -34,7 +34,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 
 	crictl inspecti $ARTIFACT_IMAGE |
 		jq -e '
-		(.status.pinned == true) and
+		(.status.pinned == false) and
 		(.status.repoDigests | length == 1) and
 		(.status.repoTags | length == 1) and
 		(.status.size != "0")'
@@ -240,6 +240,86 @@ EOF
 	run ! crictl create "$pod_id" "$TESTDIR/container_config.json" "$TESTDATA/sandbox_config.json"
 
 	[[ "$output" == *"ImageVolumeMountFailed"*"does not exist in OCI artifact volume"* ]]
+}
+
+@test "artifact should be pinned when matching pinned_images" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned-artifact.conf"
+[crio.image]
+pinned_images = [ "$ARTIFACT_IMAGE" ]
+EOF
+
+	start_crio
+	crictl pull "$ARTIFACT_IMAGE"
+
+	crictl inspecti "$ARTIFACT_IMAGE" |
+		jq -e '.status.pinned == true'
+}
+
+@test "artifact should be pinned when matching pinned_images glob pattern" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned-artifact.conf"
+[crio.image]
+pinned_images = [ "quay.io/crio/artifact*" ]
+EOF
+
+	start_crio
+	crictl pull "$ARTIFACT_IMAGE"
+
+	crictl inspecti "$ARTIFACT_IMAGE" |
+		jq -e '.status.pinned == true'
+}
+
+@test "artifact should not be pinned when pinned_images does not match" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned-artifact.conf"
+[crio.image]
+pinned_images = [ "quay.io/crio/nonexistent:latest" ]
+EOF
+
+	start_crio
+	crictl pull "$ARTIFACT_IMAGE"
+
+	crictl inspecti "$ARTIFACT_IMAGE" |
+		jq -e '.status.pinned == false'
+}
+
+@test "artifact pinned status should update after config reload" {
+	start_crio
+	crictl pull "$ARTIFACT_IMAGE"
+
+	# Initially not pinned
+	crictl inspecti "$ARTIFACT_IMAGE" |
+		jq -e '.status.pinned == false'
+
+	# Add pinned_images config and reload
+	printf '[crio.image]\npinned_images = ["%s"]\n' "$ARTIFACT_IMAGE" > "$CRIO_CONFIG_DIR"/01-pin-artifact
+	reload_crio
+	wait_for_log "Configuration reload completed"
+
+	# Now should be pinned
+	crictl inspecti "$ARTIFACT_IMAGE" |
+		jq -e '.status.pinned == true'
+}
+
+@test "artifact pinned status should be removed after config reload" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned-artifact.conf"
+[crio.image]
+pinned_images = [ "$ARTIFACT_IMAGE" ]
+EOF
+
+	start_crio
+	crictl pull "$ARTIFACT_IMAGE"
+
+	# Initially pinned
+	crictl inspecti "$ARTIFACT_IMAGE" |
+		jq -e '.status.pinned == true'
+
+	# Remove pinned_images config and reload
+	printf '[crio.image]\npinned_images = []\n' > "$CRIO_CONFIG_DIR"/99-pinned-artifact.conf
+	reload_crio
+	wait_for_log "Configuration reload completed"
+
+	# Now should not be pinned
+	crictl inspecti "$ARTIFACT_IMAGE" |
+		jq -e '.status.pinned == false'
 }
 
 @test "should pull multi-architecture image" {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Previously, all OCI artifacts were hardcoded as Pinned: true in CRIImage(). This change makes artifacts respect the same pinned_images configuration used by regular container images, by having the artifact store check artifact names against the compiled pinned image regexps.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Respect the same pinned_images configuration used by regular container images
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image pinning via configuration to mark artifacts as pinned (prevents GC); supports exact refs, globs, and digest/name patterns.
  * Pinned state exposed in image/artifact status and propagated to CRI image output; pinning can be updated at runtime without restart.

* **Tests**
  * Added tests validating pin matching, status visibility, canonical/digest matching, and dynamic updates across config reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->