### PR TITLE
Add supply chain attestation verification infrastructure

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -68,6 +68,7 @@ kata_skip_files:
   - "seccomp_notifier.bats"
   - "selinux.bats" # SELinux disabled with kata for now (see https://github.com/kata-containers/tests/issues/4248)
   - "shm_size.bats"
+  - "supply_chain.bats"
   - "timeout.bats"
   - "umask_annotation.bats"
   - "userns_annotation.bats"

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -351,7 +351,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--metrics-cert**="": Certificate for the secure metrics endpoint.
 
-**--metrics-collectors**="": Enabled metrics collectors. (default: "image_pulls_layer_size", "containers_events_dropped_total", "containers_oom_total", "processes_defunct", "operations_total", "operations_latency_seconds", "operations_latency_seconds_total", "operations_errors_total", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_failure_total", "image_pulls_success_total", "image_layer_reuse_total", "containers_oom_count_total", "containers_seccomp_notifier_count_total", "resources_stalled_at_stage", "containers_stopped_monitor_count", "default_runtime")
+**--metrics-collectors**="": Enabled metrics collectors. (default: "image_pulls_layer_size", "containers_events_dropped_total", "containers_oom_total", "processes_defunct", "operations_total", "operations_latency_seconds", "operations_latency_seconds_total", "operations_errors_total", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_failure_total", "image_pulls_success_total", "image_layer_reuse_total", "containers_oom_count_total", "containers_seccomp_notifier_count_total", "resources_stalled_at_stage", "containers_stopped_monitor_count", "default_runtime", "supply_chain_verification_total", "supply_chain_verification_duration_seconds", "supply_chain_cache_hits_total", "supply_chain_fetch_errors_total")
 
 **--metrics-host**="": Host for the metrics endpoint. (default: "127.0.0.1")
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -537,6 +537,25 @@ The valid values are "enforcing" and "disabled", and the default is "enforcing".
 If "enforcing", an image pull will fail if a short name is used, but the results are ambiguous.
 If "disabled", the first result will be chosen.
 
+### CRIO.IMAGE.SUPPLY_CHAIN TABLE
+
+The `crio.image.supply_chain` table contains settings for supply chain attestation verification of container images. When enabled, CRI-O can verify SLSA provenance, VEX, and VSA attestations before allowing containers to run. Actual attestation verification requires cosign/sigstore integration (see implementation phases in the tracking issue). This option supports live configuration reload.
+
+**verification**="disabled"
+Master toggle for supply chain verification. Valid values: "disabled" (default), "warn" (log-only), "enforce" (reject on failure). In "warn" mode, verification failures are logged but containers are allowed. In "enforce" mode, containers are rejected on verification failure.
+
+**fetch_timeout**="30s"
+Per-fetch timeout for retrieving attestations from OCI registries.
+
+**fetch_failure_policy**="warn"
+Behavior when attestation fetch fails due to network errors. Valid values: "allow", "warn" (default), "deny".
+
+**cache_ttl**="24h0m0s"
+How long verification results are cached per image digest and namespace. Set to 0 to disable caching.
+
+**policy_dir**="/etc/crio/supply-chain-policies"
+Path to the directory containing JSON policy files for per-namespace verification settings. `<dir>/default.json` is the base policy, `<dir>/<namespace>.json` overrides it for that namespace. Must be an absolute path. Namespace policies are full overrides, not merged with `default.json`. The Kubernetes `"default"` namespace uses `default.json` (same as namespaces without a dedicated policy file). Policy files support the following fields: `trust` (`{"builders", "verifiers", "issuers", "sources", "build_types"}`), `exclude` (list of glob patterns for images that skip verification; uses `path.Match` semantics where `*` matches a single path segment, not crossing `/`), `provenance` (`{"missing_policy", "reject_unknown_parameters"}`), `vex` (`{"severity_threshold", "missing_policy", "under_investigation_policy"}`), `vsa` (`{"minimum_level", "max_age", "policy"}`), `signatures` (`{"require_transparency_log"}`).
+
 ## CRIO.NETWORK TABLE
 
 The `crio.network` table containers settings pertaining to the management of CNI plugins.

--- a/internal/supplychain/cache.go
+++ b/internal/supplychain/cache.go
@@ -1,0 +1,113 @@
+package supplychain
+
+import (
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// cacheKey combines image digest and namespace for per-namespace caching.
+type cacheKey struct {
+	digest    string
+	namespace string
+}
+
+// cacheEntry holds a cached verification result with expiry.
+type cacheEntry struct {
+	result    *Result
+	expiresAt time.Time
+}
+
+// maxCacheSize is the maximum number of entries allowed in the cache.
+// This prevents unbounded memory growth on nodes with many unique images.
+const maxCacheSize = 10000
+
+// Cache stores supply chain verification results with TTL-based expiry.
+type Cache struct {
+	mu      sync.Mutex
+	entries map[cacheKey]cacheEntry
+	ttl     time.Duration
+}
+
+// NewCache creates a new verification result cache with the given TTL.
+func NewCache(ttl time.Duration) *Cache {
+	return &Cache{
+		entries: make(map[cacheKey]cacheEntry),
+		ttl:     ttl,
+	}
+}
+
+// Get retrieves a cached result for the given digest and namespace.
+// Returns nil if no valid cache entry exists. Expired entries are evicted.
+func (c *Cache) Get(digest, namespace string) *Result {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := cacheKey{digest: digest, namespace: namespace}
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil
+	}
+
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, key)
+
+		return nil
+	}
+
+	return entry.result
+}
+
+// Set stores a verification result in the cache.
+func (c *Cache) Set(digest, namespace string, result *Result) {
+	if c.ttl <= 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Evict expired entries if the cache is at capacity.
+	if len(c.entries) >= maxCacheSize {
+		c.evictExpiredLocked()
+	}
+
+	// If still at capacity after eviction, skip caching this entry
+	// rather than growing unboundedly.
+	if len(c.entries) >= maxCacheSize {
+		logrus.WithFields(logrus.Fields{
+			"capacity":  maxCacheSize,
+			"namespace": namespace,
+			"digest":    digest,
+		}).Warn("Supply chain verification cache at capacity, dropping entry")
+
+		return
+	}
+
+	key := cacheKey{digest: digest, namespace: namespace}
+	c.entries[key] = cacheEntry{
+		result:    result,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+// evictExpiredLocked removes all expired entries. Caller must hold c.mu.
+func (c *Cache) evictExpiredLocked() {
+	now := time.Now()
+
+	for k, e := range c.entries {
+		if now.After(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+}
+
+// Clear removes all cached entries. Used in tests.
+func (c *Cache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries = make(map[cacheKey]cacheEntry)
+}

--- a/internal/supplychain/cache_test.go
+++ b/internal/supplychain/cache_test.go
@@ -1,0 +1,134 @@
+package supplychain_test
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cri-o/cri-o/internal/supplychain"
+)
+
+var _ = Describe("Cache", func() {
+	var cache *supplychain.Cache
+
+	newAllowed := func() *supplychain.Result {
+		return &supplychain.Result{Allowed: true, Reason: "test pass"}
+	}
+
+	newDenied := func() *supplychain.Result {
+		return &supplychain.Result{Allowed: false, Reason: "test fail"}
+	}
+
+	Describe("with a positive TTL", func() {
+		BeforeEach(func() {
+			cache = supplychain.NewCache(1 * time.Hour)
+		})
+
+		It("should return nil for a cache miss", func() {
+			Expect(cache.Get("sha256:abc", "default")).To(BeNil())
+		})
+
+		It("should return a cached result after Set", func() {
+			cache.Set("sha256:abc", "default", newAllowed())
+			result := cache.Get("sha256:abc", "default")
+			Expect(result).ToNot(BeNil())
+			Expect(result.Allowed).To(BeTrue())
+			Expect(result.Reason).To(Equal("test pass"))
+		})
+
+		It("should distinguish entries by digest", func() {
+			cache.Set("sha256:aaa", "default", newAllowed())
+			cache.Set("sha256:bbb", "default", newDenied())
+
+			Expect(cache.Get("sha256:aaa", "default").Allowed).To(BeTrue())
+			Expect(cache.Get("sha256:bbb", "default").Allowed).To(BeFalse())
+		})
+
+		It("should distinguish entries by namespace", func() {
+			cache.Set("sha256:abc", "ns1", newAllowed())
+			cache.Set("sha256:abc", "ns2", newDenied())
+
+			Expect(cache.Get("sha256:abc", "ns1").Allowed).To(BeTrue())
+			Expect(cache.Get("sha256:abc", "ns2").Allowed).To(BeFalse())
+		})
+
+		It("should return nil for a different namespace", func() {
+			cache.Set("sha256:abc", "ns1", newAllowed())
+			Expect(cache.Get("sha256:abc", "ns2")).To(BeNil())
+		})
+
+		It("should clear all entries", func() {
+			cache.Set("sha256:aaa", "default", newAllowed())
+			cache.Set("sha256:bbb", "other", newDenied())
+			cache.Clear()
+			Expect(cache.Get("sha256:aaa", "default")).To(BeNil())
+			Expect(cache.Get("sha256:bbb", "other")).To(BeNil())
+		})
+
+		It("should overwrite existing entries", func() {
+			cache.Set("sha256:abc", "default", newAllowed())
+			cache.Set("sha256:abc", "default", newDenied())
+			result := cache.Get("sha256:abc", "default")
+			Expect(result).ToNot(BeNil())
+			Expect(result.Allowed).To(BeFalse())
+		})
+	})
+
+	Describe("with expired entries", func() {
+		It("should return nil and evict expired entries", func() {
+			cache = supplychain.NewCache(1 * time.Nanosecond)
+			cache.Set("sha256:abc", "default", newAllowed())
+			time.Sleep(2 * time.Millisecond)
+			Expect(cache.Get("sha256:abc", "default")).To(BeNil())
+		})
+	})
+
+	Describe("with size limit", func() {
+		It("should stop accepting new entries when at capacity", func() {
+			cache = supplychain.NewCache(1 * time.Hour)
+
+			// Fill the cache to capacity.
+			for i := range 10000 {
+				cache.Set(fmt.Sprintf("sha256:%d", i), "default", newAllowed())
+			}
+
+			// New entry beyond capacity should be silently dropped.
+			cache.Set("sha256:overflow", "default", newAllowed())
+			Expect(cache.Get("sha256:overflow", "default")).To(BeNil())
+		})
+	})
+
+	Describe("with zero TTL", func() {
+		It("should not store entries", func() {
+			cache = supplychain.NewCache(0)
+			cache.Set("sha256:abc", "default", newAllowed())
+			Expect(cache.Get("sha256:abc", "default")).To(BeNil())
+		})
+	})
+
+	Describe("concurrent access", func() {
+		It("should handle concurrent reads and writes safely", func() {
+			cache = supplychain.NewCache(1 * time.Hour)
+
+			var wg sync.WaitGroup
+
+			for range 100 {
+				wg.Go(func() {
+					cache.Set("sha256:abc", "default", newAllowed())
+				})
+				wg.Go(func() {
+					cache.Get("sha256:abc", "default")
+				})
+			}
+
+			wg.Go(func() {
+				cache.Clear()
+			})
+
+			wg.Wait()
+		})
+	})
+})

--- a/internal/supplychain/config.go
+++ b/internal/supplychain/config.go
@@ -1,0 +1,86 @@
+package supplychain
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/cri-o/cri-o/utils"
+)
+
+// Config represents the "crio.image.supply_chain" TOML config table.
+type Config struct {
+	// Verification is the master toggle for supply chain verification.
+	// Valid values: "disabled" (default), "warn" (log-only), "enforce" (reject on failure).
+	Verification string `toml:"verification"`
+	// FetchTimeout is the per-fetch timeout for retrieving attestations.
+	// SLSA and VEX fetches run in parallel, each gets this timeout independently.
+	FetchTimeout time.Duration `toml:"fetch_timeout"`
+	// FetchFailurePolicy controls behavior when attestation fetch fails due to
+	// network errors. Valid values: "allow", "warn" (default), "deny".
+	FetchFailurePolicy string `toml:"fetch_failure_policy"`
+	// CacheTTL is how long verification results are cached per image digest + namespace.
+	CacheTTL time.Duration `toml:"cache_ttl"`
+	// PolicyDir is the path to the directory containing JSON policy files for
+	// per-namespace verification settings and trust roots. <dir>/default.json is the
+	// base policy, <dir>/<namespace>.json overrides it for that namespace.
+	PolicyDir string `toml:"policy_dir"`
+}
+
+// DefaultConfig returns the default supply chain verification config.
+func DefaultConfig() Config {
+	return Config{
+		Verification:       "disabled",
+		FetchTimeout:       30 * time.Second,
+		FetchFailurePolicy: "warn",
+		CacheTTL:           24 * time.Hour,
+		PolicyDir:          "/etc/crio/supply-chain-policies",
+	}
+}
+
+// Enabled returns true if supply chain verification is not disabled.
+func (c *Config) Enabled() bool {
+	return c.Verification != "disabled"
+}
+
+// Validate checks the Config for invalid values.
+func (c *Config) Validate(onExecution bool) error {
+	switch c.Verification {
+	case "disabled", "warn", "enforce":
+	default:
+		return fmt.Errorf("invalid supply chain verification mode %q", c.Verification)
+	}
+
+	if !c.Enabled() {
+		return nil
+	}
+
+	if err := validatePolicyValue("fetch_failure_policy", c.FetchFailurePolicy); err != nil {
+		return err
+	}
+
+	if c.FetchTimeout <= 0 {
+		return fmt.Errorf("supply chain fetch_timeout must be positive, got %s", c.FetchTimeout)
+	}
+
+	if c.CacheTTL < 0 {
+		return fmt.Errorf("supply chain cache_ttl must be non-negative, got %s", c.CacheTTL)
+	}
+
+	if c.PolicyDir == "" {
+		return errors.New("supply chain policy_dir must not be empty when verification is enabled")
+	}
+
+	if !filepath.IsAbs(c.PolicyDir) {
+		return fmt.Errorf("supply chain policy_dir %q is not absolute", c.PolicyDir)
+	}
+
+	if onExecution {
+		if err := utils.IsDirectory(c.PolicyDir); err != nil {
+			return fmt.Errorf("invalid supply chain policy_dir %q: %w", c.PolicyDir, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/supplychain/config_test.go
+++ b/internal/supplychain/config_test.go
@@ -1,0 +1,86 @@
+package supplychain_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cri-o/cri-o/internal/supplychain"
+)
+
+const invalidValue = "invalid"
+
+var _ = Describe("Config", func() {
+	var cfg supplychain.Config
+
+	BeforeEach(func() {
+		cfg = supplychain.DefaultConfig()
+	})
+
+	Describe("DefaultConfig", func() {
+		It("should have verification disabled", func() {
+			Expect(cfg.Verification).To(Equal("disabled"))
+			Expect(cfg.Enabled()).To(BeFalse())
+		})
+	})
+
+	Describe("Validate", func() {
+		It("should pass with defaults (disabled)", func() {
+			Expect(cfg.Validate(false)).To(Succeed())
+		})
+
+		It("should accept valid verification modes", func() {
+			for _, mode := range []string{"disabled", "warn", "enforce"} {
+				cfg.Verification = mode
+				Expect(cfg.Validate(false)).To(Succeed())
+			}
+		})
+
+		It("should reject invalid verification mode", func() {
+			cfg.Verification = invalidValue
+			Expect(cfg.Validate(false)).To(MatchError(ContainSubstring("invalid supply chain verification mode")))
+		})
+
+		Context("when verification is enabled", func() {
+			BeforeEach(func() {
+				cfg.Verification = "enforce"
+			})
+
+			It("should pass with valid defaults", func() {
+				Expect(cfg.Validate(false)).To(Succeed())
+			})
+
+			It("should reject invalid fetch_failure_policy", func() {
+				cfg.FetchFailurePolicy = invalidValue
+				Expect(cfg.Validate(false)).To(MatchError(ContainSubstring("fetch_failure_policy")))
+			})
+
+			It("should reject non-positive fetch_timeout", func() {
+				cfg.FetchTimeout = 0
+				Expect(cfg.Validate(false)).To(MatchError(ContainSubstring("fetch_timeout must be positive")))
+			})
+
+			It("should reject negative cache_ttl", func() {
+				cfg.CacheTTL = -1
+				Expect(cfg.Validate(false)).To(MatchError(ContainSubstring("cache_ttl must be non-negative")))
+			})
+
+			It("should reject relative policy_dir", func() {
+				cfg.PolicyDir = "relative/path"
+				Expect(cfg.Validate(false)).To(MatchError(ContainSubstring("not absolute")))
+			})
+
+			It("should reject empty policy_dir", func() {
+				cfg.PolicyDir = ""
+				Expect(cfg.Validate(false)).To(MatchError(ContainSubstring("policy_dir must not be empty")))
+			})
+		})
+
+		Context("when verification is disabled", func() {
+			It("should skip all further validation", func() {
+				cfg.Verification = "disabled"
+				cfg.FetchFailurePolicy = invalidValue
+				Expect(cfg.Validate(false)).To(Succeed())
+			})
+		})
+	})
+})

--- a/internal/supplychain/metrics.go
+++ b/internal/supplychain/metrics.go
@@ -1,0 +1,46 @@
+package supplychain
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	// VerificationTotal counts supply chain verification attempts by type and result.
+	VerificationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "crio",
+			Name:      "supply_chain_verification_total",
+			Help:      "Total number of supply chain verification attempts.",
+		},
+		[]string{"type", "result"},
+	)
+
+	// VerificationDuration measures supply chain verification latency by type.
+	VerificationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "crio",
+			Name:      "supply_chain_verification_duration_seconds",
+			Help:      "Duration of supply chain verification in seconds.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"type"},
+	)
+
+	// CacheHitsTotal counts cache hits for supply chain verification results.
+	CacheHitsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "crio",
+			Name:      "supply_chain_cache_hits_total",
+			Help:      "Total number of supply chain verification cache hits.",
+		},
+	)
+
+	// FetchErrorsTotal counts attestation fetch errors by type.
+	// Currently unused; will be incremented once cosign attestation fetching is implemented.
+	FetchErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "crio",
+			Name:      "supply_chain_fetch_errors_total",
+			Help:      "Total number of supply chain attestation fetch errors.",
+		},
+		[]string{"type"},
+	)
+)

