### PR TITLE
OCPBUGS-81474: [1.35] cnimgr: continuously poll CNI STATUS to detect runtime health changes

### DIFF
--- a/internal/config/cnimgr/cnimgr.go
+++ b/internal/config/cnimgr/cnimgr.go
@@ -14,13 +14,17 @@ import (
 
 type PodNetworkLister func() ([]*ocicni.PodNetwork, error)
 
+var errShutdown = errors.New("CNI manager shut down")
+
 type CNIManager struct {
 	// cniPlugin is the internal OCI CNI plugin
-	plugin    ocicni.CNIPlugin
-	lastError error
-	watchers  []chan bool
-	shutdown  bool
-	mutex     sync.RWMutex
+	plugin              ocicni.CNIPlugin
+	lastError           error
+	watchers            []chan bool
+	mutex               sync.RWMutex
+	cancel              context.CancelFunc
+	initPollInterval    time.Duration
+	monitorPollInterval time.Duration
 
 	validPodList PodNetworkLister
 }
@@ -34,48 +38,77 @@ func New(defaultNetwork, networkDir string, pluginDirs ...string) (*CNIManager, 
 		return nil, fmt.Errorf("initialize CNI plugin: %w", err)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	mgr := &CNIManager{
-		plugin:    plugin,
-		lastError: errors.New("plugin status uninitialized"),
+		plugin:              plugin,
+		lastError:           errors.New("plugin status uninitialized"),
+		cancel:              cancel,
+		initPollInterval:    500 * time.Millisecond,
+		monitorPollInterval: 5 * time.Second,
 	}
-	go mgr.pollUntilReady()
+
+	go mgr.pollContinuously(ctx)
 
 	return mgr, nil
 }
 
-func (c *CNIManager) pollUntilReady() {
-	//nolint:errcheck,staticcheck
-	_ = wait.PollInfinite(500*time.Millisecond, c.pollFunc)
+func (c *CNIManager) pollContinuously(ctx context.Context) {
+	// Phase 1: fast poll until the plugin is ready for the first time.
+	// This handles startup synchronization, triggers deferred GC, and notifies
+	// watchers that are blocking pod creation.
+	//nolint:errcheck // error is intentionally ignored, status is tracked via lastError
+	wait.PollUntilContextCancel(ctx, c.initPollInterval, true,
+		func(ctx context.Context) (bool, error) {
+			return c.statusPollFunc(ctx, true)
+		})
+
+	// Phase 2: slow poll to continuously monitor plugin health.
+	// If the plugin becomes unhealthy, lastError is set so that
+	// ReadyOrError() reports not-ready and kubelet sees NetworkReady=false.
+	//nolint:errcheck // error is intentionally ignored, status is tracked via lastError
+	wait.PollUntilContextCancel(ctx, c.monitorPollInterval, true,
+		func(ctx context.Context) (bool, error) {
+			return c.statusPollFunc(ctx, false)
+		})
 }
 
-func (c *CNIManager) pollFunc() (bool, error) {
+func (c *CNIManager) statusPollFunc(ctx context.Context, isStartup bool) (bool, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	if c.shutdown {
-		return true, nil
-	}
-
-	if err := c.plugin.Status(); err != nil {
+	if err := c.plugin.StatusWithContext(ctx); err != nil {
 		c.lastError = err
 
 		return false, nil
 	}
-	// on startup, GC might have been attempted before the plugin was actually
-	// ready so we might have deferred it until now, which is still a good time
-	// to do it as the relevant context is equivalent: the same list of pods is
-	// valid and stable because new pods can't be created until the plugin is
-	// announced as ready
-	if err := c.doGC(context.Background()); err != nil {
-		logrus.Warnf("Garbage collect stale network resources during plugin startup failed: %v", err)
+
+	if c.lastError != nil {
+		c.lastError = nil
+		// on startup, GC might have been attempted before the plugin was
+		// actually ready so we might have deferred it until now, which is
+		// still a good time to do it as the relevant context is equivalent:
+		// the same list of pods is valid and stable because new pods can't
+		// be created until the plugin is announced as ready
+		if isStartup {
+			if err := c.doGC(ctx); err != nil {
+				logrus.Warnf("Garbage collect stale network resources failed: %v", err)
+			}
+		}
+		// Notify any waiters blocked on pod creation that the plugin is
+		// now ready. Non-blocking send avoids deadlock if a watcher was
+		// abandoned (e.g. timed-out pod creation) and the buffer is full.
+		for _, watcher := range c.watchers {
+			select {
+			case watcher <- true:
+			default:
+			}
+		}
+
+		c.watchers = nil
 	}
 
-	c.lastError = nil
-	for _, watcher := range c.watchers {
-		watcher <- true
-	}
-
-	return true, nil
+	return isStartup, nil
 }
 
 // ReadyOrError returns nil if the plugin is ready,
@@ -100,7 +133,15 @@ func (c *CNIManager) AddWatcher() chan bool {
 	defer c.mutex.Unlock()
 
 	watcher := make(chan bool, 1)
-	c.watchers = append(c.watchers, watcher)
+
+	switch {
+	case c.lastError == nil:
+		watcher <- true
+	case errors.Is(c.lastError, errShutdown):
+		watcher <- false
+	default:
+		c.watchers = append(c.watchers, watcher)
+	}
 
 	return watcher
 }
@@ -108,13 +149,27 @@ func (c *CNIManager) AddWatcher() chan bool {
 // Shutdown shuts down the CNI manager, and notifies the watcher
 // that the CNI manager is not ready.
 func (c *CNIManager) Shutdown() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	c.shutdown = true
+	c.lastError = errShutdown
+
+	// Non-blocking send: the buffer may already contain a `true` from a
+	// recent recovery notification. In that case the consumer will read
+	// `true` and proceed, which is acceptable since the plugin was ready
+	// at that point; the shutdown will be caught by subsequent operations.
 	for _, watcher := range c.watchers {
-		watcher <- false
+		select {
+		case watcher <- false:
+		default:
+		}
 	}
+
+	c.watchers = nil
 }
 
 // GC calls the plugin's GC to clean up any resources concerned with stale pods
@@ -126,9 +181,10 @@ func (c *CNIManager) GC(ctx context.Context, validPodList PodNetworkLister) erro
 	defer c.mutex.Unlock()
 
 	c.validPodList = validPodList
+
 	if c.lastError != nil {
 		// on startup, GC might be attempted before the plugin is actually ready
-		// so defer until it is (see pollFunc)
+		// so defer until it is (see statusPollFunc)
 		return nil
 	}
 

--- a/internal/config/cnimgr/cnimgr_test.go
+++ b/internal/config/cnimgr/cnimgr_test.go
@@ -1,0 +1,531 @@
+package cnimgr
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cri-o/ocicni/pkg/ocicni"
+)
+
+const (
+	testPollInterval = 10 * time.Millisecond
+	testTimeout      = 2 * time.Second
+)
+
+type fakeCNIPlugin struct {
+	mu        sync.Mutex
+	statusErr error
+	gcCalls   atomic.Int32
+}
+
+func (f *fakeCNIPlugin) setStatusErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.statusErr = err
+}
+
+func (f *fakeCNIPlugin) Status() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.statusErr
+}
+
+func (f *fakeCNIPlugin) Name() string                  { return "fake" }
+func (f *fakeCNIPlugin) GetDefaultNetworkName() string { return "fake-net" }
+func (f *fakeCNIPlugin) Shutdown() error               { return nil }
+
+func (f *fakeCNIPlugin) GC(context.Context, []*ocicni.PodNetwork) error {
+	f.gcCalls.Add(1)
+
+	return nil
+}
+
+func (f *fakeCNIPlugin) StatusWithContext(context.Context) error { return f.Status() }
+
+func (f *fakeCNIPlugin) SetUpPod(ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+	return nil, nil
+}
+
+func (f *fakeCNIPlugin) SetUpPodWithContext(context.Context, ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+	return nil, nil
+}
+
+func (f *fakeCNIPlugin) TearDownPod(ocicni.PodNetwork) error { return nil }
+
+func (f *fakeCNIPlugin) TearDownPodWithContext(context.Context, ocicni.PodNetwork) error {
+	return nil
+}
+
+func (f *fakeCNIPlugin) GetPodNetworkStatus(ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+	return nil, nil
+}
+
+func (f *fakeCNIPlugin) GetPodNetworkStatusWithContext(context.Context, ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+	return nil, nil
+}
+
+func newTestManager(plugin *fakeCNIPlugin) *CNIManager {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mgr := &CNIManager{
+		plugin:              plugin,
+		lastError:           errors.New("plugin status uninitialized"),
+		cancel:              cancel,
+		initPollInterval:    testPollInterval,
+		monitorPollInterval: testPollInterval,
+	}
+
+	go mgr.pollContinuously(ctx)
+
+	return mgr
+}
+
+func waitFor(t *testing.T, desc string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(testTimeout)
+
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for: %s", desc)
+}
+
+func TestStatusPolling(t *testing.T) {
+	t.Run("becomes ready when plugin is healthy", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		waitFor(t, "ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+	})
+
+	t.Run("stays not-ready while plugin is unhealthy", func(t *testing.T) {
+		fake := &fakeCNIPlugin{statusErr: errors.New("not yet")}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		time.Sleep(100 * time.Millisecond)
+
+		if err := mgr.ReadyOrError(); err == nil {
+			t.Fatal("expected not-ready")
+		}
+	})
+
+	t.Run("becomes ready after plugin recovers at startup", func(t *testing.T) {
+		fake := &fakeCNIPlugin{statusErr: errors.New("not yet")}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		fake.setStatusErr(nil)
+
+		waitFor(t, "ready after startup recovery", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+	})
+
+	t.Run("detects unhealthy after initial readiness", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		fake.setStatusErr(errors.New("plugin down"))
+
+		waitFor(t, "not-ready detected", func() bool {
+			return mgr.ReadyOrError() != nil
+		})
+	})
+
+	t.Run("self-heals after runtime failure", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		fake.setStatusErr(errors.New("plugin down"))
+
+		waitFor(t, "not-ready", func() bool {
+			return mgr.ReadyOrError() != nil
+		})
+
+		fake.setStatusErr(nil)
+
+		waitFor(t, "recovered", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+	})
+
+	t.Run("survives multiple flaps", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		for range 3 {
+			fake.setStatusErr(errors.New("plugin down"))
+
+			waitFor(t, "not-ready", func() bool {
+				return mgr.ReadyOrError() != nil
+			})
+
+			fake.setStatusErr(nil)
+
+			waitFor(t, "recovered", func() bool {
+				return mgr.ReadyOrError() == nil
+			})
+		}
+	})
+
+	t.Run("shutdown stops polling", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+
+		waitFor(t, "ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		mgr.Shutdown()
+		fake.setStatusErr(errors.New("plugin down"))
+		time.Sleep(100 * time.Millisecond)
+
+		if !errors.Is(mgr.ReadyOrError(), errShutdown) {
+			t.Fatalf("expected shutdown error, got: %v", mgr.ReadyOrError())
+		}
+	})
+
+	t.Run("ReadyOrError returns error after shutdown", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+
+		waitFor(t, "ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		mgr.Shutdown()
+
+		if err := mgr.ReadyOrError(); err == nil {
+			t.Fatal("expected error after shutdown")
+		}
+	})
+
+	t.Run("watcher notified on initial readiness", func(t *testing.T) {
+		fake := &fakeCNIPlugin{statusErr: errors.New("not yet")}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		watcher := mgr.AddWatcher()
+
+		fake.setStatusErr(nil)
+
+		select {
+		case ready := <-watcher:
+			if !ready {
+				t.Fatal("expected watcher to receive true")
+			}
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for watcher")
+		}
+	})
+
+	t.Run("watcher notified on recovery", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		fake.setStatusErr(errors.New("plugin down"))
+
+		waitFor(t, "not-ready", func() bool {
+			return mgr.ReadyOrError() != nil
+		})
+
+		watcher := mgr.AddWatcher()
+
+		fake.setStatusErr(nil)
+
+		select {
+		case ready := <-watcher:
+			if !ready {
+				t.Fatal("expected watcher to receive true on recovery")
+			}
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for watcher on recovery")
+		}
+	})
+
+	t.Run("watcher receives true immediately if already ready", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		waitFor(t, "ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		watcher := mgr.AddWatcher()
+
+		select {
+		case ready := <-watcher:
+			if !ready {
+				t.Fatal("expected watcher to receive true immediately")
+			}
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for immediate watcher notification")
+		}
+	})
+
+	t.Run("watcher receives false on shutdown", func(t *testing.T) {
+		fake := &fakeCNIPlugin{statusErr: errors.New("not yet")}
+		mgr := newTestManager(fake)
+
+		watcher := mgr.AddWatcher()
+
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			mgr.Shutdown()
+		}()
+
+		select {
+		case ready := <-watcher:
+			if ready {
+				t.Fatal("expected watcher to receive false on shutdown")
+			}
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for shutdown notification")
+		}
+	})
+
+	t.Run("abandoned watcher does not deadlock", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		_ = mgr.AddWatcher() // never consumed
+
+		for range 2 {
+			fake.setStatusErr(errors.New("plugin down"))
+
+			waitFor(t, "not-ready", func() bool {
+				return mgr.ReadyOrError() != nil
+			})
+
+			fake.setStatusErr(nil)
+
+			waitFor(t, "recovered", func() bool {
+				return mgr.ReadyOrError() == nil
+			})
+		}
+	})
+
+	t.Run("GC called on initial readiness", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		mgr.mutex.Lock()
+		mgr.validPodList = func() ([]*ocicni.PodNetwork, error) { return nil, nil }
+
+		mgr.mutex.Unlock()
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "GC called", func() bool {
+			return fake.gcCalls.Load() > 0
+		})
+	})
+
+	t.Run("GC not called on recovery", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		mgr.mutex.Lock()
+		mgr.validPodList = func() ([]*ocicni.PodNetwork, error) { return nil, nil }
+		mgr.mutex.Unlock()
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		initialGC := fake.gcCalls.Load()
+
+		fake.setStatusErr(errors.New("plugin down"))
+
+		waitFor(t, "not-ready", func() bool {
+			return mgr.ReadyOrError() != nil
+		})
+
+		fake.setStatusErr(nil)
+
+		waitFor(t, "recovered", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		time.Sleep(200 * time.Millisecond)
+
+		if calls := fake.gcCalls.Load(); calls != initialGC {
+			t.Fatalf("expected no GC calls on recovery, got %d (initial was %d)", calls, initialGC)
+		}
+	})
+
+	t.Run("GC not called while already healthy", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		mgr.mutex.Lock()
+		mgr.validPodList = func() ([]*ocicni.PodNetwork, error) { return nil, nil }
+		mgr.mutex.Unlock()
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		initialGC := fake.gcCalls.Load()
+
+		time.Sleep(200 * time.Millisecond)
+
+		if calls := fake.gcCalls.Load(); calls != initialGC {
+			t.Fatalf("expected no additional GC calls while healthy, got %d (initial was %d)", calls, initialGC)
+		}
+	})
+
+	t.Run("AddWatcher returns false after shutdown", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+
+		waitFor(t, "ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		mgr.Shutdown()
+
+		watcher := mgr.AddWatcher()
+
+		select {
+		case ready := <-watcher:
+			if ready {
+				t.Fatal("expected watcher to receive false after shutdown")
+			}
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for watcher after shutdown")
+		}
+	})
+
+	t.Run("Plugin returns the CNI plugin", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		if mgr.Plugin() == nil {
+			t.Fatal("expected non-nil plugin")
+		}
+	})
+
+	t.Run("GC deferred when plugin is not ready", func(t *testing.T) {
+		fake := &fakeCNIPlugin{statusErr: errors.New("not yet")}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		err := mgr.GC(context.Background(), func() ([]*ocicni.PodNetwork, error) {
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error when GC is deferred, got: %v", err)
+		}
+
+		if calls := fake.gcCalls.Load(); calls != 0 {
+			t.Fatalf("expected 0 GC calls while not ready, got %d", calls)
+		}
+	})
+
+	t.Run("GC runs immediately when plugin is ready", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		waitFor(t, "ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		initialGC := fake.gcCalls.Load()
+
+		err := mgr.GC(context.Background(), func() ([]*ocicni.PodNetwork, error) {
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+
+		if calls := fake.gcCalls.Load(); calls <= initialGC {
+			t.Fatalf("expected GC to run immediately, got %d calls (initial was %d)", calls, initialGC)
+		}
+	})
+
+	t.Run("GC returns error from validPodList", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+
+		mgr := newTestManager(fake)
+		defer mgr.Shutdown()
+
+		waitFor(t, "ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		expectedErr := errors.New("pod list error")
+
+		err := mgr.GC(context.Background(), func() ([]*ocicni.PodNetwork, error) {
+			return nil, expectedErr
+		})
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected pod list error, got: %v", err)
+		}
+	})
+}

--- a/internal/config/cnimgr/cnimgr_test_inject.go
+++ b/internal/config/cnimgr/cnimgr_test_inject.go
@@ -6,6 +6,8 @@
 package cnimgr
 
 import (
+	"context"
+
 	"github.com/cri-o/ocicni/pkg/ocicni"
 )
 
@@ -20,8 +22,8 @@ func (c *CNIManager) SetCNIPlugin(plugin ocicni.CNIPlugin) error {
 
 	c.plugin = plugin
 	// initialize the poll, but don't run it continuously (or else the mocks will get weird)
-	//nolint:errcheck
-	_, _ = c.pollFunc()
+	//nolint:errcheck // error is intentionally ignored in test setup
+	_, _ = c.statusPollFunc(context.Background(), false)
 
 	return nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -84,7 +84,7 @@ var _ = t.Describe("Server", func() {
 			// Given
 			graphroot := t.MustTempDir("graphroot")
 			gomock.InOrder(
-				cniPluginMock.EXPECT().Status().Return(nil),
+				cniPluginMock.EXPECT().StatusWithContext(gomock.Any()).Return(nil),
 				libMock.EXPECT().GetData().Times(2).Return(serverConfig),
 				libMock.EXPECT().GetStore().Return(storeMock, nil),
 				libMock.EXPECT().GetData().Return(serverConfig),

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -229,7 +229,7 @@ func mockNewServer() {
 
 	graphroot := t.MustTempDir("graphroot")
 	gomock.InOrder(
-		cniPluginMock.EXPECT().Status().Return(nil),
+		cniPluginMock.EXPECT().StatusWithContext(gomock.Any()).Return(nil),
 		libMock.EXPECT().GetData().Times(2).Return(serverConfig),
 		libMock.EXPECT().GetStore().Return(storeMock, nil),
 		libMock.EXPECT().GetData().Return(serverConfig),


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

CRI-O polls CNI Status() at startup to wait for readiness, but stops
after the first success. With the CNI STATUS verb (spec v1.1.0), plugins
can now report unhealthy at runtime, but CRI-O doesn't react to this
verb after initial readiness. If a plugin becomes unhealthy (e.g. daemon
restart, config regeneration, or network failure), CRI-O keeps reporting
NetworkReady=true and pods fail at network setup instead of the node
being marked not-ready.

This is analogous to containerd, which calls Status() on every CRI
Status request (see containerd/containerd#11135).

This PR changes the polling to two stages:
- **Init poll** (500ms): fast poll until first ready, triggers GC and
  notifies watchers. Same as before.
- **Monitor poll** (5s): continuous health check. Sets not-ready on
  failure, self-heals on recovery.

Also replaces the shutdown bool with context cancellation for clean
goroutine lifecycle, and handles edge cases in AddWatcher for shutdown
and already-ready states.

#### Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-81474

#### Special notes for your reviewer:

The `doGC` call is still made under the mutex (inherited from the
original code). This could be improved in a follow-up by splitting the
lock around the I/O-heavy GC operation.

cherry-pick of https://github.com/cri-o/cri-o/pull/9855 
#### Does this PR introduce a user-facing change?

```release-note
CRI-O now continuously monitors CNI plugin health using the STATUS
verb. If a plugin becomes unhealthy after initial readiness, the node
is reported as NetworkReady=false, preventing pod scheduling on
affected nodes. The node self-heals when the plugin recovers.
```