### PR TITLE
Fix patch release workflow spec file version mismatch

### DIFF
--- a/scripts/release/release.go
+++ b/scripts/release/release.go
@@ -118,7 +118,7 @@ func updateVersionAndCreatePR(
 
 	logrus.Infof("Updating version in spec file %s", utils.SpecFile)
 
-	if err := updateSpecFile(oldVersion, newVersion); err != nil {
+	if err := updateSpecFile(newVersion); err != nil {
 		return fmt.Errorf("unable to update spec file: %w", err)
 	}
 
@@ -184,15 +184,15 @@ func modifyVersionFile(filePath, oldVersion, newVersion string) error {
 	return nil
 }
 
-func updateSpecFile(oldVersion, newVersion string) error {
+func updateSpecFile(newVersion string) error {
 	content, err := os.ReadFile(utils.SpecFile)
 	if err != nil {
 		return fmt.Errorf("read file %s: %w", utils.SpecFile, err)
 	}
 
-	re := regexp.MustCompile(`(?m)^Version:\s+` + regexp.QuoteMeta(oldVersion) + `\s*$`)
+	re := regexp.MustCompile(`(?m)^Version:\s+\S+\s*$`)
 	if !re.Match(content) {
-		return fmt.Errorf("version string %q not found in %s", "Version: "+oldVersion, utils.SpecFile)
+		return fmt.Errorf("version string not found in %s", utils.SpecFile)
 	}
 
 	modifiedContent := re.ReplaceAll(content, []byte("Version: "+newVersion))


### PR DESCRIPTION
/kind bug

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The [patch release workflow failed](https://github.com/cri-o/cri-o/actions/runs/26729881084/job/78771719011) because the release script required an exact version match in `contrib/test/ci/cri-o.spec`, but release branches created before commit 0305311d2 still have a stale version (`1.32.0`) in the spec file. This caused the workflow to fail for `release-1.36`.
This change matches any `Version:` line in the spec file instead of requiring the exact old version, since the script sets the correct new version regardless.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The `release-1.33`, `release-1.34`, `release-1.35`, and `release-1.36` branches all have `Version: 1.32.0` in the spec file. With this fix, the release script will handle that gracefully.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the internal release script version update process for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->