--- a/internal/supplychain/policy.go
+++ b/internal/supplychain/policy.go
@@ -1,0 +1,282 @@
+package supplychain
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Policy defines the trust roots and per-namespace verification settings.
+// Loaded from JSON files in the policy directory.
+type Policy struct {
+	// Trust contains trust roots for verification (builders, verifiers, issuers, etc.).
+	Trust *TrustPolicy `json:"trust,omitempty"`
+
+	// Exclude is a list of glob patterns for images that skip verification.
+	Exclude []string `json:"exclude,omitempty"`
+
+	// Provenance contains SLSA provenance verification settings.
+	Provenance *ProvenancePolicy `json:"provenance,omitempty"`
+	// VEX contains VEX verification settings.
+	VEX *VEXPolicy `json:"vex,omitempty"`
+	// VSA contains Verification Summary Attestation settings.
+	VSA *VSAPolicy `json:"vsa,omitempty"`
+	// Signatures contains attestation signature verification settings.
+	Signatures *SignaturesPolicy `json:"signatures,omitempty"`
+}
+
+// TrustPolicy contains trust roots for verification.
+type TrustPolicy struct {
+	// Builders is the list of trusted SLSA provenance builders.
+	Builders []TrustedBuilder `json:"builders"`
+	// Verifiers is the list of trusted VSA verifiers.
+	Verifiers []TrustedVerifier `json:"verifiers"`
+	// Issuers is the list of trusted signing identity issuers (Fulcio/OIDC).
+	Issuers []string `json:"issuers"`
+	// Sources is a list of allowed source repository patterns.
+	Sources []string `json:"sources"`
+	// BuildTypes is a list of accepted build type URIs.
+	BuildTypes []string `json:"build_types"`
+}
+
+// ProvenancePolicy contains SLSA provenance verification settings.
+type ProvenancePolicy struct {
+	// MissingPolicy controls behavior when no provenance attestation is found.
+	// Valid values: "allow" (default), "warn", "deny".
+	MissingPolicy string `json:"missing_policy,omitempty"`
+	// RejectUnknownParameters rejects provenance with unrecognized externalParameters fields.
+	RejectUnknownParameters bool `json:"reject_unknown_parameters,omitempty"`
+}
+
+// VEXPolicy contains VEX verification settings.
+type VEXPolicy struct {
+	// SeverityThreshold is the minimum severity at which an "affected" VEX status
+	// triggers rejection. Valid values: "low", "medium", "high", "critical".
+	// Defaults to "critical" if empty.
+	SeverityThreshold string `json:"severity_threshold,omitempty"`
+	// MissingPolicy controls behavior when no VEX attestation is found.
+	// Valid values: "allow" (default), "warn", "deny".
+	MissingPolicy string `json:"missing_policy,omitempty"`
+	// UnderInvestigationPolicy controls behavior for VEX "under_investigation" status.
+	// Valid values: "allow" (default), "warn", "deny".
+	UnderInvestigationPolicy string `json:"under_investigation_policy,omitempty"`
+}
+
+// VSAPolicy contains Verification Summary Attestation settings.
+type VSAPolicy struct {
+	// MinimumLevel is the minimum SLSA level required in VSA verifiedLevels (0-3).
+	MinimumLevel int `json:"minimum_level,omitempty"`
+	// MaxAge is the maximum age of a VSA's timeVerified before it's considered stale.
+	// Uses Go duration format (e.g., "168h"). Defaults to "168h" if empty.
+	MaxAge string `json:"max_age,omitempty"`
+	// Policy is the expected policy URI in the VSA.
+	Policy string `json:"policy,omitempty"`
+}
+
+// SignaturesPolicy contains attestation signature verification settings.
+type SignaturesPolicy struct {
+	// RequireTransparencyLog requires Rekor transparency log inclusion.
+	RequireTransparencyLog bool `json:"require_transparency_log,omitempty"`
+}
+
+// TrustedBuilder represents a trusted SLSA provenance builder.
+type TrustedBuilder struct {
+	// ID is the builder identity URI (e.g., "https://github.com/actions/runner").
+	ID string `json:"id"`
+	// MaxLevel is the maximum SLSA level this builder can attest to (0-3).
+	MaxLevel int `json:"max_level"`
+}
+
+// TrustedVerifier represents a trusted VSA verifier.
+type TrustedVerifier struct {
+	// ID is the verifier identity URI.
+	ID string `json:"id"`
+	// Key is the path to the verifier's public key file.
+	Key string `json:"key"`
+}
+
+// ProvenanceMissingPolicy returns the effective provenance missing policy,
+// defaulting to "allow" if not set.
+func (p *Policy) ProvenanceMissingPolicy() string {
+	if p.Provenance != nil && p.Provenance.MissingPolicy != "" {
+		return p.Provenance.MissingPolicy
+	}
+
+	return "allow"
+}
+
+// Builders returns the trusted builders list, or nil if trust is not configured.
+func (p *Policy) Builders() []TrustedBuilder {
+	if p.Trust != nil {
+		return p.Trust.Builders
+	}
+
+	return nil
+}
+
+// Validate checks the policy for invalid values.
+func (p *Policy) Validate() error {
+	if p.Trust != nil {
+		for i, b := range p.Trust.Builders {
+			if b.ID == "" {
+				return fmt.Errorf("trust.builders[%d]: id is required", i)
+			}
+
+			if b.MaxLevel < 0 || b.MaxLevel > 3 {
+				return fmt.Errorf("trust.builders[%d] %q: max_level must be 0-3, got %d", i, b.ID, b.MaxLevel)
+			}
+		}
+
+		for i, v := range p.Trust.Verifiers {
+			if v.ID == "" {
+				return fmt.Errorf("trust.verifiers[%d]: id is required", i)
+			}
+
+			if v.Key == "" {
+				return fmt.Errorf("trust.verifiers[%d] %q: key is required", i, v.ID)
+			}
+
+			if !filepath.IsAbs(v.Key) {
+				return fmt.Errorf("trust.verifiers[%d] %q: key must be an absolute path, got %q", i, v.ID, v.Key)
+			}
+		}
+	}
+
+	for _, pattern := range p.Exclude {
+		if _, err := path.Match(pattern, ""); err != nil {
+			return fmt.Errorf("invalid exclude pattern %q: %w", pattern, err)
+		}
+	}
+
+	if p.Provenance != nil {
+		if p.Provenance.MissingPolicy != "" {
+			if err := validatePolicyValue("provenance.missing_policy", p.Provenance.MissingPolicy); err != nil {
+				return err
+			}
+		}
+	}
+
+	if p.VEX != nil {
+		if p.VEX.SeverityThreshold != "" {
+			switch p.VEX.SeverityThreshold {
+			case "low", "medium", "high", "critical":
+			default:
+				return fmt.Errorf("invalid vex.severity_threshold %q", p.VEX.SeverityThreshold)
+			}
+		}
+
+		if p.VEX.MissingPolicy != "" {
+			if err := validatePolicyValue("vex.missing_policy", p.VEX.MissingPolicy); err != nil {
+				return err
+			}
+		}
+
+		if p.VEX.UnderInvestigationPolicy != "" {
+			if err := validatePolicyValue("vex.under_investigation_policy", p.VEX.UnderInvestigationPolicy); err != nil {
+				return err
+			}
+		}
+	}
+
+	if p.VSA != nil {
+		if p.VSA.MinimumLevel < 0 || p.VSA.MinimumLevel > 3 {
+			return fmt.Errorf("invalid vsa.minimum_level %d, must be 0-3", p.VSA.MinimumLevel)
+		}
+
+		if p.VSA.MaxAge != "" {
+			if _, err := time.ParseDuration(p.VSA.MaxAge); err != nil {
+				return fmt.Errorf("invalid vsa.max_age %q: %w", p.VSA.MaxAge, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validatePolicyValue(name, value string) error {
+	switch value {
+	case "allow", "warn", "deny":
+		return nil
+	default:
+		return fmt.Errorf("invalid %s %q", name, value)
+	}
+}
+
+// LoadPolicy loads and validates a policy file from disk.
+func LoadPolicy(policyPath string) (*Policy, error) {
+	data, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading policy file %q: %w", policyPath, err)
+	}
+
+	var p Policy
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	if err := dec.Decode(&p); err != nil {
+		return nil, fmt.Errorf("parsing policy file %q: %w", policyPath, err)
+	}
+
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("parsing policy file %q: unexpected trailing content after JSON object", policyPath)
+		}
+
+		return nil, fmt.Errorf("parsing policy file %q: unexpected trailing content after JSON object: %w", policyPath, err)
+	}
+
+	if err := p.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid policy file %q: %w", policyPath, err)
+	}
+
+	return &p, nil
+}
+
+// LoadPolicies loads all policy files from the given directory.
+// Returns a map keyed by namespace (empty string for default.json).
+func LoadPolicies(policyDir string) (map[string]*Policy, error) {
+	policies := make(map[string]*Policy)
+
+	if policyDir == "" {
+		return policies, nil
+	}
+
+	entries, err := os.ReadDir(policyDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return policies, nil
+		}
+
+		return nil, fmt.Errorf("reading policy directory %q: %w", policyDir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		fullPath := filepath.Join(policyDir, entry.Name())
+
+		policy, err := LoadPolicy(fullPath)
+		if err != nil {
+			return nil, err
+		}
+
+		// "default.json" maps to empty string key (the fallback).
+		namespace := strings.TrimSuffix(entry.Name(), ".json")
+		if namespace == "default" {
+			namespace = ""
+		}
+
+		policies[namespace] = policy
+	}
+
+	return policies, nil
+}

--- a/internal/supplychain/policy_test.go
+++ b/internal/supplychain/policy_test.go
@@ -1,0 +1,358 @@
+package supplychain_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cri-o/cri-o/internal/supplychain"
+)
+
+var _ = Describe("Policy", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+
+		tmpDir, err = os.MkdirTemp("", "supplychain-policy-test-*")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	writePolicy := func(name string, content string) {
+		path := filepath.Join(tmpDir, name+".json")
+		Expect(os.WriteFile(path, []byte(content), 0o644)).To(Succeed())
+	}
+
+	Describe("LoadPolicy", func() {
+		It("should load a valid policy file", func() {
+			policyJSON := `{
+				"trust": {
+					"builders": [
+						{"id": "https://github.com/actions/runner", "max_level": 3},
+						{"id": "https://tekton.dev/chains/v2", "max_level": 2}
+					],
+					"verifiers": [
+						{"id": "https://verify.example.com", "key": "/etc/keys/v.pub"}
+					],
+					"issuers": ["https://accounts.google.com"],
+					"sources": ["github.com/my-org/*"],
+					"build_types": ["https://slsa.dev/container-based-build/v0.1"]
+				}
+			}`
+
+			path := filepath.Join(tmpDir, "default.json")
+			Expect(os.WriteFile(path, []byte(policyJSON), 0o644)).To(Succeed())
+
+			policy, err := supplychain.LoadPolicy(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policy.Trust.Builders).To(HaveLen(2))
+			Expect(policy.Trust.Builders[0].ID).To(Equal("https://github.com/actions/runner"))
+			Expect(policy.Trust.Builders[0].MaxLevel).To(Equal(3))
+			Expect(policy.Trust.Builders[1].MaxLevel).To(Equal(2))
+			Expect(policy.Trust.Verifiers).To(HaveLen(1))
+			Expect(policy.Trust.Verifiers[0].Key).To(Equal("/etc/keys/v.pub"))
+			Expect(policy.Trust.Issuers).To(ConsistOf("https://accounts.google.com"))
+			Expect(policy.Trust.Sources).To(ConsistOf("github.com/my-org/*"))
+			Expect(policy.Trust.BuildTypes).To(ConsistOf("https://slsa.dev/container-based-build/v0.1"))
+		})
+
+		It("should return an error for a non-existent file", func() {
+			_, err := supplychain.LoadPolicy("/does/not/exist.json")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("reading policy file"))
+		})
+
+		It("should return an error for invalid JSON", func() {
+			path := filepath.Join(tmpDir, "bad.json")
+			Expect(os.WriteFile(path, []byte("not json"), 0o644)).To(Succeed())
+
+			_, err := supplychain.LoadPolicy(path)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parsing policy file"))
+		})
+
+		It("should handle an empty policy file", func() {
+			path := filepath.Join(tmpDir, "empty.json")
+			Expect(os.WriteFile(path, []byte("{}"), 0o644)).To(Succeed())
+
+			policy, err := supplychain.LoadPolicy(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policy.Trust).To(BeNil())
+			Expect(policy.Builders()).To(BeEmpty())
+		})
+
+		It("should reject a builder with empty id", func() {
+			writePolicy("bad-builder", `{"trust": {"builders": [{"id": "", "max_level": 1}]}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "bad-builder.json"))
+			Expect(err).To(MatchError(ContainSubstring("id is required")))
+		})
+
+		It("should reject a builder with invalid max_level", func() {
+			writePolicy("bad-level", `{"trust": {"builders": [{"id": "https://example.com", "max_level": 5}]}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "bad-level.json"))
+			Expect(err).To(MatchError(ContainSubstring("max_level must be 0-3")))
+		})
+
+		It("should reject a verifier with empty key", func() {
+			writePolicy("bad-verifier", `{"trust": {"verifiers": [{"id": "https://example.com", "key": ""}]}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "bad-verifier.json"))
+			Expect(err).To(MatchError(ContainSubstring("key is required")))
+		})
+
+		It("should reject a verifier with relative key path", func() {
+			writePolicy("bad-key-path", `{"trust": {"verifiers": [{"id": "https://example.com", "key": "relative/path.pub"}]}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "bad-key-path.json"))
+			Expect(err).To(MatchError(ContainSubstring("key must be an absolute path")))
+		})
+
+		It("should reject invalid provenance.missing_policy", func() {
+			writePolicy("bad-prov", `{"provenance": {"missing_policy": "bogus"}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "bad-prov.json"))
+			Expect(err).To(MatchError(ContainSubstring("provenance.missing_policy")))
+		})
+
+		It("should accept valid provenance.missing_policy values", func() {
+			for _, val := range []string{"allow", "warn", "deny"} {
+				writePolicy("prov-valid", `{"provenance": {"missing_policy": "`+val+`"}}`)
+
+				_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "prov-valid.json"))
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		It("should accept valid vex.severity_threshold values", func() {
+			for _, sev := range []string{"low", "medium", "high", "critical"} {
+				writePolicy("vex-sev", `{"vex": {"severity_threshold": "`+sev+`"}}`)
+
+				_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "vex-sev.json"))
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		It("should reject invalid vex.severity_threshold", func() {
+			writePolicy("vex-bad-sev", `{"vex": {"severity_threshold": "bogus"}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "vex-bad-sev.json"))
+			Expect(err).To(MatchError(ContainSubstring("vex.severity_threshold")))
+		})
+
+		It("should reject invalid vex.missing_policy", func() {
+			writePolicy("vex-bad-missing", `{"vex": {"missing_policy": "bogus"}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "vex-bad-missing.json"))
+			Expect(err).To(MatchError(ContainSubstring("vex.missing_policy")))
+		})
+
+		It("should reject invalid vex.under_investigation_policy", func() {
+			writePolicy("vex-bad-ui", `{"vex": {"under_investigation_policy": "bogus"}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "vex-bad-ui.json"))
+			Expect(err).To(MatchError(ContainSubstring("vex.under_investigation_policy")))
+		})
+
+		It("should accept empty nested fields as defaults", func() {
+			writePolicy("empty-nested", `{}`)
+
+			policy, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "empty-nested.json"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policy.Trust).To(BeNil())
+			Expect(policy.VEX).To(BeNil())
+			Expect(policy.Provenance).To(BeNil())
+			Expect(policy.VSA).To(BeNil())
+			Expect(policy.Signatures).To(BeNil())
+		})
+
+		It("should reject invalid vsa.minimum_level", func() {
+			writePolicy("vsa-bad-level", `{"vsa": {"minimum_level": 5}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "vsa-bad-level.json"))
+			Expect(err).To(MatchError(ContainSubstring("vsa.minimum_level")))
+		})
+
+		It("should reject invalid vsa.max_age", func() {
+			writePolicy("vsa-bad-age", `{"vsa": {"max_age": "not-a-duration"}}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "vsa-bad-age.json"))
+			Expect(err).To(MatchError(ContainSubstring("vsa.max_age")))
+		})
+
+		It("should accept valid vsa.max_age", func() {
+			writePolicy("vsa-good-age", `{"vsa": {"max_age": "168h"}}`)
+
+			policy, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "vsa-good-age.json"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policy.VSA.MaxAge).To(Equal("168h"))
+		})
+
+		It("should accept all per-namespace fields", func() {
+			writePolicy("full", `{
+				"trust": {
+					"builders": [{"id": "https://example.com", "max_level": 3}],
+					"verifiers": [{"id": "https://verify.example.com", "key": "/etc/keys/v.pub"}],
+					"issuers": ["https://accounts.google.com"],
+					"sources": ["github.com/my-org/*"],
+					"build_types": ["https://slsa.dev/container-based-build/v0.1"]
+				},
+				"exclude": ["registry.k8s.io/pause:*"],
+				"provenance": {
+					"missing_policy": "deny",
+					"reject_unknown_parameters": true
+				},
+				"vex": {
+					"severity_threshold": "high",
+					"missing_policy": "deny",
+					"under_investigation_policy": "warn"
+				},
+				"vsa": {
+					"minimum_level": 2,
+					"max_age": "72h",
+					"policy": "https://example.com/policy"
+				},
+				"signatures": {
+					"require_transparency_log": true
+				}
+			}`)
+
+			policy, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "full.json"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policy.Trust.Builders).To(HaveLen(1))
+			Expect(policy.Trust.Verifiers).To(HaveLen(1))
+			Expect(policy.Trust.Issuers).To(ConsistOf("https://accounts.google.com"))
+			Expect(policy.Trust.Sources).To(ConsistOf("github.com/my-org/*"))
+			Expect(policy.Trust.BuildTypes).To(ConsistOf("https://slsa.dev/container-based-build/v0.1"))
+			Expect(policy.Provenance.MissingPolicy).To(Equal("deny"))
+			Expect(policy.Provenance.RejectUnknownParameters).To(BeTrue())
+			Expect(policy.VEX.SeverityThreshold).To(Equal("high"))
+			Expect(policy.VEX.MissingPolicy).To(Equal("deny"))
+			Expect(policy.VEX.UnderInvestigationPolicy).To(Equal("warn"))
+			Expect(policy.VSA.MinimumLevel).To(Equal(2))
+			Expect(policy.VSA.MaxAge).To(Equal("72h"))
+			Expect(policy.VSA.Policy).To(Equal("https://example.com/policy"))
+			Expect(policy.Signatures.RequireTransparencyLog).To(BeTrue())
+			Expect(policy.Exclude).To(ConsistOf("registry.k8s.io/pause:*"))
+		})
+
+		It("should reject malformed exclude patterns", func() {
+			writePolicy("bad-exempt", `{"exclude": ["[invalid"]}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "bad-exempt.json"))
+			Expect(err).To(MatchError(ContainSubstring("exclude pattern")))
+		})
+
+		It("should reject trailing content after JSON object", func() {
+			writePolicy("trailing", `{"exclude": ["a:*"]}{"exclude": ["b:*"]}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "trailing.json"))
+			Expect(err).To(MatchError(ContainSubstring("unexpected trailing content")))
+		})
+
+		It("should reject trailing delimiters after JSON object", func() {
+			writePolicy("trailing-delim", `{"exclude": ["a:*"]}]`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "trailing-delim.json"))
+			Expect(err).To(MatchError(ContainSubstring("unexpected trailing content")))
+		})
+
+		It("should reject unknown fields", func() {
+			writePolicy("unknown", `{"unknown_field": true}`)
+
+			_, err := supplychain.LoadPolicy(filepath.Join(tmpDir, "unknown.json"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parsing policy file"))
+		})
+	})
+
+	Describe("LoadPolicies", func() {
+		It("should return empty map for empty policy dir", func() {
+			policies, err := supplychain.LoadPolicies("")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policies).To(BeEmpty())
+		})
+
+		It("should return empty map for non-existent directory", func() {
+			policies, err := supplychain.LoadPolicies("/nonexistent/path")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policies).To(BeEmpty())
+		})
+
+		It("should load default.json as empty-string key", func() {
+			writePolicy("default", `{"trust": {"issuers": ["issuer-default"]}}`)
+
+			policies, err := supplychain.LoadPolicies(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policies).To(HaveKey(""))
+			Expect(policies[""].Trust.Issuers).To(ConsistOf("issuer-default"))
+		})
+
+		It("should load namespace-specific policies", func() {
+			writePolicy("default", `{"trust": {"issuers": ["issuer-default"]}}`)
+			writePolicy("production", `{"trust": {"issuers": ["issuer-prod"]}}`)
+
+			policies, err := supplychain.LoadPolicies(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policies).To(HaveLen(2))
+			Expect(policies[""].Trust.Issuers).To(ConsistOf("issuer-default"))
+			Expect(policies["production"].Trust.Issuers).To(ConsistOf("issuer-prod"))
+		})
+
+		It("should skip non-json files", func() {
+			writePolicy("default", `{"trust": {"issuers": ["issuer-default"]}}`)
+			Expect(os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("hi"), 0o644)).To(Succeed())
+
+			policies, err := supplychain.LoadPolicies(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policies).To(HaveLen(1))
+		})
+
+		It("should return an error for malformed policy file", func() {
+			writePolicy("broken", "not json at all")
+
+			_, err := supplychain.LoadPolicies(tmpDir)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parsing policy file"))
+		})
+	})
+
+	Describe("ProvenanceMissingPolicy", func() {
+		It("should return allow by default", func() {
+			p := &supplychain.Policy{}
+			Expect(p.ProvenanceMissingPolicy()).To(Equal("allow"))
+		})
+
+		It("should return the configured value", func() {
+			p := &supplychain.Policy{
+				Provenance: &supplychain.ProvenancePolicy{MissingPolicy: "deny"},
+			}
+			Expect(p.ProvenanceMissingPolicy()).To(Equal("deny"))
+		})
+	})
+
+	Describe("Builders", func() {
+		It("should return nil when trust is not configured", func() {
+			p := &supplychain.Policy{}
+			Expect(p.Builders()).To(BeEmpty())
+		})
+
+		It("should return builders when configured", func() {
+			p := &supplychain.Policy{
+				Trust: &supplychain.TrustPolicy{
+					Builders: []supplychain.TrustedBuilder{
+						{ID: "https://example.com", MaxLevel: 3},
+					},
+				},
+			}
+			Expect(p.Builders()).To(HaveLen(1))
+		})
+	})
+})

