### PR TITLE
runtimehandlerhooks: document irqbalance restart coalescing behavior

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -851,6 +851,13 @@ func (h *HighPerformanceHooks) handleIRQBalanceRestart(ctx context.Context, cNam
 	// quick succession and the parameter must be reconfigured for this to work correctly.
 	// See:
 	// https://github.com/cri-o/cri-o/pull/8834/commits/b96928dcbb7956e0ebde42238e88955831411216
+	//
+	// Note on restart coalescing: systemd coalesces restart requests that arrive close together
+	// in time — for example, deploying 10 pods simultaneously typically results in only 4-5
+	// counted restarts rather than 10. Coalescing also occurs on pod deletion, often at an even
+	// higher rate since pods are removed faster than they are created. As a result, starting or
+	// deleting N > StartLimitBurst pods within StartLimitIntervalUSec does not necessarily
+	// trigger start-limit-hit.
 	if !serviceManager.IsServiceEnabled(irqBalancedName) || !fileExists(h.irqBalanceConfigFile) {
 		return false
 	}


### PR DESCRIPTION
Expand the comment in handleIRQBalanceRestart to explain that systemd coalesces restart requests arriving close in time, making the actual restart count lower than the number of triggering pods.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind documentation

#### What this PR does / why we need it:
Adds documentation for a subtle systemd coalescing behavior that is not
widely known.
Without this context, it is hard to understand why irqbalance restart
counts caused by pod activity do not always match the number of pods,
and why start-limit-hit may trigger in some runs but not others with
the exact same setup.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:

Context came from investigating OCPBUGS-45112, where the coalescing behavior
made the bug hard to reproduce and a functional test unreliable.
Relates to https://github.com/cri-o/cri-o/pull/8834
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated internal code documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->