### PR TITLE
Invoke NRI StopPodSandbox hook before tearing down network namespace

### DIFF
--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -34,15 +34,26 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 		}
 	}
 
-	// Clean up sandbox networking and close its network namespace.
-	if err := s.networkStop(ctx, sb); err != nil {
-		return err
-	}
-
 	if sb.Stopped() {
+		// Network cleanup may still be needed even for already-stopped sandboxes.
+		if err := s.networkStop(ctx, sb); err != nil {
+			return fmt.Errorf("failed to stop network for pod sandbox %s: %w", sb.ID(), err)
+		}
+
 		log.Infof(ctx, "Stopped pod sandbox (already stopped): %s", sb.ID())
 
 		return nil
+	}
+
+	// NRI StopPodSandbox must run before network namespace teardown so that
+	// NRI plugins (e.g. network plugins) can still access the network namespace.
+	if err := s.nri.stopPodSandbox(ctx, sb); err != nil {
+		return fmt.Errorf("failed to stop NRI pod sandbox %s: %w", sb.ID(), err)
+	}
+
+	// Clean up sandbox networking and close its network namespace.
+	if err := s.networkStop(ctx, sb); err != nil {
+		return fmt.Errorf("failed to stop network for pod sandbox %s: %w", sb.ID(), err)
 	}
 
 	// Calculate the timeout once. Regular containers get most of the timeout,
@@ -94,10 +105,6 @@ func (s *Server) stopPodSandbox(ctx context.Context, sb *sandbox.Sandbox) error 
 	}
 
 	if err := sb.UnmountShm(ctx); err != nil {
-		return err
-	}
-
-	if err := s.nri.stopPodSandbox(ctx, sb); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
NRI StopPodSandbox hook was being called after the network namespace was already torn down. NRI network plugins (e.g. dranet) need the netns to be alive during this hook to perform cleanup. This moves the hook to run before networkStop.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes #9905

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed NRI StopPodSandbox hook being called after network namespace deletion.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted sandbox shutdown to always perform network cleanup even for already-stopped sandboxes.
  * Reordered shutdown steps so external runtime teardown runs before network namespace cleanup for consistent shutdown behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9943)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->