--- a/internal/supplychain/suite_test.go
+++ b/internal/supplychain/suite_test.go
@@ -1,0 +1,27 @@
+package supplychain_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cri-o/cri-o/test/framework"
+)
+
+// TestRun runs the created specs.
+func TestRun(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunFrameworkSpecs(t, "SupplyChain")
+}
+
+var t *TestFramework
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+})
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+})

--- a/internal/supplychain/supplychain.go
+++ b/internal/supplychain/supplychain.go
@@ -1,0 +1,317 @@
+package supplychain
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	crierrors "k8s.io/cri-api/pkg/errors"
+
+	"github.com/cri-o/cri-o/internal/log"
+)
+
+// defaultEmptyPolicy is a shared zero-value policy for namespaces without a
+// dedicated policy. Safe to share because Verify never mutates policies.
+var defaultEmptyPolicy = &Policy{}
+
+// Result represents the outcome of a supply chain verification.
+type Result struct {
+	// Allowed indicates whether the image passed verification.
+	Allowed bool
+	// Reason provides details about the verification decision.
+	Reason string
+	// CheckResults contains per-check outcomes for audit logging.
+	CheckResults []CheckResult
+}
+
+// CheckResult represents the outcome of an individual verification check.
+type CheckResult struct {
+	// Type is the check type (e.g., "slsa_provenance", "vex", "vsa").
+	Type string
+	// Passed indicates whether this check passed.
+	Passed bool
+	// Status is the check outcome: "pass", "warn", or "fail".
+	Status string
+	// Detail provides additional information about the check result.
+	Detail string
+}
+
+// verifierSnapshot holds the config, policies, and cache snapshotted atomically
+// from Verifier under a single RLock, so that Verify uses a consistent triple.
+// Including the cache ensures that in-flight Verify calls don't write stale
+// results into a freshly created cache after Reload.
+type verifierSnapshot struct {
+	config   *Config
+	policies map[string]*Policy
+	cache    *Cache
+}
+
+// Verifier performs supply chain attestation verification on container images.
+type Verifier struct {
+	mu       sync.RWMutex
+	config   *Config
+	cache    *Cache
+	policies map[string]*Policy // namespace -> policy, "" key = default
+}
+
+// NewVerifier creates a new supply chain Verifier with the given configuration.
+func NewVerifier(cfg *Config) (*Verifier, error) {
+	cfgCopy := *cfg
+
+	v := &Verifier{
+		config: &cfgCopy,
+		cache:  NewCache(cfgCopy.CacheTTL),
+	}
+
+	if cfgCopy.Enabled() {
+		policies, err := LoadPolicies(cfgCopy.PolicyDir)
+		if err != nil {
+			return nil, fmt.Errorf("loading supply chain policies: %w", err)
+		}
+
+		v.policies = policies
+	}
+
+	return v, nil
+}
+
+// snapshot returns a consistent copy of config, policies, and cache under a
+// single lock. All three are safe to use after unlock because Reload replaces
+// them atomically rather than mutating in-place.
+func (v *Verifier) snapshot() verifierSnapshot {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	return verifierSnapshot{
+		config:   v.config,
+		policies: v.policies,
+		cache:    v.cache,
+	}
+}
+
+// Verify performs supply chain verification for the given image.
+// The imageRef is the image reference string, digest is the resolved image digest,
+// and namespace is the Kubernetes namespace (for per-namespace policy lookup).
+// Returns nil error on success (allowed or warn-mode), or a wrapped
+// ErrSignatureValidationFailed on enforce-mode rejection.
+func (v *Verifier) Verify(ctx context.Context, imageRef, digest, namespace string) (*Result, error) {
+	snap := v.snapshot()
+
+	if !snap.config.Enabled() {
+		return &Result{Allowed: true, Reason: "supply chain verification disabled"}, nil
+	}
+
+	log.Debugf(ctx, "Supply chain verification for image %s (digest: %s, namespace: %s)", imageRef, digest, namespace)
+
+	// Look up policy for namespace first (cheap map lookup).
+	policy := policyForNamespace(snap.policies, namespace)
+
+	// Check excluded images before the cache. Exclusions depend on imageRef,
+	// but the cache is keyed by (digest, namespace). Checking exclusions
+	// first avoids a cached non-excluded result blocking an excluded ref and
+	// vice versa. Exclusion results are not cached because the check is
+	// cheap and caching them could leak across different image refs that
+	// share the same digest.
+	if isExcluded(policy.Exclude, imageRef) {
+		log.Infof(ctx, "Image %s is excluded from supply chain verification", imageRef)
+
+		return &Result{Allowed: true, Reason: "image is excluded"}, nil
+	}
+
+	// Check cache after exclusions.
+	if cached := snap.cache.Get(digest, namespace); cached != nil {
+		CacheHitsTotal.Inc()
+		logResult(ctx, imageRef, digest, namespace, cached)
+
+		return cached, nil
+	}
+
+	// Run verification checks.
+	result := runChecks(ctx, snap.config, policy, imageRef, digest)
+
+	// Audit log the result.
+	logResult(ctx, imageRef, digest, namespace, result)
+
+	// Record metrics.
+	recordMetrics(result)
+
+	if !result.Allowed {
+		if snap.config.Verification == "enforce" {
+			// Don't cache denied results so that retries can succeed
+			// immediately after the issue is fixed (e.g., provenance added).
+			// Operators can SIGHUP to clear the cache if needed for other cases.
+			return result, fmt.Errorf("%w: supply chain verification failed for %s: %s",
+				crierrors.ErrSignatureValidationFailed, imageRef, result.Reason)
+		}
+
+		// Warn mode: log but allow. Create a new Result with Allowed=true
+		// so that the cached entry reflects the warn-adjusted outcome.
+		// If the mode later changes to "enforce" via SIGHUP, Reload creates
+		// a fresh cache, so stale warn-adjusted entries won't leak.
+		log.Warnf(ctx, "Supply chain verification failed for %s (warn mode, allowing): %s", imageRef, result.Reason)
+		result = &Result{
+			Allowed:      true,
+			Reason:       result.Reason,
+			CheckResults: result.CheckResults,
+		}
+	}
+
+	// Cache the final (possibly warn-adjusted) result.
+	snap.cache.Set(digest, namespace, result)
+
+	return result, nil
+}
+
+// runChecks executes all configured verification checks for the image.
+func runChecks(ctx context.Context, cfg *Config, policy *Policy, imageRef, digest string) *Result {
+	result := &Result{Allowed: true}
+
+	// SLSA provenance verification.
+	slsaResult := verifySLSAProvenance(ctx, cfg, policy, imageRef, digest)
+	result.CheckResults = append(result.CheckResults, slsaResult)
+
+	if !slsaResult.Passed {
+		result.Allowed = false
+		result.Reason = slsaResult.Detail
+	} else if slsaResult.Status == "warn" {
+		result.Reason = slsaResult.Detail
+	}
+
+	return result
+}
+
+// verifySLSAProvenance verifies SLSA provenance attestations for the given image.
+// The digest parameter will be used once cosign integration lands to match the subject digest.
+func verifySLSAProvenance(_ context.Context, _ *Config, policy *Policy, imageRef, _ string) CheckResult {
+	start := time.Now()
+
+	defer func() {
+		VerificationDuration.WithLabelValues("slsa_provenance").Observe(time.Since(start).Seconds())
+	}()
+
+	// If no trusted builders are configured, provenance verification is a no-op.
+	// This is distinct from "missing attestation": the policy simply has no
+	// builder trust roots, so there is nothing to verify.
+	if len(policy.Builders()) == 0 {
+		return CheckResult{
+			Type:   "slsa_provenance",
+			Passed: true,
+			Status: "pass",
+			Detail: "no trusted builders configured for image " + imageRef,
+		}
+	}
+
+	// TODO: Fetch attestations via cosign API (OCI Referrers) and verify:
+	// 1. Envelope signature against trusted issuers
+	// 2. subject digest matches pulled image digest
+	// 3. predicateType is SLSA provenance (v1 or v0.2)
+	// 4. builder.id is in trusted builders list with sufficient level
+	// 5. buildType matches trusted build types
+	// 6. source repo matches trusted sources
+	// 7. reject unknown externalParameters (if configured)
+	//
+	// For now, treat as "no provenance found" and apply the missing policy.
+	return handleMissingAttestation(policy.ProvenanceMissingPolicy(), "slsa_provenance",
+		fmt.Sprintf("provenance attestation not found for image %s (cosign integration pending)", imageRef))
+}
+
+// handleMissingAttestation applies the configured policy for a missing attestation type.
+func handleMissingAttestation(policy, checkType, detail string) CheckResult {
+	switch policy {
+	case "deny":
+		return CheckResult{Type: checkType, Passed: false, Status: "fail", Detail: detail}
+	case "warn":
+		return CheckResult{Type: checkType, Passed: true, Status: "warn", Detail: "warn: " + detail}
+	case "allow":
+		return CheckResult{Type: checkType, Passed: true, Status: "pass", Detail: detail}
+	default:
+		// Policy values are validated at config load time, so this is unreachable.
+		// Default to deny as the safe fallback for a security-relevant decision.
+		return CheckResult{Type: checkType, Passed: false, Status: "fail", Detail: detail}
+	}
+}
+
+// logResult emits structured audit log entries for the verification decision.
+func logResult(ctx context.Context, imageRef, digest, namespace string, result *Result) {
+	for _, cr := range result.CheckResults {
+		log.WithFields(ctx, logrus.Fields{
+			"image":     imageRef,
+			"digest":    digest,
+			"namespace": namespace,
+			"check":     cr.Type,
+			"status":    cr.Status,
+			"detail":    cr.Detail,
+		}).Info("Supply chain audit")
+	}
+}
+
+// recordMetrics updates prometheus counters for verification results.
+func recordMetrics(result *Result) {
+	for _, cr := range result.CheckResults {
+		VerificationTotal.WithLabelValues(cr.Type, cr.Status).Inc()
+	}
+}
+
+// Reload reloads the verifier's configuration and policies. Called on SIGHUP.
+// Policies are loaded outside the lock to avoid blocking concurrent Verify calls
+// during disk I/O.
+func (v *Verifier) Reload(cfg *Config) error {
+	cfgCopy := *cfg
+
+	var policies map[string]*Policy
+
+	if cfgCopy.Enabled() {
+		var err error
+
+		policies, err = LoadPolicies(cfgCopy.PolicyDir)
+		if err != nil {
+			return fmt.Errorf("reloading supply chain policies: %w", err)
+		}
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	v.config = &cfgCopy
+	v.cache = NewCache(cfgCopy.CacheTTL)
+	v.policies = policies
+
+	return nil
+}
+
+// policyForNamespace returns the policy for the given namespace.
+// Falls back to the default policy if no namespace-specific one exists.
+func policyForNamespace(policies map[string]*Policy, namespace string) *Policy {
+	if p, ok := policies[namespace]; ok {
+		return p
+	}
+
+	if p, ok := policies[""]; ok {
+		return p
+	}
+
+	return defaultEmptyPolicy
+}
+
+// isExcluded checks whether the image matches any exclude glob pattern.
+// Note: path.Match treats '*' as matching a single path segment (not crossing '/').
+// For example, "gcr.io/org/*" matches "gcr.io/org/app" but not "gcr.io/org/team/app".
+func isExcluded(excludedImages []string, imageRef string) bool {
+	for _, pattern := range excludedImages {
+		matched, err := path.Match(pattern, imageRef)
+		if err != nil {
+			logrus.Debugf("Malformed exclude pattern %q for image %s: %v", pattern, imageRef, err)
+
+			continue
+		}
+
+		if matched {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/supplychain/supplychain_test.go
+++ b/internal/supplychain/supplychain_test.go
@@ -1,0 +1,382 @@
+package supplychain_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	crierrors "k8s.io/cri-api/pkg/errors"
+
+	"github.com/cri-o/cri-o/internal/supplychain"
+)
+
+const (
+	warnMode = "warn"
+	denyMode = "deny"
+)
+
+var _ = Describe("Verifier", func() {
+	var cfg supplychain.Config
+
+	BeforeEach(func() {
+		cfg = supplychain.DefaultConfig()
+	})
+
+	Describe("NewVerifier", func() {
+		It("should return a verifier when verification is disabled", func() {
+			cfg.Verification = "disabled"
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v).ToNot(BeNil())
+		})
+
+		It("should return a verifier when verification is enabled", func() {
+			cfg.Verification = warnMode
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v).ToNot(BeNil())
+		})
+	})
+
+	Describe("Verify", func() {
+		var (
+			ctx    context.Context
+			tmpDir string
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			var err error
+
+			tmpDir, err = os.MkdirTemp("", "supplychain-verify-test-*")
+			Expect(err).ToNot(HaveOccurred())
+
+			cfg.Verification = "enforce"
+			cfg.PolicyDir = tmpDir
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tmpDir)
+		})
+
+		It("should short-circuit when verification is disabled", func() {
+			cfg.Verification = "disabled"
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+			Expect(result.Reason).To(ContainSubstring("disabled"))
+		})
+
+		It("should allow excluded images", func() {
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{"exclude": ["registry.k8s.io/pause:*"]}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "registry.k8s.io/pause:3.9", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+			Expect(result.Reason).To(ContainSubstring("excluded"))
+		})
+
+		It("should not exclude non-matching images", func() {
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{"exclude": ["registry.k8s.io/pause:*"]}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "docker.io/library/nginx:latest", "sha256:def", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Reason).ToNot(ContainSubstring("excluded"))
+		})
+
+		It("should support multiple exclude patterns", func() {
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{"exclude": ["registry.k8s.io/pause:*", "gcr.io/internal/*"]}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "gcr.io/internal/sidecar", "sha256:xyz", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+			Expect(result.Reason).To(ContainSubstring("excluded"))
+		})
+
+		It("should use namespace-specific policy when available", func() {
+			// Default policy: no builders (passes even with deny).
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{}`),
+				0o644,
+			)).To(Succeed())
+
+			// Production policy: has builders + deny, so missing provenance triggers deny.
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "production.json"),
+				[]byte(`{"trust": {"builders": [{"id": "https://example.com", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Default namespace should pass (no builders configured).
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+
+			// Production namespace should fail (has builders + deny policy).
+			_, err = v.Verify(ctx, "myimage:latest", "sha256:def", "production")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, crierrors.ErrSignatureValidationFailed)).To(BeTrue())
+		})
+
+		It("should return cached results on subsequent calls", func() {
+			cfg.CacheTTL = 1 * time.Hour
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result1, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+
+			result2, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Same pointer from cache.
+			Expect(result1).To(BeIdenticalTo(result2))
+		})
+
+		It("should not return cached results after Reload", func() {
+			cfg.CacheTTL = 1 * time.Hour
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result1, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(v.Reload(&cfg)).To(Succeed())
+
+			result2, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Different pointer after reload.
+			Expect(result1).ToNot(BeIdenticalTo(result2))
+		})
+
+		It("should reload config and policies on Reload", func() {
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Without the new-ns policy, new-ns falls back to default (no builders), so passes.
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "new-ns")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+
+			// Add a namespace policy with trusted builders + deny after initial creation.
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "new-ns.json"),
+				[]byte(`{"trust": {"builders": [{"id": "https://example.com", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}`),
+				0o644,
+			)).To(Succeed())
+
+			Expect(v.Reload(&cfg)).To(Succeed())
+
+			// After reload, new-ns has builders + deny policy, so verification fails.
+			_, err = v.Verify(ctx, "myimage:latest", "sha256:def", "new-ns")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, crierrors.ErrSignatureValidationFailed)).To(BeTrue())
+		})
+
+		It("should disable verification after Reload with disabled config", func() {
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			disabledCfg := cfg
+			disabledCfg.Verification = "disabled"
+			Expect(v.Reload(&disabledCfg)).To(Succeed())
+
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Reason).To(ContainSubstring("disabled"))
+		})
+
+		It("should preserve verifier state when Reload fails", func() {
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify works with the initial config.
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+
+			// Reload with a config pointing to a directory containing a malformed policy.
+			badDir, err := os.MkdirTemp("", "supplychain-bad-policy-*")
+			Expect(err).ToNot(HaveOccurred())
+
+			defer os.RemoveAll(badDir)
+
+			Expect(os.WriteFile(filepath.Join(badDir, "default.json"), []byte("not json"), 0o644)).To(Succeed())
+
+			badCfg := cfg
+			badCfg.PolicyDir = badDir
+			Expect(v.Reload(&badCfg)).To(HaveOccurred())
+
+			// Verifier should still work with the original config after failed reload.
+			result, err = v.Verify(ctx, "myimage:latest", "sha256:def", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+		})
+
+		It("should return ErrSignatureValidationFailed in enforce mode with deny provenance policy", func() {
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, crierrors.ErrSignatureValidationFailed)).To(BeTrue())
+			Expect(result.Allowed).To(BeFalse())
+		})
+
+		It("should allow in warn mode even when provenance is denied", func() {
+			cfg.Verification = warnMode
+
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+		})
+
+		It("should allow with provenance missing_policy=allow", func() {
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "allow"}}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+			Expect(result.CheckResults).To(HaveLen(1))
+			Expect(result.CheckResults[0].Type).To(Equal("slsa_provenance"))
+			Expect(result.CheckResults[0].Passed).To(BeTrue())
+			Expect(result.CheckResults[0].Status).To(Equal("pass"))
+		})
+
+		It("should warn with provenance missing_policy=warn", func() {
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "warn"}}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+			Expect(result.CheckResults[0].Passed).To(BeTrue())
+			Expect(result.CheckResults[0].Status).To(Equal("warn"))
+			Expect(result.CheckResults[0].Detail).To(HavePrefix("warn:"))
+		})
+
+		It("should allow when no trusted builders are configured", func() {
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+			Expect(result.CheckResults).To(HaveLen(1))
+			Expect(result.CheckResults[0].Passed).To(BeTrue())
+			Expect(result.CheckResults[0].Detail).To(ContainSubstring("no trusted builders configured"))
+		})
+
+		It("should allow when no trusted builders are configured even with deny provenance policy", func() {
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+			Expect(result.CheckResults[0].Passed).To(BeTrue())
+		})
+
+		It("should allow in enforce mode with allow provenance policy and trusted builders", func() {
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "allow"}}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeTrue())
+			Expect(result.CheckResults[0].Detail).To(ContainSubstring("cosign integration pending"))
+		})
+
+		It("should cache the warn-adjusted result not the original denied result", func() {
+			cfg.Verification = warnMode
+			cfg.CacheTTL = 1 * time.Hour
+
+			Expect(os.WriteFile(
+				filepath.Join(tmpDir, "default.json"),
+				[]byte(`{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}`),
+				0o644,
+			)).To(Succeed())
+
+			v, err := supplychain.NewVerifier(&cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			result1, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result1.Allowed).To(BeTrue())
+
+			// Second call should return cached result with Allowed=true.
+			result2, err := v.Verify(ctx, "myimage:latest", "sha256:abc", "default")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result2.Allowed).To(BeTrue())
+			Expect(result1).To(BeIdenticalTo(result2))
+		})
+	})
+})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/ulimits"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/storage/references"
+	"github.com/cri-o/cri-o/internal/supplychain"
 	v2 "github.com/cri-o/cri-o/pkg/annotations/v2"
 	"github.com/cri-o/cri-o/server/metrics/collectors"
 	"github.com/cri-o/cri-o/server/useragent"
