### PR TITLE
Embed git commit in static binaries via ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,11 @@ else
     BUILD_DATE ?= $(shell date -u "$(DATE_FMT)")
 endif
 
+BUILD_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || true)
+
 BASE_LDFLAGS = ${SHRINKFLAGS} \
-	-X ${PROJECT}/internal/version.buildDate=${BUILD_DATE}
+	-X ${PROJECT}/internal/version.buildDate=${BUILD_DATE} \
+	-X ${PROJECT}/internal/version.buildCommit=${BUILD_COMMIT}
 
 GO_LDFLAGS = -ldflags '${BASE_LDFLAGS} ${EXTRA_LDFLAGS}'
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,8 +35,9 @@
             crossSystem = crossSystem;
             overlays = [ (import ./nix/overlay.nix) ];
           };
+          rev = self.rev or self.dirtyRev or "unknown";
         in
-        pkgs.callPackage ./nix/derivation.nix { };
+        pkgs.callPackage ./nix/derivation.nix { gitCommit = rev; };
 
       # Map target config to native nix system string
       configToSystem = {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,7 +28,8 @@ var ReleaseMinorVersions = []string{"1.35", "1.34", "1.33"}
 
 // Variables injected during build-time.
 var (
-	buildDate string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate   string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildCommit string // git commit, used as fallback when VCS info is unavailable (e.g. nix builds)
 )
 
 type Info struct {
@@ -180,6 +181,17 @@ func Get(verbose bool) (*Info, error) {
 
 		case "-ldflags":
 			ldFlags = s.Value
+		}
+	}
+
+	// Use the ldflags-injected commit as fallback when VCS info is
+	// unavailable (e.g. nix builds where .git is excluded).
+	if gitCommit == unknown && buildCommit != "" {
+		if commit, ok := strings.CutSuffix(buildCommit, "-dirty"); ok {
+			gitCommit = commit
+			gitTreeState = "dirty"
+		} else {
+			gitCommit = buildCommit
 		}
 	}
 

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,5 +1,6 @@
 { stdenv
 , pkgs
+, gitCommit ? "unknown"
 }:
 with pkgs; buildGo126Module /* use go 1.26 */ {
   name = "cri-o";
@@ -36,6 +37,7 @@ with pkgs; buildGo126Module /* use go 1.26 */ {
     export CGO_ENABLED=1
     export CGO_LDFLAGS='-lgpgme -lassuan -lgpg-error'
     export SOURCE_DATE_EPOCH=0
+    export BUILD_COMMIT="${gitCommit}"
   '';
   buildPhase = ''
     make binaries


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

The nix flake build copies source to the nix store without `.git`, so Go's built-in VCS stamping (`vcs.revision`) produces `"unknown"` for the git commit. This causes the packaging bundle test to fail because `crio version -j` reports `gitCommit: "unknown"` instead of the actual commit hash.

This adds a `buildCommit` variable injected via ldflags as a fallback when VCS info is unavailable, and passes the flake's `self.rev` through to the nix derivation.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Before the flakes migration in #9842, `nix-build` operated on the real filesystem where `.git` was still available. With `nix build` (flakes), the source is copied to the nix store without `.git`, breaking Go's VCS stamping.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build pipeline now captures the git commit ID (and detects a dirty state) and includes this information in the application version output across builds, ensuring produced artifacts report a reproducible commit identifier and improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->