### PR TITLE
pinns: terminate long_options array for getopt_long

### DIFF
--- a/pinns/src/pinns.c
+++ b/pinns/src/pinns.c
@@ -66,6 +66,7 @@ int main(int argc, char **argv) {
       {"uid-mapping", optional_argument, NULL, UID_MAPPING},
       {"gid-mapping", optional_argument, NULL, GID_MAPPING},
       {"sysctl", optional_argument, NULL, 's'},
+      {NULL, 0, NULL, 0},
   };
 
   sysctls = calloc(argc/2, sizeof(char *));


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

`long_options[]` in `pinns/src/pinns.c` is missing the `{NULL, 0, NULL, 0}` sentinel that GNU `getopt_long(3)` requires. The glibc manual entry for `struct option` says: "Terminate the array with an element containing all zeros."

https://sourceware.org/glibc/manual/2.43/html_node/Getopt-Long-Options.html

Without the sentinel, the matching loop walks past the end of the array into adjacent `.rodata`. The bug is latent in most builds because the linker happens to place zeroed bytes after the array, and the loop self-terminates by luck. On builds where `.rodata` layout puts a non-zero word immediately after `long_options[]` (observed with ThinLTO release builds for armv7 musl), `getopt_long` dereferences a garbage pointer in its inner string compare and segfaults inside `__getopt_long`.

This adds the sentinel, making the contract explicit and removing the layout-dependent crash.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The fix is one line. Reproduces reliably on `armv7-musleabihf` release builds with ThinLTO; latent on glibc/x86_64 dev builds.

#### Does this PR introduce a user-facing change?

```release-note
Fix a latent crash in `pinns` caused by a missing zero terminator on the `getopt_long` long options array. The crash surfaces on builds whose linker places non-zero data immediately after the array (observed with ThinLTO release builds on armv7 musl).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command-line option parsing to properly terminate the options configuration, ensuring reliable command-line argument processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->