### PR TITLE
WIP: Add inject_gomaxprocs config (static value approach)

### DIFF
--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -285,6 +285,10 @@ func mergeRuntimeConfig(config *libconfig.Config, ctx *cli.Context) error {
 		config.DefaultEnv = StringSliceTrySplit(ctx, "default-env")
 	}
 
+	if ctx.IsSet("inject-gomaxprocs") {
+		config.InjectGOMAXPROCS = ctx.Int64("inject-gomaxprocs")
+	}
+
 	if ctx.IsSet("default-sysctls") {
 		config.DefaultSysctls = StringSliceTrySplit(ctx, "default-sysctls")
 	}
@@ -1330,6 +1334,12 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 			Value:   cli.NewStringSlice(defConf.DefaultEnv...),
 			Usage:   "Additional environment variables to set for all containers.",
 			EnvVars: []string{"CONTAINER_DEFAULT_ENV"},
+		},
+		&cli.Int64Flag{
+			Name:    "inject-gomaxprocs",
+			Value:   defConf.InjectGOMAXPROCS,
+			Usage:   "Set GOMAXPROCS in burstable/best-effort pod containers to this value. Guaranteed pods are skipped. 0 to disable.",
+			EnvVars: []string{"CONTAINER_INJECT_GOMAXPROCS"},
 		},
 		&cli.StringFlag{
 			Name:      "container-attach-socket-dir",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -398,6 +398,14 @@ type RuntimeConfig struct {
 	// container image spec or in the container runtime configuration.
 	DefaultEnv []string `toml:"default_env"`
 
+	// InjectGOMAXPROCS sets the GOMAXPROCS environment variable in
+	// burstable and best-effort pod containers to the specified value.
+	// Guaranteed pods are skipped (they get exclusive CPUs via CPU Manager).
+	// The value is only injected if the container does not already have
+	// GOMAXPROCS set via the image or pod spec. Set to 0 to disable.
+	// Defaults to 0 (disabled).
+	InjectGOMAXPROCS int64 `toml:"inject_gomaxprocs"`
+
 	// Sysctls to add to all containers.
 	DefaultSysctls []string `toml:"default_sysctls"`
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -268,6 +268,11 @@ func initCrioTemplateConfig(c *Config) ([]*templateConfigValue, error) {
 			isDefaultValue: slices.Equal(dc.DefaultEnv, c.DefaultEnv),
 		},
 		{
+			templateString: templateStringCrioRuntimeInjectGOMAXPROCS,
+			group:          crioRuntimeConfig,
+			isDefaultValue: simpleEqual(dc.InjectGOMAXPROCS, c.InjectGOMAXPROCS),
+		},
+		{
 			templateString: templateStringCrioRuntimeSelinux,
 			group:          crioRuntimeConfig,
 			isDefaultValue: simpleEqual(dc.SELinux, c.SELinux),
@@ -988,6 +993,15 @@ const templateStringCrioRuntimeDefaultEnv = `# Additional environment variables 
 # container image spec or in the container runtime configuration.
 {{ $.Comment }}default_env = [
 {{ range $env := .DefaultEnv }}{{ $.Comment }}{{ printf "\t%q,\n" $env }}{{ end }}{{ $.Comment }}]
+
+`
+
+const templateStringCrioRuntimeInjectGOMAXPROCS = `# Sets the GOMAXPROCS environment variable in burstable and best-effort pod
+# containers to the specified value. Guaranteed pods are skipped. This helps
+# Go workloads on high-core-count machines avoid excessive thread scheduling
+# overhead. The value is only injected if the container does not already have
+# GOMAXPROCS set via the image or pod spec. Set to 0 to disable (default).
+{{ $.Comment }}inject_gomaxprocs = {{ .InjectGOMAXPROCS }}
 
 `
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -849,7 +849,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		return nil, err
 	}
 
-	volumeMounts, err := s.setupContainerEnvironmentAndWorkdir(ctx, specgen, containerConfig, containerImageConfig, containerInfo, mountPoint, mountLabel, linux, securityContext)
+	volumeMounts, err := s.setupContainerEnvironmentAndWorkdir(ctx, sb, specgen, containerConfig, containerImageConfig, containerInfo, mountPoint, mountLabel, linux, securityContext)
 	if err != nil {
 		return nil, err
 	}
@@ -1016,7 +1016,7 @@ func (s *Server) setupContainerMounts(ctr container.Container, sb *sandbox.Sandb
 	return nil
 }
 
-func (s *Server) setupContainerEnvironmentAndWorkdir(ctx context.Context, specgen *generate.Generator, containerConfig *types.ContainerConfig, containerImageConfig *v1.Image, containerInfo *storage.ContainerInfo, mountPoint, mountLabel string, linux *types.LinuxContainerConfig, securityContext *types.LinuxContainerSecurityContext) ([]rspec.Mount, error) {
+func (s *Server) setupContainerEnvironmentAndWorkdir(ctx context.Context, sb *sandbox.Sandbox, specgen *generate.Generator, containerConfig *types.ContainerConfig, containerImageConfig *v1.Image, containerInfo *storage.ContainerInfo, mountPoint, mountLabel string, linux *types.LinuxContainerConfig, securityContext *types.LinuxContainerSecurityContext) ([]rspec.Mount, error) {
 	// First add any configured environment variables from crio config.
 	// They will get overridden if specified in the image or container config.
 	specgen.AddMultipleProcessEnv(s.ContainerServer.Config().DefaultEnv)
@@ -1026,6 +1026,16 @@ func (s *Server) setupContainerEnvironmentAndWorkdir(ctx context.Context, specge
 	for _, e := range envs {
 		parts := strings.SplitN(e, "=", 2)
 		specgen.AddProcessEnv(parts[0], parts[1])
+	}
+
+	// Inject GOMAXPROCS for burstable/best-effort pods if configured and not already set.
+	// Guaranteed pods get exclusive CPUs via CPU Manager, so GOMAXPROCS is not needed.
+	maxProcs := s.ContainerServer.Config().InjectGOMAXPROCS
+	if maxProcs > 0 {
+		cgroupParent := sb.CgroupParent()
+		if strings.Contains(cgroupParent, "burstable") || strings.Contains(cgroupParent, "besteffort") {
+			injectGOMAXPROCS(ctx, specgen, envs, s.ContainerServer.Config().DefaultEnv, maxProcs)
+		}
 	}
 
 	// Setup user and groups
@@ -1062,6 +1072,25 @@ func (s *Server) setupContainerEnvironmentAndWorkdir(ctx context.Context, specge
 	}
 
 	return volumeMounts, nil
+}
+
+// injectGOMAXPROCS sets the GOMAXPROCS environment variable to the given value.
+// Injection is skipped if GOMAXPROCS is already set in defaultEnv, image, or pod spec.
+func injectGOMAXPROCS(ctx context.Context, specgen *generate.Generator, envs, defaultEnv []string, maxProcs int64) {
+	for _, env := range defaultEnv {
+		if strings.HasPrefix(env, "GOMAXPROCS=") {
+			return
+		}
+	}
+
+	for _, env := range envs {
+		if strings.HasPrefix(env, "GOMAXPROCS=") {
+			return
+		}
+	}
+
+	log.Infof(ctx, "Injecting GOMAXPROCS=%d", maxProcs)
+	specgen.AddProcessEnv("GOMAXPROCS", strconv.FormatInt(maxProcs, 10))
 }
 
 func (s *Server) setupSeccomp(ctx context.Context, ctr container.Container, sb *sandbox.Sandbox, containerID string, imgResult *storage.ImageResult, securityContext *types.LinuxContainerSecurityContext, specgen *generate.Generator) (string, error) {


### PR DESCRIPTION
## Summary

**Jira:** [OCPNODE-4221](https://redhat.atlassian.net/browse/OCPNODE-4221)

> **WIP — for review and discussion, not ready to merge.**

Adds an `inject_gomaxprocs` config option to CRI-O that sets a fixed `GOMAXPROCS` environment variable in burstable and best-effort pod containers. This addresses excessive Go thread scheduling overhead on high-core-count machines (64+ CPUs).

### Approach: Static Value

- Admin sets `inject_gomaxprocs = N` in `crio.conf`
- All burstable/best-effort containers get `GOMAXPROCS=N`
- Guaranteed pods are skipped (CPU Manager handles these)
- Existing GOMAXPROCS in pod spec or image is preserved
- `inject_gomaxprocs = 0` (default) disables the feature

### Why

On a 128-core host, burstable pods see `runtime.NumCPU()=128` and Go defaults `GOMAXPROCS=128`, creating 128 OS threads regardless of the pod's actual CPU request. Workload partitioning doesn't help — it only covers platform pods via the admission webhook.

### Test Results (128-vCPU host)

| Pod Type | CPU Request | Vanilla `GOMAXPROCS` | Patched `GOMAXPROCS` | Source |
|---|---|---|---|---|
| Burstable | 2 CPU | 128 | **4** | config value |
| Burstable | 500m | 128 | **4** | config value |
| Burstable | 8 CPU | 128 | **4** | config value |
| BestEffort | none | 128 | **4** | config value |
| Guaranteed | 2 CPU (limit) | 128 | 128 | skipped |
| Preset=16 | — | 16 | 16 | preserved |

Full report with Go diagnostic program output, CRI-O debug logs, and container inspect JSON: [Google Doc](https://docs.google.com/document/d/1JnI1C6Ah-tZGQQ4uW6-W0dbqZZthjFYUJDjGxjwWrcU/edit) (see "Approach 1: Static Value").

### Related

- See also: https://github.com/cri-o/cri-o/pull/9844 (dynamic calculation approach)
- RFE: [RFE-7881](https://redhat.atlassian.net/browse/RFE-7881)

🤖 Generated with [Claude Code](https://claude.com/claude-code)