### PR TITLE
Feat: Add pinned_artifacts support with crio artifact pull

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -160,6 +160,7 @@ func main() {
 
 	app.Commands = criocli.DefaultCommands
 	app.Commands = append(app.Commands,
+		criocli.ArtifactCommand,
 		criocli.CheckCommand,
 		criocli.ConfigCommand,
 		criocli.PublishCommand,

--- a/completions/bash/crio
+++ b/completions/bash/crio
@@ -2,7 +2,8 @@ _cli_bash_autocomplete() {
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    opts="check
+    opts="artifact
+check
 complete
 completion
 config
@@ -112,6 +113,7 @@ h
 --pause-image
 --pause-image-auth-file
 --pids-limit
+--pinned-artifacts
 --pinned-images
 --pinns-path
 --privileged-seccomp-profile

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -2,7 +2,7 @@
 
 function __fish_crio_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i check complete completion help h config man markdown md status config c containers container cs s info i goroutines g heap hp version wipe help h
+        if contains -- $i artifact pull check complete completion help h config man markdown md status config c containers container cs s info i goroutines g heap hp version wipe help h
             return 1
         end
     end
@@ -147,6 +147,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l pause-command -r -d 'Path 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l pause-image -r -d 'Image which contains the pause executable.'
 complete -c crio -n '__fish_crio_no_subcommand' -l pause-image-auth-file -r -d 'Path to a config file containing credentials for --pause-image.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l pids-limit -r -d 'Maximum number of processes allowed in a container. This option is deprecated. The Kubelet flag \'--pod-pids-limit\' should be used instead.'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l pinned-artifacts -r -d 'A list of OCI artifact references to pre-pull and keep in CRI-O\'s artifact store.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l pinned-images -r -d 'A list of images that will be excluded from the kubelet\'s garbage collection.'
 complete -c crio -n '__fish_crio_no_subcommand' -l pinns-path -r -d 'The path to find the pinns binary, which is needed to manage namespace lifecycle. Will be searched for in $PATH if empty.'
 complete -c crio -n '__fish_crio_no_subcommand' -l privileged-seccomp-profile -r -d 'Enable a seccomp profile for privileged containers from the local path.'
@@ -189,6 +190,10 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l help -s h -d 'show help'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l version -s v -d 'print the version'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l help -s h -d 'show help'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l version -s v -d 'print the version'
+complete -c crio -n '__fish_seen_subcommand_from artifact' -f -l help -s h -d 'show help'
+complete -r -c crio -n '__fish_crio_no_subcommand' -a 'artifact' -d 'Manage OCI artifacts in CRI-O\'s artifact store'
+complete -c crio -n '__fish_seen_subcommand_from pull' -f -l help -s h -d 'show help'
+complete -r -c crio -n '__fish_seen_subcommand_from artifact' -a 'pull' -d 'Pull an OCI artifact into CRI-O\'s artifact store'
 complete -c crio -n '__fish_seen_subcommand_from check' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'check' -d 'Check CRI-O storage directory for errors.
 

--- a/completions/zsh/_crio
+++ b/completions/zsh/_crio
@@ -2,6 +2,7 @@ _cli_zsh_autocomplete() {
 
   local -a cmds
   cmds=(
+        "artifact:Manage OCI artifacts in CRI-O's artifact store"
         "check:Check CRI-O storage directory for errors.
 
 This command can also repair damaged containers, images and layers.
@@ -137,6 +138,7 @@ it later with **--config**. Global options will modify the output.'
         '--pause-image'
         '--pause-image-auth-file'
         '--pids-limit'
+        '--pinned-artifacts'
         '--pinned-images'
         '--pinns-path'
         '--privileged-seccomp-profile'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -108,6 +108,7 @@ crio
 [--pause-image-auth-file]=[value]
 [--pause-image]=[value]
 [--pids-limit]=[value]
+[--pinned-artifacts]=[value]
 [--pinned-images]=[value]
 [--pinns-path]=[value]
 [--privileged-seccomp-profile]=[value]
@@ -409,6 +410,8 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--pids-limit**="": Maximum number of processes allowed in a container. This option is deprecated. The Kubelet flag '--pod-pids-limit' should be used instead. (default: -1)
 
+**--pinned-artifacts**="": A list of OCI artifact references to pre-pull and keep in CRI-O's artifact store.
+
 **--pinned-images**="": A list of images that will be excluded from the kubelet's garbage collection.
 
 **--pinns-path**="": The path to find the pinns binary, which is needed to manage namespace lifecycle. Will be searched for in $PATH if empty.
@@ -489,6 +492,14 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 
 # COMMANDS
+
+## artifact
+
+Manage OCI artifacts in CRI-O's artifact store
+
+### pull
+
+Pull an OCI artifact into CRI-O's artifact store
 
 ## check
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -501,6 +501,9 @@ The command to run to have a container stay in the paused state. This option sup
 **pinned_images**=[]
 A list of images to be excluded from the kubelet's garbage collection. It allows specifying image names using either exact, glob, or keyword patterns. Exact matches must match the entire name, glob matches can have a wildcard \* at the end, and keyword matches can have wildcards on both ends. By default, this list includes the `pause` image if configured by the user, which is used as a placeholder in Kubernetes pods.
 
+**pinned_artifacts**=[]
+A list of OCI artifact references that CRI-O should pre-pull into its artifact store at startup and on SIGHUP reload. Use this to warm caches for large artifacts (e.g. AI/ML model files) so pods that reference them via image-volume mounts start without waiting for a network pull. References must be fully-qualified (e.g. `ghcr.io/example/model:v1`). Failures (bad reference, network error, registry returning a container image instead of an artifact) are logged and skipped — startup is not blocked, and the artifact will still be pulled on-demand as a fallback. This option supports live configuration reload.
+
 **signature_policy**=""
 Path to the file which decides what sort of policy we use when deciding whether or not to trust an image that we've pulled. It is not recommended that this option be used, as the default behavior of using the system-wide default policy (i.e., /etc/containers/policy.json) is most often preferred. Please refer to containers-policy.json(5) for more details.
 

--- a/internal/criocli/artifact.go
+++ b/internal/criocli/artifact.go
@@ -1,0 +1,72 @@
+package criocli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+	"go.podman.io/common/libimage"
+	"go.podman.io/image/v5/docker"
+	"go.podman.io/image/v5/docker/reference"
+
+	"github.com/cri-o/cri-o/internal/ociartifact"
+)
+
+// ArtifactCommand is the top-level CLI command for managing OCI artifacts.
+var ArtifactCommand = &cli.Command{
+	Name:  "artifact",
+	Usage: "Manage OCI artifacts in CRI-O's artifact store",
+	Subcommands: []*cli.Command{
+		artifactPullCommand,
+	},
+}
+
+var artifactPullCommand = &cli.Command{
+	Name:      "pull",
+	Usage:     "Pull an OCI artifact into CRI-O's artifact store",
+	ArgsUsage: "<reference>",
+	Action:    artifactPull,
+}
+
+func artifactPull(c *cli.Context) error {
+	if c.NArg() != 1 {
+		return errors.New("usage: crio artifact pull <reference>")
+	}
+
+	refStr := c.Args().First()
+
+	named, err := reference.ParseNormalizedNamed(refStr)
+	if err != nil {
+		return fmt.Errorf("invalid reference %q: %w", refStr, err)
+	}
+
+	config, err := GetConfigFromContext(c)
+	if err != nil {
+		return err
+	}
+
+	store, err := config.GetStore()
+	if err != nil {
+		return fmt.Errorf("open container storage: %w", err)
+	}
+
+	artStore, err := ociartifact.NewStore(store.GraphRoot(), config.AdditionalArtifactStores, config.SystemContext, nil)
+	if err != nil {
+		return fmt.Errorf("create artifact store: %w", err)
+	}
+
+	imageRef, err := docker.NewReference(named)
+	if err != nil {
+		return fmt.Errorf("create image reference for %q: %w", refStr, err)
+	}
+
+	if _, err := artStore.Pull(c.Context, imageRef, &libimage.CopyOptions{
+		RemoveSignatures: true, // OCI layout destination does not support signature storage
+	}); err != nil {
+		return fmt.Errorf("pull artifact %q: %w", refStr, err)
+	}
+
+	fmt.Printf("Successfully pulled artifact: %s\n", refStr)
+
+	return nil
+}

--- a/internal/criocli/artifact_test.go
+++ b/internal/criocli/artifact_test.go
@@ -1,0 +1,45 @@
+package criocli_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/urfave/cli/v2"
+
+	"github.com/cri-o/cri-o/internal/criocli"
+	libconfig "github.com/cri-o/cri-o/pkg/config"
+)
+
+var _ = t.Describe("ArtifactCommand", func() {
+	newApp := func() *cli.App {
+		cfg, err := libconfig.DefaultConfig()
+		Expect(err).NotTo(HaveOccurred())
+
+		app := cli.NewApp()
+		app.Metadata = map[string]any{"config": cfg}
+		app.Commands = []*cli.Command{criocli.ArtifactCommand}
+
+		return app
+	}
+
+	It("should error when no reference is given", func() {
+		err := newApp().Run([]string{"crio", "artifact", "pull"})
+		Expect(err).To(MatchError(ContainSubstring("usage: crio artifact pull <reference>")))
+	})
+
+	It("should error when more than one reference is given", func() {
+		err := newApp().Run([]string{"crio", "artifact", "pull", "ref1", "ref2"})
+		Expect(err).To(MatchError(ContainSubstring("usage: crio artifact pull <reference>")))
+	})
+
+	It("should error when the reference cannot be parsed", func() {
+		err := newApp().Run([]string{"crio", "artifact", "pull", ":::bad:::"})
+		Expect(err).To(MatchError(ContainSubstring("invalid reference")))
+	})
+
+	It("should error when GetConfigFromContext fails", func() {
+		app := cli.NewApp()
+		app.Commands = []*cli.Command{criocli.ArtifactCommand}
+		err := app.Run([]string{"crio", "artifact", "pull", "registry.example.com/models/llama:v1"})
+		Expect(err).To(MatchError(ContainSubstring("type assertion error")))
+	})
+})

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -206,6 +206,10 @@ func mergeImageConfig(config *libconfig.Config, ctx *cli.Context) {
 		config.PinnedImages = StringSliceTrySplit(ctx, "pinned-images")
 	}
 
+	if ctx.IsSet("pinned-artifacts") {
+		config.PinnedArtifacts = StringSliceTrySplit(ctx, "pinned-artifacts")
+	}
+
 	if ctx.IsSet("short-name-mode") {
 		config.ShortNameMode = ctx.String("short-name-mode")
 	}
@@ -1566,6 +1570,12 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 			Usage:   "A list of images that will be excluded from the kubelet's garbage collection.",
 			EnvVars: []string{"CONTAINER_PINNED_IMAGES"},
 			Value:   cli.NewStringSlice(defConf.PinnedImages...),
+		},
+		&cli.StringSliceFlag{
+			Name:    "pinned-artifacts",
+			Usage:   "A list of OCI artifact references to pre-pull and keep in CRI-O's artifact store.",
+			EnvVars: []string{"CONTAINER_PINNED_ARTIFACTS"},
+			Value:   cli.NewStringSlice(defConf.PinnedArtifacts...),
 		},
 		&cli.BoolFlag{
 			Name:    "disable-hostport-mapping",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -661,6 +661,12 @@ type ImageConfig struct {
 	// Pinned images will remain in the container runtime's storage until
 	// they are manually removed. Default value: empty list (no images pinned)
 	PinnedImages []string `toml:"pinned_images"`
+	// PinnedArtifacts is a list of OCI artifact references that CRI-O should
+	// pre-pull and keep available in the artifact store. CRI-O pulls listed
+	// artifacts on startup and on every SIGHUP config reload. This is the
+	// primary mechanism to pre-warm large AI/ML model artifacts before pods
+	// need them, eliminating cold-start delays. Default value: empty list.
+	PinnedArtifacts []string `toml:"pinned_artifacts"`
 	// SignaturePolicyPath is the name of the file which decides what sort
 	// of policy we use when deciding whether or not to trust an image that
 	// we've pulled.  Outside of testing situations, it is strongly advised

--- a/pkg/config/reload.go
+++ b/pkg/config/reload.go
@@ -60,6 +60,8 @@ func (c *Config) Reload(ctx context.Context) error {
 
 	c.ReloadPinnedImages(newConfig)
 
+	c.ReloadPinnedArtifacts(newConfig)
+
 	if err := c.ReloadRegistries(); err != nil {
 		return err
 	}
@@ -200,6 +202,38 @@ func (c *Config) ReloadPinnedImages(newConfig *Config) {
 	logConfig("pinned_images", strings.Join(pinnedImages, ","))
 
 	c.PinnedImages = pinnedImages
+}
+
+// ReloadPinnedArtifacts replaces the PinnedArtifacts list with the provided
+// newConfig.PinnedArtifacts. The method skips empty items and logs changes.
+func (c *Config) ReloadPinnedArtifacts(newConfig *Config) {
+	if len(newConfig.PinnedArtifacts) == 0 {
+		c.PinnedArtifacts = []string{}
+
+		logConfig("pinned_artifacts", "[]")
+
+		return
+	}
+
+	if cmp.Equal(c.PinnedArtifacts, newConfig.PinnedArtifacts,
+		cmpopts.SortSlices(func(a, b string) bool {
+			return a < b
+		}),
+	) {
+		return
+	}
+
+	pinnedArtifacts := []string{}
+
+	for _, ref := range newConfig.PinnedArtifacts {
+		if ref != "" {
+			pinnedArtifacts = append(pinnedArtifacts, ref)
+		}
+	}
+
+	logConfig("pinned_artifacts", strings.Join(pinnedArtifacts, ","))
+
+	c.PinnedArtifacts = pinnedArtifacts
 }
 
 // ReloadRegistries reloads the registry configuration from the Configs

--- a/pkg/config/reload_test.go
+++ b/pkg/config/reload_test.go
@@ -478,4 +478,46 @@ var _ = t.Describe("Config", func() {
 			Expect(sut.PinnedImages).To(Equal([]string{"image1", "image2", "image3"}))
 		})
 	})
+
+	t.Describe("ReloadPinnedArtifacts", func() {
+		It("should update PinnedArtifacts when the new list differs", func() {
+			sut.PinnedArtifacts = []string{"registry.example.com/old:v1"}
+			newConfig := &config.Config{}
+			newConfig.PinnedArtifacts = []string{"registry.example.com/new:v2"}
+			sut.ReloadPinnedArtifacts(newConfig)
+			Expect(sut.PinnedArtifacts).To(Equal([]string{"registry.example.com/new:v2"}))
+		})
+
+		It("should not update PinnedArtifacts when the lists are identical", func() {
+			sut.PinnedArtifacts = []string{"registry.example.com/model:v1", "registry.example.com/model:v2"}
+			newConfig := &config.Config{}
+			newConfig.PinnedArtifacts = []string{"registry.example.com/model:v1", "registry.example.com/model:v2"}
+			sut.ReloadPinnedArtifacts(newConfig)
+			Expect(sut.PinnedArtifacts).To(Equal([]string{"registry.example.com/model:v1", "registry.example.com/model:v2"}))
+		})
+
+		It("should clear PinnedArtifacts when the new list is empty", func() {
+			sut.PinnedArtifacts = []string{"registry.example.com/model:v1"}
+			newConfig := &config.Config{}
+			newConfig.PinnedArtifacts = []string{}
+			sut.ReloadPinnedArtifacts(newConfig)
+			Expect(sut.PinnedArtifacts).To(BeEmpty())
+		})
+
+		It("should skip empty entries in the new list", func() {
+			sut.PinnedArtifacts = []string{}
+			newConfig := &config.Config{}
+			newConfig.PinnedArtifacts = []string{"registry.example.com/model:v1", "", "registry.example.com/model:v2"}
+			sut.ReloadPinnedArtifacts(newConfig)
+			Expect(sut.PinnedArtifacts).To(Equal([]string{"registry.example.com/model:v1", "registry.example.com/model:v2"}))
+		})
+
+		It("should treat order-only differences as equal (no update)", func() {
+			sut.PinnedArtifacts = []string{"registry.example.com/a:1", "registry.example.com/b:1"}
+			newConfig := &config.Config{}
+			newConfig.PinnedArtifacts = []string{"registry.example.com/b:1", "registry.example.com/a:1"}
+			sut.ReloadPinnedArtifacts(newConfig)
+			Expect(sut.PinnedArtifacts).To(Equal([]string{"registry.example.com/a:1", "registry.example.com/b:1"}))
+		})
+	})
 })

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -543,6 +543,11 @@ func initCrioTemplateConfig(c *Config) ([]*templateConfigValue, error) {
 			isDefaultValue: slices.Equal(dc.PinnedImages, c.PinnedImages),
 		},
 		{
+			templateString: templateStringCrioImagePinnedArtifacts,
+			group:          crioImageConfig,
+			isDefaultValue: slices.Equal(dc.PinnedArtifacts, c.PinnedArtifacts),
+		},
+		{
 			templateString: templateStringCrioImageSignaturePolicy,
 			group:          crioImageConfig,
 			isDefaultValue: simpleEqual(dc.SignaturePolicyPath, c.SignaturePolicyPath),
@@ -1559,6 +1564,16 @@ const templateStringCrioImagePinnedImages = `# List of images to be excluded fro
 # configured by the user, which is used as a placeholder in Kubernetes pods.
 {{ $.Comment }}pinned_images = [
 {{ range $opt := .PinnedImages }}{{ $.Comment }}{{ printf "\t%q,\n" $opt }}{{ end }}{{ $.Comment }}]
+
+`
+
+const templateStringCrioImagePinnedArtifacts = `# List of OCI artifact references to pre-pull and keep in CRI-O's artifact store.
+# CRI-O pulls each listed artifact on startup and on every SIGHUP config reload,
+# eliminating cold-start delays for workloads that use large OCI artifacts such
+# as AI/ML models. References use standard image reference format.
+# This option supports live configuration reload.
+{{ $.Comment }}pinned_artifacts = [
+{{ range $opt := .PinnedArtifacts }}{{ $.Comment }}{{ printf "\t%q,\n" $opt }}{{ end }}{{ $.Comment }}]
 
 `
 

--- a/server/pull_pinned_artifacts_test.go
+++ b/server/pull_pinned_artifacts_test.go
@@ -1,0 +1,131 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	godigest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.uber.org/mock/gomock"
+
+	"github.com/cri-o/cri-o/internal/ociartifact"
+	"github.com/cri-o/cri-o/server"
+	ociartifactmock "github.com/cri-o/cri-o/test/mocks/ociartifact"
+)
+
+const pinnedArtifactTestDigest = godigest.Digest("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+
+// makePinnedArtifactManifest returns a minimal OCI manifest that passes
+// EnsureNotContainerImage (artifactType is set).
+func makePinnedArtifactManifest() []byte {
+	b, err := json.Marshal(map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     specs.MediaTypeImageManifest,
+		"artifactType":  "application/vnd.test.artifact",
+		"config": map[string]any{
+			"mediaType": specs.MediaTypeImageConfig,
+			"digest":    string(pinnedArtifactTestDigest),
+			"size":      0,
+		},
+		"layers": []any{},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+var _ = t.Describe("PullPinnedArtifacts", func() {
+	// Wire up the standard mock lifecycle so mockCtrl, cniPluginMock etc.
+	// are freshly initialised and properly finished for each spec.
+	BeforeEach(beforeEach)
+	AfterEach(afterEach)
+
+	var (
+		ctx        = context.Background()
+		implMock   *ociartifactmock.MockImpl
+		libartMock *ociartifactmock.MockLibartifactStore
+		srv        *server.Server
+	)
+
+	// JustBeforeEach runs after all BeforeEach hooks, so mockCtrl is ready.
+	JustBeforeEach(func() {
+		mockNewServer()
+
+		var err error
+
+		srv, err = server.New(ctx, libMock)
+		Expect(err).NotTo(HaveOccurred())
+
+		srv.SetStorageImageServer(imageServerMock)
+		srv.SetStorageRuntimeServer(runtimeServerMock)
+
+		implMock = ociartifactmock.NewMockImpl(mockCtrl)
+		libartMock = ociartifactmock.NewMockLibartifactStore(mockCtrl)
+
+		artStore, err := ociartifact.NewStore(t.MustTempDir("artifact-store"), nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		artStore.SetFakeImpl(implMock)
+		artStore.SetFakeStore(&ociartifact.FakeLibartifactStore{MockLibartifactStore: libartMock})
+
+		srv.SetArtifactStoreForTest(artStore)
+	})
+
+	It("should do nothing when PinnedArtifacts is empty", func() {
+		// No mock expectations — the store must not be touched.
+		srv.SetPinnedArtifactsForTest([]string{})
+		srv.PullPinnedArtifactsForTest(ctx)
+	})
+
+	It("should call Store.Pull for a valid artifact reference", func() {
+		libartMock.EXPECT().SystemContext().Return(nil)
+		implMock.EXPECT().
+			GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(makePinnedArtifactManifest(), specs.MediaTypeImageManifest, nil)
+		libartMock.EXPECT().
+			Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(pinnedArtifactTestDigest, nil)
+
+		srv.SetPinnedArtifactsForTest([]string{"registry.example.com/models/llama:v1"})
+		srv.PullPinnedArtifactsForTest(ctx)
+	})
+
+	It("should skip an unparsable reference without touching the store", func() {
+		// ":::bad:::" cannot be parsed by ParseNormalizedNamed — no store calls.
+		srv.SetPinnedArtifactsForTest([]string{":::bad:::"})
+		srv.PullPinnedArtifactsForTest(ctx)
+	})
+
+	It("should skip a reference with both tag and digest (docker.NewReference rejects it)", func() {
+		// docker.NewReference rejects refs with both a tag and a digest; no store calls.
+		srv.SetPinnedArtifactsForTest([]string{
+			"registry.example.com/models/llama:v1@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		})
+		srv.PullPinnedArtifactsForTest(ctx)
+	})
+
+	It("should continue pulling remaining refs after a store error", func() {
+		// Both refs pass EnsureNotContainerImage; first pull fails, second succeeds.
+		libartMock.EXPECT().SystemContext().Return(nil).Times(2)
+		implMock.EXPECT().
+			GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(makePinnedArtifactManifest(), specs.MediaTypeImageManifest, nil).
+			Times(2)
+		libartMock.EXPECT().
+			Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(pinnedArtifactTestDigest, errors.New("network timeout"))
+		libartMock.EXPECT().
+			Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(pinnedArtifactTestDigest, nil)
+
+		srv.SetPinnedArtifactsForTest([]string{
+			"registry.example.com/models/bad:v1",
+			"registry.example.com/models/good:v1",
+		})
+		srv.PullPinnedArtifactsForTest(ctx)
+	})
+})

--- a/server/server.go
+++ b/server/server.go
@@ -10,11 +10,15 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"go.podman.io/common/libimage"
+	"go.podman.io/image/v5/docker"
+	"go.podman.io/image/v5/docker/reference"
 	imageTypes "go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/idtools"
 	storageTypes "go.podman.io/storage/types"
@@ -101,6 +105,10 @@ type Server struct {
 	hooksRetriever *runtimehandlerhooks.HooksRetriever
 
 	artifactStore *ociartifact.Store
+	// pinnedArtifactsPullMu serializes concurrent pullPinnedArtifacts goroutines
+	// (triggered at startup and on each SIGHUP) so they don't race on the shared
+	// store or pull the same artifact concurrently.
+	pinnedArtifactsPullMu sync.Mutex
 }
 
 // pullArguments are used to identify a pullOperation via an input image name and
@@ -478,6 +486,8 @@ func New(
 		artifactStore:            artifactStore,
 	}
 
+	go s.pullPinnedArtifacts(ctx, append([]string(nil), s.config.PinnedArtifacts...))
+
 	if s.config.EnablePodEvents {
 		// creating a container events channel only if the evented pleg is enabled
 		s.ContainerEventsChan = make(chan types.ContainerEventResponse, 1000)
@@ -627,6 +637,10 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			// Block until the signal is received
 			<-ch
 
+			// Snapshot the artifact list before reload so we can detect whether
+			// it actually changed (avoids network I/O on unrelated reloads).
+			prevArtifacts := append([]string(nil), s.config.PinnedArtifacts...)
+
 			if err := s.config.Reload(ctx); err != nil {
 				log.Errorf(ctx, "Unable to reload configuration: %v", err)
 
@@ -639,6 +653,18 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 			// pinned and sandbox/pause images, we need to update them
 			s.ContainerServer.StorageImageServer().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))
 			s.artifactStore.SetPinnedImageRegexps(s.ContainerServer.StorageImageServer().PinnedImageRegexps())
+
+			// Only re-pull when the list changed; use sorted comparison to
+			// match ReloadPinnedArtifacts' order-insensitive equality check.
+			slices.Sort(prevArtifacts)
+
+			currArtifacts := append([]string(nil), s.config.PinnedArtifacts...)
+			slices.Sort(currArtifacts)
+
+			if !slices.Equal(prevArtifacts, currArtifacts) {
+				go s.pullPinnedArtifacts(ctx, append([]string(nil), s.config.PinnedArtifacts...))
+			}
+
 			log.Infof(ctx, "Configuration reload completed")
 			// Print the current configuration.
 			tomlConfig, err := s.config.ToString()
@@ -653,12 +679,63 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 	log.Infof(ctx, "Registered SIGHUP reload watcher")
 }
 
+// pullPinnedArtifacts pulls every artifact in refs.
+// Errors are logged and skipped so a single bad reference does not block the
+// others. Intended to run in a background goroutine on startup and reload.
+// refs must be a snapshot taken before launching the goroutine so the caller
+// and this function do not race on s.config.PinnedArtifacts.
+func (s *Server) pullPinnedArtifacts(ctx context.Context, refs []string) {
+	if len(refs) == 0 {
+		return
+	}
+
+	s.pinnedArtifactsPullMu.Lock()
+	defer s.pinnedArtifactsPullMu.Unlock()
+
+	log.Infof(ctx, "Pre-pulling %d pinned artifact(s)", len(refs))
+
+	seen := make(map[string]struct{}, len(refs))
+
+	for _, refStr := range refs {
+		if _, ok := seen[refStr]; ok {
+			continue
+		}
+
+		seen[refStr] = struct{}{}
+
+		named, err := reference.ParseNormalizedNamed(refStr)
+		if err != nil {
+			log.Errorf(ctx, "Failed to parse pinned artifact reference %q: %v", refStr, err)
+
+			continue
+		}
+
+		imageRef, err := docker.NewReference(named)
+		if err != nil {
+			log.Errorf(ctx, "Failed to create image reference for pinned artifact %q: %v", refStr, err)
+
+			continue
+		}
+
+		if _, err := s.artifactStore.Pull(ctx, imageRef, &libimage.CopyOptions{
+			RemoveSignatures: true, // OCI layout destination does not support signature storage
+		}); err != nil {
+			log.Errorf(ctx, "Failed to pull pinned artifact %q: %v", refStr, err)
+
+			continue
+		}
+
+		log.Infof(ctx, "Pinned artifact pre-pulled: %s", refStr)
+	}
+}
+
 func useDefaultUmask(ctx context.Context) {
 	const defaultUmask = 0o022
 
 	oldUmask := unix.Umask(defaultUmask)
 	if oldUmask != defaultUmask {
-		log.Infof(ctx,
+		log.Infof(
+			ctx,
 			"Using default umask 0o%#o instead of 0o%#o",
 			defaultUmask, oldUmask,
 		)

--- a/server/server_test_inject.go
+++ b/server/server_test_inject.go
@@ -5,7 +5,30 @@
 
 package server
 
-// SetStorageRuntimeServer sets the runtime server for the ContainerServer.
+import (
+	"context"
+
+	"github.com/cri-o/cri-o/internal/ociartifact"
+)
+
+// SetRuntimeServer sets the runtime server for the ContainerServer.
 func (s *StreamService) SetRuntimeServer(server *Server) {
 	s.runtimeServer = server
+}
+
+// SetArtifactStoreForTest replaces the artifact store, allowing tests to
+// inject a store pre-configured with mock internals.
+func (s *Server) SetArtifactStoreForTest(store *ociartifact.Store) {
+	s.artifactStore = store
+}
+
+// SetPinnedArtifactsForTest overwrites the server's pinned artifact list so
+// tests can configure it after server construction.
+func (s *Server) SetPinnedArtifactsForTest(refs []string) {
+	s.config.PinnedArtifacts = append([]string(nil), refs...)
+}
+
+// PullPinnedArtifactsForTest exposes pullPinnedArtifacts for unit tests.
+func (s *Server) PullPinnedArtifactsForTest(ctx context.Context) {
+	s.pullPinnedArtifacts(ctx, append([]string(nil), s.config.PinnedArtifacts...))
 }

--- a/test/pinned_artifacts.bats
+++ b/test/pinned_artifacts.bats
@@ -1,0 +1,237 @@
+#!/usr/bin/env bats
+# Integration tests for the pinned_artifacts pre-pull feature.
+#
+# Tests cover:
+#   - CLI: "crio artifact pull" argument validation and successful pull
+#   - Config: pinned_artifacts field acceptance
+#   - Server startup: background pre-pull logging behavior
+#   - Config reload (SIGHUP): updated list triggers pull; identical list is a no-op
+
+load helpers
+
+ARTIFACT_REPO="quay.io/crio/artifact"
+ARTIFACT_IMAGE="$ARTIFACT_REPO:singlefile"
+ARTIFACT_IMAGE_2="$ARTIFACT_REPO:multiplefiles"
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+# ---------------------------------------------------------------------------
+# CLI: "crio artifact pull" — argument validation (no running server needed)
+# ---------------------------------------------------------------------------
+
+@test "crio artifact pull: missing argument exits non-zero with usage message" {
+	run -1 "$CRIO_BINARY_PATH" -c /dev/null artifact pull
+	[[ "$output" == *"usage: crio artifact pull"* ]]
+}
+
+@test "crio artifact pull: extra argument exits non-zero with usage message" {
+	run -1 "$CRIO_BINARY_PATH" -c /dev/null artifact pull ref1 extra
+	[[ "$output" == *"usage: crio artifact pull"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Config: pinned_artifacts field is accepted in the config
+# ---------------------------------------------------------------------------
+
+@test "pinned_artifacts config field is accepted and appears in status output" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = ["$ARTIFACT_IMAGE"]
+EOF
+	start_crio
+	run -0 "$CRIO_BINARY_PATH" status --socket="$CRIO_SOCKET" config
+	[[ "$output" == *"pinned_artifacts"* ]]
+}
+
+@test "empty pinned_artifacts config is accepted without error" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = []
+EOF
+	start_crio
+	run -0 "$CRIO_BINARY_PATH" status --socket="$CRIO_SOCKET" config
+	[[ "$output" == *"pinned_artifacts"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Server startup: pre-pull log behavior (start_crio_no_setup already passes -l debug)
+# ---------------------------------------------------------------------------
+
+@test "startup with one pinned artifact logs pre-pull count" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = ["$ARTIFACT_IMAGE"]
+EOF
+	start_crio
+	wait_for_log "Pre-pulling 1 pinned artifact"
+}
+
+@test "startup with two pinned artifacts logs correct count" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = [
+	"$ARTIFACT_IMAGE",
+	"$ARTIFACT_IMAGE_2"
+]
+EOF
+	start_crio
+	wait_for_log "Pre-pulling 2 pinned artifact"
+}
+
+@test "startup with empty pinned_artifacts does not log a pre-pull message" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = []
+EOF
+	start_crio
+	run ! grep -i "pre-pulling.*pinned" "$CRIO_LOG"
+}
+
+@test "unparsable pinned artifact ref is logged as error and server still starts" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = ["://not-a-valid-ref"]
+EOF
+	start_crio
+	wait_for_log "Failed to parse pinned artifact reference"
+	# Server must still be reachable despite the bad ref
+	crictl info
+}
+
+@test "bad pinned artifact ref does not block startup of subsequent refs" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = [
+	"://bad-ref",
+	"$ARTIFACT_IMAGE"
+]
+EOF
+	start_crio
+	# The bad ref is skipped, the good one is attempted
+	wait_for_log "Pre-pulling 2 pinned artifact"
+	wait_for_log "Failed to parse pinned artifact reference"
+}
+
+# ---------------------------------------------------------------------------
+# Config reload: SIGHUP applies updated pinned_artifacts list
+# ---------------------------------------------------------------------------
+
+@test "reload config with new pinned_artifacts logs config-update entry" {
+	setup_crio
+	# Persist debug log level so it survives the SIGHUP reload.
+	replace_config "log_level" "debug"
+	start_crio_no_setup
+
+	printf '[crio.image]\npinned_artifacts = ["%s"]\n' "$ARTIFACT_IMAGE" \
+		> "$CRIO_CONFIG_DIR/99-pinned.conf"
+	reload_crio
+
+	wait_for_log "set config pinned_artifacts to"
+}
+
+@test "reload config with new pinned_artifacts triggers pre-pull" {
+	setup_crio
+	replace_config "log_level" "debug"
+	start_crio_no_setup
+
+	# Server started with empty pinned_artifacts; no pre-pull should have fired.
+	run ! grep -i "pre-pulling.*pinned" "$CRIO_LOG"
+
+	printf '[crio.image]\npinned_artifacts = ["%s"]\n' "$ARTIFACT_IMAGE" \
+		> "$CRIO_CONFIG_DIR/99-pinned.conf"
+	reload_crio
+
+	wait_for_log "Pre-pulling 1 pinned artifact"
+}
+
+@test "reload config with empty pinned_artifacts logs cleared list" {
+	setup_crio
+	replace_config "log_level" "debug"
+	printf '[crio.image]\npinned_artifacts = ["%s"]\n' "$ARTIFACT_IMAGE" \
+		> "$CRIO_CONFIG_DIR/99-pinned.conf"
+	start_crio_no_setup
+	wait_for_log "Pre-pulling 1 pinned artifact"
+
+	printf '[crio.image]\npinned_artifacts = []\n' \
+		> "$CRIO_CONFIG_DIR/99-pinned.conf"
+	reload_crio
+
+	wait_for_log 'set config pinned_artifacts to.*\[\]'
+}
+
+@test "reload config with identical pinned_artifacts does not log a config-update" {
+	setup_crio
+	replace_config "log_level" "debug"
+	printf '[crio.image]\npinned_artifacts = ["%s"]\n' "$ARTIFACT_IMAGE" \
+		> "$CRIO_CONFIG_DIR/99-pinned.conf"
+	start_crio_no_setup
+
+	reload_crio
+	wait_for_log "Configuration reload completed"
+
+	# Identical lists must not trigger a logConfig("pinned_artifacts", ...) call.
+	run ! grep -i "set config pinned_artifacts" "$CRIO_LOG"
+}
+
+@test "reload config with order-swapped pinned_artifacts does not log a config-update" {
+	setup_crio
+	replace_config "log_level" "debug"
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = ["$ARTIFACT_IMAGE", "$ARTIFACT_IMAGE_2"]
+EOF
+	start_crio_no_setup
+
+	# Reverse the order — sorted comparison should treat this as identical.
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = ["$ARTIFACT_IMAGE_2", "$ARTIFACT_IMAGE"]
+EOF
+	reload_crio
+	wait_for_log "Configuration reload completed"
+
+	run ! grep -i "set config pinned_artifacts" "$CRIO_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Network: actual artifact pull (requires registry access)
+# ---------------------------------------------------------------------------
+
+@test "pinned_artifacts pre-pulls artifact at startup and logs success" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = ["$ARTIFACT_IMAGE"]
+EOF
+	start_crio
+	wait_for_log "Pinned artifact pre-pulled: $ARTIFACT_IMAGE"
+}
+
+@test "crio artifact pull: CLI pulls artifact into store and prints success" {
+	# Initialize container storage via a normal crio start.
+	start_crio
+
+	run -0 "$CRIO_BINARY_PATH" \
+		-c "$CRIO_CONFIG" \
+		-d "$CRIO_CONFIG_DIR" \
+		artifact pull "$ARTIFACT_IMAGE"
+	[[ "$output" == *"Successfully pulled artifact"* ]]
+}
+
+@test "pinned_artifacts pull failure on bad network ref does not crash server" {
+	cat << EOF > "$CRIO_CONFIG_DIR/99-pinned.conf"
+[crio.image]
+pinned_artifacts = ["localhost:65535/nonexistent:latest"]
+EOF
+	start_crio
+	wait_for_log "Pre-pulling 1 pinned artifact"
+	wait_for_log "Failed to pull pinned artifact"
+
+	# Server must remain reachable.
+	crictl info
+}


### PR DESCRIPTION
Fixes: https://github.com/cri-o/cri-o/issues/9583

/kind feature


```release-note
Fetch pinned Artifacts from CLI and Fetch during startup.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `artifact pull` CLI command and a `--pinned-artifacts` option; server pre-pulls listed OCI artifacts asynchronously at startup and on SIGHUP, skipping invalid refs and logging failures without blocking.

* **Documentation**
  * Updated manpage and config docs and included the new config template entry for `pinned_artifacts`.

* **Shell Completions**
  * Updated Bash, Fish, and Zsh completions to include the new command and option.

* **Tests**
  * Added unit, integration, and E2E tests covering CLI, pre-pull behavior, and reload semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9939)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->