### PR TITLE
ci: set GOTOOLCHAIN=auto when building cri-tools

### DIFF
--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -96,7 +96,7 @@ install_critools() {
         kubernetes-sigs \
         cri-tools \
         master \
-        sudo -E PATH="$PATH" make BINDIR=/usr/bin install
+        sudo -E PATH="$PATH" GOTOOLCHAIN=auto make BINDIR=/usr/bin install
 
     sudo critest --version
     sudo crictl --version


### PR DESCRIPTION
Allow cri-tools to use a different Go version than cri-o by setting GOTOOLCHAIN=auto during the cri-tools build. This lets Go automatically download the required toolchain version instead of failing when cri-tools' go.mod requires a newer Go than what cri-o specifies.

Assisted-by: Claude Code <https://claude.com/claude-code>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

I'm hesitant to update the go version for cri-o, because it may cause another static build error.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI/setup script to alter an installation step in the build pipeline. No runtime or user-facing behavior changes; build environment configuration was modified to affect how tools are installed during CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->