### PR TITLE
User namespace - Handle UID/GID mappings from the infra container

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -398,6 +398,14 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 	scontainer.SetSpec(&m)
 	scontainer.SetMountPoint(m.Annotations[annotations.MountPoint])
 
+	// Restore ID mappings from the OCI spec if user namespace is in use
+	if m.Linux != nil && len(m.Linux.UIDMappings) > 0 && len(m.Linux.GIDMappings) > 0 {
+		if mappings := ConvertOCIToStorageIDMappings(m.Linux.UIDMappings, m.Linux.GIDMappings); mappings != nil {
+			scontainer.SetIDMappings(mappings)
+			log.Debugf(ctx, "Restored ID mappings for sandbox %s from OCI spec", id)
+		}
+	}
+
 	if err := restoreVolumes(&m, scontainer); err != nil {
 		return sb, fmt.Errorf("restore volumes: %w", err)
 	}

--- a/internal/lib/idmappings_freebsd.go
+++ b/internal/lib/idmappings_freebsd.go
@@ -1,0 +1,19 @@
+package lib
+
+import (
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"go.podman.io/storage/pkg/idtools"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// ConvertOCIToStorageIDMappings converts OCI runtime spec ID mappings to storage ID mappings.
+func ConvertOCIToStorageIDMappings(uidMappings, gidMappings []rspec.LinuxIDMapping) *idtools.IDMappings {
+	// FreeBSD doesn't support user namespaces, so this is a no-op
+	return nil
+}
+
+// ConvertCRIToOCIMappings converts CRI ID mappings to OCI runtime spec ID mappings.
+func ConvertCRIToOCIMappings(m []*types.IDMapping) []rspec.LinuxIDMapping {
+	// FreeBSD doesn't support user namespaces, so this is a no-op
+	return nil
+}

--- a/internal/lib/idmappings_linux.go
+++ b/internal/lib/idmappings_linux.go
@@ -1,0 +1,45 @@
+package lib
+
+import (
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"go.podman.io/storage/pkg/idtools"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// ConvertOCIToStorageIDMappings converts OCI runtime spec ID mappings to storage ID mappings.
+func ConvertOCIToStorageIDMappings(uidMappings, gidMappings []rspec.LinuxIDMapping) *idtools.IDMappings {
+	if len(uidMappings) == 0 || len(gidMappings) == 0 {
+		return nil
+	}
+
+	uids := make([]idtools.IDMap, len(uidMappings))
+	gids := make([]idtools.IDMap, len(gidMappings))
+
+	for i, v := range uidMappings {
+		uids[i] = idtools.IDMap{ContainerID: int(v.ContainerID), HostID: int(v.HostID), Size: int(v.Size)}
+	}
+
+	for i, v := range gidMappings {
+		gids[i] = idtools.IDMap{ContainerID: int(v.ContainerID), HostID: int(v.HostID), Size: int(v.Size)}
+	}
+
+	return idtools.NewIDMappingsFromMaps(uids, gids)
+}
+
+// ConvertCRIToOCIMappings converts CRI ID mappings to OCI runtime spec ID mappings.
+func ConvertCRIToOCIMappings(m []*types.IDMapping) []rspec.LinuxIDMapping {
+	if len(m) == 0 {
+		return nil
+	}
+
+	ids := make([]rspec.LinuxIDMapping, 0, len(m))
+	for _, mapping := range m {
+		ids = append(ids, rspec.LinuxIDMapping{
+			ContainerID: mapping.GetContainerId(),
+			HostID:      mapping.GetHostId(),
+			Size:        mapping.GetLength(),
+		})
+	}
+
+	return ids
+}

--- a/internal/lib/idmappings_linux_test.go
+++ b/internal/lib/idmappings_linux_test.go
@@ -1,0 +1,178 @@
+package lib
+
+import (
+	"testing"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestConvertCRIToOCIMappings(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    []*types.IDMapping
+		expected []rspec.LinuxIDMapping
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty input",
+			input:    []*types.IDMapping{},
+			expected: nil,
+		},
+		{
+			name: "single mapping",
+			input: []*types.IDMapping{
+				{ContainerId: 0, HostId: 1000, Length: 65536},
+			},
+			expected: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 65536},
+			},
+		},
+		{
+			name: "multiple mappings",
+			input: []*types.IDMapping{
+				{ContainerId: 0, HostId: 1000, Length: 1},
+				{ContainerId: 1, HostId: 100000, Length: 65536},
+			},
+			expected: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 1},
+				{ContainerID: 1, HostID: 100000, Size: 65536},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertCRIToOCIMappings(tc.input)
+
+			if len(result) != len(tc.expected) {
+				t.Fatalf("Expected %d mappings, got %d", len(tc.expected), len(result))
+			}
+
+			for i, mapping := range result {
+				if mapping.ContainerID != tc.expected[i].ContainerID {
+					t.Errorf("Mapping %d: expected ContainerID %d, got %d", i, tc.expected[i].ContainerID, mapping.ContainerID)
+				}
+
+				if mapping.HostID != tc.expected[i].HostID {
+					t.Errorf("Mapping %d: expected HostID %d, got %d", i, tc.expected[i].HostID, mapping.HostID)
+				}
+
+				if mapping.Size != tc.expected[i].Size {
+					t.Errorf("Mapping %d: expected Size %d, got %d", i, tc.expected[i].Size, mapping.Size)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertOCIToStorageIDMappings(t *testing.T) {
+	cases := []struct {
+		name        string
+		uidMappings []rspec.LinuxIDMapping
+		gidMappings []rspec.LinuxIDMapping
+		expectNil   bool
+	}{
+		{
+			name:        "nil inputs",
+			uidMappings: nil,
+			gidMappings: nil,
+			expectNil:   true,
+		},
+		{
+			name:        "empty UID mappings",
+			uidMappings: []rspec.LinuxIDMapping{},
+			gidMappings: []rspec.LinuxIDMapping{{ContainerID: 0, HostID: 1000, Size: 65536}},
+			expectNil:   true,
+		},
+		{
+			name:        "empty GID mappings",
+			uidMappings: []rspec.LinuxIDMapping{{ContainerID: 0, HostID: 1000, Size: 65536}},
+			gidMappings: []rspec.LinuxIDMapping{},
+			expectNil:   true,
+		},
+		{
+			name: "valid single mapping",
+			uidMappings: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 65536},
+			},
+			gidMappings: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 65536},
+			},
+			expectNil: false,
+		},
+		{
+			name: "valid multiple mappings",
+			uidMappings: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 1},
+				{ContainerID: 1, HostID: 100000, Size: 65536},
+			},
+			gidMappings: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 2000, Size: 1},
+				{ContainerID: 1, HostID: 200000, Size: 65536},
+			},
+			expectNil: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertOCIToStorageIDMappings(tc.uidMappings, tc.gidMappings)
+
+			if tc.expectNil {
+				if result != nil {
+					t.Fatalf("Expected nil result, got non-nil")
+				}
+
+				return
+			}
+
+			if result == nil {
+				t.Fatalf("Expected non-nil result, got nil")
+			}
+
+			uids := result.UIDs()
+			gids := result.GIDs()
+
+			if len(uids) != len(tc.uidMappings) {
+				t.Fatalf("Expected %d UID mappings, got %d", len(tc.uidMappings), len(uids))
+			}
+
+			if len(gids) != len(tc.gidMappings) {
+				t.Fatalf("Expected %d GID mappings, got %d", len(tc.gidMappings), len(gids))
+			}
+
+			for i, uid := range uids {
+				if uid.ContainerID != int(tc.uidMappings[i].ContainerID) {
+					t.Errorf("UID mapping %d: expected ContainerID %d, got %d", i, tc.uidMappings[i].ContainerID, uid.ContainerID)
+				}
+
+				if uid.HostID != int(tc.uidMappings[i].HostID) {
+					t.Errorf("UID mapping %d: expected HostID %d, got %d", i, tc.uidMappings[i].HostID, uid.HostID)
+				}
+
+				if uid.Size != int(tc.uidMappings[i].Size) {
+					t.Errorf("UID mapping %d: expected Size %d, got %d", i, tc.uidMappings[i].Size, uid.Size)
+				}
+			}
+
+			for i, gid := range gids {
+				if gid.ContainerID != int(tc.gidMappings[i].ContainerID) {
+					t.Errorf("GID mapping %d: expected ContainerID %d, got %d", i, tc.gidMappings[i].ContainerID, gid.ContainerID)
+				}
+
+				if gid.HostID != int(tc.gidMappings[i].HostID) {
+					t.Errorf("GID mapping %d: expected HostID %d, got %d", i, tc.gidMappings[i].HostID, gid.HostID)
+				}
+
+				if gid.Size != int(tc.gidMappings[i].Size) {
+					t.Errorf("GID mapping %d: expected Size %d, got %d", i, tc.gidMappings[i].Size, gid.Size)
+				}
+			}
+		})
+	}
+}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/device"
 	"github.com/cri-o/cri-o/internal/config/node"
 	ctrfactory "github.com/cri-o/cri-o/internal/factory/container"
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
@@ -375,8 +376,8 @@ func (s *Server) addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container,
 			Image:             m.GetImage(),
 		})
 
