### PR TITLE
OCPBUGS-86735: [release-1.34] Persist image repo digest across CRI-O restarts

### DIFF
--- a/internal/factory/container/container.go
+++ b/internal/factory/container/container.go
@@ -234,6 +234,11 @@ func (c *container) SpecAddAnnotations(ctx context.Context, sb SandboxIFace, con
 
 	c.spec.AddAnnotation(annotations.SomeNameOfTheImage, someNameOfThisImage)
 	c.spec.AddAnnotation(annotations.ImageRef, imageResult.ID.IDStringForOutOfProcessConsumptionOnly())
+
+	if len(imageResult.RepoDigests) > 0 {
+		c.spec.AddAnnotation(annotations.ImageRepoDigests, strings.Join(imageResult.RepoDigests, ","))
+	}
+
 	c.spec.AddAnnotation(annotations.Name, c.Name())
 	c.spec.AddAnnotation(annotations.ContainerID, c.ID())
 	c.spec.AddAnnotation(annotations.SandboxID, sb.ID())

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -541,7 +542,12 @@ func (c *ContainerServer) LoadContainer(ctx context.Context, id string) (retErr 
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, userRequestedImage, someNameOfTheImage, imageID, "", &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, m.Annotations[annotations.StopSignalAnnotation])
+	someRepoDigest := ""
+	if repoDigests := m.Annotations[annotations.ImageRepoDigests]; repoDigests != "" {
+		someRepoDigest = strings.SplitN(repoDigests, ",", 2)[0]
+	}
+
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], labels, m.Annotations, kubeAnnotations, userRequestedImage, someNameOfTheImage, imageID, someRepoDigest, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.RuntimeHandler(), containerDir, created, m.Annotations[annotations.StopSignalAnnotation])
 	if err != nil {
 		return err
 	}

--- a/pkg/annotations/internal.go
+++ b/pkg/annotations/internal.go
@@ -44,6 +44,9 @@ const (
 	// ImageRef is the container image ref annotation.
 	ImageRef = "io.kubernetes.cri-o.ImageRef"
 
+	// ImageRepoDigests are the repo@digest values of the image, persisted for restore.
+	ImageRepoDigests = "io.kubernetes.cri-o.ImageRepoDigests"
+
 	// KubeName is the kubernetes name annotation.
 	KubeName = "io.kubernetes.cri-o.KubeName"
 

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -411,6 +411,22 @@ function teardown() {
 	[[ "${output}" == "${ctr_status_info}" ]]
 }
 
+@test "crio restore imageRef for containers" {
+	start_crio
+	[[ -n "$REDIS_IMAGEREF" ]]
+
+	ctr_id=$(crictl run "$TESTDATA"/container_config.json "$TESTDATA"/sandbox_config.json)
+
+	imageRef=$(crictl inspect -o json "$ctr_id" | jq -r '.status.imageRef')
+	[[ "$imageRef" == "$REDIS_IMAGEREF" ]]
+
+	stop_crio
+	start_crio
+
+	imageRef=$(crictl inspect -o json "$ctr_id" | jq -r '.status.imageRef')
+	[[ "$imageRef" == "$REDIS_IMAGEREF" ]]
+}
+
 @test "crio restore volumes for containers" {
 	start_crio
 


### PR DESCRIPTION
This is a manual cherry-pick of #9925

/assign bitoku

```release-note
Fixed a bug where ImageRef in container status changed from a repo@digest to a raw image ID hash after CRI-O restart.
```