### PR TITLE
Document that pinned_images applies to OCI artifacts

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -147,7 +147,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l pause-command -r -d 'Path 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l pause-image -r -d 'Image which contains the pause executable.'
 complete -c crio -n '__fish_crio_no_subcommand' -l pause-image-auth-file -r -d 'Path to a config file containing credentials for --pause-image.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l pids-limit -r -d 'Maximum number of processes allowed in a container. This option is deprecated. The Kubelet flag \'--pod-pids-limit\' should be used instead.'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l pinned-images -r -d 'A list of images that will be excluded from the kubelet\'s garbage collection.'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l pinned-images -r -d 'A list of images and OCI artifacts that will be excluded from the kubelet\'s garbage collection.'
 complete -c crio -n '__fish_crio_no_subcommand' -l pinns-path -r -d 'The path to find the pinns binary, which is needed to manage namespace lifecycle. Will be searched for in $PATH if empty.'
 complete -c crio -n '__fish_crio_no_subcommand' -l privileged-seccomp-profile -r -d 'Enable a seccomp profile for privileged containers from the local path.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l profile -d 'Enable pprof remote profiler on 127.0.0.1:6060.'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -409,7 +409,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--pids-limit**="": Maximum number of processes allowed in a container. This option is deprecated. The Kubelet flag '--pod-pids-limit' should be used instead. (default: -1)
 
-**--pinned-images**="": A list of images that will be excluded from the kubelet's garbage collection.
+**--pinned-images**="": A list of images and OCI artifacts that will be excluded from the kubelet's garbage collection.
 
 **--pinns-path**="": The path to find the pinns binary, which is needed to manage namespace lifecycle. Will be searched for in $PATH if empty.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -499,7 +499,7 @@ The path to a file like /var/lib/kubelet/config.json holding credentials specifi
 The command to run to have a container stay in the paused state. This option supports live configuration reload.
 
 **pinned_images**=[]
-A list of images to be excluded from the kubelet's garbage collection. It allows specifying image names using either exact, glob, or keyword patterns. Exact matches must match the entire name, glob matches can have a wildcard \* at the end, and keyword matches can have wildcards on both ends. By default, this list includes the `pause` image if configured by the user, which is used as a placeholder in Kubernetes pods.
+A list of images and OCI artifacts to be excluded from the kubelet's garbage collection. It allows specifying image names using either exact, glob, or keyword patterns. Exact matches must match the entire name, glob matches can have a wildcard \* at the end, and keyword matches can have wildcards on both ends. By default, this list includes the `pause` image if configured by the user, which is used as a placeholder in Kubernetes pods.
 
 **signature_policy**=""
 Path to the file which decides what sort of policy we use when deciding whether or not to trust an image that we've pulled. It is not recommended that this option be used, as the default behavior of using the system-wide default policy (i.e., /etc/containers/policy.json) is most often preferred. Please refer to containers-policy.json(5) for more details.

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -1563,7 +1563,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:    "pinned-images",
-			Usage:   "A list of images that will be excluded from the kubelet's garbage collection.",
+			Usage:   "A list of images and OCI artifacts that will be excluded from the kubelet's garbage collection.",
 			EnvVars: []string{"CONTAINER_PINNED_IMAGES"},
 			Value:   cli.NewStringSlice(defConf.PinnedImages...),
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -656,10 +656,11 @@ type ImageConfig struct {
 	// PauseCommand is the path of the binary we run in an infra
 	// container that's been instantiated using PauseImage.
 	PauseCommand string `toml:"pause_command"`
-	// PinnedImages is a list of container images that should be pinned
-	// and not subject to garbage collection by kubelet.
-	// Pinned images will remain in the container runtime's storage until
-	// they are manually removed. Default value: empty list (no images pinned)
+	// PinnedImages is a list of container images and OCI artifacts that
+	// should be pinned and not subject to garbage collection by kubelet.
+	// Pinned images and artifacts will remain in the container runtime's
+	// storage until they are manually removed.
+	// Default value: empty list (no images or artifacts pinned)
 	PinnedImages []string `toml:"pinned_images"`
 	// SignaturePolicyPath is the name of the file which decides what sort
 	// of policy we use when deciding whether or not to trust an image that

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1551,10 +1551,10 @@ const templateStringCrioImagePauseCommand = `# The command to run to have a cont
 
 `
 
-const templateStringCrioImagePinnedImages = `# List of images to be excluded from the kubelet's garbage collection.
-# It allows specifying image names using either exact, glob, or keyword
-# patterns. Exact matches must match the entire name, glob matches can
-# have a wildcard * at the end, and keyword matches can have wildcards
+const templateStringCrioImagePinnedImages = `# List of images and OCI artifacts to be excluded from the kubelet's garbage
+# collection. It allows specifying image names using either exact, glob, or
+# keyword patterns. Exact matches must match the entire name, glob matches
+# can have a wildcard * at the end, and keyword matches can have wildcards
 # on both ends. By default, this list includes the "pause" image if
 # configured by the user, which is used as a placeholder in Kubernetes pods.
 {{ $.Comment }}pinned_images = [


### PR DESCRIPTION
/kind documentation

#### What this PR does / why we need it:
The `pinned_images` configuration option already matches OCI artifacts in addition to container images, but the documentation only mentioned images. This updates all related docs, comments, and config templates to clarify that artifacts are covered as well.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified across docs, config reference, CLI help and shell completions that the `--pinned-images` / `pinned_images` setting excludes both container images and OCI artifacts (not just images) from kubelet garbage collection. Noted that pinned items persist in the container runtime storage until manually removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/cri-o/pull/9983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->