-		uidMappings := getOCIMappings(m.GetUidMappings())
-		gidMappings := getOCIMappings(m.GetGidMappings())
+		uidMappings := lib.ConvertCRIToOCIMappings(m.GetUidMappings())
+		gidMappings := lib.ConvertCRIToOCIMappings(m.GetGidMappings())
 
 		if (uidMappings != nil || gidMappings != nil) && !idMapSupport {
 			return nil, nil, nil, errors.New("idmap mounts specified but OCI runtime does not support them. Perhaps the OCI runtime is too old")
@@ -470,8 +471,8 @@ func (s *Server) mountArtifact(ctx context.Context, specgen *generate.Generator,
 			Source:      path.SourcePath,
 			Destination: dest,
 			Options:     options,
-			UIDMappings: getOCIMappings(m.GetUidMappings()),
-			GIDMappings: getOCIMappings(m.GetGidMappings()),
+			UIDMappings: lib.ConvertCRIToOCIMappings(m.GetUidMappings()),
+			GIDMappings: lib.ConvertCRIToOCIMappings(m.GetGidMappings()),
 		})
 	}
 
@@ -574,8 +575,8 @@ func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, im
 		Options: []string{
 			"lowerdir=" + mountPoint + ":" + imageVolumesPath,
 		},
-		UIDMappings: getOCIMappings(m.GetUidMappings()),
-		GIDMappings: getOCIMappings(m.GetGidMappings()),
+		UIDMappings: lib.ConvertCRIToOCIMappings(m.GetUidMappings()),
+		GIDMappings: lib.ConvertCRIToOCIMappings(m.GetGidMappings()),
 	})
 	log.Debugf(ctx, "Added overlay mount from %s to %s", mountPoint, imageVolumesPath)
 
