### PR TITLE
cnimgr: add configurable grace period for CNI status monitoring

### DIFF
--- a/internal/config/cnimgr/cnimgr.go
+++ b/internal/config/cnimgr/cnimgr.go
@@ -25,11 +25,13 @@ type CNIManager struct {
 	cancel              context.CancelFunc
 	initPollInterval    time.Duration
 	monitorPollInterval time.Duration
+	gracePeriod         time.Duration
+	firstFailureTime    time.Time
 
 	validPodList PodNetworkLister
 }
 
-func New(defaultNetwork, networkDir string, pluginDirs ...string) (*CNIManager, error) {
+func New(defaultNetwork, networkDir string, gracePeriod time.Duration, pluginDirs ...string) (*CNIManager, error) {
 	// Init CNI plugin
 	plugin, err := ocicni.InitCNI(
 		defaultNetwork, networkDir, pluginDirs...,
@@ -46,6 +48,7 @@ func New(defaultNetwork, networkDir string, pluginDirs ...string) (*CNIManager, 
 		cancel:              cancel,
 		initPollInterval:    500 * time.Millisecond,
 		monitorPollInterval: 5 * time.Second,
+		gracePeriod:         gracePeriod,
 	}
 
 	go mgr.pollContinuously(ctx)
@@ -78,12 +81,35 @@ func (c *CNIManager) statusPollFunc(ctx context.Context, isStartup bool) (bool, 
 	defer c.mutex.Unlock()
 
 	if err := c.plugin.StatusWithContext(ctx); err != nil {
+		// During Phase 2 monitoring, apply a grace period before reporting
+		// unhealthy. This tolerates brief CNI disruptions (e.g. OVN-K
+		// daemonset rollout where the plugin is unavailable for ~10-15s).
+		if !isStartup && c.lastError == nil && c.gracePeriod > 0 {
+			if c.firstFailureTime.IsZero() {
+				c.firstFailureTime = time.Now()
+				logrus.Warnf("CNI plugin status check failed, will report unhealthy after grace period (%v): %v", c.gracePeriod, err)
+			}
+
+			if time.Since(c.firstFailureTime) < c.gracePeriod {
+				return false, nil
+			}
+
+			logrus.Errorf("CNI plugin unhealthy beyond grace period (%v): %v", c.gracePeriod, err)
+		} else if c.lastError == nil {
+			logrus.Errorf("CNI plugin became unhealthy: %v", err)
+		}
+
 		c.lastError = err
 
 		return false, nil
 	}
 
+	// Plugin is healthy -- reset grace period timer
+	c.firstFailureTime = time.Time{}
+
 	if c.lastError != nil {
+		logrus.Infof("CNI plugin is now healthy (was: %v)", c.lastError)
+
 		c.lastError = nil
 		// on startup, GC might have been attempted before the plugin was
 		// actually ready so we might have deferred it until now, which is

--- a/internal/config/cnimgr/cnimgr_test.go
+++ b/internal/config/cnimgr/cnimgr_test.go
@@ -529,3 +529,210 @@ func TestStatusPolling(t *testing.T) {
 		}
 	})
 }
+
+func newTestManagerWithGrace(plugin *fakeCNIPlugin, gracePeriod time.Duration) *CNIManager {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mgr := &CNIManager{
+		plugin:              plugin,
+		lastError:           errors.New("plugin status uninitialized"),
+		cancel:              cancel,
+		initPollInterval:    testPollInterval,
+		monitorPollInterval: testPollInterval,
+		gracePeriod:         gracePeriod,
+	}
+
+	go mgr.pollContinuously(ctx)
+
+	return mgr
+}
+
+func TestGracePeriod(t *testing.T) {
+	t.Run("tolerates brief failure within grace period", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+		mgr := newTestManagerWithGrace(fake, 2*time.Second)
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		fake.setStatusErr(errors.New("plugin down"))
+		time.Sleep(200 * time.Millisecond)
+
+		if mgr.ReadyOrError() != nil {
+			t.Fatal("expected still ready within grace period")
+		}
+
+		fake.setStatusErr(nil)
+		time.Sleep(100 * time.Millisecond)
+
+		if mgr.ReadyOrError() != nil {
+			t.Fatal("expected ready after recovery within grace period")
+		}
+	})
+
+	t.Run("reports unhealthy after grace period expires", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+		mgr := newTestManagerWithGrace(fake, 200*time.Millisecond)
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		fake.setStatusErr(errors.New("plugin down"))
+
+		waitFor(t, "not-ready after grace period", func() bool {
+			return mgr.ReadyOrError() != nil
+		})
+	})
+
+	t.Run("zero grace period reports immediately", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+		mgr := newTestManagerWithGrace(fake, 0)
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		fake.setStatusErr(errors.New("plugin down"))
+
+		waitFor(t, "not-ready immediately", func() bool {
+			return mgr.ReadyOrError() != nil
+		})
+	})
+
+	t.Run("grace timer resets after recovery", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+		mgr := newTestManagerWithGrace(fake, 500*time.Millisecond)
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		// First failure -- recover within grace
+		fake.setStatusErr(errors.New("plugin down"))
+		time.Sleep(200 * time.Millisecond)
+		fake.setStatusErr(nil)
+
+		waitFor(t, "recovered", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		// Second failure -- grace timer should have reset
+		fake.setStatusErr(errors.New("plugin down again"))
+		time.Sleep(200 * time.Millisecond)
+
+		if mgr.ReadyOrError() != nil {
+			t.Fatal("expected still ready -- grace timer should have reset")
+		}
+
+		fake.setStatusErr(nil)
+		time.Sleep(100 * time.Millisecond)
+
+		if mgr.ReadyOrError() != nil {
+			t.Fatal("expected ready after second recovery")
+		}
+	})
+
+	t.Run("startup phase ignores grace period", func(t *testing.T) {
+		fake := &fakeCNIPlugin{statusErr: errors.New("not yet")}
+		mgr := newTestManagerWithGrace(fake, 2*time.Second)
+
+		defer mgr.Shutdown()
+
+		time.Sleep(100 * time.Millisecond)
+
+		if mgr.ReadyOrError() == nil {
+			t.Fatal("expected not-ready during startup despite grace period")
+		}
+
+		fake.setStatusErr(nil)
+
+		waitFor(t, "ready after startup recovery", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+	})
+
+	t.Run("self-heals after grace period expiry", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+		mgr := newTestManagerWithGrace(fake, 200*time.Millisecond)
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		fake.setStatusErr(errors.New("plugin down"))
+
+		waitFor(t, "not-ready after grace", func() bool {
+			return mgr.ReadyOrError() != nil
+		})
+
+		fake.setStatusErr(nil)
+
+		waitFor(t, "recovered", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+	})
+
+	t.Run("watcher notified only after grace period expires", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+		mgr := newTestManagerWithGrace(fake, 200*time.Millisecond)
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		fake.setStatusErr(errors.New("plugin down"))
+
+		waitFor(t, "not-ready after grace", func() bool {
+			return mgr.ReadyOrError() != nil
+		})
+
+		watcher := mgr.AddWatcher()
+
+		fake.setStatusErr(nil)
+
+		select {
+		case ready := <-watcher:
+			if !ready {
+				t.Fatal("expected watcher to receive true on recovery")
+			}
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for watcher on recovery")
+		}
+	})
+
+	t.Run("multiple flaps within grace period", func(t *testing.T) {
+		fake := &fakeCNIPlugin{}
+		mgr := newTestManagerWithGrace(fake, 2*time.Second)
+
+		defer mgr.Shutdown()
+
+		waitFor(t, "initial ready", func() bool {
+			return mgr.ReadyOrError() == nil
+		})
+
+		for range 3 {
+			fake.setStatusErr(errors.New("plugin down"))
+			time.Sleep(50 * time.Millisecond)
+			fake.setStatusErr(nil)
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		if mgr.ReadyOrError() != nil {
+			t.Fatal("expected ready -- all flaps were within grace period")
+		}
+	})
+}

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -527,6 +527,10 @@ func mergeNetworkConfig(config *libconfig.Config, ctx *cli.Context) {
 	if ctx.IsSet("cni-plugin-dir") {
 		config.PluginDirs = StringSliceTrySplit(ctx, "cni-plugin-dir")
 	}
+
+	if ctx.IsSet("cni-status-grace-period") {
+		config.CNIStatusGracePeriod = ctx.Duration("cni-status-grace-period")
+	}
 }
 
 // mergeAPIConfig merges APIConfig-related CLI flags into the config, including gRPC and streaming settings.
