### PR TITLE
Retain container runtime information

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -405,6 +405,9 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 		return sb, err
 	}
 
+	// Pre-populate the runtime handler config cache while the handler is still available in the live config.
+	c.Runtime().EnsureRuntimeHandlerConfig(scontainer)
+
 	// We should restore the infraContainer to the container state store
 	c.AddInfraContainer(ctx, scontainer)
 
@@ -604,6 +607,9 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 	ctr.SetCreated()
 
 	ctr.SetRuntimePathForPlatform(platformRuntimePath)
+
+	// Pre-populate the runtime handler config cache while the handler is still available in the live config.
+	c.Runtime().EnsureRuntimeHandlerConfig(ctr)
 
 	c.AddContainer(ctx, ctr)
 

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -48,6 +48,9 @@ type Runtime struct {
 	config              *config.Config
 	runtimeImplMap      map[string]RuntimeImpl
 	runtimeImplMapMutex sync.RWMutex
+	// runtimeHandlerConfigMap caches handler config per container ID for fallback when handler is removed from live config.
+	runtimeHandlerConfigMap      map[string]*config.RuntimeHandler
+	runtimeHandlerConfigMapMutex sync.RWMutex
 }
 
 // RuntimeImpl is an interface used by the caller to interact with the
@@ -93,8 +96,9 @@ func New(c *config.Config) (*Runtime, error) {
 	}
 
 	return &Runtime{
-		config:         c,
-		runtimeImplMap: make(map[string]RuntimeImpl),
+		config:                  c,
+		runtimeImplMap:          make(map[string]RuntimeImpl),
+		runtimeHandlerConfigMap: make(map[string]*config.RuntimeHandler),
 	}, nil
 }
 
@@ -269,7 +273,20 @@ func (r *Runtime) RuntimeStreamWebsockets(runtimeHandler string) (bool, error) {
 func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
 	rh, err := r.getRuntimeHandler(c.runtimeHandler)
 	if err != nil {
-		return nil, err
+		// Handler removed from live config; fall back to cached config so the container can still be stopped/deleted.
+		r.runtimeHandlerConfigMapMutex.RLock()
+		rh = r.runtimeHandlerConfigMap[c.ID()]
+		r.runtimeHandlerConfigMapMutex.RUnlock()
+
+		if rh == nil {
+			return nil, err
+		}
+
+		log.Warnf(context.Background(), "Runtime handler %q no longer in config; using cached handler config for container %s", c.runtimeHandler, c.ID())
+	} else {
+		r.runtimeHandlerConfigMapMutex.Lock()
+		r.runtimeHandlerConfigMap[c.ID()] = rh
+		r.runtimeHandlerConfigMapMutex.Unlock()
 	}
 
 	if rh.RuntimeType == config.RuntimeTypeVM {
@@ -283,6 +300,26 @@ func (r *Runtime) newRuntimeImpl(c *Container) (RuntimeImpl, error) {
 	// If the runtime type is different from "vm", then let's fallback
 	// onto the OCI implementation by default.
 	return newRuntimeOCI(r, rh), nil
+}
+
+// EnsureRuntimeHandlerConfig snapshots the handler config for a container at restore time so it survives config reloads.
+func (r *Runtime) EnsureRuntimeHandlerConfig(c *Container) {
+	r.runtimeHandlerConfigMapMutex.RLock()
+	_, already := r.runtimeHandlerConfigMap[c.ID()]
+	r.runtimeHandlerConfigMapMutex.RUnlock()
+
+	if already {
+		return
+	}
+
+	rh, err := r.getRuntimeHandler(c.runtimeHandler)
+	if err != nil {
+		return
+	}
+
+	r.runtimeHandlerConfigMapMutex.Lock()
+	r.runtimeHandlerConfigMap[c.ID()] = rh
+	r.runtimeHandlerConfigMapMutex.Unlock()
 }
 
 // RuntimeImpl returns the runtime implementation for a given container.
@@ -410,6 +447,10 @@ func (r *Runtime) DeleteContainer(ctx context.Context, c *Container) (err error)
 				r.runtimeImplMapMutex.Lock()
 				delete(r.runtimeImplMap, c.ID())
 				r.runtimeImplMapMutex.Unlock()
+
+				r.runtimeHandlerConfigMapMutex.Lock()
+				delete(r.runtimeHandlerConfigMap, c.ID())
+				r.runtimeHandlerConfigMapMutex.Unlock()
 			}
 		}()
 	}