@@ -624,23 +625,6 @@ func (s *Server) ensureImageVolumesPath(ctx context.Context, mounts []*types.Mou
 	}
 
 	return imageVolumesPath, nil
-}
-
-func getOCIMappings(m []*types.IDMapping) []rspec.LinuxIDMapping {
-	if len(m) == 0 {
-		return nil
-	}
-
-	ids := make([]rspec.LinuxIDMapping, 0, len(m))
-	for _, m := range m {
-		ids = append(ids, rspec.LinuxIDMapping{
-			ContainerID: m.GetContainerId(),
-			HostID:      m.GetHostId(),
-			Size:        m.GetLength(),
-		})
-	}
-
-	return ids
 }
 
 // mountExists returns true if dest exists in the list of mounts.

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -381,35 +381,28 @@ func (s *Server) getSandboxIDMappings(ctx context.Context, sb *libsandbox.Sandbo
 		return nil, errors.New("infra container not found")
 	}
 
-	icPid, err := ic.Pid()
+	if !ic.Spoofed() && s.defaultIDMappings == nil {
+		return nil, nil
+	}
 
-	var (
-		uids, gids []spec.LinuxIDMapping
-	)
+	var uids, gids []spec.LinuxIDMapping
 
-	// Treat PID errors the same as PID 0 - both indicate we should read from config.json
-	if err != nil || icPid == 0 {
-		// read the UID/GID mappings from the infra container's saved config.json
-		configPath := filepath.Join(ic.Dir(), "config.json")
+	// If infra container is spoofed (drop_infra_ctr=true), read mappings from namespace options
+	if ic.Spoofed() {
+		usernsOpts := sb.NamespaceOptions().GetUsernsOptions()
 
-		configData, readErr := os.ReadFile(configPath)
-		if readErr != nil {
-			return nil, fmt.Errorf("cannot read infra container config.json: %w", readErr)
-		}
+		uids = getOCIMappings(usernsOpts.GetUids())
+		gids = getOCIMappings(usernsOpts.GetGids())
 
-		var containerConfig spec.Spec
-		if parseErr := json.Unmarshal(configData, &containerConfig); parseErr != nil {
-			return nil, fmt.Errorf("cannot parse infra container config.json: %w", parseErr)
-		}
-
-		if containerConfig.Linux == nil ||
-			(len(containerConfig.Linux.UIDMappings) == 0 && len(containerConfig.Linux.GIDMappings) == 0) {
+		if len(uids) == 0 || len(gids) == 0 {
 			return nil, nil
 		}
-
-		uids = containerConfig.Linux.UIDMappings
-		gids = containerConfig.Linux.GIDMappings
 	} else {
+		icPid, err := ic.Pid()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get infra container PID: %w", err)
+		}
+
 		uids, gids, err = unshare.GetHostIDMappings(strconv.Itoa(icPid))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get ID mappings from infra container PID %d: %w", icPid, err)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -372,8 +372,7 @@ func (s *Server) getSandboxIDMappings(ctx context.Context, sb *libsandbox.Sandbo
 		}
 	}
 
