### PR TITLE
[release-1.33]: OCPBUGS-84972: fix: prevent panic on concurrent StopContainer calls

### DIFF
--- a/internal/oci/container.go
+++ b/internal/oci/container.go
@@ -66,6 +66,7 @@ type Container struct {
 	created            bool
 	spoofed            bool
 	stopping           bool
+	stopDone           bool
 	stopLock           sync.Mutex
 	// stopTimeoutChan is used to update the stop timeout.
 	// After the container goes into the kill loop, the channel must not be used
@@ -656,7 +657,7 @@ func (c *Container) SetStopKillLoopBegun() {
 
 func (c *Container) WaitOnStopTimeout(ctx context.Context, timeout int64) {
 	c.stopLock.Lock()
-	if !c.stopping {
+	if !c.stopping || c.stopDone {
 		c.stopLock.Unlock()
 
 		return
@@ -685,6 +686,8 @@ func (c *Container) WaitOnStopTimeout(ctx context.Context, timeout int64) {
 
 func (c *Container) SetAsDoneStopping() {
 	c.stopLock.Lock()
+	c.stopDone = true
+
 	for _, watcher := range c.stopWatchers {
 		close(watcher)
 	}

--- a/internal/oci/container_test.go
+++ b/internal/oci/container_test.go
@@ -1,6 +1,7 @@
 package oci_test
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path"
@@ -675,6 +676,20 @@ var _ = t.Describe("Container", func() {
 			Expect(stime).To(Equal("22"))
 			Expect(err).ToNot(HaveOccurred())
 		})
+	})
+
+	// Regression test for a race between concurrent StopContainer calls.
+	// When a second StopContainer arrives after the first has already
+	// completed (SetAsDoneStopping closed stopTimeoutChan),
+	// WaitOnStopTimeout used to panic on the closed channel.
+	// The stopDone guard ensures it returns early instead.
+	It("should not panic when WaitOnStopTimeout is called after SetAsDoneStopping", func() {
+		ctx := context.Background()
+		sut.SetAsStopping()
+		sut.SetAsDoneStopping()
+		Expect(func() {
+			sut.WaitOnStopTimeout(ctx, 1000)
+		}).ToNot(Panic())
 	})
 })
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it:**
Manual cherry-pick of #9799 to release-1.33. The automated cherry-pick (via `/cherry-pick release-1.33` on #9920) failed due to a merge conflict in `container.go` caused by structural differences on the 1.33 branch (protobuf getters, monitor process fields absent on 1.33).

**Which issue(s) this PR fixes:**
Fixes OCPBUGS-84972 (depends on OCPBUGS-84922)

**Special notes for reviewer:**
- `container.go` changes are identical to #9799
- The regression test in `container_test.go` was adapted to fit the release-1.33 test structure (standalone `It()` block vs nested `Describe` on main)

```release-note
Fix a panic caused by concurrent StopContainer calls racing to send
on an already-closed channel.
```