### PR TITLE
Remove incorrect deprecation notice from crio.conf

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -159,7 +159,6 @@ This option is deprecated, and be interpreted from whether SELinux is enabled on
 
 **seccomp_profile**=""
 Path to the seccomp.json profile which is used as the default seccomp profile for the runtime. If not specified, then the internal default seccomp profile will be used.
-This option is currently deprecated, and will be replaced by the SeccompDefault FeatureGate in Kubernetes.
 
 **privileged_seccomp_profile**=""
 Enable a seccomp profile for privileged containers from the local path.


### PR DESCRIPTION
This deprecation notice was added in error to the seccomp_profile field by 48cf728ddee325cceb58cdf4597d0fecf124c766. The notice was intended for the seccomp_use_default_when_empty field, which was being deprecated at the time.

As per the discussion on #9941, it has been confirmed that the seccomp_profile field is not deprecated.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

An error in the documentation for crio.conf suggested a field was deprecated as Kubernetes was taking over the job of specifying what the runtime default seccomp profile should be. Kubernetes has no such behaviour: it can defer to the runtime's default profile, or it can specify what the profile should be explicitly on a per container basis, but Kubernetes won't specify what the default should be. The configuration of what the runtime default is remains a matter for cri-o. This deprecation was added in error.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #9941

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed incorrect deprecation notice of seccomp_profile configuration field
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the runtime configuration documentation by removing outdated deprecation information from the seccomp_profile option. The change clarifies the current status and proper usage of this configuration setting while preserving comprehensive documentation that describes default seccomp profile behavior, helping users better understand and more effectively configure container runtime security policies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9946)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->