### PR TITLE
Add stateLock to protect container state from concurrent access

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -60,18 +60,27 @@ type Container struct {
 	conmonCgroupfsPath string
 	crioAnnotations    fields.Set
 	state              *ContainerState
-	opLock             sync.RWMutex // For handling the container OCI runtime state transitions (i.e: anything that needs to call OCI runtime)
-	metaLock           sync.RWMutex // For handling the internal oci.Container metadata. Currently only used for Spec and Resources fields
-	spec               *specs.Spec
-	idMappings         *idtools.IDMappings
-	terminal           bool
-	stdin              bool
-	stdinOnce          bool
-	created            bool
-	spoofed            bool
-	stopping           bool
-	stopDone           bool
-	stopLock           sync.Mutex
+	// stateLock protects the state pointer for memory-safe reads and writes.
+	// Use opLock to prevent data inconsistency.
+	// Do not acquire opLock while stateLock is being acquired.
+	stateLock sync.RWMutex
+	// opLock serializes OCI runtime operations on this container (create, start, stop,
+	// delete, update, pause, unpause, checkpoint, status queries, and stats collection).
+	// It is held across external runtime calls (e.g. runc/crun invocations) to prevent
+	// concurrent runtime operations from racing against each other for the same container.
+	// Do not acquire opLock while stateLock is being acquired.
+	opLock     sync.RWMutex
+	metaLock   sync.RWMutex // For handling the internal oci.Container metadata. Currently only used for Spec and Resources fields
+	spec       *specs.Spec
+	idMappings *idtools.IDMappings
+	terminal   bool
+	stdin      bool
+	stdinOnce  bool
+	created    bool
+	spoofed    bool
+	stopping   bool
+	stopDone   bool
+	stopLock   sync.Mutex
 	// stopTimeoutChan is used to update the stop timeout.
 	// After the container goes into the kill loop, the channel must not be used
 	// because it is not controlled by the timeout anymore.
@@ -339,7 +348,9 @@ func (c *Container) FromDisk() error {
 		logrus.Infof("PID information for container %s updated to %d %s", c.ID(), tmpState.InitPid, tmpState.InitStartTime)
 	}
 
-	c.state = tmpState
+	c.ModifyState(func(s *ContainerState) {
+		*s = *tmpState
+	})
 
 	return nil
 }
@@ -364,6 +375,26 @@ func (cstate *ContainerState) SetInitPid(pid int) error {
 	return nil
 }
 
+// SetContainerInitPid initializes the InitPid and InitStartTime for the
+// container while holding the stateLock.
+func (c *Container) SetContainerInitPid(pid int) error {
+	startTime, err := getPidStartTime(pid)
+	if err != nil {
+		return err
+	}
+
+	return c.ModifyStateWithError(func(s *ContainerState) error {
+		if s.InitPid != 0 || s.InitStartTime != "" {
+			return fmt.Errorf("pid and start time already initialized: %d %s", s.InitPid, s.InitStartTime)
+		}
+
+		s.InitPid = pid
+		s.InitStartTime = startTime
+
+		return nil
+	})
+}
+
 // StatePath returns the containers state.json path.
 func (c *Container) StatePath() string {
 	return filepath.Join(c.dir, "state.json")
@@ -381,7 +412,9 @@ func (c *Container) CheckpointedAt() time.Time {
 
 // SetCheckpointedAt sets the time of checkpointing.
 func (c *Container) SetCheckpointedAt(checkpointedAt time.Time) {
-	c.state.CheckpointedAt = checkpointedAt
+	c.ModifyState(func(s *ContainerState) {
+		s.CheckpointedAt = checkpointedAt
+	})
 }
 
 // Name returns the name of the container.
@@ -481,6 +514,48 @@ func (c *Container) StateNoLock() *ContainerState {
 	return c.state
 }
 
+// GetState returns a deep copy of the container's state, safe for reading outside of locks.
+// Accessing pointer fields other than ExitCode is not safe. Use the accessor.
+func (c *Container) GetState() ContainerState {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+
+	state := *c.state
+	if c.state.ExitCode != nil {
+		state.ExitCode = new(*c.state.ExitCode)
+	}
+
+	return state
+}
+
+// GetStatus returns the container's status, safe for reading outside of locks.
+func (c *Container) GetStatus() specs.ContainerState {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+
+	return c.state.Status
+}
+
+// ModifyState calls the provided function with the container's state
+// while holding the stateLock for writing, allowing safe mutation.
+// Must NOT run external/long-running (even if potentially) functions.
+func (c *Container) ModifyState(modify func(*ContainerState)) {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+
+	modify(c.state)
+}
+
+// ModifyStateWithError calls the provided function with the container's state
+// while holding the stateLock for writing, allowing safe mutation.
+// Must NOT run external/long-running (even if potentially) functions.
+func (c *Container) ModifyStateWithError(modify func(*ContainerState) error) error {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+
+	return modify(c.state)
+}
+
 // AddVolume adds a volume to list of container volumes.
 func (c *Container) AddVolume(v ContainerVolume) {
 	c.volumes = append(c.volumes, v)
@@ -526,10 +601,12 @@ func (c *Container) SetStartFailed(err error) {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 	// adjust finished and started times
-	c.state.Finished, c.state.Started = c.state.Created, c.state.Created
-	if err != nil {
-		c.state.Error = err.Error()
-	}
+	c.ModifyState(func(s *ContainerState) {
+		s.Finished, s.Started = s.Created, s.Created
+		if err != nil {
+			s.Error = err.Error()
+		}
+	})
 }
 
 // Description returns a description for the container.
@@ -998,7 +1075,9 @@ func (c *Container) SetMonitorProcess(ctx context.Context) {
 		return nil
 	}()
 	if err != nil {
-		c.state.ContainerMonitorProcess = nil
+		c.ModifyState(func(s *ContainerState) {
+			s.ContainerMonitorProcess = nil
+		})
 		log.Errorf(ctx, "Failed to load conmon process for container %s: %q", c.ID(), err)
 	}
 }

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -900,6 +900,212 @@ var _ = t.Describe("Container", func() {
 		})
 	})
 
