### PR TITLE
fix(oci): fix goroutine leak in AttachContainer

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1382,6 +1382,10 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 		return nil
 	}
 
+	// cancel ensures all goroutines are cleaned up when the function returns
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	controlPath := filepath.Join(c.BundlePath(), "ctl")
 
 	controlFile, err := os.OpenFile(controlPath, os.O_WRONLY, 0)
@@ -1409,15 +1413,31 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 
 	defer conn.Close()
 
-	receiveStdout := make(chan error)
-
+	// Close conn when ctx is done to unblock any pending Read()
+	// in redirectResponseToOutputStreams(). This is necessary because
+	// conmon keeps the other side of the socket open as long as the
+	// container is running, so conn.Close() via defer alone is not
+	// sufficient to unblock the Read() in the goroutine below.
 	go func() {
-		receiveStdout <- redirectResponseToOutputStreams(outputStream, errorStream, conn)
-
-		close(receiveStdout)
+		<-ctx.Done()
+		conn.Close()
 	}()
 
-	stdinDone := make(chan error)
+	// Buffered channels of size 1 prevent goroutine leaks when the receiver
+	// exits early. Context cancellation provides an additional safety net.
+	receiveStdout := make(chan error, 1)
+
+	go func() {
+
+		streamErr := redirectResponseToOutputStreams(outputStream, errorStream, conn)
+		select {
+		case receiveStdout <- streamErr:
+		case <-ctx.Done():
+			log.Debugf(ctx, "receiveStdout goroutine cancelled: %v", ctx.Err())
+		}
+	}()
+
+	stdinDone := make(chan error, 1)
 
 	go func() {
 		var err, closeErr error
@@ -1426,17 +1446,21 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 			closeErr = conn.CloseWrite()
 		}
 
+		var result error
 		switch {
 		case err != nil:
-			stdinDone <- err
+			result = err
 		case closeErr != nil:
-			stdinDone <- closeErr
+			result = closeErr
 		default:
 			// neither CopyDetachable nor CloseWrite returned error
-			stdinDone <- nil
 		}
 
-		close(stdinDone)
+		select {
+		case stdinDone <- result:
+		case <-ctx.Done():
+			log.Debugf(ctx, "stdinDone goroutine cancelled: %v", ctx.Err())
+		}
 	}()
 
 	select {
@@ -1457,7 +1481,14 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 			return nil
 		}
 
-		return <-receiveStdout
+		select {
+		case err := <-receiveStdout:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 


### PR DESCRIPTION
Please note that this fix was implemented with the help of AI. The AI helped me understand the problem (by analyzing the goroutines in the running program) and write clean comments.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a goroutine leak in `AttachContainer` where goroutines accumulated
indefinitely when containers were stopped with SIGKILL after a SIGTERM
timeout.

Two issues caused the leak:

1. Unbuffered channels blocked forever when early-return paths
   (`leave-stdin-open`, `DetachError`) exited without draining
   `receiveStdout`.

2. `defer conn.Close()` alone did not unblock a pending `Read()` in the
   `receiveStdout` goroutine since conmon keeps the attach socket open
   as long as the container runs.

Fix uses buffered channels, `context.WithCancel` and explicitly closes
`conn` on `ctx.Done()` to unblock any pending `Read()`.

The leak was introduced between v1.29 and v1.30 when the `outputStream`
guard was removed to fix conmon blocking on large stdin data. This PR
fixes both issues simultaneously.

Verified in production with 200+ GitLab CI jobs on OpenShift/CRI-O 1.34.4.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

`conn.Close()` is called via both `defer` and the `ctx.Done()` goroutine.
`net.Conn.Close()` is idempotent so this is safe.

Backports to release-1.30 through release-1.37 are recommended.

#### Does this PR introduce a user-facing change?
No

```release-note
Fixed a goroutine leak in AttachContainer caused by SIGKILL after
SIGTERM timeout. Over time this could lead to increased memory usage
and resource exhaustion.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container attach reliability by adding cancellable handling to attachment I/O, ensuring prompt cleanup when operations are cancelled.
  * Prevented potential hangs by unblocking pending reads and making stdin/stdout termination cooperative with cancellation, improving overall responsiveness during detach/timeout scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->