### PR TITLE
feat: Add support for containerd-shim-runsc-v1

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -357,7 +357,11 @@ Path to the OCI compatible runtime used for this runtime handler.
 Root directory used to store runtime data
 
 **runtime_type**="oci"
-Type of the runtime used for this runtime handler. "oci", "vm"
+Type of the runtime used for this runtime handler. Valid values are:
+
+- `"oci"` (default): Standard OCI runtime (e.g. runc, crun). The `runtime_path` should point to the OCI runtime binary.
+- `"vm"`: VM-isolation shim using the containerd shimv2/ttrpc protocol. The `runtime_path` must be a `containerd-shim-*` binary. This runtime type is exercised in CI with [Kata Containers](https://github.com/kata-containers/kata-containers) (`containerd-shim-kata-v2`). Other shimv2 shims implement the same protocol and may work — for example [gVisor](https://github.com/google/gvisor)'s `containerd-shim-runsc-v1` — but are not currently covered by CI.
+- `"pod"`: Pod-level runtime using [conmon-rs](https://github.com/containers/conmon-rs) instead of conmon. conmon-rs operates at pod granularity.
 
 **inherit_default_runtime**=false
 Override the runtime path, runtime config path, runtime root and runtime type from the default runtime on load.

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -254,6 +254,28 @@ func (r *runtimeVM) CreateContainer(ctx context.Context, c *Container, cgroupPar
 	return nil
 }
 
+// ParseShimAddress extracts the shim's ttrpc address from its "start" stdout
+// output. It mirrors containerd's own parseStartResponse:
+// https://github.com/containerd/containerd/blob/v1.7.31/runtime/v2/shim.go#L211
+//
+// Modern shims (the containerd v2 shim API, including gVisor's
+// containerd-shim-runsc-v1) emit a JSON BootstrapParams object; legacy shims
+// emit just the address string. If the output does not unmarshal into a
+// versioned (>= 2) BootstrapParams object, it is treated as a raw address.
+func ParseShimAddress(out []byte) (string, error) {
+	var params client.BootstrapParams
+	if err := json.Unmarshal(out, &params); err != nil || params.Version < 2 {
+		// Legacy shim: the raw output is the ttrpc address.
+		return strings.TrimSpace(string(out)), nil
+	}
+
+	if params.Version > 2 {
+		return "", fmt.Errorf("unsupported shim version (%d): %w", params.Version, errdefs.ErrNotImplemented)
+	}
+
+	return params.Address, nil
+}
+
 func (r *runtimeVM) startRuntimeDaemon(ctx context.Context, c *Container) error {
 	log.Debugf(ctx, "RuntimeVM.startRuntimeDaemon() start")
 	defer log.Debugf(ctx, "RuntimeVM.startRuntimeDaemon() end")
@@ -301,14 +323,22 @@ func (r *runtimeVM) startRuntimeDaemon(ctx context.Context, c *Container) error 
 		}
 	}()
 
-	// Start the server
-	out, err := cmd.CombinedOutput()
+	// Capture stderr separately so that anything the shim writes
+	// there cannot corrupt the BootstrapParams JSON (or raw address)
+	// it emits on stdout, which we can parse below.
+	var stderr bytes.Buffer
+
+	cmd.Stderr = &stderr
+
+	out, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("%s: %w", string(out), err)
+		return fmt.Errorf("%s: %w", stderr.String(), err)
 	}
 
-	// Retrieve the address from the output
-	address := strings.TrimSpace(string(out))
+	address, err := ParseShimAddress(out)
+	if err != nil {
+		return fmt.Errorf("parsing shim address: %w", err)
+	}
 
 	// Now the RPC server is running, let's connect to it
 	conn, err := client.Connect(address, client.AnonDialer)

