### PR TITLE
Confidential Container: do not pull images on the host

### DIFF
--- a/contrib/test/ci/build/kata.yml
+++ b/contrib/test/ci/build/kata.yml
@@ -85,3 +85,156 @@
         path: "/opt/kata/share/defaults/kata-containers/configuration.toml"
         regexp: "^#enable_debug = true"
         replace: "enable_debug = true"
+
+- name: Set up kata-remote (peer pods) environment
+  block:
+    - name: Install libvirt and QEMU
+      become: yes
+      package:
+        name:
+          - podman
+          - qemu-kvm
+          - libvirt
+          - libvirt-client
+          - virt-install
+          - edk2-ovmf
+          - "{{ 'guestfs-tools' if ansible_distribution_major_version | int >= 40 else 'libguestfs-tools-c' }}"
+        state: present
+
+    - name: Start and enable libvirtd
+      become: yes
+      systemd:
+        name: libvirtd
+        state: started
+        enabled: yes
+
+    - name: Configure libvirt storage pool
+      become: yes
+      shell: |
+        virsh pool-define-as default dir --target /var/lib/libvirt/images || true
+        virsh pool-autostart default
+        virsh pool-start default || true
+      args:
+        executable: /bin/bash
+
+    - name: Configure libvirt default network
+      become: yes
+      shell: |
+        virsh net-start default || true
+        virsh net-autostart default
+      args:
+        executable: /bin/bash
+
+    - name: Create required directories
+      become: yes
+      file:
+        path: "{{ item }}"
+        state: directory
+      loop:
+        - /run/peerpod
+        - /run/netns
+        - /opt/data-dir
+
+    - name: Create xtables lock file
+      become: yes
+      file:
+        path: /run/xtables.lock
+        state: touch
+
+    - name: Enable SSH root login for libvirt access
+      become: yes
+      shell: |
+        sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+        systemctl restart sshd
+      args:
+        executable: /bin/bash
+
+    - name: Generate SSH key for libvirt access
+      become: yes
+      shell: |
+        ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa
+        cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+        chmod 700 /root/.ssh
+        chmod 600 /root/.ssh/authorized_keys
+        restorecon -Rv /root/.ssh/
+        ssh-keyscan -H 192.168.122.1 >> /root/.ssh/known_hosts 2>/dev/null || true
+      args:
+        executable: /bin/bash
+        creates: /root/.ssh/id_rsa
+
+    - name: Verify SSH connectivity to libvirt host
+      become: yes
+      shell: ssh -o StrictHostKeyChecking=no root@192.168.122.1 'virsh version'
+      args:
+        executable: /bin/bash
+
+    - name: Write systemd mount unit for cloud-init ISO
+      become: yes
+      copy:
+        dest: /tmp/media-cidata.mount
+        content: |
+          [Unit]
+          Description=Mount cloud-init NoCloud ISO
+          DefaultDependencies=no
+          Before=process-user-data.service cloud-init-local.service
+          After=systemd-udevd.service
+
+          [Mount]
+          What=/dev/sr0
+          Where=/media/cidata
+          Type=iso9660
+          Options=ro,nofail
+
+          [Install]
+          WantedBy=local-fs.target
+
+    - name: Pull and extract podvm image
+      become: yes
+      shell: |
+        podman pull {{ podvm_image }}
+        podman create --name qcow_extractor {{ podvm_image }} /bin/true
+        QCOW=$(podman export qcow_extractor | tar t | grep '\.qcow2$')
+        podman cp "qcow_extractor:/$QCOW" /tmp/podvm.qcow2
+        podman rm qcow_extractor
+        LIBGUESTFS_BACKEND=direct virt-customize -a /tmp/podvm.qcow2 \
+          --run-command 'mkdir -p /media/cidata' \
+          --copy-in /tmp/media-cidata.mount:/etc/systemd/system/ \
+          --run-command 'systemctl enable media-cidata.mount'
+        rm -f /tmp/media-cidata.mount
+        virsh vol-create-as --pool default --name podvm-base.qcow2 \
+          --capacity 20G --allocation 2G --prealloc-metadata --format qcow2 || true
+        virsh vol-upload --vol podvm-base.qcow2 /tmp/podvm.qcow2 --pool default --sparse
+        rm -f /tmp/podvm.qcow2
+      args:
+        executable: /bin/bash
+
+    - name: Start Cloud API Adaptor container
+      become: yes
+      shell: |
+        podman pull {{ caa_image }}
+        podman run -d \
+          --name caa \
+          --network host \
+          --security-opt label=disable \
+          --cap-add NET_ADMIN \
+          --cap-add SYS_ADMIN \
+          --device /dev/kvm \
+          -e CLOUD_PROVIDER=libvirt \
+          -e LIBVIRT_URI="qemu+ssh://root@192.168.122.1/system?no_verify=1" \
+          -e LIBVIRT_POOL=default \
+          -e LIBVIRT_NET=default \
+          -e LIBVIRT_VOL_NAME=podvm-base.qcow2 \
+          -e DISABLECVM=true \
+          -e LIBVIRT_EFI_FIRMWARE=/usr/share/edk2/ovmf/OVMF_CODE.fd \
+          -v /root/.ssh/id_rsa:/root/.ssh/id_rsa:ro \
+          -v /run/peerpod:/run/peerpod \
+          -v /run/netns:/run/netns:rslave \
+          -v /run/xtables.lock:/run/xtables.lock \
+          -v /lib/modules:/lib/modules:ro \
+          -v /opt/data-dir:/opt/data-dir \
+          {{ caa_image }}
+        sleep 5
+        podman ps -a --filter name=caa
+        podman logs caa 2>&1 | tail -30
+      args:
+        executable: /bin/bash

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -48,6 +48,8 @@ kata_version: "3.31.0"
 # https://github.com/kata-containers/kata-containers/attestations/28048664/download
 kata_amd64_checksum: "sha256:68c2786a0b97023f62f3eca02dc868b78a794e5469d4ddd6cc9e0bd4a7212b0b"
 int_test_timeout: "{{ 120 * 60 }}"
