### PR TITLE
feature: Support per-container targeting for high-performance annotations

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -148,7 +148,9 @@ func (h *HighPerformanceHooks) PreCreate(ctx context.Context, specgen *generate.
 		}
 	}
 
-	if requestedSharedCPUs(s.Annotations(), c.CRIContainer().GetMetadata().GetName()) {
+	containerName := c.CRIContainer().GetMetadata().GetName()
+
+	if requestedSharedCPUs(s.Annotations(), containerName) {
 		if exclusiveCPUSet.IsEmpty() {
 			return fmt.Errorf("no cpus found for container %q", c.Name())
 		}
@@ -175,7 +177,7 @@ func (h *HighPerformanceHooks) PreCreate(ctx context.Context, specgen *generate.
 		specgen.Config.Linux.Resources.CPU.Cpus = exclusiveCPUSet.Union(sharedCPUSet).String()
 	}
 
-	housekeepingSiblings, err := h.getHousekeepingCPUs(specgen.Config, s.Annotations())
+	housekeepingSiblings, err := h.getHousekeepingCPUs(specgen.Config, s.Annotations(), containerName)
 	if err != nil {
 		return err
 	}
@@ -241,7 +243,9 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 		return err
 	}
 
-	sharedCPUsRequested := requestedSharedCPUs(s.Annotations(), c.CRIContainer().GetMetadata().GetName())
+	containerName := c.CRIContainer().GetMetadata().GetName()
+
+	sharedCPUsRequested := requestedSharedCPUs(s.Annotations(), containerName)
 	if sharedCPUsRequested {
 		if containerManagers, err = setSharedCPUs(c, containerManagers, h.sharedCPUs); err != nil {
 			return fmt.Errorf("setSharedCPUs: failed to set shared CPUs for container %q; %w", c.Name(), err)
@@ -253,17 +257,19 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 	}
 
 	// disable the CPU load balancing for the container CPUs
-	if shouldCPULoadBalancingBeDisabled(ctx, s.Annotations()) {
+	if shouldCPULoadBalancingBeDisabled(ctx, s.Annotations(), containerName) {
+		log.Infof(ctx, "Disable CPU load balancing for container %q", c.ID())
+
 		if err := h.setCPULoadBalancing(ctx, c, podManager, containerManagers, false, sharedCPUsRequested); err != nil {
 			return fmt.Errorf("set CPU load balancing: %w", err)
 		}
 	}
 
 	// disable the IRQ smp load balancing for the container CPUs
-	if shouldIRQLoadBalancingBeDisabled(ctx, s.Annotations()) {
+	if shouldIRQLoadBalancingBeDisabled(ctx, s.Annotations(), containerName) {
 		log.Infof(ctx, "Disable irq smp balancing for container %q", c.ID())
 
-		housekeepingSiblings, err := h.getHousekeepingCPUs(&cSpec, s.Annotations())
+		housekeepingSiblings, err := h.getHousekeepingCPUs(&cSpec, s.Annotations(), containerName)
 		if err != nil {
 			return err
 		}
@@ -274,7 +280,7 @@ func (h *HighPerformanceHooks) PreStart(ctx context.Context, c *oci.Container, s
 	}
 
 	// disable the CFS quota for the container CPUs
-	if shouldCPUQuotaBeDisabled(ctx, s.Annotations()) {
+	if shouldCPUQuotaBeDisabled(ctx, s.Annotations(), containerName) {
 		log.Infof(ctx, "Disable cpu cfs quota for container %q", c.ID())
 
 		if err := setCPUQuota(podManager, containerManagers); err != nil {
@@ -382,14 +388,16 @@ func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s 
 		return nil
 	}
 
+	containerName := c.CRIContainer().GetMetadata().GetName()
+
 	// disable the CPU load balancing for the container CPUs
-	if shouldCPULoadBalancingBeDisabled(ctx, s.Annotations()) {
+	if shouldCPULoadBalancingBeDisabled(ctx, s.Annotations(), containerName) {
 		podManager, containerManagers, err := h.PodAndContainerCgroupManagers(s.CgroupParent(), c.ID())
 		if err != nil {
 			return err
 		}
 
-		sharedCPUsRequested := requestedSharedCPUs(s.Annotations(), c.CRIContainer().GetMetadata().GetName())
+		sharedCPUsRequested := requestedSharedCPUs(s.Annotations(), containerName)
 		if sharedCPUsRequested && node.CgroupIsV2() {
 			// Add the cgroup-child so that we can safely remove the isolated cpuset cgroup
 			// Otherwise cpuset may be kept isolated even after the cgroup is deleted.
@@ -437,9 +445,11 @@ func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s 
 // If CPU load balancing is enabled, then *all* containers must run this PostStop hook.
 func (h *HighPerformanceHooks) PostStop(ctx context.Context, c *oci.Container, s *sandbox.Sandbox) error {
 	cSpec := c.Spec()
+	containerName := c.CRIContainer().GetMetadata().GetName()
+
 	if shouldRunHooks(ctx, c.ID(), &cSpec, s) {
 		// enable the IRQ smp balancing for the container CPUs
-		if shouldIRQLoadBalancingBeDisabled(ctx, s.Annotations()) {
+		if shouldIRQLoadBalancingBeDisabled(ctx, s.Annotations(), containerName) {
 			if err := h.setIRQLoadBalancing(ctx, c, cpuset.CPUSet{}, true); err != nil {
 				return fmt.Errorf("set IRQ load balancing: %w", err)
 			}
@@ -456,32 +466,31 @@ func (h *HighPerformanceHooks) PostStop(ctx context.Context, c *oci.Container, s
 	return dh.PostStop(ctx, c, s)
 }
 
-func shouldCPULoadBalancingBeDisabled(ctx context.Context, annotations fields.Set) bool {
-	if annotations[crioannotations.CPULoadBalancing] == annotationTrue {
+func shouldCPULoadBalancingBeDisabled(ctx context.Context, annotations fields.Set, containerName string) bool {
+	value, _ := getAnnotationValueForContainer(annotations, crioannotations.CPULoadBalancing, containerName)
+	if value == annotationTrue {
 		log.Warnf(ctx, "%s", annotationValueDeprecationWarning(crioannotations.CPULoadBalancing))
 	}
 
-	return annotations[crioannotations.CPULoadBalancing] == annotationTrue ||
-		annotations[crioannotations.CPULoadBalancing] == annotationDisable
+	return value == annotationTrue || value == annotationDisable
 }
 
-func shouldCPUQuotaBeDisabled(ctx context.Context, annotations fields.Set) bool {
-	if annotations[crioannotations.CPUQuota] == annotationTrue {
+func shouldCPUQuotaBeDisabled(ctx context.Context, annotations fields.Set, containerName string) bool {
+	value, _ := getAnnotationValueForContainer(annotations, crioannotations.CPUQuota, containerName)
+	if value == annotationTrue {
 		log.Warnf(ctx, "%s", annotationValueDeprecationWarning(crioannotations.CPUQuota))
 	}
 
-	return annotations[crioannotations.CPUQuota] == annotationTrue ||
-		annotations[crioannotations.CPUQuota] == annotationDisable
+	return value == annotationTrue || value == annotationDisable
 }
 
-func shouldIRQLoadBalancingBeDisabled(ctx context.Context, annotations fields.Set) bool {
-	if annotations[crioannotations.IRQLoadBalancing] == annotationTrue {
+func shouldIRQLoadBalancingBeDisabled(ctx context.Context, annotations fields.Set, containerName string) bool {
+	value, _ := getAnnotationValueForContainer(annotations, crioannotations.IRQLoadBalancing, containerName)
+	if value == annotationTrue {
 		log.Warnf(ctx, "%s", annotationValueDeprecationWarning(crioannotations.IRQLoadBalancing))
 	}
 
-	return annotations[crioannotations.IRQLoadBalancing] == annotationTrue ||
-		annotations[crioannotations.IRQLoadBalancing] == annotationDisable ||
-		annotations[crioannotations.IRQLoadBalancing] == annotationHousekeeping
+	return value == annotationTrue || value == annotationDisable || value == annotationHousekeeping
 }
 
 func shouldCStatesBeConfigured(annotations fields.Set) (present bool, value string) {
@@ -498,6 +507,19 @@ func shouldFreqGovernorBeConfigured(annotations fields.Set) (present bool, value
 
 func annotationValueDeprecationWarning(annotation string) string {
 	return fmt.Sprintf("The usage of the annotation %q with value %q will be deprecated under 1.21", annotation, "true")
+}
+
+func getAnnotationValueForContainer(annotations fields.Set, baseKey, containerName string) (string, bool) {
+	if containerName != "" {
+		containerKey := baseKey + "/" + containerName
+		if value, ok := annotations[containerKey]; ok {
+			return value, true
+		}
+	}
+
+	value, ok := annotations[baseKey]
+
+	return value, ok
 }
 
 func requestedSharedCPUs(annotations fields.Set, cName string) bool {
@@ -1536,15 +1558,17 @@ func injectCpusetEnv(specgen *generate.Generator, isolated, shared *cpuset.CPUSe
 }
 
 // isRequestedHousekeepingCPUs checks if sandbox annotation "irq-load-balancing.crio.io" equals "housekeeping".
-func isRequestedHousekeepingCPUs(annotations fields.Set) bool {
-	return annotations[crioannotations.IRQLoadBalancing] == annotationHousekeeping
+func isRequestedHousekeepingCPUs(annotations fields.Set, containerName string) bool {
+	value, _ := getAnnotationValueForContainer(annotations, crioannotations.IRQLoadBalancing, containerName)
+
+	return value == annotationHousekeeping
 }
 
 // getHousekeepingCPUs determines which CPUs should be preserved for housekeeping tasks.
 // When housekeeping mode is enabled, it returns the thread siblings of the first container CPU.
 // These CPUs will continue to handle interrupts while other container CPUs are isolated.
-func (h *HighPerformanceHooks) getHousekeepingCPUs(containerSpec *specs.Spec, annotations map[string]string) (cpuset.CPUSet, error) {
-	if !isRequestedHousekeepingCPUs(annotations) {
+func (h *HighPerformanceHooks) getHousekeepingCPUs(containerSpec *specs.Spec, annotations map[string]string, containerName string) (cpuset.CPUSet, error) {
+	if !isRequestedHousekeepingCPUs(annotations, containerName) {
 		return cpuset.CPUSet{}, nil
 	}
 

--- a/internal/runtimehandlerhooks/high_performance_hooks_test.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/fields"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/utils/cpuset"
 
@@ -363,7 +364,7 @@ var _ = Describe("high_performance_hooks", func() {
 			if !enabled {
 				spec := c.Spec()
 
-				housekeepingSiblings, err = h.getHousekeepingCPUs(&spec, sb.Annotations())
+				housekeepingSiblings, err = h.getHousekeepingCPUs(&spec, sb.Annotations(), c.CRIContainer().GetMetadata().GetName())
 				if expectFailure {
 					Expect(err).To(HaveOccurred())
 
@@ -1842,6 +1843,150 @@ var _ = Describe("high_performance_hooks", func() {
 				wg.Wait()
 				verifySetIRQLoadBalancing(flags, bannedCPUFlags)
 			})
+		})
+	})
+
+	Describe("getAnnotationValueForContainer", func() {
+		It("should return pod-level value when no container-specific annotation exists", func() {
+			annotations := map[string]string{
+				crioannotations.CPULoadBalancing: "disable",
+			}
+			v, ok := getAnnotationValueForContainer(annotations, crioannotations.CPULoadBalancing, "container1")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal("disable"))
+		})
+
+		It("should return container-specific value when present", func() {
+			annotations := map[string]string{
+				crioannotations.CPULoadBalancing:                 "disable",
+				crioannotations.CPULoadBalancing + "/container1": "enable",
+			}
+			v, ok := getAnnotationValueForContainer(annotations, crioannotations.CPULoadBalancing, "container1")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal("enable"))
+		})
+
+		It("should fall back to pod-level for a different container name", func() {
+			annotations := map[string]string{
+				crioannotations.CPULoadBalancing:                 "disable",
+				crioannotations.CPULoadBalancing + "/container1": "enable",
+			}
+			v, ok := getAnnotationValueForContainer(annotations, crioannotations.CPULoadBalancing, "container2")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal("disable"))
+		})
+
+		It("should return not found when no annotation exists", func() {
+			annotations := map[string]string{}
+			_, ok := getAnnotationValueForContainer(annotations, crioannotations.CPULoadBalancing, "container1")
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should return container-specific value even when no pod-level exists", func() {
+			annotations := map[string]string{
+				crioannotations.CPULoadBalancing + "/container1": "disable",
+			}
+			v, ok := getAnnotationValueForContainer(annotations, crioannotations.CPULoadBalancing, "container1")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal("disable"))
+		})
+
+		It("should fall back to pod-level when container name is empty", func() {
+			annotations := map[string]string{
+				crioannotations.CPULoadBalancing: "disable",
+			}
+			v, ok := getAnnotationValueForContainer(annotations, crioannotations.CPULoadBalancing, "")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal("disable"))
+		})
+	})
+
+	Describe("per-container targeting for should* decision functions", func() {
+		ctx := context.TODO()
+
+		type decisionFunc func(context.Context, fields.Set, string) bool
+
+		testPerContainerTargeting := func(annotationKey string, fn decisionFunc) {
+			It("should use pod-level annotation for all containers", func() {
+				annotations := map[string]string{
+					annotationKey: "disable",
+				}
+				Expect(fn(ctx, annotations, "container1")).To(BeTrue())
+				Expect(fn(ctx, annotations, "container2")).To(BeTrue())
+			})
+
+			It("should use container-specific annotation when present", func() {
+				annotations := map[string]string{
+					annotationKey + "/container1": "disable",
+				}
+				Expect(fn(ctx, annotations, "container1")).To(BeTrue())
+				Expect(fn(ctx, annotations, "container2")).To(BeFalse())
+			})
+
+			It("should let container-specific override pod-level", func() {
+				annotations := map[string]string{
+					annotationKey:                 "disable",
+					annotationKey + "/container1": "enable",
+				}
+				Expect(fn(ctx, annotations, "container1")).To(BeFalse())
+				Expect(fn(ctx, annotations, "container2")).To(BeTrue())
+			})
+		}
+
+		Context("shouldCPULoadBalancingBeDisabled", func() {
+			testPerContainerTargeting(crioannotations.CPULoadBalancing, shouldCPULoadBalancingBeDisabled)
+		})
+
+		Context("shouldCPUQuotaBeDisabled", func() {
+			testPerContainerTargeting(crioannotations.CPUQuota, shouldCPUQuotaBeDisabled)
+		})
+
+		Context("shouldIRQLoadBalancingBeDisabled", func() {
+			testPerContainerTargeting(crioannotations.IRQLoadBalancing, shouldIRQLoadBalancingBeDisabled)
+
+			It("should support housekeeping value per container", func() {
+				annotations := map[string]string{
+					crioannotations.IRQLoadBalancing + "/container1": "housekeeping",
+				}
+				Expect(shouldIRQLoadBalancingBeDisabled(ctx, annotations, "container1")).To(BeTrue())
+				Expect(shouldIRQLoadBalancingBeDisabled(ctx, annotations, "container2")).To(BeFalse())
+			})
+
+			It("should let container-specific housekeeping override pod-level enable", func() {
+				annotations := map[string]string{
+					crioannotations.IRQLoadBalancing:                 "enable",
+					crioannotations.IRQLoadBalancing + "/container1": "housekeeping",
+				}
+				Expect(shouldIRQLoadBalancingBeDisabled(ctx, annotations, "container1")).To(BeTrue())
+				Expect(shouldIRQLoadBalancingBeDisabled(ctx, annotations, "container2")).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("isRequestedHousekeepingCPUs with per-container targeting", func() {
+		It("should use pod-level annotation for all containers", func() {
+			annotations := map[string]string{
+				crioannotations.IRQLoadBalancing: "housekeeping",
+			}
+			Expect(isRequestedHousekeepingCPUs(annotations, "container1")).To(BeTrue())
+			Expect(isRequestedHousekeepingCPUs(annotations, "container2")).To(BeTrue())
+		})
+
+		It("should use container-specific annotation when present", func() {
+			annotations := map[string]string{
+				crioannotations.IRQLoadBalancing + "/container1": "housekeeping",
+			}
+			Expect(isRequestedHousekeepingCPUs(annotations, "container1")).To(BeTrue())
+			Expect(isRequestedHousekeepingCPUs(annotations, "container2")).To(BeFalse())
+		})
+
+		It("should let container-specific override pod-level", func() {
+			annotations := map[string]string{
+				crioannotations.IRQLoadBalancing:                 "housekeeping",
+				crioannotations.IRQLoadBalancing + "/container1": "disable",
+			}
+			Expect(isRequestedHousekeepingCPUs(annotations, "container1")).To(BeFalse())
+			Expect(isRequestedHousekeepingCPUs(annotations, "container2")).To(BeTrue())
 		})
 	})
 })

--- a/pkg/annotations/v2/annotations.go
+++ b/pkg/annotations/v2/annotations.go
@@ -66,9 +66,15 @@ const (
 	UsernsMode = "userns-mode.crio.io"
 
 	// CPULoadBalancing indicates that load balancing should be disabled for CPUs used by the container.
+	// A container name can optionally be appended to target a specific container. The container specific annotation
+	// takes precedence if both are present.
+	// Example: cpu-load-balancing.crio.io/containerA.
 	CPULoadBalancing = "cpu-load-balancing.crio.io"
 
 	// CPUQuota indicates that CPU quota should be disabled for CPUs used by the container.
+	// A container name can optionally be appended to target a specific container. The container specific annotation
+	// takes precedence if both are present.
+	// Example: cpu-quota.crio.io/containerA.
 	CPUQuota = "cpu-quota.crio.io"
 
 	// CPUCStates indicates that c-states should be enabled or disabled for CPUs used by the container.
@@ -87,6 +93,9 @@ const (
 	// Set to "disable" to turn off IRQ balancing on all container CPUs.
 	// Set to "housekeeping" to preserve interrupts on the first CPU core and its siblings, but to turn off on all other
 	// container CPUs.
+	// A container name can optionally be appended to target a specific container. The container specific annotation
+	// takes precedence if both are present.
+	// Example: irq-load-balancing.crio.io/containerA.
 	IRQLoadBalancing = "irq-load-balancing.crio.io"
 
 	// OCISeccompBPFHook is the annotation used by the OCI seccomp BPF hook for tracing container syscalls.

--- a/test/cpu_load_balancing.bats
+++ b/test/cpu_load_balancing.bats
@@ -4,12 +4,15 @@
 load helpers
 
 function setup() {
+	setup_test
+}
+
+function setup_cgroupv1_test() {
 	if is_cgroup_v2; then
 		skip "not yet supported on cgroup2"
 	fi
 	export activation="cpu-load-balancing.crio.io"
 	export prefix="io.openshift.workload.management"
-	setup_test
 	sboxconfig="$TESTDIR/sbox.json"
 	ctrconfig="$TESTDIR/ctr.json"
 	shares="1024"
@@ -50,6 +53,7 @@ function check_sched_load_balance() {
 
 # Verify the pre start runtime handler hooks run when triggered by annotation and workload.
 @test "test cpu load balancing" {
+	setup_cgroupv1_test
 	start_crio
 
 	# first, create a container with load balancing disabled
@@ -71,6 +75,7 @@ function check_sched_load_balance() {
 
 # Verify the post stop runtime handler hooks run when a container is stopped manually.
 @test "test cpu load balance disabled on manual stop" {
+	setup_cgroupv1_test
 	start_crio
 
 	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
@@ -85,6 +90,7 @@ function check_sched_load_balance() {
 
 # Verify the post stop runtime handler hooks run when a container exits on its own.
 @test "test cpu load balance disabled on container exit" {
+	setup_cgroupv1_test
 	start_crio
 
 	jq '	  .command = ["/bin/sh", "-c", "sleep 5 && exit 0"]' \
@@ -96,4 +102,118 @@ function check_sched_load_balance() {
 
 	# check for sched_load_balance
 	check_sched_load_balance "$ctr_id" 0 # disabled
+}
+
+function setup_per_container_test() {
+	if ! is_cgroup_v2; then
+		skip "node must be configured with cgroupv2 for this test"
+	fi
+	if [[ "$(basename "$RUNTIME_BINARY_PATH")" != "crun" ]]; then
+		skip "this test requires crun"
+	fi
+	if [[ $(nproc) -lt 4 ]]; then
+		skip "this test requires at least 4 CPUs"
+	fi
+	cat << EOF > "$CRIO_CONFIG_DIR/01-high-performance.conf"
+[crio.runtime]
+infra_ctr_cpuset = "0-1"
+[crio.runtime.runtimes.high-performance]
+runtime_path = "$RUNTIME_BINARY_PATH"
+runtime_root = "$RUNTIME_ROOT"
+runtime_type = "$RUNTIME_TYPE"
+allowed_annotations = ["cpu-load-balancing.crio.io"]
+default_annotations = {"run.oci.systemd.subgroup" = ""}
+EOF
+}
+
+function check_partition() {
+	local ctr_id="$1"
+	local expected="$2"
+	set_container_pod_cgroup_root "" "$ctr_id"
+	[[ $(cat "$CTR_CGROUP"/cpuset.cpus.partition) == "$expected" ]]
+}
+
+function create_container_config() {
+	local name="$1"
+	local outfile="$2"
+	local cpuset="$3"
+	jq --arg name "$name" --arg cpuset "$cpuset" \
+		'.metadata.name = $name
+		| .linux.resources.cpu_shares = 1024
+		| .linux.resources.cpuset_cpus = $cpuset' \
+		"$TESTDATA"/container_sleep.json > "$outfile"
+}
+
+# Verify per-container annotation only applies to the targeted container.
+# bats test_tags=crio:serial
+@test "test cpu load balancing per-container annotation targets specific container" {
+	setup_per_container_test
+	start_crio
+
+	# Apply annotation to container-a
+	jq '.annotations."cpu-load-balancing.crio.io/container-a" = "disable"' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sbox.json
+
+	create_container_config "container-a" "$TESTDIR"/ctr_a.json "2"
+	create_container_config "container-b" "$TESTDIR"/ctr_b.json "3"
+
+	pod_id=$(crictl runp --runtime high-performance "$TESTDIR"/sbox.json)
+	ctr_a=$(crictl create "$pod_id" "$TESTDIR"/ctr_a.json "$TESTDIR"/sbox.json)
+	crictl start "$ctr_a"
+	ctr_b=$(crictl create "$pod_id" "$TESTDIR"/ctr_b.json "$TESTDIR"/sbox.json)
+	crictl start "$ctr_b"
+
+	# Verify only container-a is isolated
+	check_partition "$ctr_a" "isolated"
+	check_partition "$ctr_b" "member"
+}
+
+# Verify pod-level annotation applies to all containers.
+# bats test_tags=crio:serial
+@test "test cpu load balancing pod-level annotation applies to all containers" {
+	setup_per_container_test
+	start_crio
+
+	# Apply annotation to pod
+	jq '.annotations."cpu-load-balancing.crio.io" = "disable"' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sbox.json
+
+	create_container_config "container-a" "$TESTDIR"/ctr_a.json "2"
+	create_container_config "container-b" "$TESTDIR"/ctr_b.json "3"
+
+	pod_id=$(crictl runp --runtime high-performance "$TESTDIR"/sbox.json)
+	ctr_a=$(crictl create "$pod_id" "$TESTDIR"/ctr_a.json "$TESTDIR"/sbox.json)
+	crictl start "$ctr_a"
+
+	ctr_b=$(crictl create "$pod_id" "$TESTDIR"/ctr_b.json "$TESTDIR"/sbox.json)
+	crictl start "$ctr_b"
+
+	# Verify both containers are isolated
+	check_partition "$ctr_a" "isolated"
+	check_partition "$ctr_b" "isolated"
+}
+
+# Verify container-specific annotation overrides pod-level.
+# bats test_tags=crio:serial
+@test "test cpu load balancing container annotation overrides pod-level" {
+	setup_per_container_test
+	start_crio
+
+	# Apply annotation to pod, but undo it for container-b
+	jq '.annotations."cpu-load-balancing.crio.io" = "disable"
+		| .annotations."cpu-load-balancing.crio.io/container-b" = "enable"' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sbox.json
+
+	create_container_config "container-a" "$TESTDIR"/ctr_a.json "2"
+	create_container_config "container-b" "$TESTDIR"/ctr_b.json "3"
+
+	pod_id=$(crictl runp --runtime high-performance "$TESTDIR"/sbox.json)
+	ctr_a=$(crictl create "$pod_id" "$TESTDIR"/ctr_a.json "$TESTDIR"/sbox.json)
+	crictl start "$ctr_a"
+	ctr_b=$(crictl create "$pod_id" "$TESTDIR"/ctr_b.json "$TESTDIR"/sbox.json)
+	crictl start "$ctr_b"
+
+	# Verify only container-a is isolated
+	check_partition "$ctr_a" "isolated"
+	check_partition "$ctr_b" "member"
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Extend cpu-load-balancing.crio.io, irq-load-balancing.crio.io and cpu-quota.crio.io annotations to support optional per-container targeting using a /containerName suffix.

For example:
  cpu-load-balancing.crio.io: "disable"              # all containers
  cpu-load-balancing.crio.io/container-a: "disable"  # container-a only

When both a pod-level and container-specific annotation are present, the container-specific annotation takes precedence.

This is needed to satisfy the use case where a pod with guaranteed QoS has multiple containers using whole CPUs and these containers need different annotations. For example some of the containers may need the cpu-load-balancing.crio.io annotation but others don't. There is no way to do this today as the annotation always applies to all the containers in the pod.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Yes - although the change is 100% backwards compatible so no user action is required
```release-note
Added support for per-container targeting of cpu-load-balancing.crio.io, irq-load-balancing.crio.io, and cpu-quota.crio.io annotations. A container name can be appended to the annotation key (e.g. cpu-load-balancing.crio.io/my-container: "disable") to apply the setting to a specific container rather than all containers in the pod. Container-specific annotations take precedence over pod-level annotations when both are present.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CPU load-balancing, CPU quota, and IRQ load-balancing can now be targeted to a specific container via annotations, defaulting to pod-level settings when no container target is provided.
  * Housekeeping CPU preservation and related IRQ handling now support container-specific overrides, using pod-level defaults when applicable.

* **Documentation**
  * Clarified per-container annotation formats and precedence rules, with examples.

* **Tests**
  * Expanded coverage for container-scoped targeting, precedence/fallback behavior, and housekeeping calculations across cgroup v1 and v2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->