### PR TITLE
metrics: add default_runtime

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cri-o/cri-o/internal/version"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/server"
+	"github.com/cri-o/cri-o/server/metrics"
 	"github.com/cri-o/cri-o/utils"
 )
 
@@ -397,6 +398,10 @@ func main() {
 				logrus.Errorf("Failed to sync parent directory of clean shutdown file: %v", err)
 			}
 		}
+
+		// Set the default runtime metric after config has been validated.
+		// This is done here rather than in pkg/config to avoid cyclic imports.
+		metrics.Instance().MetricDefaultRuntimeSet(config.DefaultRuntime)
 
 		// We always use 'Volatile: true' when creating containers, which means that in
 		// the event of an unclean shutdown, we might lose track of containers and layers.

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -350,7 +350,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--metrics-cert**="": Certificate for the secure metrics endpoint.
 
-**--metrics-collectors**="": Enabled metrics collectors. (default: "image_pulls_layer_size", "containers_events_dropped_total", "containers_oom_total", "processes_defunct", "operations_total", "operations_latency_seconds", "operations_latency_seconds_total", "operations_errors_total", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_failure_total", "image_pulls_success_total", "image_layer_reuse_total", "containers_oom_count_total", "containers_seccomp_notifier_count_total", "resources_stalled_at_stage", "containers_stopped_monitor_count")
+**--metrics-collectors**="": Enabled metrics collectors. (default: "image_pulls_layer_size", "containers_events_dropped_total", "containers_oom_total", "processes_defunct", "operations_total", "operations_latency_seconds", "operations_latency_seconds_total", "operations_errors_total", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_failure_total", "image_pulls_success_total", "image_layer_reuse_total", "containers_oom_count_total", "containers_seccomp_notifier_count_total", "resources_stalled_at_stage", "containers_stopped_monitor_count", "default_runtime")
 
 **--metrics-host**="": Host for the metrics endpoint. (default: "127.0.0.1")
 

--- a/server/metrics/collectors/collectors.go
+++ b/server/metrics/collectors/collectors.go
@@ -66,6 +66,9 @@ const (
 
 	// ContainersStoppedMonitorCount is the key for the containers whose monitor is stopped per container name.
 	ContainersStoppedMonitorCount Collector = crioPrefix + "containers_stopped_monitor_count"
+
+	// DefaultRuntime is the key for the default container runtime configured in CRI-O.
+	DefaultRuntime Collector = crioPrefix + "default_runtime"
 )
 
 // FromSlice converts a string slice to a Collectors type.
@@ -107,6 +110,7 @@ func All() Collectors {
 		ContainersSeccompNotifierCountTotal.Stripped(),
 		ResourcesStalledAtStage.Stripped(),
 		ContainersStoppedMonitorCount.Stripped(),
+		DefaultRuntime.Stripped(),
 	}
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -83,6 +83,7 @@ type Metrics struct {
 	metricContainersSeccompNotifierCountTotal *prometheus.CounterVec
 	metricResourcesStalledAtStage             *prometheus.CounterVec
 	metricContainersStoppedMonitorCount       *prometheus.CounterVec
+	metricDefaultRuntime                      *prometheus.GaugeVec
 }
 
 var instance *Metrics
@@ -249,6 +250,14 @@ func New(config *libconfig.MetricsConfig, apiConfig *libconfig.APIConfig) *Metri
 				Help:      "Amount of containers whose monitor process has exited by their name",
 			},
 			[]string{"name"},
+		),
+		metricDefaultRuntime: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Subsystem: collectors.Subsystem,
+				Name:      collectors.DefaultRuntime.String(),
+				Help:      "Default container runtime configured. Value is always 1.",
+			},
+			[]string{"runtime"},
 		),
 	}
 
@@ -452,6 +461,19 @@ func (m *Metrics) MetricContainersStoppedMonitorCountInc(name string) {
 	c.Inc()
 }
 
