### PR TITLE
OCPBUGS-81547: oci: wait for exit file before defaulting to exit code 255

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1192,8 +1192,18 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 			// We always populate the fields below so kube can restart/reschedule
 			// containers failing.
 			c.state.Status = ContainerStateStopped
-			if err := updateContainerStatusFromExitFile(c); err != nil {
-				log.Errorf(ctx, "Failed to update container status from exit file for %s: %v", c.ID(), err)
+
+			// The exit file may not exist yet if conmon hasn't written it.
+			// Wait for it to appear before defaulting to exit code 255.
+			// This prevents a race where fast-exiting containers
+			// get a spurious exit code 255.
+			waitErr := waitForExitFile(c)
+			if waitErr != nil {
+				log.Errorf(ctx, "Failed to update container status from exit file for %s: %v", c.ID(), waitErr)
+				c.state.Finished = time.Now()
+				c.state.ExitCode = new(int32(255))
+			} else if err := updateContainerStatusFromExitFile(c); err != nil {
+				log.Errorf(ctx, "Failed to read exit file for %s after wait: %v", c.ID(), err)
 				c.state.Finished = time.Now()
 				c.state.ExitCode = new(int32(255))
 			}
@@ -1224,26 +1234,11 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 
 		return nil
 	}
-	// release the lock before waiting
+
 	c.opLock.Unlock()
-	exitFilePath := c.exitFilePath()
-	err = kwait.ExponentialBackoff(
-		kwait.Backoff{
-			Duration: 500 * time.Millisecond,
-			Factor:   1.2,
-			Steps:    6,
-		},
-		func() (bool, error) {
-			_, err := os.Stat(exitFilePath)
-			if err != nil {
-				// wait longer
-				return false, nil
-			}
-
-			return true, nil
-		})
-
+	err = waitForExitFile(c)
 	c.opLock.Lock()
+
 	// run command again
 	state, _, err2 := stateCmd()
 	if err2 != nil {
@@ -1283,6 +1278,28 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 	}
 
 	return nil
+}
+
+// waitForExitFile waits for the container's exit file to appear using
+// exponential backoff. Returns nil if the file appeared, or an error if it did
+// not appear within the timeout (~5s total: 500ms initial, 1.2 factor, 6 steps).
+func waitForExitFile(c *Container) error {
+	exitFilePath := c.exitFilePath()
+
+	return kwait.ExponentialBackoff(
+		kwait.Backoff{
+			Duration: 500 * time.Millisecond,
+			Factor:   1.2,
+			Steps:    6,
+		},
+		func() (bool, error) {
+			_, err := os.Stat(exitFilePath)
+			if err != nil {
+				return false, nil
+			}
+
+			return true, nil
+		})
 }
 
 // PauseContainer pauses a container.

--- a/internal/oci/runtime_oci_test.go
+++ b/internal/oci/runtime_oci_test.go
@@ -11,9 +11,12 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kclock "k8s.io/utils/clock"
 
 	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/internal/storage/references"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	runnerMock "github.com/cri-o/cri-o/test/mocks/cmdrunner"
 	"github.com/cri-o/cri-o/utils/cmdrunner"
@@ -229,6 +232,118 @@ var _ = t.Describe("Oci", func() {
 				Expect(found).To(Equal(test.expected))
 			})
 		}
