### PR TITLE
rootless: Allow cgroupv2 hierarchy

### DIFF
--- a/server/rootless_linux.go
+++ b/server/rootless_linux.go
@@ -103,8 +103,6 @@ func makeOCIConfigurationRootless(g *generate.Generator) {
 		}
 		g.AddMount(sysMnt)
 	}
-
-	g.SetLinuxCgroupsPath("")
 }
 
 // getAvailableV2Controllers returns the entries in /sys/fs/cgroup/<SELF>/cgroup.controllers.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Clearing path to cgroup in rootless mode conflicts with stats collector. Therefore calling e.g. `crictl stats` ends up with empty stats as it looks for non-existing cgroup. As managing internal cgroup hierarchy by non-root user is absolutely correct, we do not need to clear provided cgroup path.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
Bugfix: rootless: Stats collection
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mount handling for rootless Linux containers: when network isolation is in effect, /sys is remounted with stricter, read-only and no-exec/device/suid options to enhance container security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->