### PR TITLE
Add support for env var injection in container exec

### DIFF
--- a/internal/oci/env_utils.go
+++ b/internal/oci/env_utils.go
@@ -1,0 +1,101 @@
+package oci
+
+import (
+	"slices"
+	"strings"
+)
+
+// mergeProcessEnvOverlay returns a new environment list for an OCI process: it
+// starts from base (entries are typically KEY=value as in spec process.env),
+// then applies overlay strings (CRI exec env: KEY=value lines) by case-sensitive
+// key match.
+//
+// Semantics:
+//   - Each overlay line with a non-empty key (per first '=') replaces any base
+//     entry with the same key, or is appended if that key did not appear in base.
+//   - Duplicate keys in overlay: the last entry wins.
+//   - Relative order of base entries is preserved; new keys (not present in base)
+//     are appended in first-appearance order among overlay keys (after last-wins
+//     folding within overlay).
+//   - Base entries that do not contain '=' are preserved as-is when not overridden.
+//   - Empty overlay lines and lines with no valid key before '=' are skipped.
+func mergeProcessEnvOverlay(base, overlay []string) []string {
+	if len(overlay) == 0 {
+		return slices.Clone(base)
+	}
+
+	ov := make(map[string]string, len(overlay))
+	order := make([]string, 0, len(overlay))
+	seen := make(map[string]struct{}, len(overlay))
+
+	for _, line := range overlay {
+		if line == "" {
+			continue
+		}
+
+		k, ok := envLineKey(line)
+		if !ok || k == "" {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+
+		val := ""
+		if len(parts) == 2 {
+			val = parts[1]
+		}
+
+		ov[k] = val
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			order = append(order, k)
+		}
+	}
+
+	baseKeys := make(map[string]struct{}, len(base))
+	for _, line := range base {
+		k, ok := envLineKey(line)
+		if ok {
+			baseKeys[k] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(base)+len(order))
+	for _, line := range base {
+		k, ok := envLineKey(line)
+		if !ok {
+			out = append(out, line)
+
+			continue
+		}
+
+		if val, replace := ov[k]; replace {
+			out = append(out, k+"="+val)
+
+			continue
+		}
+
+		out = append(out, line)
+	}
+
+	for _, k := range order {
+		if _, inBase := baseKeys[k]; inBase {
+			continue
+		}
+
+		out = append(out, k+"="+ov[k])
+	}
+
+	return out
+}
+
+// envLineKey returns the key portion of a process.env entry. The OCI spec uses
+// NAME=value strings; value may be empty and may contain '=' (use SplitN).
+func envLineKey(line string) (key string, ok bool) {
+	parts := strings.SplitN(line, "=", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return "", false
+	}
+
+	return parts[0], true
+}

--- a/internal/oci/env_utils_test.go
+++ b/internal/oci/env_utils_test.go
@@ -1,0 +1,102 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMergeProcessEnvOverlay(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		base    []string
+		overlay []string
+		want    []string
+	}{
+		"nil overlay": {
+			base:    []string{"A=1", "B=2"},
+			overlay: nil,
+			want:    []string{"A=1", "B=2"},
+		},
+		"empty overlay": {
+			base:    []string{"A=1"},
+			overlay: []string{},
+			want:    []string{"A=1"},
+		},
+		"replace existing": {
+			base:    []string{"A=1", "B=2"},
+			overlay: []string{"B=3"},
+			want:    []string{"A=1", "B=3"},
+		},
+		"append new": {
+			base:    []string{"A=1"},
+			overlay: []string{"C=3"},
+			want:    []string{"A=1", "C=3"},
+		},
+		"replace and append": {
+			base:    []string{"A=1", "B=2"},
+			overlay: []string{"B=x", "C=y"},
+			want:    []string{"A=1", "B=x", "C=y"},
+		},
+		"duplicate overlay keys last wins": {
+			base:    []string{"A=1"},
+			overlay: []string{"B=first", "B=second"},
+			want:    []string{"A=1", "B=second"},
+		},
+		"duplicate overlay keys replace base last wins": {
+			base:    []string{"A=1", "B=old"},
+			overlay: []string{"B=mid", "B=new"},
+			want:    []string{"A=1", "B=new"},
+		},
+		"value with equals sign": {
+			base:    []string{"A=b=c"},
+			overlay: []string{"A=d=e=f"},
+			want:    []string{"A=d=e=f"},
+		},
+		"empty overlay value": {
+			base:    []string{"A=1"},
+			overlay: []string{"B="},
+			want:    []string{"A=1", "B="},
+		},
+		"overlay key only implies empty value": {
+			base:    []string{"A=1"},
+			overlay: []string{"B"},
+			want:    []string{"A=1", "B="},
+		},
+		"skip empty overlay line": {
+			base:    []string{"A=1"},
+			overlay: []string{"", "B=2"},
+			want:    []string{"A=1", "B=2"},
+		},
+		"skip line with empty key before equals": {
+			base:    []string{"A=1"},
+			overlay: []string{"=x", "B=2"},
+			want:    []string{"A=1", "B=2"},
+		},
+		"new key order follows first appearance in overlay": {
+			base:    []string{"A=1"},
+			overlay: []string{"Z=z", "Y=y"},
+			want:    []string{"A=1", "Z=z", "Y=y"},
+		},
+		"base line without equals preserved when not overridden": {
+			base:    []string{"A=1", "WEIRD"},
+			overlay: []string{"B=2"},
+			want:    []string{"A=1", "WEIRD", "B=2"},
+		},
+		"case sensitive keys": {
+			base:    []string{"a=1", "A=2"},
+			overlay: []string{"A=upper"},
+			want:    []string{"a=1", "A=upper"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeProcessEnvOverlay(tc.base, tc.overlay)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mergeProcessEnvOverlay() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -60,9 +60,8 @@ type Runtime struct {
 type RuntimeImpl interface {
 	CreateContainer(context.Context, *Container, string, bool) error
 	StartContainer(context.Context, *Container) error
-	ExecContainer(context.Context, *Container, []string, io.Reader, io.WriteCloser, io.WriteCloser,
-		bool, <-chan remotecommand.TerminalSize) error
-	ExecSyncContainer(context.Context, *Container, []string, int64) (*types.ExecSyncResponse, error)
+	ExecContainer(ctx context.Context, c *Container, cmd, env []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error
+	ExecSyncContainer(ctx context.Context, c *Container, command, env []string, timeout int64) (*types.ExecSyncResponse, error)
 	UpdateContainer(context.Context, *Container, *rspec.LinuxResources) error
 	StopContainer(context.Context, *Container, int64) error
 	DeleteContainer(context.Context, *Container) error
@@ -81,7 +80,7 @@ type RuntimeImpl interface {
 	IsContainerAlive(*Container) bool
 	// ProbeMonitor is used to check the liveness of the container monitor process.
 	ProbeMonitor(context.Context, *Container) error
-	ServeExecContainer(context.Context, *Container, []string, bool, bool, bool, bool) (string, error)
+	ServeExecContainer(ctx context.Context, c *Container, cmd, env []string, tty, stdin, stdout, stderr bool) (string, error)
 	ServeAttachContainer(context.Context, *Container, bool, bool, bool) (string, error)
 }
 
@@ -340,7 +339,7 @@ func (r *Runtime) StartContainer(ctx context.Context, c *Container) error {
 }
 
 // ExecContainer prepares a streaming endpoint to execute a command in the container.
-func (r *Runtime) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
+func (r *Runtime) ExecContainer(ctx context.Context, c *Container, cmd, env []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -349,11 +348,11 @@ func (r *Runtime) ExecContainer(ctx context.Context, c *Container, cmd []string,
 		return err
 	}
 
-	return impl.ExecContainer(ctx, c, cmd, stdin, stdout, stderr, tty, resizeChan)
+	return impl.ExecContainer(ctx, c, cmd, env, stdin, stdout, stderr, tty, resizeChan)
 }
 
 // ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
-func (r *Runtime) ExecSyncContainer(ctx context.Context, c *Container, command []string, timeout int64) (*types.ExecSyncResponse, error) {
+func (r *Runtime) ExecSyncContainer(ctx context.Context, c *Container, command, env []string, timeout int64) (*types.ExecSyncResponse, error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -362,7 +361,7 @@ func (r *Runtime) ExecSyncContainer(ctx context.Context, c *Container, command [
 		return nil, err
 	}
 
-	return impl.ExecSyncContainer(ctx, c, command, timeout)
+	return impl.ExecSyncContainer(ctx, c, command, env, timeout)
 }
 
 // UpdateContainer updates container resources.
@@ -571,13 +570,13 @@ func (r *Runtime) ProbeMonitor(ctx context.Context, c *Container) error {
 	return impl.ProbeMonitor(ctx, c)
 }
 
-func (r *Runtime) ServeExecContainer(ctx context.Context, c *Container, cmd []string, tty, stdin, stdout, stderr bool) (string, error) {
+func (r *Runtime) ServeExecContainer(ctx context.Context, c *Container, cmd, env []string, tty, stdin, stdout, stderr bool) (string, error) {
 	impl, err := r.RuntimeImpl(c)
 	if err != nil {
 		return "", err
 	}
 
-	return impl.ServeExecContainer(ctx, c, cmd, tty, stdin, stdout, stderr)
+	return impl.ServeExecContainer(ctx, c, cmd, env, tty, stdin, stdout, stderr)
 }
 
 func (r *Runtime) ServeAttachContainer(ctx context.Context, c *Container, stdin, stdout, stderr bool) (string, error) {

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -479,7 +479,7 @@ func parseLog(ctx context.Context, l []byte) (stdout, stderr []byte) {
 }
 
 // ExecContainer prepares a streaming endpoint to execute a command in the container.
-func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
+func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd, env []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
 	_, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -487,7 +487,7 @@ func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []stri
 		return nil
 	}
 
-	processFile, err := prepareProcessExec(c, cmd, tty)
+	processFile, err := prepareProcessExec(c, cmd, env, tty)
 	if err != nil {
 		return err
 	}
@@ -590,7 +590,7 @@ func (r *runtimeOCI) ExecContainer(ctx context.Context, c *Container, cmd []stri
 }
 
 // ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
-func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, command []string, timeout int64) (*types.ExecSyncResponse, error) {
+func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, command, env []string, timeout int64) (*types.ExecSyncResponse, error) {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -669,7 +669,7 @@ func (r *runtimeOCI) ExecSyncContainer(ctx context.Context, c *Container, comman
 		args = append(args, "-s")
 	}
 
-	processFile, err := prepareProcessExec(c, command, c.terminal)
+	processFile, err := prepareProcessExec(c, command, env, c.terminal)
 	if err != nil {
 		return nil, &ExecSyncError{
 			ExitCode: -1,
@@ -1548,7 +1548,7 @@ func (r *runtimeOCI) ReopenContainerLog(ctx context.Context, c *Container) error
 
 // prepareProcessExec returns the path of the process.json used in runc exec -p
 // caller is responsible for removing the returned file, if prepareProcessExec succeeds.
-func prepareProcessExec(c *Container, cmd []string, tty bool) (processFile string, retErr error) {
+func prepareProcessExec(c *Container, cmd, env []string, tty bool) (processFile string, retErr error) {
 	f, err := os.CreateTemp("", "exec-process-")
 	if err != nil {
 		return "", err
@@ -1567,6 +1567,8 @@ func prepareProcessExec(c *Container, cmd []string, tty bool) (processFile strin
 	// process spec
 	pspec := *c.Spec().Process
 	pspec.Args = cmd
+
+	pspec.Env = mergeProcessEnvOverlay(c.Spec().Process.Env, env)
 	// We need to default this to false else it will inherit terminal as true
 	// from the container.
 	pspec.Terminal = false
@@ -1847,7 +1849,7 @@ func (r *runtimeOCI) ProbeMonitor(ctx context.Context, c *Container) error {
 	return nil
 }
 
-func (r *runtimeOCI) ServeExecContainer(context.Context, *Container, []string, bool, bool, bool, bool) (string, error) {
+func (r *runtimeOCI) ServeExecContainer(_ context.Context, _ *Container, _, _ []string, _, _, _, _ bool) (string, error) {
 	return "", nil
 }
 

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -226,11 +226,11 @@ func (r *runtimePod) RestoreContainer(
 	return r.oci.RestoreContainer(ctx, c, cgroupParent, mountLabel)
 }
 
-func (r *runtimePod) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
-	return r.oci.ExecContainer(ctx, c, cmd, stdin, stdout, stderr, tty, resizeChan)
+func (r *runtimePod) ExecContainer(ctx context.Context, c *Container, cmd, env []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
+	return r.oci.ExecContainer(ctx, c, cmd, env, stdin, stdout, stderr, tty, resizeChan)
 }
 
-func (r *runtimePod) ExecSyncContainer(ctx context.Context, c *Container, cmd []string, timeout int64) (*types.ExecSyncResponse, error) {
+func (r *runtimePod) ExecSyncContainer(ctx context.Context, c *Container, cmd, env []string, timeout int64) (*types.ExecSyncResponse, error) {
 	if c.Spoofed() {
 		return nil, nil
 	}
@@ -368,7 +368,7 @@ func (r *runtimePod) ProbeMonitor(ctx context.Context, c *Container) error {
 	return r.oci.ProbeMonitor(ctx, c)
 }
 
-func (r *runtimePod) ServeExecContainer(ctx context.Context, c *Container, cmd []string, tty, stdin, stdout, stderr bool) (string, error) {
+func (r *runtimePod) ServeExecContainer(ctx context.Context, c *Container, cmd, env []string, tty, stdin, stdout, stderr bool) (string, error) {
 	res, err := r.client.ServeExecContainer(ctx, &conmonClient.ServeExecContainerConfig{
 		ID:      c.ID(),
 		Command: cmd,

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -364,11 +364,11 @@ func (r *runtimeVM) StartContainer(ctx context.Context, c *Container) error {
 }
 
 // ExecContainer prepares a streaming endpoint to execute a command in the container.
-func (r *runtimeVM) ExecContainer(ctx context.Context, c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
+func (r *runtimeVM) ExecContainer(ctx context.Context, c *Container, cmd, env []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
 	log.Debugf(ctx, "RuntimeVM.ExecContainer() start")
 	defer log.Debugf(ctx, "RuntimeVM.ExecContainer() end")
 
-	exitCode, err := r.execContainerCommon(ctx, c, cmd, 0, stdin, stdout, stderr, tty, resizeChan)
+	exitCode, err := r.execContainerCommon(ctx, c, cmd, env, 0, stdin, stdout, stderr, tty, resizeChan)
 	if err != nil {
 		return err
 	}
@@ -397,7 +397,7 @@ func (w *writeCloserWrapper) Close() error {
 }
 
 // ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
-func (r *runtimeVM) ExecSyncContainer(ctx context.Context, c *Container, command []string, timeout int64) (*types.ExecSyncResponse, error) {
+func (r *runtimeVM) ExecSyncContainer(ctx context.Context, c *Container, command, env []string, timeout int64) (*types.ExecSyncResponse, error) {
 	log.Debugf(ctx, "RuntimeVM.ExecSyncContainer() start")
 	defer log.Debugf(ctx, "RuntimeVM.ExecSyncContainer() end")
 
@@ -406,7 +406,7 @@ func (r *runtimeVM) ExecSyncContainer(ctx context.Context, c *Container, command
 	stdout := &writeCloserWrapper{limitWriter(&stdoutBuf, maxExecSyncSize)}
 	stderr := &writeCloserWrapper{limitWriter(&stderrBuf, maxExecSyncSize)}
 
-	exitCode, err := r.execContainerCommon(ctx, c, command, timeout, nil, stdout, stderr, c.terminal, nil)
+	exitCode, err := r.execContainerCommon(ctx, c, command, env, timeout, nil, stdout, stderr, c.terminal, nil)
 	if err != nil {
 		return nil, fmt.Errorf("ExecSyncContainer failed: %w", err)
 	}
@@ -464,7 +464,7 @@ func (l *limitedWriter) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
-func (r *runtimeVM) execContainerCommon(ctx context.Context, c *Container, cmd []string, timeout int64, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) (exitCode int32, retErr error) {
+func (r *runtimeVM) execContainerCommon(ctx context.Context, c *Container, cmd, env []string, timeout int64, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) (exitCode int32, retErr error) {
 	log.Debugf(ctx, "RuntimeVM.execContainerCommon() start")
 	defer log.Debugf(ctx, "RuntimeVM.execContainerCommon() end")
 
@@ -513,6 +513,7 @@ func (r *runtimeVM) execContainerCommon(ctx context.Context, c *Container, cmd [
 	// process spec
 	pSpec := *c.Spec().Process
 	pSpec.Args = cmd
+	pSpec.Env = mergeProcessEnvOverlay(pSpec.Env, env)
 
 	anyType, err := typeurl.MarshalAny(&pSpec)
 	if err != nil {
@@ -1233,7 +1234,7 @@ func (r *runtimeVM) ProbeMonitor(ctx context.Context, c *Container) error {
 	return nil
 }
 
-func (r *runtimeVM) ServeExecContainer(context.Context, *Container, []string, bool, bool, bool, bool) (string, error) {
+func (r *runtimeVM) ServeExecContainer(_ context.Context, _ *Container, _, _ []string, _, _, _, _ bool) (string, error) {
 	return "", nil
 }
 

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -24,7 +24,7 @@ func (s *Server) Exec(ctx context.Context, req *types.ExecRequest) (*types.ExecR
 	if streamWebsocket, err := s.Runtime().RuntimeStreamWebsockets(runtimeHandler); err == nil && streamWebsocket {
 		log.Debugf(ctx, "Runtime handler %q is configured to use websockets", runtimeHandler)
 
-		url, err := s.Runtime().ServeExecContainer(ctx, c, req.GetCmd(), req.GetTty(), req.GetStdin(), req.GetStdout(), req.GetStderr())
+		url, err := s.Runtime().ServeExecContainer(ctx, c, req.GetCmd(), req.GetEnv(), req.GetTty(), req.GetStdin(), req.GetStdout(), req.GetStderr())
 		if err != nil {
 			return nil, fmt.Errorf("could not serve exec for container %q: %w", req.GetContainerId(), err)
 		}
@@ -43,7 +43,7 @@ func (s *Server) Exec(ctx context.Context, req *types.ExecRequest) (*types.ExecR
 }
 
 // Exec endpoint for streaming.Runtime.
-func (s *StreamService) Exec(ctx context.Context, containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
+func (s *StreamService) Exec(ctx context.Context, containerID string, cmd, env []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
 	ctx, span := log.StartSpan(ctx)
 	defer span.End()
 
@@ -56,5 +56,5 @@ func (s *StreamService) Exec(ctx context.Context, containerID string, cmd []stri
 		return status.Errorf(codes.NotFound, "container is not created or running: %v", err)
 	}
 
-	return s.runtimeServer.ContainerServer.Runtime().ExecContainer(s.ctx, c, cmd, stdin, stdout, stderr, tty, resizeChan)
+	return s.runtimeServer.ContainerServer.Runtime().ExecContainer(s.ctx, c, cmd, env, stdin, stdout, stderr, tty, resizeChan)
 }

--- a/server/container_exec_test.go
+++ b/server/container_exec_test.go
@@ -68,7 +68,7 @@ var _ = t.Describe("ContainerExec", func() {
 		It("should fail when container not found", func() {
 			// Given
 			// When
-			err := testStreamService.Exec(context.Background(), testContainer.ID(), []string{},
+			err := testStreamService.Exec(context.Background(), testContainer.ID(), []string{}, nil,
 				nil, nil, nil, false, make(chan remotecommand.TerminalSize))
 
 			// Then
@@ -86,7 +86,7 @@ var _ = t.Describe("ContainerExec", func() {
 			})
 
 			// When
-			err := testStreamService.Exec(context.Background(), testContainer.ID(), []string{"/bin/sh"},
+			err := testStreamService.Exec(context.Background(), testContainer.ID(), []string{"/bin/sh"}, nil,
 				nil, nil, nil, false, make(chan remotecommand.TerminalSize))
 
 			// Then - Should succeed because container is running
@@ -120,7 +120,7 @@ var _ = t.Describe("ContainerExec", func() {
 			})
 
 			// When
-			err := testStreamService.Exec(context.Background(), testContainer.ID(), []string{"/bin/sh"},
+			err := testStreamService.Exec(context.Background(), testContainer.ID(), []string{"/bin/sh"}, nil,
 				nil, nil, nil, false, make(chan remotecommand.TerminalSize))
 
 			// Then - Should fail the Living() check

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -30,5 +30,5 @@ func (s *Server) ExecSync(ctx context.Context, req *types.ExecSyncRequest) (*typ
 		return nil, errors.New("exec command cannot be empty")
 	}
 
-	return s.ContainerServer.Runtime().ExecSyncContainer(ctx, c, cmd, req.GetTimeout())
+	return s.ContainerServer.Runtime().ExecSyncContainer(ctx, c, cmd, req.GetEnv(), req.GetTimeout())
 }

--- a/test/mocks/oci/oci.go
+++ b/test/mocks/oci/oci.go
@@ -133,32 +133,32 @@ func (mr *MockRuntimeImplMockRecorder) DiskStats(arg0, arg1, arg2 any) *gomock.C
 }
 
 // ExecContainer mocks base method.
-func (m *MockRuntimeImpl) ExecContainer(arg0 context.Context, arg1 *oci.Container, arg2 []string, arg3 io.Reader, arg4, arg5 io.WriteCloser, arg6 bool, arg7 <-chan remotecommand.TerminalSize) error {
+func (m *MockRuntimeImpl) ExecContainer(ctx context.Context, c *oci.Container, cmd, env []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret := m.ctrl.Call(m, "ExecContainer", ctx, c, cmd, env, stdin, stdout, stderr, tty, resizeChan)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ExecContainer indicates an expected call of ExecContainer.
-func (mr *MockRuntimeImplMockRecorder) ExecContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) ExecContainer(ctx, c, cmd, env, stdin, stdout, stderr, tty, resizeChan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ExecContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ExecContainer), ctx, c, cmd, env, stdin, stdout, stderr, tty, resizeChan)
 }
 
 // ExecSyncContainer mocks base method.
-func (m *MockRuntimeImpl) ExecSyncContainer(arg0 context.Context, arg1 *oci.Container, arg2 []string, arg3 int64) (*v1.ExecSyncResponse, error) {
+func (m *MockRuntimeImpl) ExecSyncContainer(ctx context.Context, c *oci.Container, command, env []string, timeout int64) (*v1.ExecSyncResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecSyncContainer", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "ExecSyncContainer", ctx, c, command, env, timeout)
 	ret0, _ := ret[0].(*v1.ExecSyncResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExecSyncContainer indicates an expected call of ExecSyncContainer.
-func (mr *MockRuntimeImplMockRecorder) ExecSyncContainer(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) ExecSyncContainer(ctx, c, command, env, timeout any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecSyncContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ExecSyncContainer), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecSyncContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ExecSyncContainer), ctx, c, command, env, timeout)
 }
 
 // IsContainerAlive mocks base method.
@@ -261,18 +261,18 @@ func (mr *MockRuntimeImplMockRecorder) ServeAttachContainer(arg0, arg1, arg2, ar
 }
 
 // ServeExecContainer mocks base method.
-func (m *MockRuntimeImpl) ServeExecContainer(arg0 context.Context, arg1 *oci.Container, arg2 []string, arg3, arg4, arg5, arg6 bool) (string, error) {
+func (m *MockRuntimeImpl) ServeExecContainer(ctx context.Context, c *oci.Container, cmd, env []string, tty, stdin, stdout, stderr bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServeExecContainer", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "ServeExecContainer", ctx, c, cmd, env, tty, stdin, stdout, stderr)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ServeExecContainer indicates an expected call of ServeExecContainer.
-func (mr *MockRuntimeImplMockRecorder) ServeExecContainer(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+func (mr *MockRuntimeImplMockRecorder) ServeExecContainer(ctx, c, cmd, env, tty, stdin, stdout, stderr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServeExecContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ServeExecContainer), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServeExecContainer", reflect.TypeOf((*MockRuntimeImpl)(nil).ServeExecContainer), ctx, c, cmd, env, tty, stdin, stdout, stderr)
 }
 
 // StartContainer mocks base method.

--- a/vendor/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/vendor/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -40,11 +40,12 @@ limitations under the License.
 package v1
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -7187,7 +7188,9 @@ type ExecSyncRequest struct {
 	// Command to execute.
 	Cmd []string `protobuf:"bytes,2,rep,name=cmd,proto3" json:"cmd,omitempty"`
 	// Timeout in seconds to stop the command. Default: 0 (run forever).
-	Timeout       int64 `protobuf:"varint,3,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	Timeout int64 `protobuf:"varint,3,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	// Environment variables to set in the container.
+	Env           []string `protobuf:"bytes,4,rep,name=env,proto3" json:"env,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7232,6 +7235,13 @@ func (x *ExecSyncRequest) GetContainerId() string {
 func (x *ExecSyncRequest) GetCmd() []string {
 	if x != nil {
 		return x.Cmd
+	}
+	return nil
+}
+
+func (x *ExecSyncRequest) GetEnv() []string {
+	if x != nil {
+		return x.Env
 	}
 	return nil
 }
@@ -7333,7 +7343,9 @@ type ExecRequest struct {
 	// If `tty` is true, `stderr` MUST be false. Multiplexing is not supported
 	// in this case. The output of stdout and stderr will be combined to a
 	// single stream.
-	Stderr        bool `protobuf:"varint,6,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	Stderr bool `protobuf:"varint,6,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	// Environment variables to set in the container.
+	Env           []string `protobuf:"bytes,7,rep,name=env,proto3" json:"env,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7408,6 +7420,13 @@ func (x *ExecRequest) GetStderr() bool {
 		return x.Stderr
 	}
 	return false
+}
+
+func (x *ExecRequest) GetEnv() []string {
+	if x != nil {
+		return x.Env
+	}
+	return nil
 }
 
 type ExecResponse struct {

--- a/vendor/k8s.io/cri-streaming/pkg/streaming/remotecommand/exec.go
+++ b/vendor/k8s.io/cri-streaming/pkg/streaming/remotecommand/exec.go
@@ -31,13 +31,13 @@ import (
 type Executor interface {
 	// ExecInContainer executes a command in a container in the pod, copying data
 	// between in/out/err and the container's stdin/stdout/stderr.
-	ExecInContainer(ctx context.Context, name string, uid string, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan TerminalSize, timeout time.Duration) error
+	ExecInContainer(ctx context.Context, name string, uid string, container string, cmd []string, env []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan TerminalSize, timeout time.Duration) error
 }
 
 // ServeExec handles requests to execute a command in a container. After
 // creating/receiving the required streams, it delegates the actual execution
 // to the executor.
-func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podName string, uid string, container string, cmd []string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
+func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podName string, uid string, container string, cmd []string, env []string, streamOpts *Options, idleTimeout, streamCreationTimeout time.Duration, supportedProtocols []string) {
 	ctx, ok := createStreams(req, w, streamOpts, supportedProtocols, idleTimeout, streamCreationTimeout)
 	if !ok {
 		// error is handled by createStreams
@@ -45,7 +45,7 @@ func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podN
 	}
 	defer ctx.conn.Close()
 
-	err := executor.ExecInContainer(req.Context(), podName, uid, container, cmd, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
+	err := executor.ExecInContainer(req.Context(), podName, uid, container, cmd, env, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
 	if err != nil {
 		if exitErr, ok := err.(utilexec.ExitError); ok && exitErr.Exited() {
 			rc := exitErr.ExitStatus()

--- a/vendor/k8s.io/cri-streaming/pkg/streaming/server.go
+++ b/vendor/k8s.io/cri-streaming/pkg/streaming/server.go
@@ -59,7 +59,7 @@ type Server interface {
 
 // Runtime is the interface to execute the commands and provide the streams.
 type Runtime interface {
-	Exec(ctx context.Context, containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error
+	Exec(ctx context.Context, containerID string, cmd []string, env []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error
 	Attach(ctx context.Context, containerID string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error
 	PortForward(ctx context.Context, podSandboxID string, port int32, stream io.ReadWriteCloser) error
 }
@@ -288,6 +288,7 @@ func (s *server) serveExec(req *restful.Request, resp *restful.Response) {
 		"", // unusued: podUID
 		exec.ContainerId,
 		exec.Cmd,
+		exec.Env,
 		streamOpts,
 		s.config.StreamIdleTimeout,
 		s.config.StreamCreationTimeout,
@@ -367,8 +368,8 @@ var _ remotecommandserver.Executor = &criAdapter{}
 var _ remotecommandserver.Attacher = &criAdapter{}
 var _ portforward.PortForwarder = &criAdapter{}
 
-func (a *criAdapter) ExecInContainer(ctx context.Context, podName string, podUID string, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize, timeout time.Duration) error {
-	return a.Runtime.Exec(ctx, container, cmd, in, out, err, tty, resize)
+func (a *criAdapter) ExecInContainer(ctx context.Context, podName string, podUID string, container string, cmd []string, env []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize, timeout time.Duration) error {
+	return a.Runtime.Exec(ctx, container, cmd, env, in, out, err, tty, resize)
 }
 
 func (a *criAdapter) AttachContainer(ctx context.Context, podName string, podUID string, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Pod exec currently has no CRI-level way to pass additional environment variables that apply only to the process being exec'd inside a container. The usual workaround is to prepend an `env` invocation to the command, for example:

`kubectl exec pod -it -- env FOO=BAR /bin/bash`

That approach depends on an `env` binary being present in the container image, which is not guaranteed. It also couples environment injection to binaries or shell behavior inside the image.

This PR implements the container runtime side of the exec environment contract by honoring the new `env` field in `ExecRequest`. When an exec process is created, the requested environment variables are merged into the existing process environment before writing `process.json`.

If a key is present in both the existing environment and `ExecRequest.Env`, the value from `ExecRequest.Env` takes precedence. This lets kubelet inject environment variables specifically for the exec'd process without requiring the runtime to understand the semantic meaning of those variables.

The upstream kubelet-side implementation of this contract is tracked in kubernetes/kubernetes#139023.
#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

This is an implementation supporting a KEP that has been submitted to `kubernetes/kubernetes` - _Link to be included_
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

/cc @haircommander @ngopalak-redhat @nispriha