--- a/internal/oci/oci_fallback_test.go
+++ b/internal/oci/oci_fallback_test.go
@@ -1,0 +1,186 @@
+package oci_test
+
+// Tests for the runtime handler config fallback introduced to fix issue #9521:
+// pods must not be stuck in Terminating when their runtime class is removed
+// from the live config (e.g. nvidia-container-toolkit teardown race).
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/oci"
+	libconfig "github.com/cri-o/cri-o/pkg/config"
+)
+
+var _ = t.Describe("RuntimeHandlerFallback", func() {
+	var sut *oci.Runtime
+
+	const removedRuntime = "removed-runtime"
+
+	newCtr := func(id, handler string) *oci.Container {
+		ctr, err := oci.NewContainer(
+			id, "", "", "",
+			map[string]string{}, map[string]string{}, map[string]string{},
+			"", nil, nil, "", &types.ContainerMetadata{}, sandboxID,
+			false, false, false, handler, "", time.Now(), "")
+		Expect(err).ToNot(HaveOccurred())
+
+		return ctr
+	}
+
+	var removedHandler *libconfig.RuntimeHandler
+
+	BeforeEach(func() {
+		var err error
+
+		// Fresh config for each test.
+		config, err = libconfig.DefaultConfig()
+		Expect(err).ToNot(HaveOccurred())
+
+		config.ContainerAttachSocketDir = t.MustTempDir("crio")
+
+		removedHandler = &libconfig.RuntimeHandler{
+			RuntimePath: "/bin/sh",
+			RuntimeRoot: "/run/crun",
+		}
+
+		// Start with both the default and the to-be-removed runtime present.
+		config.DefaultRuntime = "crun"
+		config.Runtimes = libconfig.Runtimes{
+			"crun": &libconfig.RuntimeHandler{
+				RuntimePath: "/bin/sh",
+				RuntimeRoot: "/run/crun",
+			},
+			removedRuntime: removedHandler,
+		}
+
+		sut, err = oci.New(config)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	simulateConfigReload := func() {
+		config.Runtimes = libconfig.Runtimes{
+			"crun": config.Runtimes["crun"],
+		}
+	}
+
+	// Main fix: EnsureRuntimeHandlerConfig + RuntimeImpl fallback
+	It("RuntimeImpl fails when handler removed before any caching", func() {
+		ctr := newCtr("ctr-no-cache", removedRuntime)
+
+		simulateConfigReload()
+
+		_, err := sut.RuntimeImpl(ctr)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(removedRuntime))
+	})
+
+	It("RuntimeImpl succeeds when handler removed after EnsureRuntimeHandlerConfig", func() {
+		ctr := newCtr("ctr-with-cache", removedRuntime)
+
+		// Pre-populate while the handler is present — this is what
+		// LoadSandbox / LoadContainer call on restore.
+		sut.EnsureRuntimeHandlerConfig(ctr)
+
+		// Simulate the race: nvidia-container-toolkit removes the runtime.
+		simulateConfigReload()
+
+		// The container must still be stoppable via the fallback config.
+		impl, err := sut.RuntimeImpl(ctr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(impl).NotTo(BeNil())
+	})
+
+	It("RuntimeImpl auto-caches handler config on the first successful call", func() {
+		ctr := newCtr("ctr-auto-cache", removedRuntime)
+
+		impl, err := sut.RuntimeImpl(ctr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(impl).NotTo(BeNil())
+
+		simulateConfigReload()
+
+		ctr2 := newCtr("ctr-auto-cache-2", removedRuntime)
+		_, err = sut.RuntimeImpl(ctr2)
+		Expect(err).To(HaveOccurred(), "different container ID has no cached config")
+	})
+
+	It("EnsureRuntimeHandlerConfig is a silent no-op for an unknown handler", func() {
+		ctr := newCtr("ctr-unknown", "nonexistent-handler")
+
+		// Must not panic or return an error.
+		Expect(func() { sut.EnsureRuntimeHandlerConfig(ctr) }).ToNot(Panic())
+
+		// No fallback entry was created, so RuntimeImpl still fails.
+		_, err := sut.RuntimeImpl(ctr)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("nonexistent-handler"))
+	})
+
+	It("EnsureRuntimeHandlerConfig is idempotent", func() {
+		ctr := newCtr("ctr-idempotent", removedRuntime)
+
+		sut.EnsureRuntimeHandlerConfig(ctr)
+		sut.EnsureRuntimeHandlerConfig(ctr) // second call must be a no-op
+
+		simulateConfigReload()
+
+		impl, err := sut.RuntimeImpl(ctr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(impl).NotTo(BeNil())
+	})
+
+	It("EnsureRuntimeHandlerConfig does nothing when handler already cached by RuntimeImpl", func() {
+		ctr := newCtr("ctr-already-impl-cached", removedRuntime)
+
+		// Populate runtimeImplMap (and runtimeHandlerConfigMap) via RuntimeImpl.
+		_, err := sut.RuntimeImpl(ctr)
+		Expect(err).ToNot(HaveOccurred())
+
+		// The subsequent EnsureRuntimeHandlerConfig should be a no-op.
+		Expect(func() { sut.EnsureRuntimeHandlerConfig(ctr) }).ToNot(Panic())
+
+		simulateConfigReload()
+
+		// Still succeeds because runtimeImplMap cache hit takes priority.
+		impl, err := sut.RuntimeImpl(ctr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(impl).NotTo(BeNil())
+	})
+
+	// Handler-config cache isolation: each container ID is independent
+
+	It("cached handler config for one container does not bleed into another", func() {
+		ctr1 := newCtr("ctr-bleed-1", removedRuntime)
+		ctr2 := newCtr("ctr-bleed-2", removedRuntime)
+
+		// Only cache for ctr1.
+		sut.EnsureRuntimeHandlerConfig(ctr1)
+
+		simulateConfigReload()
+
+		// ctr1 must succeed.
+		impl, err := sut.RuntimeImpl(ctr1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(impl).NotTo(BeNil())
+
+		// ctr2 must fail — it was never explicitly cached.
+		_, err = sut.RuntimeImpl(ctr2)
+		Expect(err).To(HaveOccurred())
+	})
+
+	// Default runtime is always usable (regression guard)
+
+	It("RuntimeImpl still works for the default runtime after removedRuntime is gone", func() {
+		ctr := newCtr("ctr-default", "crun")
+
+		simulateConfigReload()
+
+		impl, err := sut.RuntimeImpl(ctr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(impl).NotTo(BeNil())
+	})
+})

--- a/server/server.go
+++ b/server/server.go
@@ -1067,30 +1067,15 @@ func (s *Server) startWatcherForMirrorRegistries(ctx context.Context, registries
 }
 
 func (s *Server) watchAndReloadMirrorRegistriesConfiguration(ctx context.Context, watcher *fsnotify.Watcher) {
-	var timer *time.Timer
-
-	reloadChannel := make(chan string, 1)
-
-	go func() {
-		// The for loop ensures that the channel is properly drained, even if
-		// no new events are received, thus preventing potential deadlocks.
-		// For each event name received, the goroutine checks if it's not
-		// an empty string and then reloads the registries.
-		for evenName := range reloadChannel {
-			log.Infof(ctx, "File %q changed, reloading registries configuration", evenName)
-
-			if err := s.config.ReloadRegistries(); err != nil {
-				log.Errorf(ctx, "Failed to reload registry configuration: %v", err)
-			}
-		}
-	}()
+	var (
+		timerCh  <-chan time.Time
+		lastName string
+	)
 
 	for {
 		select {
 		case event, ok := <-watcher.Events:
 			if !ok {
-				close(reloadChannel)
-
 				return
 			}
 
@@ -1099,20 +1084,26 @@ func (s *Server) watchAndReloadMirrorRegistriesConfiguration(ctx context.Context
 			}
 
 			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Chmod) != 0 {
-				// Reset timer if exists, else create a new one.
-				if timer != nil {
-					timer.Reset(debounceDuration)
-				} else {
-					timer = time.AfterFunc(debounceDuration, func() {
-						reloadChannel <- event.Name
-					})
-				}
+				// Reassigning timerCh replaces any pending timer: the old
+				// time.After channel is no longer selected and is GC'd when
+				// its internal timer fires.  This gives trailing-edge
+				// debounce without the AfterFunc.Reset race where Reset on an
+				// already-fired AfterFunc timer schedules the function again.
+				lastName = event.Name
+				timerCh = time.After(debounceDuration)
+			}
+
+		case <-timerCh:
+			timerCh = nil
+
+			log.Infof(ctx, "File %q changed, reloading registries configuration", lastName)
+
+			if err := s.config.ReloadRegistries(); err != nil {
+				log.Errorf(ctx, "Failed to reload registry configuration: %v", err)
 			}
 
 		case err, ok := <-watcher.Errors:
 			if !ok {
-				close(reloadChannel)
-
 				return
 			}
 


### PR DESCRIPTION
Caching ConfigRuntimes

Fixes: https://github.com/cri-o/cri-o/issues/9521

```release-note
Retain per-container cached runtime information
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored containers now pre-populate and retain per-container runtime-handler cache so stop/delete/recreate succeed even if the configured runtime is later removed or changed.
  * Improved mirror-registries config watcher debounce to better coalesce rapid file events and trigger reliable reloads.

* **Tests**
  * Added tests covering runtime-handler caching, fallback behavior, idempotence, container isolation, and config-reload regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9938)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->