### PR TITLE
Fold all the Accept Headers.

### DIFF
--- a/internal/storage/image.go
+++ b/internal/storage/image.go
@@ -49,6 +49,14 @@ const (
 //nolint:gochecknoinits // Init function is intentional here.
 func init() {
 	reexec.Register("crio-pull-image", pullImageChild)
+	// Collapse Accept MIME types into one comma-separated value so proxies like
+	// CloudFront (which drop all but the first header line) see the full list.
+	// See https://github.com/cri-o/cri-o/issues/9902.
+	if len(manifest.DefaultRequestedManifestMIMETypes) > 0 {
+		manifest.DefaultRequestedManifestMIMETypes = []string{
+			strings.Join(manifest.DefaultRequestedManifestMIMETypes, ", "),
+		}
+	}
 }
 
 // ImageResult wraps a subset of information about an image: its ID, its names,


### PR DESCRIPTION
I've been looking further into [RFC 9110, Section 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3), and it seems that `Set-Cookie` is the primary exception we need to account for. The specification is explicit about how recipients should handle multiple field lines:
 
> "This means that, aside from the well-known exception noted below, a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list (i.e., at least one alternative of the field's definition allows a comma-separated list, such as an ABNF rule of #(values) defined in Section 5.6.1)."
 
> "Note: In practice, the `Set-Cookie` header field ([COOKIE]) often appears in a response message across multiple field lines and does not use the list syntax, violating the above requirements on multiple field lines with the same field name. Since it cannot be combined into a single field value, recipients ought to handle `Set-Cookie` as a special case while processing fields. (See Appendix A.2.3 of [Kri2001] for details.)"
 
From this it safe to assume that if we fold the accept headers it should be generally safe.


Fixes: https://github.com/cri-o/cri-o/issues/9902


```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image manifest handling compatibility with proxies that have header line limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->