### PR TITLE
server: run OCI poststop hooks on StopContainer

### DIFF
--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -81,7 +81,7 @@ func (c *ContainerServer) ContainerCheckpoint(
 			}
 		}
 		// container state needs to be written _after_ unpausing
-		if err = c.ContainerStateToDisk(ctx, ctr); err != nil {
+		if err = c.ContainerStateToDiskWithUpdate(ctx, ctr); err != nil {
 			log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
 		}
 	}()

--- a/internal/lib/checkpoint.go
+++ b/internal/lib/checkpoint.go
@@ -85,7 +85,7 @@ func (c *ContainerServer) ContainerCheckpoint(
 			}
 		}
 		// container state needs to be written _after_ unpausing
-		if err = c.ContainerStateToDisk(ctx, ctr); err != nil {
+		if err = c.ContainerStateToDiskWithUpdate(ctx, ctr); err != nil {
 			log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
 		}
 	}()

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -435,7 +435,7 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 
 	// We write back the state because it is possible that crio did not have a chance to
 	// read the exit file and persist exit code into the state on reboot.
-	if err := c.ContainerStateToDisk(ctx, scontainer); err != nil {
+	if err := c.ContainerStateToDiskWithUpdate(ctx, scontainer); err != nil {
 		return sb, fmt.Errorf("failed to write container %q state to disk: %w", scontainer.ID(), err)
 	}
 
@@ -597,7 +597,7 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 
 	// We write back the state because it is possible that crio did not have a chance to
 	// read the exit file and persist exit code into the state on reboot.
-	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
+	if err := c.ContainerStateToDiskWithUpdate(ctx, ctr); err != nil {
 		return fmt.Errorf("failed to write container state to disk %q: %w", ctr.ID(), err)
 	}
 
@@ -629,9 +629,11 @@ func isTrue(annotaton string) bool {
 	return annotaton == "true"
 }
 
-// ContainerStateToDisk writes the container's state information to a JSON file
-// on disk.
-func (c *ContainerServer) ContainerStateToDisk(ctx context.Context, ctr *oci.Container) error {
+// ContainerStateToDiskWithUpdate refreshes the container status from the
+// runtime (best-effort) and then writes the container's state to disk.
+// The runtime update failure is non-fatal: a stale runtime view (e.g., after
+// the runtime container has been deleted) must not block state persistence.
+func (c *ContainerServer) ContainerStateToDiskWithUpdate(ctx context.Context, ctr *oci.Container) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -639,6 +641,12 @@ func (c *ContainerServer) ContainerStateToDisk(ctx context.Context, ctr *oci.Con
 		log.Warnf(ctx, "Error updating the container status %q: %v", ctr.ID(), err)
 	}
 
+	return c.ContainerStateToDisk(ctx, ctr)
+}
+
+// ContainerStateToDisk writes the container's state information to a JSON file
+// on disk.
+func (c *ContainerServer) ContainerStateToDisk(ctx context.Context, ctr *oci.Container) error {
 	jsonSource, err := ioutils.NewAtomicFileWriter(ctr.StatePath(), 0o644)
 	if err != nil {
 		return err

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -592,7 +592,7 @@ func (c *ContainerServer) LoadSandbox(
 
 	// We write back the state because it is possible that crio did not have a chance to
 	// read the exit file and persist exit code into the state on reboot.
-	if err := c.ContainerStateToDisk(ctx, scontainer); err != nil {
+	if err := c.ContainerStateToDiskWithUpdate(ctx, scontainer); err != nil {
 		return sb, fmt.Errorf(
 			"failed to write container %q state to disk: %w",
 			scontainer.ID(),
@@ -806,7 +806,7 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 
 	// We write back the state because it is possible that crio did not have a chance to
 	// read the exit file and persist exit code into the state on reboot.
-	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
+	if err := c.ContainerStateToDiskWithUpdate(ctx, ctr); err != nil {
 		return fmt.Errorf("failed to write container state to disk %q: %w", ctr.ID(), err)
 	}
 
@@ -841,9 +841,14 @@ func isTrue(annotaton string) bool {
 	return annotaton == "true"
 }
 
-// ContainerStateToDisk writes the container's state information to a JSON file
-// on disk.
-func (c *ContainerServer) ContainerStateToDisk(ctx context.Context, ctr *oci.Container) error {
+// ContainerStateToDiskWithUpdate refreshes the container status from the
+// runtime (best-effort) and then writes the container's state to disk.
+// The runtime update failure is non-fatal: a stale runtime view (e.g., after
+// the runtime container has been deleted) must not block state persistence.
+func (c *ContainerServer) ContainerStateToDiskWithUpdate(
+	ctx context.Context,
+	ctr *oci.Container,
+) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -851,6 +856,12 @@ func (c *ContainerServer) ContainerStateToDisk(ctx context.Context, ctr *oci.Con
 		log.Warnf(ctx, "Error updating the container status %q: %v", ctr.ID(), err)
 	}
 
+	return c.ContainerStateToDisk(ctx, ctr)
+}
+
+// ContainerStateToDisk writes the container's state information to a JSON file
+// on disk.
+func (c *ContainerServer) ContainerStateToDisk(ctx context.Context, ctr *oci.Container) error {
 	jsonSource, err := ioutils.NewAtomicFileWriter(ctr.StatePath(), 0o644)
 	if err != nil {
 		return err

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -3,6 +3,7 @@ package lib_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -715,6 +716,41 @@ var _ = t.Describe("ContainerServer", func() {
 	})
 
 	t.Describe("ContainerStateToDisk", func() {
+		It("should write the container state to disk", func() {
+			// Given
+			stateDir := t.MustTempDir("container-state")
+			container, err := oci.NewContainer(containerID, "", "", "",
+				make(map[string]string), make(map[string]string),
+				make(map[string]string), "", nil, nil, "",
+				&types.ContainerMetadata{}, sandboxID, false,
+				false, false, "", stateDir, time.Now(), "")
+			Expect(err).ToNot(HaveOccurred())
+
+			exitCode := int32(42)
+			expectedState := &oci.ContainerState{
+				Created:  time.Now().UTC().Round(0),
+				Started:  time.Now().UTC().Add(time.Second).Round(0),
+				Finished: time.Now().UTC().Add(2 * time.Second).Round(0),
+				ExitCode: &exitCode,
+				Error:    "state persisted",
+				InitPid:  7,
+			}
+			container.SetState(expectedState)
+
+			// When
+			err = sut.ContainerStateToDisk(context.Background(), container)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+
+			content, err := os.ReadFile(container.StatePath())
+			Expect(err).ToNot(HaveOccurred())
+
+			var stateOnDisk oci.ContainerState
+			Expect(json.Unmarshal(content, &stateOnDisk)).To(Succeed())
+			Expect(stateOnDisk).To(Equal(*expectedState))
+		})
+
 		It("should fail when state path invalid", func() {
 			// Given
 			container, err := oci.NewContainer(containerID, "", "", "",
@@ -726,6 +762,89 @@ var _ = t.Describe("ContainerServer", func() {
 
 			// When
 			err = sut.ContainerStateToDisk(context.Background(), container)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	t.Describe("ContainerStateToDiskWithUpdate", func() {
+		It("should update status before writing the container state to disk", func() {
+			// Given
+			stateDir := t.MustTempDir("container-state")
+			container, err := oci.NewContainer(containerID, "", "", "",
+				make(map[string]string), make(map[string]string),
+				make(map[string]string), "", nil, nil, "",
+				&types.ContainerMetadata{}, sandboxID, false,
+				false, false, "", stateDir, time.Now(), "")
+			Expect(err).ToNot(HaveOccurred())
+
+			exitCode := int32(42)
+			expectedState := &oci.ContainerState{
+				Created:  time.Now().UTC().Round(0),
+				Started:  time.Now().UTC().Add(time.Second).Round(0),
+				Finished: time.Now().UTC().Add(2 * time.Second).Round(0),
+				ExitCode: &exitCode,
+				Error:    "state persisted",
+				InitPid:  7,
+			}
+			container.SetState(&oci.ContainerState{Error: "initial state"})
+			sut.Runtime().SetRuntimeImplForContainer(container, ociRuntimeMock)
+			ociRuntimeMock.EXPECT().UpdateContainerStatus(gomock.Any(), container).DoAndReturn(func(ctx context.Context, c *oci.Container) error {
+				c.SetState(expectedState)
+				return nil
+			})
+
+			// When
+			err = sut.ContainerStateToDiskWithUpdate(context.Background(), container)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+
+			content, err := os.ReadFile(container.StatePath())
+			Expect(err).ToNot(HaveOccurred())
+
+			var stateOnDisk oci.ContainerState
+			Expect(json.Unmarshal(content, &stateOnDisk)).To(Succeed())
+			Expect(stateOnDisk).To(Equal(*expectedState))
+		})
+
+		It("should still write the state to disk when status update fails", func() {
+			// Given
+			stateDir := t.MustTempDir("container-state")
+			container, err := oci.NewContainer(containerID, "", "", "",
+				make(map[string]string), make(map[string]string),
+				make(map[string]string), "", nil, nil, "",
+				&types.ContainerMetadata{}, sandboxID, false,
+				false, false, "", stateDir, time.Now(), "")
+			Expect(err).ToNot(HaveOccurred())
+
+			container.SetState(&oci.ContainerState{Error: "written after update failure"})
+			sut.Runtime().SetRuntimeImplForContainer(container, ociRuntimeMock)
+			ociRuntimeMock.EXPECT().UpdateContainerStatus(gomock.Any(), container).Return(t.TestError)
+
+			// When
+			err = sut.ContainerStateToDiskWithUpdate(context.Background(), container)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(container.StatePath()).To(BeAnExistingFile())
+		})
+
+		It("should fail when the state cannot be written to disk", func() {
+			// Given
+			container, err := oci.NewContainer(containerID, "", "", "",
+				make(map[string]string), make(map[string]string),
+				make(map[string]string), "", nil, nil, "",
+				&types.ContainerMetadata{}, sandboxID, false,
+				false, false, "", "/invalid", time.Now(), "")
+			Expect(err).ToNot(HaveOccurred())
+
+			sut.Runtime().SetRuntimeImplForContainer(container, ociRuntimeMock)
+			ociRuntimeMock.EXPECT().UpdateContainerStatus(gomock.Any(), container).Return(nil)
+
+			// When
+			err = sut.ContainerStateToDiskWithUpdate(context.Background(), container)
 
 			// Then
 			Expect(err).To(HaveOccurred())

--- a/internal/lib/container_server_test.go
+++ b/internal/lib/container_server_test.go
@@ -3,6 +3,7 @@ package lib_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -733,6 +734,41 @@ var _ = t.Describe("ContainerServer", func() {
 	})
 
 	t.Describe("ContainerStateToDisk", func() {
+		It("should write the container state to disk", func() {
+			// Given
+			stateDir := t.MustTempDir("container-state")
+			container, err := oci.NewContainer(containerID, "", "", "",
+				make(map[string]string), make(map[string]string),
+				make(map[string]string), "", nil, nil, "",
+				&types.ContainerMetadata{}, sandboxID, false,
+				false, false, "", stateDir, time.Now(), "")
+			Expect(err).ToNot(HaveOccurred())
+
+			exitCode := int32(42)
+			expectedState := &oci.ContainerState{
+				Created:  time.Now().UTC().Round(0),
+				Started:  time.Now().UTC().Add(time.Second).Round(0),
+				Finished: time.Now().UTC().Add(2 * time.Second).Round(0),
+				ExitCode: &exitCode,
+				Error:    "state persisted",
+				InitPid:  7,
+			}
+			container.SetState(expectedState)
+
+			// When
+			err = sut.ContainerStateToDisk(context.Background(), container)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+
+			content, err := os.ReadFile(container.StatePath())
+			Expect(err).ToNot(HaveOccurred())
+
+			var stateOnDisk oci.ContainerState
+			Expect(json.Unmarshal(content, &stateOnDisk)).To(Succeed())
+			Expect(stateOnDisk).To(Equal(*expectedState))
+		})
+
 		It("should fail when state path invalid", func() {
 			// Given
 			container, err := oci.NewContainer(containerID, "", "", "",
@@ -744,6 +780,103 @@ var _ = t.Describe("ContainerServer", func() {
 
 			// When
 			err = sut.ContainerStateToDisk(context.Background(), container)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	t.Describe("ContainerStateToDiskWithUpdate", func() {
+		It("should update status before writing the container state to disk", func() {
+			// Given
+			stateDir := t.MustTempDir("container-state")
+			container, err := oci.NewContainer(containerID, "", "", "",
+				make(map[string]string), make(map[string]string),
+				make(map[string]string), "", nil, nil, "",
+				&types.ContainerMetadata{}, sandboxID, false,
+				false, false, "", stateDir, time.Now(), "")
+			Expect(err).ToNot(HaveOccurred())
+
+			exitCode := int32(42)
+			expectedState := &oci.ContainerState{
+				Created:  time.Now().UTC().Round(0),
+				Started:  time.Now().UTC().Add(time.Second).Round(0),
+				Finished: time.Now().UTC().Add(2 * time.Second).Round(0),
+				ExitCode: &exitCode,
+				Error:    "state persisted",
+				InitPid:  7,
+			}
+			container.SetState(&oci.ContainerState{Error: "initial state"})
+			sut.Runtime().SetRuntimeImplForContainer(container, ociRuntimeMock)
+			DeferCleanup(func() {
+				sut.Runtime().SetRuntimeImplForContainer(container, nil)
+			})
+			ociRuntimeMock.EXPECT().
+				UpdateContainerStatus(gomock.Any(), container).
+				DoAndReturn(func(ctx context.Context, c *oci.Container) error {
+					c.SetState(expectedState)
+
+					return nil
+				})
+
+			// When
+			err = sut.ContainerStateToDiskWithUpdate(context.Background(), container)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+
+			content, err := os.ReadFile(container.StatePath())
+			Expect(err).ToNot(HaveOccurred())
+
+			var stateOnDisk oci.ContainerState
+			Expect(json.Unmarshal(content, &stateOnDisk)).To(Succeed())
+			Expect(stateOnDisk).To(Equal(*expectedState))
+		})
+
+		It("should still write the state to disk when status update fails", func() {
+			// Given
+			stateDir := t.MustTempDir("container-state")
+			container, err := oci.NewContainer(containerID, "", "", "",
+				make(map[string]string), make(map[string]string),
+				make(map[string]string), "", nil, nil, "",
+				&types.ContainerMetadata{}, sandboxID, false,
+				false, false, "", stateDir, time.Now(), "")
+			Expect(err).ToNot(HaveOccurred())
+
+			container.SetState(&oci.ContainerState{Error: "written after update failure"})
+			sut.Runtime().SetRuntimeImplForContainer(container, ociRuntimeMock)
+			DeferCleanup(func() {
+				sut.Runtime().SetRuntimeImplForContainer(container, nil)
+			})
+			ociRuntimeMock.EXPECT().
+				UpdateContainerStatus(gomock.Any(), container).
+				Return(t.TestError)
+
+			// When
+			err = sut.ContainerStateToDiskWithUpdate(context.Background(), container)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(container.StatePath()).To(BeAnExistingFile())
+		})
+
+		It("should fail when the state cannot be written to disk", func() {
+			// Given
+			container, err := oci.NewContainer(containerID, "", "", "",
+				make(map[string]string), make(map[string]string),
+				make(map[string]string), "", nil, nil, "",
+				&types.ContainerMetadata{}, sandboxID, false,
+				false, false, "", "/invalid", time.Now(), "")
+			Expect(err).ToNot(HaveOccurred())
+
+			sut.Runtime().SetRuntimeImplForContainer(container, ociRuntimeMock)
+			DeferCleanup(func() {
+				sut.Runtime().SetRuntimeImplForContainer(container, nil)
+			})
+			ociRuntimeMock.EXPECT().UpdateContainerStatus(gomock.Any(), container).Return(nil)
+
+			// When
+			err = sut.ContainerStateToDiskWithUpdate(context.Background(), container)
 
 			// Then
 			Expect(err).To(HaveOccurred())

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -302,7 +302,7 @@ func (c *ContainerServer) ContainerRestore(
 		return "", fmt.Errorf("failed to restore container %s: %w", ctr.ID(), err)
 	}
 
-	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
+	if err := c.ContainerStateToDiskWithUpdate(ctx, ctr); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
 

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -325,7 +325,7 @@ func (c *ContainerServer) ContainerRestore(
 		return "", fmt.Errorf("failed to restore container %s: %w", ctr.ID(), err)
 	}
 
-	if err := c.ContainerStateToDisk(ctx, ctr); err != nil {
+	if err := c.ContainerStateToDiskWithUpdate(ctx, ctr); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}
 

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -423,8 +423,31 @@ func (r *Runtime) StopContainer(ctx context.Context, c *Container, timeout int64
 	return impl.StopContainer(ctx, c, timeout)
 }
 
-// DeleteContainer deletes a container.
-func (r *Runtime) DeleteContainer(ctx context.Context, c *Container) (err error) {
+// DeleteContainer deletes a container and its cached runtime implementation.
+func (r *Runtime) DeleteContainer(ctx context.Context, c *Container) error {
+	return r.deleteContainer(ctx, c)
+}
+
+// DeleteRuntimeContainer deletes the OCI runtime container while retaining its
+// runtime implementation for the later CRI RemoveContainer call.
+func (r *Runtime) DeleteRuntimeContainer(ctx context.Context, c *Container) error {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
+	r.runtimeImplMapMutex.RLock()
+	impl, ok := r.runtimeImplMap[c.ID()]
+	r.runtimeImplMapMutex.RUnlock()
+
+	// A late post-stop cleanup must not reconstruct a pod-scoped runtime.
+	// The final RemoveContainer call has already completed in this case.
+	if !ok {
+		return nil
+	}
+
+	return impl.DeleteContainer(ctx, c)
+}
+
+func (r *Runtime) deleteContainer(ctx context.Context, c *Container) (err error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 

--- a/internal/oci/runtime_test_inject.go
+++ b/internal/oci/runtime_test_inject.go
@@ -1,0 +1,11 @@
+//go:build test
+
+package oci
+
+// SetRuntimeImplForContainer injects a RuntimeImpl for the provided container.
+func (r *Runtime) SetRuntimeImplForContainer(c *Container, impl RuntimeImpl) {
+	r.runtimeImplMapMutex.Lock()
+	defer r.runtimeImplMapMutex.Unlock()
+
+	r.runtimeImplMap[c.ID()] = impl
+}

--- a/internal/oci/runtime_test_inject.go
+++ b/internal/oci/runtime_test_inject.go
@@ -15,5 +15,16 @@ func (r *Runtime) SetRuntimeImpl(containerID string, impl RuntimeImpl) {
 	r.runtimeImplMapMutex.Lock()
 	defer r.runtimeImplMapMutex.Unlock()
 
+	if impl == nil {
+		delete(r.runtimeImplMap, containerID)
+
+		return
+	}
+
 	r.runtimeImplMap[containerID] = impl
+}
+
+// SetRuntimeImplForContainer injects a RuntimeImpl for the provided container.
+func (r *Runtime) SetRuntimeImplForContainer(c *Container, impl RuntimeImpl) {
+	r.SetRuntimeImpl(c.ID(), impl)
 }

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -768,8 +768,8 @@ func (r *runtimeVM) deleteContainer(c *Container, force bool) error {
 	cInfo, ok := r.ctrs[c.ID()]
 	r.Unlock()
 
-	if !ok && !force {
-		return errors.New("could not retrieve container information")
+	if !ok {
+		return nil
 	}
 
 	if err := cInfo.cio.Close(); err != nil && !force {

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -905,8 +905,8 @@ func (r *runtimeVM) deleteContainer(c *Container, force bool) error {
 	cInfo, ok := r.ctrs[c.ID()]
 	r.Unlock()
 
-	if !ok && !force {
-		return errors.New("could not retrieve container information")
+	if !ok {
+		return nil
 	}
 
 	if err := cInfo.cio.Close(); err != nil && !force {

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -582,7 +582,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *types.CreateContainer
 		return nil
 	})
 
-	if err := s.ContainerStateToDisk(ctx, newContainer); err != nil {
+	if err := s.ContainerStateToDiskWithUpdate(ctx, newContainer); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", newContainer.ID(), err)
 	}
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -642,7 +642,7 @@ func (s *Server) CreateContainer(
 		},
 	)
 
-	if err := s.ContainerStateToDisk(ctx, newContainer); err != nil {
+	if err := s.ContainerStateToDiskWithUpdate(ctx, newContainer); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", newContainer.ID(), err)
 	}
 

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -76,6 +76,7 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 	}
 
 	defer func() {
+		cleanupCtx := context.WithoutCancel(ctx)
 		// if the call to StartContainer fails below we still want to fill
 		// some fields of a container status. In particular, we're going to
 		// adjust container started/finished time and set an error to be
@@ -84,22 +85,31 @@ func (s *Server) StartContainer(ctx context.Context, req *types.StartContainerRe
 			c.SetStartFailed(retErr)
 
 			if hooks != nil {
-				if err := hooks.PreStop(ctx, c, sandbox); err != nil {
-					log.Warnf(ctx, "Failed to run pre-stop hook for container %q: %v", c.ID(), err)
+				if err := hooks.PreStop(cleanupCtx, c, sandbox); err != nil {
+					log.Warnf(cleanupCtx, "Failed to run pre-stop hook for container %q: %v", c.ID(), err)
 				}
 			}
 
-			if err := s.nri.stopContainer(ctx, sandbox, c, false); err != nil {
-				log.Warnf(ctx, "NRI stop failed for container %q: %v", c.ID(), err)
+			// Remove OCI runtime container to trigger OCI poststop hooks
+			if err := s.ContainerServer.Runtime().DeleteContainer(cleanupCtx, c); err != nil {
+				log.Warnf(cleanupCtx, "Failed to delete runtime container %s in pod sandbox %s: %v", c.Name(), sandbox.ID(), err)
 			}
 
-			if err := s.removeContainerInPod(ctx, sandbox, c); err != nil {
-				log.Warnf(ctx, "Failed to delete container in runtime %s: %v", c.ID(), err)
+			if err := s.nri.stopContainer(cleanupCtx, sandbox, c); err != nil {
+				log.Warnf(cleanupCtx, "NRI stop failed for container %q: %v", c.ID(), err)
+			}
+
+			if err := s.removeContainerInPod(cleanupCtx, sandbox, c); err != nil {
+				log.Warnf(cleanupCtx, "Failed to delete container in runtime %s: %v", c.ID(), err)
+			}
+		} else {
+			if err := s.Runtime().UpdateContainerStatus(cleanupCtx, c); err != nil {
+				log.Warnf(cleanupCtx, "Error updating the container status %q: %v", c.ID(), err)
 			}
 		}
 
-		if err := s.ContainerStateToDisk(ctx, c); err != nil {
-			log.Warnf(ctx, "Unable to write containers %s state to disk: %v", c.ID(), err)
+		if err := s.ContainerStateToDisk(cleanupCtx, c); err != nil {
+			log.Warnf(cleanupCtx, "Unable to write containers %s state to disk: %v", c.ID(), err)
 		}
 	}()
 

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -96,6 +96,10 @@ func (s *Server) StartContainer(
 	}
 
 	defer func() {
+		// Detach from client request cancellation/timeout so cleanup, runtime
+		// deletion, and state persistence run to completion even if the request
+		// context was canceled or timed out, while preserving trace and log context.
+		cleanupCtx := context.WithoutCancel(ctx)
 		// if the call to StartContainer fails below we still want to fill
 		// some fields of a container status. In particular, we're going to
 		// adjust container started/finished time and set an error to be
@@ -104,22 +108,31 @@ func (s *Server) StartContainer(
 			c.SetStartFailed(retErr)
 
 			if hooks != nil {
-				if err := hooks.PreStop(ctx, c, sandbox); err != nil {
-					log.Warnf(ctx, "Failed to run pre-stop hook for container %q: %v", c.ID(), err)
+				if err := hooks.PreStop(cleanupCtx, c, sandbox); err != nil {
+					log.Warnf(
+						cleanupCtx,
+						"Failed to run pre-stop hook for container %q: %v",
+						c.ID(),
+						err,
+					)
 				}
 			}
 
-			if err := s.nri.stopContainer(ctx, sandbox, c, false); err != nil {
-				log.Warnf(ctx, "NRI stop failed for container %q: %v", c.ID(), err)
+			if err := s.nri.stopContainer(cleanupCtx, sandbox, c); err != nil {
+				log.Warnf(cleanupCtx, "NRI stop failed for container %q: %v", c.ID(), err)
 			}
 
-			if err := s.removeContainerInPod(ctx, sandbox, c); err != nil {
-				log.Warnf(ctx, "Failed to delete container in runtime %s: %v", c.ID(), err)
+			if err := s.removeContainerInPod(cleanupCtx, sandbox, c); err != nil {
+				log.Warnf(cleanupCtx, "Failed to delete container in runtime %s: %v", c.ID(), err)
+			}
+		} else {
+			if err := s.Runtime().UpdateContainerStatus(cleanupCtx, c); err != nil {
+				log.Warnf(cleanupCtx, "Error updating the container status %q: %v", c.ID(), err)
 			}
 		}
 
-		if err := s.ContainerStateToDisk(ctx, c); err != nil {
-			log.Warnf(ctx, "Unable to write containers %s state to disk: %v", c.ID(), err)
+		if err := s.ContainerStateToDisk(cleanupCtx, c); err != nil {
+			log.Warnf(cleanupCtx, "Unable to write containers %s state to disk: %v", c.ID(), err)
 		}
 	}()
 

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -79,12 +79,21 @@ func (s *Server) postStopCleanup(ctx context.Context, ctr *oci.Container, sb *sa
 		}
 	}
 
-	if err := s.nri.stopContainer(ctx, sb, ctr, true); err != nil {
+	if err := s.Runtime().UpdateContainerStatus(ctx, ctr); err != nil {
+		log.Warnf(ctx, "Error updating the container status %q: %v", ctr.ID(), err)
+	}
+
+	// Remove OCI runtime container to trigger OCI poststop hooks
+	if err := s.ContainerServer.Runtime().DeleteContainer(ctx, ctr); err != nil {
+		log.Warnf(ctx, "Failed to delete runtime container %s in pod sandbox %s: %v", ctr.Name(), sb.ID(), err)
+	}
+
+	if err := s.nri.stopContainer(ctx, sb, ctr); err != nil {
 		log.Warnf(ctx, "NRI stop container request of %s failed: %v", ctr.ID(), err)
 	}
 
 	// persist container state at the end, so there's no window where CRI-O reports the container
-	// as stopped, but hasn't run post stop hooks.
+	// as stopped, but hasn't run post stop hooks
 	if err := s.ContainerStateToDisk(ctx, ctr); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -95,12 +95,26 @@ func (s *Server) postStopCleanup(
 		}
 	}
 
-	if err := s.nri.stopContainer(ctx, sb, ctr, true); err != nil {
+	if err := s.Runtime().UpdateContainerStatus(ctx, ctr); err != nil {
+		log.Warnf(ctx, "Error updating the container status %q: %v", ctr.ID(), err)
+	}
+
+	if err := s.ContainerServer.Runtime().DeleteRuntimeContainer(ctx, ctr); err != nil {
+		log.Warnf(
+			ctx,
+			"Failed to delete runtime container %s in pod sandbox %s: %v",
+			ctr.Name(),
+			sb.ID(),
+			err,
+		)
+	}
+
+	if err := s.nri.stopContainer(ctx, sb, ctr); err != nil {
 		log.Warnf(ctx, "NRI stop container request of %s failed: %v", ctr.ID(), err)
 	}
 
 	// persist container state at the end, so there's no window where CRI-O reports the container
-	// as stopped, but hasn't run post stop hooks.
+	// as stopped, but hasn't run post stop hooks
 	if err := s.ContainerStateToDisk(ctx, ctr); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", ctr.ID(), err)
 	}

--- a/server/container_stop_test.go
+++ b/server/container_stop_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,14 +24,45 @@ var _ = t.Describe("ContainerStop", func() {
 	AfterEach(afterEach)
 
 	t.Describe("ContainerStop", func() {
+		It("should succeed even if runtime DeleteContainer fails", func() {
+			// Given
+			addContainerAndSandbox()
+			testContainer.SetState(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateStopped},
+			})
+			sut.Runtime().SetRuntimeImplForContainer(testContainer, ociRuntimeMock)
+			gomock.InOrder(
+				ociRuntimeMock.EXPECT().StopContainer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil),
+				ociRuntimeMock.EXPECT().UpdateContainerStatus(gomock.Any(), gomock.Any()).Return(nil),
+				ociRuntimeMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).
+					Return(errors.New("boom")),
+			)
+
+			// When
+			_, err := sut.StopContainer(context.Background(),
+				&types.StopContainerRequest{
+					ContainerId: testContainer.ID(),
+				})
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
 		It("should succeed", func() {
 			// Given
 			addContainerAndSandbox()
 			testContainer.SetState(&oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateStopped},
 			})
+			sut.Runtime().SetRuntimeImplForContainer(testContainer, ociRuntimeMock)
 			gomock.InOrder(
+				ociRuntimeMock.EXPECT().StopContainer(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil),
 				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).
+					Return(nil),
+				ociRuntimeMock.EXPECT().UpdateContainerStatus(gomock.Any(), gomock.Any()).
+					Return(nil),
+				ociRuntimeMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).
 					Return(nil),
 			)
 

--- a/server/container_stop_test.go
+++ b/server/container_stop_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,17 +21,60 @@ var _ = t.Describe("ContainerStop", func() {
 		setupSUT()
 	})
 
-	AfterEach(afterEach)
+	AfterEach(func() {
+		if sut != nil {
+			sut.Runtime().SetRuntimeImplForContainer(testContainer, nil)
+		}
+
+		afterEach()
+	})
 
 	t.Describe("ContainerStop", func() {
+		It("should succeed even if runtime DeleteContainer fails", func() {
+			// Given
+			addContainerAndSandbox()
+			testContainer.SetState(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateStopped},
+			})
+			sut.Runtime().SetRuntimeImplForContainer(testContainer, ociRuntimeMock)
+			ociRuntimeMock.EXPECT().ProbeMonitor(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			gomock.InOrder(
+				ociRuntimeMock.EXPECT().
+					StopContainer(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil),
+				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil),
+				ociRuntimeMock.EXPECT().
+					UpdateContainerStatus(gomock.Any(), gomock.Any()).
+					Return(nil),
+				ociRuntimeMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).
+					Return(errors.New("boom")),
+			)
+
+			// When
+			_, err := sut.StopContainer(context.Background(),
+				&types.StopContainerRequest{
+					ContainerId: testContainer.ID(),
+				})
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
 		It("should succeed", func() {
 			// Given
 			addContainerAndSandbox()
 			testContainer.SetState(&oci.ContainerState{
 				State: specs.State{Status: oci.ContainerStateStopped},
 			})
+			sut.Runtime().SetRuntimeImplForContainer(testContainer, ociRuntimeMock)
+			ociRuntimeMock.EXPECT().ProbeMonitor(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			gomock.InOrder(
+				ociRuntimeMock.EXPECT().StopContainer(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil),
 				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).
+					Return(nil),
+				ociRuntimeMock.EXPECT().UpdateContainerStatus(gomock.Any(), gomock.Any()).
+					Return(nil),
+				ociRuntimeMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).
 					Return(nil),
 			)
 
@@ -39,6 +83,55 @@ var _ = t.Describe("ContainerStop", func() {
 				&types.StopContainerRequest{
 					ContainerId: testContainer.ID(),
 				})
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should retain the runtime implementation until container removal", func() {
+			// Given
+			addContainerAndSandbox()
+			testContainer.SetState(&oci.ContainerState{
+				State: specs.State{Status: oci.ContainerStateStopped},
+			})
+			testSandbox.SetStopped(context.Background(), true)
+			sut.Runtime().SetRuntimeImplForContainer(testContainer, ociRuntimeMock)
+			ociRuntimeMock.EXPECT().ProbeMonitor(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			gomock.InOrder(
+				ociRuntimeMock.EXPECT().
+					StopContainer(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil),
+				runtimeServerMock.EXPECT().StopContainer(gomock.Any(), gomock.Any()).Return(nil),
+				ociRuntimeMock.EXPECT().
+					UpdateContainerStatus(gomock.Any(), gomock.Any()).
+					Return(nil),
+				ociRuntimeMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).Return(nil),
+				ociRuntimeMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).Return(nil),
+				runtimeServerMock.EXPECT().DeleteContainer(gomock.Any(), gomock.Any()).Return(nil),
+			)
+
+			// When
+			_, err := sut.StopContainer(
+				context.Background(),
+				&types.StopContainerRequest{ContainerId: testContainer.ID()},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = sut.RemoveContainer(
+				context.Background(),
+				&types.RemoveContainerRequest{ContainerId: testContainer.ID()},
+			)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should skip runtime deletion when the implementation is absent", func() {
+			// Given
+			addContainerAndSandbox()
+			sut.Runtime().SetRuntimeImplForContainer(testContainer, nil)
+
+			// When
+			err := sut.Runtime().DeleteRuntimeContainer(context.Background(), testContainer)
 
 			// Then
 			Expect(err).ToNot(HaveOccurred())

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -293,15 +293,9 @@ func (a *nriAPI) postUpdateContainer(ctx context.Context, criCtr *oci.Container)
 	return a.nri.PostUpdateContainer(ctx, pod, ctr)
 }
 
-func (a *nriAPI) stopContainer(ctx context.Context, criPod *sandbox.Sandbox, criCtr *oci.Container, updateState bool) error {
+func (a *nriAPI) stopContainer(ctx context.Context, criPod *sandbox.Sandbox, criCtr *oci.Container) error {
 	if !a.isEnabled() {
 		return nil
-	}
-
-	if updateState {
-		if err := a.cri.Runtime().UpdateContainerStatus(ctx, criCtr); err != nil {
-			log.Warnf(ctx, "Error updating the container status  %q: %v", criCtr.ID(), err)
-		}
 	}
 
 	ctr := &criContainer{

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -336,16 +336,9 @@ func (a *nriAPI) stopContainer(
 	ctx context.Context,
 	criPod *sandbox.Sandbox,
 	criCtr *oci.Container,
-	updateState bool,
 ) error {
 	if !a.isEnabled() {
 		return nil
-	}
-
-	if updateState {
-		if err := a.cri.Runtime().UpdateContainerStatus(ctx, criCtr); err != nil {
-			log.Warnf(ctx, "Error updating the container status  %q: %v", criCtr.ID(), err)
-		}
 	}
 
 	ctr := &criContainer{

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -543,7 +543,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
-	if err := s.ContainerStateToDisk(ctx, container); err != nil {
+	if err := s.ContainerStateToDiskWithUpdate(ctx, container); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", container.ID(), err)
 	}
 

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -559,7 +559,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 		return nil, err
 	}
 
-	if err := s.ContainerStateToDisk(ctx, container); err != nil {
+	if err := s.ContainerStateToDiskWithUpdate(ctx, container); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", container.ID(), err)
 	}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1394,7 +1394,7 @@ func (s *Server) createAndStartInfraContainer(ctx context.Context, sb *libsandbo
 		return nil
 	})
 
-	if err := s.ContainerStateToDisk(ctx, container); err != nil {
+	if err := s.ContainerStateToDiskWithUpdate(ctx, container); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", container.ID(), err)
 	}
 

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1837,7 +1837,7 @@ func (s *Server) createAndStartInfraContainer(
 		return nil
 	})
 
-	if err := s.ContainerStateToDisk(ctx, container); err != nil {
+	if err := s.ContainerStateToDiskWithUpdate(ctx, container); err != nil {
 		log.Warnf(ctx, "Unable to write containers %s state to disk: %v", container.ID(), err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1112,16 +1112,20 @@ func (s *Server) generateCRIEvent(
 		return
 	}
 
-	if err := s.ContainerServer.Runtime().UpdateContainerStatus(ctx, container); err != nil {
-		log.Errorf(
-			ctx,
-			"GenerateCRIEvent: event type: %s, failed to update the container status %s: %v",
-			eventType,
-			container.ID(),
-			err,
-		)
+	// Stop and remove cleanup update the status before deleting the runtime
+	// container, so probing the runtime again would fail for runtimes such as Kata.
+	if eventNeedsStatusRefresh(eventType) {
+		if err := s.ContainerServer.Runtime().UpdateContainerStatus(ctx, container); err != nil {
+			log.Errorf(
+				ctx,
+				"GenerateCRIEvent: event type: %s, failed to update the container status %s: %v",
+				eventType,
+				container.ID(),
+				err,
+			)
 
-		return
+			return
+		}
 	}
 
 	if !s.HasSandbox(container.Sandbox()) {
@@ -1175,6 +1179,11 @@ func (s *Server) generateCRIEvent(
 
 		return
 	}
+}
+
+func eventNeedsStatusRefresh(eventType types.ContainerEventType) bool {
+	return eventType != types.ContainerEventType_CONTAINER_STOPPED_EVENT &&
+		eventType != types.ContainerEventType_CONTAINER_DELETED_EVENT
 }
 
 func isNotFound(err error) bool {

--- a/server/server_event_test.go
+++ b/server/server_event_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"testing"
+
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestEventStatusRefreshPolicy(t *testing.T) {
+	tests := map[string]struct {
+		eventType types.ContainerEventType
+		want      bool
+	}{
+		"created event": {
+			eventType: types.ContainerEventType_CONTAINER_CREATED_EVENT,
+			want:      true,
+		},
+		"started event": {
+			eventType: types.ContainerEventType_CONTAINER_STARTED_EVENT,
+			want:      true,
+		},
+		"stopped event": {
+			eventType: types.ContainerEventType_CONTAINER_STOPPED_EVENT,
+			want:      false,
+		},
+		"deleted event": {
+			eventType: types.ContainerEventType_CONTAINER_DELETED_EVENT,
+			want:      false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := eventNeedsStatusRefresh(test.eventType)
+			if got != test.want {
+				t.Errorf("status refresh = %t, want %t", got, test.want)
+			}
+		})
+	}
+}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1070,7 +1070,7 @@ function assert_log_linking() {
 	crictl inspectp "$pod_id" | grep '"security.alpha.kubernetes.io/seccomp/pod": "unconfined"'
 
 	# sandbox annotations passed through to container OCI config
-	ctr_id=$(crictl run "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
 	check_oci_annotation "$ctr_id" "com.example.test" "sandbox annotation"
 }
 

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -20,7 +20,12 @@ function teardown() {
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$ctr_id"
-	crictl stopp "$pod_id"
-	crictl rmp "$pod_id"
+	# check prestart
 	cat "${HOOKSCHECK}"
+	rm "${HOOKSCHECK}"
+	crictl stopp "$pod_id"
+	# check poststop
+	cat "${HOOKSCHECK}"
+	rm "${HOOKSCHECK}"
+	crictl rmp "$pod_id"
 }

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -20,7 +20,12 @@ function teardown() {
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$ctr_id"
+	# check prestart for the workload container
+	grep -F "${ctr_id}" "${HOOKSCHECK}"
+	rm "${HOOKSCHECK}"
 	crictl stopp "$pod_id"
+	# check poststop for the workload container, before it is removed
+	grep -F "${ctr_id}" "${HOOKSCHECK}"
+	rm "${HOOKSCHECK}"
 	crictl rmp "$pod_id"
-	cat "${HOOKSCHECK}"
 }

--- a/test/hooks/checkhook.json
+++ b/test/hooks/checkhook.json
@@ -1,5 +1,5 @@
 {
   "cmd": [".*"],
   "hook": "HOOKSDIR/checkhook.sh",
-  "stage": ["prestart"]
+  "stage": ["prestart", "poststop"]
 }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
CRI-O currently leaves the OCI runtime container in place after StopContainer and only deletes it during RemoveContainer. Because OCI poststop hooks are triggered by runtime container deletion, that delays poststop execution until container removal instead of container stop.

Delete the OCI runtime container as part of post-stop cleanup so OCI poststop hooks run when the container is stopped. Keep the delete best-effort and log failures without blocking shutdown.

Update the stop-container unit test to expect runtime deletion and extend the hooks test to validate both prestart and poststop execution.

#### Does this PR introduce a user-facing change?
```release-note
Fixed OCI poststop hooks to run at container stop time instead of container removal by deleting the OCI runtime container during stop cleanup.
```

Which issue(s) this PR fixes:
Fixes: #9732





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container state persistence now refreshes runtime status before writing to disk during lifecycle operations.
  * Stop and cleanup flows now update status and trigger post-stop hooks more reliably.
  * Container deletion in some VM scenarios now succeeds when runtime I/O information is unavailable.

* **Tests**
  * Expanded coverage for state persistence, lifecycle cleanup, error handling, and hook sequencing.
  * Added test support for controlled runtime behavior.

* **Documentation**
  * Hook tests now validate both prestart and poststop hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->