@@ -700,6 +701,8 @@ type ImageConfig struct {
 	// If "enforcing", an image pull will fail if a short name is used, but the results are ambiguous.
 	// If "disabled", the first result will be chosen.
 	ShortNameMode string `toml:"short_name_mode"`
+	// SupplyChain configures supply chain attestation verification for pulled images.
+	SupplyChain supplychain.Config `toml:"supply_chain"`
 }
 
 // NetworkConfig represents the "crio.network" TOML config table.
@@ -1096,6 +1099,7 @@ func DefaultConfig() (*Config, error) {
 			OCIArtifactMountSupport: true,
 			ShortNameMode:           "enforcing",
 			NamespacedAuthDir:       cpConfig.AuthDir,
+			SupplyChain:             supplychain.DefaultConfig(),
 		},
 		NetworkConfig: NetworkConfig{
 			NetworkDir: cniConfigDir,
@@ -1865,6 +1869,10 @@ func (c *ImageConfig) Validate(onExecution bool) error {
 	case "enforcing", "disabled", "":
 	default:
 		return fmt.Errorf("invalid short name mode %q", c.ShortNameMode)
+	}
+
+	if err := c.SupplyChain.Validate(onExecution); err != nil {
+		return fmt.Errorf("validating supply chain config: %w", err)
 	}
 
 	return nil

--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -90,6 +90,27 @@ func (c *Config) Reload(ctx context.Context) error {
 		return err
 	}
 
+	if err := c.UpdateSupplyChainConfig(newConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateSupplyChainConfig updates the SupplyChain config with the provided
+// `newConfig`. The actual verifier reload (policy loading, cache clearing)
+// happens in server.go via Verifier.Reload.
+func (c *Config) UpdateSupplyChainConfig(newConfig *Config) error {
+	if err := newConfig.SupplyChain.Validate(true); err != nil {
+		return fmt.Errorf("unable to reload supply chain config: %w", err)
+	}
+
+	if c.SupplyChain.Verification != newConfig.SupplyChain.Verification {
+		logConfig("supply_chain.verification", newConfig.SupplyChain.Verification)
+	}
+
+	c.SupplyChain = newConfig.SupplyChain
+
 	return nil
 }
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -40,6 +40,9 @@ func assembleTemplateString(displayAllConfig bool, c *Config) string {
 	// [crio.image] configuration
 	templateString += crioTemplateString(crioImageConfig, templateStringCrioImage, displayAllConfig, crioTemplateConfig)
 
+	// [crio.image.supply_chain] configuration
+	templateString += crioTemplateString(crioSupplyChainConfig, templateStringCrioImageSupplyChain, displayAllConfig, crioTemplateConfig)
+
 	// [crio.network] configuration
 	templateString += crioTemplateString(crioNetworkConfig, templateStringCrioNetwork, displayAllConfig, crioTemplateConfig)
 
@@ -97,6 +100,7 @@ const (
 	crioTracingConfig
 	crioStatsConfig
 	crioNRIConfig
+	crioSupplyChainConfig
 )
 
 type templateConfigValue struct {
@@ -586,6 +590,31 @@ func initCrioTemplateConfig(c *Config) ([]*templateConfigValue, error) {
 			templateString: templateStringOCIArtifactMountSupport,
 			group:          crioImageConfig,
 			isDefaultValue: simpleEqual(dc.OCIArtifactMountSupport, c.OCIArtifactMountSupport),
+		},
+		{
+			templateString: templateStringCrioSupplyChainVerification,
+			group:          crioSupplyChainConfig,
+			isDefaultValue: simpleEqual(dc.SupplyChain.Verification, c.SupplyChain.Verification),
+		},
+		{
+			templateString: templateStringCrioSupplyChainFetchTimeout,
+			group:          crioSupplyChainConfig,
+			isDefaultValue: simpleEqual(dc.SupplyChain.FetchTimeout, c.SupplyChain.FetchTimeout),
+		},
+		{
+			templateString: templateStringCrioSupplyChainFetchFailurePolicy,
+			group:          crioSupplyChainConfig,
+			isDefaultValue: simpleEqual(dc.SupplyChain.FetchFailurePolicy, c.SupplyChain.FetchFailurePolicy),
+		},
+		{
+			templateString: templateStringCrioSupplyChainCacheTTL,
+			group:          crioSupplyChainConfig,
+			isDefaultValue: simpleEqual(dc.SupplyChain.CacheTTL, c.SupplyChain.CacheTTL),
+		},
+		{
+			templateString: templateStringCrioSupplyChainPolicyDir,
+			group:          crioSupplyChainConfig,
+			isDefaultValue: simpleEqual(dc.SupplyChain.PolicyDir, c.SupplyChain.PolicyDir),
 		},
 		{
 			templateString: templateStringCrioNetworkCniDefaultNetwork,
@@ -1618,6 +1647,47 @@ const templateStringCrioImageShortNameMode = `# The mode of short name resolutio
 # If "enforcing", an image pull will fail if a short name is used, but the results are ambiguous.
 # If "disabled", the first result will be chosen.
 {{ $.Comment }}short_name_mode = "{{ .ShortNameMode }}"
+
+`
+
+const templateStringCrioImageSupplyChain = `# The crio.image.supply_chain table contains settings for supply chain
+# attestation verification of container images. When enabled, CRI-O can verify
+# SLSA provenance, VEX, and VSA attestations before allowing containers to run.
+# This option supports live configuration reload.
+[crio.image.supply_chain]
+
+`
+
+const templateStringCrioSupplyChainVerification = `# Master toggle for supply chain verification.
+# Valid values: "disabled" (default), "warn" (log-only), "enforce" (reject on failure).
+{{ $.Comment }}verification = "{{ .SupplyChain.Verification }}"
+
+`
+
+const templateStringCrioSupplyChainFetchTimeout = `# Per-fetch timeout for retrieving attestations from OCI registries.
+{{ $.Comment }}fetch_timeout = "{{ .SupplyChain.FetchTimeout }}"
+
+`
+
+const templateStringCrioSupplyChainFetchFailurePolicy = `# Behavior when attestation fetch fails due to network errors.
+# Valid values: "allow", "warn" (default), "deny".
+{{ $.Comment }}fetch_failure_policy = "{{ .SupplyChain.FetchFailurePolicy }}"
+
+`
+
+const templateStringCrioSupplyChainCacheTTL = `# How long verification results are cached per image digest and namespace.
+# Set to 0 to disable caching.
+{{ $.Comment }}cache_ttl = "{{ .SupplyChain.CacheTTL }}"
+
+`
+
+const templateStringCrioSupplyChainPolicyDir = `# Path to the directory containing JSON policy files for per-namespace
+# verification settings. <dir>/default.json is the base policy,
+# <dir>/<namespace>.json overrides it for that namespace.
+# Policy files configure: trust (builders, verifiers, issuers, sources,
+# build_types), exclude, provenance, vex, vsa, and signatures
+# settings. Must be absolute.
+{{ $.Comment }}policy_dir = "{{ .SupplyChain.PolicyDir }}"
 
 `
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1322,6 +1322,11 @@ func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr contain
 		return nil, err
 	}
 
+	// Verify supply chain attestations for the image.
+	if _, err := s.supplyChainVerifier.Verify(ctx, ctr.Config().GetImage().GetUserSpecifiedImage(), imgResult.Digest.String(), sb.Metadata().GetNamespace()); err != nil {
+		return nil, err
+	}
+
 	return &containerImageResult{
 		userRequestedImage: userRequestedImage,
 		imgResult:          imgResult,

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -532,6 +532,11 @@ func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, im
 		return nil, nil, err
 	}
 
+	// Verify supply chain attestations for the image.
+	if _, err := s.supplyChainVerifier.Verify(ctx, m.GetImage().GetUserSpecifiedImage(), status.Digest.String(), namespace); err != nil {
+		return nil, nil, err
+	}
+
 	log.Debugf(ctx, "Image ID to mount: %v", imageID)
 
 	options := []string{"ro", "noexec", "nosuid", "nodev"}

--- a/server/metrics/collectors/collectors.go
+++ b/server/metrics/collectors/collectors.go
@@ -69,6 +69,18 @@ const (
 
 	// DefaultRuntime is the key for the default container runtime configured in CRI-O.
 	DefaultRuntime Collector = crioPrefix + "default_runtime"
+
+	// SupplyChainVerificationTotal is the key for supply chain verification attempts.
+	SupplyChainVerificationTotal Collector = crioPrefix + "supply_chain_verification_total"
+
+	// SupplyChainVerificationDurationSeconds is the key for supply chain verification latency.
+	SupplyChainVerificationDurationSeconds Collector = crioPrefix + "supply_chain_verification_duration_seconds"
+
+	// SupplyChainCacheHitsTotal is the key for supply chain verification cache hits.
+	SupplyChainCacheHitsTotal Collector = crioPrefix + "supply_chain_cache_hits_total"
+
+	// SupplyChainFetchErrorsTotal is the key for supply chain attestation fetch errors.
+	SupplyChainFetchErrorsTotal Collector = crioPrefix + "supply_chain_fetch_errors_total"
 )
 
 // FromSlice converts a string slice to a Collectors type.
@@ -111,6 +123,10 @@ func All() Collectors {
 		ResourcesStalledAtStage.Stripped(),
 		ContainersStoppedMonitorCount.Stripped(),
 		DefaultRuntime.Stripped(),
+		SupplyChainVerificationTotal.Stripped(),
+		SupplyChainVerificationDurationSeconds.Stripped(),
+		SupplyChainCacheHitsTotal.Stripped(),
+		SupplyChainFetchErrorsTotal.Stripped(),
 	}
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/process"
 	"github.com/cri-o/cri-o/internal/storage/references"
+	"github.com/cri-o/cri-o/internal/supplychain"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/server/metrics/collectors"
 )
@@ -477,24 +478,28 @@ func (m *Metrics) MetricDefaultRuntimeSet(runtime string) {
 // createEndpoint creates a /metrics endpoint for prometheus monitoring.
 func (m *Metrics) createEndpoint() (*http.ServeMux, error) {
 	for collector, metric := range map[collectors.Collector]prometheus.Collector{
-		collectors.ContainersEventsDropped:             m.metricContainersEventsDropped,
-		collectors.ContainersOOMCountTotal:             m.metricContainersOOMCountTotal,
-		collectors.ContainersOOMTotal:                  m.metricContainersOOMTotal,
-		collectors.ContainersSeccompNotifierCountTotal: m.metricContainersSeccompNotifierCountTotal,
-		collectors.ImageLayerReuseTotal:                m.metricImageLayerReuseTotal,
-		collectors.ImagePullsBytesTotal:                m.metricImagePullsBytesTotal,
-		collectors.ImagePullsFailureTotal:              m.metricImagePullsFailureTotal,
-		collectors.ImagePullsLayerSize:                 m.metricImagePullsLayerSize,
-		collectors.ImagePullsSkippedBytesTotal:         m.metricImagePullsSkippedBytesTotal,
-		collectors.ImagePullsSuccessTotal:              m.metricImagePullsSuccessTotal,
-		collectors.OperationsErrorsTotal:               m.metricOperationsErrorsTotal,
-		collectors.OperationsLatencySeconds:            m.metricOperationsLatencySeconds,
-		collectors.OperationsLatencySecondsTotal:       m.metricOperationsLatencySecondsTotal,
-		collectors.OperationsTotal:                     m.metricOperationsTotal,
-		collectors.ProcessesDefunct:                    m.metricProcessesDefunct,
-		collectors.ResourcesStalledAtStage:             m.metricResourcesStalledAtStage,
-		collectors.ContainersStoppedMonitorCount:       m.metricContainersStoppedMonitorCount,
-		collectors.DefaultRuntime:                      m.metricDefaultRuntime,
+		collectors.ContainersEventsDropped:                m.metricContainersEventsDropped,
+		collectors.ContainersOOMCountTotal:                m.metricContainersOOMCountTotal,
+		collectors.ContainersOOMTotal:                     m.metricContainersOOMTotal,
+		collectors.ContainersSeccompNotifierCountTotal:    m.metricContainersSeccompNotifierCountTotal,
+		collectors.ImageLayerReuseTotal:                   m.metricImageLayerReuseTotal,
+		collectors.ImagePullsBytesTotal:                   m.metricImagePullsBytesTotal,
+		collectors.ImagePullsFailureTotal:                 m.metricImagePullsFailureTotal,
+		collectors.ImagePullsLayerSize:                    m.metricImagePullsLayerSize,
+		collectors.ImagePullsSkippedBytesTotal:            m.metricImagePullsSkippedBytesTotal,
+		collectors.ImagePullsSuccessTotal:                 m.metricImagePullsSuccessTotal,
+		collectors.OperationsErrorsTotal:                  m.metricOperationsErrorsTotal,
+		collectors.OperationsLatencySeconds:               m.metricOperationsLatencySeconds,
+		collectors.OperationsLatencySecondsTotal:          m.metricOperationsLatencySecondsTotal,
+		collectors.OperationsTotal:                        m.metricOperationsTotal,
+		collectors.ProcessesDefunct:                       m.metricProcessesDefunct,
+		collectors.ResourcesStalledAtStage:                m.metricResourcesStalledAtStage,
+		collectors.ContainersStoppedMonitorCount:          m.metricContainersStoppedMonitorCount,
+		collectors.DefaultRuntime:                         m.metricDefaultRuntime,
+		collectors.SupplyChainVerificationTotal:           supplychain.VerificationTotal,
+		collectors.SupplyChainVerificationDurationSeconds: supplychain.VerificationDuration,
+		collectors.SupplyChainCacheHitsTotal:              supplychain.CacheHitsTotal,
+		collectors.SupplyChainFetchErrorsTotal:            supplychain.FetchErrorsTotal,
 	} {
 		if m.config.MetricsCollectors.Contains(collector) {
 			logrus.Debugf("Enabling metric: %s", collector.Stripped())

--- a/server/server.go
+++ b/server/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cri-o/cri-o/internal/runtimehandlerhooks"
 	"github.com/cri-o/cri-o/internal/signals"
 	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/supplychain"
 	"github.com/cri-o/cri-o/internal/version"
 	"github.com/cri-o/cri-o/internal/watchdog"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
@@ -100,7 +101,8 @@ type Server struct {
 	// hooksRetriever allows getting the runtime hooks for the sandboxes.
 	hooksRetriever *runtimehandlerhooks.HooksRetriever
 
-	artifactStore *ociartifact.Store
+	artifactStore       *ociartifact.Store
+	supplyChainVerifier *supplychain.Verifier
 }
 
 // pullArguments are used to identify a pullOperation via an input image name and
@@ -463,6 +465,11 @@ func New(
 		return nil, err
 	}
 
+	scVerifier, err := supplychain.NewVerifier(&config.SupplyChain)
+	if err != nil {
+		return nil, fmt.Errorf("initializing supply chain verifier: %w", err)
+	}
+
 	s := &Server{
 		ContainerServer:          containerServer,
 		hostportManager:          hostportManager,
@@ -476,6 +483,7 @@ func New(
 		resourceStore:            resourcestore.New(),
 		hooksRetriever:           runtimehandlerhooks.NewHooksRetriever(ctx, config),
 		artifactStore:            artifactStore,
+		supplyChainVerifier:      scVerifier,
 	}
 
 	if s.config.EnablePodEvents {
@@ -627,6 +635,8 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			// Block until the signal is received
 			<-ch
 
+			oldSupplyChain := s.config.SupplyChain
+
 			if err := s.config.Reload(ctx); err != nil {
 				log.Errorf(ctx, "Unable to reload configuration: %v", err)
 
@@ -639,6 +649,13 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			// pinned and sandbox/pause images, we need to update them
 			s.ContainerServer.StorageImageServer().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
 			s.artifactStore.SetPinnedImageRegexps(s.ContainerServer.StorageImageServer().PinnedImageRegexps())
+
+			if err := s.supplyChainVerifier.Reload(&s.config.SupplyChain); err != nil {
+				log.Errorf(ctx, "Unable to reload supply chain verifier, restoring previous config: %v", err)
+
+				s.config.SupplyChain = oldSupplyChain
+			}
+
 			log.Infof(ctx, "Configuration reload completed")
 			// Print the current configuration.
 			tomlConfig, err := s.config.ToString()

--- a/test/docs-validation/main.go
+++ b/test/docs-validation/main.go
@@ -35,6 +35,7 @@ var (
 		"manage_network_ns_lifecycle", // deprecated
 		"default_validator",           // printed as a separate table
 		"namespaced_auth_dir",         // hidden
+		"supply_chain",                // printed as separate table
 	}
 
 	// Tags where it should not validate the values.
@@ -50,6 +51,16 @@ var (
 		"workloads", // too complex an option for a CLI flag
 		"default_validator",
 		"namespaced_auth_dir", // hidden
+		// Supply chain config is file-only, no CLI flags.
+		// These are bare TOML tag names from supplychain.Config.
+		// If a future config section adds fields with the same tag names,
+		// the exclusion list must be refactored to use qualified paths.
+		"supply_chain",
+		"verification",
+		"fetch_timeout",
+		"fetch_failure_policy",
+		"cache_ttl",
+		"policy_dir",
 	}
 
 	// Mapping for inconsistencies between tags and CLI arguments.

--- a/test/supply_chain.bats
+++ b/test/supply_chain.bats
@@ -1,0 +1,334 @@
+#!/usr/bin/env bats
+# vim:set ft=bash :
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
+TEST_IMAGE="quay.io/crio/fedora-crio-ci:latest"
+
+# Helper: write a supply chain drop-in config.
+function write_supply_chain_config() {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-supply-chain.conf"
+[crio.image.supply_chain]
+$1
+EOF
+}
+
+# Helper: write a supply chain policy JSON file.
+function write_supply_chain_policy() {
+	local dir="$1"
+	local name="$2"
+	local content="$3"
+	echo "$content" > "$dir/$name.json"
+}
+
+# Helper: create a container config JSON for the test image.
+# Usage: create_container_config [name]
+# Sets CTR_CONFIG to the output path.
+function create_container_config() {
+	local name="${1:-}"
+	CTR_CONFIG="$TESTDIR/ctr-config.json"
+	if [ -n "$name" ]; then
+		jq --arg img "$TEST_IMAGE" --arg name "$name" \
+			'.image.image = $img | .image.user_specified_image = $img | .metadata.name = $name' \
+			"$TESTDATA/container_config.json" > "$CTR_CONFIG"
+	else
+		jq --arg img "$TEST_IMAGE" \
+			'.image.image = $img | .image.user_specified_image = $img' \
+			"$TESTDATA/container_config.json" > "$CTR_CONFIG"
+	fi
+}
+
+@test "supply chain: disabled by default" {
+	start_crio
+
+	crictl pull "$TEST_IMAGE"
+
+	POD_ID=$(crictl runp "$SANDBOX_CONFIG")
+	create_container_config
+	crictl create "$POD_ID" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+
+	run ! grep -q "Supply chain verification" "$CRIO_LOG"
+	run ! grep -q "Supply chain audit" "$CRIO_LOG"
+}
+
+@test "supply chain: config validation rejects invalid verification mode" {
+	write_supply_chain_config 'verification = "bogus"'
+
+	run -1 "$CRIO_BINARY_PATH" --config-dir "$CRIO_CONFIG_DIR" config
+	[[ "$output" == *"invalid supply chain verification mode"* ]]
+}
+
+@test "supply chain: config validation rejects relative policy_dir" {
+	write_supply_chain_config '
+verification = "warn"
+policy_dir = "relative/path"
+'
+
+	run -1 "$CRIO_BINARY_PATH" --config-dir "$CRIO_CONFIG_DIR" config
+	[[ "$output" == *"not absolute"* ]]
+}
+
+@test "supply chain: config validation rejects invalid fetch_failure_policy" {
+	write_supply_chain_config '
+verification = "warn"
+fetch_failure_policy = "bogus"
+'
+
+	run -1 "$CRIO_BINARY_PATH" --config-dir "$CRIO_CONFIG_DIR" config
+	[[ "$output" == *"fetch_failure_policy"* ]]
+}
+
+@test "supply chain: config validation accepts valid warn config" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+
+	write_supply_chain_config "
+verification = \"warn\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	run -0 "$CRIO_BINARY_PATH" --config-dir "$CRIO_CONFIG_DIR" config
+}
+
+@test "supply chain: warn mode allows container creation and logs audit" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	write_supply_chain_policy "$POLICY_DIR" "default" \
+		'{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}'
+
+	write_supply_chain_config "
+verification = \"warn\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	start_crio
+
+	POD_ID=$(crictl runp "$SANDBOX_CONFIG")
+	create_container_config
+
+	# Container creation should succeed in warn mode even with deny provenance policy.
+	crictl create "$POD_ID" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+
+	# Verify audit log was written.
+	wait_for_log "Supply chain audit"
+	wait_for_log "warn mode, allowing"
+}
+
+@test "supply chain: enforce mode rejects container creation with deny provenance policy" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	write_supply_chain_policy "$POLICY_DIR" "default" \
+		'{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}'
+
+	write_supply_chain_config "
+verification = \"enforce\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	start_crio
+
+	POD_ID=$(crictl runp "$SANDBOX_CONFIG")
+	create_container_config
+
+	run ! crictl create "$POD_ID" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+	[[ "$output" == *"SignatureValidationFailed"* ]]
+}
+
+@test "supply chain: enforce mode allows exempt images" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	write_supply_chain_policy "$POLICY_DIR" "default" \
+		"{\"trust\": {\"builders\": [{\"id\": \"https://github.com/actions/runner\", \"max_level\": 3}]}, \"provenance\": {\"missing_policy\": \"deny\"}, \"exclude\": [\"$TEST_IMAGE\"]}"
+
+	write_supply_chain_config "
+verification = \"enforce\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	start_crio
+
+	POD_ID=$(crictl runp "$SANDBOX_CONFIG")
+	create_container_config
+
+	# Exempt image should be allowed even in enforce mode.
+	crictl create "$POD_ID" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+
+	wait_for_log "excluded from supply chain verification"
+}
+
+@test "supply chain: enforce mode allows with provenance_missing_policy=allow" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	write_supply_chain_policy "$POLICY_DIR" "default" \
+		'{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "allow"}}'
+
+	write_supply_chain_config "
+verification = \"enforce\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	start_crio
+
+	POD_ID=$(crictl runp "$SANDBOX_CONFIG")
+	create_container_config
+
+	# Should succeed when provenance is missing but policy is allow.
+	crictl create "$POD_ID" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+
+	wait_for_log "Supply chain audit"
+}
+
+@test "supply chain: enforce mode allows when no trusted builders configured" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	# Policy with deny but no trusted builders.
+	write_supply_chain_policy "$POLICY_DIR" "default" '{"provenance": {"missing_policy": "deny"}}'
+
+	write_supply_chain_config "
+verification = \"enforce\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	start_crio
+
+	POD_ID=$(crictl runp "$SANDBOX_CONFIG")
+	create_container_config
+
+	# No trusted builders means provenance check is a no-op, even with deny policy.
+	crictl create "$POD_ID" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+
+	wait_for_log "no trusted builders configured"
+}
+
+@test "supply chain: namespace-specific policy is used" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	# Default policy: no builders (passes).
+	write_supply_chain_policy "$POLICY_DIR" "default" '{}'
+	# Namespace "testns": has builders configured + deny, provenance will be missing.
+	write_supply_chain_policy "$POLICY_DIR" "testns" \
+		'{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}'
+
+	write_supply_chain_config "
+verification = \"enforce\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	start_crio
+
+	# Create sandbox in the "testns" namespace.
+	NS_SANDBOX_CONFIG="$TESTDIR/sandbox-testns.json"
+	jq '.metadata.namespace = "testns"' "$SANDBOX_CONFIG" > "$NS_SANDBOX_CONFIG"
+	POD_ID=$(crictl runp "$NS_SANDBOX_CONFIG")
+
+	create_container_config
+
+	# testns namespace has builders configured + deny policy, so should fail.
+	run ! crictl create "$POD_ID" "$CTR_CONFIG" "$NS_SANDBOX_CONFIG"
+	[[ "$output" == *"SignatureValidationFailed"* ]]
+}
+
+@test "supply chain: reload enables verification via SIGHUP" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	write_supply_chain_policy "$POLICY_DIR" "default" \
+		'{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}'
+
+	# Start with verification disabled.
+	write_supply_chain_config 'verification = "disabled"'
+
+	start_crio
+
+	# Container creation should work with disabled verification.
+	POD_ID=$(crictl runp "$SANDBOX_CONFIG")
+	create_container_config
+	crictl create "$POD_ID" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+
+	run ! grep -q "Supply chain verification" "$CRIO_LOG"
+
+	# Now switch to enforce mode.
+	write_supply_chain_config "
+verification = \"enforce\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	reload_crio
+	wait_for_log "Configuration reload completed"
+
+	# New container creation should fail after reload.
+	# Use a different container name to avoid duplicate name optimization.
+	POD_ID2=$(crictl runp "$SANDBOX_CONFIG")
+	create_container_config "container2"
+	run ! crictl create "$POD_ID2" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+	[[ "$output" == *"SignatureValidationFailed"* ]]
+}
+
+@test "supply chain: reload disables verification via SIGHUP" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	write_supply_chain_policy "$POLICY_DIR" "default" \
+		'{"trust": {"builders": [{"id": "https://github.com/actions/runner", "max_level": 3}]}, "provenance": {"missing_policy": "deny"}}'
+
+	# Start with enforce mode.
+	write_supply_chain_config "
+verification = \"enforce\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	start_crio
+
+	POD_ID=$(crictl runp "$SANDBOX_CONFIG")
+	create_container_config
+
+	# Should fail with enforce + deny.
+	run ! crictl create "$POD_ID" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+	[[ "$output" == *"SignatureValidationFailed"* ]]
+
+	# Now disable verification.
+	write_supply_chain_config 'verification = "disabled"'
+
+	reload_crio
+	wait_for_log "Configuration reload completed"
+
+	# New container should succeed after disabling.
+	POD_ID2=$(crictl runp "$SANDBOX_CONFIG")
+	crictl create "$POD_ID2" "$CTR_CONFIG" "$SANDBOX_CONFIG"
+}
+
+@test "supply chain: malformed policy file prevents startup" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	echo "not json" > "$POLICY_DIR/default.json"
+
+	write_supply_chain_config "
+verification = \"warn\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	run ! start_crio
+	grep -q "parsing policy file" "$CRIO_LOG"
+}
+
+@test "supply chain: invalid policy file (bad builder) prevents startup" {
+	POLICY_DIR="$TESTDIR/supply-chain-policies"
+	mkdir -p "$POLICY_DIR"
+	write_supply_chain_policy "$POLICY_DIR" "default" \
+		'{"trust": {"builders": [{"id": "", "max_level": 1}]}}'
+
+	write_supply_chain_config "
+verification = \"warn\"
+policy_dir = \"$POLICY_DIR\"
+"
+
+	run ! start_crio
+	grep -q "id is required" "$CRIO_LOG"
+}