-	// UsernsMode() is empty but UserNsPath() is set when the cri-o restarts and container is killed
-	if sb.UsernsMode() == "" && sb.UserNsPath() == "" && s.defaultIDMappings == nil {
+	if sb.UsernsMode() == "" && s.defaultIDMappings == nil {
 		return nil, nil
 	}
 
@@ -381,32 +380,9 @@ func (s *Server) getSandboxIDMappings(ctx context.Context, sb *libsandbox.Sandbo
 		return nil, errors.New("infra container not found")
 	}
 
-	if !ic.Spoofed() && s.defaultIDMappings == nil {
-		return nil, nil
-	}
-
-	var uids, gids []spec.LinuxIDMapping
-
-	// If infra container is spoofed (drop_infra_ctr=true), read mappings from namespace options
-	if ic.Spoofed() {
-		usernsOpts := sb.NamespaceOptions().GetUsernsOptions()
-
-		uids = getOCIMappings(usernsOpts.GetUids())
-		gids = getOCIMappings(usernsOpts.GetGids())
-
-		if len(uids) == 0 || len(gids) == 0 {
-			return nil, nil
-		}
-	} else {
-		icPid, err := ic.Pid()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get infra container PID: %w", err)
-		}
-
-		uids, gids, err = unshare.GetHostIDMappings(strconv.Itoa(icPid))
-		if err != nil {
-			return nil, fmt.Errorf("failed to get ID mappings from infra container PID %d: %w", icPid, err)
-		}
+	uids, gids, err := unshare.GetHostIDMappings(strconv.Itoa(ic.State().Pid))
+	if err != nil {
+		return nil, err
 	}
 
 	mappings := convertToStorageIDMappings(uids, gids)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -372,7 +372,8 @@ func (s *Server) getSandboxIDMappings(ctx context.Context, sb *libsandbox.Sandbo
 		}
 	}
 