+	t.Describe("GetState", func() {
+		It("should return a copy of the container state", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Status = oci.ContainerStateRunning
+			state.Pid = alwaysRunningPid
+			sut.SetState(state)
+
+			// When
+			stateCopy := sut.GetState()
+
+			// Then
+			Expect(stateCopy.Status).To(Equal(specs.ContainerState(oci.ContainerStateRunning)))
+			Expect(stateCopy.Pid).To(Equal(alwaysRunningPid))
+		})
+
+		It("should not be affected by subsequent state modifications", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Status = oci.ContainerStateRunning
+			sut.SetState(state)
+
+			// When
+			stateCopy := sut.GetState()
+			sut.ModifyState(func(s *oci.ContainerState) {
+				s.Status = oci.ContainerStateStopped
+			})
+
+			// Then - the copy should still have the original value
+			Expect(stateCopy.Status).To(Equal(specs.ContainerState(oci.ContainerStateRunning)))
+			Expect(sut.GetState().Status).To(Equal(specs.ContainerState(oci.ContainerStateStopped)))
+		})
+	})
+
+	t.Describe("GetStatus", func() {
+		It("should return the container status", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Status = oci.ContainerStateCreated
+			sut.SetState(state)
+
+			// When
+			status := sut.GetStatus()
+
+			// Then
+			Expect(status).To(Equal(specs.ContainerState(oci.ContainerStateCreated)))
+		})
+
+		It("should reflect status changes", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Status = oci.ContainerStateCreated
+			sut.SetState(state)
+
+			// When
+			sut.ModifyState(func(s *oci.ContainerState) {
+				s.Status = oci.ContainerStatePaused
+			})
+
+			// Then
+			Expect(sut.GetStatus()).To(Equal(specs.ContainerState(oci.ContainerStatePaused)))
+		})
+	})
+
+	t.Describe("ModifyState", func() {
+		It("should modify the container state", func() {
+			// Given
+			state := &oci.ContainerState{}
+			sut.SetState(state)
+
+			// When
+			now := time.Now()
+
+			sut.ModifyState(func(s *oci.ContainerState) {
+				s.Started = now
+				s.Status = oci.ContainerStateRunning
+			})
+
+			// Then
+			result := sut.GetState()
+			Expect(result.Started).To(Equal(now))
+			Expect(result.Status).To(Equal(specs.ContainerState(oci.ContainerStateRunning)))
+		})
+
+		It("should allow multiple fields to be set atomically", func() {
+			// Given
+			state := &oci.ContainerState{}
+			sut.SetState(state)
+
+			exitCode := int32(137)
+
+			// When
+			sut.ModifyState(func(s *oci.ContainerState) {
+				s.Status = oci.ContainerStateStopped
+				s.ExitCode = &exitCode
+				s.Finished = time.Now()
+				s.OOMKilled = true
+			})
+
+			// Then
+			result := sut.GetState()
+			Expect(result.Status).To(Equal(specs.ContainerState(oci.ContainerStateStopped)))
+			Expect(*result.ExitCode).To(Equal(int32(137)))
+			Expect(result.OOMKilled).To(BeTrue())
+		})
+	})
+
+	t.Describe("ModifyStateWithError", func() {
+		It("should return nil on success", func() {
+			// Given
+			state := &oci.ContainerState{}
+			sut.SetState(state)
+
+			// When
+			err := sut.ModifyStateWithError(func(s *oci.ContainerState) error {
+				s.Status = oci.ContainerStateRunning
+
+				return nil
+			})
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sut.GetStatus()).To(Equal(specs.ContainerState(oci.ContainerStateRunning)))
+		})
+
+		It("should propagate errors from the modify function", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Status = oci.ContainerStateCreated
+			sut.SetState(state)
+
+			expectedErr := errors.New("modification failed")
+
+			// When
+			err := sut.ModifyStateWithError(func(s *oci.ContainerState) error {
+				return expectedErr
+			})
+
+			// Then
+			Expect(err).To(Equal(expectedErr))
+		})
+
+		It("should not apply partial changes on error", func() {
+			// Given
+			state := &oci.ContainerState{}
+			state.Status = oci.ContainerStateCreated
+			sut.SetState(state)
+
+			// When - modify changes status then returns error
+			err := sut.ModifyStateWithError(func(s *oci.ContainerState) error {
+				s.Status = oci.ContainerStateRunning
+
+				return errors.New("rollback not automatic")
+			})
+
+			// Then - the state IS modified since there's no rollback mechanism
+			Expect(err).To(HaveOccurred())
+			// Note: ModifyStateWithError does not roll back; the caller is responsible
+			Expect(sut.GetStatus()).To(Equal(specs.ContainerState(oci.ContainerStateRunning)))
+		})
+	})
+
+	t.Describe("SetContainerInitPid", func() {
+		It("should succeed with a running pid", func() {
+			// Given
+			state := &oci.ContainerState{}
+			sut.SetState(state)
+
+			// When
+			err := sut.SetContainerInitPid(alwaysRunningPid)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+
+			result := sut.GetState()
+			Expect(result.InitPid).To(Equal(alwaysRunningPid))
+			Expect(result.InitStartTime).ToNot(BeEmpty())
+		})
+
+		It("should fail if already initialized", func() {
+			// Given
+			state := &oci.ContainerState{}
+			sut.SetState(state)
+			Expect(sut.SetContainerInitPid(alwaysRunningPid)).To(Succeed())
+
+			// When
+			err := sut.SetContainerInitPid(alwaysRunningPid)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already initialized"))
+		})
+
+		It("should fail with a non-running pid", func() {
+			// Given
+			state := &oci.ContainerState{}
+			sut.SetState(state)
+
+			// When
+			err := sut.SetContainerInitPid(neverRunningPid)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	t.Describe("SetAsDoneStopping", func() {
 		It("should complete without error when no watchers exist", func() {
 			// Given - No watchers registered

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -355,14 +355,18 @@ func (r *runtimeOCI) CreateContainer(ctx context.Context, c *Container, cgroupPa
 	}
 
 	// Now we know the container has started, save the pid to verify against future calls.
-	if err := c.state.SetInitPid(pid); err != nil {
+	if err := c.SetContainerInitPid(pid); err != nil {
 		return err
 	}
 
-	c.state.ContainerMonitorProcess, err = r.getConmonProcess(c)
+	conmonProcess, err := r.getConmonProcess(c)
 	if err != nil {
 		return err
 	}
+
+	c.ModifyState(func(s *ContainerState) {
+		s.ContainerMonitorProcess = conmonProcess
+	})
 
 	c.SetMonitorProcess(ctx)
 
@@ -403,7 +407,9 @@ func (r *runtimeOCI) StartContainer(ctx context.Context, c *Container) error {
 		return err
 	}
 
-	c.state.Started = time.Now()
+	c.ModifyState(func(s *ContainerState) {
+		s.Started = time.Now()
+	})
 
 	return nil
 }
@@ -938,15 +944,19 @@ func (r *runtimeOCI) StopContainer(ctx context.Context, c *Container, timeout in
 	defer span.End()
 
 	if c.Spoofed() {
-		c.state.Status = ContainerStateStopped
-		c.state.Finished = time.Now()
+		c.ModifyState(func(s *ContainerState) {
+			s.Status = ContainerStateStopped
+			s.Finished = time.Now()
+		})
 
 		return nil
 	}
 
 	// The initial container process either doesn't exist, or isn't ours.
 	if err := c.Living(); err != nil {
-		c.state.Finished = time.Now()
+		c.ModifyState(func(s *ContainerState) {
+			s.Finished = time.Now()
+		})
 
 		return nil
 	}
@@ -987,12 +997,14 @@ func (r *runtimeOCI) StopLoopForContainer(ctx context.Context, c *Container, bm 
 		// Kill the exec PIDs after the main container to avoid pod lifecycle regressions:
 		// Ref: https://github.com/kubernetes/kubernetes/issues/124743
 		c.KillExecPIDs()
-		c.state.Finished = time.Now()
+		c.ModifyState(func(s *ContainerState) {
+			s.Finished = time.Now()
+		})
 		c.opLock.Unlock()
 		c.SetAsDoneStopping()
 	}()
 
-	if c.state.Status == ContainerStatePaused {
+	if c.GetStatus() == ContainerStatePaused {
 		if _, err := r.runtimeCmd("resume", c.ID()); err != nil {
 			log.Errorf(ctx, "Failed to unpause container %s: %v", c.Name(), err)
 		}
@@ -1003,7 +1015,9 @@ func (r *runtimeOCI) StopLoopForContainer(ctx context.Context, c *Container, bm 
 		if err := c.Living(); err != nil {
 			// The initial container process either doesn't exist, or isn't ours.
 			// Set state accordingly.
-			c.state.Finished = time.Now()
+			c.ModifyState(func(s *ContainerState) {
+				s.Finished = time.Now()
+			})
 
 			return
 		}
@@ -1143,10 +1157,14 @@ func updateContainerStatusFromExitFile(c *Container) error {
 		return fmt.Errorf("failed to find container exit file for %s: %w", c.ID(), err)
 	}
 
-	c.state.Finished, err = getFinishedTime(fi)
+	finished, err := getFinishedTime(fi)
 	if err != nil {
 		return fmt.Errorf("failed to get finished time: %w", err)
 	}
+
+	c.ModifyState(func(s *ContainerState) {
+		s.Finished = finished
+	})
 
 	statusCodeStr, err := os.ReadFile(exitFilePath)
 	if err != nil {
@@ -1158,7 +1176,9 @@ func updateContainerStatusFromExitFile(c *Container) error {
 		return fmt.Errorf("status code conversion failed: %w", err)
 	}
 
-	c.state.ExitCode = new(int32(statusCode))
+	c.ModifyState(func(s *ContainerState) {
+		s.ExitCode = new(int32(statusCode))
+	})
 
 	return nil
 }
@@ -1191,11 +1211,16 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 			// went away we do not error out stopping kubernetes to recover.
 			// We always populate the fields below so kube can restart/reschedule
 			// containers failing.
-			c.state.Status = ContainerStateStopped
+			c.ModifyState(func(s *ContainerState) {
+				s.Status = ContainerStateStopped
+			})
+
 			if err := updateContainerStatusFromExitFile(c); err != nil {
 				log.Errorf(ctx, "Failed to update container status from exit file for %s: %v", c.ID(), err)
-				c.state.Finished = time.Now()
-				c.state.ExitCode = new(int32(255))
+				c.ModifyState(func(s *ContainerState) {
+					s.Finished = time.Now()
+					s.ExitCode = new(int32(255))
+				})
 			}
 
 			return nil, true, nil
@@ -1219,7 +1244,9 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 	}
 
 	if state.Status != ContainerStateStopped {
-		*c.state = *state
+		c.ModifyState(func(s *ContainerState) {
+			*s = *state
+		})
 		c.SetMonitorProcess(ctx)
 
 		return nil
@@ -1254,7 +1281,10 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 		return errors.New("state command returned nil")
 	}
 
-	*c.state = *state
+	c.ModifyState(func(s *ContainerState) {
+		*s = *state
+	})
+
 	if err != nil {
 		log.Warnf(ctx, "Failed to find container exit file for %v: %v", c.ID(), err)
 	} else {
@@ -1267,7 +1297,9 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 
 	oomFilePath := filepath.Join(c.bundlePath, "oom")
 	if _, err = os.Stat(oomFilePath); err == nil {
-		c.state.OOMKilled = true
+		c.ModifyState(func(s *ContainerState) {
+			s.OOMKilled = true
+		})
 
 		// Collect total metric
 		metrics.Instance().MetricContainersOOMTotalInc()
@@ -1714,9 +1746,11 @@ func (r *runtimeOCI) CheckpointContainer(ctx context.Context, c *Container, spec
 	c.SetCheckpointedAt(time.Now())
 
 	if !leaveRunning {
-		c.state.Status = ContainerStateStopped
-		c.state.ExitCode = new(int32(0))
-		c.state.Finished = c.CheckpointedAt()
+		c.ModifyState(func(s *ContainerState) {
+			s.Status = ContainerStateStopped
+			s.ExitCode = new(int32(0))
+			s.Finished = c.CheckpointedAt()
+		})
 	}
 
 	return nil
@@ -1750,8 +1784,10 @@ func (r *runtimeOCI) RestoreContainer(ctx context.Context, c *Container, cgroupP
 		return fmt.Errorf("error removing container %s winsz file: %w", c.ID(), err)
 	}
 
-	c.state.InitPid = 0
-	c.state.InitStartTime = ""
+	c.ModifyState(func(s *ContainerState) {
+		s.InitPid = 0
+		s.InitStartTime = ""
+	})
 
 	// It is possible to tell runc to place the CRIU log files
 	// at a custom location '--work-path'. But for restoring a
@@ -1772,19 +1808,21 @@ func (r *runtimeOCI) RestoreContainer(ctx context.Context, c *Container, cgroupP
 	}
 
 	// Once the container is restored, update the metadata
-	// 1. Container is running again
-	c.state.Status = ContainerStateRunning
-	// 2. Update PID of the container (without that stopping will fail)
+	// Update PID of the container (without that stopping will fail)
 	pid, err := ReadConmonPidFile(c)
 	if err != nil {
 		return err
 	}
 
-	c.state.Pid = pid
-	// 3. Reset ExitCode (also needed for stopping)
-	c.state.ExitCode = nil
-	// 4. Set start time (also restore time)
-	c.state.Started = time.Now()
+	c.ModifyState(func(s *ContainerState) {
+		// Container is running again
+		s.Status = ContainerStateRunning
+		s.Pid = pid
+		// Reset ExitCode (also needed for stopping)
+		s.ExitCode = nil
+		// Set start time (also restore time)
+		s.Started = time.Now()
+	})
 
 	return nil
 }

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -176,14 +176,18 @@ func (r *runtimePod) CreateContainer(ctx context.Context, c *Container, cgroupPa
 		return fmt.Errorf("create container: %w", err)
 	}
 	// Now we know the container has started, save the pid to verify against future calls.
-	if err := c.state.SetInitPid(int(resp.PID)); err != nil {
+	if err := c.SetContainerInitPid(int(resp.PID)); err != nil {
 		return fmt.Errorf("set init PID: %w", err)
 	}
 
-	c.state.ContainerMonitorProcess, err = r.getConmonrsProcess()
+	conmonProcess, err := r.getConmonrsProcess()
 	if err != nil {
 		return err
 	}
+
+	c.ModifyState(func(s *ContainerState) {
+		s.ContainerMonitorProcess = conmonProcess
+	})
 
 	c.SetMonitorProcess(ctx)
 

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -231,7 +231,7 @@ func (r *runtimeVM) CreateContainer(ctx context.Context, c *Container, cgroupPar
 		// Create the container
 		if resp, err := r.task.Create(taskCtx, request); err != nil {
 			createdCh <- errdefs.FromGRPC(err)
-		} else if err := c.state.SetInitPid(int(resp.GetPid())); err != nil {
+		} else if err := c.SetContainerInitPid(int(resp.GetPid())); err != nil {
 			createdCh <- err
 		}
 
@@ -339,7 +339,9 @@ func (r *runtimeVM) StartContainer(ctx context.Context, c *Container) error {
 		return err
 	}
 
-	c.state.Started = time.Now()
+	c.ModifyState(func(s *ContainerState) {
+		s.Started = time.Now()
+	})
 
 	// Spawn a goroutine waiting for the container to terminate. Once it
 	// happens, the container status is retrieved to be updated.
@@ -685,7 +687,9 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 
 		err := r.waitCtrTerminate(sig, stopCh, timeoutDuration)
 		if err == nil {
-			c.state.Finished = time.Now()
+			c.ModifyState(func(s *ContainerState) {
+				s.Finished = time.Now()
+			})
 
 			return nil
 		}
@@ -705,7 +709,9 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 		return err
 	}
 
-	c.state.Finished = time.Now()
+	c.ModifyState(func(s *ContainerState) {
+		s.Finished = time.Now()
+	})
 
 	return nil
 }
@@ -872,16 +878,21 @@ func (r *runtimeVM) updateContainerStatus(ctx context.Context, c *Container) err
 		status = ContainerStatePaused
 	}
 
-	c.state.Status = status
-	c.state.Finished = response.GetExitedAt().AsTime()
 	exitCode := int32(response.GetExitStatus())
-	c.state.ExitCode = &exitCode
-	c.state.Pid = int(response.GetPid())
+
+	c.ModifyState(func(s *ContainerState) {
+		s.Status = status
+		s.Finished = response.GetExitedAt().AsTime()
+		s.ExitCode = &exitCode
+		s.Pid = int(response.GetPid())
+	})
 
 	if exitCode != 0 {
 		oomFilePath := filepath.Join(c.bundlePath, "oom")
 		if _, err = os.Stat(oomFilePath); err == nil {
-			c.state.OOMKilled = true
+			c.ModifyState(func(s *ContainerState) {
+				s.OOMKilled = true
+			})
 
 			// Collect total metric
 			metrics.Instance().MetricContainersOOMTotalInc()

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -403,7 +403,7 @@ func (a *nriAPI) ListContainers() []nri.Container {
 	}
 
 	for _, ctr := range ctrList {
-		switch ctr.State().Status {
+		switch ctr.GetStatus() {
 		case oci.ContainerStateCreated, oci.ContainerStateRunning, oci.ContainerStatePaused:
 			containers = append(containers, &criContainer{
 				api: a,
@@ -450,7 +450,7 @@ func (a *nriAPI) UpdateContainer(ctx context.Context, u *api.ContainerUpdate) er
 		return nil
 	}
 
-	if s := ctr.State().Status; s != oci.ContainerStateRunning && s != oci.ContainerStateCreated {
+	if s := ctr.GetStatus(); s != oci.ContainerStateRunning && s != oci.ContainerStateCreated {
 		return nil
 	}
 
@@ -698,19 +698,19 @@ func (c *criContainer) GetStatus() *nri.ContainerStatus {
 		return status
 	}
 
-	cState := c.ctr.State()
+	cState := c.ctr.GetState()
 
 	switch cState.Status {
 	case oci.ContainerStateCreated:
 		status.State = api.ContainerState_CONTAINER_CREATED
-		status.CreatedAt = c.ctr.CreatedAt().UnixNano()
+		status.CreatedAt = cState.Created.UnixNano()
 	case oci.ContainerStateRunning, oci.ContainerStatePaused:
 		status.State = api.ContainerState_CONTAINER_RUNNING
-		status.CreatedAt = c.ctr.CreatedAt().UnixNano()
+		status.CreatedAt = cState.Created.UnixNano()
 		status.StartedAt = cState.Started.UnixNano()
 	case oci.ContainerStateStopped:
 		status.State = api.ContainerState_CONTAINER_STOPPED
-		status.CreatedAt = c.ctr.CreatedAt().UnixNano()
+		status.CreatedAt = cState.Created.UnixNano()
 		status.StartedAt = cState.Started.UnixNano()
 		status.FinishedAt = cState.Finished.UnixNano()
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Introduce stateLock RWMutex and ModifyState/GetStatus methods to protect concurrent access to container state.Status. ModifyState acquires the write lock and is used exclusively for runtime state transitions (created, running, stopped, paused).

All state modification across runtime_oci, runtime_pod, and runtime_vm are now wrapped with ModifyState. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This fixes the NRI livelock when one container is stuck due to interruptible sleep.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed the NRI livelock when one container is stuck due to interruptible sleep.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safe container state APIs: snapshot reads, status accessors, controlled mutation helpers, and guarded init-PID initialization.

* **Refactor**
  * Centralized state locking and routed container lifecycle state updates through the new locked APIs to improve concurrency safety.

* **Tests**
  * Added tests verifying state snapshot immutability, mutation semantics and error propagation, and init-PID initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->