### PR DESCRIPTION
/kind feature

#### What type of PR is this?

#### What this PR does / why we need it:
Adds infrastructure for supply chain attestation verification (phase 1 of #9766).

This PR includes:
- `internal/supplychain/` package with config, validation, cache, policy loading, verifier, and metrics
- Per-namespace JSON policy files with nested `trust`, `provenance`, `vex`, `vsa`, and `signatures` groups
- `exclude` glob patterns per namespace for skipping verification
- Config template strings and `crio.conf(5)` man page documentation
- Config reload support (SIGHUP) with rollback on failure
- Integration into `container_create.go` and `container_create_linux.go`
- Prometheus metrics for verification counts, duration, cache hits, and fetch errors
- Unit tests (Ginkgo) and integration tests (BATS)

#### Which issue(s) this PR fixes:
Part of #9766

#### Special notes for your reviewer:
Actual cosign integration for fetching and verifying attestation envelopes is not yet implemented. The verification path currently treats all images as "no provenance found" and applies the configured `provenance.missing_policy`.

Global TOML config contains only operational settings (`verification`, `fetch_timeout`, `fetch_failure_policy`, `cache_ttl`, `policy_dir`). All security posture settings (trust roots, missing attestation policies, VEX thresholds, VSA config, transparency log requirements, exclude patterns) live in per-namespace JSON policy files.

#### Does this PR introduce a user-facing change?
```release-note
Add supply chain attestation verification infrastructure with config, policy, caching, metrics, and audit logging.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added supply-chain attestation verification for container images with configurable verification modes (disabled, warn, enforce)
  * New `crio.image.supply_chain` configuration section enabling policy-based verification, result caching, and namespace-specific controls with image exclusion patterns
  * Four new Prometheus metrics for tracking verification attempts, latency, cache performance, and fetch errors

* **Documentation**
  * Updated metrics and configuration documentation with supply-chain verification settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->