+func (m *Metrics) MetricDefaultRuntimeSet(runtime string) {
+	m.metricDefaultRuntime.Reset()
+
+	g, err := m.metricDefaultRuntime.GetMetricWithLabelValues(runtime)
+	if err != nil {
+		logrus.Warnf("Unable to write default runtime metric: %v", err)
+
+		return
+	}
+
+	g.Set(1)
+}
+
 // createEndpoint creates a /metrics endpoint for prometheus monitoring.
 func (m *Metrics) createEndpoint() (*http.ServeMux, error) {
 	for collector, metric := range map[collectors.Collector]prometheus.Collector{
@@ -472,6 +494,7 @@ func (m *Metrics) createEndpoint() (*http.ServeMux, error) {
 		collectors.ProcessesDefunct:                    m.metricProcessesDefunct,
 		collectors.ResourcesStalledAtStage:             m.metricResourcesStalledAtStage,
 		collectors.ContainersStoppedMonitorCount:       m.metricContainersStoppedMonitorCount,
+		collectors.DefaultRuntime:                      m.metricDefaultRuntime,
 	} {
 		if m.config.MetricsCollectors.Contains(collector) {
 			logrus.Debugf("Enabling metric: %s", collector.Stripped())

--- a/server/server.go
+++ b/server/server.go
@@ -631,6 +631,9 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 
 				continue
 			}
+
+			metrics.Instance().MetricDefaultRuntimeSet(s.config.DefaultRuntime)
+
 			// ImageServer compiles the list with regex for both
 			// pinned and sandbox/pause images, we need to update them
 			s.ContainerServer.StorageImageServer().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))

--- a/test/metrics.bats
+++ b/test/metrics.bats
@@ -84,6 +84,32 @@ function teardown() {
 	curl -sfk "https://localhost:$PORT/metrics" | grep crio_operations
 }
 
+@test "default runtime metric" {
+	PORT=$(free_port)
+	CONTAINER_ENABLE_METRICS=true CONTAINER_METRICS_PORT=$PORT start_crio
+
+	# Check that the default runtime metric is present
+	METRIC=$(curl -sf "http://localhost:$PORT/metrics" | grep "^container_runtime_crio_default_runtime{runtime=\"${CONTAINER_DEFAULT_RUNTIME}\"}")
+	[[ "$METRIC" == "container_runtime_crio_default_runtime{runtime=\"${CONTAINER_DEFAULT_RUNTIME}\"} 1" ]]
+
+	# reload with new runtime
+	cat << EOF > "$CRIO_CONFIG_DIR/999-newRuntime.conf"
+[crio.runtime]
+default_runtime = "new"
+[crio.runtime.runtimes.new]
+runtime_path = "$RUNTIME_BINARY_PATH"
+EOF
+
+	reload_crio
+	wait_for_log '"updating runtime configuration"'
+
+	# Check that the new default runtime metric is present
+	METRIC=$(curl -sf "http://localhost:$PORT/metrics" | grep "^container_runtime_crio_default_runtime{runtime=\"new\"}")
+	[[ "$METRIC" == "container_runtime_crio_default_runtime{runtime=\"new\"} 1" ]]
+	# and the old is not
+	run curl -sf "http://localhost:$PORT/metrics" | grep -v "^container_runtime_crio_default_runtime{runtime=\"${BACKUP_RUNTIME}\"}"
+}
+
 # TODO: deflake and re-enable the test
 #@test "metrics container oom" {
 #	PORT=$(free_port)


### PR DESCRIPTION
we consistently need to find which runtime a user is using, and have talked about adding this for a while. Now's the time!

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add `container_runtime_crio_default_runtime` metric to display which default runtime the node is configured to use
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default-runtime metric to the metrics endpoint; it is set at startup and updated on configuration reload to reflect the currently configured default runtime.

* **Tests**
  * Added an integration test validating the default-runtime metric is exposed and reports value 1 for the configured runtime before and after reload.

* **Documentation**
  * Updated metrics collectors docs to include the default-runtime collector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->