### PR TITLE
ci: bump kata version to 3.31.0 and update tarball extraction

### DIFF
--- a/contrib/test/ci/build/kata.yml
+++ b/contrib/test/ci/build/kata.yml
@@ -59,11 +59,24 @@
 
 - name: Install Kata Containers
   block:
-    - name: Get and extract kata tarball from upstream release
-      unarchive:
-        src: "https://github.com/kata-containers/kata-containers/releases/download/{{ kata_version }}/kata-static-{{ kata_version }}-amd64.tar.xz"
-        dest: "/"
-        remote_src: yes
+    - name: Install zstd for kata tarball extraction
+      package:
+        name: zstd
+        state: present
+
+    - name: Download kata tarball from upstream release
+      get_url:
+        url: "https://github.com/kata-containers/kata-containers/releases/download/{{ kata_version }}/kata-static-{{ kata_version }}-amd64.tar.zst"
+        dest: "/tmp/kata-static-{{ kata_version }}-amd64.tar.zst"
+        checksum: "{{ kata_amd64_checksum }}"
+
+    - name: Extract kata tarball
+      command: tar -I zstd -xf /tmp/kata-static-{{ kata_version }}-amd64.tar.zst -C /
+
+    - name: Remove kata tarball
+      file:
+        path: "/tmp/kata-static-{{ kata_version }}-amd64.tar.zst"
+        state: absent
 
 - name: Set debugging logs
   block:

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -42,7 +42,12 @@ ssh_user: "{{ lookup('env','USER') }}"
 ssh_location: "{{ lookup('env','HOME') }}/.ssh/id_rsa"
 
 # variables for testing with the kata-containers runtime
-kata_version: "3.6.0"
+kata_version: "3.31.0"
+# sha256 sourced from the GitHub release attestation — decode the
+# base64 payload and look up kata-static-<version>-amd64.tar.zst:
+# https://github.com/kata-containers/kata-containers/attestations/28048664/download
+kata_amd64_checksum: "sha256:68c2786a0b97023f62f3eca02dc868b78a794e5469d4ddd6cc9e0bd4a7212b0b"
+int_test_timeout: "{{ 120 * 60 }}"
 
 kata_skip_files:
   - "apparmor.bats"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind ci

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Bumps the kata-containers version used in CI from 3.6.0 to 3.31.0 to
verify whether existing integration tests catch the pod termination
regression introduced in kata 3.25.0 (commit 956f43c6c — "runtime:
skip MoveTo for systemd cgroups").

Also updates `build/kata.yml` to handle the `.tar.zst` tarball format
used by newer kata-containers releases.


#### Which issue(s) this PR fixes:

None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI runtime/tooling versions: Kata to 3.31.0 (with refreshed checksum), CRI-Tools to v1.36.0, runc to v1.5.0, and crun to 1.28, plus increased integration test timeout.
  * Improved Kata installation/build handling by switching to zstd-compressed archive downloading, checksum verification, and direct extraction (with cleanup of temporary archives).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->