### PR TITLE
OCPBUGS-81273: Persist image repo digest across CRI-O restarts

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -44,6 +44,9 @@ const (
 	// ImageRef is the container image ref annotation.
 	ImageRef = "io.kubernetes.cri-o.ImageRef"
 
+	// ImageRepoDigests are the repo@digest values of the image, persisted for restore.
+	ImageRepoDigests = "io.kubernetes.cri-o.ImageRepoDigests"
+
 	// KubeName is the kubernetes name annotation.
 	KubeName = "io.kubernetes.cri-o.KubeName"
 

--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -240,6 +240,11 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb SandboxIFace, con
 
 	c.spec.AddAnnotation(annotations.SomeNameOfTheImage, someNameOfThisImage)
 	c.spec.AddAnnotation(annotations.ImageRef, imageResult.ID.IDStringForOutOfProcessConsumptionOnly())
+
+	if len(imageResult.RepoDigests) > 0 {
+		c.spec.AddAnnotation(annotations.ImageRepoDigests, strings.Join(imageResult.RepoDigests, ","))
+	}
+
 	c.spec.AddAnnotation(annotations.Name, c.Name())
 	c.spec.AddAnnotation(annotations.ContainerID, c.ID())
 	c.spec.AddAnnotation(annotations.SandboxID, sb.ID())

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -577,7 +578,12 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, userRequestedImage, someNameOfTheImage, imageID, "", &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, stopSignal)
+	someRepoDigest := ""
+	if repoDigests := m.Annotations[annotations.ImageRepoDigests]; repoDigests != "" {
+		someRepoDigest = strings.SplitN(repoDigests, ",", 2)[0]
+	}
+
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, userRequestedImage, someNameOfTheImage, imageID, someRepoDigest, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, stopSignal)
 	if err != nil {
 		return err
 	}

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -411,6 +411,22 @@ function teardown() {
 	[[ "${output}" == "${ctr_status_info}" ]]
 }
 
+@test "crio restore imageRef for containers" {
+	start_crio
+	[[ -n "$REDIS_IMAGEREF" ]]
+
+	ctr_id=$(crictl run "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
+
+	imageRef=$(crictl inspect -o json "$ctr_id" | jq -r '.status.imageRef')
+	[[ "$imageRef" == "$REDIS_IMAGEREF" ]]
+
+	stop_crio
+	start_crio
+
+	imageRef=$(crictl inspect -o json "$ctr_id" | jq -r '.status.imageRef')
+	[[ "$imageRef" == "$REDIS_IMAGEREF" ]]
+}
+
 @test "crio restore volumes for containers" {
 	start_crio
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The repo@digest used for ImageRef in container status was only held in memory and lost on CRI-O restart, causing imageID in pod status to change from a repo@digest to a raw image ID hash. This persists it as a new annotation (`io.kubernetes.cri-o.ImageRepoDigest`) so it can be restored when containers are loaded after a restart.

#### Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-81273

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where ImageRef in container status changed from a repo@digest to a raw image ID hash after CRI-O restart.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository digests for container images are now captured and attached to containers so image references are preserved across restarts.

* **Tests**
  * Added an integration test that verifies a container's image reference (imageRef) persists before and after service restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->