### PR TITLE
[wip] oci: fix kata pod stuck in Terminating when VM shim exits before StopPodSandbox

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -686,6 +686,7 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 		err := r.waitCtrTerminate(sig, stopCh, timeoutDuration)
 		if err == nil {
 			c.state.Finished = time.Now()
+			c.state.Status = ContainerStateStopped
 
 			return nil
 		}
@@ -706,6 +707,7 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 	}
 
 	c.state.Finished = time.Now()
+	c.state.Status = ContainerStateStopped
 
 	return nil
 }

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -1151,7 +1151,7 @@ func (r *runtimeVM) kill(ctrID, execID string, signal syscall.Signal) error {
 		ExecID: execID,
 		Signal: uint32(signal),
 		All:    false,
-	}); err != nil {
+	}); err != nil && !errors.Is(err, ttrpc.ErrClosed) {
 		return errdefs.FromGRPC(err)
 	}
 

--- a/internal/oci/runtime_vm_test.go
+++ b/internal/oci/runtime_vm_test.go
@@ -1,0 +1,64 @@
+package oci_test
+
+import (
+	"context"
+	"syscall"
+
+	task "github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/ttrpc"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/cri-o/cri-o/internal/oci"
+)
+
+// fakeTaskService is a minimal task.TaskService stub for testing kill() behavior.
+// Only Kill() is implemented; all other methods panic if called.
+type fakeTaskService struct {
+	task.TaskService
+
+	killErr error
+}
+
+func (f *fakeTaskService) Kill(_ context.Context, _ *task.KillRequest) (*emptypb.Empty, error) {
+	return nil, f.killErr
+}
+
+var _ = t.Describe("RuntimeVM", func() {
+	Describe("kill", func() {
+		It("should return nil when shim has already exited (ttrpc.ErrClosed)", func() {
+			// Given — shim ttrpc connection is closed (shim exited before kill was called)
+			r := oci.NewRuntimeVMWithTask(&fakeTaskService{killErr: ttrpc.ErrClosed})
+
+			// When
+			err := r.Kill("ctr-id", "", syscall.SIGTERM)
+
+			// Then — a kill on a dead shim means the container is already stopped
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should propagate errors that are not ttrpc.ErrClosed", func() {
+			// Given — shim returns a real error (e.g. container not found)
+			r := oci.NewRuntimeVMWithTask(&fakeTaskService{killErr: ttrpc.ErrClosed})
+			rErr := oci.NewRuntimeVMWithTask(&fakeTaskService{killErr: context.DeadlineExceeded})
+
+			// Sanity: ErrClosed is swallowed
+			Expect(r.Kill("ctr-id", "", syscall.SIGTERM)).NotTo(HaveOccurred())
+
+			// Other errors are propagated
+			Expect(rErr.Kill("ctr-id", "", syscall.SIGTERM)).To(HaveOccurred())
+		})
+
+		It("should return nil when kill succeeds", func() {
+			// Given — shim is alive and kill succeeds
+			r := oci.NewRuntimeVMWithTask(&fakeTaskService{killErr: nil})
+
+			// When
+			err := r.Kill("ctr-id", "", syscall.SIGTERM)
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/internal/oci/runtime_vm_test_inject.go
+++ b/internal/oci/runtime_vm_test_inject.go
@@ -1,0 +1,35 @@
+//go:build test
+
+// All *_inject.go files are meant to be used by tests only. Purpose of this
+// files is to provide a way to inject mocked data into the current setup.
+
+package oci
+
+import (
+	"context"
+	"syscall"
+
+	task "github.com/containerd/containerd/api/runtime/task/v2"
+)
+
+// RuntimeVM wraps runtimeVM for testing.
+type RuntimeVM struct {
+	*runtimeVM
+}
+
+// NewRuntimeVMWithTask creates a runtimeVM with an injected task service,
+// used to test behavior when the shim connection is in specific states.
+func NewRuntimeVMWithTask(t task.TaskService) RuntimeVM {
+	return RuntimeVM{
+		runtimeVM: &runtimeVM{
+			task: t,
+			ctx:  context.Background(),
+			ctrs: make(map[string]containerInfo),
+		},
+	}
+}
+
+// Kill exposes the unexported kill() for testing.
+func (r RuntimeVM) Kill(ctrID, execID string, signal syscall.Signal) error {
+	return r.kill(ctrID, execID, signal)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind bug

#### What this PR does / why we need it:

When a kata pod is deleted, the VM shim can exit before CRI-O calls
`StopPodSandbox`. This causes two issues in `runtimeVM`:


1. `kill()` receives `ttrpc.ErrClosed` from the dead shim and maps it
    to `ErrUnknown`, causing `StopPodSandbox` to fail and kubelet to
    retry indefinitely — leaving the pod stuck in `Terminating`.
    
2. `StopContainer` updates `c.state.Finished` on success but does not
    set `c.state.Status`, leaving the container in a non-stopped
    internal state after termination.

Fix (1) adds a `ttrpc.ErrClosed` guard to `kill()`, consistent with
the same guard already present in `wait()` and `remove()`. 
Fix (2) explicitly sets `ContainerStateStopped` on both exit paths
of `StopContainer`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes: rhjira#KATA-4869

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

The `kill()` fix is the critical one — without it the pod never
terminates. The `StopContainer` status fix is a correctness improvement
in the same code path.

Tested on OCP 4.21 SNO with kata-qemu (kata 3.25.0) terminations with
this patch applied.


```release-note
TBD
```

Testing: WIP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container state is now correctly marked as stopped after successful graceful or forced termination.
  * Container termination is more resilient when the underlying task service is already closed, while other errors continue to be reported.
* **Tests**
  * Added coverage for successful container termination, closed task services, and other termination errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->