### PR TITLE
[release-1.34] Pin runc to v1.4.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -73,7 +73,7 @@ dependencies:
         match: build-libpathrs.sh
 
   - name: runc
-    version: main
+    version: v1.4.2
     refPaths:
       - path: scripts/versions
         match: runc

--- a/scripts/versions
+++ b/scripts/versions
@@ -2,7 +2,7 @@
 declare -A VERSIONS=(
     ["cni-plugins"]=v1.7.1
     ["conmon"]=v2.1.13
-    ["runc"]=main
+    ["runc"]=v1.4.2
     ["bats"]=v1.11.1
     ["buildah"]=v1.38.0
     ["libpathrs"]=0.2.4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Building runc from its main branch started failing on release-1.34 because runc now requires Go 1.25.0 via its toolchain directive. The CI runner installs an older Go version, causing a permission error when Go tries to auto-download the newer toolchain.

Pin to the latest stable release (v1.4.2) which requires Go 1.24.0 and has no toolchain directive, avoiding the auto-download issue and making builds reproducible.

Eventually, all release branches shouldn't build any binary except for cri-o, but should use released versions.
However I haven't done that in this PR.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
