### PR TITLE
FIx: Clean recover gingko in case of panic

### DIFF
--- a/server/container_events_test.go
+++ b/server/container_events_test.go
@@ -64,6 +64,8 @@ var _ = t.Describe("ContainerEvents", func() {
 			}
 
 			recv := func(ces types.RuntimeService_GetContainerEventsServer) {
+				defer GinkgoRecover()
+
 				err := sut.GetContainerEvents(nil, ces)
 				Expect(err).ToNot(HaveOccurred())
 			}


### PR DESCRIPTION
If the test fails or panics we need to recover it cleanly and report failure.

/kind bug

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability for concurrent operations by ensuring proper recovery from panics within a parallel test execution path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->