### PR TITLE
Add SLSA provenance attestation to release notes

### DIFF
--- a/scripts/release-notes/release_notes.go
+++ b/scripts/release-notes/release_notes.go
@@ -151,6 +151,13 @@ The [OpenVEX](https://openvex.dev) report for this release is available at:
 
 - [cri-o.%s.openvex.json](https://storage.googleapis.com/cri-o/artifacts/cri-o.%s.openvex.json)
 
+The [SLSA](https://slsa.dev) provenance attestation for this release is available at:
+
+- [cri-o.%s.provenance.json](https://storage.googleapis.com/cri-o/artifacts/cri-o.%s.provenance.json)
+  - [cri-o.%s.provenance.json.bundle](https://storage.googleapis.com/cri-o/artifacts/cri-o.%s.provenance.json.bundle)
+
+All release artifacts (bundles, SBOMs, VEX, and provenance) are also available as signed [OCI artifacts](https://github.com/opencontainers/image-spec/blob/main/manifest.md) at `+"`"+`ghcr.io/cri-o/bundle:%s`+"`"+`.
+
 To verify the artifact signatures via [cosign](https://github.com/sigstore/cosign), run:
 
 `+"```"+`console
@@ -179,6 +186,17 @@ To verify the [OpenVEX](https://openvex.dev) vulnerability report, run:
     --certificate-github-workflow-repository cri-o/packaging \
     --certificate-github-workflow-ref refs/heads/main \
     --bundle cri-o.%s.openvex.json.bundle
+`+"```"+`
+
+To verify the [SLSA](https://slsa.dev) provenance attestation, run:
+
+`+"```"+`console
+> cosign verify-blob cri-o.%s.provenance.json \
+    --certificate-identity https://github.com/cri-o/packaging/.github/workflows/obs.yml@refs/heads/main \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-github-workflow-repository cri-o/packaging \
+    --certificate-github-workflow-ref refs/heads/main \
+    --bundle cri-o.%s.provenance.json.bundle
 `+"```"+`
 
 ## Changelog since %s
@@ -225,6 +243,10 @@ To verify the [OpenVEX](https://openvex.dev) vulnerability report, run:
 		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,
 		bundleVersion, bundleVersion,
+		bundleVersion, bundleVersion,
+		bundleVersion, bundleVersion,
+		bundleVersion, bundleVersion,
+		bundleVersion,
 		startTag,
 	); err != nil {
 		return fmt.Errorf("writing template to file: %w", err)


### PR DESCRIPTION
/kind feature

#### What type of PR is this?

#### What this PR does / why we need it:
Add download links and cosign verification command for the SLSA provenance attestation generated by tejolote in the packaging repo (cri-o/packaging#352).

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Depends on cri-o/packaging#352 landing first.

#### Does this PR introduce a user-facing change?
```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notes now list SLSA provenance attestation artifacts (provenance JSON and bundle) alongside release binaries and signed OCI bundle references.
  * Added a verification example showing how to validate provenance artifacts using certificate identity, OIDC issuer, and workflow references.

* **Documentation**
  * Expanded release-note content to include download locations and verification instructions for provenance artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->