### PR TITLE
Validate that /run/netns is pointing to nsfs file

### DIFF
--- a/internal/config/nsmgr/types_default.go
+++ b/internal/config/nsmgr/types_default.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package nsmgr
+
+// IsShadowedMountError returns true if the error indicates a shadowed mount.
+// On non-Linux platforms, this always returns false.
+func IsShadowedMountError(err error) bool {
+	return false
+}

--- a/internal/config/nsmgr/types_default.go
+++ b/internal/config/nsmgr/types_default.go
@@ -2,8 +2,8 @@
 
 package nsmgr
 
-// IsShadowedMountError returns true if the error indicates a shadowed mount.
+// IsInvalidNamespaceMountError returns true if the error indicates an invalid namespace mount.
 // On non-Linux platforms, this always returns false.
-func IsShadowedMountError(err error) bool {
+func IsInvalidNamespaceMountError(err error) bool {
 	return false
 }

--- a/internal/config/nsmgr/types_linux.go
+++ b/internal/config/nsmgr/types_linux.go
@@ -20,27 +20,25 @@ func supportedNamespacesForPinning() []NSType {
 	return []NSType{NETNS, IPCNS, UTSNS, USERNS, PIDNS}
 }
 
-// ShadowedMountError indicates a namespace bind mount is shadowed by a directory overmount.
-// This error should never be ignored, even for stopped sandboxes, as it will cause
-// setns EINVAL when containers try to use the namespace.
-type ShadowedMountError struct {
+// InvalidNamespaceMountError indicates a namespace path does not point to a valid namespace filesystem.
+type InvalidNamespaceMountError struct {
 	Path string
 	Err  error
 }
 
-func (e *ShadowedMountError) Error() string {
-	return fmt.Sprintf("namespace bind mount at %s is shadowed by directory overmount: %v", e.Path, e.Err)
+func (e *InvalidNamespaceMountError) Error() string {
+	return fmt.Sprintf("namespace path %s is not a valid namespace filesystem: %v", e.Path, e.Err)
 }
 
-func (e *ShadowedMountError) Unwrap() error {
+func (e *InvalidNamespaceMountError) Unwrap() error {
 	return e.Err
 }
 
-// IsShadowedMountError returns true if the error indicates a shadowed mount.
-func IsShadowedMountError(err error) bool {
-	var shadowedErr *ShadowedMountError
+// IsInvalidNamespaceMountError returns true if the error indicates an invalid namespace mount.
+func IsInvalidNamespaceMountError(err error) bool {
+	var invalidErr *InvalidNamespaceMountError
 
-	return errors.As(err, &shadowedErr)
+	return errors.As(err, &invalidErr)
 }
 
 type PodNamespacesConfig struct {
@@ -126,10 +124,9 @@ func (n *namespace) Remove() error {
 func GetNamespace(nsPath string, nsType NSType) (Namespace, error) {
 	ns, err := nspkg.GetNS(nsPath)
 	if err != nil {
-		// Wrap NSPathNotNSErr to indicate potential mount shadowing
 		var nsPathNotNSErr nspkg.NSPathNotNSErr
 		if errors.As(err, &nsPathNotNSErr) {
-			return &namespace{nsType: nsType, nsPath: nsPath, closed: true}, &ShadowedMountError{Path: nsPath, Err: err}
+			return &namespace{nsType: nsType, nsPath: nsPath, closed: true}, &InvalidNamespaceMountError{Path: nsPath, Err: err}
 		}
 		// Failed to GetNS. It's possible this is expected (pod is stopped).
 		return &namespace{nsType: nsType, nsPath: nsPath, closed: true}, err

--- a/internal/config/nsmgr/types_linux.go
+++ b/internal/config/nsmgr/types_linux.go
@@ -20,6 +20,29 @@ func supportedNamespacesForPinning() []NSType {
 	return []NSType{NETNS, IPCNS, UTSNS, USERNS, PIDNS}
 }
 
+// ShadowedMountError indicates a namespace bind mount is shadowed by a directory overmount.
+// This error should never be ignored, even for stopped sandboxes, as it will cause
+// setns EINVAL when containers try to use the namespace.
+type ShadowedMountError struct {
+	Path string
+	Err  error
+}
+
+func (e *ShadowedMountError) Error() string {
+	return fmt.Sprintf("namespace bind mount at %s is shadowed by directory overmount: %v", e.Path, e.Err)
+}
+
+func (e *ShadowedMountError) Unwrap() error {
+	return e.Err
+}
+
+// IsShadowedMountError returns true if the error indicates a shadowed mount.
+func IsShadowedMountError(err error) bool {
+	var shadowedErr *ShadowedMountError
+
+	return errors.As(err, &shadowedErr)
+}
+
 type PodNamespacesConfig struct {
 	Namespaces []*PodNamespaceConfig
 	IDMappings *idtools.IDMappings
@@ -103,6 +126,11 @@ func (n *namespace) Remove() error {
 func GetNamespace(nsPath string, nsType NSType) (Namespace, error) {
 	ns, err := nspkg.GetNS(nsPath)
 	if err != nil {
+		// Wrap NSPathNotNSErr to indicate potential mount shadowing
+		var nsPathNotNSErr nspkg.NSPathNotNSErr
+		if errors.As(err, &nsPathNotNSErr) {
+			return &namespace{nsType: nsType, nsPath: nsPath, closed: true}, &ShadowedMountError{Path: nsPath, Err: err}
+		}
 		// Failed to GetNS. It's possible this is expected (pod is stopped).
 		return &namespace{nsType: nsType, nsPath: nsPath, closed: true}, err
 	}

--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -110,8 +110,8 @@ func (s *Sandbox) NetNsJoin(nspath string) error {
 	ns, err := nsJoin(nspath, nsmgr.NETNS, s.netns)
 	// Regardless of error, set the namespace
 	s.netns = ns
-	// Shadowed mounts must fail even for stopped sandboxes to prevent setns EINVAL.
-	if err != nil && (!s.stopped || nsmgr.IsShadowedMountError(err)) {
+	// Invalid namespace mounts must fail even for stopped sandboxes to prevent setns EINVAL.
+	if err != nil && (!s.stopped || nsmgr.IsInvalidNamespaceMountError(err)) {
 		return err
 	}
 
@@ -132,8 +132,8 @@ func (s *Sandbox) IpcNsJoin(nspath string) error {
 	ns, err := nsJoin(nspath, nsmgr.IPCNS, s.ipcns)
 	// Regardless of error, set the namespace
 	s.ipcns = ns
-	// Shadowed mounts must fail even for stopped sandboxes to prevent setns EINVAL.
-	if err != nil && (!s.stopped || nsmgr.IsShadowedMountError(err)) {
+	// Invalid namespace mounts must fail even for stopped sandboxes to prevent setns EINVAL.
+	if err != nil && (!s.stopped || nsmgr.IsInvalidNamespaceMountError(err)) {
 		return err
 	}
 
@@ -154,8 +154,8 @@ func (s *Sandbox) UtsNsJoin(nspath string) error {
 	ns, err := nsJoin(nspath, nsmgr.UTSNS, s.utsns)
 	// Regardless of error, set the namespace
 	s.utsns = ns
-	// Shadowed mounts must fail even for stopped sandboxes to prevent setns EINVAL.
-	if err != nil && (!s.stopped || nsmgr.IsShadowedMountError(err)) {
+	// Invalid namespace mounts must fail even for stopped sandboxes to prevent setns EINVAL.
+	if err != nil && (!s.stopped || nsmgr.IsInvalidNamespaceMountError(err)) {
 		return err
 	}
 
@@ -176,8 +176,8 @@ func (s *Sandbox) UserNsJoin(nspath string) error {
 	ns, err := nsJoin(nspath, nsmgr.USERNS, s.userns)
 	// Regardless of error, set the namespace
 	s.userns = ns
-	// Shadowed mounts must fail even for stopped sandboxes to prevent setns EINVAL.
-	if err != nil && (!s.stopped || nsmgr.IsShadowedMountError(err)) {
+	// Invalid namespace mounts must fail even for stopped sandboxes to prevent setns EINVAL.
+	if err != nil && (!s.stopped || nsmgr.IsInvalidNamespaceMountError(err)) {
 		return err
 	}
 

--- a/internal/lib/sandbox/namespaces.go
+++ b/internal/lib/sandbox/namespaces.go
@@ -110,8 +110,8 @@ func (s *Sandbox) NetNsJoin(nspath string) error {
 	ns, err := nsJoin(nspath, nsmgr.NETNS, s.netns)
 	// Regardless of error, set the namespace
 	s.netns = ns
-	// Only error if the sandbox is not stopped
-	if err != nil && !s.stopped {
+	// Shadowed mounts must fail even for stopped sandboxes to prevent setns EINVAL.
+	if err != nil && (!s.stopped || nsmgr.IsShadowedMountError(err)) {
 		return err
 	}
 
@@ -129,15 +129,11 @@ func (s *Sandbox) IpcNsPath() string {
 // IpcNsJoin attempts to join the sandbox to an existing IPC namespace
 // This will fail if the sandbox is already part of a IPC namespace.
 func (s *Sandbox) IpcNsJoin(nspath string) error {
-	if s.stopped {
-		return nil
-	}
-
 	ns, err := nsJoin(nspath, nsmgr.IPCNS, s.ipcns)
 	// Regardless of error, set the namespace
 	s.ipcns = ns
-	// Only error if the sandbox is not stopped
-	if err != nil && !s.stopped {
+	// Shadowed mounts must fail even for stopped sandboxes to prevent setns EINVAL.
+	if err != nil && (!s.stopped || nsmgr.IsShadowedMountError(err)) {
 		return err
 	}
 
@@ -155,15 +151,11 @@ func (s *Sandbox) UtsNsPath() string {
 // UtsNsJoin attempts to join the sandbox to an existing UTS namespace
 // This will fail if the sandbox is already part of a UTS namespace.
 func (s *Sandbox) UtsNsJoin(nspath string) error {
-	if s.stopped {
-		return nil
-	}
-
 	ns, err := nsJoin(nspath, nsmgr.UTSNS, s.utsns)
 	// Regardless of error, set the namespace
 	s.utsns = ns
-	// Only error if the sandbox is not stopped
-	if err != nil && !s.stopped {
+	// Shadowed mounts must fail even for stopped sandboxes to prevent setns EINVAL.
+	if err != nil && (!s.stopped || nsmgr.IsShadowedMountError(err)) {
 		return err
 	}
 
@@ -184,8 +176,8 @@ func (s *Sandbox) UserNsJoin(nspath string) error {
 	ns, err := nsJoin(nspath, nsmgr.USERNS, s.userns)
 	// Regardless of error, set the namespace
 	s.userns = ns
-	// Only error if the sandbox is not stopped
-	if err != nil && !s.stopped {
+	// Shadowed mounts must fail even for stopped sandboxes to prevent setns EINVAL.
+	if err != nil && (!s.stopped || nsmgr.IsShadowedMountError(err)) {
 		return err
 	}
 

--- a/test/network.bats
+++ b/test/network.bats
@@ -324,26 +324,26 @@ function check_networking() {
 	ls -la "$NETNS_PATH$NS" || true
 
 	# Restart CRI-O - this triggers LoadSandbox which calls NetNsJoin
-	# NetNsJoin should fail to GetNS but will store partial namespace anyway
+	# With the shadowing detection fix, CRI-O should detect the invalid namespace
+	# and auto-delete the broken sandbox during startup
 	restart_crio
 
-	echo "After CRI-O restart, checking if invalid file still exists..."
-	if [[ -f "$NETNS_PATH$NS" ]]; then
-		echo "BUG CONFIRMED: Invalid netns file still exists: $NETNS_PATH$NS"
-		ls -la "$NETNS_PATH$NS"
-	else
-		echo "File was cleaned up (bug may be fixed)"
-	fi
+	# CRI-O should have auto-deleted the broken sandbox and cleaned up the file
+	echo "After CRI-O restart, verifying sandbox was auto-deleted..."
+	run ! crictl inspectp "$pod_id"
 
-	# Try to remove the pod - this should cleanup the invalid file
-	crictl rmp -f "$pod_id"
+	# Verify CRI-O logged the shadowed mount detection and cleanup
+	grep -q "is shadowed by directory overmount" "$CRIO_LOG" || grep -q "unknown FS magic" "$CRIO_LOG"
+	grep -q "Could not restore sandbox.*$pod_id" "$CRIO_LOG"
+	grep -q "Deleting all containers under sandbox $pod_id" "$CRIO_LOG"
+	grep -q "Successfully cleaned up network for pod $pod_id" "$CRIO_LOG"
 
-	echo "After pod removal, verifying file cleanup..."
+	# Verify the invalid file was cleaned up during auto-deletion
+	echo "Verifying invalid file was cleaned up..."
 	if [[ -f "$NETNS_PATH$NS" ]]; then
 		echo "LEAKED: Invalid netns file was not cleaned up: $NETNS_PATH$NS"
 		ls -la "$NETNS_PATH$NS" || true
-		# Fail the test - this demonstrates the bug
-		echo "TEST FAILED: Bug reproduced - netns file leaked"
+		echo "TEST FAILED: File leaked despite auto-deletion"
 		return 1
 	else
 		echo "SUCCESS: Invalid netns file was properly cleaned up"
@@ -353,4 +353,101 @@ function check_networking() {
 	new_pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	output=$(crictl inspectp "$new_pod_id" | jq -r '.status.state')
 	[[ "$output" == "SANDBOX_READY" ]]
+}
+
+@test "detect and handle shadowed netns bind mount after overmount" {
+	# Reproduces mount shadowing where directory-level overmount at /run/netns
+	# shadows earlier sandbox bind mounts, making them unreachable via path lookup.
+
+	NETNS_PATH=/var/run/netns/
+	trap 'umount "$NETNS_PATH" 2>/dev/null || true' EXIT INT TERM
+
+	start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	NS=$(crictl inspectp "$pod_id" |
+		jq -er '.info.runtimeSpec.linux.namespaces[] | select(.type == "network").path | sub("'$NETNS_PATH'"; "")')
+
+	echo "Pod $pod_id created with netns: $NETNS_PATH$NS"
+
+	[[ -f "$NETNS_PATH$NS" ]]
+	original_fstype=$(stat -f -c %t "$NETNS_PATH$NS")
+	echo "Original filesystem type: 0x$original_fstype"
+	[[ "$original_fstype" == "6e736673" ]]
+
+	# Stop CRI-O without stopping sandbox (bind mount persists via pinns)
+	stop_crio
+
+	echo "Stopped CRI-O, bind mount should persist via pinns"
+	[[ -f "$NETNS_PATH$NS" ]]
+	still_nsfs=$(stat -f -c %t "$NETNS_PATH$NS")
+	echo "After stopping CRI-O, filesystem type still: 0x$still_nsfs"
+	[[ "$still_nsfs" == "6e736673" ]]
+
+	[[ -d "$NETNS_PATH" ]]
+
+	# Create directory-level overmount that shadows existing bind mounts
+	echo "Creating directory-level overmount at $NETNS_PATH"
+	mount --bind "$NETNS_PATH" "$NETNS_PATH" || {
+		echo "Failed to create bind mount at $NETNS_PATH" >&2
+		exit 1
+	}
+	mount --make-shared "$NETNS_PATH" || {
+		echo "Failed to make mount shared at $NETNS_PATH" >&2
+		exit 1
+	}
+
+	if ! findmnt -n -o PROPAGATION "$NETNS_PATH" | grep -q "shared"; then
+		echo "Failed to create shared overmount at $NETNS_PATH" >&2
+		echo "Mount information:" >&2
+		findmnt "$NETNS_PATH" >&2
+		exit 1
+	fi
+	echo "Successfully created shared overmount at $NETNS_PATH"
+
+	if ! grep -q "nsfs.*$NETNS_PATH$NS" /proc/self/mountinfo; then
+		echo "WARNING: Original nsfs bind mount not found in mountinfo" >&2
+		echo "This may be expected in some test environments" >&2
+	fi
+
+	# Path lookup now returns tmpfs file instead of nsfs
+	shadowed_fstype=$(stat -f -c %t "$NETNS_PATH$NS" 2> /dev/null || echo "missing")
+	echo "After overmount, filesystem type: 0x$shadowed_fstype"
+
+	if [[ "$shadowed_fstype" == "6e736673" ]]; then
+		echo "ERROR: Bind mount was not shadowed - still shows nsfs" >&2
+		findmnt "$NETNS_PATH" >&2
+		exit 1
+	fi
+	echo "Confirmed: bind mount is shadowed (fstype: 0x$shadowed_fstype, not nsfs)"
+
+	# CRI-O restart must detect shadowing even for stopped sandboxes
+	start_crio
+
+	if ! grep -q "is shadowed by directory overmount" "$CRIO_LOG"; then
+		echo "ERROR: CRI-O did not detect the shadowed mount for stopped sandbox" >&2
+		echo "=== CRI-O log excerpt ===" >&2
+		grep -i "namespace\|netns\|shadowed" "$CRIO_LOG" | tail -20 >&2
+		exit 1
+	fi
+	echo "CRI-O correctly detected the shadowed mount for stopped sandbox"
+
+	grep -q "Could not restore sandbox.*$pod_id" "$CRIO_LOG"
+	grep -q "Deleting all containers under sandbox $pod_id" "$CRIO_LOG"
+	grep -q "Successfully cleaned up network for pod $pod_id" "$CRIO_LOG"
+
+	run ! crictl inspectp "$pod_id"
+
+	new_pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+
+	output=$(crictl inspectp "$new_pod_id" | jq -r '.status.state')
+	[[ "$output" == "SANDBOX_READY" ]]
+
+	NEW_NS=$(crictl inspectp "$new_pod_id" |
+		jq -er '.info.runtimeSpec.linux.namespaces[] | select(.type == "network").path | sub("'$NETNS_PATH'"; "")')
+
+	new_fstype=$(stat -f -c %t "$NETNS_PATH$NEW_NS" 2> /dev/null)
+	echo "New pod filesystem type: 0x$new_fstype"
+	[[ "$new_fstype" == "6e736673" ]]
 }

--- a/test/network.bats
+++ b/test/network.bats
@@ -332,8 +332,8 @@ function check_networking() {
 	echo "After CRI-O restart, verifying sandbox was auto-deleted..."
 	run ! crictl inspectp "$pod_id"
 
-	# Verify CRI-O logged the shadowed mount detection and cleanup
-	grep -q "is shadowed by directory overmount" "$CRIO_LOG" || grep -q "unknown FS magic" "$CRIO_LOG"
+	# Verify CRI-O logged the invalid namespace detection and cleanup
+	grep -q "is not a valid namespace filesystem" "$CRIO_LOG"
 	grep -q "Could not restore sandbox.*$pod_id" "$CRIO_LOG"
 	grep -q "Deleting all containers under sandbox $pod_id" "$CRIO_LOG"
 	grep -q "Successfully cleaned up network for pod $pod_id" "$CRIO_LOG"
@@ -360,7 +360,7 @@ function check_networking() {
 	# shadows earlier sandbox bind mounts, making them unreachable via path lookup.
 
 	NETNS_PATH=/var/run/netns/
-	trap 'umount "$NETNS_PATH" 2>/dev/null || true' EXIT INT TERM
+	trap 'umount -l "$NETNS_PATH" 2>/dev/null || true' EXIT INT TERM
 
 	start_crio
 
@@ -422,16 +422,16 @@ function check_networking() {
 	fi
 	echo "Confirmed: bind mount is shadowed (fstype: 0x$shadowed_fstype, not nsfs)"
 
-	# CRI-O restart must detect shadowing even for stopped sandboxes
+	# CRI-O restart must detect invalid namespace even for stopped sandboxes
 	start_crio
 
-	if ! grep -q "is shadowed by directory overmount" "$CRIO_LOG"; then
-		echo "ERROR: CRI-O did not detect the shadowed mount for stopped sandbox" >&2
+	if ! grep -q "is not a valid namespace filesystem" "$CRIO_LOG"; then
+		echo "ERROR: CRI-O did not detect the invalid namespace for stopped sandbox" >&2
 		echo "=== CRI-O log excerpt ===" >&2
-		grep -i "namespace\|netns\|shadowed" "$CRIO_LOG" | tail -20 >&2
+		grep -i "namespace\|netns" "$CRIO_LOG" | tail -20 >&2
 		exit 1
 	fi
-	echo "CRI-O correctly detected the shadowed mount for stopped sandbox"
+	echo "CRI-O correctly detected the invalid namespace for stopped sandbox"
 
 	grep -q "Could not restore sandbox.*$pod_id" "$CRIO_LOG"
 	grep -q "Deleting all containers under sandbox $pod_id" "$CRIO_LOG"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

### Problem
  When a directory-level overmount (e.g., `mount --bind /run/netns /run/netns`) is created after CRI-O creates sandbox bind mounts, earlier bind mounts become shadowed - visible in mountinfo but unreachable via
  path lookup. This causes `setns EINVAL` errors when containers try to use the namespace.

  Customer scenario: ovnkube-node creates overmount at /run/netns after CRI-O restart, shadowing stopped sandbox bind mounts. CRI-O fails to detect the issue because errors for stopped sandboxes were swallowed.

  ### Solution
  - Add `ShadowedMountError` type to identify mount shadowing
  - Update `GetNamespace()` to wrap `NSPathNotNSErr` as `ShadowedMountError`
  - Never swallow shadowed mount errors, even for stopped sandboxes
  - Auto-delete broken sandboxes during CRI-O restart

  ### Testing
  Added E2E test reproducing the exact customer scenario with mount overmount, filesystem type validation, and auto-deletion verification.

The bug is based on customer analysis of a failure. The analysis was done by AI and the customer shared the results with us. The key parts of the analysis are these:

**/run/netns mount hierarchy (inside container-mount-namespace)**
Mount 273 — tmpfs at /run
Mount 12967 — ← tmpfs[/netns] at /run/netns
Mount 1077 — nsfs at /run/netns/3eb3af07-… (parent 12967 ✓)
Mount 2174 — nsfs at /run/netns/e3dd4dac-… (parent 12967 ✓)
… all other working sandboxes (parent 12967 ✓)
PATH LOOKUP STOPS HERE — files below are unreachable
Mount 7437 — nsfs[net:4026539247] at /run/netns/cc30bf0a-… SHADOWED
Mount 14629 — nsfs[net:4026540775] at /run/netns/921b97ff-… SHADOWED
Mount 16795 — nsfs[net:4026543886] at /run/netns/5b51a85c-… SHADOWED

**Startup Race — Corrected Timeline, May 5 2026**
07:08:14 | Node boots: /run tmpfs created fresh. All previous namespaces gone.
07:08:37 | container-mount-namespace.service starts: Creates private mount NS mnt:[4026537777] via unshare --mount --propagation slave.
07:08:51 | CRI-O and kubelet start: Both enter the container-mount-namespace. No overmount exists yet.
07:09:47 | Race window begins: 3 broken sandboxes created by pinns (parent 273). All 3 have parent=273 because mount 12967 does not yet exist.
~07:09:50 | Race window ends: ovnkube-node creates /run/netns self-bind-mount (mount 12967), shadowing the 3 pinns bind mounts.
07:21:12 | MCO restarts CRI-O: CRI-O restores records from JSON but does not re-run pinns. The shadowed mounts remain shadowed.
07:56 onward | First setns EINVAL: Containers crash. crun opens the path but gets the empty tmpfs file from the overmount. setns() returns EINVAL.

In short it validates that "/run/netns" is pointing to nsfs file and not created by other mounts.


**Local testing**
I couldn't fully recreate the issue, but when I investigated the `/run/netns` folder 
```
sh-5.1# findmnt -o TARGET,PARENT,FSTYPE -T /run/netns/8e4e68d0-92a0-4a6a-9809-9d52cbe555c3
TARGET                                          PARENT FSTYPE
/run/netns/8e4e68d0-92a0-4a6a-9809-9d52cbe555c3   9049 nsfs
grep "/run/netns" /proc/self/mountinfo
9057 9049 0:4 net:[4026531840] /run/netns/90606e92-cea2-4f11-af31-473a13d64231 rw master:235 - nsfs nsfs rw
9061 9049 0:4 net:[4026531840] /run/netns/bbaf7a84-532a-4138-ad4a-ad7a43357a4f rw master:438 - nsfs nsfs rw
...
```
Normally the parent is nsfs. In the customer case its changed.

Also the magic number for nsfs used in the code can be confirmed from a node:
```
stat -f -c %t /run/netns/*
6e736673
6e736673
```



#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detect and treat invalid or shadowed network-namespace mounts as broken; affected stopped sandboxes are now detected, logged, and cleaned up on startup instead of remaining silently orphaned.
  * Namespace-join failures caused by invalid mounts are surfaced even for stopped sandboxes to ensure proper cleanup.

* **Tests**
  * Added integration tests validating detection and cleanup of shadowed/invalid netns bind mounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->