### PR TITLE
netns file cleanup after CRI-O restart with invalid namespace

### DIFF
--- a/internal/config/nsmgr/types_linux.go
+++ b/internal/config/nsmgr/types_linux.go
@@ -51,7 +51,7 @@ type NS interface {
 
 // Path returns the bind mount path of the namespace.
 func (n *namespace) Path() string {
-	if n == nil || n.ns == nil {
+	if n == nil {
 		return ""
 	}
 
@@ -68,18 +68,18 @@ func (n *namespace) Remove() error {
 	n.Lock()
 	defer n.Unlock()
 
-	if n.closed {
-		// Remove() can be called multiple
-		// times without returning an error.
-		return nil
+	// Close the namespace handle if not already closed and if we have a valid handle
+	if !n.closed && n.ns != nil {
+		if err := n.ns.Close(); err != nil {
+			return err
+		}
+
+		n.closed = true
 	}
 
-	if err := n.ns.Close(); err != nil {
-		return err
-	}
-
-	n.closed = true
-
+	// Always attempt to clean up the file, even if already closed or if ns is nil.
+	// This ensures that invalid namespace files (created by partial namespace objects)
+	// are properly cleaned up.
 	fp := n.Path()
 	if fp == "" {
 		return nil

--- a/test/network.bats
+++ b/test/network.bats
@@ -281,3 +281,76 @@ function check_networking() {
 
 	run ! crictl inspectp "$pod_id"
 }
+
+@test "netns file cleanup after CRI-O restart with invalid namespace" {
+	# This test reproduces the bug where invalid netns files are not cleaned up
+	# after CRI-O restart, preventing pods from restarting.
+	start_crio
+
+	# Create and run a pod
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	# Get the network namespace path
+	NETNS_PATH=/var/run/netns/
+	NS=$(crictl inspectp "$pod_id" |
+		jq -er '.info.runtimeSpec.linux.namespaces[] | select(.type == "network").path | sub("'$NETNS_PATH'"; "")')
+
+	echo "Pod $pod_id created with netns: $NETNS_PATH$NS"
+
+	# Verify the netns file exists before stopping
+	[[ -f "$NETNS_PATH$NS" ]] || [[ -f "/run/netns/$NS" ]]
+
+	# Stop the pod (this marks it as stopped in CRI-O state)
+	crictl stopp "$pod_id"
+
+	# After stopping, the namespace might already be cleaned up by CRI-O
+	# We need to recreate the invalid file scenario that happens after reboot
+	# where the kernel namespace is gone but the file remains
+
+	# Try to delete the kernel namespace if it still exists (may fail if already gone)
+	ip netns del "$NS" 2> /dev/null || true
+
+	# Create a fake/invalid netns file (kernel namespace is gone but file exists)
+	touch "$NETNS_PATH$NS" || touch "/run/netns/$NS"
+
+	# Use whichever path actually exists
+	if [[ -f "/run/netns/$NS" ]]; then
+		NETNS_PATH=/run/netns/
+	fi
+
+	# Verify the invalid file exists
+	[[ -f "$NETNS_PATH$NS" ]]
+	echo "Invalid netns file created at: $NETNS_PATH$NS"
+	ls -la "$NETNS_PATH$NS" || true
+
+	# Restart CRI-O - this triggers LoadSandbox which calls NetNsJoin
+	# NetNsJoin should fail to GetNS but will store partial namespace anyway
+	restart_crio
+
+	echo "After CRI-O restart, checking if invalid file still exists..."
+	if [[ -f "$NETNS_PATH$NS" ]]; then
+		echo "BUG CONFIRMED: Invalid netns file still exists: $NETNS_PATH$NS"
+		ls -la "$NETNS_PATH$NS"
+	else
+		echo "File was cleaned up (bug may be fixed)"
+	fi
+
+	# Try to remove the pod - this should cleanup the invalid file
+	crictl rmp -f "$pod_id"
+
+	echo "After pod removal, verifying file cleanup..."
+	if [[ -f "$NETNS_PATH$NS" ]]; then
+		echo "LEAKED: Invalid netns file was not cleaned up: $NETNS_PATH$NS"
+		ls -la "$NETNS_PATH$NS" || true
+		# Fail the test - this demonstrates the bug
+		echo "TEST FAILED: Bug reproduced - netns file leaked"
+		return 1
+	else
+		echo "SUCCESS: Invalid netns file was properly cleaned up"
+	fi
+
+	# Verify we can create a new pod now (would fail with leaked file)
+	new_pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	output=$(crictl inspectp "$new_pod_id" | jq -r '.status.state')
+	[[ "$output" == "SANDBOX_READY" ]]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
This fix ensures that invalid namespace files are properly cleaned up even when the namespace handle is nil.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
This was initially raised for 1.33 in https://github.com/cri-o/cri-o/pull/9896 , I'm raising this to the main branch. This should merge first

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Test output:
```
1..13
ok 1 ensure correct hostname
ok 2 ensure correct hostname for hostnetwork:true
ok 3 Check for valid pod netns CIDR
ok 4 Ensure correct CNI plugin namespace/name/container-id arguments
ok 5 Connect to pod hostport from the host # skip node configured with cgroupv2 flakes this test sometimes
ok 6 Clean up network if pod sandbox fails
ok 7 Clean up network if pod sandbox fails after plugin success
ok 8 Clean up network if pod sandbox gets killed
ok 9 Clean up network if pod netns gets destroyed
ok 10 Network recovery after reboot with destroyed netns
ok 11 CNI teardown called even with missing or invalid netns to prevent IP leaks
ok 12 pod deletion succeeds when NetNS path is missing
ok 13 netns file cleanup after CRI-O restart with invalid namespace
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network namespace cleanup now reliably removes stale or orphaned namespace files even when namespace handles are missing or already closed, preventing leaked namespace files after restarts.

* **Tests**
  * Added an end-to-end test that validates removal of invalid/stale network namespace files across service restart and verifies new pods reach ready state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->