### PR TITLE
Bump version to v1.37.0

### DIFF
--- a/contrib/test/ci/cri-o.spec
+++ b/contrib/test/ci/cri-o.spec
@@ -27,7 +27,7 @@
 %global service_name crio
 
 Name: %{repo}
-Version: 1.36.0
+Version: 1.37.0
 Release: 1.ci.git%{shortcommit0}%{?dist}
 Summary: Kubernetes Container Runtime Interface for OCI-based containers
 License: ASL 2.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -15,7 +15,7 @@ dependencies:
   # tag the .0 release if it does not already exist. If the .0 release is done,
   # increase the development version to the next minor (1.x.0).
   - name: development version
-    version: 1.36.0
+    version: 1.37.0
     refPaths:
       - path: internal/version/version.go
         match: Version
@@ -23,7 +23,7 @@ dependencies:
         match: Version
 
   - name: supported versions
-    version: '{"1.35", "1.34", "1.33"}'
+    version: '{"1.36", "1.35", "1.34", "1.33"}'
     refPaths:
       - path: internal/version/version.go
         match: ReleaseMinorVersions

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 // Version is the version of the build.
-const Version = "1.36.0"
+const Version = "1.37.0"
 
 // ReleaseMinorVersions are the currently supported minor versions.
-var ReleaseMinorVersions = []string{"1.35", "1.34", "1.33"}
+var ReleaseMinorVersions = []string{"1.36", "1.35", "1.34", "1.33"}
 
 // Variables injected during build-time.
 var (


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
Bump the version on main to v1.37.0 and add v1.36 to `ReleaseMinorVersions` to enable prerelease package builds for v1.37.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
@cri-o/cri-o-maintainers PTAL

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Released version 1.37.0 and updated supported versions list to include version 1.36 alongside existing stable releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9959)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->