### PR TITLE
Implement UpdateRuntimeConfig CRI method

### DIFF
--- a/server/update_runtime_config.go
+++ b/server/update_runtime_config.go
@@ -4,10 +4,20 @@ import (
 	"context"
 
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/log"
 )
 
 func (s *Server) UpdateRuntimeConfig(
 	ctx context.Context, req *types.UpdateRuntimeConfigRequest,
 ) (*types.UpdateRuntimeConfigResponse, error) {
+	ctx, span := log.StartSpan(ctx)
+	defer span.End()
+
+	podCIDR := req.GetRuntimeConfig().GetNetworkConfig().GetPodCidr()
+	if podCIDR != "" {
+		log.Infof(ctx, "Updating runtime config with pod CIDR: %s", podCIDR)
+	}
+
 	return &types.UpdateRuntimeConfigResponse{}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `UpdateRuntimeConfig` CRI method was a no-op that returned an empty response with no logging or tracing. This adds OpenTelemetry tracing and pod CIDR logging, consistent with other CRI methods.

#### Which issue(s) this PR fixes:

Fixes #9931

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging instrumentation for improved observability of runtime configuration operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9952)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->