### PR TITLE
MAINTAINERS: move @kolyshkin to alumni

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,7 +14,6 @@ describes the CRI-O governance.
 | Sascha Grunert    | [saschagrunert](https://github.com/saschagrunert)   | Approver      | [Red Hat](https://www.github.com/redhat/) |
 | Peter Hunt        | [pehunt](https://github.com/pehunt)                 | Approver      | [Red Hat](https://www.github.com/redhat/) |
 | Fabiano Fidêncio  | [fidencio](https://github.com/fidencio)             | Approver      | [Intel](https://github.com/intel)         |
-| Kir Kolyshkin     | [kolyshkin](https://github.com/kolyshkin)           | Approver      | [Red Hat](https://www.github.com/redhat/) |
 | Sohan Kunkerkar   | [sohankunkerkar](https://github.com/sohankunkerkar) | Approver      | [Red Hat](https://www.github.com/redhat/) |
 | Skyler Clark      | [wgahnagl](https://github.com/wgahnagl)             | Reviewer      | [Red Hat](https://www.github.com/redhat/) |
 | Qi Wang           | [QiWang19](https://github.com/QiWang19)             | Reviewer      | [Red Hat](https://www.github.com/redhat/) |
@@ -29,6 +28,7 @@ describes the CRI-O governance.
 | Antonio Murdaca   | [runcom](https://github.com/runcom)       | Approver      | [Red Hat](https://www.github.com/redhat/) |
 | Dan Walsh         | [rhatdan](https://github.com/rhatdan)     | Approver      | [Red Hat](https://github.com/redhat)      |
 | Valentin Rothberg | [vrothberg](https://github.com/vrothberg) | Approver      | [Red Hat](https://github.com/redhat)      |
+| Kir Kolyshkin     | [kolyshkin](https://github.com/kolyshkin) | Approver      | [Red Hat](https://www.github.com/redhat/) |
 
 ## Credits
 

--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,7 @@ filters:
     - runcom
     - rhatdan
     - vrothberg
+    - kolyshkin
   # go.{mod,sum}, vendor/* files related to go dependencies,
   # and should be reviewed by the cri-o reviewers
   "go\\.(mod|sum)$":

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,7 +7,6 @@ aliases:
     - saschagrunert
     - haircommander
     - fidencio
-    - kolyshkin
     - sohankunkerkar
   cri-o-reviewers:
     - wgahnagl


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

I am not that involved in cri-o as I used to be, and while I can still
help occasionally, I am not able to be a maintainer anymore.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated maintainer and alumni listings to reflect current team composition.
* **Chores**
  * Added an additional approver for repository approval rules covering the relevant paths.
  * Removed a user from an approver alias, adjusting the set of users associated with that alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->