### PR TITLE
feat: add support for containerd-shim-runsc-v1 (release-1.35 backport)

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -257,6 +257,24 @@ func (r *runtimeVM) CreateContainer(ctx context.Context, c *Container, cgroupPar
 	return nil
 }
 
+// ParseShimAddress extracts the shim's ttrpc address from its stdout output.
+// Modern shims (containerd v2 shim API, including gVisor's
+// containerd-shim-runsc-v1) emit a JSON BootstrapParams object; older shims
+// emit just the address string. This function accepts both formats.
+func ParseShimAddress(out []byte) (string, error) {
+	address := strings.TrimSpace(string(out))
+	if strings.HasPrefix(address, "{") {
+		var params client.BootstrapParams
+		if err := json.Unmarshal(out, &params); err != nil {
+			return "", fmt.Errorf("parse shim bootstrap params %q: %w", address, err)
+		}
+
+		address = params.Address
+	}
+
+	return address, nil
+}
+
 func (r *runtimeVM) startRuntimeDaemon(ctx context.Context, c *Container) error {
 	log.Debugf(ctx, "RuntimeVM.startRuntimeDaemon() start")
 	defer log.Debugf(ctx, "RuntimeVM.startRuntimeDaemon() end")
@@ -310,8 +328,10 @@ func (r *runtimeVM) startRuntimeDaemon(ctx context.Context, c *Container) error 
 		return fmt.Errorf("%s: %w", string(out), err)
 	}
 
-	// Retrieve the address from the output
-	address := strings.TrimSpace(string(out))
+	address, err := ParseShimAddress(out)
+	if err != nil {
+		return err
+	}
 
 	// Now the RPC server is running, let's connect to it
 	conn, err := client.Connect(address, client.AnonDialer)

--- a/internal/oci/runtime_vm_test.go
+++ b/internal/oci/runtime_vm_test.go
@@ -1,0 +1,71 @@
+package oci_test
+
+import (
+	"testing"
+
+	"github.com/cri-o/cri-o/internal/oci"
+)
+
+func TestParseShimAddress(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "plain address string",
+			input: "unix:///run/containerd/s/abc123\n",
+			want:  "unix:///run/containerd/s/abc123",
+		},
+		{
+			name:  "plain address no newline",
+			input: "unix:///run/containerd/s/abc123",
+			want:  "unix:///run/containerd/s/abc123",
+		},
+		{
+			name:  "JSON BootstrapParams from gVisor shim",
+			input: `{"version":2,"address":"unix:///run/containerd/s/abc123","protocol":"ttrpc"}`,
+			want:  "unix:///run/containerd/s/abc123",
+		},
+		{
+			name:  "JSON BootstrapParams with whitespace",
+			input: "  {\"version\":2,\"address\":\"unix:///run/containerd/s/abc123\",\"protocol\":\"ttrpc\"}\n",
+			want:  "unix:///run/containerd/s/abc123",
+		},
+		{
+			name:    "invalid JSON starting with brace",
+			input:   "{not valid json}",
+			wantErr: true,
+		},
+		{
+			name:  "empty output",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace only",
+			input: "  \n  ",
+			want:  "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := oci.ParseShimAddress([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseShimAddress(%q) = %q, want error", tc.input, got)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseShimAddress(%q) error: %v", tc.input, err)
+			}
+
+			if got != tc.want {
+				t.Errorf("ParseShimAddress(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,10 +71,11 @@ const (
 	RuntimeTypePod                = "pod"
 	defaultCtrStopTimeout         = 30 // seconds
 	defaultNamespacesDir          = "/var/run"
-	RuntimeTypeVMBinaryPattern    = "containerd-shim-([a-zA-Z0-9\\-\\+])+-v2"
-	tasksetBinary                 = "taskset"
-	MonitorExecCgroupDefault      = ""
-	MonitorExecCgroupContainer    = "container"
+	// runsc (gVisor) uses the v1 shim; all other VM runtimes are expected to use v2.
+	RuntimeTypeVMBinaryPattern = "containerd-shim-(runsc-v1|([a-zA-Z0-9\\-\\+])+-v2)"
+	tasksetBinary              = "taskset"
+	MonitorExecCgroupDefault   = ""
+	MonitorExecCgroupContainer = "container"
 )
 
 // When updating metrics, remember to update the document as well.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1599,6 +1599,36 @@ var _ = t.Describe("Config", func() {
 			Expect(ok).To(BeTrue())
 		})
 
+		It("should succeed when using RuntimeTypeVM and runtime_path follows the containerd v1 pattern", func() {
+			// Given
+			sut.Runtimes["runsc"] = &config.RuntimeHandler{
+				RuntimePath: "containerd-shim-runsc-v1", RuntimeType: config.RuntimeTypeVM,
+			}
+
+			// When
+			ok := sut.Runtimes["runsc"].ValidateRuntimeVMBinaryPattern()
+
+			// Then
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should succeed with gVisor runtime handler (v1 shim with config path)", func() {
+			// Given
+			sut.Runtimes["runsc"] = &config.RuntimeHandler{
+				RuntimePath:       "containerd-shim-runsc-v1",
+				RuntimeType:       config.RuntimeTypeVM,
+				RuntimeConfigPath: validFilePath,
+			}
+
+			// When
+			okPattern := sut.Runtimes["runsc"].ValidateRuntimeVMBinaryPattern()
+			errPath := sut.Runtimes["runsc"].ValidateRuntimeConfigPath("runsc")
+
+			// Then
+			Expect(okPattern).To(BeTrue())
+			Expect(errPath).ToNot(HaveOccurred())
+		})
+
 		It("should fail when using RuntimeTypeVM and runtime_path does not follow the containerd pattern", func() {
 			// Given
 			sut.Runtimes["kata"] = &config.RuntimeHandler{


### PR DESCRIPTION
Backport of cri-o#9974 to release-1.35. cri-o#9974 targets main (~1.37); OKE runs cri-o 1.35.x, so this ports the change verbatim (it applies cleanly to release-1.35).

Lets gVisor's containerd-shim-runsc-v1 be used as a runtime_type="vm" runtime:
- RuntimeTypeVMBinaryPattern accepts the runsc-v1 shim name (the v1 shim implements the shimv2 protocol but is not named "...-v2").
- ParseShimAddress() handles the JSON BootstrapParams that modern shims (including runsc-v1) emit on stdout, alongside the legacy plain-address form.

Validated on an OKE/cri-o node: crio built from this branch registers the runsc runtime and runs a gVisor pod (kernel 4.19.0-gvisor) with working oci-cni networking; TestParseShimAddress passes.

Backport-of: https://github.com/cri-o/cri-o/pull/9974
Refs: https://github.com/google/gvisor/issues/10313

rolling out this change to cpu nodes makes gvisor work in cri-o base images: https://github.com/luccabb/gvisor-crio-installer/tree/main#gvisor-crio-installer
