### PR TITLE
Mark v1.33 EOL

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -23,7 +23,7 @@ dependencies:
         match: Version
 
   - name: supported versions
-    version: '{"1.36", "1.35", "1.34", "1.33"}'
+    version: '{"1.36", "1.35", "1.34"}'
     refPaths:
       - path: internal/version/version.go
         match: ReleaseMinorVersions

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,7 +24,7 @@ import (
 const Version = "1.37.0"
 
 // ReleaseMinorVersions are the currently supported minor versions.
-var ReleaseMinorVersions = []string{"1.36", "1.35", "1.34", "1.33"}
+var ReleaseMinorVersions = []string{"1.36", "1.35", "1.34"}
 
 // Variables injected during build-time.
 var (


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
Mark v1.33 EOL by removing it from `ReleaseMinorVersions`.

#### Which issue(s) this PR fixes:

Fixes https://github.com/cri-o/packaging/issues/334

#### Special notes for your reviewer:
The last v1.33 release will be v1.33.13.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for Go version 1.33. Supported versions are now 1.36, 1.35, and 1.34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->