--- a/internal/oci/runtime_vm_test.go
+++ b/internal/oci/runtime_vm_test.go
@@ -1,0 +1,86 @@
+package oci_test
+
+import (
+	"testing"
+
+	"github.com/cri-o/cri-o/internal/oci"
+)
+
+func TestParseShimAddress(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "plain address string",
+			input: "unix:///run/containerd/s/abc123\n",
+			want:  "unix:///run/containerd/s/abc123",
+		},
+		{
+			name:  "plain address no newline",
+			input: "unix:///run/containerd/s/abc123",
+			want:  "unix:///run/containerd/s/abc123",
+		},
+		{
+			name:  "JSON BootstrapParams from gVisor shim",
+			input: `{"version":2,"address":"unix:///run/containerd/s/abc123","protocol":"ttrpc"}`,
+			want:  "unix:///run/containerd/s/abc123",
+		},
+		{
+			name:  "JSON BootstrapParams with whitespace",
+			input: "  {\"version\":2,\"address\":\"unix:///run/containerd/s/abc123\",\"protocol\":\"ttrpc\"}\n",
+			want:  "unix:///run/containerd/s/abc123",
+		},
+		{
+			// Like containerd's parseStartResponse, output that does not
+			// unmarshal into a versioned BootstrapParams is treated as a raw
+			// (legacy) address rather than an error.
+			name:  "malformed JSON falls back to raw address",
+			input: "{not valid json}",
+			want:  "{not valid json}",
+		},
+		{
+			// version < 2 is treated as a legacy shim: the raw output is the
+			// address.
+			name:  "JSON with version below 2 treated as legacy",
+			input: `{"version":1,"address":"unix:///run/containerd/s/abc123"}`,
+			want:  `{"version":1,"address":"unix:///run/containerd/s/abc123"}`,
+		},
+		{
+			name:    "unsupported shim version",
+			input:   `{"version":3,"address":"unix:///run/containerd/s/abc123","protocol":"ttrpc"}`,
+			wantErr: true,
+		},
+		{
+			name:  "empty output",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace only",
+			input: "  \n  ",
+			want:  "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := oci.ParseShimAddress([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseShimAddress(%q) = %q, want error", tc.input, got)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseShimAddress(%q) error: %v", tc.input, err)
+			}
+
+			if got != tc.want {
+				t.Errorf("ParseShimAddress(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,7 +70,7 @@ const (
 	RuntimeTypePod                = "pod"
 	defaultCtrStopTimeout         = 30 // seconds
 	defaultNamespacesDir          = "/var/run"
-	RuntimeTypeVMBinaryPattern    = "containerd-shim-([a-zA-Z0-9\\-\\+])+-v2"
+	RuntimeTypeVMBinaryPattern    = "^containerd-shim-[a-zA-Z0-9\\-\\+]+$"
 	tasksetBinary                 = "taskset"
 	MonitorExecCgroupDefault      = ""
 	MonitorExecCgroupContainer    = "container"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1705,6 +1705,36 @@ var _ = t.Describe("Config", func() {
 			Expect(ok).To(BeTrue())
 		})
 
+		It("should succeed when using RuntimeTypeVM and runtime_path is a containerd-shim binary with v1 suffix", func() {
+			// Given
+			sut.Runtimes["runsc"] = &config.RuntimeHandler{
+				RuntimePath: "containerd-shim-runsc-v1", RuntimeType: config.RuntimeTypeVM,
+			}
+
+			// When
+			ok := sut.Runtimes["runsc"].ValidateRuntimeVMBinaryPattern()
+
+			// Then
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should succeed with gVisor runtime handler (v1 shim with config path)", func() {
+			// Given
+			sut.Runtimes["runsc"] = &config.RuntimeHandler{
+				RuntimePath:       "containerd-shim-runsc-v1",
+				RuntimeType:       config.RuntimeTypeVM,
+				RuntimeConfigPath: validFilePath,
+			}
+
+			// When
+			okPattern := sut.Runtimes["runsc"].ValidateRuntimeVMBinaryPattern()
+			errPath := sut.Runtimes["runsc"].ValidateRuntimeConfigPath("runsc")
+
+			// Then
+			Expect(okPattern).To(BeTrue())
+			Expect(errPath).ToNot(HaveOccurred())
+		})
+
 		It("should fail when using RuntimeTypeVM and runtime_path does not follow the containerd pattern", func() {
 			// Given
 			sut.Runtimes["kata"] = &config.RuntimeHandler{
@@ -1716,6 +1746,26 @@ var _ = t.Describe("Config", func() {
 
 			// Then
 			Expect(ok).To(BeFalse())
+		})
+
+		It("should fail when the binary name only contains the containerd-shim pattern as a substring", func() {
+			// Given the pattern is anchored, near-miss names that embed
+			// containerd-shim-* as a prefix or suffix must not match.
+			for _, name := range []string{
+				"my-containerd-shim-kata-v2",
+				"containerd-shim-runsc-v1.bak",
+				"containerd-shim",
+			} {
+				sut.Runtimes["runsc"] = &config.RuntimeHandler{
+					RuntimePath: name, RuntimeType: config.RuntimeTypeVM,
+				}
+
+				// When
+				ok := sut.Runtimes["runsc"].ValidateRuntimeVMBinaryPattern()
+
+				// Then
+				Expect(ok).To(BeFalse(), "expected %q to be rejected", name)
+			}
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind feature

#### What this PR does / why we need it:

To support gVisor in CRI-O, this update extends the `RuntimeTypeVMBinaryPattern` to accept the `runsc-v1` shim naming convention and refactors `ParseShimAddress()` to handle gVisor’s JSON-formatted `BootstrapParams` alongside standard address strings. Additionally, the configuration now requires `runtime_type` to be set to `vm` to ensure CRI-O correctly creates the pause container via the shim path, a necessary step for gVisor sandbox initialization.


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes https://github.com/google/gvisor/issues/10313

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support gVisor containerd-shim-runsc-v1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional VM shim naming conventions (e.g., v1-style shims) alongside existing v2 support.

* **Bug Fixes**
  * Improved shim address extraction with stricter JSON handling and clearer parsing errors.

* **Documentation**
  * Expanded runtime type docs to list valid values (oci, vm, pod) and updated runtime selection examples to include gVisor.

* **Tests**
  * Added tests for shim address parsing and runtime binary validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->