### PR TITLE
[release-1.34] gomaxprocs hook: run hook if pod is in workload partition

### DIFF
--- a/internal/runtimehandlerhooks/gomaxprocs_hooks_linux.go
+++ b/internal/runtimehandlerhooks/gomaxprocs_hooks_linux.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/oci"
 	crioann "github.com/cri-o/cri-o/pkg/annotations"
-	"github.com/cri-o/cri-o/pkg/config"
 )
 
 // GomaxprocsHooks injects the GOMAXPROCS environment variable into containers
@@ -19,8 +18,7 @@ import (
 // for burstable pods with a CPU request, GOMAXPROCS is auto-calculated from
 // the request's CPU shares and only used if it exceeds the floor.
 type GomaxprocsHooks struct {
-	fallback  int64
-	workloads config.Workloads
+	fallback int64
 }
 
 func (g *GomaxprocsHooks) PreCreate(ctx context.Context, specgen *generate.Generator, s *sandbox.Sandbox, c *oci.Container) error {
@@ -31,13 +29,6 @@ func (g *GomaxprocsHooks) PreCreate(ctx context.Context, specgen *generate.Gener
 	// Skip if pod has the skip annotation.
 	if skipAnnotation, ok := annotations[crioann.SkipGoMaxProcsAnnotation]; ok && skipAnnotation == "true" {
 		log.Debugf(ctx, "Skipping GOMAXPROCS injection: %s annotation is set", crioann.SkipGoMaxProcsAnnotation)
-
-		return nil
-	}
-
-	// Skip workload-partitioned pods — their cpuset is managed by workload partitioning.
-	if g.workloads.IsWorkloadPartitioned(annotations) {
-		log.Debugf(ctx, "Skipping GOMAXPROCS injection: pod is workload-partitioned")
 
 		return nil
 	}

--- a/internal/runtimehandlerhooks/gomaxprocs_hooks_linux.go
+++ b/internal/runtimehandlerhooks/gomaxprocs_hooks_linux.go
@@ -91,9 +91,12 @@ func (*GomaxprocsHooks) PostStop(context.Context, *oci.Container, *sandbox.Sandb
 // calculateGOMAXPROCS derives the GOMAXPROCS value from CPU shares and a floor.
 // Kubelet sets shares = cpu_request_in_millicores * 1024 / 1000.
 // We reverse that with ceil(shares / 1024) to get the CPU count.
+// We then double that CPU count, as having GOMAXPROCS double the actual requested number reduces the likelihood
+// the go runtime will throttle itself in cases where there is excess CPU capacity (which is the intended result
+// of a cpu request).
 // The floor is used when the calculated value is lower.
 func calculateGOMAXPROCS(shares, fallbackMaxProcs int64) int64 {
-	return max(max((shares+1023)/1024, 1), fallbackMaxProcs)
+	return max(max((shares*2+1023)/1024, 1), fallbackMaxProcs)
 }
 
 // injectGOMAXPROCS sets the GOMAXPROCS environment variable to the given value.

--- a/internal/runtimehandlerhooks/gomaxprocs_hooks_linux_test.go
+++ b/internal/runtimehandlerhooks/gomaxprocs_hooks_linux_test.go
@@ -120,7 +120,7 @@ func TestCalculateGOMAXPROCS(t *testing.T) {
 			name:             "8 CPU request (shares=8192), floor=4 -> use calculated",
 			shares:           8192,
 			fallbackMaxProcs: 4,
-			expectedMaxProcs: 8,
+			expectedMaxProcs: 16,
 		},
 		{
 			name:             "1 CPU request (shares=1024), floor=4 -> use floor",
@@ -129,16 +129,16 @@ func TestCalculateGOMAXPROCS(t *testing.T) {
 			expectedMaxProcs: 4,
 		},
 		{
-			name:             "4 CPU request (shares=4096), floor=4 -> use floor (equal, not greater)",
+			name:             "4 CPU request (shares=4096), floor=4 -> use calculated (double is past floor)",
 			shares:           4096,
 			fallbackMaxProcs: 4,
-			expectedMaxProcs: 4,
+			expectedMaxProcs: 8,
 		},
 		{
 			name:             "16 CPU request (shares=16384), floor=4 -> use calculated",
 			shares:           16384,
 			fallbackMaxProcs: 4,
-			expectedMaxProcs: 16,
+			expectedMaxProcs: 32,
 		},
 		{
 			name:             "best-effort (shares=2), floor=4 -> use floor",
@@ -156,7 +156,7 @@ func TestCalculateGOMAXPROCS(t *testing.T) {
 			name:             "5 CPU request (shares=5120), floor=2 -> use calculated",
 			shares:           5120,
 			fallbackMaxProcs: 2,
-			expectedMaxProcs: 5,
+			expectedMaxProcs: 10,
 		},
 		{
 			name:             "250m request (shares=256), floor=1 -> use floor",
@@ -168,7 +168,7 @@ func TestCalculateGOMAXPROCS(t *testing.T) {
 			name:             "3 CPU request (shares=3072), floor=2 -> use calculated",
 			shares:           3072,
 			fallbackMaxProcs: 2,
-			expectedMaxProcs: 3,
+			expectedMaxProcs: 6,
 		},
 	}
 

--- a/internal/runtimehandlerhooks/gomaxprocs_hooks_linux_test.go
+++ b/internal/runtimehandlerhooks/gomaxprocs_hooks_linux_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runtime-tools/generate"
-
-	"github.com/cri-o/cri-o/pkg/config"
 )
 
 func TestMinInjectedGOMAXPROCS(t *testing.T) {
@@ -184,76 +182,4 @@ func TestCalculateGOMAXPROCS(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestIsWorkloadPartitioned(t *testing.T) {
-	workloads := config.Workloads{
-		"management": &config.WorkloadConfig{
-			ActivationAnnotation: "target.workload.openshift.io/management",
-			AnnotationPrefix:     "resources.workload.openshift.io",
-			Resources: &config.Resources{
-				CPUShares: 0,
-			},
-		},
-	}
-
-	cases := []struct {
-		name        string
-		annotations map[string]string
-		expected    bool
-	}{
-		{
-			name: "workload-partitioned pod",
-			annotations: map[string]string{
-				"target.workload.openshift.io/management": `{"effect":"PreferredDuringScheduling"}`,
-			},
-			expected: true,
-		},
-		{
-			name: "non-workload-partitioned pod",
-			annotations: map[string]string{
-				"some-other-annotation": "value",
-			},
-			expected: false,
-		},
-		{
-			name:        "no annotations",
-			annotations: map[string]string{},
-			expected:    false,
-		},
-		{
-			name:        "nil annotations",
-			annotations: nil,
-			expected:    false,
-		},
-		{
-			name: "workload annotation with other annotations",
-			annotations: map[string]string{
-				"target.workload.openshift.io/management": `{"effect":"PreferredDuringScheduling"}`,
-				"resources.workload.openshift.io/dns":     `{"cpushares":51}`,
-			},
-			expected: true,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := workloads.IsWorkloadPartitioned(tc.annotations)
-			if result != tc.expected {
-				t.Errorf("expected IsWorkloadPartitioned=%v, got %v", tc.expected, result)
-			}
-		})
-	}
-
-	t.Run("empty workloads config", func(t *testing.T) {
-		emptyWorkloads := config.Workloads{}
-
-		annotations := map[string]string{
-			"target.workload.openshift.io/management": `{"effect":"PreferredDuringScheduling"}`,
-		}
-
-		if emptyWorkloads.IsWorkloadPartitioned(annotations) {
-			t.Error("expected false when no workloads are configured")
-		}
-	})
 }

--- a/internal/runtimehandlerhooks/gomaxprocs_hooks_linux_test.go
+++ b/internal/runtimehandlerhooks/gomaxprocs_hooks_linux_test.go
@@ -2,184 +2,94 @@ package runtimehandlerhooks
 
 import (
 	"strings"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/opencontainers/runtime-tools/generate"
 )
 
-func TestMinInjectedGOMAXPROCS(t *testing.T) {
-	cases := []struct {
-		name      string
-		specEnvs  []string
-		maxProcs  int64
-		expectSet bool
-		expectVal string
-	}{
-		{
-			name:      "injects when not set",
-			specEnvs:  []string{"FOO=bar"},
-			maxProcs:  4,
-			expectSet: true,
-			expectVal: "4",
-		},
-		{
-			name:      "skips when set in spec envs",
-			specEnvs:  []string{"GOMAXPROCS=16"},
-			maxProcs:  4,
-			expectSet: false,
-		},
-		{
-			name:      "skips when set via default_env (already merged into spec)",
-			specEnvs:  []string{"FOO=bar", "GOMAXPROCS=8"},
-			maxProcs:  4,
-			expectSet: false,
-		},
-		{
-			name:      "skips when GOMAXPROCS prefix matches in envs",
-			specEnvs:  []string{"GOMAXPROCS=0"},
-			maxProcs:  4,
-			expectSet: false,
-		},
-		{
-			name:      "injects with large value",
-			specEnvs:  nil,
-			maxProcs:  128,
-			expectSet: true,
-			expectVal: "128",
-		},
-		{
-			name:      "injects with value 1",
-			specEnvs:  nil,
-			maxProcs:  1,
-			expectSet: true,
-			expectVal: "1",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+var _ = Describe("GOMAXPROCS injection", func() {
+	DescribeTable("injectGOMAXPROCS",
+		func(specEnvs []string, maxProcs int64, expectSet bool, expectVal string) {
 			g, err := generate.New("linux")
-			if err != nil {
-				t.Fatalf("failed to create generator: %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
 
 			// Pre-populate the spec's process env to simulate image/pod envs.
-			for _, env := range tc.specEnvs {
+			for _, env := range specEnvs {
 				parts := strings.SplitN(env, "=", 2)
 				g.AddProcessEnv(parts[0], parts[1])
 			}
 
 			envsBefore := len(g.Config.Process.Env)
 
-			injectGOMAXPROCS(&g, tc.maxProcs)
+			injectGOMAXPROCS(&g, maxProcs)
 
 			envsAfter := len(g.Config.Process.Env)
 			injected := envsAfter > envsBefore
 
-			if tc.expectSet && !injected {
-				t.Error("expected GOMAXPROCS to be injected, but it was not")
-			}
+			if expectSet {
+				Expect(injected).To(BeTrue(), "expected GOMAXPROCS to be injected, but it was not")
 
-			if !tc.expectSet && injected {
-				t.Error("expected GOMAXPROCS to not be injected, but it was")
-			}
+				var found bool
 
-			if tc.expectSet {
 				for _, env := range g.Config.Process.Env {
 					if val, ok := strings.CutPrefix(env, "GOMAXPROCS="); ok {
-						if val != tc.expectVal {
-							t.Errorf("expected GOMAXPROCS=%s, got GOMAXPROCS=%s", tc.expectVal, val)
-						}
+						Expect(val).To(Equal(expectVal))
+
+						found = true
+
+						break
 					}
 				}
+
+				Expect(found).To(BeTrue(), "GOMAXPROCS was injected but value not found")
+			} else {
+				Expect(injected).To(BeFalse(), "expected GOMAXPROCS to not be injected, but it was")
 			}
-		})
-	}
-}
+		},
+		Entry("injects when not set",
+			[]string{"FOO=bar"}, int64(4), true, "4"),
+		Entry("skips when set in spec envs",
+			[]string{"GOMAXPROCS=16"}, int64(4), false, ""),
+		Entry("skips when set via default_env (already merged into spec)",
+			[]string{"FOO=bar", "GOMAXPROCS=8"}, int64(4), false, ""),
+		Entry("skips when GOMAXPROCS prefix matches in envs",
+			[]string{"GOMAXPROCS=0"}, int64(4), false, ""),
+		Entry("injects with large value",
+			nil, int64(128), true, "128"),
+		Entry("injects with value 1",
+			nil, int64(1), true, "1"),
+	)
+})
 
-func TestCalculateGOMAXPROCS(t *testing.T) {
-	cases := []struct {
-		name             string
-		shares           int64
-		fallbackMaxProcs int64
-		expectedMaxProcs int64
-	}{
-		{
-			name:             "2 CPU request (shares=2048), floor=4 -> use floor",
-			shares:           2048,
-			fallbackMaxProcs: 4,
-			expectedMaxProcs: 4,
+var _ = Describe("GOMAXPROCS calculation", func() {
+	DescribeTable("calculateGOMAXPROCS",
+		func(shares, fallbackMaxProcs, expectedMaxProcs int64) {
+			got := calculateGOMAXPROCS(shares, fallbackMaxProcs)
+			Expect(got).To(Equal(expectedMaxProcs),
+				"shares=%d, floor=%d", shares, fallbackMaxProcs)
 		},
-		{
-			name:             "500m request (shares=512), floor=4 -> use floor",
-			shares:           512,
-			fallbackMaxProcs: 4,
-			expectedMaxProcs: 4,
-		},
-		{
-			name:             "8 CPU request (shares=8192), floor=4 -> use calculated",
-			shares:           8192,
-			fallbackMaxProcs: 4,
-			expectedMaxProcs: 16,
-		},
-		{
-			name:             "1 CPU request (shares=1024), floor=4 -> use floor",
-			shares:           1024,
-			fallbackMaxProcs: 4,
-			expectedMaxProcs: 4,
-		},
-		{
-			name:             "4 CPU request (shares=4096), floor=4 -> use calculated (double is past floor)",
-			shares:           4096,
-			fallbackMaxProcs: 4,
-			expectedMaxProcs: 8,
-		},
-		{
-			name:             "16 CPU request (shares=16384), floor=4 -> use calculated",
-			shares:           16384,
-			fallbackMaxProcs: 4,
-			expectedMaxProcs: 32,
-		},
-		{
-			name:             "best-effort (shares=2), floor=4 -> use floor",
-			shares:           2,
-			fallbackMaxProcs: 4,
-			expectedMaxProcs: 4,
-		},
-		{
-			name:             "100m request (shares=102), floor=4 -> use floor",
-			shares:           102,
-			fallbackMaxProcs: 4,
-			expectedMaxProcs: 4,
-		},
-		{
-			name:             "5 CPU request (shares=5120), floor=2 -> use calculated",
-			shares:           5120,
-			fallbackMaxProcs: 2,
-			expectedMaxProcs: 10,
-		},
-		{
-			name:             "250m request (shares=256), floor=1 -> use floor",
-			shares:           256,
-			fallbackMaxProcs: 1,
-			expectedMaxProcs: 1,
-		},
-		{
-			name:             "3 CPU request (shares=3072), floor=2 -> use calculated",
-			shares:           3072,
-			fallbackMaxProcs: 2,
-			expectedMaxProcs: 6,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := calculateGOMAXPROCS(tc.shares, tc.fallbackMaxProcs)
-
-			if got != tc.expectedMaxProcs {
-				t.Errorf("expected GOMAXPROCS=%d, got %d (shares=%d, floor=%d)",
-					tc.expectedMaxProcs, got, tc.shares, tc.fallbackMaxProcs)
-			}
-		})
-	}
-}
+		Entry("2 CPU request (shares=2048), floor=4 -> use floor",
+			int64(2048), int64(4), int64(4)),
+		Entry("500m request (shares=512), floor=4 -> use floor",
+			int64(512), int64(4), int64(4)),
+		Entry("8 CPU request (shares=8192), floor=4 -> use calculated",
+			int64(8192), int64(4), int64(16)),
+		Entry("1 CPU request (shares=1024), floor=4 -> use floor",
+			int64(1024), int64(4), int64(4)),
+		Entry("4 CPU request (shares=4096), floor=4 -> use calculated (double is past floor)",
+			int64(4096), int64(4), int64(8)),
+		Entry("16 CPU request (shares=16384), floor=4 -> use calculated",
+			int64(16384), int64(4), int64(32)),
+		Entry("best-effort (shares=2), floor=4 -> use floor",
+			int64(2), int64(4), int64(4)),
+		Entry("100m request (shares=102), floor=4 -> use floor",
+			int64(102), int64(4), int64(4)),
+		Entry("5 CPU request (shares=5120), floor=2 -> use calculated",
+			int64(5120), int64(2), int64(10)),
+		Entry("250m request (shares=256), floor=1 -> use floor",
+			int64(256), int64(1), int64(1)),
+		Entry("3 CPU request (shares=3072), floor=2 -> use calculated",
+			int64(3072), int64(2), int64(6)),
+	)
+})

--- a/internal/runtimehandlerhooks/runtime_handler_hooks_linux.go
+++ b/internal/runtimehandlerhooks/runtime_handler_hooks_linux.go
@@ -73,8 +73,7 @@ func (hr *HooksRetriever) Get(ctx context.Context, runtimeName string, sandboxAn
 
 	if hr.config.MinInjectedGOMAXPROCS > 0 {
 		hooks = append(hooks, &GomaxprocsHooks{
-			fallback:  hr.config.MinInjectedGOMAXPROCS,
-			workloads: hr.config.Workloads,
+			fallback: hr.config.MinInjectedGOMAXPROCS,
 		})
 	}
 

--- a/pkg/config/workloads.go
+++ b/pkg/config/workloads.go
@@ -166,12 +166,6 @@ func (w Workloads) workloadGivenActivationAnnotation(sboxAnnotations map[string]
 	return nil
 }
 
-// IsWorkloadPartitioned returns true if the pod has a workload partitioning
-// activation annotation, meaning its cpuset is managed by workload partitioning.
-func (w Workloads) IsWorkloadPartitioned(sboxAnnotations map[string]string) bool {
-	return w.workloadGivenActivationAnnotation(sboxAnnotations) != nil
-}
-
 func resourcesFromAnnotation(prefix, ctrName string, allAnnotations map[string]string, defaultResources *Resources) (*Resources, error) {
 	annotationKey := prefix + "/" + ctrName
 

--- a/test/inject_gomaxprocs.bats
+++ b/test/inject_gomaxprocs.bats
@@ -83,7 +83,7 @@ function get_gomaxprocs() {
 		"$TESTDATA"/container_sleep.json > "$ctrconfig"
 
 	ctr_id=$(crictl run "$ctrconfig" "$sboxconfig")
-	[[ $(get_gomaxprocs "$ctr_id") == "GOMAXPROCS=8" ]]
+	[[ $(get_gomaxprocs "$ctr_id") == "GOMAXPROCS=16" ]]
 }
 
 # Verify GOMAXPROCS is injected for best-effort pods (no shares).

--- a/test/inject_gomaxprocs.bats
+++ b/test/inject_gomaxprocs.bats
@@ -178,33 +178,6 @@ function get_gomaxprocs() {
 	[[ $(get_gomaxprocs "$ctr_id") == "not-set" ]]
 }
 
-# Verify workload-partitioned pods are skipped.
-@test "min_injected_gomaxprocs skips workload-partitioned pods" {
-	cat << EOF > "$CRIO_CONFIG_DIR/01-gomaxprocs.conf"
-[crio.runtime]
-min_injected_gomaxprocs = 4
-
-[crio.runtime.workloads.management]
-activation_annotation = "target.workload.openshift.io/management"
-annotation_prefix = "resources.workload.openshift.io"
-[crio.runtime.workloads.management.resources]
-cpuset = "0-1"
-EOF
-	start_crio
-
-	jq '.metadata.name = "wp-sandbox"
-		| .linux.cgroup_parent = "kubepods-burstable-pod123.slice"
-		| .annotations["target.workload.openshift.io/management"] = "{\"effect\":\"PreferredDuringScheduling\"}"' \
-		"$TESTDATA"/sandbox_config.json > "$sboxconfig"
-
-	jq '.linux.resources.cpu_shares = 2048
-		| .linux.resources.cpu_quota = 0' \
-		"$TESTDATA"/container_sleep.json > "$ctrconfig"
-
-	ctr_id=$(crictl run "$ctrconfig" "$sboxconfig")
-	[[ $(get_gomaxprocs "$ctr_id") == "not-set" ]]
-}
-
 # Verify configurable floor value works.
 @test "min_injected_gomaxprocs respects custom floor value" {
 	enable_gomaxprocs 8


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug 
#### What this PR does / why we need it:
cherry-pick of https://github.com/cri-o/cri-o/pull/10009
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
update gomaxprocs hook to ignore workload partitioning when considering whether to inject, as well as update the calculation to ensure containers get at least double the requested number of CPUs, to reduce potential go scheduler throttling.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GOMAXPROCS injection for burstable/best-effort pods with configurable minimum value
  * Added namespaced auth directory support for image pull credentials
  * Added exec CPU affinity cgroup support
  * Added default runtime metrics reporting

* **Bug Fixes**
  * Fixed container stop race condition with WaitOnStopTimeout
  * Fixed pod deletion when network namespace path is missing
  * Improved exit code handling for fast-exiting containers

* **Documentation**
  * Updated configuration options and CLI flags for new features
  * Updated shell completions for new options

* **Chores**
  * Updated dependencies: Kubernetes 0.34.0→0.34.1, golangci-lint v2.2.1→v2.5.0, Go 1.34.0→1.34.9, runc main→v1.4.2
  * Added libpathrs 0.2.4 build support to CI

* **Tests**
  * Added integration tests for GOMAXPROCS injection, namespaced auth, exec CPU affinity, checkpoint/restore, and network scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->