-	if sb.UsernsMode() == "" && s.defaultIDMappings == nil {
+	// UsernsMode() is empty but UserNsPath() is set when the cri-o restarts and container is killed
+	if sb.UsernsMode() == "" && sb.UserNsPath() == "" && s.defaultIDMappings == nil {
 		return nil, nil
 	}
 
@@ -380,9 +381,39 @@ func (s *Server) getSandboxIDMappings(ctx context.Context, sb *libsandbox.Sandbo
 		return nil, errors.New("infra container not found")
 	}
 
-	uids, gids, err := unshare.GetHostIDMappings(strconv.Itoa(ic.State().Pid))
-	if err != nil {
-		return nil, err
+	icPid, err := ic.Pid()
+
+	var (
+		uids, gids []spec.LinuxIDMapping
+	)
+
+	// Treat PID errors the same as PID 0 - both indicate we should read from config.json
+	if err != nil || icPid == 0 {
+		// read the UID/GID mappings from the infra container's saved config.json
+		configPath := filepath.Join(ic.Dir(), "config.json")
+
+		configData, readErr := os.ReadFile(configPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("cannot read infra container config.json: %w", readErr)
+		}
+
+		var containerConfig spec.Spec
+		if parseErr := json.Unmarshal(configData, &containerConfig); parseErr != nil {
+			return nil, fmt.Errorf("cannot parse infra container config.json: %w", parseErr)
+		}
+
+		if containerConfig.Linux == nil ||
+			(len(containerConfig.Linux.UIDMappings) == 0 && len(containerConfig.Linux.GIDMappings) == 0) {
+			return nil, nil
+		}
+
+		uids = containerConfig.Linux.UIDMappings
+		gids = containerConfig.Linux.GIDMappings
+	} else {
+		uids, gids, err = unshare.GetHostIDMappings(strconv.Itoa(icPid))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get ID mappings from infra container PID %d: %w", icPid, err)
+		}
 	}
 
 	mappings := convertToStorageIDMappings(uids, gids)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cri-o/cri-o/internal/annotations"
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	ctrfactory "github.com/cri-o/cri-o/internal/factory/container"
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/constants"
 	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/linklogs"
@@ -385,25 +386,10 @@ func (s *Server) getSandboxIDMappings(ctx context.Context, sb *libsandbox.Sandbo
 		return nil, err
 	}
 
-	mappings := convertToStorageIDMappings(uids, gids)
+	mappings := lib.ConvertOCIToStorageIDMappings(uids, gids)
 	ic.SetIDMappings(mappings)
 
 	return mappings, nil
-}
-
-func convertToStorageIDMappings(uidMappings, gidMappings []spec.LinuxIDMapping) *idtools.IDMappings {
-	uids := make([]idtools.IDMap, len(uidMappings))
-	gids := make([]idtools.IDMap, len(gidMappings))
-
-	for i, v := range uidMappings {
-		uids[i] = idtools.IDMap{ContainerID: int(v.ContainerID), HostID: int(v.HostID), Size: int(v.Size)}
-	}
-
-	for i, v := range gidMappings {
-		gids[i] = idtools.IDMap{ContainerID: int(v.ContainerID), HostID: int(v.HostID), Size: int(v.Size)}
-	}
-
-	return idtools.NewIDMappingsFromMaps(uids, gids)
 }
 
 func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequest) (resp *types.RunPodSandboxResponse, retErr error) {

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -27,3 +27,36 @@ function teardown() {
 	[[ "$out" == *"100000"* ]]
 	[[ "$out" == *"200000"* ]]
 }
+
+# This test follows a similar pattern to the one above but adds
+# an adds extra step of crio restart.
+@test "ctr_userns mappings persist after crio restart" {
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	restart_crio
+	crictl inspectp "$pod_id" | jq -e '.status.state == "SANDBOX_READY"'
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+	state=$(crictl inspect "$ctr_id")
+	pid=$(echo "$state" | jq .info.pid)
+	grep 100000 /proc/"$pid"/uid_map
+	grep 200000 /proc/"$pid"/gid_map
+}
+
+@test "ctr_userns mappings persist after container kill and restart" {
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$ctr_id"
+
+	restart_crio
+
+	runtime delete -f "$ctr_id"
+	crictl rm "$ctr_id"
+
+	new_ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	crictl start "$new_ctr_id"
+
+	state=$(crictl inspect "$new_ctr_id")
+	pid=$(echo "$state" | jq .info.pid)
+	grep 100000 /proc/"$pid"/uid_map
+	grep 200000 /proc/"$pid"/gid_map
+}

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -3,9 +3,6 @@
 load helpers
 
 function setup() {
-	if [ -z "$CONTAINER_UID_MAPPINGS" ]; then
-		skip "userns testing not enabled"
-	fi
 	setup_test
 	start_crio
 }
@@ -14,16 +11,94 @@ function teardown() {
 	cleanup_test
 }
 
-@test "ctr_userns run container" {
-	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+function run_userns_container_test() {
+	# Create sandbox config with userns options using jq
+	jq '.linux.security_context.namespace_options.userns_options = {
+		"mode": 0,
+		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
+		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
+	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
 	crictl start "$ctr_id"
 	state=$(crictl inspect "$ctr_id")
 	pid=$(echo "$state" | jq .info.pid)
 	grep 100000 /proc/"$pid"/uid_map
 	grep 200000 /proc/"$pid"/gid_map
+}
 
-	out=$(echo -e "GET /info HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:"$CRIO_SOCKET")
-	[[ "$out" == *"100000"* ]]
-	[[ "$out" == *"200000"* ]]
+@test "ctr_userns run container" {
+	run_userns_container_test
+}
+
+@test "ctr_userns run container with drop_infra_ctr disabled" {
+	CONTAINER_DROP_INFRA_CTR=false restart_crio
+	run_userns_container_test
+}
+
+function run_userns_restart_test() {
+	# Create sandbox config with userns options using jq
+	jq '.linux.security_context.namespace_options.userns_options = {
+		"mode": 0,
+		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
+		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
+	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
+	restart_crio
+	crictl inspectp "$pod_id" | jq -e '.status.state == "SANDBOX_READY"'
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
+	crictl start "$ctr_id"
+	state=$(crictl inspect "$ctr_id")
+	pid=$(echo "$state" | jq .info.pid)
+	grep 100000 /proc/"$pid"/uid_map
+	grep 200000 /proc/"$pid"/gid_map
+}
+
+# This test follows a similar pattern to the one above but adds
+# an extra step of crio restart.
+@test "ctr_userns mappings persist after crio restart" {
+	run_userns_restart_test
+}
+
+@test "ctr_userns mappings persist after crio restart with drop_infra_ctr disabled" {
+	CONTAINER_DROP_INFRA_CTR=false restart_crio
+	run_userns_restart_test
+}
+
+function run_userns_kill_restart_test() {
+	# Create sandbox config with userns options using jq
+	jq '.linux.security_context.namespace_options.userns_options = {
+		"mode": 0,
+		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
+		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
+	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
+	crictl start "$ctr_id"
+
+	restart_crio
+
+	crictl stop "$ctr_id"
+	runtime delete -f "$ctr_id"
+	crictl rm "$ctr_id"
+
+	new_ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
+	crictl start "$new_ctr_id"
+
+	state=$(crictl inspect "$new_ctr_id")
+	pid=$(echo "$state" | jq .info.pid)
+	grep 100000 /proc/"$pid"/uid_map
+	grep 200000 /proc/"$pid"/gid_map
+}
+
+@test "ctr_userns mappings persist after container kill and restart" {
+	run_userns_kill_restart_test
+}
+
+@test "ctr_userns mappings persist after container kill and restart with drop_infra_ctr disabled" {
+	CONTAINER_DROP_INFRA_CTR=false restart_crio
+	run_userns_kill_restart_test
 }

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -3,6 +3,9 @@
 load helpers
 
 function setup() {
+	if [ -z "$CONTAINER_UID_MAPPINGS" ]; then
+		skip "userns testing not enabled"
+	fi
 	setup_test
 	start_crio
 }
@@ -12,66 +15,15 @@ function teardown() {
 }
 
 @test "ctr_userns run container" {
-	# Create sandbox config with userns options using jq
-	jq '.linux.security_context.namespace_options.userns_options = {
-		"mode": 0,
-		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
-		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
-	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
-
-	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
 	crictl start "$ctr_id"
 	state=$(crictl inspect "$ctr_id")
 	pid=$(echo "$state" | jq .info.pid)
 	grep 100000 /proc/"$pid"/uid_map
 	grep 200000 /proc/"$pid"/gid_map
-}
 
-# This test follows a similar pattern to the one above but adds
-# an extra step of crio restart.
-@test "ctr_userns mappings persist after crio restart" {
-	# Create sandbox config with userns options using jq
-	jq '.linux.security_context.namespace_options.userns_options = {
-		"mode": 0,
-		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
-		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
-	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
-
-	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
-	restart_crio
-	crictl inspectp "$pod_id" | jq -e '.status.state == "SANDBOX_READY"'
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
-	crictl start "$ctr_id"
-	state=$(crictl inspect "$ctr_id")
-	pid=$(echo "$state" | jq .info.pid)
-	grep 100000 /proc/"$pid"/uid_map
-	grep 200000 /proc/"$pid"/gid_map
-}
-
-@test "ctr_userns mappings persist after container kill and restart" {
-	# Create sandbox config with userns options using jq
-	jq '.linux.security_context.namespace_options.userns_options = {
-		"mode": 0,
-		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
-		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
-	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
-
-	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
-	crictl start "$ctr_id"
-
-	restart_crio
-
-	crictl stop "$ctr_id"
-	runtime delete -f "$ctr_id"
-	crictl rm "$ctr_id"
-
-	new_ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
-	crictl start "$new_ctr_id"
-
-	state=$(crictl inspect "$new_ctr_id")
-	pid=$(echo "$state" | jq .info.pid)
-	grep 100000 /proc/"$pid"/uid_map
-	grep 200000 /proc/"$pid"/gid_map
+	out=$(echo -e "GET /info HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:"$CRIO_SOCKET")
+	[[ "$out" == *"100000"* ]]
+	[[ "$out" == *"200000"* ]]
 }

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -3,9 +3,6 @@
 load helpers
 
 function setup() {
-	if [ -z "$CONTAINER_UID_MAPPINGS" ]; then
-		skip "userns testing not enabled"
-	fi
 	setup_test
 	start_crio
 }
@@ -15,26 +12,36 @@ function teardown() {
 }
 
 @test "ctr_userns run container" {
-	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	# Create sandbox config with userns options using jq
+	jq '.linux.security_context.namespace_options.userns_options = {
+		"mode": 0,
+		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
+		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
+	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
 	crictl start "$ctr_id"
 	state=$(crictl inspect "$ctr_id")
 	pid=$(echo "$state" | jq .info.pid)
 	grep 100000 /proc/"$pid"/uid_map
 	grep 200000 /proc/"$pid"/gid_map
-
-	out=$(echo -e "GET /info HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:"$CRIO_SOCKET")
-	[[ "$out" == *"100000"* ]]
-	[[ "$out" == *"200000"* ]]
 }
 
 # This test follows a similar pattern to the one above but adds
-# an adds extra step of crio restart.
+# an extra step of crio restart.
 @test "ctr_userns mappings persist after crio restart" {
-	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	# Create sandbox config with userns options using jq
+	jq '.linux.security_context.namespace_options.userns_options = {
+		"mode": 0,
+		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
+		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
+	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
 	restart_crio
 	crictl inspectp "$pod_id" | jq -e '.status.state == "SANDBOX_READY"'
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
 	crictl start "$ctr_id"
 	state=$(crictl inspect "$ctr_id")
 	pid=$(echo "$state" | jq .info.pid)
@@ -43,16 +50,24 @@ function teardown() {
 }
 
 @test "ctr_userns mappings persist after container kill and restart" {
-	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	# Create sandbox config with userns options using jq
+	jq '.linux.security_context.namespace_options.userns_options = {
+		"mode": 0,
+		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
+		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
+	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
 	crictl start "$ctr_id"
 
 	restart_crio
 
+	crictl stop "$ctr_id"
 	runtime delete -f "$ctr_id"
 	crictl rm "$ctr_id"
 
-	new_ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+	new_ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
 	crictl start "$new_ctr_id"
 
 	state=$(crictl inspect "$new_ctr_id")


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug

#### What this PR does / why we need it:

When using user namespaces with ID-mapped mounts, containers fail with "permission denied" errors after:
  1. CRI-O is restarted
  2. The real container process is killed (kill 1)

Here's the error the user has been facing:
```
2026-02-16T22:15:29.874393249Z I0216 22:15:29.874325       1 cmd.go:253] Using service-serving-cert provided certificates
2026-02-16T22:15:29.874393249Z I0216 22:15:29.874375       1 leaderelection.go:121] The leader election gives 4 retries and allows for 30s of clock skew. The kube-apiserver downtime tolerance is 78s. Worst non-graceful lease acquisition is 2m43s. Worst graceful lease acquisition is {26s}.
2026-02-16T22:15:29.874528883Z F0216 22:15:29.874507       1 cmd.go:182] open /var/run/secrets/kubernetes.io/serviceaccount/token: permission denied
```
### Note on AI assistance
I tried initially using AI but it suspected the kernel and not cri-o. But I was pretty sure that cri-o restart was causing the issue. Then I added logs for container creation and capture the config.json during the creation and crash looping. That helped me find the issue.
AI was helpful in find some in-built functions and test case while I was writing the fix.

### Current Flow
Here's the current flow of code (AI didn't help)
- `UserNsMode()` - Deprecated - This is set only when there is an annotation
- `UserNsPath()` - This is the real path where the user namespace is created. If host namespace is used this will return empty string
- `DefaultIDMappings` - Applied to all the pods if set on the crio.config but will be overridden by the pod mappings
- `sandbox_run_linux.go:getSandboxIDMappings()` - This is lazy loading the ID mappings
- `drop_infra_ctr` set to true - Spoofed Containers - Pause container is not created to keep the linux namespace alive. cri-o uses pinns and creates bind mounts

### Reason why cri-o restart affects
- The namespace mappings are not loaded on restart for running containers. Lazy load doesn't work in this case

Some Observations:
1. From OpenShift 4.20 user namespaces are used by etcd operator pods. The issue does not occur in OCP 4.19 where user namespaces are disabled
2. The cri-o restart is a required step in the recreate process. The pod should be running before the cri-o is restarted

During the crashloop backoff I have been able to capture the cat /run/containers/storage/overlay-containers/$CONTAINER_ID/userdata/config.json and I observed this missing section (after linux):
```
	"linux": {
		"uidMappings": [
			{
				"containerID": 0,
				"hostID": 3417243648,
				"size": 65536
			}
		],
		"gidMappings": [
			{
				"containerID": 0,
				"hostID": 3417243648,
				"size": 65536
			}
		],
```

The Projected volumes is setup but above missing part indicated that something is wrong. Also confirmed that a new pod has all these sections

I initially thought this should fix: https://github.com/cri-o/cri-o/pull/9712. But it didn't help

@Chandan9112 If we are backporting this, we need to include https://github.com/cri-o/cri-o/pull/9712



#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix user namespace mappings persistence across CRI-O restarts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of Linux user-namespace UID/GID mappings for sandboxes and infra containers, with clearer error context and ensured application of mappings when available to improve container startup consistency.
* **Tests**
  * Added integration tests validating UID/GID mapping persistence across service restarts and across container delete/recreate flows, plus a new userns-configured sandbox test fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->