### PR TITLE
fix: sync default metrics collector docs

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -557,7 +557,7 @@ The `crio.metrics` table containers settings pertaining to the Prometheus based 
 **enable_metrics**=false
 Globally enable or disable metrics support.
 
-**metrics_collectors**=["image_pulls_layer_size", "containers_events_dropped_total", "containers_oom_total", "processes_defunct", "operations_total", "operations_latency_seconds", "operations_latency_seconds_total", "operations_errors_total", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_failure_total", "image_pulls_success_total", "image_layer_reuse_total", "containers_oom_count_total", "containers_seccomp_notifier_count_total", "resources_stalled_at_stage"]
+**metrics_collectors**=["image_pulls_layer_size", "containers_events_dropped_total", "containers_oom_total", "processes_defunct", "operations_total", "operations_latency_seconds", "operations_latency_seconds_total", "operations_errors_total", "image_pulls_bytes_total", "image_pulls_skipped_bytes_total", "image_pulls_failure_total", "image_pulls_success_total", "image_layer_reuse_total", "containers_oom_count_total", "containers_seccomp_notifier_count_total", "resources_stalled_at_stage", "containers_stopped_monitor_count", "default_runtime"]
 Specify enabled metrics collectors. Per default all metrics are enabled.
 
 **metrics_host**="127.0.0.1"


### PR DESCRIPTION
/kind documentation

Tiny docs drift fix. The default metrics list was low-key out of sync, so the manpage was telling a stale story. Now it matches the real default output again.

Repro:
`go run -tags 'containers_image_openpgp containers_image_ostree_stub exclude_graphdriver_btrfs' ./cmd/crio config --default | sed -n '/metrics_collectors = \[/,/\]/p'`
Compare that output with `docs/crio.conf.5.md`.

#### What this PR does / why we need it:
Keeps the docs in step with the actual default metrics collector list.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
`make BUILDTAGS='containers_image_openpgp containers_image_ostree_stub exclude_graphdriver_btrfs' docs-validation` passes after the change.

#### Does this PR introduce a user-facing change?
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metrics documentation to extend the list of available metrics collectors, providing additional monitoring capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9942)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->