+podvm_image: "quay.io/confidential-containers/podvm-generic-ubuntu-amd64:v0.18.0"
+caa_image: "quay.io/confidential-containers/cloud-api-adaptor:v0.18.0-dev"
 
 kata_skip_files:
   - "apparmor.bats"

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -115,7 +115,7 @@ func (c *ContainerServer) ContainerCheckpoint(
 	}
 
 	if !opts.KeepRunning {
-		if err := c.storageRuntimeServer.StopContainer(ctx, ctr.ID()); err != nil {
+		if err := c.StorageRuntimeServer().StopContainer(ctx, ctr.ID()); err != nil {
 			return "", fmt.Errorf("failed to unmount container %s: %w", ctr.ID(), err)
 		}
 	}

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -115,7 +115,16 @@ func (c *ContainerServer) ContainerCheckpoint(
 	}
 
 	if !opts.KeepRunning {
-		if err := c.StorageRuntimeServer().StopContainer(ctx, ctr.ID()); err != nil {
+		runtimeHandler := ""
+		if sb, err := c.LookupSandbox(ctr.Sandbox()); err == nil {
+			runtimeHandler = sb.RuntimeHandler()
+		} else {
+			// don't abort in case of error - we can use the default runtime
+			// handler here (""), to at least try and stop the container.
+			log.Warnf(ctx, "Failed to lookup sandbox %s for checkpoint cleanup: %v", ctr.Sandbox(), err)
+		}
+
+		if err := c.StorageRuntimeServer(runtimeHandler).StopContainer(ctx, ctr.ID()); err != nil {
 			return "", fmt.Errorf("failed to unmount container %s: %w", ctr.ID(), err)
 		}
 	}
@@ -309,7 +318,12 @@ func (c *ContainerServer) exportCheckpoint(ctx context.Context, ctr *oci.Contain
 		return fmt.Errorf("error exporting root file-system diff for %q: %w", id, err)
 	}
 
-	mountPoint, err := c.StorageImageServer().GetStore().Mount(id, specgen.Linux.MountLabel)
+	sb, err := c.LookupSandbox(ctr.Sandbox())
+	if err != nil {
+		return fmt.Errorf("failed to lookup sandbox %s: %w", ctr.Sandbox(), err)
+	}
+
+	mountPoint, err := c.StorageImageServer(sb.RuntimeHandler()).GetStore().Mount(id, specgen.Linux.MountLabel)
 	if err != nil {
 		return fmt.Errorf("not able to get mountpoint for container %q: %w", id, err)
 	}

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -122,7 +122,12 @@ func (c *ContainerServer) ContainerCheckpoint(
 			log.Warnf(ctx, "Failed to lookup sandbox %s for checkpoint cleanup: %v", ctr.Sandbox(), err)
 		}
 
-		if err := c.StorageRuntimeServer(sb).StopContainer(ctx, ctr.ID()); err != nil {
+		runtimeSvc, err := c.StorageRuntimeServer(sb)
+		if err != nil {
+			return "", fmt.Errorf("failed to get runtime service for container %s: %w", ctr.ID(), err)
+		}
+
+		if err := runtimeSvc.StopContainer(ctx, ctr.ID()); err != nil {
 			return "", fmt.Errorf("failed to unmount container %s: %w", ctr.ID(), err)
 		}
 	}
@@ -321,7 +326,12 @@ func (c *ContainerServer) exportCheckpoint(ctx context.Context, ctr *oci.Contain
 		return fmt.Errorf("failed to lookup sandbox %s: %w", ctr.Sandbox(), err)
 	}
 
-	mountPoint, err := c.StorageImageServer(sb).GetStore().Mount(id, specgen.Linux.MountLabel)
+	imageServer, err := c.StorageImageServer(sb)
+	if err != nil {
+		return fmt.Errorf("failed to get image service for sandbox %s: %w", sb.ID(), err)
+	}
+
+	mountPoint, err := imageServer.GetStore().Mount(id, specgen.Linux.MountLabel)
 	if err != nil {
 		return fmt.Errorf("not able to get mountpoint for container %q: %w", id, err)
 	}

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -115,16 +115,14 @@ func (c *ContainerServer) ContainerCheckpoint(
 	}
 
 	if !opts.KeepRunning {
-		runtimeHandler := ""
-		if sb, err := c.LookupSandbox(ctr.Sandbox()); err == nil {
-			runtimeHandler = sb.RuntimeHandler()
-		} else {
+		sb, err := c.LookupSandbox(ctr.Sandbox())
+		if err != nil {
 			// don't abort in case of error - we can use the default runtime
-			// handler here (""), to at least try and stop the container.
+			// handler here (sb == nil), to at least try and stop the container.
 			log.Warnf(ctx, "Failed to lookup sandbox %s for checkpoint cleanup: %v", ctr.Sandbox(), err)
 		}
 
-		if err := c.StorageRuntimeServer(runtimeHandler).StopContainer(ctx, ctr.ID()); err != nil {
+		if err := c.StorageRuntimeServer(sb).StopContainer(ctx, ctr.ID()); err != nil {
 			return "", fmt.Errorf("failed to unmount container %s: %w", ctr.ID(), err)
 		}
 	}
@@ -323,7 +321,7 @@ func (c *ContainerServer) exportCheckpoint(ctx context.Context, ctr *oci.Contain
 		return fmt.Errorf("failed to lookup sandbox %s: %w", ctr.Sandbox(), err)
 	}
 
-	mountPoint, err := c.StorageImageServer(sb.RuntimeHandler()).GetStore().Mount(id, specgen.Linux.MountLabel)
+	mountPoint, err := c.StorageImageServer(sb).GetStore().Mount(id, specgen.Linux.MountLabel)
 	if err != nil {
 		return fmt.Errorf("not able to get mountpoint for container %q: %w", id, err)
 	}

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -50,8 +50,8 @@ type ContainerServer struct {
 
 	runtime              *oci.Runtime
 	store                cstorage.Store
-	storageImageServer   storage.ImageServer
-	storageRuntimeServer storage.RuntimeServer
+	storageImgSvcMgr     *storage.ImageServiceManager
+	storageRuntimeSvcMgr *storage.RuntimeServiceManager
 	ctrNameIndex         *registrar.Registrar
 	ctrIDIndex           *truncindex.TruncIndex
 	podNameIndex         *registrar.Registrar
@@ -78,7 +78,7 @@ func (c *ContainerServer) Store() cstorage.Store {
 
 // StorageImageServer returns the ImageServer for the ContainerServer.
 func (c *ContainerServer) StorageImageServer() storage.ImageServer {
-	return c.storageImageServer
+	return c.storageImgSvcMgr.GetImageService("")
 }
 
 // CtrIDIndex returns the TruncIndex for the ContainerServer.
@@ -98,7 +98,7 @@ func (c *ContainerServer) Config() *libconfig.Config {
 
 // StorageRuntimeServer gets the runtime server for the ContainerServer.
 func (c *ContainerServer) StorageRuntimeServer() storage.RuntimeServer {
-	return c.storageRuntimeServer
+	return c.storageRuntimeSvcMgr.GetRuntimeService("")
 }
 
 // New creates a new ContainerServer with options provided.
@@ -145,12 +145,15 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 		}
 	}
 
-	imageService, err := storage.GetImageService(ctx, store, nil, config)
+	storageImageServiceMgr, err := storage.GetImageServiceManager(ctx, store, nil, config)
 	if err != nil {
 		return nil, err
 	}
 
-	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, nil)
+	storageRuntimeServiceMgr, err := storage.GetRuntimeServiceManager(ctx, storageImageServiceMgr, nil, config)
+	if err != nil {
+		return nil, err
+	}
 
 	runtime, err := oci.New(config)
 	if err != nil {
@@ -165,8 +168,8 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 	c := &ContainerServer{
 		runtime:              runtime,
 		store:                store,
-		storageImageServer:   imageService,
-		storageRuntimeServer: storageRuntimeService,
+		storageImgSvcMgr:     storageImageServiceMgr,
+		storageRuntimeSvcMgr: storageRuntimeServiceMgr,
 		ctrNameIndex:         registrar.NewRegistrar(),
 		ctrIDIndex:           truncindex.NewTruncIndex([]string{}),
 		podNameIndex:         registrar.NewRegistrar(),

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -77,8 +77,8 @@ func (c *ContainerServer) Store() cstorage.Store {
 }
 
 // StorageImageServer returns the ImageServer for the ContainerServer.
-func (c *ContainerServer) StorageImageServer(runtimeHandler string) storage.ImageServer {
-	return c.storageImgSvcMgr.GetImageService(runtimeHandler)
+func (c *ContainerServer) StorageImageServer(sb *sandbox.Sandbox) storage.ImageServer {
+	return c.storageImgSvcMgr.GetImageService(sb)
 }
 
 // CtrIDIndex returns the TruncIndex for the ContainerServer.
@@ -97,8 +97,8 @@ func (c *ContainerServer) Config() *libconfig.Config {
 }
 
 // StorageRuntimeServer gets the runtime server for the ContainerServer.
-func (c *ContainerServer) StorageRuntimeServer(runtimeHandler string) storage.RuntimeServer {
-	return c.storageRuntimeSvcMgr.GetRuntimeService(runtimeHandler)
+func (c *ContainerServer) StorageRuntimeServer(sb storage.SandboxInfo) storage.RuntimeServer {
+	return c.storageRuntimeSvcMgr.GetRuntimeService(sb)
 }
 
 // StorageImageManager gets the ImageServiceManager for the ContainerServer.

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -77,8 +77,8 @@ func (c *ContainerServer) Store() cstorage.Store {
 }
 
 // StorageImageServer returns the ImageServer for the ContainerServer.
-func (c *ContainerServer) StorageImageServer() storage.ImageServer {
-	return c.storageImgSvcMgr.GetImageService("")
+func (c *ContainerServer) StorageImageServer(runtimeHandler string) storage.ImageServer {
+	return c.storageImgSvcMgr.GetImageService(runtimeHandler)
 }
 
 // CtrIDIndex returns the TruncIndex for the ContainerServer.
@@ -97,8 +97,13 @@ func (c *ContainerServer) Config() *libconfig.Config {
 }
 
 // StorageRuntimeServer gets the runtime server for the ContainerServer.
-func (c *ContainerServer) StorageRuntimeServer() storage.RuntimeServer {
-	return c.storageRuntimeSvcMgr.GetRuntimeService("")
+func (c *ContainerServer) StorageRuntimeServer(runtimeHandler string) storage.RuntimeServer {
+	return c.storageRuntimeSvcMgr.GetRuntimeService(runtimeHandler)
+}
+
+// StorageImageManager gets the ImageServiceManager for the ContainerServer.
+func (c *ContainerServer) StorageImageManager() *storage.ImageServiceManager {
+	return c.storageImgSvcMgr
 }
 
 // New creates a new ContainerServer with options provided.

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -901,6 +901,8 @@ func (c *ContainerServer) RemoveSandbox(ctx context.Context, id string) error {
 
 	c.RemoveStatsForSandbox(sb)
 	c.state.sandboxes.Delete(id)
+	c.storageImgSvcMgr.RemoveImageService(id)
+	c.storageRuntimeSvcMgr.RemoveRuntimeService(id)
 
 	return nil
 }

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -78,6 +78,10 @@ func (c *ContainerServer) Store() cstorage.Store {
 
 // StorageImageServer returns the ImageServer for the ContainerServer.
 func (c *ContainerServer) StorageImageServer(sb *sandbox.Sandbox) storage.ImageServer {
+	if sb == nil {
+		return c.storageImgSvcMgr.GetImageService(nil)
+	}
+
 	return c.storageImgSvcMgr.GetImageService(sb)
 }
 
@@ -98,6 +102,10 @@ func (c *ContainerServer) Config() *libconfig.Config {
 
 // StorageRuntimeServer gets the runtime server for the ContainerServer.
 func (c *ContainerServer) StorageRuntimeServer(sb storage.SandboxInfo) storage.RuntimeServer {
+	if sb == nil {
+		return c.storageRuntimeSvcMgr.GetRuntimeService(nil)
+	}
+
 	return c.storageRuntimeSvcMgr.GetRuntimeService(sb)
 }
 

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -77,7 +77,7 @@ func (c *ContainerServer) Store() cstorage.Store {
 }
 
 // StorageImageServer returns the ImageServer for the ContainerServer.
-func (c *ContainerServer) StorageImageServer(sb *sandbox.Sandbox) storage.ImageServer {
+func (c *ContainerServer) StorageImageServer(sb *sandbox.Sandbox) (storage.ImageServer, error) {
 	if sb == nil {
 		return c.storageImgSvcMgr.GetImageService(nil)
 	}
@@ -101,7 +101,7 @@ func (c *ContainerServer) Config() *libconfig.Config {
 }
 
 // StorageRuntimeServer gets the runtime server for the ContainerServer.
-func (c *ContainerServer) StorageRuntimeServer(sb storage.SandboxInfo) storage.RuntimeServer {
+func (c *ContainerServer) StorageRuntimeServer(sb storage.SandboxInfo) (storage.RuntimeServer, error) {
 	if sb == nil {
 		return c.storageRuntimeSvcMgr.GetRuntimeService(nil)
 	}

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -109,7 +109,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed to get the StorageImageServer", func() {
 			// Given
 			// When
-			res := sut.StorageImageServer()
+			res := sut.StorageImageServer("")
 
 			// Then
 			Expect(res).NotTo(BeNil())
@@ -145,7 +145,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed to get the StorageRuntimeServer", func() {
 			// Given
 			// When
-			res := sut.StorageRuntimeServer()
+			res := sut.StorageRuntimeServer("")
 
 			// Then
 			Expect(res).NotTo(BeNil())

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -109,7 +109,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed to get the StorageImageServer", func() {
 			// Given
 			// When
-			res := sut.StorageImageServer("")
+			res := sut.StorageImageServer(nil)
 
 			// Then
 			Expect(res).NotTo(BeNil())
@@ -145,7 +145,7 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed to get the StorageRuntimeServer", func() {
 			// Given
 			// When
-			res := sut.StorageRuntimeServer("")
+			res := sut.StorageRuntimeServer(nil)
 
 			// Then
 			Expect(res).NotTo(BeNil())

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -109,9 +109,10 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed to get the StorageImageServer", func() {
 			// Given
 			// When
-			res := sut.StorageImageServer(nil)
+			res, err := sut.StorageImageServer(nil)
 
 			// Then
+			Expect(err).ToNot(HaveOccurred())
 			Expect(res).NotTo(BeNil())
 		})
 
@@ -145,9 +146,10 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should succeed to get the StorageRuntimeServer", func() {
 			// Given
 			// When
-			res := sut.StorageRuntimeServer(nil)
+			res, err := sut.StorageRuntimeServer(nil)
 
 			// Then
+			Expect(err).ToNot(HaveOccurred())
 			Expect(res).NotTo(BeNil())
 		})
 	})

--- a/internal/lib/container_server_test_inject.go
+++ b/internal/lib/container_server_test_inject.go
@@ -11,10 +11,10 @@ import (
 
 // SetStorageRuntimeServer sets the runtime server for the ContainerServer.
 func (c *ContainerServer) SetStorageRuntimeServer(server storage.RuntimeServer) {
-	c.storageRuntimeServer = server
+	c.storageRuntimeSvcMgr.SetStorageRuntimeServer(server)
 }
 
 // SetStorageImageServer sets the ImageServer for the ContainerServer.
 func (c *ContainerServer) SetStorageImageServer(server storage.ImageServer) {
-	c.storageImageServer = server
+	c.storageImgSvcMgr.SetStorageImageServer(server)
 }

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -47,8 +47,16 @@ func (c *ContainerServer) ContainerRestore(
 	if err != nil {
 		return "", err
 	}
+
+	sb, err := c.LookupSandbox(ctr.Sandbox())
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup sandbox %s: %w", ctr.Sandbox(), err)
+	}
+
+	imageService := c.StorageImageServer(sb.RuntimeHandler())
+
 	// During checkpointing the container is unmounted. This mounts the container again.
-	mountPoint, err := c.StorageImageServer().GetStore().Mount(ctr.ID(), ctrSpec.Config.Linux.MountLabel)
+	mountPoint, err := imageService.GetStore().Mount(ctr.ID(), ctrSpec.Config.Linux.MountLabel)
 	if err != nil {
 		log.Debugf(ctx, "Failed to mount container %q: %v", ctr.ID(), err)
 
@@ -59,16 +67,11 @@ func (c *ContainerServer) ContainerRestore(
 	log.Debugf(ctx, "Sandbox %v", ctr.Sandbox())
 	log.Debugf(ctx, "Specgen.Config.Annotations[io.kubernetes.cri-o.SandboxID] %v", ctrSpec.Config.Annotations["io.kubernetes.cri-o.SandboxID"])
 
-	sb, err := c.LookupSandbox(ctr.Sandbox())
-	if err != nil {
-		return "", err
-	}
-
 	if ctr.RestoreArchivePath() != "" || ctr.RestoreStorageImageID() != nil {
 		if ctr.RestoreStorageImageID() != nil {
 			log.Debugf(ctx, "Restoring from %v", ctr.RestoreStorageImageID())
 			// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-			imageMountPoint, err := c.StorageImageServer().GetStore().MountImage(ctr.RestoreStorageImageID().IDStringForOutOfProcessConsumptionOnly(), nil, "")
+			imageMountPoint, err := imageService.GetStore().MountImage(ctr.RestoreStorageImageID().IDStringForOutOfProcessConsumptionOnly(), nil, "")
 			if err != nil {
 				return "", err
 			}
@@ -77,7 +80,7 @@ func (c *ContainerServer) ContainerRestore(
 
 			defer func() {
 				// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-				_, err := c.StorageImageServer().GetStore().UnmountImage(ctr.RestoreStorageImageID().IDStringForOutOfProcessConsumptionOnly(), true)
+				_, err := imageService.GetStore().UnmountImage(ctr.RestoreStorageImageID().IDStringForOutOfProcessConsumptionOnly(), true)
 				if err != nil {
 					log.Errorf(ctx, "Failed to unmount checkpoint image: %q", err)
 				}

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -53,7 +53,7 @@ func (c *ContainerServer) ContainerRestore(
 		return "", fmt.Errorf("failed to lookup sandbox %s: %w", ctr.Sandbox(), err)
 	}
 
-	imageService := c.StorageImageServer(sb.RuntimeHandler())
+	imageService := c.StorageImageServer(sb)
 
 	// During checkpointing the container is unmounted. This mounts the container again.
 	mountPoint, err := imageService.GetStore().Mount(ctr.ID(), ctrSpec.Config.Linux.MountLabel)

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -53,7 +53,10 @@ func (c *ContainerServer) ContainerRestore(
 		return "", fmt.Errorf("failed to lookup sandbox %s: %w", ctr.Sandbox(), err)
 	}
 
-	imageService := c.StorageImageServer(sb)
+	imageService, err := c.StorageImageServer(sb)
+	if err != nil {
+		return "", fmt.Errorf("failed to get image service for sandbox %s: %w", sb.ID(), err)
+	}
 
 	// During checkpointing the container is unmounted. This mounts the container again.
 	mountPoint, err := imageService.GetStore().Mount(ctr.ID(), ctrSpec.Config.Linux.MountLabel)

--- a/internal/lib/sandbox/builder.go
+++ b/internal/lib/sandbox/builder.go
@@ -320,16 +320,22 @@ func (b *sandboxBuilder) GenerateNameAndID() error {
 
 	id := stringid.GenerateNonCryptoID()
 	b.SetID(id)
-	name := strings.Join([]string{
-		"k8s",
-		b.config.GetMetadata().GetName(),
-		b.config.GetMetadata().GetNamespace(),
-		b.config.GetMetadata().GetUid(),
-		strconv.FormatUint(uint64(b.config.GetMetadata().GetAttempt()), 10),
-	}, "_")
-	b.SetName(name)
+	b.SetName(PodName(b.config.GetMetadata()))
 
 	return nil
+}
+
+// PodName returns the canonical name for a pod sandbox derived from its
+// metadata. The same format is used when looking up sandboxes by name during
+// image pulls; see server/image_pull.go.
+func PodName(meta *types.PodSandboxMetadata) string {
+	return strings.Join([]string{
+		"k8s",
+		meta.GetName(),
+		meta.GetNamespace(),
+		meta.GetUid(),
+		strconv.FormatUint(uint64(meta.GetAttempt()), 10),
+	}, "_")
 }
 
 // Config returns the sandbox configuration.

--- a/internal/lib/sandbox/builder.go
+++ b/internal/lib/sandbox/builder.go
@@ -36,6 +36,9 @@ type Builder interface {
 	// Name returns the id of the pod sandbox
 	Name() string
 
+	// RuntimeHandler returns the runtime handler for the pod sandbox.
+	RuntimeHandler() string
+
 	// InitInfraContainer initializes the sandbox's infra container
 	InitInfraContainer(*libconfig.Config, *storage.ContainerInfo, *idtools.IDMappings) error
 
@@ -346,6 +349,15 @@ func (b *sandboxBuilder) ID() string {
 // Name returns the name of the pod sandbox.
 func (b *sandboxBuilder) Name() string {
 	return b.sandboxRef.name
+}
+
+// RuntimeHandler returns the runtime handler for the pod sandbox.
+func (b *sandboxBuilder) RuntimeHandler() string {
+	if b.sandboxRef == nil || b.sandboxRef.criSandbox == nil {
+		return ""
+	}
+
+	return b.sandboxRef.runtimeHandler
 }
 
 func (b *sandboxBuilder) ResolvPath() string {

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -152,6 +152,14 @@ func (r *runtimeVM) CreateContainer(ctx context.Context, c *Container, cgroupPar
 	log.Debugf(ctx, "RuntimeVM.CreateContainer() start")
 	defer log.Debugf(ctx, "RuntimeVM.CreateContainer() end")
 
+	// This runtime will not drop the infra container, so we don't expect
+	// to run into this. But if the default runtimeHandler is kata, we might end
+	// here for a spoofed container, which is always set with the default handler.
+	// This test guards against it.
+	if c.Spoofed() {
+		return nil
+	}
+
 	// Lock the container
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
@@ -360,6 +368,10 @@ func (r *runtimeVM) startRuntimeDaemon(ctx context.Context, c *Container) error 
 func (r *runtimeVM) StartContainer(ctx context.Context, c *Container) error {
 	log.Debugf(ctx, "RuntimeVM.StartContainer() start")
 	defer log.Debugf(ctx, "RuntimeVM.StartContainer() end")
+
+	if c.Spoofed() {
+		return nil
+	}
 
 	// Lock the container
 	c.opLock.Lock()
@@ -673,6 +685,13 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 	log.Debugf(ctx, "RuntimeVM.StopContainer() start")
 	defer log.Debugf(ctx, "RuntimeVM.StopContainer() end")
 
+	if c.Spoofed() {
+		c.state.Status = ContainerStateStopped
+		c.state.Finished = time.Now()
+
+		return nil
+	}
+
 	if err := r.shouldBeStopped(ctx, c); err != nil {
 		if errors.Is(err, ErrContainerStopped) {
 			err = nil
@@ -781,6 +800,10 @@ func (r *runtimeVM) DeleteContainer(ctx context.Context, c *Container) error {
 	// Lock the container
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
+
+	if c.Spoofed() {
+		return nil
+	}
 
 	if c.state.OOMKilled {
 		// Collect metric by container name

--- a/internal/ociartifact/datastore/artifact.go
+++ b/internal/ociartifact/datastore/artifact.go
@@ -1,0 +1,60 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opencontainers/go-digest"
+	libart "go.podman.io/common/pkg/libartifact"
+	"go.podman.io/image/v5/docker/reference"
+
+	"github.com/cri-o/cri-o/internal/log"
+)
+
+// unknownArtifactRef is a sentinel Named reference used when the artifact name cannot be parsed.
+type unknownArtifactRef struct{}
+
+func (u unknownArtifactRef) String() string { return "unknown" }
+func (u unknownArtifactRef) Name() string   { return u.String() }
+
+// Artifact wraps a libartifact.Artifact to expose the named-reference methods expected
+// by runtimePulledImageService (Reference, CanonicalName, Digest).  libartifact.Artifact
+// stores the name and digest as plain fields; this wrapper parses the name into a
+// reference.Named once so that callers get well-formed, normalised strings without
+// duplicating that logic throughout image_vm.go.
+type Artifact struct {
+	*libart.Artifact
+
+	namedRef reference.Named
+}
+
+func newArtifact(art *libart.Artifact) *Artifact {
+	a := &Artifact{Artifact: art, namedRef: unknownArtifactRef{}}
+
+	if art.Name != "" {
+		if ref, err := reference.ParseNormalizedNamed(art.Name); err == nil {
+			a.namedRef = ref
+		} else {
+			log.Warnf(context.Background(), "Failed to parse artifact name %q: %v", art.Name, err)
+		}
+	}
+
+	return a
+}
+
+// Reference returns the normalised string form of the artifact's named reference
+// (e.g. "docker.io/library/ubuntu:latest").
+func (a *Artifact) Reference() string {
+	return a.namedRef.String()
+}
+
+// CanonicalName returns the name-plus-digest form used as a stable cache key
+// (e.g. "docker.io/library/ubuntu@sha256:...").
+func (a *Artifact) CanonicalName() string {
+	return fmt.Sprintf("%s@%s", a.namedRef.Name(), a.Artifact.Digest)
+}
+
+// Digest returns the manifest digest of the artifact.
+func (a *Artifact) Digest() digest.Digest {
+	return a.Artifact.Digest
+}

--- a/internal/ociartifact/datastore/impl.go
+++ b/internal/ociartifact/datastore/impl.go
@@ -21,6 +21,8 @@ type Impl interface {
 type LibartifactStore interface {
 	Pull(ctx context.Context, ref libartifact.ArtifactReference, opts libimage.CopyOptions) (digest.Digest, error)
 	BlobMountPaths(ctx context.Context, asr libartifact.ArtifactStoreReference, opts *libartTypes.BlobMountPathOptions) ([]libartTypes.BlobMountPath, error)
+	List(ctx context.Context) (libartifact.ArtifactList, error)
+	Remove(ctx context.Context, asr libartifact.ArtifactStoreReference) (*digest.Digest, error)
 }
 
 // defaultImpl is the default implementation for the OCI artifact handling.

--- a/internal/ociartifact/datastore/store.go
+++ b/internal/ociartifact/datastore/store.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
+	"github.com/opencontainers/go-digest"
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/pkg/libartifact"
 	libartTypes "go.podman.io/common/pkg/libartifact/types"
+	"go.podman.io/image/v5/manifest"
+	"go.podman.io/image/v5/oci/layout"
+	"go.podman.io/image/v5/pkg/blobinfocache/none"
 	"go.podman.io/image/v5/types"
 
 	"github.com/cri-o/cri-o/internal/log"
@@ -29,8 +34,10 @@ func (a *ArtifactData) Data() []byte {
 // Store handles pulling artifact data and reading blobs using the podman
 // libartifact store directly.
 type Store struct {
-	store LibartifactStore
-	impl  Impl
+	store         LibartifactStore
+	impl          Impl
+	storePath     string
+	systemContext *types.SystemContext
 }
 
 // New creates a new OCI artifact data store.
@@ -43,8 +50,10 @@ func New(rootPath string, systemContext *types.SystemContext) (*Store, error) {
 	}
 
 	return &Store{
-		store: artStore,
-		impl:  &defaultImpl{},
+		store:         artStore,
+		impl:          &defaultImpl{},
+		storePath:     storePath,
+		systemContext: systemContext,
 	}, nil
 }
 
@@ -121,4 +130,193 @@ func sanitizeOptions(opts *PullOptions) *PullOptions {
 	}
 
 	return opts
+}
+
+// PullManifestOnly fetches only the manifest and config blob from the remote
+// registry and records them in the local OCI layout store without downloading
+// any layer blobs.  It is intended for use when layer data is retrieved
+// externally (e.g. inside a confidential VM by the kata-agent).
+// Returns the digest of the stored manifest.
+func (s *Store) PullManifestOnly(
+	ctx context.Context,
+	ref types.ImageReference,
+	opts *libimage.CopyOptions,
+) (*digest.Digest, error) {
+	strRef := ref.DockerReference().String()
+
+	log.Infof(ctx, "Pulling OCI manifest and config (no layers): %s", strRef)
+
+	// Merge per-request auth credentials from opts into a local copy of the
+	// system context, mirroring what libimage.NewCopier does.
+	sys := s.systemContext
+	if sys == nil {
+		sys = &types.SystemContext{}
+	}
+
+	if opts != nil && (opts.Username != "" || opts.AuthFilePath != "") {
+		sysCopy := *sys
+
+		if opts.Username != "" {
+			sysCopy.DockerAuthConfig = &types.DockerAuthConfig{
+				Username: opts.Username,
+				Password: opts.Password,
+			}
+		}
+
+		if opts.AuthFilePath != "" {
+			sysCopy.AuthFilePath = opts.AuthFilePath
+		}
+
+		sys = &sysCopy
+	}
+
+	// Open the remote source once to fetch both the manifest and config blob.
+	remoteSrc, err := ref.NewImageSource(ctx, sys)
+	if err != nil {
+		return nil, fmt.Errorf("open remote source: %w", err)
+	}
+	defer remoteSrc.Close()
+
+	manifestBytes, mimeType, err := remoteSrc.GetManifest(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get manifest: %w", err)
+	}
+
+	// If the registry returned a manifest list, resolve to the
+	// platform-specific instance for the current host.
+	if manifest.MIMETypeIsMultiImage(mimeType) {
+		list, err := manifest.ListFromBlob(manifestBytes, mimeType)
+		if err != nil {
+			return nil, fmt.Errorf("parse manifest list: %w", err)
+		}
+
+		instanceDigest, err := list.ChooseInstance(sys)
+		if err != nil {
+			return nil, fmt.Errorf("choose manifest instance: %w", err)
+		}
+
+		manifestBytes, mimeType, err = remoteSrc.GetManifest(ctx, &instanceDigest)
+		if err != nil {
+			return nil, fmt.Errorf("get platform manifest: %w", err)
+		}
+	}
+
+	// Parse the (platform-specific) manifest to obtain the config descriptor.
+	parsedManifest, err := manifest.FromBlob(manifestBytes, mimeType)
+	if err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+
+	configInfo := parsedManifest.ConfigInfo()
+
+	// Open the local OCI layout destination inside the libartifact store path.
+	// Writing here makes the entry visible to libartifact's List/Remove.
+	ir, err := layout.NewReference(s.storePath, strRef)
+	if err != nil {
+		return nil, fmt.Errorf("layout reference: %w", err)
+	}
+
+	imgDest, err := ir.NewImageDestination(ctx, sys)
+	if err != nil {
+		return nil, fmt.Errorf("image destination: %w", err)
+	}
+	defer imgDest.Close()
+
+	// Fetch the config blob from remote and write it locally so that
+	// PullConfig can read the OCI image config after this call.
+	configRC, _, err := remoteSrc.GetBlob(ctx, types.BlobInfo{Digest: configInfo.Digest, Size: configInfo.Size}, none.NoCache)
+	if err != nil {
+		return nil, fmt.Errorf("get config blob: %w", err)
+	}
+	defer configRC.Close()
+
+	if _, err := imgDest.PutBlob(ctx, configRC, types.BlobInfo{Digest: configInfo.Digest, Size: configInfo.Size}, none.NoCache, true); err != nil {
+		return nil, fmt.Errorf("store config blob: %w", err)
+	}
+
+	if err := imgDest.PutManifest(ctx, manifestBytes, nil); err != nil {
+		return nil, fmt.Errorf("put manifest: %w", err)
+	}
+
+	unparsed := &manifestOnlyUnparsed{ir: ir, manifestBytes: manifestBytes, mimeType: mimeType}
+	if err := imgDest.Commit(ctx, unparsed); err != nil {
+		return nil, fmt.Errorf("commit manifest: %w", err)
+	}
+
+	dgst := digest.FromBytes(manifestBytes)
+
+	return &dgst, nil
+}
+
+// ImageSource returns an ImageSource for the entry identified by dgstStr.
+// dgstStr is the hex-encoded manifest digest (without the "sha256:" prefix).
+// The caller is responsible for closing the returned ImageSource.
+//
+// It searches the OCI layout index directly so that it works regardless of
+// whether the manifest is OCI v1 or Docker v2 format.
+func (s *Store) ImageSource(ctx context.Context, dgstStr string) (types.ImageSource, error) {
+	entries, err := layout.List(s.storePath)
+	if err != nil {
+		return nil, fmt.Errorf("list OCI layout: %w", err)
+	}
+
+	sys := s.systemContext
+	if sys == nil {
+		sys = &types.SystemContext{}
+	}
+
+	for i := range entries {
+		if strings.HasPrefix(entries[i].ManifestDescriptor.Digest.Encoded(), dgstStr) {
+			return entries[i].Reference.NewImageSource(ctx, sys)
+		}
+	}
+
+	return nil, fmt.Errorf("no artifact found with digest %q", dgstStr)
+}
+
+// List returns all entries currently recorded in the libartifact OCI layout store.
+func (s *Store) List(ctx context.Context) ([]*Artifact, error) {
+	arts, err := s.store.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list artifacts: %w", err)
+	}
+
+	result := make([]*Artifact, 0, len(arts))
+	for _, art := range arts {
+		result = append(result, newArtifact(art))
+	}
+
+	return result, nil
+}
+
+// Remove deletes the entry identified by nameOrDigest from the store.
+func (s *Store) Remove(ctx context.Context, nameOrDigest string) error {
+	artRef, err := libartifact.NewArtifactStorageReference(nameOrDigest)
+	if err != nil {
+		return fmt.Errorf("invalid nameOrDigest: %w", err)
+	}
+
+	if _, err := s.store.Remove(ctx, artRef); err != nil {
+		return fmt.Errorf("remove artifact: %w", err)
+	}
+
+	return nil
+}
+
+// manifestOnlyUnparsed is a minimal types.UnparsedImage used when committing
+// a manifest-only entry to the OCI layout store (no layer blobs written).
+type manifestOnlyUnparsed struct {
+	ir            types.ImageReference
+	manifestBytes []byte
+	mimeType      string
+}
+
+func (m *manifestOnlyUnparsed) Reference() types.ImageReference { return m.ir }
+
+func (m *manifestOnlyUnparsed) Manifest(_ context.Context) (manifestBlob []byte, mimeType string, err error) {
+	return m.manifestBytes, m.mimeType, nil
+}
+
+func (m *manifestOnlyUnparsed) Signatures(_ context.Context) ([][]byte, error) {
+	return [][]byte{}, nil
 }

--- a/internal/ociartifact/datastore/store.go
+++ b/internal/ociartifact/datastore/store.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 
 	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.podman.io/common/libimage"
 	"go.podman.io/common/pkg/libartifact"
 	libartTypes "go.podman.io/common/pkg/libartifact/types"
+	"go.podman.io/image/v5/image"
 	"go.podman.io/image/v5/manifest"
 	"go.podman.io/image/v5/oci/layout"
 	"go.podman.io/image/v5/pkg/blobinfocache/none"
@@ -319,4 +321,60 @@ func (m *manifestOnlyUnparsed) Manifest(_ context.Context) (manifestBlob []byte,
 
 func (m *manifestOnlyUnparsed) Signatures(_ context.Context) ([][]byte, error) {
 	return [][]byte{}, nil
+}
+
+// PullConfig reads the OCI image config for an entry previously stored by
+// PullManifestOnly.  refStr is the full image reference string used during the
+// original pull (e.g. "docker.io/library/ubuntu:latest").
+func (s *Store) PullConfig(ctx context.Context, refStr string) (*specs.Image, error) {
+	imageReference, err := layout.NewReference(s.storePath, refStr)
+	if err != nil {
+		return nil, fmt.Errorf("create layout reference: %w", err)
+	}
+
+	sys := s.systemContext
+	if sys == nil {
+		sys = &types.SystemContext{}
+	}
+
+	imageSource, err := imageReference.NewImageSource(ctx, sys)
+	if err != nil {
+		return nil, fmt.Errorf("build image source: %w", err)
+	}
+
+	defer func() {
+		if err := imageSource.Close(); err != nil {
+			log.Warnf(ctx, "Unable to close image source: %v", err)
+		}
+	}()
+
+	unparsedToplevel := image.UnparsedInstance(imageSource, nil)
+
+	topManifest, topMIMEType, err := unparsedToplevel.Manifest(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get manifest: %w", err)
+	}
+
+	unparsedInstance := unparsedToplevel
+
+	if manifest.MIMETypeIsMultiImage(topMIMEType) {
+		manifestList, err := manifest.ListFromBlob(topManifest, topMIMEType)
+		if err != nil {
+			return nil, fmt.Errorf("parse manifest list: %w", err)
+		}
+
+		instanceDigest, err := manifestList.ChooseInstance(sys)
+		if err != nil {
+			return nil, fmt.Errorf("choose manifest instance: %w", err)
+		}
+
+		unparsedInstance = image.UnparsedInstance(imageSource, &instanceDigest)
+	}
+
+	sourcedImage, err := image.FromUnparsedImage(ctx, sys, unparsedInstance)
+	if err != nil {
+		return nil, fmt.Errorf("build image from unparsed: %w", err)
+	}
+
+	return sourcedImage.OCIConfig(ctx)
 }

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -128,6 +128,34 @@ func (i *ImageServiceManager) DeleteImage(ctx context.Context, systemContext *ty
 	return err
 }
 
+// IDPrefixMatch pairs a resolved image ID with the ImageServer that holds it.
+type IDPrefixMatch struct {
+	ID     *StorageImageID
+	Server ImageServer
+}
+
+// HeuristicallyTryResolvingStringAsIDPrefix calls the same function on each
+// image store and returns all matches, each paired with the ImageServer it was
+// found in, allowing direct calls to the right store.
+func (i *ImageServiceManager) HeuristicallyTryResolvingStringAsIDPrefix(heuristicInput string) []IDPrefixMatch {
+	var matches []IDPrefixMatch
+
+	if id := i.imageService.HeuristicallyTryResolvingStringAsIDPrefix(heuristicInput); id != nil {
+		matches = append(matches, IDPrefixMatch{ID: id, Server: i.imageService})
+	}
+
+	i.imageServiceRPLock.RLock()
+	defer i.imageServiceRPLock.RUnlock()
+
+	for index := range i.imageServiceRP {
+		if id := i.imageServiceRP[index].HeuristicallyTryResolvingStringAsIDPrefix(heuristicInput); id != nil {
+			matches = append(matches, IDPrefixMatch{ID: id, Server: i.imageServiceRP[index]})
+		}
+	}
+
+	return matches
+}
+
 func GetImageServiceManager(ctx context.Context, store storage.Store, storageTransport StorageTransport, serverConfig *config.Config) (*ImageServiceManager, error) {
 	is, err := GetImageService(ctx, store, storageTransport, serverConfig)
 	if err != nil {

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"go.podman.io/image/v5/types"
@@ -35,14 +36,14 @@ type ImageServiceManager struct {
 	imageServiceRPLock sync.RWMutex
 }
 
-func (i *ImageServiceManager) GetImageService(sb SandboxInfo) ImageServer {
+func (i *ImageServiceManager) GetImageService(sb SandboxInfo) (ImageServer, error) {
 	if sb == nil {
-		return i.imageService
+		return i.imageService, nil
 	}
 
 	r, ok := i.serverConfig.Runtimes[sb.RuntimeHandler()]
 	if !ok || !r.RuntimePullImage {
-		return i.imageService
+		return i.imageService, nil
 	}
 
 	i.imageServiceRPLock.RLock()
@@ -50,7 +51,7 @@ func (i *ImageServiceManager) GetImageService(sb SandboxInfo) ImageServer {
 	i.imageServiceRPLock.RUnlock()
 
 	if is != nil {
-		return is
+		return is, nil
 	}
 
 	rootDir, err := i.imageService.GetStore().ContainerRunDirectory(sb.ID())
@@ -61,22 +62,20 @@ func (i *ImageServiceManager) GetImageService(sb SandboxInfo) ImageServer {
 		// for it.
 		log.Warnf(i.ctx, "Failed to retrieve root dir for sandbox %s: %v", sb.ID(), err)
 
-		return i.imageService
+		return i.imageService, nil
 	}
 
 	regularIS, ok := i.imageService.(*imageService)
 	if !ok {
 		log.Warnf(i.ctx, "Failed to get an imageService")
 
-		return i.imageService
+		return i.imageService, nil
 	}
 
 	is, err = GetRuntimePulledImageService(i.ctx, regularIS, rootDir)
 	if err != nil {
-		// if we can't get the specific image server, return the default
-		log.Warnf(i.ctx, "Failed to get ImageServiceVM for sandbox %s: %v", sb.ID(), err)
-
-		return i.imageService
+		// if we can't get the specific image server, return an error
+		return nil, fmt.Errorf("failed to get ImageServiceVM for sandbox %s: %w", sb.ID(), err)
 	}
 
 	i.imageServiceRPLock.Lock()
@@ -84,12 +83,12 @@ func (i *ImageServiceManager) GetImageService(sb SandboxInfo) ImageServer {
 
 	// double-check that an instance was not created in parallel
 	if existing := i.imageServiceRP[sb.ID()]; existing != nil {
-		return existing
+		return existing, nil
 	}
 
 	i.imageServiceRP[sb.ID()] = is
 
-	return is
+	return is, nil
 }
 
 // DeleteImage deletes the image with the given ID from all storage backends.

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"errors"
-	"reflect"
 	"sync"
 
 	"go.podman.io/image/v5/types"
@@ -37,8 +36,7 @@ type ImageServiceManager struct {
 }
 
 func (i *ImageServiceManager) GetImageService(sb SandboxInfo) ImageServer {
-	v := reflect.ValueOf(sb)
-	if sb == nil || v.Kind() != reflect.Pointer || v.IsNil() {
+	if sb == nil {
 		return i.imageService
 	}
 

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -1,0 +1,89 @@
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"go.podman.io/image/v5/types"
+	"go.podman.io/storage"
+
+	"github.com/cri-o/cri-o/pkg/config"
+)
+
+// The ImageServiceManager object is responsible for maintaining different
+// implementations of the ImageServer interface.
+// It allows for easy switching between different image storage backends
+// depending on the configuration or environment.
+type ImageServiceManager struct {
+	serverConfig   *config.Config
+	imageService   ImageServer
+	imageServiceRP ImageServer
+}
+
+func (i *ImageServiceManager) GetImageService(runtimeHandler string) ImageServer {
+	isRuntimePullImage := false
+
+	if runtimeHandler != "" {
+		r, ok := i.serverConfig.Runtimes[runtimeHandler]
+		if ok {
+			isRuntimePullImage = r.RuntimePullImage
+		}
+	}
+
+	if isRuntimePullImage {
+		return i.imageServiceRP
+	}
+
+	return i.imageService
+}
+
+// DeleteImage deletes the image with the given ID from all storage backends.
+// This is needed as there is no way, most of the time, to know which runtime
+// is handling the image, and kubernetes expects the image to exist in a single
+// store anyway.
+func (i *ImageServiceManager) DeleteImage(systemContext *types.SystemContext, id StorageImageID) error {
+	err := i.imageService.DeleteImage(systemContext, id)
+	errRP := i.imageServiceRP.DeleteImage(systemContext, id)
+
+	if err == nil || errRP == nil {
+		// the image was successfully removed from one of the stores
+		// consider it a success.
+		return nil
+	}
+	// When an error occurred on both default and runtime-pulled stores,
+	// we report the error from the default one, as we expect this is the most
+	// used and relevant for troubleshooting.
+	return err
+}
+
+func GetImageServiceManager(ctx context.Context, store storage.Store, storageTransport StorageTransport, serverConfig *config.Config) (*ImageServiceManager, error) {
+	is, err := GetImageService(ctx, store, storageTransport, serverConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	imgSvc, ok := is.(*imageService)
+	if !ok {
+		return nil, errors.New("failed to assert imageService type")
+	}
+
+	is_rp, err := GetRuntimePulledImageService(ctx, imgSvc)
+	if err != nil {
+		return nil, err
+	}
+
+	imgSvcRP, ok := is_rp.(*runtimePulledImageService)
+	if !ok {
+		return nil, errors.New("failed to assert runtimePulledImageService type")
+	}
+
+	return &ImageServiceManager{
+		serverConfig:   serverConfig,
+		imageService:   imgSvc,
+		imageServiceRP: imgSvcRP,
+	}, nil
+}
+
+func (m *ImageServiceManager) SetStorageImageServer(server ImageServer) {
+	m.imageService = server
+}

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -38,57 +38,60 @@ type ImageServiceManager struct {
 
 func (i *ImageServiceManager) GetImageService(sb SandboxInfo) ImageServer {
 	v := reflect.ValueOf(sb)
-	if sb != nil && v.Kind() == reflect.Ptr && !v.IsNil() {
-		r, ok := i.serverConfig.Runtimes[sb.RuntimeHandler()]
-		if ok && r.RuntimePullImage {
-			i.imageServiceRPLock.RLock()
-			is := i.imageServiceRP[sb.ID()]
-			i.imageServiceRPLock.RUnlock()
-
-			if is == nil {
-				rootDir, err := i.imageService.GetStore().ContainerRunDirectory(sb.ID())
-				if err != nil {
-					// This will happen when the sandbox is being created.
-					// After that, we will get the proper information allowing
-					// to retrieve the sandbox and create the appropriate ImageServer
-					// for it.
-					log.Warnf(i.ctx, "Failed to retrieve root dir for sandbox %s: %v", sb.ID(), err)
-
-					return i.imageService
-				}
-
-				regularIS, ok := i.imageService.(*imageService)
-				if !ok {
-					log.Warnf(i.ctx, "Failed to get an imageService")
-
-					return i.imageService
-				}
-
-				is, err = GetRuntimePulledImageService(i.ctx, regularIS, rootDir)
-				if err != nil {
-					// if we can't get the specific image server, return the default
-					log.Warnf(i.ctx, "Failed to get ImageServiceVM for sandbox %s: %v", sb.ID(), err)
-
-					return i.imageService
-				}
-
-				i.imageServiceRPLock.Lock()
-				// double-check that an instance was not created in parallel
-				if existing := i.imageServiceRP[sb.ID()]; existing != nil {
-					i.imageServiceRPLock.Unlock()
-
-					return existing
-				}
-
-				i.imageServiceRP[sb.ID()] = is
-				i.imageServiceRPLock.Unlock()
-			}
-
-			return is
-		}
+	if sb == nil || v.Kind() != reflect.Pointer || v.IsNil() {
+		return i.imageService
 	}
 
-	return i.imageService
+	r, ok := i.serverConfig.Runtimes[sb.RuntimeHandler()]
+	if !ok || !r.RuntimePullImage {
+		return i.imageService
+	}
+
+	i.imageServiceRPLock.RLock()
+	is := i.imageServiceRP[sb.ID()]
+	i.imageServiceRPLock.RUnlock()
+
+	if is != nil {
+		return is
+	}
+
+	rootDir, err := i.imageService.GetStore().ContainerRunDirectory(sb.ID())
+	if err != nil {
+		// This will happen when the sandbox is being created.
+		// After that, we will get the proper information allowing
+		// to retrieve the sandbox and create the appropriate ImageServer
+		// for it.
+		log.Warnf(i.ctx, "Failed to retrieve root dir for sandbox %s: %v", sb.ID(), err)
+
+		return i.imageService
+	}
+
+	regularIS, ok := i.imageService.(*imageService)
+	if !ok {
+		log.Warnf(i.ctx, "Failed to get an imageService")
+
+		return i.imageService
+	}
+
+	is, err = GetRuntimePulledImageService(i.ctx, regularIS, rootDir)
+	if err != nil {
+		// if we can't get the specific image server, return the default
+		log.Warnf(i.ctx, "Failed to get ImageServiceVM for sandbox %s: %v", sb.ID(), err)
+
+		return i.imageService
+	}
+
+	i.imageServiceRPLock.Lock()
+	defer i.imageServiceRPLock.Unlock()
+
+	// double-check that an instance was not created in parallel
+	if existing := i.imageServiceRP[sb.ID()]; existing != nil {
+		return existing
+	}
+
+	i.imageServiceRP[sb.ID()] = is
+
+	return is
 }
 
 // DeleteImage deletes the image with the given ID from all storage backends.

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -150,3 +150,11 @@ func GetImageServiceManager(ctx context.Context, store storage.Store, storageTra
 func (m *ImageServiceManager) SetStorageImageServer(server ImageServer) {
 	m.imageService = server
 }
+
+// RemoveImageService removes the cached runtimePulledImageService for the
+// given sandbox ID, freeing the associated in-memory state.
+func (m *ImageServiceManager) RemoveImageService(sandboxID string) {
+	m.imageServiceRPLock.Lock()
+	delete(m.imageServiceRP, sandboxID)
+	m.imageServiceRPLock.Unlock()
+}

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -3,35 +3,79 @@ package storage
 import (
 	"context"
 	"errors"
+	"reflect"
+	"sync"
 
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
 
+	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/pkg/config"
 )
+
+// SandboxInfo provides the minimal interface for accessing sandbox information
+// needed by the ImageServiceManager.
+type SandboxInfo interface {
+	RuntimeHandler() string
+	ID() string
+}
 
 // The ImageServiceManager object is responsible for maintaining different
 // implementations of the ImageServer interface.
 // It allows for easy switching between different image storage backends
 // depending on the configuration or environment.
 type ImageServiceManager struct {
-	serverConfig   *config.Config
-	imageService   ImageServer
-	imageServiceRP ImageServer
+	ctx          context.Context
+	serverConfig *config.Config
+	imageService ImageServer
+
+	// runtimePulledImageService instances mapped to the sandbox ID using them
+	imageServiceRP map[string]*runtimePulledImageService
+
+	// imageServiceRPLock protects concurrent access to imageServiceRP
+	imageServiceRPLock sync.RWMutex
 }
 
-func (i *ImageServiceManager) GetImageService(runtimeHandler string) ImageServer {
-	isRuntimePullImage := false
+func (i *ImageServiceManager) GetImageService(sb SandboxInfo) ImageServer {
+	v := reflect.ValueOf(sb)
+	if sb != nil && v.Kind() == reflect.Ptr && !v.IsNil() {
+		r, ok := i.serverConfig.Runtimes[sb.RuntimeHandler()]
+		if ok && r.RuntimePullImage {
+			i.imageServiceRPLock.RLock()
+			is := i.imageServiceRP[sb.ID()]
+			i.imageServiceRPLock.RUnlock()
 
-	if runtimeHandler != "" {
-		r, ok := i.serverConfig.Runtimes[runtimeHandler]
-		if ok {
-			isRuntimePullImage = r.RuntimePullImage
+			if is == nil {
+				regularIS, ok := i.imageService.(*imageService)
+				if !ok {
+					log.Warnf(i.ctx, "Failed to get an imageService")
+
+					return i.imageService
+				}
+
+				var err error
+				is, err = GetRuntimePulledImageService(i.ctx, regularIS)
+				if err != nil {
+					// if we can't get the specific image server, return the default
+					log.Warnf(i.ctx, "Failed to get ImageServiceVM for sandbox %s: %v", sb.ID(), err)
+
+					return i.imageService
+				}
+
+				i.imageServiceRPLock.Lock()
+				// double-check that an instance was not created in parallel
+				if existing := i.imageServiceRP[sb.ID()]; existing != nil {
+					i.imageServiceRPLock.Unlock()
+
+					return existing
+				}
+
+				i.imageServiceRP[sb.ID()] = is
+				i.imageServiceRPLock.Unlock()
+			}
+
+			return is
 		}
-	}
-
-	if isRuntimePullImage {
-		return i.imageServiceRP
 	}
 
 	return i.imageService
@@ -41,11 +85,29 @@ func (i *ImageServiceManager) GetImageService(runtimeHandler string) ImageServer
 // This is needed as there is no way, most of the time, to know which runtime
 // is handling the image, and kubernetes expects the image to exist in a single
 // store anyway.
-func (i *ImageServiceManager) DeleteImage(systemContext *types.SystemContext, id StorageImageID) error {
+func (i *ImageServiceManager) DeleteImage(ctx context.Context, systemContext *types.SystemContext, id StorageImageID) error {
 	err := i.imageService.DeleteImage(systemContext, id)
-	errRP := i.imageServiceRP.DeleteImage(systemContext, id)
+	if err != nil {
+		log.Debugf(ctx, "Failed to delete image %s from main store: %v", id, err)
+	}
 
-	if err == nil || errRP == nil {
+	ok := (err == nil)
+
+	i.imageServiceRPLock.RLock()
+	defer i.imageServiceRPLock.RUnlock()
+
+	for index := range i.imageServiceRP {
+		e := i.imageServiceRP[index].DeleteImage(systemContext, id)
+		if e != nil {
+			log.Debugf(ctx, "Failed to delete image %s from runtime-pulled store %s: %v", id, index, e)
+		}
+
+		if !ok {
+			ok = (e == nil)
+		}
+	}
+
+	if ok {
 		// the image was successfully removed from one of the stores
 		// consider it a success.
 		return nil
@@ -67,20 +129,11 @@ func GetImageServiceManager(ctx context.Context, store storage.Store, storageTra
 		return nil, errors.New("failed to assert imageService type")
 	}
 
-	is_rp, err := GetRuntimePulledImageService(ctx, imgSvc)
-	if err != nil {
-		return nil, err
-	}
-
-	imgSvcRP, ok := is_rp.(*runtimePulledImageService)
-	if !ok {
-		return nil, errors.New("failed to assert runtimePulledImageService type")
-	}
-
 	return &ImageServiceManager{
+		ctx:            ctx,
 		serverConfig:   serverConfig,
 		imageService:   imgSvc,
-		imageServiceRP: imgSvcRP,
+		imageServiceRP: make(map[string]*runtimePulledImageService),
 	}, nil
 }
 

--- a/internal/storage/image_mgr.go
+++ b/internal/storage/image_mgr.go
@@ -46,6 +46,17 @@ func (i *ImageServiceManager) GetImageService(sb SandboxInfo) ImageServer {
 			i.imageServiceRPLock.RUnlock()
 
 			if is == nil {
+				rootDir, err := i.imageService.GetStore().ContainerRunDirectory(sb.ID())
+				if err != nil {
+					// This will happen when the sandbox is being created.
+					// After that, we will get the proper information allowing
+					// to retrieve the sandbox and create the appropriate ImageServer
+					// for it.
+					log.Warnf(i.ctx, "Failed to retrieve root dir for sandbox %s: %v", sb.ID(), err)
+
+					return i.imageService
+				}
+
 				regularIS, ok := i.imageService.(*imageService)
 				if !ok {
 					log.Warnf(i.ctx, "Failed to get an imageService")
@@ -53,8 +64,7 @@ func (i *ImageServiceManager) GetImageService(sb SandboxInfo) ImageServer {
 					return i.imageService
 				}
 
-				var err error
-				is, err = GetRuntimePulledImageService(i.ctx, regularIS)
+				is, err = GetRuntimePulledImageService(i.ctx, regularIS, rootDir)
 				if err != nil {
 					// if we can't get the specific image server, return the default
 					log.Warnf(i.ctx, "Failed to get ImageServiceVM for sandbox %s: %v", sb.ID(), err)

--- a/internal/storage/image_mgr_test.go
+++ b/internal/storage/image_mgr_test.go
@@ -80,13 +80,6 @@ var _ = t.Describe("ImageServiceManager", func() {
 			Expect(sut.GetImageService(nil)).To(Equal(mockImageServer))
 		})
 
-		// Typed-nil: a non-nil interface value wrapping a nil pointer must not panic
-		// and must behave like nil (return main store).
-		It("should return the main store for a typed-nil sandbox without panicking", func() {
-			var sb *fakeSandboxInfo // typed nil: non-nil interface, nil pointer
-			Expect(sut.GetImageService(sb)).To(Equal(mockImageServer))
-		})
-
 		// Item 2: the default "runc" handler has RuntimePullImage=false.
 		It("should return the main store when the handler has RuntimePullImage=false", func() {
 			sb := &fakeSandboxInfo{id: "sb-runc", runtimeHandler: "runc"}

--- a/internal/storage/image_mgr_test.go
+++ b/internal/storage/image_mgr_test.go
@@ -1,0 +1,139 @@
+package storage_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.podman.io/image/v5/types"
+	"go.uber.org/mock/gomock"
+
+	"github.com/cri-o/cri-o/internal/storage"
+	"github.com/cri-o/cri-o/pkg/config"
+	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
+	criostoragemock "github.com/cri-o/cri-o/test/mocks/criostorage"
+)
+
+// fakeSandboxInfo is a minimal SandboxInfo test shared across storage tests.
+type fakeSandboxInfo struct {
+	id             string
+	runtimeHandler string
+}
+
+func (f *fakeSandboxInfo) ID() string             { return f.id }
+func (f *fakeSandboxInfo) RuntimeHandler() string { return f.runtimeHandler }
+
+// newTestConfig returns a minimal *config.Config for ImageServiceManager / RuntimeServiceManager tests.
+// The registriesFile must be a path to a (possibly empty) file that will be used as the
+// SystemRegistriesConfPath.
+func newTestConfig(registriesFile string) *config.Config {
+	return &config.Config{
+		SystemContext: &types.SystemContext{
+			SystemRegistriesConfPath: registriesFile,
+		},
+		ImageConfig: config.ImageConfig{
+			DefaultTransport: "docker://",
+		},
+		RuntimeConfig: config.RuntimeConfig{
+			Runtimes: config.Runtimes{
+				"runc":        &config.RuntimeHandler{RuntimePullImage: false},
+				"kata-remote": &config.RuntimeHandler{RuntimePullImage: true},
+			},
+		},
+	}
+}
+
+var _ = t.Describe("ImageServiceManager", func() {
+	var (
+		mockCtrl             *gomock.Controller
+		storeMock            *containerstoragemock.MockStore
+		storageTransportMock *criostoragemock.MockStorageTransport
+		mockImageServer      *criostoragemock.MockImageServer
+		sut                  *storage.ImageServiceManager
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		storeMock = containerstoragemock.NewMockStore(mockCtrl)
+		storageTransportMock = criostoragemock.NewMockStorageTransport(mockCtrl)
+		mockImageServer = criostoragemock.NewMockImageServer(mockCtrl)
+
+		var err error
+
+		sut, err = storage.GetImageServiceManager(
+			context.Background(), storeMock, storageTransportMock,
+			newTestConfig(t.MustTempFile("registries")),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Inject the mock so routing tests don't need a real store.
+		sut.SetStorageImageServer(mockImageServer)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	t.Describe("GetImageService", func() {
+		// Item 1: a nil sandbox means "no sandbox context" — always routes to main store.
+		It("should return the main store for a nil sandbox", func() {
+			Expect(sut.GetImageService(nil)).To(Equal(mockImageServer))
+		})
+
+		// Typed-nil: a non-nil interface value wrapping a nil pointer must not panic
+		// and must behave like nil (return main store).
+		It("should return the main store for a typed-nil sandbox without panicking", func() {
+			var sb *fakeSandboxInfo // typed nil: non-nil interface, nil pointer
+			Expect(sut.GetImageService(sb)).To(Equal(mockImageServer))
+		})
+
+		// Item 2: the default "runc" handler has RuntimePullImage=false.
+		It("should return the main store when the handler has RuntimePullImage=false", func() {
+			sb := &fakeSandboxInfo{id: "sb-runc", runtimeHandler: "runc"}
+			Expect(sut.GetImageService(sb)).To(Equal(mockImageServer))
+		})
+
+		// An unknown handler (not present in config.Runtimes) falls back to the main store.
+		It("should return the main store for an unknown runtime handler", func() {
+			sb := &fakeSandboxInfo{id: "sb-unknown", runtimeHandler: "unknown-runtime"}
+			Expect(sut.GetImageService(sb)).To(Equal(mockImageServer))
+		})
+	})
+
+	t.Describe("RemoveImageService", func() {
+		It("should be a no-op for a sandbox that was never registered", func() {
+			Expect(func() { sut.RemoveImageService("non-existent-sandbox") }).NotTo(Panic())
+		})
+	})
+
+	t.Describe("SetStorageImageServer", func() {
+		It("should update the store returned by GetImageService for a nil sandbox", func() {
+			anotherMock := criostoragemock.NewMockImageServer(mockCtrl)
+			sut.SetStorageImageServer(anotherMock)
+			Expect(sut.GetImageService(nil)).To(Equal(anotherMock))
+		})
+	})
+
+	t.Describe("HeuristicallyTryResolvingStringAsIDPrefix", func() {
+		It("should return an empty slice when the main store reports no match", func() {
+			mockImageServer.EXPECT().HeuristicallyTryResolvingStringAsIDPrefix("cafe").Return(nil)
+			Expect(sut.HeuristicallyTryResolvingStringAsIDPrefix("cafe")).To(BeEmpty())
+		})
+
+		It("should return a match paired with the server that owns it", func() {
+			const testHex = "2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812"
+
+			testID, err := storage.ParseStorageImageIDFromOutOfProcessData(testHex)
+			Expect(err).ToNot(HaveOccurred())
+
+			mockImageServer.EXPECT().
+				HeuristicallyTryResolvingStringAsIDPrefix("2a03a").
+				Return(&testID)
+
+			matches := sut.HeuristicallyTryResolvingStringAsIDPrefix("2a03a")
+			Expect(matches).To(HaveLen(1))
+			Expect(matches[0].Server).To(Equal(mockImageServer))
+			Expect(matches[0].ID).To(Equal(&testID))
+		})
+	})
+})

--- a/internal/storage/image_mgr_test.go
+++ b/internal/storage/image_mgr_test.go
@@ -77,19 +77,25 @@ var _ = t.Describe("ImageServiceManager", func() {
 	t.Describe("GetImageService", func() {
 		// Item 1: a nil sandbox means "no sandbox context" — always routes to main store.
 		It("should return the main store for a nil sandbox", func() {
-			Expect(sut.GetImageService(nil)).To(Equal(mockImageServer))
+			result, err := sut.GetImageService(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(mockImageServer))
 		})
 
 		// Item 2: the default "runc" handler has RuntimePullImage=false.
 		It("should return the main store when the handler has RuntimePullImage=false", func() {
 			sb := &fakeSandboxInfo{id: "sb-runc", runtimeHandler: "runc"}
-			Expect(sut.GetImageService(sb)).To(Equal(mockImageServer))
+			result, err := sut.GetImageService(sb)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(mockImageServer))
 		})
 
 		// An unknown handler (not present in config.Runtimes) falls back to the main store.
 		It("should return the main store for an unknown runtime handler", func() {
 			sb := &fakeSandboxInfo{id: "sb-unknown", runtimeHandler: "unknown-runtime"}
-			Expect(sut.GetImageService(sb)).To(Equal(mockImageServer))
+			result, err := sut.GetImageService(sb)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(mockImageServer))
 		})
 	})
 
@@ -103,7 +109,9 @@ var _ = t.Describe("ImageServiceManager", func() {
 		It("should update the store returned by GetImageService for a nil sandbox", func() {
 			anotherMock := criostoragemock.NewMockImageServer(mockCtrl)
 			sut.SetStorageImageServer(anotherMock)
-			Expect(sut.GetImageService(nil)).To(Equal(anotherMock))
+			result, err := sut.GetImageService(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(anotherMock))
 		})
 	})
 

--- a/internal/storage/image_vm.go
+++ b/internal/storage/image_vm.go
@@ -53,7 +53,7 @@ type runtimePulledImageService struct {
 }
 
 // GetRuntimePulledImageService creates a new runtimePulledImageService instance.
-func GetRuntimePulledImageService(ctx context.Context, imageService *imageService) (ImageServer, error) {
+func GetRuntimePulledImageService(ctx context.Context, imageService *imageService) (*runtimePulledImageService, error) {
 	// Create a new OCI artifact store for pulling the artifact.
 	// We make the store point to a dedicated location to avoid any risk of
 	// mixing the pulled artifacts with regular container images.

--- a/internal/storage/image_vm.go
+++ b/internal/storage/image_vm.go
@@ -9,7 +9,11 @@ import (
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.podman.io/common/libimage"
+	"go.podman.io/image/v5/docker"
 	"go.podman.io/image/v5/docker/reference"
+	cimage "go.podman.io/image/v5/image"
+	"go.podman.io/image/v5/manifest"
+	"go.podman.io/image/v5/signature"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
 
@@ -347,10 +351,90 @@ func (i *runtimePulledImageService) PinnedImageRegexps() []*regexp.Regexp {
 // - userSpecifiedImage: a RegistryImageReference that expresses users’ _intended_ image.
 // - imageID: A StorageImageID of the image.
 func (i *runtimePulledImageService) IsRunningImageAllowed(ctx context.Context, systemContext *types.SystemContext, userSpecifiedImage RegistryImageReference, imageID StorageImageID) error {
-	log.Debugf(i.ctx, "runtimePulledImageService.IsRunningImageAllowed() start")
-	defer log.Debugf(i.ctx, "runtimePulledImageService.IsRunningImageAllowed() end")
+	policy, err := signature.DefaultPolicy(systemContext)
+	if err != nil {
+		return fmt.Errorf("get default policy: %w", err)
+	}
 
-	return i.storageImageServer.IsRunningImageAllowed(ctx, systemContext, userSpecifiedImage, imageID)
+	policyContext, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		return fmt.Errorf("create policy context: %w", err)
+	}
+
+	defer func() {
+		if err := policyContext.Destroy(); err != nil {
+			log.Errorf(ctx, "Error destroying policy: %+v", err)
+		}
+	}()
+
+	if err := i.checkSignature(ctx, systemContext, policyContext, userSpecifiedImage, imageID); err != nil {
+		return fmt.Errorf("checking signature of %q: %w", userSpecifiedImage, err)
+	}
+
+	log.Debugf(ctx, "Is allowed to run config image %s (policy path: %q)", userSpecifiedImage, systemContext.SignaturePolicyPath)
+
+	return nil
+}
+
+// checkSignature verifies the image signature against the artifact store.
+// Unlike imageService.checkSignature, this reads the image from the OCI layout
+// in the artifact store rather than from local containers/storage.
+func (i *runtimePulledImageService) checkSignature(ctx context.Context, sys *types.SystemContext, policyContext *signature.PolicyContext, userSpecifiedImage RegistryImageReference, imageID StorageImageID) error {
+	userSpecifiedImageRef, err := docker.NewReference(userSpecifiedImage.Raw())
+	if err != nil {
+		return fmt.Errorf("creating docker:// reference for %q: %w", userSpecifiedImage.Raw().String(), err)
+	}
+
+	// imageID is authoritative, but it may be a deduplicated image with several manifests,
+	// and only one of them might be signed with the signatures required by policy.
+	//
+	// Here we could, possibly:
+	// - if userSpecifiedImage is a repo@digest, resolve up that image, CHECK THAT IT MATCHES storageID, and use that
+	//   reference (to use certainly the right digest)
+	// - if userSpecifiedImage is a repo:tag, resolve up that image, CHECK THAT IT MATCHES storageID, and use that
+	//   reference (assuming some future c/storage that can map repo:tag to the right digest)
+	// Failing that (e.g. if a subsequent pull moved the tag, or if the image was untagged), try with the raw imageID.
+	storageSource, err := i.store.ImageSource(ctx, imageID.IDStringForOutOfProcessConsumptionOnly())
+	if err != nil {
+		return fmt.Errorf("creating image source for artifact store image: %w", err)
+	}
+	defer storageSource.Close()
+
+	unparsedToplevel := cimage.UnparsedInstance(storageSource, nil)
+
+	topManifest, topMIMEType, err := unparsedToplevel.Manifest(ctx)
+	if err != nil {
+		return fmt.Errorf("get top level manifest: %w", err)
+	}
+
+	unparsedInstance := unparsedToplevel
+
+	if manifest.MIMETypeIsMultiImage(topMIMEType) {
+		manifestList, err := manifest.ListFromBlob(topManifest, topMIMEType)
+		if err != nil {
+			return fmt.Errorf("parsing list manifest: %w", err)
+		}
+
+		instanceDigest, err := manifestList.ChooseInstance(sys)
+		if err != nil {
+			return fmt.Errorf("choosing instance: %w", err)
+		}
+
+		unparsedInstance = cimage.UnparsedInstance(storageSource, &instanceDigest)
+	}
+
+	mixedUnparsedInstance := cimage.UnparsedInstanceWithReference(unparsedInstance, userSpecifiedImageRef)
+
+	allowed, err := policyContext.IsRunningImageAllowed(ctx, mixedUnparsedInstance)
+	if err != nil {
+		return fmt.Errorf("verifying signatures: %w", WrapSignatureCRIErrorIfNeeded(err))
+	}
+
+	if !allowed {
+		panic("Internal inconsistency: IsRunningImageAllowed returned !allowed and no error when checking image signature")
+	}
+
+	return nil
 }
 
 // GetConfigForImage returns the OCI config for the given image reference.

--- a/internal/storage/image_vm.go
+++ b/internal/storage/image_vm.go
@@ -53,13 +53,13 @@ type runtimePulledImageService struct {
 }
 
 // GetRuntimePulledImageService creates a new runtimePulledImageService instance.
-func GetRuntimePulledImageService(ctx context.Context, imageService *imageService) (*runtimePulledImageService, error) {
+func GetRuntimePulledImageService(ctx context.Context, imageService *imageService, rootPath string) (*runtimePulledImageService, error) {
 	// Create a new OCI artifact store for pulling the artifact.
 	// We make the store point to a dedicated location to avoid any risk of
 	// mixing the pulled artifacts with regular container images.
 	srcSystemContext := *imageService.config.SystemContext // shallow copy to inherit auth, policy, etc.
 
-	artifactStore, artifactErr := datastore.New("/var/lib/containers/storage-for-coco", &srcSystemContext)
+	artifactStore, artifactErr := datastore.New(rootPath, &srcSystemContext)
 	if artifactErr != nil {
 		return nil, fmt.Errorf("unable to create the datastore: %w", artifactErr)
 	}

--- a/internal/storage/image_vm.go
+++ b/internal/storage/image_vm.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.podman.io/common/libimage"
 	"go.podman.io/image/v5/docker"
@@ -45,11 +46,9 @@ type runtimePulledImageService struct {
 	// interface for runtimes that need it.
 	storageImageServer *imageService
 
-	// FIXME: we're currently storing the StorageImageId and ImageResult in memory.
-	// We should find a way to persist this information in the storage, so that
-	// it can survive a restart of CRI-O.
-
-	// list of known RegistryImageReference with associated ImageResult and StorageID
+	// list of known RegistryImageReference with associated ImageResult and StorageID.
+	// Populated on startup from the artifact store (see loadKnownImagesFromStore) and
+	// kept up to date by PullImage / DeleteImage / UntagImage.
 	knownImages map[RegistryImageReference]cachedImageRefs
 
 	// knownImagesLock protects concurrent access to knownImages
@@ -68,12 +67,16 @@ func GetRuntimePulledImageService(ctx context.Context, imageService *imageServic
 		return nil, fmt.Errorf("unable to create the datastore: %w", artifactErr)
 	}
 
-	return &runtimePulledImageService{
+	svc := &runtimePulledImageService{
 		ctx:                ctx,
 		store:              artifactStore,
 		storageImageServer: imageService,
 		knownImages:        make(map[RegistryImageReference]cachedImageRefs),
-	}, nil
+	}
+
+	svc.loadKnownImagesFromStore(ctx)
+
+	return svc, nil
 }
 
 // ListImages returns list of known images.
@@ -184,60 +187,113 @@ func (i *runtimePulledImageService) PullImage(ctx context.Context, imageName Reg
 
 	imageRef := references.RegistryImageReferenceFromRaw(canonicalRef)
 
-	// create the StorageImageID from the manifest digest
-	ID := newExactStorageImageID(artifactManifestDigest.Encoded())
-
-	// Get the OCIConfig
-	ociConfig, err := i.store.PullConfig(ctx, imageName.Raw().String())
+	entry, err := i.buildCachedImageRefs(ctx, *artifactManifestDigest, imageName, imageName.StringForOutOfProcessConsumptionOnly())
 	if err != nil {
-		return RegistryImageReference{}, fmt.Errorf("unable to pull image or OCI artifact: pull config err: %w", err)
+		return RegistryImageReference{}, fmt.Errorf("unable to pull image or OCI artifact: %w", err)
 	}
 
-	// Generate an ImageResult with the available information, so that it can be
-	// returned by ImageStatus when asked with the same reference.
-	// Note that this structure is incomplete, since we're not actually pulling
-	// the image.
-	var (
-		repoTags    []string
-		repoDigests = make([]string, 0, 1)
-	)
-
-	if tagged, ok := imageRef.Raw().(reference.NamedTagged); ok {
-		repoTags = append(repoTags, tagged.String())
-	}
-
-	repoDigests = append(repoDigests, artifactManifestDigest.String())
-
-	imageResult := &ImageResult{
-		ID: ID,
-		// reuse the imageName here: this is the name that the runtime
-		// will use to pull the image on its side. It is useless to give it any
-		// already resolved name, as it will need to do the resolution on its side.
-		SomeNameOfThisImage: &imageName,
-		RepoTags:            repoTags,
-		RepoDigests:         repoDigests,
-		Digest:              *artifactManifestDigest,
-		OCIConfig:           ociConfig,
-		// Following fields are not available at this stage, and will be left
-		// empty, or with default value
-		Size:         nil,
-		User:         "",
-		PreviousName: "",
-		Labels:       nil,
-		Annotations:  nil,
-		Pinned:       false,
-		MountPoint:   "",
-	}
-
-	// Store the generated ImageResult and StorageImageID in a cache of known images
 	i.knownImagesLock.Lock()
-	i.knownImages[imageRef] = cachedImageRefs{
-		imageResult: *imageResult,
-		imageName:   imageName.StringForOutOfProcessConsumptionOnly(),
-	}
+	i.knownImages[imageRef] = *entry
 	i.knownImagesLock.Unlock()
 
 	return imageRef, nil
+}
+
+// buildCachedImageRefs constructs a cachedImageRefs for an artifact by fetching
+// its OCI config from the artifact store and building an ImageResult.
+//
+// pullRef is used as SomeNameOfThisImage — for a freshly pulled image this is
+// the original pull reference; when restoring from disk it is the tagged
+// reference stored in the artifact (best approximation of the original name).
+// originalNameStr is stored separately for heuristic name matching.
+//
+// Note: the resulting ImageResult is intentionally incomplete because CRI-O
+// does not pull the image data itself for this runtime type.
+func (i *runtimePulledImageService) buildCachedImageRefs(
+	ctx context.Context,
+	artifactManifestDigest digest.Digest,
+	pullRef RegistryImageReference,
+	originalNameStr string,
+) (*cachedImageRefs, error) {
+	ociConfig, err := i.store.PullConfig(ctx, pullRef.Raw().String())
+	if err != nil {
+		return nil, fmt.Errorf("pull config: %w", err)
+	}
+
+	var repoTags []string
+	if tagged, ok := pullRef.Raw().(reference.NamedTagged); ok {
+		repoTags = append(repoTags, tagged.String())
+	}
+
+	id := newExactStorageImageID(artifactManifestDigest.Encoded())
+	ref := pullRef
+
+	return &cachedImageRefs{
+		imageResult: ImageResult{
+			ID:                  id,
+			SomeNameOfThisImage: &ref,
+			RepoTags:            repoTags,
+			RepoDigests:         []string{artifactManifestDigest.String()},
+			Digest:              artifactManifestDigest,
+			OCIConfig:           ociConfig,
+		},
+		imageName: originalNameStr,
+	}, nil
+}
+
+// loadKnownImagesFromStore populates knownImages from artifacts already present
+// on disk. Called once at startup to restore the cache after a process restart.
+// Failures for individual artifacts are logged and skipped so that a single
+// corrupted entry does not prevent the service from starting.
+func (i *runtimePulledImageService) loadKnownImagesFromStore(ctx context.Context) {
+	artifacts, err := i.store.List(ctx)
+	if err != nil {
+		log.Warnf(ctx, "Unable to restore image cache from store: %v", err)
+
+		return
+	}
+
+	restoredCount := 0
+
+	for _, artifact := range artifacts {
+		imageRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData(artifact.CanonicalName())
+		if err != nil {
+			log.Warnf(ctx, "Skipping artifact %q: could not parse canonical reference: %v",
+				artifact.Digest(), err)
+
+			continue
+		}
+
+		pullRefStr := artifact.Reference()
+
+		pullRef, err := references.ParseRegistryImageReferenceFromOutOfProcessData(pullRefStr)
+		if err != nil {
+			// The tagged reference failed to parse (e.g. "unknown" placeholder);
+			// fall back to the canonical digest reference.
+			log.Warnf(ctx, "Artifact %q has unparsable pull reference %q, using canonical: %v",
+				artifact.Digest(), pullRefStr, err)
+
+			pullRef = imageRef
+			pullRefStr = imageRef.StringForOutOfProcessConsumptionOnly()
+		}
+
+		entry, err := i.buildCachedImageRefs(ctx, artifact.Digest(), pullRef, pullRefStr)
+		if err != nil {
+			log.Warnf(ctx, "Skipping artifact %q: could not build cache entry: %v",
+				artifact.Digest(), err)
+
+			continue
+		}
+
+		i.knownImagesLock.Lock()
+		i.knownImages[imageRef] = *entry
+		i.knownImagesLock.Unlock()
+
+		restoredCount++
+	}
+
+	log.Infof(ctx, "RuntimePulledImageService: restored %d/%d image(s) from artifact store into cache",
+		restoredCount, len(artifacts))
 }
 
 // DeleteImage deletes a storage image (impacting all its tags).

--- a/internal/storage/image_vm.go
+++ b/internal/storage/image_vm.go
@@ -1,0 +1,383 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.podman.io/common/libimage"
+	"go.podman.io/image/v5/docker/reference"
+	"go.podman.io/image/v5/types"
+	"go.podman.io/storage"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/internal/ociartifact/datastore"
+	"github.com/cri-o/cri-o/internal/storage/references"
+)
+
+type cachedImageRefs struct {
+	// store the imageResult for later use
+	imageResult ImageResult
+
+	// keep track of the original image name that was used to pull the image,
+	// so that it can be used for heuristics when asked with a short name.
+	imageName string
+}
+
+// runtimePulledImageService is an ImageServer implementation that used with
+// runtimes that perform the PullImage phase themselves.
+type runtimePulledImageService struct {
+	ctx context.Context
+
+	// link to the datastore that will be used by this ImageServer
+	store *datastore.Store
+
+	// link to an ImageServer that is used to perform some of the image management
+	// operations. This allows runtimePulledImageService to delegate the core image
+	// handling tasks to the storage.ImageServer, while providing a specific
+	// interface for runtimes that need it.
+	storageImageServer *imageService
+
+	// FIXME: we're currently storing the StorageImageId and ImageResult in memory.
+	// We should find a way to persist this information in the storage, so that
+	// it can survive a restart of CRI-O.
+
+	// list of known RegistryImageReference with associated ImageResult and StorageID
+	knownImages map[RegistryImageReference]cachedImageRefs
+
+	// knownImagesLock protects concurrent access to knownImages
+	knownImagesLock sync.RWMutex
+}
+
+// GetRuntimePulledImageService creates a new runtimePulledImageService instance.
+func GetRuntimePulledImageService(ctx context.Context, imageService *imageService) (ImageServer, error) {
+	// Create a new OCI artifact store for pulling the artifact.
+	// We make the store point to a dedicated location to avoid any risk of
+	// mixing the pulled artifacts with regular container images.
+	srcSystemContext := *imageService.config.SystemContext // shallow copy to inherit auth, policy, etc.
+
+	artifactStore, artifactErr := datastore.New("/var/lib/containers/storage-for-coco", &srcSystemContext)
+	if artifactErr != nil {
+		return nil, fmt.Errorf("unable to create the datastore: %w", artifactErr)
+	}
+
+	return &runtimePulledImageService{
+		ctx:                ctx,
+		store:              artifactStore,
+		storageImageServer: imageService,
+		knownImages:        make(map[RegistryImageReference]cachedImageRefs),
+	}, nil
+}
+
+// ListImages returns list of known images.
+func (i *runtimePulledImageService) ListImages(systemContext *types.SystemContext) ([]ImageResult, error) {
+	log.Debugf(i.ctx, "runtimePulledImageService.ListImages() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.ListImages() end")
+
+	i.knownImagesLock.RLock()
+	defer i.knownImagesLock.RUnlock()
+
+	results := make([]ImageResult, 0, len(i.knownImages))
+	for id := range i.knownImages {
+		results = append(results, i.knownImages[id].imageResult)
+	}
+
+	return results, nil
+}
+
+// ImageStatusByID returns status of a single image.
+func (i *runtimePulledImageService) ImageStatusByID(systemContext *types.SystemContext, id StorageImageID) (*ImageResult, error) {
+	log.Debugf(i.ctx, "runtimePulledImageService.ImageStatusByID() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.ImageStatusByID() end")
+
+	i.knownImagesLock.RLock()
+	defer i.knownImagesLock.RUnlock()
+
+	for idx := range i.knownImages {
+		if i.knownImages[idx].imageResult.ID == id {
+			result := i.knownImages[idx].imageResult
+
+			return &result, nil
+		}
+	}
+
+	return nil, fmt.Errorf("image not found: %s", id.IDStringForOutOfProcessConsumptionOnly())
+}
+
+// ImageStatusByName returns status of an image tagged with name.
+func (i *runtimePulledImageService) ImageStatusByName(systemContext *types.SystemContext, name RegistryImageReference) (*ImageResult, error) {
+	log.Debugf(i.ctx, "runtimePulledImageService.ImageStatusByName() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.ImageStatusByName() end")
+
+	i.knownImagesLock.RLock()
+	defer i.knownImagesLock.RUnlock()
+
+	// look at our list of known image references, and if we find a match
+	// return the associated ImageResult.
+	if result, exists := i.knownImages[name]; exists {
+		return &result.imageResult, nil
+	}
+
+	// if not found by canonical digest key, check against the original pull reference
+	nameStr := name.StringForOutOfProcessConsumptionOnly()
+	for idx := range i.knownImages {
+		if i.knownImages[idx].imageName == nameStr {
+			result := i.knownImages[idx].imageResult
+
+			return &result, nil
+		}
+	}
+
+	return nil, fmt.Errorf("image not found: %s", nameStr)
+}
+
+// PullImage: do not pull the data, only get the manifest and return an image reference
+//
+// For this runtime, the image management is done by the runtime itself.
+// CRI-O has nothing to do with the image, and must actually avoid
+// pulling it, as it may fail if the image is encrypted for instance.
+func (i *runtimePulledImageService) PullImage(ctx context.Context, imageName RegistryImageReference, options *ImageCopyOptions) (RegistryImageReference, error) {
+	log.Debugf(i.ctx, "runtimePulledImageService.PullImage() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.PullImage() end")
+
+	log.Debugf(ctx, "Skip image pull - image %s", imageName)
+
+	srcRef, err := i.storageImageServer.lookup.remoteImageReference(imageName)
+	if err != nil {
+		return RegistryImageReference{}, err
+	}
+
+	copyOptions := &libimage.CopyOptions{
+		OciDecryptConfig: options.OciDecryptConfig,
+		Progress:         options.Progress,
+		RemoveSignatures: true, // signature is not supported for OCI layout dest
+	}
+
+	// copy the SourceCtx options to keep per-request authentication credentials
+	if options.SourceCtx != nil {
+		if options.SourceCtx.AuthFilePath != "" {
+			copyOptions.AuthFilePath = options.SourceCtx.AuthFilePath
+		}
+
+		if options.SourceCtx.DockerAuthConfig != nil {
+			copyOptions.Username = options.SourceCtx.DockerAuthConfig.Username
+			copyOptions.Password = options.SourceCtx.DockerAuthConfig.Password
+		}
+	}
+
+	artifactManifestDigest, err := i.store.PullManifestOnly(ctx, srcRef, copyOptions)
+	if err != nil {
+		return RegistryImageReference{}, fmt.Errorf("unable to pull OCI artifact: %w", err)
+	}
+
+	canonicalRef, err := reference.WithDigest(reference.TrimNamed(imageName.Raw()), *artifactManifestDigest)
+	if err != nil {
+		return RegistryImageReference{}, fmt.Errorf("create canonical reference: %w", err)
+	}
+
+	imageRef := references.RegistryImageReferenceFromRaw(canonicalRef)
+
+	// create the StorageImageID from the manifest digest
+	ID := newExactStorageImageID(artifactManifestDigest.Encoded())
+
+	// Get the OCIConfig
+	ociConfig, err := i.store.PullConfig(ctx, imageName.Raw().String())
+	if err != nil {
+		return RegistryImageReference{}, fmt.Errorf("unable to pull image or OCI artifact: pull config err: %w", err)
+	}
+
+	// Generate an ImageResult with the available information, so that it can be
+	// returned by ImageStatus when asked with the same reference.
+	// Note that this structure is incomplete, since we're not actually pulling
+	// the image.
+	var (
+		repoTags    []string
+		repoDigests = make([]string, 0, 1)
+	)
+
+	if tagged, ok := imageRef.Raw().(reference.NamedTagged); ok {
+		repoTags = append(repoTags, tagged.String())
+	}
+
+	repoDigests = append(repoDigests, artifactManifestDigest.String())
+
+	imageResult := &ImageResult{
+		ID: ID,
+		// reuse the imageName here: this is the name that the runtime
+		// will use to pull the image on its side. It is useless to give it any
+		// already resolved name, as it will need to do the resolution on its side.
+		SomeNameOfThisImage: &imageName,
+		RepoTags:            repoTags,
+		RepoDigests:         repoDigests,
+		Digest:              *artifactManifestDigest,
+		OCIConfig:           ociConfig,
+		// Following fields are not available at this stage, and will be left
+		// empty, or with default value
+		Size:         nil,
+		User:         "",
+		PreviousName: "",
+		Labels:       nil,
+		Annotations:  nil,
+		Pinned:       false,
+		MountPoint:   "",
+	}
+
+	// Store the generated ImageResult and StorageImageID in a cache of known images
+	i.knownImagesLock.Lock()
+	i.knownImages[imageRef] = cachedImageRefs{
+		imageResult: *imageResult,
+		imageName:   imageName.StringForOutOfProcessConsumptionOnly(),
+	}
+	i.knownImagesLock.Unlock()
+
+	return imageRef, nil
+}
+
+// DeleteImage deletes a storage image (impacting all its tags).
+func (i *runtimePulledImageService) DeleteImage(systemContext *types.SystemContext, id StorageImageID) error {
+	log.Debugf(i.ctx, "runtimePulledImageService.DeleteImage() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.DeleteImage() end")
+
+	err := i.store.Remove(i.ctx, id.IDStringForOutOfProcessConsumptionOnly())
+	if err != nil {
+		return fmt.Errorf("failed to delete image with ID %s: %w", id.IDStringForOutOfProcessConsumptionOnly(), err)
+	}
+
+	// remove the image from our cache
+	i.knownImagesLock.Lock()
+	defer i.knownImagesLock.Unlock()
+
+	for index := range i.knownImages {
+		if i.knownImages[index].imageResult.ID == id {
+			delete(i.knownImages, index)
+
+			break
+		}
+	}
+
+	return nil
+}
+
+// UntagImage removes a name from the specified image, and if it was
+// the only name the image had, removes the image.
+func (i *runtimePulledImageService) UntagImage(systemContext *types.SystemContext, name RegistryImageReference) error {
+	log.Debugf(i.ctx, "runtimePulledImageService.UntagImage() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.UntagImage() end")
+
+	err := i.store.Remove(i.ctx, name.StringForOutOfProcessConsumptionOnly())
+	if err != nil {
+		return fmt.Errorf("failed to untag image %s: %w", name.StringForOutOfProcessConsumptionOnly(), err)
+	}
+
+	// remove the image from our cache
+	i.knownImagesLock.Lock()
+	delete(i.knownImages, name)
+	i.knownImagesLock.Unlock()
+
+	return nil
+}
+
+// GetStore returns the reference to the default image store.
+// This instance of the store holds an ociartifact store, which can't be used here.
+// We return the default store instead, for compatibility.
+func (i *runtimePulledImageService) GetStore() storage.Store {
+	log.Debugf(i.ctx, "runtimePulledImageService.GetStore() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.GetStore() end")
+
+	return i.storageImageServer.GetStore()
+}
+
+// HeuristicallyTryResolvingStringAsIDPrefix checks if heuristicInput could be a valid image ID or a prefix, and returns
+// a StorageImageID if so, or nil if the input can be something else.
+// DO NOT CALL THIS from in-process callers who know what their input is and don't NEED to involve heuristics.
+func (i *runtimePulledImageService) HeuristicallyTryResolvingStringAsIDPrefix(heuristicInput string) *StorageImageID {
+	log.Debugf(i.ctx, "runtimePulledImageService.HeuristicallyTryResolvingStringAsIDPrefix() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.HeuristicallyTryResolvingStringAsIDPrefix() end")
+
+	i.knownImagesLock.RLock()
+	defer i.knownImagesLock.RUnlock()
+
+	if len(heuristicInput) >= minimumTruncatedIDLength {
+		for index := range i.knownImages {
+			if strings.HasPrefix(i.knownImages[index].imageResult.ID.IDStringForOutOfProcessConsumptionOnly(), heuristicInput) {
+				id := i.knownImages[index].imageResult.ID
+
+				return &id
+			}
+		}
+	}
+
+	return nil
+}
+
+// CandidatesForPotentiallyShortImageName resolves an image name into a set of fully-qualified image names (domain/repo/image:tag|@digest).
+// It will only return an empty slice if err != nil.
+// For this implementation of ImageServer, nothing specific is needed here.
+// Name resolution can be done with the underlying storage image server.
+func (i *runtimePulledImageService) CandidatesForPotentiallyShortImageName(systemContext *types.SystemContext, imageName string) ([]RegistryImageReference, error) {
+	log.Debugf(i.ctx, "runtimePulledImageService.CandidatesForPotentiallyShortImageName() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.CandidatesForPotentiallyShortImageName() end")
+
+	return i.storageImageServer.CandidatesForPotentiallyShortImageName(systemContext, imageName)
+}
+
+// UpdatePinnedImagesList updates pinned and pause images list in imageService.
+func (i *runtimePulledImageService) UpdatePinnedImagesList(imageList []string) {
+	log.Debugf(i.ctx, "runtimePulledImageService.UpdatePinnedImagesList() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.UpdatePinnedImagesList() end")
+
+	i.storageImageServer.UpdatePinnedImagesList(imageList)
+}
+
+func (i *runtimePulledImageService) PinnedImageRegexps() []*regexp.Regexp {
+	log.Debugf(i.ctx, "runtimePulledImageService.PinnedImageRegexps() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.PinnedImageRegexps() end")
+
+	return i.storageImageServer.PinnedImageRegexps()
+}
+
+// IsRunningImageAllowed verifies if running of the container image is allowed.
+//
+// Arguments:
+// - ctx: The context for controlling the function's execution
+// - systemContext: server's system context for the given namespace, notably it might have a customized SignaturePolicyPath.
+// - userSpecifiedImage: a RegistryImageReference that expresses users’ _intended_ image.
+// - imageID: A StorageImageID of the image.
+func (i *runtimePulledImageService) IsRunningImageAllowed(ctx context.Context, systemContext *types.SystemContext, userSpecifiedImage RegistryImageReference, imageID StorageImageID) error {
+	log.Debugf(i.ctx, "runtimePulledImageService.IsRunningImageAllowed() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.IsRunningImageAllowed() end")
+
+	return i.storageImageServer.IsRunningImageAllowed(ctx, systemContext, userSpecifiedImage, imageID)
+}
+
+// GetConfigForImage returns the OCI config for the given image reference.
+//
+// The config is retrieved as part of the PullImage process, and stored in our
+// in-memory list of known images, so that it can be returned here without
+// pulling anything.
+func (i *runtimePulledImageService) GetConfigForImage(ctx context.Context, imageName string) (*v1.Image, error) {
+	log.Debugf(i.ctx, "runtimePulledImageService.GetConfigForImage() start")
+	defer log.Debugf(i.ctx, "runtimePulledImageService.GetConfigForImage() end")
+
+	i.knownImagesLock.RLock()
+	defer i.knownImagesLock.RUnlock()
+
+	for index := range i.knownImages {
+		if i.knownImages[index].imageName == imageName {
+			return i.knownImages[index].imageResult.OCIConfig, nil
+		}
+
+		if index.Raw().String() == imageName {
+			return i.knownImages[index].imageResult.OCIConfig, nil
+		}
+
+		if i.knownImages[index].imageResult.ID.IDStringForOutOfProcessConsumptionOnly() == imageName {
+			return i.knownImages[index].imageResult.OCIConfig, nil
+		}
+	}
+
+	return nil, fmt.Errorf("image not found: %s", imageName)
+}

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 
 	"github.com/cri-o/cri-o/pkg/config"
 )
@@ -17,6 +18,10 @@ type RuntimeServiceManager struct {
 	runtimeService  RuntimeServer
 	imageServiceMgr *ImageServiceManager
 	ctx             context.Context
+
+	// runtimePulledRuntimeService instances mapped to sandbox ID
+	runtimeServiceRP     map[string]RuntimeServer
+	runtimeServiceRPLock sync.RWMutex
 }
 
 func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) RuntimeServer {
@@ -24,9 +29,43 @@ func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) RuntimeServer 
 	if sb != nil && v.Kind() == reflect.Ptr && !v.IsNil() {
 		rt, ok := r.serverConfig.Runtimes[sb.RuntimeHandler()]
 		if ok && rt.RuntimePullImage {
-			is := r.imageServiceMgr.GetImageService(sb)
+			id := sb.ID()
 
-			return GetRuntimePulledRuntimeService(r.ctx, r.runtimeService, is)
+			r.runtimeServiceRPLock.RLock()
+			rs := r.runtimeServiceRP[id]
+			r.runtimeServiceRPLock.RUnlock()
+
+			if rs == nil {
+				is := r.imageServiceMgr.GetImageService(sb)
+
+				// GetRuntimeService() is called first at sandbox creation,
+				// at a time where the sandbox creation is not complete, and we
+				// don't have a root dir to work with.
+				// The ImageServer we get in this case is the default one, which
+				// can be used for this early sandbox creation step, but should
+				// not be cached.
+				// The next call will get the proper runtimePulledImageService
+				// that we can use to create and cache our runtimePulledRuntimeService.
+				_, ok := is.(*runtimePulledImageService)
+				if !ok {
+					return r.runtimeService
+				}
+
+				rs = GetRuntimePulledRuntimeService(r.ctx, r.runtimeService, is)
+
+				r.runtimeServiceRPLock.Lock()
+				// double-check that an instance was not created in parallel
+				if existing := r.runtimeServiceRP[id]; existing != nil {
+					r.runtimeServiceRPLock.Unlock()
+
+					return existing
+				}
+
+				r.runtimeServiceRP[id] = rs
+				r.runtimeServiceRPLock.Unlock()
+			}
+
+			return rs
 		}
 	}
 
@@ -42,10 +81,11 @@ func GetRuntimeServiceManager(ctx context.Context, imageServiceMgr *ImageService
 	}
 
 	return &RuntimeServiceManager{
-		serverConfig:    serverConfig,
-		runtimeService:  runtimeSvc,
-		imageServiceMgr: imageServiceMgr,
-		ctx:             ctx,
+		serverConfig:     serverConfig,
+		runtimeService:   runtimeSvc,
+		imageServiceMgr:  imageServiceMgr,
+		ctx:              ctx,
+		runtimeServiceRP: make(map[string]RuntimeServer),
 	}, nil
 }
 

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -23,14 +23,14 @@ type RuntimeServiceManager struct {
 	runtimeServiceRPLock sync.RWMutex
 }
 
-func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) RuntimeServer {
+func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) (RuntimeServer, error) {
 	if sb == nil {
-		return r.runtimeService
+		return r.runtimeService, nil
 	}
 
 	rt, ok := r.serverConfig.Runtimes[sb.RuntimeHandler()]
 	if !ok || !rt.RuntimePullImage {
-		return r.runtimeService
+		return r.runtimeService, nil
 	}
 
 	id := sb.ID()
@@ -40,10 +40,13 @@ func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) RuntimeServer 
 	r.runtimeServiceRPLock.RUnlock()
 
 	if rs != nil {
-		return rs
+		return rs, nil
 	}
 
-	is := r.imageServiceMgr.GetImageService(sb)
+	is, err := r.imageServiceMgr.GetImageService(sb)
+	if err != nil {
+		return nil, err
+	}
 
 	// GetRuntimeService() is called first at sandbox creation,
 	// at a time where the sandbox creation is not complete, and we
@@ -54,7 +57,7 @@ func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) RuntimeServer 
 	// The next call will get the proper runtimePulledImageService
 	// that we can use to create and cache our runtimePulledRuntimeService.
 	if _, ok = is.(*runtimePulledImageService); !ok {
-		return r.runtimeService
+		return r.runtimeService, nil
 	}
 
 	rs = GetRuntimePulledRuntimeService(r.ctx, r.runtimeService, is)
@@ -64,12 +67,12 @@ func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) RuntimeServer 
 
 	// double-check that an instance was not created in parallel
 	if existing := r.runtimeServiceRP[id]; existing != nil {
-		return existing
+		return existing, nil
 	}
 
 	r.runtimeServiceRP[id] = rs
 
-	return rs
+	return rs, nil
 }
 
 func GetRuntimeServiceManager(ctx context.Context, imageServiceMgr *ImageServiceManager, storageTransport StorageTransport, serverConfig *config.Config) (*RuntimeServiceManager, error) {

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -92,3 +92,11 @@ func GetRuntimeServiceManager(ctx context.Context, imageServiceMgr *ImageService
 func (m *RuntimeServiceManager) SetStorageRuntimeServer(server RuntimeServer) {
 	m.runtimeService = server
 }
+
+// RemoveRuntimeService removes the cached runtimePulledRuntimeService for the
+// given sandbox ID, freeing the associated in-memory state.
+func (m *RuntimeServiceManager) RemoveRuntimeService(sandboxID string) {
+	m.runtimeServiceRPLock.Lock()
+	delete(m.runtimeServiceRP, sandboxID)
+	m.runtimeServiceRPLock.Unlock()
+}

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"errors"
-	"reflect"
 	"sync"
 
 	"github.com/cri-o/cri-o/pkg/config"
@@ -25,8 +24,7 @@ type RuntimeServiceManager struct {
 }
 
 func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) RuntimeServer {
-	v := reflect.ValueOf(sb)
-	if sb == nil || v.Kind() != reflect.Pointer || v.IsNil() {
+	if sb == nil {
 		return r.runtimeService
 	}
 

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -1,0 +1,66 @@
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cri-o/cri-o/pkg/config"
+)
+
+// The runtimeServiceManager object is responsible for maintaining different
+// instances of runtimeService.
+// It allows for easy switching between different runtime services using different
+// image service managers in the backend.
+type RuntimeServiceManager struct {
+	serverConfig     *config.Config
+	runtimeService   RuntimeServer
+	runtimeServiceRP RuntimeServer
+}
+
+func (r *RuntimeServiceManager) GetRuntimeService(runtimeHandler string) RuntimeServer {
+	isRuntimePullImage := false
+
+	if runtimeHandler != "" {
+		r, ok := r.serverConfig.Runtimes[runtimeHandler]
+		if ok {
+			isRuntimePullImage = r.RuntimePullImage
+		}
+	}
+
+	if isRuntimePullImage {
+		return r.runtimeServiceRP
+	}
+
+	return r.runtimeService
+}
+
+func GetRuntimeServiceManager(ctx context.Context, imageServiceMgr *ImageServiceManager, storageTransport StorageTransport, serverConfig *config.Config) (*RuntimeServiceManager, error) {
+	rs := GetRuntimeService(ctx, imageServiceMgr.imageService, storageTransport)
+
+	runtimeSvc, ok := rs.(*runtimeService)
+	if !ok {
+		return nil, errors.New("failed to assert runtimeService type")
+	}
+
+	imgSvcRP, ok := imageServiceMgr.imageServiceRP.(*runtimePulledImageService)
+	if !ok {
+		return nil, errors.New("failed to assert runtimePulledImageService type")
+	}
+
+	rs_rp := GetRuntimePulledRuntimeService(ctx, rs, imgSvcRP)
+
+	runtimeSvcRP, ok := rs_rp.(*runtimePulledRuntimeService)
+	if !ok {
+		return nil, errors.New("failed to assert runtimePulledRuntimeService type")
+	}
+
+	return &RuntimeServiceManager{
+		serverConfig:     serverConfig,
+		runtimeService:   runtimeSvc,
+		runtimeServiceRP: runtimeSvcRP,
+	}, nil
+}
+
+func (m *RuntimeServiceManager) SetStorageRuntimeServer(server RuntimeServer) {
+	m.runtimeService = server
+}

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -26,50 +26,52 @@ type RuntimeServiceManager struct {
 
 func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) RuntimeServer {
 	v := reflect.ValueOf(sb)
-	if sb != nil && v.Kind() == reflect.Ptr && !v.IsNil() {
-		rt, ok := r.serverConfig.Runtimes[sb.RuntimeHandler()]
-		if ok && rt.RuntimePullImage {
-			id := sb.ID()
-
-			r.runtimeServiceRPLock.RLock()
-			rs := r.runtimeServiceRP[id]
-			r.runtimeServiceRPLock.RUnlock()
-
-			if rs == nil {
-				is := r.imageServiceMgr.GetImageService(sb)
-
-				// GetRuntimeService() is called first at sandbox creation,
-				// at a time where the sandbox creation is not complete, and we
-				// don't have a root dir to work with.
-				// The ImageServer we get in this case is the default one, which
-				// can be used for this early sandbox creation step, but should
-				// not be cached.
-				// The next call will get the proper runtimePulledImageService
-				// that we can use to create and cache our runtimePulledRuntimeService.
-				_, ok := is.(*runtimePulledImageService)
-				if !ok {
-					return r.runtimeService
-				}
-
-				rs = GetRuntimePulledRuntimeService(r.ctx, r.runtimeService, is)
-
-				r.runtimeServiceRPLock.Lock()
-				// double-check that an instance was not created in parallel
-				if existing := r.runtimeServiceRP[id]; existing != nil {
-					r.runtimeServiceRPLock.Unlock()
-
-					return existing
-				}
-
-				r.runtimeServiceRP[id] = rs
-				r.runtimeServiceRPLock.Unlock()
-			}
-
-			return rs
-		}
+	if sb == nil || v.Kind() != reflect.Pointer || v.IsNil() {
+		return r.runtimeService
 	}
 
-	return r.runtimeService
+	rt, ok := r.serverConfig.Runtimes[sb.RuntimeHandler()]
+	if !ok || !rt.RuntimePullImage {
+		return r.runtimeService
+	}
+
+	id := sb.ID()
+
+	r.runtimeServiceRPLock.RLock()
+	rs := r.runtimeServiceRP[id]
+	r.runtimeServiceRPLock.RUnlock()
+
+	if rs != nil {
+		return rs
+	}
+
+	is := r.imageServiceMgr.GetImageService(sb)
+
+	// GetRuntimeService() is called first at sandbox creation,
+	// at a time where the sandbox creation is not complete, and we
+	// don't have a root dir to work with.
+	// The ImageServer we get in this case is the default one, which
+	// can be used for this early sandbox creation step, but should
+	// not be cached.
+	// The next call will get the proper runtimePulledImageService
+	// that we can use to create and cache our runtimePulledRuntimeService.
+	if _, ok = is.(*runtimePulledImageService); !ok {
+		return r.runtimeService
+	}
+
+	rs = GetRuntimePulledRuntimeService(r.ctx, r.runtimeService, is)
+
+	r.runtimeServiceRPLock.Lock()
+	defer r.runtimeServiceRPLock.Unlock()
+
+	// double-check that an instance was not created in parallel
+	if existing := r.runtimeServiceRP[id]; existing != nil {
+		return existing
+	}
+
+	r.runtimeServiceRP[id] = rs
+
+	return rs
 }
 
 func GetRuntimeServiceManager(ctx context.Context, imageServiceMgr *ImageServiceManager, storageTransport StorageTransport, serverConfig *config.Config) (*RuntimeServiceManager, error) {

--- a/internal/storage/runtime_mgr.go
+++ b/internal/storage/runtime_mgr.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"reflect"
 
 	"github.com/cri-o/cri-o/pkg/config"
 )
@@ -12,23 +13,21 @@ import (
 // It allows for easy switching between different runtime services using different
 // image service managers in the backend.
 type RuntimeServiceManager struct {
-	serverConfig     *config.Config
-	runtimeService   RuntimeServer
-	runtimeServiceRP RuntimeServer
+	serverConfig    *config.Config
+	runtimeService  RuntimeServer
+	imageServiceMgr *ImageServiceManager
+	ctx             context.Context
 }
 
-func (r *RuntimeServiceManager) GetRuntimeService(runtimeHandler string) RuntimeServer {
-	isRuntimePullImage := false
+func (r *RuntimeServiceManager) GetRuntimeService(sb SandboxInfo) RuntimeServer {
+	v := reflect.ValueOf(sb)
+	if sb != nil && v.Kind() == reflect.Ptr && !v.IsNil() {
+		rt, ok := r.serverConfig.Runtimes[sb.RuntimeHandler()]
+		if ok && rt.RuntimePullImage {
+			is := r.imageServiceMgr.GetImageService(sb)
 
-	if runtimeHandler != "" {
-		r, ok := r.serverConfig.Runtimes[runtimeHandler]
-		if ok {
-			isRuntimePullImage = r.RuntimePullImage
+			return GetRuntimePulledRuntimeService(r.ctx, r.runtimeService, is)
 		}
-	}
-
-	if isRuntimePullImage {
-		return r.runtimeServiceRP
 	}
 
 	return r.runtimeService
@@ -42,22 +41,11 @@ func GetRuntimeServiceManager(ctx context.Context, imageServiceMgr *ImageService
 		return nil, errors.New("failed to assert runtimeService type")
 	}
 
-	imgSvcRP, ok := imageServiceMgr.imageServiceRP.(*runtimePulledImageService)
-	if !ok {
-		return nil, errors.New("failed to assert runtimePulledImageService type")
-	}
-
-	rs_rp := GetRuntimePulledRuntimeService(ctx, rs, imgSvcRP)
-
-	runtimeSvcRP, ok := rs_rp.(*runtimePulledRuntimeService)
-	if !ok {
-		return nil, errors.New("failed to assert runtimePulledRuntimeService type")
-	}
-
 	return &RuntimeServiceManager{
-		serverConfig:     serverConfig,
-		runtimeService:   runtimeSvc,
-		runtimeServiceRP: runtimeSvcRP,
+		serverConfig:    serverConfig,
+		runtimeService:  runtimeSvc,
+		imageServiceMgr: imageServiceMgr,
+		ctx:             ctx,
 	}, nil
 }
 

--- a/internal/storage/runtime_mgr_test.go
+++ b/internal/storage/runtime_mgr_test.go
@@ -72,13 +72,6 @@ var _ = t.Describe("RuntimeServiceManager", func() {
 			Expect(sut.GetRuntimeService(nil)).To(Equal(mockRuntimeServer))
 		})
 
-		// Typed-nil safety: same as ImageServiceManager — the Kind-based guard
-		// must prevent a panic on a non-nil interface wrapping a nil pointer.
-		It("should return the main service for a typed-nil sandbox without panicking", func() {
-			var sb *fakeSandboxInfo
-			Expect(sut.GetRuntimeService(sb)).To(Equal(mockRuntimeServer))
-		})
-
 		// A sandbox using a handler without RuntimePullImage skips the rp path entirely.
 		It("should return the main service when the handler has RuntimePullImage=false", func() {
 			sb := &fakeSandboxInfo{id: "sb-runc", runtimeHandler: "runc"}

--- a/internal/storage/runtime_mgr_test.go
+++ b/internal/storage/runtime_mgr_test.go
@@ -1,0 +1,102 @@
+package storage_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	"github.com/cri-o/cri-o/internal/storage"
+	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
+	criostoragemock "github.com/cri-o/cri-o/test/mocks/criostorage"
+)
+
+var _ = t.Describe("RuntimeServiceManager", func() {
+	var (
+		mockCtrl                *gomock.Controller
+		storeMock               *containerstoragemock.MockStore
+		storageTransportMock    *criostoragemock.MockStorageTransport
+		mockRuntimeServer       *criostoragemock.MockRuntimeServer
+		mockInternalImageServer *criostoragemock.MockImageServer
+		imgMgr                  *storage.ImageServiceManager
+		sut                     *storage.RuntimeServiceManager
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		storeMock = containerstoragemock.NewMockStore(mockCtrl)
+		storageTransportMock = criostoragemock.NewMockStorageTransport(mockCtrl)
+		mockRuntimeServer = criostoragemock.NewMockRuntimeServer(mockCtrl)
+		mockInternalImageServer = criostoragemock.NewMockImageServer(mockCtrl)
+
+		cfg := newTestConfig(t.MustTempFile("registries"))
+
+		// Build the image manager with the real *imageService so that
+		// GetRuntimeServiceManager's internal type assertion (*runtimeService) succeeds.
+		var err error
+
+		imgMgr, err = storage.GetImageServiceManager(
+			context.Background(), storeMock, storageTransportMock, cfg,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Build the runtime manager while the real *imageService is still set.
+		sut, err = storage.GetRuntimeServiceManager(
+			context.Background(), imgMgr, storageTransportMock, cfg,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Replace the image server with a mock.  Any attempt to create a
+		// runtimePulledImageService will now hit GetStore() → ContainerRunDirectory
+		// and fail, causing GetImageService to fall back to mockInternalImageServer.
+		// AnyTimes() covers tests that don't hit the rp=true path at all.
+		imgMgr.SetStorageImageServer(mockInternalImageServer)
+		sut.SetStorageRuntimeServer(mockRuntimeServer)
+
+		mockInternalImageServer.EXPECT().GetStore().Return(storeMock).AnyTimes()
+		storeMock.EXPECT().
+			ContainerRunDirectory(gomock.Any()).
+			Return("", errors.New("no run dir for test")).
+			AnyTimes()
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	t.Describe("GetRuntimeService", func() {
+		// Nil sandbox — early return, no routing decision needed.
+		It("should return the main service for a nil sandbox", func() {
+			Expect(sut.GetRuntimeService(nil)).To(Equal(mockRuntimeServer))
+		})
+
+		// Typed-nil safety: same as ImageServiceManager — the Kind-based guard
+		// must prevent a panic on a non-nil interface wrapping a nil pointer.
+		It("should return the main service for a typed-nil sandbox without panicking", func() {
+			var sb *fakeSandboxInfo
+			Expect(sut.GetRuntimeService(sb)).To(Equal(mockRuntimeServer))
+		})
+
+		// A sandbox using a handler without RuntimePullImage skips the rp path entirely.
+		It("should return the main service when the handler has RuntimePullImage=false", func() {
+			sb := &fakeSandboxInfo{id: "sb-runc", runtimeHandler: "runc"}
+			Expect(sut.GetRuntimeService(sb)).To(Equal(mockRuntimeServer))
+		})
+	})
+
+	t.Describe("RemoveRuntimeService", func() {
+		It("should be a no-op for a sandbox that was never registered", func() {
+			Expect(func() { sut.RemoveRuntimeService("non-existent-sandbox") }).NotTo(Panic())
+		})
+	})
+
+	t.Describe("SetStorageRuntimeServer", func() {
+		It("should update the service returned by GetRuntimeService for a nil sandbox", func() {
+			anotherMock := criostoragemock.NewMockRuntimeServer(mockCtrl)
+			sut.SetStorageRuntimeServer(anotherMock)
+			Expect(sut.GetRuntimeService(nil)).To(Equal(anotherMock))
+		})
+	})
+})

--- a/internal/storage/runtime_mgr_test.go
+++ b/internal/storage/runtime_mgr_test.go
@@ -69,13 +69,17 @@ var _ = t.Describe("RuntimeServiceManager", func() {
 	t.Describe("GetRuntimeService", func() {
 		// Nil sandbox — early return, no routing decision needed.
 		It("should return the main service for a nil sandbox", func() {
-			Expect(sut.GetRuntimeService(nil)).To(Equal(mockRuntimeServer))
+			result, err := sut.GetRuntimeService(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(mockRuntimeServer))
 		})
 
 		// A sandbox using a handler without RuntimePullImage skips the rp path entirely.
 		It("should return the main service when the handler has RuntimePullImage=false", func() {
 			sb := &fakeSandboxInfo{id: "sb-runc", runtimeHandler: "runc"}
-			Expect(sut.GetRuntimeService(sb)).To(Equal(mockRuntimeServer))
+			result, err := sut.GetRuntimeService(sb)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(mockRuntimeServer))
 		})
 	})
 
@@ -89,7 +93,9 @@ var _ = t.Describe("RuntimeServiceManager", func() {
 		It("should update the service returned by GetRuntimeService for a nil sandbox", func() {
 			anotherMock := criostoragemock.NewMockRuntimeServer(mockCtrl)
 			sut.SetStorageRuntimeServer(anotherMock)
-			Expect(sut.GetRuntimeService(nil)).To(Equal(anotherMock))
+			result, err := sut.GetRuntimeService(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(anotherMock))
 		})
 	})
 })

--- a/internal/storage/runtime_vm.go
+++ b/internal/storage/runtime_vm.go
@@ -1,0 +1,232 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	json "github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
+	"go.podman.io/image/v5/types"
+	"go.podman.io/storage"
+)
+
+// runtimePulledRuntimeService is a RuntimeServer implementation dedicated to
+// runtimes that handle image management. It is designed to do most operation
+// using the regular container management workflow, but will delegate to a
+// different ImageService when image management must be done by the runtime.
+type runtimePulledRuntimeService struct {
+	// Pointer to the runtimeService used for regular containers operations
+	// Must be provided by the caller, and will be used to delegate operations
+	// that don't need a specific behaviour for the runtime.
+	runtimeServiceOCI RuntimeServer
+
+	storageImageServer *runtimePulledImageService
+	ctx                context.Context
+}
+
+func (r *runtimePulledRuntimeService) createContainerOrPodSandbox(containerID string, template *runtimeContainerMetadataTemplate, idMappingsOptions *storage.IDMappingOptions, labelOptions []string) (ci ContainerInfo, retErr error) {
+	if template.podName == "" || template.podID == "" {
+		return ContainerInfo{}, ErrInvalidPodName
+	}
+
+	if template.containerName == "" {
+		return ContainerInfo{}, ErrInvalidContainerName
+	}
+
+	// Build metadata to store with the container.
+	metadata := RuntimeContainerMetadata{
+		PodName:       template.podName,
+		PodID:         template.podID,
+		ImageName:     template.userRequestedImage,
+		ImageID:       template.imageID.IDStringForOutOfProcessConsumptionOnly(),
+		ContainerName: template.containerName,
+		MetadataName:  template.metadataName,
+		UID:           template.uid,
+		Namespace:     template.namespace,
+		MountLabel:    "",
+		// CreatedAt is set later
+		Attempt: template.attempt,
+		// Pod is set later
+		Privileged: template.privileged,
+	}
+	if metadata.MetadataName == "" {
+		metadata.MetadataName = metadata.ContainerName
+	}
+
+	// Pull out a copy of the image's configuration.
+	imageConfig, err := r.storageImageServer.GetConfigForImage(r.ctx, template.userRequestedImage)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	metadata.Pod = (containerID == metadata.PodID) // Or should this be hard-coded in callers? The caller should know whether it is creating the infra container.
+	metadata.CreatedAt = time.Now().Unix()
+
+	mdata, err := json.Marshal(&metadata)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	// Build the container.
+	names := []string{metadata.ContainerName}
+	if metadata.Pod {
+		names = append(names, metadata.PodName)
+	}
+
+	coptions := storage.ContainerOptions{
+		LabelOpts: labelOptions,
+		Volatile:  true,
+	}
+	if idMappingsOptions != nil {
+		coptions.IDMappingOptions = *idMappingsOptions
+	}
+
+	// Call CreateContainer with an empty image name, to avoid image lookup
+	// as we don't actually want to create this container with a local image.
+	imageID := ""
+
+	container, err := r.storageImageServer.GetStore().CreateContainer(containerID, names, imageID, "", string(mdata), &coptions)
+	if err != nil {
+		if metadata.Pod {
+			logrus.Debugf("Failed to create pod sandbox %s(%s): %v", metadata.PodName, metadata.PodID, err)
+		} else {
+			logrus.Debugf("Failed to create container %s(%s): %v", metadata.ContainerName, containerID, err)
+		}
+
+		return ContainerInfo{}, err
+	}
+
+	if idMappingsOptions != nil {
+		idMappingsOptions.UIDMap = container.UIDMap
+		idMappingsOptions.GIDMap = container.GIDMap
+	}
+
+	if metadata.Pod {
+		logrus.Debugf("Created pod sandbox %q", container.ID)
+	} else {
+		logrus.Debugf("Created container %q", container.ID)
+	}
+
+	// If anything fails after this point, we need to delete the incomplete
+	// container before returning.
+	defer func() {
+		if retErr != nil {
+			if err2 := r.storageImageServer.GetStore().DeleteContainer(container.ID); err2 != nil {
+				if metadata.Pod {
+					logrus.Debugf("%v deleting partially-created pod sandbox %q", err2, container.ID)
+				} else {
+					logrus.Debugf("%v deleting partially-created container %q", err2, container.ID)
+				}
+
+				return
+			}
+
+			logrus.Debugf("Deleted partially-created container %q", container.ID)
+		}
+	}()
+
+	// Add a name to the container's layer so that it's easier to follow
+	// what's going on if we're just looking at the storage-eye view of things.
+	layerName := metadata.ContainerName + "-layer"
+
+	err = r.storageImageServer.GetStore().AddNames(container.LayerID, []string{layerName})
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	// Find out where the container work directories are, so that we can return them.
+	containerDir, err := r.storageImageServer.GetStore().ContainerDirectory(container.ID)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	if metadata.Pod {
+		logrus.Debugf("Pod sandbox %q has work directory %q", container.ID, containerDir)
+	} else {
+		logrus.Debugf("Container %q has work directory %q", container.ID, containerDir)
+	}
+
+	containerRunDir, err := r.storageImageServer.GetStore().ContainerRunDirectory(container.ID)
+	if err != nil {
+		return ContainerInfo{}, err
+	}
+
+	if metadata.Pod {
+		logrus.Debugf("Pod sandbox %q has run directory %q", container.ID, containerRunDir)
+	} else {
+		logrus.Debugf("Container %q has run directory %q", container.ID, containerRunDir)
+	}
+
+	metadata.MountLabel = container.MountLabel()
+
+	return ContainerInfo{
+		ID:           container.ID,
+		Dir:          containerDir,
+		RunDir:       containerRunDir,
+		Config:       imageConfig,
+		ProcessLabel: container.ProcessLabel(),
+		MountLabel:   container.MountLabel(),
+	}, nil
+}
+
+func (r *runtimePulledRuntimeService) CreatePodSandbox(systemContext *types.SystemContext, podName, podID string, pauseImage RegistryImageReference, imageAuthFile, containerName, metadataName, uid, namespace string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {
+	// For runtime doing image management, we create the pod sandbox using the
+	// same underlying service as for regular containers, because image handling
+	// is done for the containers, not for the pod sandbox.
+	return r.runtimeServiceOCI.CreatePodSandbox(systemContext, podName, podID, pauseImage, imageAuthFile, containerName, metadataName, uid, namespace, attempt, idMappingsOptions, labelOptions, privileged)
+}
+
+func (r *runtimePulledRuntimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, userRequestedImage string, imageID StorageImageID, containerName, containerID, metadataName string, attempt uint32, idMappingsOptions *storage.IDMappingOptions, labelOptions []string, privileged bool) (ContainerInfo, error) {
+	return r.createContainerOrPodSandbox(containerID, &runtimeContainerMetadataTemplate{
+		podName:            podName,
+		podID:              podID,
+		userRequestedImage: userRequestedImage,
+		imageID:            imageID,
+		containerName:      containerName,
+		metadataName:       metadataName,
+		uid:                "",
+		namespace:          "",
+		attempt:            attempt,
+		privileged:         privileged,
+	}, idMappingsOptions, labelOptions)
+}
+
+func (r *runtimePulledRuntimeService) DeleteContainer(ctx context.Context, idOrName string) error {
+	return r.runtimeServiceOCI.DeleteContainer(ctx, idOrName)
+}
+
+func (r *runtimePulledRuntimeService) SetContainerMetadata(idOrName string, metadata *RuntimeContainerMetadata) error {
+	return r.runtimeServiceOCI.SetContainerMetadata(idOrName, metadata)
+}
+
+func (r *runtimePulledRuntimeService) GetContainerMetadata(idOrName string) (RuntimeContainerMetadata, error) {
+	return r.runtimeServiceOCI.GetContainerMetadata(idOrName)
+}
+
+func (r *runtimePulledRuntimeService) StartContainer(idOrName string) (string, error) {
+	return r.runtimeServiceOCI.StartContainer(idOrName)
+}
+
+func (r *runtimePulledRuntimeService) StopContainer(ctx context.Context, idOrName string) error {
+	return r.runtimeServiceOCI.StopContainer(ctx, idOrName)
+}
+
+func (r *runtimePulledRuntimeService) GetWorkDir(id string) (string, error) {
+	return r.runtimeServiceOCI.GetWorkDir(id)
+}
+
+func (r *runtimePulledRuntimeService) GetRunDir(id string) (string, error) {
+	return r.runtimeServiceOCI.GetRunDir(id)
+}
+
+// GetRuntimePulledRuntimeService returns a RuntimeServer that uses the passed-in image
+// service to pull and manage images, and its store to manage containers based
+// on those images.
+// The provided ImageServer must be an instance of runtimePulledImageService.
+func GetRuntimePulledRuntimeService(ctx context.Context, runtimeService RuntimeServer, storageImageServer *runtimePulledImageService) RuntimeServer {
+	return &runtimePulledRuntimeService{
+		runtimeServiceOCI:  runtimeService,
+		storageImageServer: storageImageServer,
+		ctx:                ctx,
+	}
+}

--- a/internal/storage/runtime_vm.go
+++ b/internal/storage/runtime_vm.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	json "github.com/json-iterator/go"
@@ -20,7 +21,7 @@ type runtimePulledRuntimeService struct {
 	// that don't need a specific behaviour for the runtime.
 	runtimeServiceOCI RuntimeServer
 
-	storageImageServer *runtimePulledImageService
+	storageImageServer ImageServer
 	ctx                context.Context
 }
 
@@ -54,7 +55,12 @@ func (r *runtimePulledRuntimeService) createContainerOrPodSandbox(containerID st
 	}
 
 	// Pull out a copy of the image's configuration.
-	imageConfig, err := r.storageImageServer.GetConfigForImage(r.ctx, template.userRequestedImage)
+	is, ok := r.storageImageServer.(*runtimePulledImageService)
+	if !ok {
+		return ContainerInfo{}, errors.New("internal error: RuntimeServiceVM bound to default image server")
+	}
+
+	imageConfig, err := is.GetConfigForImage(r.ctx, template.userRequestedImage)
 	if err != nil {
 		return ContainerInfo{}, err
 	}
@@ -223,7 +229,7 @@ func (r *runtimePulledRuntimeService) GetRunDir(id string) (string, error) {
 // service to pull and manage images, and its store to manage containers based
 // on those images.
 // The provided ImageServer must be an instance of runtimePulledImageService.
-func GetRuntimePulledRuntimeService(ctx context.Context, runtimeService RuntimeServer, storageImageServer *runtimePulledImageService) RuntimeServer {
+func GetRuntimePulledRuntimeService(ctx context.Context, runtimeService RuntimeServer, storageImageServer ImageServer) RuntimeServer {
 	return &runtimePulledRuntimeService{
 		runtimeServiceOCI:  runtimeService,
 		storageImageServer: storageImageServer,

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -537,7 +537,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 	}
 
 	resourceCleaner.Add(ctx, "createCtr: deleting container "+ctr.ID()+" from storage", func() error {
-		if err := s.ContainerServer.StorageRuntimeServer().DeleteContainer(ctx, ctr.ID()); err != nil {
+		if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, ctr.ID()); err != nil {
 			return fmt.Errorf("failed to cleanup container storage: %w", err)
 		}
 
@@ -670,7 +670,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		if retErr != nil {
 			log.Infof(ctx, "CreateCtrLinux: deleting container %s from storage", containerInfo.ID)
 
-			if err := s.ContainerServer.StorageRuntimeServer().DeleteContainer(ctx, containerInfo.ID); err != nil {
+			if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, containerInfo.ID); err != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err)
 			}
 		}
@@ -722,7 +722,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage start")
 
-	mountPoint, err := s.ContainerServer.StorageRuntimeServer().StartContainer(containerID)
+	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StartContainer(containerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount container %s(%s): %w", containerName, containerID, err)
 	}
@@ -731,7 +731,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		if retErr != nil {
 			log.Infof(ctx, "CreateCtrLinux: stopping storage container %s", containerID)
 
-			if err := s.ContainerServer.StorageRuntimeServer().StopContainer(ctx, containerID); err != nil {
+			if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StopContainer(ctx, containerID); err != nil {
 				log.Warnf(ctx, "Couldn't stop storage container: %v: %v", containerID, err)
 			}
 		}
@@ -1256,7 +1256,7 @@ func (s *Server) createStorageContainer(ctx context.Context, ctr container.Conta
 
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage creation")
 
-	containerInfo, err := s.ContainerServer.StorageRuntimeServer().CreateContainer(s.config.SystemContext,
+	containerInfo, err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).CreateContainer(s.config.SystemContext,
 		sb.Name(), sb.ID(),
 		userRequestedImage, imageID,
 		containerName, containerID,
@@ -1282,20 +1282,22 @@ func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr contain
 	}
 
 	var imgResult *storage.ImageResult
-	if id := s.ContainerServer.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
-		imgResult, err = s.ContainerServer.StorageImageServer().ImageStatusByID(s.config.SystemContext, *id)
+
+	imageService := s.StorageImageServer(sb.RuntimeHandler())
+	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
+		imgResult, err = imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		potentialMatches, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, userRequestedImage)
+		potentialMatches, err := imageService.CandidatesForPotentiallyShortImageName(s.config.SystemContext, userRequestedImage)
 		if err != nil {
 			return nil, err
 		}
 
 		var imgResultErr error
 		for _, name := range potentialMatches {
-			imgResult, imgResultErr = s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, name)
+			imgResult, imgResultErr = imageService.ImageStatusByName(s.config.SystemContext, name)
 			if imgResultErr == nil {
 				break
 			}
@@ -1318,7 +1320,7 @@ func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr contain
 		someRepoDigest = imgResult.RepoDigests[0]
 	}
 
-	if err := s.verifyImageSignature(ctx, sb.Metadata().GetNamespace(), ctr.Config().GetImage().GetUserSpecifiedImage(), imgResult); err != nil {
+	if err := s.verifyImageSignature(ctx, sb.Metadata().GetNamespace(), ctr.Config().GetImage().GetUserSpecifiedImage(), imgResult, sb.RuntimeHandler()); err != nil {
 		return nil, err
 	}
 
@@ -1420,7 +1422,7 @@ func configureTimezone(tz, containerRunDir, mountPoint, mountLabel, etcPath, con
 }
 
 // verifyImageSignature verifies the signature of a container image.
-func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecifiedImage string, status *storage.ImageResult) error {
+func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecifiedImage string, status *storage.ImageResult, runtimeHandler string) error {
 	systemCtx, err := s.contextForNamespace(namespace)
 	if err != nil {
 		return fmt.Errorf("get context for namespace: %w", err)
@@ -1444,7 +1446,7 @@ func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecif
 			return fmt.Errorf("unable to get userSpecifiedImageRef from user specified image %q: %w", userSpecifiedImage, err)
 		}
 
-		if err := s.ContainerServer.StorageImageServer().IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
+		if err := s.ContainerServer.StorageImageServer(runtimeHandler).IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
 			return err
 		}
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -537,7 +537,12 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 	}
 
 	resourceCleaner.Add(ctx, "createCtr: deleting container "+ctr.ID()+" from storage", func() error {
-		if err := s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, ctr.ID()); err != nil {
+		runtimeSvc, err := s.StorageRuntimeServer(sb)
+		if err != nil {
+			return fmt.Errorf("failed to get runtime service for cleanup: %w", err)
+		}
+
+		if err := runtimeSvc.DeleteContainer(ctx, ctr.ID()); err != nil {
 			return fmt.Errorf("failed to cleanup container storage: %w", err)
 		}
 
@@ -670,7 +675,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		if retErr != nil {
 			log.Infof(ctx, "CreateCtrLinux: deleting container %s from storage", containerInfo.ID)
 
-			if err := s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, containerInfo.ID); err != nil {
+			runtimeSvc, err := s.StorageRuntimeServer(sb)
+			if err != nil {
+				log.Warnf(ctx, "Failed to get runtime service for cleanup: %v", err)
+			} else if err := runtimeSvc.DeleteContainer(ctx, containerInfo.ID); err != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err)
 			}
 		}
@@ -722,7 +730,12 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage start")
 
-	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sb).StartContainer(containerID)
+	runtimeSvc, err := s.StorageRuntimeServer(sb)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get runtime service for container %s(%s): %w", containerName, containerID, err)
+	}
+
+	mountPoint, err := runtimeSvc.StartContainer(containerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount container %s(%s): %w", containerName, containerID, err)
 	}
@@ -731,7 +744,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		if retErr != nil {
 			log.Infof(ctx, "CreateCtrLinux: stopping storage container %s", containerID)
 
-			if err := s.ContainerServer.StorageRuntimeServer(sb).StopContainer(ctx, containerID); err != nil {
+			if err := runtimeSvc.StopContainer(ctx, containerID); err != nil {
 				log.Warnf(ctx, "Couldn't stop storage container: %v: %v", containerID, err)
 			}
 		}
@@ -1256,7 +1269,12 @@ func (s *Server) createStorageContainer(ctx context.Context, ctr container.Conta
 
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage creation")
 
-	containerInfo, err := s.ContainerServer.StorageRuntimeServer(sb).CreateContainer(s.config.SystemContext,
+	runtimeSvc, err := s.StorageRuntimeServer(sb)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	containerInfo, err := runtimeSvc.CreateContainer(s.config.SystemContext,
 		sb.Name(), sb.ID(),
 		userRequestedImage, imageID,
 		containerName, containerID,
@@ -1283,7 +1301,11 @@ func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr contain
 
 	var imgResult *storage.ImageResult
 
-	imageService := s.StorageImageServer(sb)
+	imageService, err := s.StorageImageServer(sb)
+	if err != nil {
+		return nil, err
+	}
+
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
 		imgResult, err = imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {
@@ -1446,7 +1468,12 @@ func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecif
 			return fmt.Errorf("unable to get userSpecifiedImageRef from user specified image %q: %w", userSpecifiedImage, err)
 		}
 
-		if err := s.ContainerServer.StorageImageServer(sb).IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
+		imageServer, err := s.StorageImageServer(sb)
+		if err != nil {
+			return err
+		}
+
+		if err := imageServer.IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
 			return err
 		}
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -537,7 +537,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 	}
 
 	resourceCleaner.Add(ctx, "createCtr: deleting container "+ctr.ID()+" from storage", func() error {
-		if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, ctr.ID()); err != nil {
+		if err := s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, ctr.ID()); err != nil {
 			return fmt.Errorf("failed to cleanup container storage: %w", err)
 		}
 
@@ -670,7 +670,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		if retErr != nil {
 			log.Infof(ctx, "CreateCtrLinux: deleting container %s from storage", containerInfo.ID)
 
-			if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, containerInfo.ID); err != nil {
+			if err := s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, containerInfo.ID); err != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err)
 			}
 		}
@@ -706,7 +706,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		}
 	}()
 
-	containerVolumes, ociMounts, safeMounts, err := s.addOCIBindMounts(ctx, ctr, containerInfo, maybeRelabel, skipRelabel, cgroup2RW, idMapSupport, rroSupport)
+	containerVolumes, ociMounts, safeMounts, err := s.addOCIBindMounts(ctx, ctr, containerInfo, maybeRelabel, skipRelabel, cgroup2RW, idMapSupport, rroSupport, sb)
 	if err != nil {
 		return nil, err
 	}
@@ -722,7 +722,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage start")
 
-	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StartContainer(containerID)
+	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sb).StartContainer(containerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount container %s(%s): %w", containerName, containerID, err)
 	}
@@ -731,7 +731,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		if retErr != nil {
 			log.Infof(ctx, "CreateCtrLinux: stopping storage container %s", containerID)
 
-			if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StopContainer(ctx, containerID); err != nil {
+			if err := s.ContainerServer.StorageRuntimeServer(sb).StopContainer(ctx, containerID); err != nil {
 				log.Warnf(ctx, "Couldn't stop storage container: %v: %v", containerID, err)
 			}
 		}
@@ -1256,7 +1256,7 @@ func (s *Server) createStorageContainer(ctx context.Context, ctr container.Conta
 
 	s.resourceStore.SetStageForResource(ctx, ctr.Name(), "container storage creation")
 
-	containerInfo, err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).CreateContainer(s.config.SystemContext,
+	containerInfo, err := s.ContainerServer.StorageRuntimeServer(sb).CreateContainer(s.config.SystemContext,
 		sb.Name(), sb.ID(),
 		userRequestedImage, imageID,
 		containerName, containerID,
@@ -1283,7 +1283,7 @@ func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr contain
 
 	var imgResult *storage.ImageResult
 
-	imageService := s.StorageImageServer(sb.RuntimeHandler())
+	imageService := s.StorageImageServer(sb)
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(userRequestedImage); id != nil {
 		imgResult, err = imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {
@@ -1320,7 +1320,7 @@ func (s *Server) resolveAndVerifyContainerImage(ctx context.Context, ctr contain
 		someRepoDigest = imgResult.RepoDigests[0]
 	}
 
-	if err := s.verifyImageSignature(ctx, sb.Metadata().GetNamespace(), ctr.Config().GetImage().GetUserSpecifiedImage(), imgResult, sb.RuntimeHandler()); err != nil {
+	if err := s.verifyImageSignature(ctx, sb.Metadata().GetNamespace(), ctr.Config().GetImage().GetUserSpecifiedImage(), imgResult, sb); err != nil {
 		return nil, err
 	}
 
@@ -1422,7 +1422,7 @@ func configureTimezone(tz, containerRunDir, mountPoint, mountLabel, etcPath, con
 }
 
 // verifyImageSignature verifies the signature of a container image.
-func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecifiedImage string, status *storage.ImageResult, runtimeHandler string) error {
+func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecifiedImage string, status *storage.ImageResult, sb *sandbox.Sandbox) error {
 	systemCtx, err := s.contextForNamespace(namespace)
 	if err != nil {
 		return fmt.Errorf("get context for namespace: %w", err)
@@ -1446,7 +1446,7 @@ func (s *Server) verifyImageSignature(ctx context.Context, namespace, userSpecif
 			return fmt.Errorf("unable to get userSpecifiedImageRef from user specified image %q: %w", userSpecifiedImage, err)
 		}
 
-		if err := s.ContainerServer.StorageImageServer(runtimeHandler).IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
+		if err := s.ContainerServer.StorageImageServer(sb).IsRunningImageAllowed(ctx, &systemCtx, userSpecifiedImageRef, status.ID); err != nil {
 			return err
 		}
 	}

--- a/server/container_create_freebsd.go
+++ b/server/container_create_freebsd.go
@@ -45,7 +45,7 @@ func addSysfsMounts(ctr ctrfactory.Container, containerConfig *types.ContainerCo
 func setOCIBindMountsPrivileged(g *generate.Generator) {
 }
 
-func (s *Server) addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container, ctrInfo *storage.ContainerInfo, maybeRelabel, skipRelabel, cgroup2RW, idMapSupport, rroSupport bool) ([]oci.ContainerVolume, []rspec.Mount, []*safeMountInfo, error) {
+func (s *Server) addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container, ctrInfo *storage.ContainerInfo, maybeRelabel, skipRelabel, cgroup2RW, idMapSupport, rroSupport bool, sb *sandbox.Sandbox) ([]oci.ContainerVolume, []rspec.Mount, []*safeMountInfo, error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -149,7 +149,7 @@ func clearReadOnly(m *rspec.Mount) {
 	m.Options = append(m.Options, "rw")
 }
 
-func (s *Server) addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container, ctrInfo *storage.ContainerInfo, maybeRelabel, skipRelabel, cgroup2RW, idMapSupport, rroSupport bool) ([]oci.ContainerVolume, []rspec.Mount, []*safeMountInfo, error) {
+func (s *Server) addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container, ctrInfo *storage.ContainerInfo, maybeRelabel, skipRelabel, cgroup2RW, idMapSupport, rroSupport bool, sb *sandbox.Sandbox) ([]oci.ContainerVolume, []rspec.Mount, []*safeMountInfo, error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -233,7 +233,7 @@ func (s *Server) addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container,
 				log.Debugf(ctx, "Skipping artifact mount because OCI artifact mount support is disabled")
 			}
 
-			volume, safeMount, err := s.mountImage(ctx, specgen, imageVolumesPath, m, ctrInfo.RunDir, namespace)
+			volume, safeMount, err := s.mountImage(ctx, specgen, imageVolumesPath, m, ctrInfo.RunDir, namespace, sb)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("%w: %w", crierrors.ErrImageVolumeMountFailed, err)
 			}
@@ -508,7 +508,7 @@ func FilterMountPathsBySubPath(ctx context.Context, artifact, subPath string, pa
 }
 
 // mountImage adds required image mounts to the provided spec generator and returns a corresponding ContainerVolume.
-func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, imageVolumesPath string, m *types.Mount, runDir, namespace string) (*oci.ContainerVolume, *safeMountInfo, error) {
+func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, imageVolumesPath string, m *types.Mount, runDir, namespace string, sb *sandbox.Sandbox) (*oci.ContainerVolume, *safeMountInfo, error) {
 	if m == nil || m.GetImage() == nil || m.GetImage().GetImage() == "" || m.GetContainerPath() == "" {
 		return nil, nil, fmt.Errorf("invalid mount specified: %+v", m)
 	}
@@ -529,7 +529,7 @@ func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, im
 	imageID := status.ID.IDStringForOutOfProcessConsumptionOnly()
 
 	// Check the signature of the image
-	if err := s.verifyImageSignature(ctx, namespace, m.GetImage().GetUserSpecifiedImage(), status, m.GetImage().GetRuntimeHandler()); err != nil {
+	if err := s.verifyImageSignature(ctx, namespace, m.GetImage().GetUserSpecifiedImage(), status, sb); err != nil {
 		return nil, nil, err
 	}
 

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -529,7 +529,7 @@ func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, im
 	imageID := status.ID.IDStringForOutOfProcessConsumptionOnly()
 
 	// Check the signature of the image
-	if err := s.verifyImageSignature(ctx, namespace, m.GetImage().GetUserSpecifiedImage(), status); err != nil {
+	if err := s.verifyImageSignature(ctx, namespace, m.GetImage().GetUserSpecifiedImage(), status, m.GetImage().GetRuntimeHandler()); err != nil {
 		return nil, nil, err
 	}
 

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -40,7 +40,7 @@ func TestAddOCIBindsForDev(t *testing.T) {
 		MountLabel: "",
 	}
 
-	_, binds, _, err := sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, false, false)
+	_, binds, _, err := sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, false, false, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -95,7 +95,7 @@ func TestAddOCIBindsForSys(t *testing.T) {
 		MountLabel: "",
 	}
 
-	_, binds, _, err := sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, false, false)
+	_, binds, _, err := sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, false, false, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -152,7 +152,7 @@ func TestAddOCIBindsRROMounts(t *testing.T) {
 		MountLabel: "",
 	}
 
-	_, binds, _, err := sut.addOCIBindMounts(ctx, ctr, ctrInfo, false, false, false, false, true)
+	_, binds, _, err := sut.addOCIBindMounts(ctx, ctr, ctrInfo, false, false, false, false, true, nil)
 	if err != nil {
 		t.Errorf("Should not fail to create RRO mount, got: %v", err)
 	}
@@ -253,7 +253,7 @@ func TestAddOCIBindsRROMountsError(t *testing.T) {
 				MountLabel: "",
 			}
 
-			_, _, _, err = sut.addOCIBindMounts(ctx, ctr, ctrInfo, false, false, false, false, tc.rroSupport)
+			_, _, _, err = sut.addOCIBindMounts(ctx, ctr, ctrInfo, false, false, false, false, tc.rroSupport, nil)
 			if err == nil {
 				t.Error("Should fail to add an RRO mount with a specific error")
 			}
@@ -289,7 +289,7 @@ func TestAddOCIBindsCGroupRW(t *testing.T) {
 	}
 
 	//nolint:dogsled // test only needs the error return
-	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, true, false, false)
+	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, true, false, false, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -330,7 +330,7 @@ func TestAddOCIBindsCGroupRW(t *testing.T) {
 	var hasCgroupRO bool
 
 	//nolint:dogsled // test only needs the error return
-	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, false, false)
+	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, false, false, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -387,13 +387,13 @@ func TestAddOCIBindsErrorWithoutIDMap(t *testing.T) {
 	}
 
 	//nolint:dogsled // test only needs the error return
-	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, false, false)
+	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, false, false, nil)
 	if err == nil {
 		t.Errorf("Should have failed to create id mapped mount with no id map support")
 	}
 
 	//nolint:dogsled // test only needs the error return
-	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, true, false)
+	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, true, false, nil)
 	if err != nil {
 		t.Errorf("%v", err)
 	}

--- a/server/container_events_test.go
+++ b/server/container_events_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -70,8 +71,11 @@ var _ = t.Describe("ContainerEvents", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			go recv(client1)
-			go recv(client2)
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			go func() { defer wg.Done(); recv(client1) }()
+			go func() { defer wg.Done(); recv(client2) }()
 
 			// wait so that both goroutines are ready
 			// when we send the events
@@ -81,6 +85,12 @@ var _ = t.Describe("ContainerEvents", func() {
 			for _, event := range events {
 				sut.ContainerEventsChan <- event
 			}
+
+			// wait for both goroutines to finish processing all events
+			// before AfterEach runs; ContainerEventsChan is buffered so sends
+			// above are non-blocking, and without this the mock Finish() check
+			// races against the broadcaster goroutine.
+			wg.Wait()
 		})
 	})
 })

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -77,7 +77,7 @@ func (s *Server) removeContainerInPod(ctx context.Context, sb *sandbox.Sandbox, 
 
 	c.CleanupConmonCgroup(ctx)
 
-	if err := s.ContainerServer.StorageRuntimeServer().DeleteContainer(ctx, c.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
+	if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, c.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
 		return fmt.Errorf("failed to delete container %s in pod sandbox %s: %w", c.Name(), sb.ID(), err)
 	}
 

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -77,7 +77,12 @@ func (s *Server) removeContainerInPod(ctx context.Context, sb *sandbox.Sandbox, 
 
 	c.CleanupConmonCgroup(ctx)
 
-	if err := s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, c.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
+	runtimeSvc, err := s.StorageRuntimeServer(sb)
+	if err != nil {
+		return fmt.Errorf("failed to get runtime service for container %s: %w", c.Name(), err)
+	}
+
+	if err := runtimeSvc.DeleteContainer(ctx, c.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
 		return fmt.Errorf("failed to delete container %s in pod sandbox %s: %w", c.Name(), sb.ID(), err)
 	}
 

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -77,7 +77,7 @@ func (s *Server) removeContainerInPod(ctx context.Context, sb *sandbox.Sandbox, 
 
 	c.CleanupConmonCgroup(ctx)
 
-	if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, c.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
+	if err := s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, c.ID()); err != nil && !errors.Is(err, storage.ErrContainerUnknown) {
 		return fmt.Errorf("failed to delete container %s in pod sandbox %s: %w", c.Name(), sb.ID(), err)
 	}
 

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -94,7 +94,7 @@ func (s *Server) CRImportCheckpoint(
 		log.Debugf(ctx, "Restoring from oci image %s", inputImage)
 
 		// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-		mountPoint, err = s.ContainerServer.StorageImageServer().GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
+		mountPoint, err = s.ContainerServer.StorageImageServer(sb.RuntimeHandler()).GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
 		if err != nil {
 			return "", err
 		}
@@ -103,7 +103,7 @@ func (s *Server) CRImportCheckpoint(
 
 		defer func() {
 			// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-			if _, err := s.ContainerServer.StorageImageServer().GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
+			if _, err := s.ContainerServer.StorageImageServer(sb.RuntimeHandler()).GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
 				log.Errorf(ctx, "Could not unmount checkpoint image %s: %q", restoreStorageImageID, err)
 			}
 		}()
@@ -373,7 +373,7 @@ func (s *Server) CRImportCheckpoint(
 		if retErr != nil {
 			log.Infof(ctx, "RestoreCtr: deleting container %s from storage", ctr.ID())
 
-			err2 := s.ContainerServer.StorageRuntimeServer().DeleteContainer(ctx, ctr.ID())
+			err2 := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, ctr.ID())
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
 			}

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -94,7 +94,7 @@ func (s *Server) CRImportCheckpoint(
 		log.Debugf(ctx, "Restoring from oci image %s", inputImage)
 
 		// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-		mountPoint, err = s.ContainerServer.StorageImageServer(sb.RuntimeHandler()).GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
+		mountPoint, err = s.ContainerServer.StorageImageServer(sb).GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
 		if err != nil {
 			return "", err
 		}
@@ -103,7 +103,7 @@ func (s *Server) CRImportCheckpoint(
 
 		defer func() {
 			// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-			if _, err := s.ContainerServer.StorageImageServer(sb.RuntimeHandler()).GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
+			if _, err := s.ContainerServer.StorageImageServer(sb).GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
 				log.Errorf(ctx, "Could not unmount checkpoint image %s: %q", restoreStorageImageID, err)
 			}
 		}()
@@ -373,7 +373,7 @@ func (s *Server) CRImportCheckpoint(
 		if retErr != nil {
 			log.Infof(ctx, "RestoreCtr: deleting container %s from storage", ctr.ID())
 
-			err2 := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, ctr.ID())
+			err2 := s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, ctr.ID())
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
 			}

--- a/server/container_restore.go
+++ b/server/container_restore.go
@@ -93,8 +93,13 @@ func (s *Server) CRImportCheckpoint(
 
 		log.Debugf(ctx, "Restoring from oci image %s", inputImage)
 
+		imageServer, err := s.StorageImageServer(sb)
+		if err != nil {
+			return "", err
+		}
+
 		// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-		mountPoint, err = s.ContainerServer.StorageImageServer(sb).GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
+		mountPoint, err = imageServer.GetStore().MountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), nil, "")
 		if err != nil {
 			return "", err
 		}
@@ -103,7 +108,7 @@ func (s *Server) CRImportCheckpoint(
 
 		defer func() {
 			// This is not out-of-process, but it is at least out of the CRI-O codebase; containers/storage uses raw strings.
-			if _, err := s.ContainerServer.StorageImageServer(sb).GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
+			if _, err := imageServer.GetStore().UnmountImage(restoreStorageImageID.IDStringForOutOfProcessConsumptionOnly(), true); err != nil {
 				log.Errorf(ctx, "Could not unmount checkpoint image %s: %q", restoreStorageImageID, err)
 			}
 		}()
@@ -373,7 +378,11 @@ func (s *Server) CRImportCheckpoint(
 		if retErr != nil {
 			log.Infof(ctx, "RestoreCtr: deleting container %s from storage", ctr.ID())
 
-			err2 := s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, ctr.ID())
+			runtimeSvc, err2 := s.StorageRuntimeServer(sb)
+			if err2 == nil {
+				err2 = runtimeSvc.DeleteContainer(ctx, ctr.ID())
+			}
+
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
 			}

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -55,7 +55,7 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 				log.Warnf(ctx, "Failed to lookup sandbox %s: %v", c.Sandbox(), err2)
 			}
 
-			err2 = s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, c.ID())
+			err2 = s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, c.ID())
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
 			}

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -47,7 +47,15 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 
 			s.ReleaseContainerName(ctx, ociContainer.Name())
 
-			err2 := s.ContainerServer.StorageRuntimeServer().DeleteContainer(ctx, c.ID())
+			sb, err2 := s.LookupSandbox(c.Sandbox())
+			if err2 != nil {
+				// log the error, but proceed with a "nil" sandbox
+				// This will continue the cleanup process using the default
+				// runtime server, as "best effort" cleanup.
+				log.Warnf(ctx, "Failed to lookup sandbox %s: %v", c.Sandbox(), err2)
+			}
+
+			err2 = s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).DeleteContainer(ctx, c.ID())
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
 			}

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -55,7 +55,11 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 				log.Warnf(ctx, "Failed to lookup sandbox %s: %v", c.Sandbox(), err2)
 			}
 
-			err2 = s.ContainerServer.StorageRuntimeServer(sb).DeleteContainer(ctx, c.ID())
+			runtimeSvc, err2 := s.StorageRuntimeServer(sb)
+			if err2 == nil {
+				err2 = runtimeSvc.DeleteContainer(ctx, c.ID())
+			}
+
 			if err2 != nil {
 				log.Warnf(ctx, "Failed to cleanup container directory: %v", err2)
 			}

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -166,7 +166,12 @@ func (s *Server) createContainerInfo(ctx context.Context, container *oci.Contain
 		log.Debugf(ctx, "Failed to lookup sandbox %s: %v", container.Sandbox(), err)
 	}
 
-	metadata, err := s.ContainerServer.StorageRuntimeServer(sb).GetContainerMetadata(container.ID())
+	runtimeSvc, err := s.StorageRuntimeServer(sb)
+	if err != nil {
+		return nil, fmt.Errorf("getting runtime service: %w", err)
+	}
+
+	metadata, err := runtimeSvc.GetContainerMetadata(container.ID())
 	if err != nil {
 		return nil, fmt.Errorf("getting container metadata: %w", err)
 	}

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -135,7 +135,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *types.ContainerStatus
 	resp.Status.LogPath = c.LogPath()
 
 	if req.GetVerbose() {
-		info, err := s.createContainerInfo(c)
+		info, err := s.createContainerInfo(ctx, c)
 		if err != nil {
 			return nil, fmt.Errorf("creating container info: %w", err)
 		}
@@ -158,8 +158,19 @@ type containerInfoCheckpointRestore struct {
 	Restored       bool      `json:"restored"`
 }
 
-func (s *Server) createContainerInfo(container *oci.Container) (map[string]string, error) {
-	metadata, err := s.ContainerServer.StorageRuntimeServer().GetContainerMetadata(container.ID())
+func (s *Server) createContainerInfo(ctx context.Context, container *oci.Container) (map[string]string, error) {
+	runtimeHandler := ""
+
+	sb, err := s.LookupSandbox(container.Sandbox())
+	if err != nil {
+		// Do not treat lookup failures as an error.
+		// If it happens, log the error, and use the default ("") runtime handler.
+		log.Debugf(ctx, "Failed to lookup sandbox %s: %v", container.Sandbox(), err)
+	} else {
+		runtimeHandler = sb.RuntimeHandler()
+	}
+
+	metadata, err := s.ContainerServer.StorageRuntimeServer(runtimeHandler).GetContainerMetadata(container.ID())
 	if err != nil {
 		return nil, fmt.Errorf("getting container metadata: %w", err)
 	}

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -159,18 +159,14 @@ type containerInfoCheckpointRestore struct {
 }
 
 func (s *Server) createContainerInfo(ctx context.Context, container *oci.Container) (map[string]string, error) {
-	runtimeHandler := ""
-
 	sb, err := s.LookupSandbox(container.Sandbox())
 	if err != nil {
 		// Do not treat lookup failures as an error.
-		// If it happens, log the error, and use the default ("") runtime handler.
+		// If it happens, log the error, and use the default (nil) runtime handler.
 		log.Debugf(ctx, "Failed to lookup sandbox %s: %v", container.Sandbox(), err)
-	} else {
-		runtimeHandler = sb.RuntimeHandler()
 	}
 
-	metadata, err := s.ContainerServer.StorageRuntimeServer(runtimeHandler).GetContainerMetadata(container.ID())
+	metadata, err := s.ContainerServer.StorageRuntimeServer(sb).GetContainerMetadata(container.ID())
 	if err != nil {
 		return nil, fmt.Errorf("getting container metadata: %w", err)
 	}

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -68,7 +68,7 @@ func (s *Server) stopContainer(ctx context.Context, ctr *oci.Container, timeout 
 }
 
 func (s *Server) postStopCleanup(ctx context.Context, ctr *oci.Container, sb *sandbox.Sandbox, hooks runtimehandlerhooks.RuntimeHandlerHooks) {
-	if err := s.ContainerServer.StorageRuntimeServer().StopContainer(ctx, ctr.ID()); err != nil {
+	if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StopContainer(ctx, ctr.ID()); err != nil {
 		log.Errorf(ctx, "Failed to unmount container %s: %v", ctr.ID(), err)
 	}
 

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -68,7 +68,10 @@ func (s *Server) stopContainer(ctx context.Context, ctr *oci.Container, timeout 
 }
 
 func (s *Server) postStopCleanup(ctx context.Context, ctr *oci.Container, sb *sandbox.Sandbox, hooks runtimehandlerhooks.RuntimeHandlerHooks) {
-	if err := s.ContainerServer.StorageRuntimeServer(sb).StopContainer(ctx, ctr.ID()); err != nil {
+	runtimeSvc, err := s.StorageRuntimeServer(sb)
+	if err != nil {
+		log.Errorf(ctx, "Failed to get runtime service for container %s: %v", ctr.ID(), err)
+	} else if err := runtimeSvc.StopContainer(ctx, ctr.ID()); err != nil {
 		log.Errorf(ctx, "Failed to unmount container %s: %v", ctr.ID(), err)
 	}
 

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -68,7 +68,7 @@ func (s *Server) stopContainer(ctx context.Context, ctr *oci.Container, timeout 
 }
 
 func (s *Server) postStopCleanup(ctx context.Context, ctr *oci.Container, sb *sandbox.Sandbox, hooks runtimehandlerhooks.RuntimeHandlerHooks) {
-	if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StopContainer(ctx, ctr.ID()); err != nil {
+	if err := s.ContainerServer.StorageRuntimeServer(sb).StopContainer(ctx, ctr.ID()); err != nil {
 		log.Errorf(ctx, "Failed to unmount container %s: %v", ctr.ID(), err)
 	}
 

--- a/server/image_fs_info.go
+++ b/server/image_fs_info.go
@@ -55,7 +55,9 @@ func getStorageFsInfo(store storage.Store) (*types.ImageFsInfoResponse, error) {
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
 func (s *Server) ImageFsInfo(context.Context, *types.ImageFsInfoRequest) (*types.ImageFsInfoResponse, error) {
-	store := s.ContainerServer.StorageImageServer().GetStore()
+	// Get the default ImageServer's store. There is no need to manage filesystem
+	// info for images managed by the runtime.
+	store := s.ContainerServer.StorageImageServer("").GetStore()
 
 	fsUsage, err := getStorageFsInfo(store)
 	if err != nil {

--- a/server/image_fs_info.go
+++ b/server/image_fs_info.go
@@ -57,7 +57,7 @@ func getStorageFsInfo(store storage.Store) (*types.ImageFsInfoResponse, error) {
 func (s *Server) ImageFsInfo(context.Context, *types.ImageFsInfoRequest) (*types.ImageFsInfoResponse, error) {
 	// Get the default ImageServer's store. There is no need to manage filesystem
 	// info for images managed by the runtime.
-	store := s.ContainerServer.StorageImageServer("").GetStore()
+	store := s.ContainerServer.StorageImageServer(nil).GetStore()
 
 	fsUsage, err := getStorageFsInfo(store)
 	if err != nil {

--- a/server/image_fs_info.go
+++ b/server/image_fs_info.go
@@ -57,7 +57,12 @@ func getStorageFsInfo(store storage.Store) (*types.ImageFsInfoResponse, error) {
 func (s *Server) ImageFsInfo(context.Context, *types.ImageFsInfoRequest) (*types.ImageFsInfoResponse, error) {
 	// Get the default ImageServer's store. There is no need to manage filesystem
 	// info for images managed by the runtime.
-	store := s.ContainerServer.StorageImageServer(nil).GetStore()
+	imageServer, err := s.StorageImageServer(nil)
+	if err != nil {
+		return nil, fmt.Errorf("get image server: %w", err)
+	}
+
+	store := imageServer.GetStore()
 
 	fsUsage, err := getStorageFsInfo(store)
 	if err != nil {

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -76,7 +76,10 @@ func (s *Server) listImages(ctx context.Context, filter *types.ImageFilter) ([]*
 		}
 	}
 
-	results, err := s.ContainerServer.StorageImageServer().ListImages(s.config.SystemContext)
+	// Call "ListImages()" with the default ImageServer (using "" for runtimeHandler)
+	// so that we get only the images that CRI-O actually manages.
+	// Images handled by the underlying runtime are ignored for now.
+	results, err := s.ContainerServer.StorageImageServer("").ListImages(s.config.SystemContext)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -79,7 +79,12 @@ func (s *Server) listImages(ctx context.Context, filter *types.ImageFilter) ([]*
 	// Call "ListImages()" with the default ImageServer (using "" for runtimeHandler)
 	// so that we get only the images that CRI-O actually manages.
 	// Images handled by the underlying runtime are ignored for now.
-	results, err := s.ContainerServer.StorageImageServer(nil).ListImages(s.config.SystemContext)
+	imageServer, err := s.StorageImageServer(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := imageServer.ListImages(s.config.SystemContext)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -79,7 +79,7 @@ func (s *Server) listImages(ctx context.Context, filter *types.ImageFilter) ([]*
 	// Call "ListImages()" with the default ImageServer (using "" for runtimeHandler)
 	// so that we get only the images that CRI-O actually manages.
 	// Images handled by the underlying runtime are ignored for now.
-	results, err := s.ContainerServer.StorageImageServer("").ListImages(s.config.SystemContext)
+	results, err := s.ContainerServer.StorageImageServer(nil).ListImages(s.config.SystemContext)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -47,7 +47,12 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 	pullArgs := pullArguments{image: image}
 
 	// set the default imageServer. It will be replaced later if required
-	pullArgs.imageServer = s.StorageImageServer(nil)
+	defaultImageServer, err := s.StorageImageServer(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	pullArgs.imageServer = defaultImageServer
 
 	sc := req.GetSandboxConfig()
 	if sc != nil {
@@ -73,9 +78,12 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 			sb, sbErr = s.LookupSandbox(podID)
 			if sbErr != nil {
 				log.Debugf(ctx, "Failed to retrieve sandbox for image %s (podID: %s): %v", name, podID, sbErr)
+			} else {
+				pullArgs.imageServer, sbErr = s.StorageImageServer(sb)
+				if sbErr != nil {
+					log.Debugf(ctx, "Failed to get image server for sandbox %s: %v", podID, sbErr)
+				}
 			}
-
-			pullArgs.imageServer = s.StorageImageServer(sb)
 		}
 
 		// Double-check the runtime handler from the image spec.

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -22,6 +21,7 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	crierrors "k8s.io/cri-api/pkg/errors"
 
+	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/server/metrics"
@@ -55,20 +55,17 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 			pullArgs.sandboxCgroup = sc.GetLinux().GetCgroupParent()
 		}
 
+		var name string
+
 		if sc.GetMetadata() != nil {
 			pullArgs.namespace = sc.GetMetadata().GetNamespace()
+			name = libsandbox.PodName(sc.GetMetadata())
 		}
 
-		name := strings.Join([]string{
-			"k8s",
-			sc.GetMetadata().GetName(),
-			sc.GetMetadata().GetNamespace(),
-			sc.GetMetadata().GetUid(),
-			strconv.FormatUint(uint64(sc.GetMetadata().GetAttempt()), 10),
-		}, "_")
-
 		podID, err := s.PodIDForName(name)
-		if err == nil {
+		if err != nil {
+			log.Debugf(ctx, "PodIDForName(%s) failed during image pull, falling back to host image store: %v", name, err)
+		} else {
 			sb, _ := s.LookupSandbox(podID) //nolint:errcheck // error intentionally ignored - fallback to default ImageServer
 			pullArgs.imageServer = s.StorageImageServer(sb)
 		}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -53,6 +54,22 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 
 		if sc.GetMetadata() != nil {
 			pullArgs.namespace = sc.GetMetadata().GetNamespace()
+		}
+
+		name := strings.Join([]string{
+			"k8s",
+			sc.GetMetadata().GetName(),
+			sc.GetMetadata().GetNamespace(),
+			sc.GetMetadata().GetUid(),
+			strconv.FormatUint(uint64(sc.GetMetadata().GetAttempt()), 10),
+		}, "_")
+
+		podID, err := s.PodIDForName(name)
+		if err == nil {
+			sb, err := s.LookupSandbox(podID)
+			if err == nil {
+				pullArgs.runtimeHandler = sb.RuntimeHandler()
+			}
 		}
 	}
 
@@ -182,7 +199,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 		}
 	}
 
-	remoteCandidates, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
+	remoteCandidates, err := s.ContainerServer.StorageImageServer(pullArgs.runtimeHandler).CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
 	if err != nil {
 		return "", err
 	}
@@ -191,12 +208,12 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 	lastErr := errors.New("internal error: pullImage failed but reported no error reason")
 
 	for _, remoteCandidateName := range remoteCandidates {
-		imageRef, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup)
+		imageRef, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup, pullArgs.runtimeHandler)
 		if err == nil {
 			// Update metric for successful image pulls
 			metrics.Instance().MetricImagePullsSuccessesInc(remoteCandidateName)
 
-			return s.resolveImageRefToID(ctx, imageRef)
+			return s.resolveImageRefToID(ctx, imageRef, pullArgs.runtimeHandler)
 		}
 
 		lastErr = err
@@ -297,7 +314,7 @@ func (s *Server) prepareTempAuthFile(ctx context.Context, sysCtx *imageTypes.Sys
 	return cleanup, nil
 }
 
-func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.SystemContext, remoteCandidateName storage.RegistryImageReference, decryptConfig *encconfig.DecryptConfig, cgroup string) (storage.RegistryImageReference, error) {
+func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.SystemContext, remoteCandidateName storage.RegistryImageReference, decryptConfig *encconfig.DecryptConfig, cgroup, runtimeHandler string) (storage.RegistryImageReference, error) {
 	// Collect pull progress metrics
 	progress := make(chan imageTypes.ProgressProperties)
 	defer close(progress)
@@ -310,7 +327,7 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 	pullCtx, cancel := context.WithCancel(ctx)
 	go consumeImagePullProgress(ctx, cancel, s.ContainerServer.Config().PullProgressTimeout, progress, remoteCandidateName)
 
-	repoDigest, err := s.ContainerServer.StorageImageServer().PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
+	repoDigest, err := s.ContainerServer.StorageImageServer(runtimeHandler).PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
 		SourceCtx:        sourceCtx,
 		DestinationCtx:   s.config.SystemContext,
 		OciDecryptConfig: decryptConfig,
@@ -337,9 +354,9 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 // container images the ID is looked up via ImageStatusByName. For OCI artifacts
 // (which are not stored in container storage) it falls back to the artifact
 // store.
-func (s *Server) resolveImageRefToID(ctx context.Context, imageRef storage.RegistryImageReference) (string, error) {
+func (s *Server) resolveImageRefToID(ctx context.Context, imageRef storage.RegistryImageReference, runtimeHandler string) (string, error) {
 	// Try resolving as a regular container image first.
-	imageResult, err := s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, imageRef)
+	imageResult, err := s.ContainerServer.StorageImageServer(runtimeHandler).ImageStatusByName(s.config.SystemContext, imageRef)
 	if err == nil {
 		return imageResult.ID.IDStringForOutOfProcessConsumptionOnly(), nil
 	}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -22,7 +22,6 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	crierrors "k8s.io/cri-api/pkg/errors"
 
-	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/server/metrics"
@@ -47,6 +46,9 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 
 	pullArgs := pullArguments{image: image}
 
+	// set the default imageServer. It will be replaced later if required
+	pullArgs.imageServer = s.StorageImageServer(nil)
+
 	sc := req.GetSandboxConfig()
 	if sc != nil {
 		if sc.GetLinux() != nil {
@@ -67,7 +69,8 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 
 		podID, err := s.PodIDForName(name)
 		if err == nil {
-			pullArgs.sb, _ = s.LookupSandbox(podID)
+			sb, _ := s.LookupSandbox(podID) //nolint:errcheck // error intentionally ignored - fallback to default ImageServer
+			pullArgs.imageServer = s.StorageImageServer(sb)
 		}
 	}
 
@@ -197,7 +200,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 		}
 	}
 
-	remoteCandidates, err := s.ContainerServer.StorageImageServer(pullArgs.sb).CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
+	remoteCandidates, err := pullArgs.imageServer.CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
 	if err != nil {
 		return "", err
 	}
@@ -206,12 +209,12 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 	lastErr := errors.New("internal error: pullImage failed but reported no error reason")
 
 	for _, remoteCandidateName := range remoteCandidates {
-		imageRef, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup, pullArgs.sb)
+		imageRef, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup, pullArgs.imageServer)
 		if err == nil {
 			// Update metric for successful image pulls
 			metrics.Instance().MetricImagePullsSuccessesInc(remoteCandidateName)
 
-			return s.resolveImageRefToID(ctx, imageRef, pullArgs.sb)
+			return s.resolveImageRefToID(ctx, imageRef, pullArgs.imageServer)
 		}
 
 		lastErr = err
@@ -312,7 +315,7 @@ func (s *Server) prepareTempAuthFile(ctx context.Context, sysCtx *imageTypes.Sys
 	return cleanup, nil
 }
 
-func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.SystemContext, remoteCandidateName storage.RegistryImageReference, decryptConfig *encconfig.DecryptConfig, cgroup string, sb *sandbox.Sandbox) (storage.RegistryImageReference, error) {
+func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.SystemContext, remoteCandidateName storage.RegistryImageReference, decryptConfig *encconfig.DecryptConfig, cgroup string, is storage.ImageServer) (storage.RegistryImageReference, error) {
 	// Collect pull progress metrics
 	progress := make(chan imageTypes.ProgressProperties)
 	defer close(progress)
@@ -325,7 +328,7 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 	pullCtx, cancel := context.WithCancel(ctx)
 	go consumeImagePullProgress(ctx, cancel, s.ContainerServer.Config().PullProgressTimeout, progress, remoteCandidateName)
 
-	repoDigest, err := s.ContainerServer.StorageImageServer(sb).PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
+	repoDigest, err := is.PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
 		SourceCtx:        sourceCtx,
 		DestinationCtx:   s.config.SystemContext,
 		OciDecryptConfig: decryptConfig,
@@ -352,9 +355,9 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 // container images the ID is looked up via ImageStatusByName. For OCI artifacts
 // (which are not stored in container storage) it falls back to the artifact
 // store.
-func (s *Server) resolveImageRefToID(ctx context.Context, imageRef storage.RegistryImageReference, sb *sandbox.Sandbox) (string, error) {
+func (s *Server) resolveImageRefToID(ctx context.Context, imageRef storage.RegistryImageReference, is storage.ImageServer) (string, error) {
 	// Try resolving as a regular container image first.
-	imageResult, err := s.ContainerServer.StorageImageServer(sb).ImageStatusByName(s.config.SystemContext, imageRef)
+	imageResult, err := is.ImageStatusByName(s.config.SystemContext, imageRef)
 	if err == nil {
 		return imageResult.ID.IDStringForOutOfProcessConsumptionOnly(), nil
 	}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -22,6 +22,7 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	crierrors "k8s.io/cri-api/pkg/errors"
 
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/storage"
 	"github.com/cri-o/cri-o/server/metrics"
@@ -66,10 +67,7 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 
 		podID, err := s.PodIDForName(name)
 		if err == nil {
-			sb, err := s.LookupSandbox(podID)
-			if err == nil {
-				pullArgs.runtimeHandler = sb.RuntimeHandler()
-			}
+			pullArgs.sb, _ = s.LookupSandbox(podID)
 		}
 	}
 
@@ -199,7 +197,7 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 		}
 	}
 
-	remoteCandidates, err := s.ContainerServer.StorageImageServer(pullArgs.runtimeHandler).CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
+	remoteCandidates, err := s.ContainerServer.StorageImageServer(pullArgs.sb).CandidatesForPotentiallyShortImageName(s.config.SystemContext, pullArgs.image)
 	if err != nil {
 		return "", err
 	}
@@ -208,12 +206,12 @@ func (s *Server) pullImage(ctx context.Context, pullArgs *pullArguments) (string
 	lastErr := errors.New("internal error: pullImage failed but reported no error reason")
 
 	for _, remoteCandidateName := range remoteCandidates {
-		imageRef, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup, pullArgs.runtimeHandler)
+		imageRef, err := s.pullImageCandidate(ctx, &sourceCtx, remoteCandidateName, decryptConfig, cgroup, pullArgs.sb)
 		if err == nil {
 			// Update metric for successful image pulls
 			metrics.Instance().MetricImagePullsSuccessesInc(remoteCandidateName)
 
-			return s.resolveImageRefToID(ctx, imageRef, pullArgs.runtimeHandler)
+			return s.resolveImageRefToID(ctx, imageRef, pullArgs.sb)
 		}
 
 		lastErr = err
@@ -314,7 +312,7 @@ func (s *Server) prepareTempAuthFile(ctx context.Context, sysCtx *imageTypes.Sys
 	return cleanup, nil
 }
 
-func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.SystemContext, remoteCandidateName storage.RegistryImageReference, decryptConfig *encconfig.DecryptConfig, cgroup, runtimeHandler string) (storage.RegistryImageReference, error) {
+func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.SystemContext, remoteCandidateName storage.RegistryImageReference, decryptConfig *encconfig.DecryptConfig, cgroup string, sb *sandbox.Sandbox) (storage.RegistryImageReference, error) {
 	// Collect pull progress metrics
 	progress := make(chan imageTypes.ProgressProperties)
 	defer close(progress)
@@ -327,7 +325,7 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 	pullCtx, cancel := context.WithCancel(ctx)
 	go consumeImagePullProgress(ctx, cancel, s.ContainerServer.Config().PullProgressTimeout, progress, remoteCandidateName)
 
-	repoDigest, err := s.ContainerServer.StorageImageServer(runtimeHandler).PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
+	repoDigest, err := s.ContainerServer.StorageImageServer(sb).PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
 		SourceCtx:        sourceCtx,
 		DestinationCtx:   s.config.SystemContext,
 		OciDecryptConfig: decryptConfig,
@@ -354,9 +352,9 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 // container images the ID is looked up via ImageStatusByName. For OCI artifacts
 // (which are not stored in container storage) it falls back to the artifact
 // store.
-func (s *Server) resolveImageRefToID(ctx context.Context, imageRef storage.RegistryImageReference, runtimeHandler string) (string, error) {
+func (s *Server) resolveImageRefToID(ctx context.Context, imageRef storage.RegistryImageReference, sb *sandbox.Sandbox) (string, error) {
 	// Try resolving as a regular container image first.
-	imageResult, err := s.ContainerServer.StorageImageServer(runtimeHandler).ImageStatusByName(s.config.SystemContext, imageRef)
+	imageResult, err := s.ContainerServer.StorageImageServer(sb).ImageStatusByName(s.config.SystemContext, imageRef)
 	if err == nil {
 		return imageResult.ID.IDStringForOutOfProcessConsumptionOnly(), nil
 	}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -62,12 +62,33 @@ func (s *Server) PullImage(ctx context.Context, req *types.PullImageRequest) (*t
 			name = libsandbox.PodName(sc.GetMetadata())
 		}
 
+		var sbErr error
+
 		podID, err := s.PodIDForName(name)
 		if err != nil {
 			log.Debugf(ctx, "PodIDForName(%s) failed during image pull, falling back to host image store: %v", name, err)
 		} else {
-			sb, _ := s.LookupSandbox(podID) //nolint:errcheck // error intentionally ignored - fallback to default ImageServer
+			var sb *libsandbox.Sandbox
+
+			sb, sbErr = s.LookupSandbox(podID)
+			if sbErr != nil {
+				log.Debugf(ctx, "Failed to retrieve sandbox for image %s (podID: %s): %v", name, podID, sbErr)
+			}
+
 			pullArgs.imageServer = s.StorageImageServer(sb)
+		}
+
+		// Double-check the runtime handler from the image spec.
+		// Warn if we use the default ImageServer when we should have a runtimePulled one.
+		r, ok := s.config.Runtimes[img.GetRuntimeHandler()]
+		if ok && r.RuntimePullImage && (err != nil || sbErr != nil) {
+			log.Debugf(ctx, "Runtime handler for image %s is configured for runtime pull, but couldn't get the proper ImageServer", name)
+
+			if err != nil {
+				return nil, err
+			}
+
+			return nil, sbErr
 		}
 	}
 

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -40,22 +40,26 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
-	imageService := s.StorageImageServer(nil)
+	imageManager := s.StorageImageManager()
 
-	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
-		if err := s.volumeInUse(id.IDStringForOutOfProcessConsumptionOnly()); err != nil {
-			return err
+	if matches := imageManager.HeuristicallyTryResolvingStringAsIDPrefix(imageRef); len(matches) > 0 {
+		for _, match := range matches {
+			if err := s.volumeInUse(match.ID.IDStringForOutOfProcessConsumptionOnly()); err != nil {
+				return err
+			}
 		}
 
-		if err := imageService.DeleteImage(s.config.SystemContext, *id); err != nil {
-			if errors.Is(err, storagetypes.ErrImageUnknown) || errors.Is(err, storagetypes.ErrNotAnImage) {
-				// The RemoveImage RPC is idempotent, and must not return an
-				// error if the image has already been removed. Ref:
-				// https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto#L156-L157
-				return nil
-			}
+		for _, match := range matches {
+			if err := match.Server.DeleteImage(s.config.SystemContext, *match.ID); err != nil {
+				if errors.Is(err, storagetypes.ErrImageUnknown) || errors.Is(err, storagetypes.ErrNotAnImage) {
+					// The RemoveImage RPC is idempotent, and must not return an
+					// error if the image has already been removed. Ref:
+					// https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto#L156-L157
+					continue
+				}
 
-			return fmt.Errorf("delete image: %w", err)
+				return fmt.Errorf("delete image: %w", err)
+			}
 		}
 
 		return nil
@@ -65,6 +69,11 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 		deleted   bool
 		statusErr error
 	)
+
+	// Proceed with the default store for name-based search.
+	// Runtime-pulled images being deleted along with the pod that uses them,
+	// we only try to clean the default store here.
+	imageService := s.StorageImageServer(nil)
 
 	potentialMatches, err := imageService.CandidatesForPotentiallyShortImageName(s.config.SystemContext, imageRef)
 	if err != nil {

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -29,18 +29,18 @@ func (s *Server) RemoveImage(ctx context.Context, req *types.RemoveImageRequest)
 		return nil, errors.New("no image specified")
 	}
 
-	if err := s.removeImage(ctx, imageRef, img.GetRuntimeHandler()); err != nil {
+	if err := s.removeImage(ctx, imageRef); err != nil {
 		return nil, err
 	}
 
 	return &types.RemoveImageResponse{}, nil
 }
 
-func (s *Server) removeImage(ctx context.Context, imageRef, runtimeHandler string) (untagErr error) {
+func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
-	imageService := s.StorageImageServer(runtimeHandler)
+	imageService := s.StorageImageServer(nil)
 
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
 		if err := s.volumeInUse(id.IDStringForOutOfProcessConsumptionOnly()); err != nil {

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -29,23 +29,25 @@ func (s *Server) RemoveImage(ctx context.Context, req *types.RemoveImageRequest)
 		return nil, errors.New("no image specified")
 	}
 
-	if err := s.removeImage(ctx, imageRef); err != nil {
+	if err := s.removeImage(ctx, imageRef, img.GetRuntimeHandler()); err != nil {
 		return nil, err
 	}
 
 	return &types.RemoveImageResponse{}, nil
 }
 
-func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr error) {
+func (s *Server) removeImage(ctx context.Context, imageRef, runtimeHandler string) (untagErr error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
-	if id := s.ContainerServer.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
+	imageService := s.StorageImageServer(runtimeHandler)
+
+	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(imageRef); id != nil {
 		if err := s.volumeInUse(id.IDStringForOutOfProcessConsumptionOnly()); err != nil {
 			return err
 		}
 
-		if err := s.ContainerServer.StorageImageServer().DeleteImage(s.config.SystemContext, *id); err != nil {
+		if err := imageService.DeleteImage(s.config.SystemContext, *id); err != nil {
 			if errors.Is(err, storagetypes.ErrImageUnknown) || errors.Is(err, storagetypes.ErrNotAnImage) {
 				// The RemoveImage RPC is idempotent, and must not return an
 				// error if the image has already been removed. Ref:
@@ -64,7 +66,7 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 		statusErr error
 	)
 
-	potentialMatches, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, imageRef)
+	potentialMatches, err := imageService.CandidatesForPotentiallyShortImageName(s.config.SystemContext, imageRef)
 	if err != nil {
 		return err
 	}
@@ -72,7 +74,7 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 	for _, name := range potentialMatches {
 		var status *storage.ImageResult
 
-		status, statusErr = s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, name)
+		status, statusErr = imageService.ImageStatusByName(s.config.SystemContext, name)
 		if statusErr != nil {
 			log.Warnf(ctx, "Error getting image status %s: %v", name, statusErr)
 
@@ -83,7 +85,7 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 			return err
 		}
 
-		untagErr = s.ContainerServer.StorageImageServer().UntagImage(s.config.SystemContext, name)
+		untagErr = imageService.UntagImage(s.config.SystemContext, name)
 		if untagErr != nil {
 			log.Debugf(ctx, "Error deleting image %s: %v", name, untagErr)
 

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -73,7 +73,10 @@ func (s *Server) removeImage(ctx context.Context, imageRef string) (untagErr err
 	// Proceed with the default store for name-based search.
 	// Runtime-pulled images being deleted along with the pod that uses them,
 	// we only try to clean the default store here.
-	imageService := s.StorageImageServer(nil)
+	imageService, err := s.StorageImageServer(nil)
+	if err != nil {
+		return err
+	}
 
 	potentialMatches, err := imageService.CandidatesForPotentiallyShortImageName(s.config.SystemContext, imageRef)
 	if err != nil {

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -95,8 +95,9 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 // storageImageStatus calls ImageStatus for a k8s ImageSpec.
 // Returns (nil, nil) if image was not found.
 func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) (*pkgstorage.ImageResult, error) {
-	if id := s.ContainerServer.StorageImageServer().HeuristicallyTryResolvingStringAsIDPrefix(spec.GetImage()); id != nil {
-		status, err := s.ContainerServer.StorageImageServer().ImageStatusByID(s.config.SystemContext, *id)
+	imageService := s.StorageImageServer(spec.GetRuntimeHandler())
+	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(spec.GetImage()); id != nil {
+		status, err := imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {
 			if errors.Is(err, istorage.ErrNoSuchImage) || errors.Is(err, storage.ErrImageUnknown) {
 				log.Infof(ctx, "Image %s not found", spec.GetImage())
@@ -112,7 +113,7 @@ func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) 
 		return status, nil
 	}
 
-	potentialMatches, err := s.ContainerServer.StorageImageServer().CandidatesForPotentiallyShortImageName(s.config.SystemContext, spec.GetImage())
+	potentialMatches, err := imageService.CandidatesForPotentiallyShortImageName(s.config.SystemContext, spec.GetImage())
 	if err != nil {
 		if len(spec.GetImage()) >= 3 && isHexString(spec.GetImage()) {
 			log.Debugf(ctx, "CandidatesForPotentiallyShortImageName failed for %q, but input looks like digest/ID: %v", spec.GetImage(), err)
@@ -126,7 +127,7 @@ func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) 
 	var lastErr error
 
 	for _, name := range potentialMatches {
-		status, err := s.ContainerServer.StorageImageServer().ImageStatusByName(s.config.SystemContext, name)
+		status, err := imageService.ImageStatusByName(s.config.SystemContext, name)
 		if err != nil {
 			if errors.Is(err, istorage.ErrNoSuchImage) {
 				log.Debugf(ctx, "Can't find %s", name)

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -95,7 +95,10 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 // storageImageStatus calls ImageStatus for a k8s ImageSpec.
 // Returns (nil, nil) if image was not found.
 func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) (*pkgstorage.ImageResult, error) {
-	imageService := s.StorageImageServer(spec.GetRuntimeHandler())
+	// Use the default store here: Images managed by the runtime are ignored, to
+	// avoid confusion at the Kubernetes level, as we can't report multiple image
+	// satuses depending on the runtime being used.
+	imageService := s.StorageImageServer(nil)
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(spec.GetImage()); id != nil {
 		status, err := imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -98,7 +98,11 @@ func (s *Server) storageImageStatus(ctx context.Context, spec *types.ImageSpec) 
 	// Use the default store here: Images managed by the runtime are ignored, to
 	// avoid confusion at the Kubernetes level, as we can't report multiple image
 	// satuses depending on the runtime being used.
-	imageService := s.StorageImageServer(nil)
+	imageService, err := s.StorageImageServer(nil)
+	if err != nil {
+		return nil, err
+	}
+
 	if id := imageService.HeuristicallyTryResolvingStringAsIDPrefix(spec.GetImage()); id != nil {
 		status, err := imageService.ImageStatusByID(s.config.SystemContext, *id)
 		if err != nil {

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -113,12 +113,17 @@ func (s *Server) setPodSandboxMountLabel(ctx context.Context, sbox libsandbox.Bu
 	_, span := log.StartSpan(ctx)
 	defer span.End()
 
-	storageMetadata, err := s.ContainerServer.StorageRuntimeServer(sbox).GetContainerMetadata(sbox.ID())
+	runtimeSvc, err := s.StorageRuntimeServer(sbox)
+	if err != nil {
+		return err
+	}
+
+	storageMetadata, err := runtimeSvc.GetContainerMetadata(sbox.ID())
 	if err != nil {
 		return err
 	}
 
 	storageMetadata.SetMountLabel(mountLabel)
 
-	return s.ContainerServer.StorageRuntimeServer(sbox).SetContainerMetadata(sbox.ID(), &storageMetadata)
+	return runtimeSvc.SetContainerMetadata(sbox.ID(), &storageMetadata)
 }

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -8,6 +8,7 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/hostport"
+	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 )
 
@@ -108,16 +109,16 @@ func getHostname(id, hostname string, hostNetwork bool) (string, error) {
 	return hostname, nil
 }
 
-func (s *Server) setPodSandboxMountLabel(ctx context.Context, id, mountLabel, runtimeHandler string) error {
+func (s *Server) setPodSandboxMountLabel(ctx context.Context, sbox libsandbox.Builder, mountLabel string) error {
 	_, span := log.StartSpan(ctx)
 	defer span.End()
 
-	storageMetadata, err := s.ContainerServer.StorageRuntimeServer(runtimeHandler).GetContainerMetadata(id)
+	storageMetadata, err := s.ContainerServer.StorageRuntimeServer(sbox).GetContainerMetadata(sbox.ID())
 	if err != nil {
 		return err
 	}
 
 	storageMetadata.SetMountLabel(mountLabel)
 
-	return s.ContainerServer.StorageRuntimeServer(runtimeHandler).SetContainerMetadata(id, &storageMetadata)
+	return s.ContainerServer.StorageRuntimeServer(sbox).SetContainerMetadata(sbox.ID(), &storageMetadata)
 }

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -108,16 +108,16 @@ func getHostname(id, hostname string, hostNetwork bool) (string, error) {
 	return hostname, nil
 }
 
-func (s *Server) setPodSandboxMountLabel(ctx context.Context, id, mountLabel string) error {
+func (s *Server) setPodSandboxMountLabel(ctx context.Context, id, mountLabel, runtimeHandler string) error {
 	_, span := log.StartSpan(ctx)
 	defer span.End()
 
-	storageMetadata, err := s.ContainerServer.StorageRuntimeServer().GetContainerMetadata(id)
+	storageMetadata, err := s.ContainerServer.StorageRuntimeServer(runtimeHandler).GetContainerMetadata(id)
 	if err != nil {
 		return err
 	}
 
 	storageMetadata.SetMountLabel(mountLabel)
 
-	return s.ContainerServer.StorageRuntimeServer().SetContainerMetadata(id, &storageMetadata)
+	return s.ContainerServer.StorageRuntimeServer(runtimeHandler).SetContainerMetadata(id, &storageMetadata)
 }

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -11,8 +11,6 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
-	"go.podman.io/storage"
-	"go.podman.io/storage/pkg/idtools"
 	"github.com/cri-o/cri-o/internal/annotations"
 	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
@@ -28,6 +26,8 @@ import (
 	json "github.com/json-iterator/go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/idtools"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubeletTypes "k8s.io/kubelet/pkg/types"
 )
@@ -143,7 +143,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	if err != nil {
 		return nil, err
 	}
-	podContainer, err := s.ContainerServer.StorageRuntimeServer().CreatePodSandbox(s.config.SystemContext,
+	podContainer, err := s.ContainerServer.StorageRuntimeServer(sbox).CreatePodSandbox(s.config.SystemContext,
 		sboxName, sboxId,
 		pauseImage,
 		s.config.PauseImageAuthFile,
@@ -163,7 +163,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, fmt.Errorf("creating pod sandbox with name %q: %w", sboxName, err)
 	}
 	resourceCleaner.Add(ctx, "runSandbox: removing pod sandbox from storage: "+sboxId, func() error {
-		return s.ContainerServer.StorageRuntimeServer().DeleteContainer(ctx, sboxId)
+		return s.ContainerServer.StorageRuntimeServer(sbox).DeleteContainer(ctx, sboxId)
 	})
 
 	mountLabel := podContainer.MountLabel
@@ -392,12 +392,12 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 
 	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox storage start")
 
-	mountPoint, err := s.ContainerServer.StorageRuntimeServer().StartContainer(sboxId)
+	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sbox).StartContainer(sboxId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %w", containerName, sb.Name(), sboxId, err)
 	}
 	resourceCleaner.Add(ctx, "runSandbox: stopping storage container for sandbox "+sboxId, func() error {
-		if err := s.ContainerServer.StorageRuntimeServer().StopContainer(ctx, sboxId); err != nil {
+		if err := s.ContainerServer.StorageRuntimeServer(sbox).StopContainer(ctx, sboxId); err != nil {
 			return fmt.Errorf("could not stop storage container: %s: %w", sboxId, err)
 		}
 		return nil

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -143,7 +143,12 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	if err != nil {
 		return nil, err
 	}
-	podContainer, err := s.ContainerServer.StorageRuntimeServer(sbox).CreatePodSandbox(s.config.SystemContext,
+	runtimeSvc, err := s.ContainerServer.StorageRuntimeServer(sbox)
+	if err != nil {
+		return nil, fmt.Errorf("getting runtime service for sandbox %q: %w", sboxName, err)
+	}
+
+	podContainer, err := runtimeSvc.CreatePodSandbox(s.config.SystemContext,
 		sboxName, sboxId,
 		pauseImage,
 		s.config.PauseImageAuthFile,
@@ -163,7 +168,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, fmt.Errorf("creating pod sandbox with name %q: %w", sboxName, err)
 	}
 	resourceCleaner.Add(ctx, "runSandbox: removing pod sandbox from storage: "+sboxId, func() error {
-		return s.ContainerServer.StorageRuntimeServer(sbox).DeleteContainer(ctx, sboxId)
+		return runtimeSvc.DeleteContainer(ctx, sboxId)
 	})
 
 	mountLabel := podContainer.MountLabel
@@ -392,12 +397,17 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 
 	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox storage start")
 
-	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sbox).StartContainer(sboxId)
+	runtimeSvcStart, err := s.ContainerServer.StorageRuntimeServer(sbox)
+	if err != nil {
+		return nil, fmt.Errorf("getting runtime service for sandbox %s(%s): %w", sb.Name(), sboxId, err)
+	}
+
+	mountPoint, err := runtimeSvcStart.StartContainer(sboxId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %w", containerName, sb.Name(), sboxId, err)
 	}
 	resourceCleaner.Add(ctx, "runSandbox: stopping storage container for sandbox "+sboxId, func() error {
-		if err := s.ContainerServer.StorageRuntimeServer(sbox).StopContainer(ctx, sboxId); err != nil {
+		if err := runtimeSvcStart.StopContainer(ctx, sboxId); err != nil {
 			return fmt.Errorf("could not stop storage container: %s: %w", sboxId, err)
 		}
 		return nil

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -518,7 +518,12 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
-	podContainer, err := s.ContainerServer.StorageRuntimeServer(sbox).CreatePodSandbox(s.config.SystemContext,
+	runtimeSvc, err := s.StorageRuntimeServer(sbox)
+	if err != nil {
+		return nil, fmt.Errorf("getting runtime service for sandbox %q: %w", sboxName, err)
+	}
+
+	podContainer, err := runtimeSvc.CreatePodSandbox(s.config.SystemContext,
 		sboxName, sboxID,
 		pauseImage,
 		s.config.PauseImageAuthFile,
@@ -540,7 +545,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	}
 
 	resourceCleaner.Add(ctx, "runSandbox: removing pod sandbox from storage: "+sboxID, func() error {
-		return s.ContainerServer.StorageRuntimeServer(sbox).DeleteContainer(ctx, sboxID)
+		return runtimeSvc.DeleteContainer(ctx, sboxID)
 	})
 
 	mountLabel := podContainer.MountLabel
@@ -1570,13 +1575,18 @@ func (s *Server) prepareSandboxMetadataAndLabels(sbox libsandbox.Builder, kubeAn
 func (s *Server) setupSandboxStorage(ctx context.Context, sb *libsandbox.Sandbox, g *generate.Generator, sboxID, sboxName, containerName string, resourceCleaner *resourcestore.ResourceCleaner) (string, error) {
 	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox storage start")
 
-	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sb).StartContainer(sboxID)
+	runtimeSvc, err := s.StorageRuntimeServer(sb)
+	if err != nil {
+		return "", fmt.Errorf("getting runtime service for sandbox %s(%s): %w", sb.Name(), sboxID, err)
+	}
+
+	mountPoint, err := runtimeSvc.StartContainer(sboxID)
 	if err != nil {
 		return "", fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %w", containerName, sb.Name(), sboxID, err)
 	}
 
 	resourceCleaner.Add(ctx, "runSandbox: stopping storage container for sandbox "+sboxID, func() error {
-		if err := s.ContainerServer.StorageRuntimeServer(sb).StopContainer(ctx, sboxID); err != nil {
+		if err := runtimeSvc.StopContainer(ctx, sboxID); err != nil {
 			return fmt.Errorf("could not stop storage container: %s: %w", sboxID, err)
 		}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -518,7 +518,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
-	podContainer, err := s.ContainerServer.StorageRuntimeServer().CreatePodSandbox(s.config.SystemContext,
+	podContainer, err := s.ContainerServer.StorageRuntimeServer(runtimeHandler).CreatePodSandbox(s.config.SystemContext,
 		sboxName, sboxID,
 		pauseImage,
 		s.config.PauseImageAuthFile,
@@ -540,7 +540,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	}
 
 	resourceCleaner.Add(ctx, "runSandbox: removing pod sandbox from storage: "+sboxID, func() error {
-		return s.ContainerServer.StorageRuntimeServer().DeleteContainer(ctx, sboxID)
+		return s.ContainerServer.StorageRuntimeServer(runtimeHandler).DeleteContainer(ctx, sboxID)
 	})
 
 	mountLabel := podContainer.MountLabel
@@ -593,7 +593,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	// TODO: Pass interface instead of individual field.
 	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox spec configuration")
 
-	if err := s.setPodSandboxMountLabel(ctx, sboxID, result.mountLabel); err != nil {
+	if err := s.setPodSandboxMountLabel(ctx, sboxID, result.mountLabel, runtimeHandler); err != nil {
 		return nil, err
 	}
 
@@ -1570,13 +1570,13 @@ func (s *Server) prepareSandboxMetadataAndLabels(sbox libsandbox.Builder, kubeAn
 func (s *Server) setupSandboxStorage(ctx context.Context, sb *libsandbox.Sandbox, g *generate.Generator, sboxID, sboxName, containerName string, resourceCleaner *resourcestore.ResourceCleaner) (string, error) {
 	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox storage start")
 
-	mountPoint, err := s.ContainerServer.StorageRuntimeServer().StartContainer(sboxID)
+	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StartContainer(sboxID)
 	if err != nil {
 		return "", fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %w", containerName, sb.Name(), sboxID, err)
 	}
 
 	resourceCleaner.Add(ctx, "runSandbox: stopping storage container for sandbox "+sboxID, func() error {
-		if err := s.ContainerServer.StorageRuntimeServer().StopContainer(ctx, sboxID); err != nil {
+		if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StopContainer(ctx, sboxID); err != nil {
 			return fmt.Errorf("could not stop storage container: %s: %w", sboxID, err)
 		}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -518,7 +518,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
-	podContainer, err := s.ContainerServer.StorageRuntimeServer(runtimeHandler).CreatePodSandbox(s.config.SystemContext,
+	podContainer, err := s.ContainerServer.StorageRuntimeServer(sbox).CreatePodSandbox(s.config.SystemContext,
 		sboxName, sboxID,
 		pauseImage,
 		s.config.PauseImageAuthFile,
@@ -540,7 +540,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	}
 
 	resourceCleaner.Add(ctx, "runSandbox: removing pod sandbox from storage: "+sboxID, func() error {
-		return s.ContainerServer.StorageRuntimeServer(runtimeHandler).DeleteContainer(ctx, sboxID)
+		return s.ContainerServer.StorageRuntimeServer(sbox).DeleteContainer(ctx, sboxID)
 	})
 
 	mountLabel := podContainer.MountLabel
@@ -593,7 +593,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 	// TODO: Pass interface instead of individual field.
 	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox spec configuration")
 
-	if err := s.setPodSandboxMountLabel(ctx, sboxID, result.mountLabel, runtimeHandler); err != nil {
+	if err := s.setPodSandboxMountLabel(ctx, sbox, result.mountLabel); err != nil {
 		return nil, err
 	}
 
@@ -1570,13 +1570,13 @@ func (s *Server) prepareSandboxMetadataAndLabels(sbox libsandbox.Builder, kubeAn
 func (s *Server) setupSandboxStorage(ctx context.Context, sb *libsandbox.Sandbox, g *generate.Generator, sboxID, sboxName, containerName string, resourceCleaner *resourcestore.ResourceCleaner) (string, error) {
 	s.resourceStore.SetStageForResource(ctx, sboxName, "sandbox storage start")
 
-	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StartContainer(sboxID)
+	mountPoint, err := s.ContainerServer.StorageRuntimeServer(sb).StartContainer(sboxID)
 	if err != nil {
 		return "", fmt.Errorf("failed to mount container %s in pod sandbox %s(%s): %w", containerName, sb.Name(), sboxID, err)
 	}
 
 	resourceCleaner.Add(ctx, "runSandbox: stopping storage container for sandbox "+sboxID, func() error {
-		if err := s.ContainerServer.StorageRuntimeServer(sb.RuntimeHandler()).StopContainer(ctx, sboxID); err != nil {
+		if err := s.ContainerServer.StorageRuntimeServer(sb).StopContainer(ctx, sboxID); err != nil {
 			return fmt.Errorf("could not stop storage container: %s: %w", sboxID, err)
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -110,7 +110,7 @@ type pullArguments struct {
 	sandboxCgroup string
 	credentials   imageTypes.DockerAuthConfig
 	namespace     string
-	sb            *sandbox.Sandbox
+	imageServer   storage.ImageServer
 }
 
 // pullOperation is used to synchronize parallel pull operations via the

--- a/server/server.go
+++ b/server/server.go
@@ -106,10 +106,11 @@ type Server struct {
 // pullArguments are used to identify a pullOperation via an input image name and
 // possibly specified credentials.
 type pullArguments struct {
-	image         string
-	sandboxCgroup string
-	credentials   imageTypes.DockerAuthConfig
-	namespace     string
+	image          string
+	sandboxCgroup  string
+	credentials    imageTypes.DockerAuthConfig
+	namespace      string
+	runtimeHandler string
 }
 
 // pullOperation is used to synchronize parallel pull operations via the
@@ -171,7 +172,9 @@ func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 	deletedPods := map[string]*sandbox.Sandbox{}
 
 	for i := range containers {
-		metadata, err2 := s.ContainerServer.StorageRuntimeServer().GetContainerMetadata(containers[i].ID)
+		// use the default runtime service here, as ContainerMetadata is not
+		// treated differently for different runtimes.
+		metadata, err2 := s.ContainerServer.StorageRuntimeServer("").GetContainerMetadata(containers[i].ID)
 		if err2 != nil {
 			log.Warnf(ctx, "Error parsing metadata for %s: %v, ignoring", containers[i].ID, err2)
 
@@ -458,7 +461,7 @@ func New(
 		os.Unsetenv("DBUS_SESSION_BUS_ADDRESS")
 	}
 
-	artifactStore, err := ociartifact.NewStore(containerServer.Store().GraphRoot(), config.AdditionalArtifactStores, config.SystemContext, containerServer.StorageImageServer().PinnedImageRegexps())
+	artifactStore, err := ociartifact.NewStore(containerServer.Store().GraphRoot(), config.AdditionalArtifactStores, config.SystemContext, containerServer.StorageImageServer("").PinnedImageRegexps())
 	if err != nil {
 		return nil, err
 	}
@@ -636,9 +639,13 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			metrics.Instance().MetricDefaultRuntimeSet(s.config.DefaultRuntime)
 
 			// ImageServer compiles the list with regex for both
-			// pinned and sandbox/pause images, we need to update them
-			s.ContainerServer.StorageImageServer().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
-			s.artifactStore.SetPinnedImageRegexps(s.ContainerServer.StorageImageServer().PinnedImageRegexps())
+			// pinned and sandbox/pause images, we need to update them.
+			// For this operation, we set the "runtime handler" parameter to "",
+			// so that the default ImageServer is used. There is no need to
+			// update pinned images for runtimes that manage the images themselves.
+			imageService := s.StorageImageServer("")
+			imageService.UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
+			s.artifactStore.SetPinnedImageRegexps(imageService.PinnedImageRegexps())
 			log.Infof(ctx, "Configuration reload completed")
 			// Print the current configuration.
 			tomlConfig, err := s.config.ToString()
@@ -729,7 +736,7 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []storage
 	// disk usage gets too high.
 	if shouldWipeImages {
 		for img := range imageMapToDelete {
-			if err := s.ContainerServer.StorageImageServer().DeleteImage(s.config.SystemContext, img); err != nil {
+			if err := s.ContainerServer.StorageImageManager().DeleteImage(s.config.SystemContext, img); err != nil {
 				log.Warnf(ctx, "Failed to remove image %s: %v", img, err)
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -106,11 +106,11 @@ type Server struct {
 // pullArguments are used to identify a pullOperation via an input image name and
 // possibly specified credentials.
 type pullArguments struct {
-	image          string
-	sandboxCgroup  string
-	credentials    imageTypes.DockerAuthConfig
-	namespace      string
-	runtimeHandler string
+	image         string
+	sandboxCgroup string
+	credentials   imageTypes.DockerAuthConfig
+	namespace     string
+	sb            *sandbox.Sandbox
 }
 
 // pullOperation is used to synchronize parallel pull operations via the
@@ -174,7 +174,7 @@ func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 	for i := range containers {
 		// use the default runtime service here, as ContainerMetadata is not
 		// treated differently for different runtimes.
-		metadata, err2 := s.ContainerServer.StorageRuntimeServer("").GetContainerMetadata(containers[i].ID)
+		metadata, err2 := s.ContainerServer.StorageRuntimeServer(nil).GetContainerMetadata(containers[i].ID)
 		if err2 != nil {
 			log.Warnf(ctx, "Error parsing metadata for %s: %v, ignoring", containers[i].ID, err2)
 
@@ -461,7 +461,7 @@ func New(
 		os.Unsetenv("DBUS_SESSION_BUS_ADDRESS")
 	}
 
-	artifactStore, err := ociartifact.NewStore(containerServer.Store().GraphRoot(), config.AdditionalArtifactStores, config.SystemContext, containerServer.StorageImageServer("").PinnedImageRegexps())
+	artifactStore, err := ociartifact.NewStore(containerServer.Store().GraphRoot(), config.AdditionalArtifactStores, config.SystemContext, containerServer.StorageImageServer(nil).PinnedImageRegexps())
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +643,7 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			// For this operation, we set the "runtime handler" parameter to "",
 			// so that the default ImageServer is used. There is no need to
 			// update pinned images for runtimes that manage the images themselves.
-			imageService := s.StorageImageServer("")
+			imageService := s.StorageImageServer(nil)
 			imageService.UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
 			s.artifactStore.SetPinnedImageRegexps(imageService.PinnedImageRegexps())
 			log.Infof(ctx, "Configuration reload completed")
@@ -736,7 +736,7 @@ func (s *Server) wipeIfAppropriate(ctx context.Context, imagesToDelete []storage
 	// disk usage gets too high.
 	if shouldWipeImages {
 		for img := range imageMapToDelete {
-			if err := s.ContainerServer.StorageImageManager().DeleteImage(s.config.SystemContext, img); err != nil {
+			if err := s.ContainerServer.StorageImageManager().DeleteImage(ctx, s.config.SystemContext, img); err != nil {
 				log.Warnf(ctx, "Failed to remove image %s: %v", img, err)
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -174,7 +174,14 @@ func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 	for i := range containers {
 		// use the default runtime service here, as ContainerMetadata is not
 		// treated differently for different runtimes.
-		metadata, err2 := s.ContainerServer.StorageRuntimeServer(nil).GetContainerMetadata(containers[i].ID)
+		runtimeSvc, err2 := s.StorageRuntimeServer(nil)
+		if err2 != nil {
+			log.Warnf(ctx, "Error getting runtime service for %s: %v, ignoring", containers[i].ID, err2)
+
+			continue
+		}
+
+		metadata, err2 := runtimeSvc.GetContainerMetadata(containers[i].ID)
 		if err2 != nil {
 			log.Warnf(ctx, "Error parsing metadata for %s: %v, ignoring", containers[i].ID, err2)
 
@@ -461,7 +468,12 @@ func New(
 		os.Unsetenv("DBUS_SESSION_BUS_ADDRESS")
 	}
 
-	artifactStore, err := ociartifact.NewStore(containerServer.Store().GraphRoot(), config.AdditionalArtifactStores, config.SystemContext, containerServer.StorageImageServer(nil).PinnedImageRegexps())
+	defaultImageServer, err := containerServer.StorageImageServer(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	artifactStore, err := ociartifact.NewStore(containerServer.Store().GraphRoot(), config.AdditionalArtifactStores, config.SystemContext, defaultImageServer.PinnedImageRegexps())
 	if err != nil {
 		return nil, err
 	}
@@ -643,9 +655,14 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			// For this operation, we set the "runtime handler" parameter to "",
 			// so that the default ImageServer is used. There is no need to
 			// update pinned images for runtimes that manage the images themselves.
-			imageService := s.StorageImageServer(nil)
-			imageService.UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
-			s.artifactStore.SetPinnedImageRegexps(imageService.PinnedImageRegexps())
+			imageService, err := s.StorageImageServer(nil)
+			if err != nil {
+				log.Errorf(ctx, "Failed to get image server during config reload: %v", err)
+			} else {
+				imageService.UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
+				s.artifactStore.SetPinnedImageRegexps(imageService.PinnedImageRegexps())
+			}
+
 			log.Infof(ctx, "Configuration reload completed")
 			// Print the current configuration.
 			tomlConfig, err := s.config.ToString()

--- a/test/kata-remote.bats
+++ b/test/kata-remote.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# vim: set syntax=sh:
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "Container creation with runtime_pull_image=true" {
+	# Skip in non-kata environments where kata binaries aren't installed.
+	# In CI, RUNTIME_TYPE=vm is only set in kata matrix jobs.
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+
+	# Verify the cloud API adaptor (peerpod backend) is running
+	output=$(sudo podman inspect --format '{{.State.Status}}' caa 2> /dev/null || true)
+	[[ "$output" == "running" ]]
+
+	setup_crio
+
+	cat > "$CRIO_CONFIG_DIR/50-kata.conf" <<- EOF
+		[crio.runtime.runtimes.kata-remote]
+		  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+		  runtime_root = "/run/vc"
+		  runtime_type = "vm"
+		  privileged_without_host_devices = true
+		  runtime_config_path = "/opt/kata/share/defaults/kata-containers/configuration-remote.toml"
+		  runtime_pull_image = true
+		  container_create_timeout = 600
+	EOF
+
+	# Increase the kata create_container_timeout — the default (60s) is too
+	# short for peer pod VM boot via the Cloud API Adaptor.
+	local kata_remote_cfg="/opt/kata/share/defaults/kata-containers/configuration-remote.toml"
+	if [[ -f "$kata_remote_cfg" ]]; then
+		sudo sed -i 's/^create_container_timeout\s*=.*/create_container_timeout = 300/' "$kata_remote_cfg"
+	fi
+
+	start_crio_no_setup
+	check_images
+
+	# Verify kata-remote runtime is registered
+	wait_for_log "kata-remote"
+
+	# Remove the container image from local storage so we can verify
+	# that runtime_pull_image=true pulls it inside the peer pod VM,
+	# not into the host's local storage.
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+	crictl rmi "$test_image"
+	output=$(crictl images)
+	[[ "$output" != *"$test_image"* ]]
+
+	# Create pod — use a longer crictl timeout because the remote
+	# hypervisor needs to boot a peer pod VM via the CAA.
+	local runtimeclass=kata-remote
+	pod_id=$(CRICTL_TIMEOUT=5m crictl runp --runtime="$runtimeclass" "$TESTDATA"/sandbox_config.json)
+	[[ -n "$pod_id" ]]
+
+	# Verify pod is ready
+	output=$(crictl inspectp "$pod_id" | jq -r '.status.state')
+	[[ "$output" == "SANDBOX_READY" ]]
+
+	# Create container with image pull
+	ctr_id=$(crictl create --with-pull "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	[[ -n "$ctr_id" ]]
+
+	# Verify image is still NOT in local storage — it was pulled inside the VM
+	output=$(crictl images)
+	[[ "$output" != *"$test_image"* ]]
+
+	# Verify container is created
+	output=$(crictl inspect "$ctr_id" | jq -r '.status.state')
+	[[ "$output" == "CONTAINER_CREATED" ]]
+
+	# Start container
+	crictl start "$ctr_id"
+
+	# Verify container is running
+	output=$(crictl inspect "$ctr_id" | jq -r '.status.state')
+	[[ "$output" == "CONTAINER_RUNNING" ]]
+
+	# Verify workload is functional
+	retry 10 1 crictl exec "$ctr_id" echo ok
+
+	# Cleanup
+	crictl stop "$ctr_id"
+	crictl rm "$ctr_id"
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+
+	# Verify pod is gone
+	run ! crictl inspectp "$pod_id"
+}

--- a/test/kata-remote.bats
+++ b/test/kata-remote.bats
@@ -97,3 +97,69 @@ function teardown() {
 	# Verify pod is gone
 	run ! crictl inspectp "$pod_id"
 }
+
+@test "runtime_pull_image: image cache is restored after CRI-O restart" {
+	# Skip in non-kata environments where kata binaries aren't installed.
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+
+	# Verify the cloud API adaptor (peerpod backend) is running
+	output=$(sudo podman inspect --format '{{.State.Status}}' caa 2> /dev/null || true)
+	[[ "$output" == "running" ]]
+
+	setup_crio
+
+	cat > "$CRIO_CONFIG_DIR/50-kata.conf" <<- EOF
+		[crio.runtime.runtimes.kata-remote]
+		  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+		  runtime_root = "/run/vc"
+		  runtime_type = "vm"
+		  privileged_without_host_devices = true
+		  runtime_config_path = "/opt/kata/share/defaults/kata-containers/configuration-remote.toml"
+		  runtime_pull_image = true
+		  container_create_timeout = 600
+	EOF
+
+	local kata_remote_cfg="/opt/kata/share/defaults/kata-containers/configuration-remote.toml"
+	if [[ -f "$kata_remote_cfg" ]]; then
+		sudo sed -i 's/^create_container_timeout\s*=.*/create_container_timeout = 300/' "$kata_remote_cfg"
+	fi
+
+	start_crio_no_setup
+	wait_for_log "kata-remote"
+
+	local runtimeclass=kata-remote
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+
+	# Create a pod using the kata-remote runtime (which has runtime_pull_image=true).
+	pod_id=$(CRICTL_TIMEOUT=5m crictl runp --runtime="$runtimeclass" "$TESTDATA"/sandbox_config.json)
+	[[ -n "$pod_id" ]]
+
+	# Create container with image pull
+	ctr_id=$(crictl create --with-pull "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	[[ -n "$ctr_id" ]]
+
+	# Start container and stop it
+	# This is a workaround for a kata-side problem with deleting a container
+	# that was not started.
+	# To be fixed on the kata side.
+	crictl start "$ctr_id"
+	crictl stop "$ctr_id"
+
+	# Remove the container but keep the pod so its run directory (which holds the
+	# artifact store) is preserved across the restart.
+	crictl rm "$ctr_id"
+
+	# Restart CRI-O. The pod state and artifact store on disk survive the restart,
+	# but the known images cache is gone.
+	restart_crio
+
+	# After restart, attempt to create a container WITHOUT --with-pull.
+	# The image information should be loaded from the artifact store, and the
+	# container creation should succeed.
+	crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json
+
+	# Verify via the CRI-O log that we actually restored the previously pulled image.
+	wait_for_log "runtimePulledImageService: restored 1"
+}

--- a/test/kata-remote.bats
+++ b/test/kata-remote.bats
@@ -11,19 +11,9 @@ function teardown() {
 	cleanup_test
 }
 
-@test "Container creation with runtime_pull_image=true" {
-	# Skip in non-kata environments where kata binaries aren't installed.
-	# In CI, RUNTIME_TYPE=vm is only set in kata matrix jobs.
-	if [[ $RUNTIME_TYPE != vm ]]; then
-		skip "Not running with kata"
-	fi
-
-	# Verify the cloud API adaptor (peerpod backend) is running
-	output=$(sudo podman inspect --format '{{.State.Status}}' caa 2> /dev/null || true)
-	[[ "$output" == "running" ]]
-
-	setup_crio
-
+# kata_remote_conf writes the kata-remote runtime drop-in config and adjusts
+# the kata container timeout. Call after setup_crio but before start_crio_no_setup.
+function kata_remote_conf() {
 	cat > "$CRIO_CONFIG_DIR/50-kata.conf" <<- EOF
 		[crio.runtime.runtimes.kata-remote]
 		  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
@@ -35,13 +25,42 @@ function teardown() {
 		  container_create_timeout = 600
 	EOF
 
-	# Increase the kata create_container_timeout — the default (60s) is too
-	# short for peer pod VM boot via the Cloud API Adaptor.
 	local kata_remote_cfg="/opt/kata/share/defaults/kata-containers/configuration-remote.toml"
 	if [[ -f "$kata_remote_cfg" ]]; then
 		sudo sed -i 's/^create_container_timeout\s*=.*/create_container_timeout = 300/' "$kata_remote_cfg"
 	fi
+}
 
+# require_caa asserts that the Cloud API Adaptor peer pod backend is running.
+# Tests that call this will fail when the CAA container is absent.
+function require_caa() {
+	local caa_status
+	caa_status=$(sudo podman inspect --format '{{.State.Status}}' caa 2> /dev/null || true)
+	[[ "$caa_status" == "running" ]]
+}
+
+function cleanup() {
+	local ctr_id=$1
+	local pod_id=$2
+
+	crictl stop "$ctr_id"
+	crictl rm "$ctr_id"
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+
+}
+
+@test "Container creation with runtime_pull_image=true" {
+	# Skip in non-kata environments where kata binaries aren't installed.
+	# In CI, RUNTIME_TYPE=vm is only set in kata matrix jobs.
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+
+	require_caa
+
+	setup_crio
+	kata_remote_conf
 	start_crio_no_setup
 	check_images
 
@@ -88,11 +107,7 @@ function teardown() {
 	# Verify workload is functional
 	retry 10 1 crictl exec "$ctr_id" echo ok
 
-	# Cleanup
-	crictl stop "$ctr_id"
-	crictl rm "$ctr_id"
-	crictl stopp "$pod_id"
-	crictl rmp "$pod_id"
+	cleanup "$ctr_id" "$pod_id"
 
 	# Verify pod is gone
 	run ! crictl inspectp "$pod_id"
@@ -104,28 +119,10 @@ function teardown() {
 		skip "Not running with kata"
 	fi
 
-	# Verify the cloud API adaptor (peerpod backend) is running
-	output=$(sudo podman inspect --format '{{.State.Status}}' caa 2> /dev/null || true)
-	[[ "$output" == "running" ]]
+	require_caa
 
 	setup_crio
-
-	cat > "$CRIO_CONFIG_DIR/50-kata.conf" <<- EOF
-		[crio.runtime.runtimes.kata-remote]
-		  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
-		  runtime_root = "/run/vc"
-		  runtime_type = "vm"
-		  privileged_without_host_devices = true
-		  runtime_config_path = "/opt/kata/share/defaults/kata-containers/configuration-remote.toml"
-		  runtime_pull_image = true
-		  container_create_timeout = 600
-	EOF
-
-	local kata_remote_cfg="/opt/kata/share/defaults/kata-containers/configuration-remote.toml"
-	if [[ -f "$kata_remote_cfg" ]]; then
-		sudo sed -i 's/^create_container_timeout\s*=.*/create_container_timeout = 300/' "$kata_remote_cfg"
-	fi
-
+	kata_remote_conf
 	start_crio_no_setup
 	wait_for_log "kata-remote"
 
@@ -158,8 +155,298 @@ function teardown() {
 	# After restart, attempt to create a container WITHOUT --with-pull.
 	# The image information should be loaded from the artifact store, and the
 	# container creation should succeed.
-	crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
 
 	# Verify via the CRI-O log that we actually restored the previously pulled image.
 	wait_for_log "runtimePulledImageService: restored 1"
+}
+
+@test "runtime_pull_image: pull without sandbox context uses main store" {
+	# Requires a kata environment so that the handler binary exists and CRI-O
+	# registers the handler. Does not require the Cloud API Adaptor.
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+
+	setup_crio
+	kata_remote_conf
+	start_crio_no_setup
+	check_images
+	wait_for_log "kata-remote"
+
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+	# Ensure a clean slate in the main store.
+	crictl rmi "$test_image" || true
+
+	# Pull with no sandbox config — PullImage routes to the default store
+	# regardless of any handler's runtime_pull_image setting.
+	crictl pull "$test_image"
+
+	# The image must now be visible in the main store.
+	[[ -n "$(crictl images --quiet "$test_image")" ]]
+}
+
+@test "runtime_pull_image: crictl images excludes runtime-pulled images" {
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+	require_caa
+
+	setup_crio
+	kata_remote_conf
+	start_crio_no_setup
+	check_images
+	wait_for_log "kata-remote"
+
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+	# Remove from main store so it can only be found if routing is wrong.
+	crictl rmi "$test_image" || true
+
+	local pod_id
+	pod_id=$(CRICTL_TIMEOUT=5m crictl runp --runtime=kata-remote "$TESTDATA"/sandbox_config.json)
+	[[ -n "$pod_id" ]]
+
+	# Pull happens inside the VM; the manifest is stored in the per-sandbox artifact store.
+	local ctr_id
+	ctr_id=$(crictl create --with-pull "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	[[ -n "$ctr_id" ]]
+
+	# ListImages uses the default (local) store only.
+	# A runtime-pulled image must not appear there.
+	output=$(crictl images)
+	[[ "$output" != *"$test_image"* ]]
+
+	crictl start "$ctr_id"
+	cleanup "$ctr_id" "$pod_id"
+}
+
+@test "runtime_pull_image: crictl image status is empty for runtime-pulled image" {
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+	require_caa
+
+	setup_crio
+	kata_remote_conf
+	start_crio_no_setup
+	check_images
+	wait_for_log "kata-remote"
+
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+	crictl rmi "$test_image" || true
+
+	local pod_id
+	pod_id=$(CRICTL_TIMEOUT=5m crictl runp --runtime=kata-remote "$TESTDATA"/sandbox_config.json)
+	[[ -n "$pod_id" ]]
+
+	local ctr_id
+	ctr_id=$(crictl create --with-pull "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	[[ -n "$ctr_id" ]]
+
+	# Extract the image ID that CRI-O assigned to the runtime-pulled image.
+	# IDStringForOutOfProcessConsumptionOnly() returns bare 64-char hex (no sha256: prefix).
+	local image_id
+	image_id=$(grep "Pulled image:" "$CRIO_LOG" | tail -1 | grep -oE '[0-9a-f]{64}' | tail -1)
+	[[ -n "$image_id" ]]
+
+	# ImageStatus uses the default (local) store only.
+	# The runtime-pulled image must not appear, so the response has no image ID.
+	output=$(crictl image status "$test_image" 2>&1)
+	[[ "$output" != *"$image_id"* ]]
+
+	crictl start "$ctr_id"
+	cleanup "$ctr_id" "$pod_id"
+}
+
+@test "runtime_pull_image: sandbox removal evicts the per-sandbox image service cache" {
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+	require_caa
+
+	setup_crio
+	kata_remote_conf
+	start_crio_no_setup
+	check_images
+	wait_for_log "kata-remote"
+
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+	crictl rmi "$test_image" || true
+
+	# Pull the image into pod A's per-sandbox artifact store.
+	local pod_a
+	pod_a=$(CRICTL_TIMEOUT=5m crictl runp --runtime=kata-remote "$TESTDATA"/sandbox_config.json)
+	[[ -n "$pod_a" ]]
+
+	local ctr_id
+	ctr_id=$(crictl create --with-pull "$pod_a" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	[[ -n "$ctr_id" ]]
+
+	crictl start "$ctr_id"
+	crictl stop "$ctr_id"
+	crictl rm "$ctr_id"
+
+	# Remove pod A — RemoveImageService evicts the per-sandbox cache and
+	# removes the on-disk artifact store under the pod's run directory.
+	crictl stopp "$pod_a"
+	crictl rmp "$pod_a"
+
+	# Pod B is a fresh sandbox with its own empty artifact store.
+	local pod_b
+	pod_b=$(CRICTL_TIMEOUT=5m crictl runp --runtime=kata-remote "$TESTDATA"/sandbox_config.json)
+	[[ -n "$pod_b" ]]
+
+	# Without --with-pull the image is not available for pod B.
+	run ! crictl create "$pod_b" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json
+
+	crictl stopp "$pod_b"
+	crictl rmp "$pod_b"
+}
+
+@test "runtime_pull_image: same image stored in artifact store for kata and containers/storage for default" {
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+	require_caa
+
+	setup_crio
+	kata_remote_conf
+
+	start_crio_no_setup
+	wait_for_log "kata-remote"
+
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+	crictl rmi "$test_image" || true
+
+	# Create the kata pod (runtime_pull_image=true) and pull the image.
+	# Only a manifest is written into the per-sandbox artifact store;
+	# no layers land in the host containers/storage.
+	local kata_pod_id
+	kata_pod_id=$(CRICTL_TIMEOUT=5m crictl runp --runtime=kata-remote "$TESTDATA"/sandbox_config.json)
+	[[ -n "$kata_pod_id" ]]
+
+	local kata_ctr_id
+	kata_ctr_id=$(crictl create --with-pull "$kata_pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	[[ -n "$kata_ctr_id" ]]
+	crictl start "$kata_ctr_id"
+
+	# The image must be absent from the host-side image list: it was stored
+	# in the per-sandbox artifact store, not in containers/storage.
+	[[ -z "$(crictl images --quiet "$test_image")" ]]
+
+	# The per-sandbox artifact store must exist and contain an OCI layout
+	# index, confirming that only the manifest was persisted on the host.
+	local kata_artifact_dir
+	kata_artifact_dir=$(sudo find "$TESTDIR/crio-run" -type d -name "artifacts" 2> /dev/null | grep "/$kata_pod_id/" | head -1)
+	[[ -n "$kata_artifact_dir" ]]
+	[[ -f "$kata_artifact_dir/index.json" ]]
+
+	# Create the default (crun) pod and pull the same image with --with-pull.
+	# It must land in containers/storage as a regular image because crun does
+	# not have runtime_pull_image=true.
+	# Use a distinct UID so CRI-O doesn't mistake this for the still-running
+	# kata pod (same name/namespace/attempt would cause a name-index collision
+	# and return the kata pod ID instead of creating a fresh sandbox).
+	local default_sandbox_config
+	default_sandbox_config=$(mktemp "$TESTDIR/sandbox-XXXXXX.json")
+	jq '.metadata.uid = "redhat-test-crio-default"' "$TESTDATA"/sandbox_config.json > "$default_sandbox_config"
+
+	local default_pod_id
+	default_pod_id=$(crictl runp --runtime=crun "$default_sandbox_config")
+	[[ -n "$default_pod_id" ]]
+
+	local default_ctr_id
+	default_ctr_id=$(crictl create --with-pull "$default_pod_id" "$TESTDATA"/container_sleep.json "$default_sandbox_config")
+	[[ -n "$default_ctr_id" ]]
+
+	# The image must now appear in the host-side image list: it was pulled
+	# into containers/storage by the default handler.
+	[[ -n "$(crictl images --quiet "$test_image")" ]]
+
+	cleanup "$kata_ctr_id" "$kata_pod_id"
+	cleanup "$default_ctr_id" "$default_pod_id"
+}
+
+@test "runtime_pull_image: runtimePulledImageService pulls own manifest even when image is already in containers/storage" {
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+	require_caa
+
+	setup_crio
+	kata_remote_conf
+	start_crio_no_setup
+	wait_for_log "kata-remote"
+
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+
+	# Pull the image into the host containers/storage directly.
+	crictl pull "$test_image"
+	[[ -n "$(crictl images --quiet "$test_image")" ]]
+
+	# Record the log position right after this pull so we can detect a
+	# separate pull event later.
+	wait_for_log "Pulled image:"
+	local after_first_pull="$LAST_TIMESTAMP"
+
+	# Create the kata pod and pull the same image with --with-pull.
+	# Even though the image is already in containers/storage, the
+	# runtimePulledImageService must do its own pull into the per-sandbox
+	# artifact store rather than silently reusing the containers/storage copy.
+	local kata_pod_id
+	kata_pod_id=$(CRICTL_TIMEOUT=5m crictl runp --runtime=kata-remote "$TESTDATA"/sandbox_config.json)
+	[[ -n "$kata_pod_id" ]]
+
+	ctr_id=$(crictl create --with-pull "$kata_pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+
+	# A second "Pulled image:" entry must appear after the first pull,
+	# confirming the runtimePulledImageService performed an independent pull.
+	wait_for_log "Pulled image:" "$after_first_pull"
+
+	# The per-sandbox artifact store must also carry an independent OCI manifest.
+	local kata_artifact_dir
+	kata_artifact_dir=$(sudo find "$TESTDIR/crio-run" -type d -name "artifacts" 2> /dev/null | grep "/$kata_pod_id/" | head -1)
+	[[ -n "$kata_artifact_dir" ]]
+	[[ -f "$kata_artifact_dir/index.json" ]]
+
+	crictl start "$ctr_id"
+	cleanup "$ctr_id" "$kata_pod_id"
+}
+
+@test "runtime_pull_image: pulling the same image twice is idempotent" {
+	if [[ $RUNTIME_TYPE != vm ]]; then
+		skip "Not running with kata"
+	fi
+	require_caa
+
+	setup_crio
+	kata_remote_conf
+	start_crio_no_setup
+	check_images
+	wait_for_log "kata-remote"
+
+	local test_image="quay.io/crio/fedora-crio-ci:latest"
+	crictl rmi "$test_image" || true
+
+	local pod_id
+	pod_id=$(CRICTL_TIMEOUT=5m crictl runp --runtime=kata-remote "$TESTDATA"/sandbox_config.json)
+	[[ -n "$pod_id" ]]
+
+	# First pull.
+	local ctr1_id
+	ctr1_id=$(crictl create --with-pull "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	[[ -n "$ctr1_id" ]]
+
+	crictl start "$ctr1_id"
+	crictl stop "$ctr1_id"
+	crictl rm "$ctr1_id"
+
+	# Second pull of the same image for the same sandbox — must succeed and
+	# leave the artifact store in a valid state.
+	local ctr2_id
+	ctr2_id=$(crictl create --with-pull "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	[[ -n "$ctr2_id" ]]
+
+	crictl start "$ctr2_id"
+	cleanup "$ctr2_id" "$pod_id"
 }

--- a/test/mocks/ociartifact/datastore/datastore.go
+++ b/test/mocks/ociartifact/datastore/datastore.go
@@ -113,6 +113,21 @@ func (mr *MockLibartifactStoreMockRecorder) BlobMountPaths(ctx, asr, opts any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlobMountPaths", reflect.TypeOf((*MockLibartifactStore)(nil).BlobMountPaths), ctx, asr, opts)
 }
 
+// List mocks base method.
+func (m *MockLibartifactStore) List(ctx context.Context) (libartifact.ArtifactList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", ctx)
+	ret0, _ := ret[0].(libartifact.ArtifactList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockLibartifactStoreMockRecorder) List(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockLibartifactStore)(nil).List), ctx)
+}
+
 // Pull mocks base method.
 func (m *MockLibartifactStore) Pull(ctx context.Context, ref libartifact.ArtifactReference, opts libimage.CopyOptions) (digest.Digest, error) {
 	m.ctrl.T.Helper()
@@ -126,4 +141,19 @@ func (m *MockLibartifactStore) Pull(ctx context.Context, ref libartifact.Artifac
 func (mr *MockLibartifactStoreMockRecorder) Pull(ctx, ref, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pull", reflect.TypeOf((*MockLibartifactStore)(nil).Pull), ctx, ref, opts)
+}
+
+// Remove mocks base method.
+func (m *MockLibartifactStore) Remove(ctx context.Context, asr libartifact.ArtifactStoreReference) (*digest.Digest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Remove", ctx, asr)
+	ret0, _ := ret[0].(*digest.Digest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Remove indicates an expected call of Remove.
+func (mr *MockLibartifactStoreMockRecorder) Remove(ctx, asr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockLibartifactStore)(nil).Remove), ctx, asr)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

With #7471 we introduced a way to support Confidential Container's feature of pulling the image in the guest VM.
When this happens, cri-o is still pulling the image on the host, because kubernetes keeps sending the "PullImageRequest", and cri-o has no reason to not process it.

This has two drawbacks:
- it is a waste of time and resources, as the image that crio will pull and prepare will not be used anyway
- it can block the actual execution of the container in the Confidential Container use case: if the image is encrypted, and the key is not shared with crio, then crio will fail to prepare the image because it can't read it.
  This failure will block the container creation, as kubernetes will not proceed with CreateContainer if PullImage failed.

This PR is meant to make crio skip the pull image phase when the runtime is configured with the "runtime_pull_image" flag introduced in #7471

#### Which issue(s) this PR fixes:

Fixes: #8261

#### Special notes for your reviewer:

This PR is a follow-up to https://github.com/cri-o/cri-o/pull/8008
It tries to address some of the problems raised for it, while rebasing on the latest code.

### Design and open questions

#### Creating a separate workflow for Confidential Containers

A lot of the work done on this PR compared to #8008 is to add a separate implementation of ImageServer and RuntimeServer to handle the specific behavior of Confidential Containers.
In this respect, I have done the following:
- introduce a "manager" object for each service, allowing to keep two instances of ImageServer and RuntimeServer : one for containers running with a regular workflow (using the existing implementation), and the other for the Confidential Container use case, where the runtime class is configured to delegate the image management to the runtime.
- implemented runtimePulledImageService and runtimePulledRuntimeService
- modify the callers to provide the sandbox object as parameter whenever possible when accessing the ImageServer or RuntimeServer. The sandbox object is used to check which ImageServer/RuntimeServer must be used, and where to store the needed metadata (see below).

#### Reduce the amount of I/O done to retrieve the needed information

To be able to build internal IDs and data structures, we need to retrieve some information from the repository.
In #8008, this was done every time we needed to access this information.
To reduce the amount of I/Os, this PR retrieves the manifests and config during the PullImage request, and stores this information in memory, for later use by the modified services.
This cache is rebuilt from the locally stored metadata when CRI-O is restarted.

#### Store location and data lifecycle

To avoid mixing incomplete image data with the actual image store, we use a separate location for the store.
One aspect of it is the data lifecycle: cri-o doesn't need to keep this information longer than the pod's existence - when the pod goes away, the image it contains disappears too, so cri-o should remove this image reference from its store.
This PR uses the pod's storage to store this metadata, so that it is effectively deleted along with the pod, thanks to the existing pod cleanup code.
This is kept as a separate commit in the PR, because it makes the change more complex and further crosses the boundary between image and container management. 

#### Testing

This PR doesn't provide a test that dedicated to this use case. Testing it requires some Confidential Containers components that are not integrated to the kata side of our tests.
Our integration test makes sure the required components are installed and used for this specific use case. In the long run, will may want to add a whole "peer-pods" test, in addition to the existing "kata" test, to run all cri-o's integration tests in a remote hypervisor scenario.

Manual testing with crictl and crio in an environment where all the tools are installed is possible, but requires to configure crictl with the config option "pull-image-on-create", or call it with the "--with-pull" parameter, so that the sandbox information is provided as part of the pull (like Kubernetes does). Without this, or if we run "crictl pull" directly, crio fails to use the right ImageServer to perform the pull, and the test fails.

This PR was tested both with crio/crictl, and with a full Openshift cluster.

#### Does this PR introduce a user-facing change?

```release-note
Support for encrypted container images in Confidential Containers use case: cri-o will now ignore the container image layers, allowing the underlying Confidential Container runtime to manage the image pull management.
This makes sure that Confidential Containers can use encrypted containers without sharing the encryption key with cri-o, allowing a fully confidential use case.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-runtime image & runtime selection for storage operations; managers introduced to pick services per runtime.
  * VM-oriented image path that fetches image metadata/config without full layer pulls.
  * Artifact store option to allow image artifacts and a config-only pull API.

* **Bug Fixes**
  * Storage ops routed per-sandbox/runtime handler for better isolation.
  * Improved sandbox lookup and contextual error handling during restore, checkpoint, and lifecycle flows.

* **Tests / CI**
  * Kata-remote CI setup and new Bats test validating VM image-pull behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->