### PR TITLE
utils: prefix fully numeric names in generated passwd/group entries

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -203,6 +203,35 @@ func GetUserInfo(rootfs, userName string) (uid, gid uint32, additionalGids []uin
 	return uid, gid, additionalGids, nil
 }
 
+// isAllDigits reports whether s is non-empty and consists entirely of
+// ASCII digits. This is the same class of names that shadow-utils on
+// Fedora/RHEL rejects as usernames and group names.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+// safeAccountName returns a name safe for /etc/passwd or /etc/group.
+// Fully numeric names (e.g. "1234") are rejected by shadow-utils on
+// Fedora/RHEL, so we add a "user" prefix (e.g. "user1234").
+// See https://github.com/cri-o/cri-o/issues/9432
+func safeAccountName(name string) string {
+	if isAllDigits(name) {
+		return "user" + name
+	}
+
+	return name
+}
+
 // GeneratePasswd generates a container specific passwd file,
 // iff uid is not defined in the containers /etc/passwd.
 func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir string) (string, error) {
@@ -227,6 +256,8 @@ func GeneratePasswd(username string, uid, gid uint32, homedir, rootfs, rundir st
 	if username == "" {
 		username = "default"
 	}
+
+	username = safeAccountName(username)
 
 	if homedir == "" {
 		homedir = "/tmp"
@@ -259,7 +290,8 @@ func GenerateGroup(gid uint32, rootfs, rundir string) (string, error) {
 		return "", err
 	}
 
-	groupContent := fmt.Sprintf("%s%d:x:%d:\n", string(origContent), gid, gid)
+	groupName := safeAccountName(strconv.FormatUint(uint64(gid), 10))
+	groupContent := fmt.Sprintf("%s%s:x:%d:\n", string(origContent), groupName, gid)
 	groupFile := filepath.Join(rundir, "group")
 
 	return createAndSecureFile(groupFile, groupContent, os.FileMode(stat.Mode), int(stat.Uid), int(stat.Gid))

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -401,6 +401,83 @@ var _ = t.Describe("Utils", func() {
 			Expect(newgid).To(Equal(gid))
 			Expect(newaddgids).To(Equal(addgids))
 		})
+
+		It("should prefix numeric username in generated passwd to avoid shadow-utils issues", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+
+			// UID 300 doesn't exist in /etc/passwd, so GeneratePasswd creates an entry.
+			// With a numeric containerUser "300", the generated username must be
+			// "user300" (not "300") to stay compatible with shadow-utils on Fedora/RHEL.
+			passwdFile, err := utils.GeneratePasswd("300", 300, 250, "", dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(passwdFile).ToNot(BeEmpty())
+
+			content, err := os.ReadFile(passwdFile)
+			Expect(err).ToNot(HaveOccurred())
+			// The generated line must use "user300" as the username, not "300".
+			Expect(string(content)).To(ContainSubstring("user300:x:300:250:"))
+			Expect(string(content)).ToNot(MatchRegexp(`\n300:x:`))
+		})
+
+		It("should prefix large numeric uid username in generated passwd", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+
+			// UID 999999 doesn't exist in /etc/passwd; the numeric username
+			// "999999" must be prefixed to "user999999".
+			passwdFile, err := utils.GeneratePasswd("999999", 999999, 250, "", dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(passwdFile).ToNot(BeEmpty())
+
+			content, err := os.ReadFile(passwdFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("user999999:x:999999:250:"))
+		})
+
+		It("should not prefix non-numeric username in generated passwd", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+
+			// A non-numeric username like "myapp" should pass through unchanged.
+			passwdFile, err := utils.GeneratePasswd("myapp", 300, 250, "", dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(passwdFile).ToNot(BeEmpty())
+
+			content, err := os.ReadFile(passwdFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("myapp:x:300:250:"))
+		})
+
+		It("should not prefix mixed alphanumeric username", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+
+			// "123abc" is not fully numeric and should pass through unchanged.
+			passwdFile, err := utils.GeneratePasswd("123abc", 300, 250, "", dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(passwdFile).ToNot(BeEmpty())
+
+			content, err := os.ReadFile(passwdFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("123abc:x:300:250:"))
+		})
+
+		It("should prefix numeric group name in generated group file", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+
+			// GID 6000 doesn't exist in /etc/group, so GenerateGroup creates an entry.
+			// The generated group name must be "user6000" (not "6000").
+			groupPath, err := utils.GenerateGroup(6000, dir, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(groupPath).ToNot(BeEmpty())
+
+			content, err := os.ReadFile(groupPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("user6000:x:6000:"))
+			Expect(string(content)).ToNot(MatchRegexp(`\n6000:x:`))
+		})
 	})
 
 	t.Describe("ParseDuration", func() {


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

`GeneratePasswd` and `GenerateGroup` write fully numeric usernames and group names (e.g. `1234`) into `/etc/passwd` and `/etc/group` when a container runs with a numeric `runAsUser` whose UID doesn't exist in the image. shadow-utils on Fedora/RHEL rejects these names, causing container creation failures.

This adds `safeAccountName()` which detects all-digit names and prefixes them with `user` (e.g. `1234` becomes `user1234`). Applied to both `GeneratePasswd` (username field) and `GenerateGroup` (group name field).

#### Which issue(s) this PR fixes:

Fixes #9432

#### Special notes for your reviewer:

A previous attempt at this fix (#9446) was auto-closed for inactivity. This takes the same approach (prefix with "user") but also covers the group name path in `GenerateGroup`, which the earlier PR missed.

```
ginkgo run --focus "numeric username|numeric group|non-numeric|mixed alphanumeric" -v utils/
```

#### Does this PR introduce a user-facing change?

```release-note
Fully numeric usernames and group names generated by CRI-O are now prefixed with "user" (e.g. "1234" becomes "user1234") to avoid rejection by shadow-utils on Fedora/RHEL systems.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of numeric usernames and group names by prefixing them appropriately for valid formatting.

* **Tests**
  * Added test cases to validate numeric account name behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9940)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->