### PR TITLE
OCPBUGS-84718: server: fix unnecessary storage wipe after unclean shutdown

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	json "github.com/goccy/go-json"
@@ -119,6 +120,13 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 
 	if config.InternalRepair && ShutdownWasUnclean(config) {
 		graphRoot := store.GraphRoot()
+
+		// Clean stale overlay mounts from the unclean shutdown so that
+		// store.Check() does not report false layer errors.
+		if err := cmount.RecursiveUnmount(filepath.Join(graphRoot, "overlay")); err != nil {
+			log.Warnf(ctx, "Failed to clean stale overlay mounts under %s: %v", graphRoot, err)
+		}
+
 		log.Warnf(ctx, "Checking storage directory %s for errors because of unclean shutdown", graphRoot)
 
 		wipeStorage := false
@@ -128,7 +136,14 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 			log.Warnf(ctx, "Attempting to repair storage directory %s because of unclean shutdown", graphRoot)
 
 			if errs := store.Repair(report, cstorage.RepairEverything()); len(errs) > 0 {
-				wipeStorage = true
+				for _, repairErr := range errs {
+					log.Warnf(ctx, "Storage repair error for %s: %v", graphRoot, repairErr)
+				}
+				if allRepairErrorsAreTransient(errs) {
+					log.Warnf(ctx, "Storage repair for %s encountered only transient errors (e.g. device busy), skipping wipe", graphRoot)
+				} else {
+					wipeStorage = true
+				}
 			}
 		} else if err != nil {
 			// Storage check has failed with irrecoverable errors.
@@ -1070,4 +1085,15 @@ func (c *ContainerServer) probeMonitorProcesses(ctx context.Context) {
 
 		timer.Reset(probeInterval + time.Duration(rand.Int63n(probeJitter.Nanoseconds())))
 	}
+}
+
+// allRepairErrorsAreTransient returns true if every repair error is a transient
+// "device or resource busy" issue rather than actual storage corruption.
+func allRepairErrorsAreTransient(errs []error) bool {
+	for _, err := range errs {
+		if !errors.Is(err, syscall.EBUSY) {
+			return false
+		}
+	}
+	return len(errs) > 0
 }

--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -386,6 +386,62 @@ function start_crio_with_stopped_pod() {
 	fi
 }
 
+@test "skip wipe on unclean shutdown with only stale overlay mounts" {
+	setup_crio
+	touch "$CONTAINER_CLEAN_SHUTDOWN_FILE".supported
+
+	start_crio_no_setup
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	crictl stopp "$pod_id"
+
+	stop_crio_no_clean
+
+	# Simulate stale overlay mounts left behind after kill -9.
+	for dir in "$TESTDIR"/crio/overlay/*/merged; do
+		[ -d "$dir" ] && mount --bind "$dir" "$dir"
+	done
+
+	rm -Rf "$CONTAINER_CLEAN_SHUTDOWN_FILE"
+
+	CONTAINER_INTERNAL_REPAIR=true start_crio_no_setup
+
+	# Storage should not have been wiped.
+	[[ $(crictl images) == *"quay.io/crio"* ]]
+}
+
+@test "wipe storage on unclean shutdown with real corruption" {
+	setup_crio
+	touch "$CONTAINER_CLEAN_SHUTDOWN_FILE".supported
+
+	start_crio_no_setup
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	# This will corrupt the storage directory.
+	cp -r "$TESTDIR"/crio/overlay{,.old}
+	umount -R -l -f "$TESTDIR"/crio/overlay
+	rm -Rf "$TESTDIR"/crio/overlay
+	cp -r "$TESTDIR"/crio/overlay{.old,}
+
+	stop_crio_no_clean
+
+	rm -Rf "$CONTAINER_CLEAN_SHUTDOWN_FILE"
+
+	CONTAINER_INTERNAL_REPAIR=true start_crio_no_setup
+
+	# Storage directory wipe should leave only the metadata behind.
+	size=$(du -sb "$TESTDIR"/crio | cut -f 1)
+	if ((size > 1024 * 128)); then
+		echo "The storage directory wipe did not work" >&3
+		return 1
+	fi
+}
+
 @test "crio-wipe should create /run/crio/crio-wipe-done and not wipe again" {
 	CONTAINER_INTERNAL_WIPE=false start_crio_with_stopped_pod
 	stop_crio_no_clean


### PR DESCRIPTION
### Summary

After an unclean shutdown, stale overlay mounts cause `store.Check()` to report false layer errors. `store.Repair()` then fails with "device or resource busy" and CRI-O wipes the entire primary image store at `/var/lib/containers/storage`. This is destructive and unnecessary — the storage is not actually corrupted.

### Changes

1. Clean stale overlay mounts (via `cmount.RecursiveUnmount`) before `store.Check()` runs, preventing false layer errors.
2. If `Repair()` still fails with only transient "device or resource busy" errors, skip the wipe instead of nuking the store.
3. Add integration tests for stale mount and real corruption scenarios.


### Root Cause Evidence

Debug logging after unclean shutdown on CRI-O v1.31:
- `grep -c "device or resource busy"` → **19** (all errors are stale mounts)
- `grep -c "ted layer"` → **0** (no actual corruption)
- `grep -c "Wiping storage"` → **1** (unnecessary wipe triggered)

### Testing

- Reproduced on RHEL 9.4 + MicroShift 4.18 + CRI-O v1.31.13
- Verified fix prevents the wipe (0 wipes, 0 busy errors after stale mount cleanup)

```
level=warning msg="Checking storage directory /var/lib/containers/storage for errors because of unclean shutdown"
level=warning msg="Attempting to repair storage directory /var/lib/containers/storage because of unclean shutdown"

$ grep -c "Wiping" /tmp/fix.log
0
$ grep -c "device or resource busy" /tmp/fix.log
0

```

Fixes: https://issues.redhat.com/browse/OCPBUGS-84718

```release-note
Fix unnecessary storage wipe after unclean shutdown when only stale overlay mounts are present.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unclean shutdown handling to clean up stale overlay mounts before attempting storage repair.
  * Enhanced storage repair logic to intelligently preserve storage when encountering transient errors, avoiding unnecessary data loss.

* **Tests**
  * Added test cases validating storage behavior during unclean shutdowns with stale mounts and corruption scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->