### PR TITLE
Set the default of runtimeFeatures.UserNamespacesHostNetwork to true

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -882,7 +882,7 @@ func addSysfsMounts(ctr ctrfactory.Container, containerConfig *types.ContainerCo
 					Destination: "/sys",
 					Type:        "bind",
 					Source:      "/sys",
-					Options:     []string{"nosuid", "noexec", "nodev", "ro", "rbind"},
+					Options:     []string{"nosuid", "noexec", "nodev", "rro", "rbind"},
 				})
 			} else {
 				ctr.SpecAddMount(rspec.Mount{

--- a/server/runtime_status.go
+++ b/server/runtime_status.go
@@ -36,7 +36,8 @@ func (s *Server) Status(ctx context.Context, req *types.StatusRequest) (*types.S
 			},
 		},
 		Features: &types.RuntimeFeatures{
-			SupplementalGroupsPolicy: true,
+			SupplementalGroupsPolicy:  true,
+			UserNamespacesHostNetwork: true,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
Due to the integration with NodeDeclaredFeatures, the kubelet needs to know exactly which version of cri-o provides this feature. Therefore, I added the UserNamespacesHostNetwork field in CRI. Now we just need to set it to true

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

I've also updated the bind mount for the host network and `/sys` within the user namespace to use the `rro` option. This ensures that the mount remains recursively read-only, following discussions and implementation in containerd. For more context, please refer to: https://github.com/containerd/containerd/pull/12518#discussion_r2671832644


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
CRI-O now reports `runtimeFeatures.UserNamespacesHostNetwork` as enabled on Linux and uses a recursively read-only `/sys` bind mount for containers running with both host network and user namespaces.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime status now reports an additional capability indicating support for user-namespace host networking on Linux, improving runtime feature detection and diagnostics.

* **Bug Fixes**
  * `/sys` mounts now enforce recursive read-only behavior in the specific user-namespace + host-network scenario, tightening filesystem mount security and reducing accidental writes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->