+	})
+})
+
+var _ = t.Describe("UpdateContainerStatus", func() {
+	It("should wait for exit file when runtime state fails for fast-exiting container", func() {
+		// Set up a container with a temp directory for exit file.
+		containerDir := t.MustTempDir("container-dir")
+
+		imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("docker.io/library/image-name:latest")
+		Expect(err).ToNot(HaveOccurred())
+		imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+		Expect(err).ToNot(HaveOccurred())
+		sut, err := oci.NewContainer("test-fast-exit", "name", "bundlePath", "logPath",
+			map[string]string{}, map[string]string{}, map[string]string{},
+			"image", &imageName, &imageID, "", &types.ContainerMetadata{}, "sandbox",
+			false, false, false, "", containerDir, time.Now(), "")
+		Expect(err).ToNot(HaveOccurred())
+
+		state := &oci.ContainerState{}
+		state.Pid = 1
+		Expect(state.SetInitPid(1)).To(Succeed())
+		sut.SetState(state)
+
+		// Mock the runtime command to always fail (simulating container
+		// already cleaned up by the OCI runtime).
+		runner := runnerMock.NewMockCommandRunner(mockCtrl)
+		cmdrunner.SetMocked(runner)
+
+		defer cmdrunner.ResetPrependedCmd()
+
+		runner.EXPECT().Command(gomock.Any(), gomock.Any()).Return(
+			exec.Command("/bin/false"),
+		).AnyTimes()
+
+		// Set up the runtime.
+		cfg, err := libconfig.DefaultConfig()
+		Expect(err).ToNot(HaveOccurred())
+
+		cfg.ContainerAttachSocketDir = t.MustTempDir("attach-socket")
+		r, err := oci.New(cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		runtime := oci.NewRuntimeOCI(r, &libconfig.RuntimeHandler{})
+
+		// Write the exit file after a short delay, simulating conmon
+		// writing it after the first read attempt fails.
+		go func() {
+			time.Sleep(800 * time.Millisecond)
+			Expect(os.WriteFile(
+				containerDir+"/exit", []byte("0"), 0o644,
+			)).To(Succeed())
+		}()
+
+		// Call UpdateContainerStatus — without the fix this would
+		// default to exit code 255 immediately; with the fix it waits
+		// for the exit file and reads exit code 0.
+		Expect(runtime.UpdateContainerStatus(
+			context.Background(), sut,
+		)).To(Succeed())
+
+		Expect(sut.State().ExitCode).NotTo(BeNil())
+		Expect(*sut.State().ExitCode).To(Equal(int32(0)))
+		Expect(string(sut.State().Status)).To(Equal(oci.ContainerStateStopped))
+	})
+
+	It("should default to exit code 255 when exit file never appears", func() {
+		// Set up a container with a temp directory — no exit file will be created.
+		containerDir := t.MustTempDir("container-dir-no-exit")
+
+		imageName, err := references.ParseRegistryImageReferenceFromOutOfProcessData("docker.io/library/image-name:latest")
+		Expect(err).ToNot(HaveOccurred())
+		imageID, err := storage.ParseStorageImageIDFromOutOfProcessData("2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+		Expect(err).ToNot(HaveOccurred())
+		sut, err := oci.NewContainer("test-no-exit", "name", "bundlePath", "logPath",
+			map[string]string{}, map[string]string{}, map[string]string{},
+			"image", &imageName, &imageID, "", &types.ContainerMetadata{}, "sandbox",
+			false, false, false, "", containerDir, time.Now(), "")
+		Expect(err).ToNot(HaveOccurred())
+
+		state := &oci.ContainerState{}
+		state.Pid = 1
+		Expect(state.SetInitPid(1)).To(Succeed())
+		sut.SetState(state)
+
+		// Mock the runtime command to always fail.
+		runner := runnerMock.NewMockCommandRunner(mockCtrl)
+		cmdrunner.SetMocked(runner)
+
+		defer cmdrunner.ResetPrependedCmd()
+
+		runner.EXPECT().Command(gomock.Any(), gomock.Any()).Return(
+			exec.Command("/bin/false"),
+		).AnyTimes()
+
+		// Set up the runtime.
+		cfg, err := libconfig.DefaultConfig()
+		Expect(err).ToNot(HaveOccurred())
+
+		cfg.ContainerAttachSocketDir = t.MustTempDir("attach-socket-2")
+		r, err := oci.New(cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		runtime := oci.NewRuntimeOCI(r, &libconfig.RuntimeHandler{})
+
+		// Call UpdateContainerStatus — exit file never appears, should
+		// fall back to 255 after exhausting retries.
+		Expect(runtime.UpdateContainerStatus(
+			context.Background(), sut,
+		)).To(Succeed())
+
+		Expect(sut.State().ExitCode).NotTo(BeNil())
+		Expect(*sut.State().ExitCode).To(Equal(int32(255)))
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

When a container exits very quickly, the OCI runtime may clean
up its state before CRI-O queries it. In this case, runtimeCmd("state")
fails and CRI-O falls back to reading the exit file. However, conmon
may not have written the exit file yet, causing CRI-O to immediately
default to exit code 255 with no retry.

Extract the existing exponential backoff wait for the exit file into a
shared waitForExitFile() function and use it in both code paths:
- Path A: when runtimeCmd("state") fails and the exit file is missing
- Path B: when runtimeCmd("state") reports the container as stopped

This ensures fast-exiting containers get the correct exit code from
conmon's exit file instead of a spurious 255.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes #9840 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed the race condition where cri-o reports exitCode 255 when the container exits fast.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by waiting for container exit markers when runtime state queries fail, and clarifying related logging.
  * Ensures exit time and exit code fallback to 255 when exit status cannot be determined after retries.

* **Tests**
  * Added tests validating successful detection from delayed exit markers and fallback-to-255 when none appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->