@@ -1021,6 +1025,12 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 			Value:   cli.NewStringSlice(defConf.PluginDir),
 			Usage:   "CNI plugin binaries directory.",
 			EnvVars: []string{"CONTAINER_CNI_PLUGIN_DIR"},
+		},
+		&cli.DurationFlag{
+			Name:    "cni-status-grace-period",
+			Usage:   "Duration to wait before reporting CNI plugin as unhealthy after a status check failure. Tolerates brief CNI disruptions during plugin upgrades. Set to 0 for immediate reporting.",
+			Value:   defConf.CNIStatusGracePeriod,
+			EnvVars: []string{"CNI_STATUS_GRACE_PERIOD"},
 		},
 		&cli.StringFlag{
 			Name:  "image-volumes",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -716,6 +716,12 @@ type NetworkConfig struct {
 	// PluginDirs is where CNI plugin binaries are stored.
 	PluginDirs []string `toml:"plugin_dirs"`
 
+	// CNIStatusGracePeriod is the duration to wait before reporting the CNI
+	// plugin as unhealthy after a status check failure. This tolerates brief
+	// CNI disruptions during plugin upgrades (e.g. OVN-K daemonset rollout).
+	// Set to 0 for immediate reporting.
+	CNIStatusGracePeriod time.Duration `toml:"cni_status_grace_period"`
+
 	// cniManager manages the internal ocicni plugin
 	cniManager *cnimgr.CNIManager
 }
@@ -1098,8 +1104,9 @@ func DefaultConfig() (*Config, error) {
 			NamespacedAuthDir:       cpConfig.AuthDir,
 		},
 		NetworkConfig: NetworkConfig{
-			NetworkDir: cniConfigDir,
-			PluginDirs: []string{cniBinDir},
+			NetworkDir:           cniConfigDir,
+			PluginDirs:           []string{cniBinDir},
+			CNIStatusGracePeriod: 60 * time.Second,
 		},
 		MetricsConfig: MetricsConfig{
 			MetricsHost:       "127.0.0.1",
@@ -1915,7 +1922,7 @@ func (c *NetworkConfig) Validate(onExecution bool) error {
 
 		// Init CNI plugin
 		cniManager, err := cnimgr.New(
-			c.CNIDefaultNetwork, c.NetworkDir, c.PluginDirs...,
+			c.CNIDefaultNetwork, c.NetworkDir, c.CNIStatusGracePeriod, c.PluginDirs...,
 		)
 		if err != nil {
 			return fmt.Errorf("initialize CNI plugin: %w", err)


### PR DESCRIPTION
/kind api-change
/kind bug
During CNI plugin upgrades (e.g. OVN-K daemonset rollout), the plugin becomes briefly unavailable (~10-15s). Without a grace period, CRI-O immediately reports NetworkReady=false to kubelet, which marks the node NotReady and disrupts pod scheduling.

Add a configurable grace period (default 60s) that tolerates brief CNI disruptions. When the plugin was previously healthy and a status check fails, CRI-O waits for the grace period before reporting unhealthy. If the plugin recovers within the grace window, no disruption is visible to kubelet or the scheduler.

The grace period only applies to Phase 2 (runtime monitoring). Startup polling (Phase 1) is unaffected -- failures are reported immediately until the plugin is first ready.

Configuration:
- crio.conf: cni_status_grace_period = "60s" under [crio.network]
- CLI: --cni-status-grace-period=60s
- Env: CNI_STATUS_GRACE_PERIOD=60s
- Set to 0s for immediate reporting (no grace)


Made-with: Cursor

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
