### PR TITLE
Use compact logging only for List* RPCs

### DIFF
--- a/internal/log/interceptors/interceptors.go
+++ b/internal/log/interceptors/interceptors.go
@@ -3,6 +3,7 @@ package interceptors
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -62,7 +63,15 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 		operationStart := time.Now()
 		operation := filepath.Base(info.FullMethod)
 		newCtx, span := opentelemetry.Tracer().Start(AddRequestNameAndID(ctx, info.FullMethod), info.FullMethod)
-		log.Debugf(newCtx, "Request: %T: %+v", req, req)
+
+		// List* RPCs can return large payloads; use compact format to avoid
+		// enormous log messages that cause gRPC timeouts (see issue #9894).
+		isList := strings.HasPrefix(operation, "List")
+		if isList {
+			log.Debugf(newCtx, "Request: %#v", req)
+		} else {
+			log.Debugf(newCtx, "Request: %T: %+v", req, req)
+		}
 
 		resp, err := handler(newCtx, req)
 		// record the operation
@@ -70,10 +79,13 @@ func UnaryInterceptor() grpc.UnaryServerInterceptor {
 		metrics.Instance().MetricOperationsLatencySet(operation, operationStart)
 		metrics.Instance().MetricOperationsLatencyTotalObserve(operation, operationStart)
 
-		if err != nil {
+		switch {
+		case err != nil:
 			log.Debugf(newCtx, "Response error: %+v", err)
 			metrics.Instance().MetricOperationsErrorsInc(operation)
-		} else {
+		case isList:
+			log.Debugf(newCtx, "Response: %#v", resp)
+		default:
 			log.Debugf(newCtx, "Response: %T: %+v", resp, resp)
 		}
 


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Address regression when handling crictl requests.

#### Which issue(s) this PR fixes:
Fixes: https://github.com/cri-o/cri-o/issues/9894

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reduced the verbosity of debug logs for List* RPC calls to improve performance
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved debug logging for list-style RPCs: request and response data are now logged more compactly for clearer diagnostics.
  * Maintained existing, detailed logging for non-list operations; metrics, tracing, and error handling behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->