### PR TITLE
Add btrfs storage driver support to static builds

### DIFF
--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -22,6 +22,7 @@ with pkgs; buildGo126Module /* use go 1.26.3 */ {
     glibc
     glibc.static
   ] ++ [
+    btrfs-progs
     gpgme
     libapparmor
     libassuan
@@ -33,7 +34,7 @@ with pkgs; buildGo126Module /* use go 1.26.3 */ {
     export CFLAGS='-static -pthread'
     export LDFLAGS='-s -w -static-libgcc -static'
     export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
-    export BUILDTAGS='static netgo osusergo exclude_graphdriver_btrfs seccomp apparmor selinux'
+    export BUILDTAGS='static netgo osusergo seccomp apparmor selinux'
     export CGO_ENABLED=1
     export CGO_LDFLAGS='-lgpgme -lassuan -lgpg-error'
     export SOURCE_DATE_EPOCH=0

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -18,6 +18,7 @@ self: super:
   });
   libassuan = (static super.libassuan);
   libgpg-error = (static super.libgpg-error);
+  btrfs-progs = (static super.btrfs-progs);
   libseccomp = (static super.libseccomp);
   gnupg = super.gnupg.override {
     libusb1 = null;


### PR DESCRIPTION
/kind feature

#### What type of PR is this?

#### What this PR does / why we need it:
Adds btrfs storage driver support to the statically linked CRI-O binaries by including `btrfs-progs` as a build dependency and removing the `exclude_graphdriver_btrfs` build tag from the Nix derivation. This allows CRI-O to share storage with podman when using btrfs as the backend filesystem.

#### Which issue(s) this PR fixes:
Fixes https://github.com/cri-o/packaging/issues/377

#### Special notes for your reviewer:
Successfully built and verified for all four architectures (amd64, arm64, ppc64le, s390x). The `static.nix` overlay handles transitive dependencies (e2fsprogs, fuse, etc.) automatically.

#### Does this PR introduce a user-facing change?

```release-note
Add btrfs storage driver support to static builds
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Btrfs filesystem driver support in the build, allowing use of the Btrfs graph driver where applicable.
  * Added static compilation support for Btrfs utilities, providing a statically linked btrfs-progs package for environments needing self-contained binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->