### PR TITLE
Vendor conmon-rs v1.0.0 pre-release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.1
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/conmon-rs v0.7.3
+	github.com/containers/conmon-rs v0.8.1-0.20260702110516-b5ec72de6187
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.3.0
 	github.com/coreos/go-systemd/v22 v22.7.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/containernetworking/plugins v1.9.1 h1:8oU6WsIsU3bpnNZuvHp74a6cE1MJwbj
 github.com/containernetworking/plugins v1.9.1/go.mod h1:fj7kS55qg3o/RgS+WGsF3+ZxwIImMPusQZKzBpcSr4c=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/conmon-rs v0.7.3 h1:hwomEURoYPxT4a9wiA2CAVkCl+revlXwDhKONI64gG8=
-github.com/containers/conmon-rs v0.7.3/go.mod h1:h0eIJ1XQBseNrLl6wR1676+pVCkkng+NtgQyYl+3Cis=
+github.com/containers/conmon-rs v0.8.1-0.20260702110516-b5ec72de6187 h1:kLsKL3QbDtFQ8ag1BcSG8RR5rk0X1YHRTGODFawyi14=
+github.com/containers/conmon-rs v0.8.1-0.20260702110516-b5ec72de6187/go.mod h1:W4UCCXxBHbmMIfLgd/7zrJFxOL4PxwviWxEC6yxQ2K4=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=
 github.com/containers/kubensmnt v1.2.0/go.mod h1:1/HG09N/a1+WSD3zkurzeWtqlKRSfUUnlIF/08zloqk=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/github.com/containers/conmon-rs/internal/proto/conmon.capnp.go
+++ b/vendor/github.com/containers/conmon-rs/internal/proto/conmon.capnp.go
@@ -688,12 +688,12 @@ type Conmon_VersionRequest capnp.Struct
 const Conmon_VersionRequest_TypeID = 0xad2a33d6b9304413
 
 func NewConmon_VersionRequest(s *capnp.Segment) (Conmon_VersionRequest, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
 	return Conmon_VersionRequest(st), err
 }
 
 func NewRootConmon_VersionRequest(s *capnp.Segment) (Conmon_VersionRequest, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
 	return Conmon_VersionRequest(st), err
 }
 
@@ -737,30 +737,17 @@ func (s Conmon_VersionRequest) SetVerbose(v bool) {
 	capnp.Struct(s).SetBit(0, v)
 }
 
-func (s Conmon_VersionRequest) MetadataOld() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(0)
-	return []byte(p.Data()), err
-}
-
-func (s Conmon_VersionRequest) HasMetadataOld() bool {
-	return capnp.Struct(s).HasPtr(0)
-}
-
-func (s Conmon_VersionRequest) SetMetadataOld(v []byte) error {
-	return capnp.Struct(s).SetData(0, v)
-}
-
 func (s Conmon_VersionRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
-	p, err := capnp.Struct(s).Ptr(1)
+	p, err := capnp.Struct(s).Ptr(0)
 	return Conmon_TextTextMapEntry_List(p.List()), err
 }
 
 func (s Conmon_VersionRequest) HasMetadata() bool {
-	return capnp.Struct(s).HasPtr(1)
+	return capnp.Struct(s).HasPtr(0)
 }
 
 func (s Conmon_VersionRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
-	return capnp.Struct(s).SetPtr(1, v.ToPtr())
+	return capnp.Struct(s).SetPtr(0, v.ToPtr())
 }
 
 // NewMetadata sets the metadata field to a newly
@@ -770,7 +757,7 @@ func (s Conmon_VersionRequest) NewMetadata(n int32) (Conmon_TextTextMapEntry_Lis
 	if err != nil {
 		return Conmon_TextTextMapEntry_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
 
@@ -779,7 +766,7 @@ type Conmon_VersionRequest_List = capnp.StructList[Conmon_VersionRequest]
 
 // NewConmon_VersionRequest creates a new list of Conmon_VersionRequest.
 func NewConmon_VersionRequest_List(s *capnp.Segment, sz int32) (Conmon_VersionRequest_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
 	return capnp.StructList[Conmon_VersionRequest](l), err
 }
 
@@ -797,12 +784,12 @@ type Conmon_VersionResponse capnp.Struct
 const Conmon_VersionResponse_TypeID = 0xf34be5cbac1feed1
 
 func NewConmon_VersionResponse(s *capnp.Segment) (Conmon_VersionResponse, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 9})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 8})
 	return Conmon_VersionResponse(st), err
 }
 
 func NewRootConmon_VersionResponse(s *capnp.Segment) (Conmon_VersionResponse, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 9})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 8})
 	return Conmon_VersionResponse(st), err
 }
 
@@ -990,25 +977,12 @@ func (s Conmon_VersionResponse) SetCargoTree(v string) error {
 	return capnp.Struct(s).SetText(7, v)
 }
 
-func (s Conmon_VersionResponse) Metadata() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(8)
-	return []byte(p.Data()), err
-}
-
-func (s Conmon_VersionResponse) HasMetadata() bool {
-	return capnp.Struct(s).HasPtr(8)
-}
-
-func (s Conmon_VersionResponse) SetMetadata(v []byte) error {
-	return capnp.Struct(s).SetData(8, v)
-}
-
 // Conmon_VersionResponse_List is a list of Conmon_VersionResponse.
 type Conmon_VersionResponse_List = capnp.StructList[Conmon_VersionResponse]
 
 // NewConmon_VersionResponse creates a new list of Conmon_VersionResponse.
 func NewConmon_VersionResponse_List(s *capnp.Segment, sz int32) (Conmon_VersionResponse_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 9}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 8}, sz)
 	return capnp.StructList[Conmon_VersionResponse](l), err
 }
 
@@ -1026,12 +1000,12 @@ type Conmon_CreateContainerRequest capnp.Struct
 const Conmon_CreateContainerRequest_TypeID = 0xba77e3fa3aa9b6ca
 
 func NewConmon_CreateContainerRequest(s *capnp.Segment) (Conmon_CreateContainerRequest, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 13})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 12})
 	return Conmon_CreateContainerRequest(st), err
 }
 
 func NewRootConmon_CreateContainerRequest(s *capnp.Segment) (Conmon_CreateContainerRequest, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 13})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 12})
 	return Conmon_CreateContainerRequest(st), err
 }
 
@@ -1257,30 +1231,17 @@ func (s Conmon_CreateContainerRequest) NewCommandArgs(n int32) (capnp.TextList, 
 	err = capnp.Struct(s).SetPtr(7, l.ToPtr())
 	return l, err
 }
-func (s Conmon_CreateContainerRequest) MetadataOld() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(8)
-	return []byte(p.Data()), err
-}
-
-func (s Conmon_CreateContainerRequest) HasMetadataOld() bool {
-	return capnp.Struct(s).HasPtr(8)
-}
-
-func (s Conmon_CreateContainerRequest) SetMetadataOld(v []byte) error {
-	return capnp.Struct(s).SetData(8, v)
-}
-
 func (s Conmon_CreateContainerRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
-	p, err := capnp.Struct(s).Ptr(9)
+	p, err := capnp.Struct(s).Ptr(8)
 	return Conmon_TextTextMapEntry_List(p.List()), err
 }
 
 func (s Conmon_CreateContainerRequest) HasMetadata() bool {
-	return capnp.Struct(s).HasPtr(9)
+	return capnp.Struct(s).HasPtr(8)
 }
 
 func (s Conmon_CreateContainerRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
-	return capnp.Struct(s).SetPtr(9, v.ToPtr())
+	return capnp.Struct(s).SetPtr(8, v.ToPtr())
 }
 
 // NewMetadata sets the metadata field to a newly
@@ -1290,20 +1251,20 @@ func (s Conmon_CreateContainerRequest) NewMetadata(n int32) (Conmon_TextTextMapE
 	if err != nil {
 		return Conmon_TextTextMapEntry_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(9, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(8, l.ToPtr())
 	return l, err
 }
 func (s Conmon_CreateContainerRequest) EnvVars() (Conmon_TextTextMapEntry_List, error) {
-	p, err := capnp.Struct(s).Ptr(10)
+	p, err := capnp.Struct(s).Ptr(9)
 	return Conmon_TextTextMapEntry_List(p.List()), err
 }
 
 func (s Conmon_CreateContainerRequest) HasEnvVars() bool {
-	return capnp.Struct(s).HasPtr(10)
+	return capnp.Struct(s).HasPtr(9)
 }
 
 func (s Conmon_CreateContainerRequest) SetEnvVars(v Conmon_TextTextMapEntry_List) error {
-	return capnp.Struct(s).SetPtr(10, v.ToPtr())
+	return capnp.Struct(s).SetPtr(9, v.ToPtr())
 }
 
 // NewEnvVars sets the envVars field to a newly
@@ -1313,7 +1274,7 @@ func (s Conmon_CreateContainerRequest) NewEnvVars(n int32) (Conmon_TextTextMapEn
 	if err != nil {
 		return Conmon_TextTextMapEntry_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(10, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(9, l.ToPtr())
 	return l, err
 }
 func (s Conmon_CreateContainerRequest) CgroupManager() Conmon_CgroupManager {
@@ -1325,16 +1286,16 @@ func (s Conmon_CreateContainerRequest) SetCgroupManager(v Conmon_CgroupManager) 
 }
 
 func (s Conmon_CreateContainerRequest) AdditionalFds() (capnp.UInt64List, error) {
-	p, err := capnp.Struct(s).Ptr(11)
+	p, err := capnp.Struct(s).Ptr(10)
 	return capnp.UInt64List(p.List()), err
 }
 
 func (s Conmon_CreateContainerRequest) HasAdditionalFds() bool {
-	return capnp.Struct(s).HasPtr(11)
+	return capnp.Struct(s).HasPtr(10)
 }
 
 func (s Conmon_CreateContainerRequest) SetAdditionalFds(v capnp.UInt64List) error {
-	return capnp.Struct(s).SetPtr(11, v.ToPtr())
+	return capnp.Struct(s).SetPtr(10, v.ToPtr())
 }
 
 // NewAdditionalFds sets the additionalFds field to a newly
@@ -1344,20 +1305,20 @@ func (s Conmon_CreateContainerRequest) NewAdditionalFds(n int32) (capnp.UInt64Li
 	if err != nil {
 		return capnp.UInt64List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(11, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(10, l.ToPtr())
 	return l, err
 }
 func (s Conmon_CreateContainerRequest) LeakFds() (capnp.UInt64List, error) {
-	p, err := capnp.Struct(s).Ptr(12)
+	p, err := capnp.Struct(s).Ptr(11)
 	return capnp.UInt64List(p.List()), err
 }
 
 func (s Conmon_CreateContainerRequest) HasLeakFds() bool {
-	return capnp.Struct(s).HasPtr(12)
+	return capnp.Struct(s).HasPtr(11)
 }
 
 func (s Conmon_CreateContainerRequest) SetLeakFds(v capnp.UInt64List) error {
-	return capnp.Struct(s).SetPtr(12, v.ToPtr())
+	return capnp.Struct(s).SetPtr(11, v.ToPtr())
 }
 
 // NewLeakFds sets the leakFds field to a newly
@@ -1367,7 +1328,7 @@ func (s Conmon_CreateContainerRequest) NewLeakFds(n int32) (capnp.UInt64List, er
 	if err != nil {
 		return capnp.UInt64List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(12, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(11, l.ToPtr())
 	return l, err
 }
 
@@ -1376,7 +1337,7 @@ type Conmon_CreateContainerRequest_List = capnp.StructList[Conmon_CreateContaine
 
 // NewConmon_CreateContainerRequest creates a new list of Conmon_CreateContainerRequest.
 func NewConmon_CreateContainerRequest_List(s *capnp.Segment, sz int32) (Conmon_CreateContainerRequest_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 13}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 12}, sz)
 	return capnp.StructList[Conmon_CreateContainerRequest](l), err
 }
 
@@ -1657,12 +1618,12 @@ type Conmon_ExecSyncContainerRequest capnp.Struct
 const Conmon_ExecSyncContainerRequest_TypeID = 0xf41122f890a371a6
 
 func NewConmon_ExecSyncContainerRequest(s *capnp.Segment) (Conmon_ExecSyncContainerRequest, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 16, PointerCount: 5})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 16, PointerCount: 4})
 	return Conmon_ExecSyncContainerRequest(st), err
 }
 
 func NewRootConmon_ExecSyncContainerRequest(s *capnp.Segment) (Conmon_ExecSyncContainerRequest, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 16, PointerCount: 5})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 16, PointerCount: 4})
 	return Conmon_ExecSyncContainerRequest(st), err
 }
 
@@ -1755,30 +1716,17 @@ func (s Conmon_ExecSyncContainerRequest) SetTerminal(v bool) {
 	capnp.Struct(s).SetBit(64, v)
 }
 
-func (s Conmon_ExecSyncContainerRequest) MetadataOld() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(2)
-	return []byte(p.Data()), err
-}
-
-func (s Conmon_ExecSyncContainerRequest) HasMetadataOld() bool {
-	return capnp.Struct(s).HasPtr(2)
-}
-
-func (s Conmon_ExecSyncContainerRequest) SetMetadataOld(v []byte) error {
-	return capnp.Struct(s).SetData(2, v)
-}
-
 func (s Conmon_ExecSyncContainerRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
-	p, err := capnp.Struct(s).Ptr(3)
+	p, err := capnp.Struct(s).Ptr(2)
 	return Conmon_TextTextMapEntry_List(p.List()), err
 }
 
 func (s Conmon_ExecSyncContainerRequest) HasMetadata() bool {
-	return capnp.Struct(s).HasPtr(3)
+	return capnp.Struct(s).HasPtr(2)
 }
 
 func (s Conmon_ExecSyncContainerRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
-	return capnp.Struct(s).SetPtr(3, v.ToPtr())
+	return capnp.Struct(s).SetPtr(2, v.ToPtr())
 }
 
 // NewMetadata sets the metadata field to a newly
@@ -1788,20 +1736,20 @@ func (s Conmon_ExecSyncContainerRequest) NewMetadata(n int32) (Conmon_TextTextMa
 	if err != nil {
 		return Conmon_TextTextMapEntry_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
 	return l, err
 }
 func (s Conmon_ExecSyncContainerRequest) EnvVars() (Conmon_TextTextMapEntry_List, error) {
-	p, err := capnp.Struct(s).Ptr(4)
+	p, err := capnp.Struct(s).Ptr(3)
 	return Conmon_TextTextMapEntry_List(p.List()), err
 }
 
 func (s Conmon_ExecSyncContainerRequest) HasEnvVars() bool {
-	return capnp.Struct(s).HasPtr(4)
+	return capnp.Struct(s).HasPtr(3)
 }
 
 func (s Conmon_ExecSyncContainerRequest) SetEnvVars(v Conmon_TextTextMapEntry_List) error {
-	return capnp.Struct(s).SetPtr(4, v.ToPtr())
+	return capnp.Struct(s).SetPtr(3, v.ToPtr())
 }
 
 // NewEnvVars sets the envVars field to a newly
@@ -1811,7 +1759,7 @@ func (s Conmon_ExecSyncContainerRequest) NewEnvVars(n int32) (Conmon_TextTextMap
 	if err != nil {
 		return Conmon_TextTextMapEntry_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(4, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
 func (s Conmon_ExecSyncContainerRequest) CgroupManager() Conmon_CgroupManager {
@@ -1827,7 +1775,7 @@ type Conmon_ExecSyncContainerRequest_List = capnp.StructList[Conmon_ExecSyncCont
 
 // NewConmon_ExecSyncContainerRequest creates a new list of Conmon_ExecSyncContainerRequest.
 func NewConmon_ExecSyncContainerRequest_List(s *capnp.Segment, sz int32) (Conmon_ExecSyncContainerRequest_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 5}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 4}, sz)
 	return capnp.StructList[Conmon_ExecSyncContainerRequest](l), err
 }
 
@@ -1951,12 +1899,12 @@ type Conmon_AttachRequest capnp.Struct
 const Conmon_AttachRequest_TypeID = 0xdf703ca0befc3afc
 
 func NewConmon_AttachRequest(s *capnp.Segment) (Conmon_AttachRequest, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 5})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 4})
 	return Conmon_AttachRequest(st), err
 }
 
 func NewRootConmon_AttachRequest(s *capnp.Segment) (Conmon_AttachRequest, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 5})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 4})
 	return Conmon_AttachRequest(st), err
 }
 
@@ -2054,30 +2002,17 @@ func (s Conmon_AttachRequest) SetStopAfterStdinEof(v bool) {
 	capnp.Struct(s).SetBit(0, v)
 }
 
-func (s Conmon_AttachRequest) MetadataOld() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(3)
-	return []byte(p.Data()), err
-}
-
-func (s Conmon_AttachRequest) HasMetadataOld() bool {
-	return capnp.Struct(s).HasPtr(3)
-}
-
-func (s Conmon_AttachRequest) SetMetadataOld(v []byte) error {
-	return capnp.Struct(s).SetData(3, v)
-}
-
 func (s Conmon_AttachRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
-	p, err := capnp.Struct(s).Ptr(4)
+	p, err := capnp.Struct(s).Ptr(3)
 	return Conmon_TextTextMapEntry_List(p.List()), err
 }
 
 func (s Conmon_AttachRequest) HasMetadata() bool {
-	return capnp.Struct(s).HasPtr(4)
+	return capnp.Struct(s).HasPtr(3)
 }
 
 func (s Conmon_AttachRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
-	return capnp.Struct(s).SetPtr(4, v.ToPtr())
+	return capnp.Struct(s).SetPtr(3, v.ToPtr())
 }
 
 // NewMetadata sets the metadata field to a newly
@@ -2087,7 +2022,7 @@ func (s Conmon_AttachRequest) NewMetadata(n int32) (Conmon_TextTextMapEntry_List
 	if err != nil {
 		return Conmon_TextTextMapEntry_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(4, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
 	return l, err
 }
 
@@ -2096,7 +2031,7 @@ type Conmon_AttachRequest_List = capnp.StructList[Conmon_AttachRequest]
 
 // NewConmon_AttachRequest creates a new list of Conmon_AttachRequest.
 func NewConmon_AttachRequest_List(s *capnp.Segment, sz int32) (Conmon_AttachRequest_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 5}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 4}, sz)
 	return capnp.StructList[Conmon_AttachRequest](l), err
 }
 
@@ -2179,12 +2114,12 @@ type Conmon_ReopenLogRequest capnp.Struct
 const Conmon_ReopenLogRequest_TypeID = 0xd0476e0f34d1411a
 
 func NewConmon_ReopenLogRequest(s *capnp.Segment) (Conmon_ReopenLogRequest, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 3})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2})
 	return Conmon_ReopenLogRequest(st), err
 }
 
 func NewRootConmon_ReopenLogRequest(s *capnp.Segment) (Conmon_ReopenLogRequest, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 3})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2})
 	return Conmon_ReopenLogRequest(st), err
 }
 
@@ -2238,30 +2173,17 @@ func (s Conmon_ReopenLogRequest) SetId(v string) error {
 	return capnp.Struct(s).SetText(0, v)
 }
 
-func (s Conmon_ReopenLogRequest) MetadataOld() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(1)
-	return []byte(p.Data()), err
-}
-
-func (s Conmon_ReopenLogRequest) HasMetadataOld() bool {
-	return capnp.Struct(s).HasPtr(1)
-}
-
-func (s Conmon_ReopenLogRequest) SetMetadataOld(v []byte) error {
-	return capnp.Struct(s).SetData(1, v)
-}
-
 func (s Conmon_ReopenLogRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
-	p, err := capnp.Struct(s).Ptr(2)
+	p, err := capnp.Struct(s).Ptr(1)
 	return Conmon_TextTextMapEntry_List(p.List()), err
 }
 
 func (s Conmon_ReopenLogRequest) HasMetadata() bool {
-	return capnp.Struct(s).HasPtr(2)
+	return capnp.Struct(s).HasPtr(1)
 }
 
 func (s Conmon_ReopenLogRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
-	return capnp.Struct(s).SetPtr(2, v.ToPtr())
+	return capnp.Struct(s).SetPtr(1, v.ToPtr())
 }
 
 // NewMetadata sets the metadata field to a newly
@@ -2271,7 +2193,7 @@ func (s Conmon_ReopenLogRequest) NewMetadata(n int32) (Conmon_TextTextMapEntry_L
 	if err != nil {
 		return Conmon_TextTextMapEntry_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
 
@@ -2280,7 +2202,7 @@ type Conmon_ReopenLogRequest_List = capnp.StructList[Conmon_ReopenLogRequest]
 
 // NewConmon_ReopenLogRequest creates a new list of Conmon_ReopenLogRequest.
 func NewConmon_ReopenLogRequest_List(s *capnp.Segment, sz int32) (Conmon_ReopenLogRequest_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 3}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 2}, sz)
 	return capnp.StructList[Conmon_ReopenLogRequest](l), err
 }
 
@@ -2363,12 +2285,12 @@ type Conmon_SetWindowSizeRequest capnp.Struct
 const Conmon_SetWindowSizeRequest_TypeID = 0xb5418b8ea8ead17b
 
 func NewConmon_SetWindowSizeRequest(s *capnp.Segment) (Conmon_SetWindowSizeRequest, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
 	return Conmon_SetWindowSizeRequest(st), err
 }
 
 func NewRootConmon_SetWindowSizeRequest(s *capnp.Segment) (Conmon_SetWindowSizeRequest, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2})
 	return Conmon_SetWindowSizeRequest(st), err
 }
 
@@ -2438,30 +2360,17 @@ func (s Conmon_SetWindowSizeRequest) SetHeight(v uint16) {
 	capnp.Struct(s).SetUint16(2, v)
 }
 
-func (s Conmon_SetWindowSizeRequest) MetadataOld() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(1)
-	return []byte(p.Data()), err
-}
-
-func (s Conmon_SetWindowSizeRequest) HasMetadataOld() bool {
-	return capnp.Struct(s).HasPtr(1)
-}
-
-func (s Conmon_SetWindowSizeRequest) SetMetadataOld(v []byte) error {
-	return capnp.Struct(s).SetData(1, v)
-}
-
 func (s Conmon_SetWindowSizeRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
-	p, err := capnp.Struct(s).Ptr(2)
+	p, err := capnp.Struct(s).Ptr(1)
 	return Conmon_TextTextMapEntry_List(p.List()), err
 }
 
 func (s Conmon_SetWindowSizeRequest) HasMetadata() bool {
-	return capnp.Struct(s).HasPtr(2)
+	return capnp.Struct(s).HasPtr(1)
 }
 
 func (s Conmon_SetWindowSizeRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
-	return capnp.Struct(s).SetPtr(2, v.ToPtr())
+	return capnp.Struct(s).SetPtr(1, v.ToPtr())
 }
 
 // NewMetadata sets the metadata field to a newly
@@ -2471,7 +2380,7 @@ func (s Conmon_SetWindowSizeRequest) NewMetadata(n int32) (Conmon_TextTextMapEnt
 	if err != nil {
 		return Conmon_TextTextMapEntry_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
 
@@ -2480,7 +2389,7 @@ type Conmon_SetWindowSizeRequest_List = capnp.StructList[Conmon_SetWindowSizeReq
 
 // NewConmon_SetWindowSizeRequest creates a new list of Conmon_SetWindowSizeRequest.
 func NewConmon_SetWindowSizeRequest_List(s *capnp.Segment, sz int32) (Conmon_SetWindowSizeRequest_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 3}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 2}, sz)
 	return capnp.StructList[Conmon_SetWindowSizeRequest](l), err
 }
 
@@ -2563,12 +2472,12 @@ type Conmon_CreateNamespacesRequest capnp.Struct
 const Conmon_CreateNamespacesRequest_TypeID = 0x8b5b1693940f607e
 
 func NewConmon_CreateNamespacesRequest(s *capnp.Segment) (Conmon_CreateNamespacesRequest, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 7})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 6})
 	return Conmon_CreateNamespacesRequest(st), err
 }
 
 func NewRootConmon_CreateNamespacesRequest(s *capnp.Segment) (Conmon_CreateNamespacesRequest, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 7})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 6})
 	return Conmon_CreateNamespacesRequest(st), err
 }
 
@@ -2604,30 +2513,17 @@ func (s Conmon_CreateNamespacesRequest) Message() *capnp.Message {
 func (s Conmon_CreateNamespacesRequest) Segment() *capnp.Segment {
 	return capnp.Struct(s).Segment()
 }
-func (s Conmon_CreateNamespacesRequest) MetadataOld() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(0)
-	return []byte(p.Data()), err
-}
-
-func (s Conmon_CreateNamespacesRequest) HasMetadataOld() bool {
-	return capnp.Struct(s).HasPtr(0)
-}
-
-func (s Conmon_CreateNamespacesRequest) SetMetadataOld(v []byte) error {
-	return capnp.Struct(s).SetData(0, v)
-}
-
 func (s Conmon_CreateNamespacesRequest) Namespaces() (Conmon_Namespace_List, error) {
-	p, err := capnp.Struct(s).Ptr(1)
+	p, err := capnp.Struct(s).Ptr(0)
 	return Conmon_Namespace_List(p.List()), err
 }
 
 func (s Conmon_CreateNamespacesRequest) HasNamespaces() bool {
-	return capnp.Struct(s).HasPtr(1)
+	return capnp.Struct(s).HasPtr(0)
 }
 
 func (s Conmon_CreateNamespacesRequest) SetNamespaces(v Conmon_Namespace_List) error {
-	return capnp.Struct(s).SetPtr(1, v.ToPtr())
+	return capnp.Struct(s).SetPtr(0, v.ToPtr())
 }
 
 // NewNamespaces sets the namespaces field to a newly
@@ -2637,20 +2533,20 @@ func (s Conmon_CreateNamespacesRequest) NewNamespaces(n int32) (Conmon_Namespace
 	if err != nil {
 		return Conmon_Namespace_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(0, l.ToPtr())
 	return l, err
 }
 func (s Conmon_CreateNamespacesRequest) UidMappings() (capnp.TextList, error) {
-	p, err := capnp.Struct(s).Ptr(2)
+	p, err := capnp.Struct(s).Ptr(1)
 	return capnp.TextList(p.List()), err
 }
 
 func (s Conmon_CreateNamespacesRequest) HasUidMappings() bool {
-	return capnp.Struct(s).HasPtr(2)
+	return capnp.Struct(s).HasPtr(1)
 }
 
 func (s Conmon_CreateNamespacesRequest) SetUidMappings(v capnp.TextList) error {
-	return capnp.Struct(s).SetPtr(2, v.ToPtr())
+	return capnp.Struct(s).SetPtr(1, v.ToPtr())
 }
 
 // NewUidMappings sets the uidMappings field to a newly
@@ -2660,20 +2556,20 @@ func (s Conmon_CreateNamespacesRequest) NewUidMappings(n int32) (capnp.TextList,
 	if err != nil {
 		return capnp.TextList{}, err
 	}
-	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(1, l.ToPtr())
 	return l, err
 }
 func (s Conmon_CreateNamespacesRequest) GidMappings() (capnp.TextList, error) {
-	p, err := capnp.Struct(s).Ptr(3)
+	p, err := capnp.Struct(s).Ptr(2)
 	return capnp.TextList(p.List()), err
 }
 
 func (s Conmon_CreateNamespacesRequest) HasGidMappings() bool {
-	return capnp.Struct(s).HasPtr(3)
+	return capnp.Struct(s).HasPtr(2)
 }
 
 func (s Conmon_CreateNamespacesRequest) SetGidMappings(v capnp.TextList) error {
-	return capnp.Struct(s).SetPtr(3, v.ToPtr())
+	return capnp.Struct(s).SetPtr(2, v.ToPtr())
 }
 
 // NewGidMappings sets the gidMappings field to a newly
@@ -2683,56 +2579,56 @@ func (s Conmon_CreateNamespacesRequest) NewGidMappings(n int32) (capnp.TextList,
 	if err != nil {
 		return capnp.TextList{}, err
 	}
-	err = capnp.Struct(s).SetPtr(3, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(2, l.ToPtr())
 	return l, err
 }
 func (s Conmon_CreateNamespacesRequest) BasePath() (string, error) {
-	p, err := capnp.Struct(s).Ptr(4)
+	p, err := capnp.Struct(s).Ptr(3)
 	return p.Text(), err
 }
 
 func (s Conmon_CreateNamespacesRequest) HasBasePath() bool {
-	return capnp.Struct(s).HasPtr(4)
+	return capnp.Struct(s).HasPtr(3)
 }
 
 func (s Conmon_CreateNamespacesRequest) BasePathBytes() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(4)
+	p, err := capnp.Struct(s).Ptr(3)
 	return p.TextBytes(), err
 }
 
 func (s Conmon_CreateNamespacesRequest) SetBasePath(v string) error {
-	return capnp.Struct(s).SetText(4, v)
+	return capnp.Struct(s).SetText(3, v)
 }
 
 func (s Conmon_CreateNamespacesRequest) PodId() (string, error) {
-	p, err := capnp.Struct(s).Ptr(5)
+	p, err := capnp.Struct(s).Ptr(4)
 	return p.Text(), err
 }
 
 func (s Conmon_CreateNamespacesRequest) HasPodId() bool {
-	return capnp.Struct(s).HasPtr(5)
+	return capnp.Struct(s).HasPtr(4)
 }
 
 func (s Conmon_CreateNamespacesRequest) PodIdBytes() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(5)
+	p, err := capnp.Struct(s).Ptr(4)
 	return p.TextBytes(), err
 }
 
 func (s Conmon_CreateNamespacesRequest) SetPodId(v string) error {
-	return capnp.Struct(s).SetText(5, v)
+	return capnp.Struct(s).SetText(4, v)
 }
 
 func (s Conmon_CreateNamespacesRequest) Metadata() (Conmon_TextTextMapEntry_List, error) {
-	p, err := capnp.Struct(s).Ptr(6)
+	p, err := capnp.Struct(s).Ptr(5)
 	return Conmon_TextTextMapEntry_List(p.List()), err
 }
 
 func (s Conmon_CreateNamespacesRequest) HasMetadata() bool {
-	return capnp.Struct(s).HasPtr(6)
+	return capnp.Struct(s).HasPtr(5)
 }
 
 func (s Conmon_CreateNamespacesRequest) SetMetadata(v Conmon_TextTextMapEntry_List) error {
-	return capnp.Struct(s).SetPtr(6, v.ToPtr())
+	return capnp.Struct(s).SetPtr(5, v.ToPtr())
 }
 
 // NewMetadata sets the metadata field to a newly
@@ -2742,7 +2638,7 @@ func (s Conmon_CreateNamespacesRequest) NewMetadata(n int32) (Conmon_TextTextMap
 	if err != nil {
 		return Conmon_TextTextMapEntry_List{}, err
 	}
-	err = capnp.Struct(s).SetPtr(6, l.ToPtr())
+	err = capnp.Struct(s).SetPtr(5, l.ToPtr())
 	return l, err
 }
 
@@ -2751,7 +2647,7 @@ type Conmon_CreateNamespacesRequest_List = capnp.StructList[Conmon_CreateNamespa
 
 // NewConmon_CreateNamespacesRequest creates a new list of Conmon_CreateNamespacesRequest.
 func NewConmon_CreateNamespacesRequest_List(s *capnp.Segment, sz int32) (Conmon_CreateNamespacesRequest_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 7}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 6}, sz)
 	return capnp.StructList[Conmon_CreateNamespacesRequest](l), err
 }
 
@@ -5920,270 +5816,269 @@ func (p Conmon_servePortForwardContainer_Results_Future) Response() Conmon_Serve
 	return Conmon_ServePortForwardContainerResponse_Future{Future: p.Future.Field(0, nil)}
 }
 
-const schema_ffaaf7385bc4adad = "x\xda\xc4z}t\x14e\x96\xf7\xbdUI*\x09\xe9" +
-	"t\x8a\xea\xcc\x8b11\x04\x02o\x92!\xc3G`\x05" +
-	"\x0e\x1c\x12 \xb20\xa0\xa94\xea\x0a3.Ew\x11" +
-	"\x1a:\xddMU5\x10\xd4E\x9deu\xf0c\x84\xc5" +
-	"\xa3p\x86s\xc4o\x18P\x9c\x19\x1cE\x99#\x8c\x1e" +
-	"\x11u\xd7\xb0\x8b\xab\x1eqQ`\x14\x8e\xa88z\x04" +
-	"\x0eX{\xee\xd3]\x1f]i\xa1;rv\xff\xc8I" +
-	"\xf7\xad[\xf7>\xcf}\xee\xe7\xef\xe9Q{\xcaZ\x0b" +
-	"F\xfb\xbe\x1c\x08\x9c\xfcaa\x91\xa9\x7f\xdc\xa3=\xb9" +
-	"y\xc6\xaf@\x1c\x8a\x00\x85(\x00\xb4\xfc\xb2\xe4\x13\x04" +
-	"\x94\x96\x95L\x014\xbf}|\xff\xe4\x87\xd6}\xb9\xd6" +
-	"\xcd\xb0.\xc5\xf0\x04c\xf8p|\xd3\xa2G\xf8\xd9\xf7" +
-	"\xb8\x19\xde(\xf9\x80\x18\x0e3\x86\x7fZ\xe0\xdf\xf0\xaf" +
-	"?\x99\xcf\x18\xcc\xd3-\x8b\x0eo\xfc\xec\xea?A\xa1" +
-	"@\x8c\x17J>@\xe9\x8aR\xfaXY\xfa\x1b\x044" +
-	"\xef\xf9i\x9b\\\xfa\xe0c\x0f\xb8\xc5};\xe0$\x89" +
-	"+)#q\xa36\xbd9bS\xf3S\x1b<\xe2\x18" +
-	"cc\x19\xc7I\xede\x02\x80\xd4\xc6\x98\xdf\xbcj\xd5" +
-	"\x8d\xfe'\xefz8\x1b\xb3R\xf6\x09J\xb71\xe6\x1e" +
-	"\xc6\xdc9p\xcd\xdc\x87:\xef\xdc\xecV\xbd\xa3l\x08" +
-	"\x07(\xbd\xc6\x18\xd6\x9c\xb8\xf6\xf9\xeb\x7f\xf5\xe5#n" +
-	"\x86\xe3e_\xd3\xda\xce2\x86\x8d\xf3?[\xda>\xd3" +
-	"\xffh\xa6\xba\x02\xe2\xab\xf1mCi\x9cO\x00\xde|" +
-	"\xee@sg\xb4\xf5\xcd\xc7\xdcbD\xdf9\x123\xcc" +
-	"Gb~r\xee\xe8\xe3\xef\x06\xc7o\x05y(\xf6Y" +
-	"v;\x09\xfa\xa5\x8f\x96}\x93o\x05\xa09n\xc5s" +
-	"\x8b\xbf\x9etbk\xb6=\xee\xf2}\x8dR/c~" +
-	"\x9b\x89\xae\x7f\xf6/\xbdk'\x8d\xdc\xe6\xd6}\xcaw" +
-	"\x90tc91\xac}J\xfd\xff{w\xff\x9c\x188" +
-	"G\x1a`K]\xf9Z\x94&\x94\x93\xa8q\xe5W\x03" +
-	"\x9a+\x16\xec\x7fv\x95||{\x96\xcdN._\x8f" +
-	"\xd2\xf5\xe5\xb4Yi\xfa\xa8\x17\xdfmi\xda\xe1\xdd\x0b" +
-	"G|\xa3\x89o&\x93\xd9^\xfe,\xe0w\xdf\xef\xb9" +
-	"\xeax\xe9\xcd\xcf\xb8\xcf\xbe\xbc\x89\x0e\xc0\xe7\xa7\xc5\x8d" +
-	"\xdd\xf2\x87\xe7\xef\xffb\xe53$\x8c\xf3\xeeu\xb4\x7f" +
-	"\x09J\xed\xfe\xff\x07 \xcd\xf1?\x0bh\xde\xd2{\xf2" +
-	"\xe9\xfb\xefi\xdb\xe5U\xcd\xb3s\xf3\xefC\xe9\x82\x9f" +
-	">\x9e\xf5\xd7\x92\xe7\xf1G\x8e\x95\xde\xdf6\xf2\xf9l" +
-	"v\xac\x13\x0f\xa04Y\xa4\x85N\x10i%\xf6s\xb1" +
-	"\x9a7w\xecxu\xfe\xf8\xef\xb6\x99d\xa6\x9b\xc4*" +
-	"l\x89\x88\x7fB\x8a\x13\xe9uNZW)\x00\x98\x8d" +
-	"\x9f\xdf\xfd\xe4]\xbf\x0b\xee\xce&\xbc\xa7r\x1f\xa6\xd8" +
-	"\xa4\xfb*I\xf8\x81\xe7\xb7N<wt\xc5n\xef\xc2" +
-	"\xe9\x1c[\xf6V\x1eD\xe90q\xb7\xbc_y\x17\x0f" +
-	"hV\xcc\xff\xf7\xc9\x9f\xdf\xfc\xd7\xd7\xdcg:\xa7\x8a" +
-	"E\xa0RE\xf2>U^\xe2\xda\xdf\x8e\xbe\xeefX" +
-	"SUJv\xdd\xcc\x18^\x1b?x\xe0\x96\xf7\xd4\xfd" +
-	"\x9e\xd5\xb13\xdaS5\x84\x93\x0eW\xd1\xea\xde\xaf\"" +
-	"\x7f\xfb\x97g\x86\xaf\xf4\xdd\x7f\xef\x81\xac':\xe7\xca" +
-	"s(E\xae\xa4\x8f\xea\x95\xcc\xac\x9f\x1e\xfb~IW" +
-	"b\xe4[n\xe5\xbf\xae^O\xab\xdbXM\xca\x97\x0e" +
-	"\xd8\x1f(\x99\xa2\xff\x9b\x9b\xe1\xc5\xea}\xc4\xf0\x06c" +
-	"8S\xf9\xe7\x87\xaa&\xed\xce`8Q\xcd\xf6w\x81" +
-	"1\xd4U\xff\xf5\x0e-R\xfdN\xd6\x83\xae\xab9\x89" +
-	"\xd2\xe4\x1a\xfa8\xa1\xe6uZQU[\xefX\x7fl" +
-	"\xc6;\x9e\xdd2\xeea\xb5\x8f\xa24\xb9\x96\x1dt-" +
-	"9\xd1c\x7f{z\xc1\xaeu\x81w\xfb\xc4\xc3\x89\xda" +
-	"%(]`\x9cgkW\x03\x9a\xe7\xd7L\xba\xbd\xa6" +
-	"\xe6\xdd\xf7\xb3\xda\xa5y\xf0I\x94f\x0ef\x9e>\xf8" +
-	"S@s\xd3OW$n^8\xf1#\x0f7\x0b\x9f" +
-	"\xba\xba\x0fP\x9a\\\xc7\x16QG\x1b\xbc}\xfb\x9dO" +
-	"\x1d\xfcb\xf7G\x19Y\xba\x8e%\x9ee\x8c\xe1\xfc\xc4" +
-	"\xf3\x7f~dR\xe2\xbf\xbd\xba\x0b\x89\xf3\xc1\xba\xb5(" +
-	"\xed q-[\xebn$\x0b\\\x9f\x98!\x0e\xef," +
-	"?\xe2\x96W3t 9\xc4\xb8\xa1,\xc9\xde2c" +
-	"\xeb\xcd\x11\xe9\xa8\x9b\xe1\xa6\xa1\x9bHa\x841\xfc\x9d" +
-	"\xf4\x97\x9d\xb1u'\x8f\xbb\x19\xee\x1b\xca\xd2\xf4\x16\xc6" +
-	"\xf0\xd2-\xa7\x07\xed<~\xf0\x94\x9ba\xefP\x8eT" +
-	"\x1cb\x0c{\xe7\xb7t\xfc\xd7\xd1\xe1_\x81\xd8\xcc9" +
-	"\x81\x0d\xd8rv\xe8z\x94\xc4z\xda\xbd\xaf\xfe:@" +
-	"\xb3\xf7\x8b\xda\xedo\x1e\xff\xf9\xdf\xbc\x9b+aQ_" +
-	"\xbf\x09\xa5\x99\xf5,3\xd6_\xcd\x01\x9aO.{\xec" +
-	"\x813C\xc4o\xbcI\x82\xd9b\xe3\xf0OP\xda5" +
-	"\x9c>>7\x9cy\xc3\x0b\x9b6\xfc\xe6\xd513\xbe" +
-	"\xc9p\xbf\x06\x96\x11\xdfn\xa0\x85V\xfe\xe3\x1dG\x9a" +
-	"N\x1c\xcd`8\xd5p\x80\xa5\xccFb86\xf6\xd3" +
-	"i\x83n\xeb\xf8.[l\x0fkl\xe2\xa4\xf6FV" +
-	"\x91\x18\xf3\xcb\xb8m\xc0/\x96|v\xc6-Mid" +
-	"\x86K2\x863[~\xd7r\xfb\xdb\x7f8\x9b%\xad" +
-	"nl<\x80\xd2\xaeFJ\xab\xeb\xffcV\xf7G\x17" +
-	"^:\x97-b\xd75>\x8a\xd2V\xa6\xf3\x89\xc6\x15" +
-	"\xd0lFb\x86\xaa\xc5\x94h\xd1\xc8\x84\x167\xe2#" +
-	"C\xf1Xw<\xf6\xb3\x90\x92\x88%&NK}Q" +
-	"W\xaa\xa1`O,4-\x1e3\x94HL\xd5\xea;" +
-	"\x14MP\xbau\xb9\x80/\x00(@\x00\xd17\x15@" +
-	".\xe6Q\x0ep\xb8ZS\x97%U\xdd\xc0\x0a\xc7\xe0" +
-	"\x80X\x01\x98\x93\xba\x90\xa6*\x86z\xad\xd2\xad\xea\x09" +
-	"%\xa4\xea\xf5\x9d\xaa\x9e\x14\xa2F\x86\xbaY\x00r\x19" +
-	"\x8f\xf2 \x0eMM\xd5\x13\xf1\x98\xae\x02\x00V8u" +
-	"\xfd\xc7\xa8\xecP4\x85\xcfe\x83v\x07\x93\x87\xb6i" +
-	"\x1em\x9d$\x8d\xd7\x8d\x0eD\xb9\xdaV\xb8k!\x80" +
-	"\xfcG\x1e\xe5W8\x14\x11\x03H\xc4=\xf3\x00\xe4\x97" +
-	"y\x94\xdf\xe3P\xe4\xb8\x00r\x00\xe2!\xe2\xfcO\x1e" +
-	"\xe5\xaf8\x14y>\x80<\x80x\x8a\x88\x9f\xf3\x18," +
-	"F\x0e\xc5\x82\x82\x00\x16\x00H\x858\x0b X\x80<" +
-	"\x06+\x88^X\x18\xc0B\x8a&\x1c\x03\x10,&z" +
-	"\x80\xe8EE\x01,\x02\x90D\xc6_A\xf4\x11\xc8\xa1" +
-	"\xd9\xad\x1aJX1\x14\x10\xae\x8b\x86\xd1\x07\x1c\xfa\x00" +
-	"\xcdXz+\xc0\xab:\x96\x03v\xf0\x88~'=\x02" +
-	"\x12\xd1LF\xc2s\x94D\"\x02B\xac\xcbf+\x03" +
-	"\x8e=\xec\xba\xd8\xc3\x85\x8a\xaev(\xc6b:`\xa2" +
-	"\x95\x01\xd6&\xe2\xe1\x99a\xeb\x9b\xb3.\x00\xeb\xe5\x0a" +
-	"'\x10\xd2\x0b\xc8\xe5ltU[\xae\xb6\xafT3\x9c" +
-	"\xdd\xaf\xe5\xe4\xecv\xad\xf1\xf8\x82p\x11}A\xd2\xd7" +
-	"f\x18Jh\xb1\xad\xb1\xd3\xf2gr\x08\x97\xd6!\x8e" +
-	"V!\xa9E\xed\xcd\xf7\xcf\xe7\xf4D\\\x88\xe9\xaaG" +
-	"\xc7\xbct\\5p\xd9\x8f\xb5\xc2\xe9@=V\x15." +
-	"e\xd5\x8e\xb8f\\\x13\xd7V(Z\xb8\x1f\x99\xc4\xee" +
-	"C\xf2\x084M\x8d'\xd4\xd8\xecx\x97\xa3\xafS\xad" +
-	"\xd5\x939\xe7\x12\xbbi\xf7(-\xbc\x88\xd2NK)" +
-	"\x99\xd8\x1fO\x998w\xdf\xf3\xf8B\xfd\x14JE\xb9" +
-	"\x18\xc8\xee\xbd\xf2X\xab\xed\x0f\xee\xb5\xca\xc5\xb6\xaa\xc6" +
-	"&\x00\xb9\x9eGy\x14\x87V\x0aj&Z\x03\x8f\xf2" +
-	"X\x0e\xfdFOB\xf5\x84\xba\x1f\xd0\x9fP\x8c\xc5y" +
-	"\xb9g\xb0O\xd8u\xaazm\"\xde\xd7A\x7fL\x10" +
-	"(\x1e\xdb2\xd3b\x0e\xb6\xb5{\xa8<l;\xadK" +
-	"\x8b'\x13s\x94\x98\xd2\xa5j\xc0b\xb9\x98\xa5kq" +
-	"*\x89\x11Kf\x01\xac\xd6{tC\xed\x0e\x9b!\xc6" +
-	"\xbcH\x07\x80\x9c\x84\xa7\xbc$\x9d(0\xc3\xc3.\xf6" +
-	"\xda\x0d\xaa\xa6G\xe21Vptd\x05\xa7\xcc\xde{" +
-	";\xed\xbd\x95Gy\xb6s\xd83\xa9\x8a\xfc=\x8f\xf2" +
-	"\\\xaa7\x98\xaa72\x05L\x07\x8fr\x94\xc3\xd5\xcb" +
-	"Uma\\W\x11\x81C\x84\x1f\xaa\x10y\xe5\xe7\xfe" +
-	"e\x92NU\xf7\xe7\x1e\xd9vc\xe69\xd1\x82\x8b\xe8" +
-	"\x9e\x1d\xef\x9a\xae\xf9#\xcbUM.@w\x97\x8aM" +
-	"\xfe\xb9=\x09\xd5m\xcb\xa6,\xb6$\xdat\x1e\xe5\x0e" +
-	"\x97-\xe7Lu\x0clE\x93-8K4\xad\xeeV" +
-	"V\x06#\xabT,\x01\x0eKr\x8e.\xe3\xc6H," +
-	"\x1c_Ao\xa6\x0e\xdf`\x0e\x19\xb0\x17|[\x15\x80" +
-	"\xbc\x92G\xf9\x9f\x9d\x05\xdf1\x06@\xbe\x95G\xf9n" +
-	"\xd7\x82\xd7L\x04\x90o\xe7Q\xbe\x97\x9a\x0dL5\x1b" +
-	"\xbf&7\xb9\x9bGy\x03\xf5\x1a\x1c\xeb5\xc4ud" +
-	"\xfd\x07x\x94\xb7s\xc8G\xecZ]\xbb\"\x126\x16" +
-	"\xa3\x00\x1c\x0a\x80S\x16\xab\x91\xae\xc5\x86\xf5\xf5r\xb8" +
-	"\xcfE-a(\x9aqM8\x18\x0f-U\x0d\xbb\xce" +
-	"z\x0bm\x93\x93\x04\xb2\xa72\xfe\x87T\xf0\xf1\x98\x1c" +
-	"Et\xa0\x0d\xb1w\x953\xa4\x88\xbdw:\x03\xbc\xd8" +
-	"\xbb\xdb\x99m\xc4C\x9d.x\xe5\x90\xe6\xcc\x80\xe2\xa1" +
-	"}N\x17-\xbe\x7f\xc0\x99%\xc5\x8f\x0f:\x89I<" +
-	"\xa1\xb9P\x97\x13\xab\\\x93\xec\x89\xb5.\xf0\xe9\xd4z" +
-	"\x07\xfb\x10Oos\x8d\x14\xdf\xfe\xde\x05\xc7\x9d\xdd\xe7" +
-	"\x9an/t\xba\xc0\xb2\x0b\x07\x9c\x0e@*\xc4\xf5\x0e" +
-	"|!\x95\xe06\x07)\x91|\xf8{\xe7\x88$\x11\xd7" +
-	":\xfd\x91T\x89\x07\x1dlJ\xaa\xc1\x0f\x9c\xea%\x0d" +
-	"\xc3O\x1c Oj\xc6\x93N\xe9o\x19\x87\xa5\xae\x99" +
-	"\xaa\xa5\x0d\x07\xa2i\xe54\x98\x92rl\x9b\xc0[\xc7" +
-	"\x9b\xea}\x9c\xcab1\xb2x\x8e,W\x015\xd3\xca" +
-	"\xd6P\xcb\xf2\xb5i\xbdS\xe8\xed\xc9\xda\xbd\xc3\x90\x15" +
-	"O`Z\x8f8o'\x87\xaai%l\xa8M\xe9\xb6" +
-	"\xbfOI\xc95\xad\xb6\x01\xbb\x1c\x81n\x9a%\xc8\x8a" +
-	"e\xb4\x82\xd9\xcf\xe4y\xc9\xe9\xe2iZ}\x1f\x9f1" +
-	"l\xe8\x06X\xa5\x1f\x1d\x1e.\xa39d\x81a:l" +
-	"\xae%\xa4\x83\x08\xd3Qd-\xc1C\xb6\x960W]" +
-	"i\xd0\x1f\xceQ\x12\xed1C\xeb\x010\xadz\xcfy" +
-	"\xed\x88F\xf6g\xa4\x9b\xd7U\xd3\xea\x97\xb9\xcc\x86y" +
-	"YRHY!\xeb\xd3to\x93z\xdc\x11\xd7\xf8>" +
-	"\xd5\xc3\xb1\xf9\xc5x\xd2\x06\x90G\xf0\x85\x006z\x85" +
-	"\x16\"\"\xc98\x158\xa9\x1d\x05t\xb0\x03\xb4 *" +
-	"i\x02\xde\x09\x9c4\x1a\x05\xe4ll\x1d\xad\x99_\x1a" +
-	"\x86\xeb\x81\x93\xeaP@\xdeFb\xd1\x82\xef\xa4J\xf6" +
-	"\xae\x0f\x05,\xb0\xf1\x15\xb40g\x09q\x13p\xe2\x05" +
-	"\x01\x0bm<\x0f-\x1cG<\xbd\x1b8\xf1\x94\x80E" +
-	"6\x1c\x8f\x16p/~\xbc\x168\xf1\xb0\x80\x82\x8d\xb4" +
-	"\xa1\x05i\x88\xbd\x1ap\xe2\x1b\x02\x16\xdb\xb8;ZX" +
-	"\x93\xb8\x87\xf4\xbd(`\x89\x0dX\xa3\x05\xea\x88;\xb6" +
-	"\x01'n\x15\xb0\xd4\x06\xcd\xf1\xfb=W\x01\xc3n7" +
-	"\x1f\x04N\xdc,P\xd3@!\xda\x8af(\x1dg\x98" +
-	"62\xb4\xa2i\xe1\x0dh\x99\x1e\xb5V4\xad\xe6\xcd" +
-	"\xcd\xa9\xd9\x01\x92f\xe5Ub\xd53\x82aZ<6" +
-	"%\xf5\x8a\xad\xefZ\x05-_\x07\x92\xa3\xa7]\x17j" +
-	"\x99\xef2\x11)'\xc4\x90Gr\xca\xc1\xd0r0\x7f" +
-	"Z\xae\xd5\x97p^\xb7\xa1\xb5\xe7:\x00x\xaa\x93S" +
-	"\xa7\xb3\xb44\x0d\xdce,\x8b\xde\x0c\xe9\xea\x0f[-" +
-	"\xd5\xd2sX\x05\x10\xdc\x8e<\x06_@\x07\x93\x90v" +
-	"\xe1<\x80\xe0\x1f\x89\xfe\x0ar\x88)TB\xda\xc3\xa0" +
-	"\x83\x97\x89\xbc\x1f\x9d^Az\x8dA\x0d\xaf\x10\xfd-" +
-	"t\xda\x05\xe9\x0d\xec\x04\x08\xee'\xfa1\x06M\xf0)" +
-	"h\xe2c\\\x02\x10<B\xf4\xf3\x0c\x9a(HA\x13" +
-	"g\x99\xda3\x0c\xb2\xe08\x14\x85\xc2\x00\x0a\x00\x92\xc8" +
-	"\x11\xbd\x82\xe318\x82\xe8\xc5E\x01,\x06\x90\x1a\x19" +
-	"\xbd\x81\xe8\xd3\x89^\"\x04\xb0\x04@j\xe3\x16\x02\x04" +
-	"[\x89\xfe\x0b\xa2\x97\x16\x07\xb0\x14@\xba\x89\xd1\xff\x81" +
-	"\xe8a\xa2\x0f(\x09\xe0\x00\x00I\xe1h_\x0b\x88~" +
-	"+\xd1\xcbJ\x03X\x06 \xf5pS\x01\x82\x06\xd1\x1f" +
-	" \xba\x0f\x03\xe8\x03\x90\xee\xe34\x80\xe0\xbdD\x7f\x98" +
-	"\xe8\xe5\x03\x02X\x0e =\xc8\xe8\x1b\x88\xbe\x93\xe8\xfe" +
-	"\xb2\x00\xfa\x01\xa4\x1dL\xce\xd3D\x7f\x95\xcb\xe8\x9c\xcc" +
-	"\x85\xc9X8\xaav(\xc0\xbbz\x12C\xd5\xba#1" +
-	"%JN\x90n\xc2ku#\x1c\x89\xd9-\xb9\xba2" +
-	"b0\xf8\x04\xfb +\xf1xw;=\x05\xbfb," +
-	"\xee\xf34j\x15H^s\x01\x00.@\x96q\x85\xa2" +
-	"\xaa\x12K&\xa6\x01\xdf\x1d\xee\x03\xebD\xe3\x0b\x95h" +
-	"\x9b\x06|_T'\x14\xef\xeeVb\xe16\x10\xb4\xbe" +
-	"\x0f\xfb\xdf\x07\xaeVc\xcboP\xdc\x0b\xf6FD(" +
-	"\xb3\xd6\xa3\xdfi\xbdR\x1d\xb7\xa9\x84\xc3\x11#\x12\x8f" +
-	"A\xad\x12\xbd&l\x8b*I-nuTU\x96\xf6" +
-	"%\xf7k\x04\xedT\xf5d\x94\xcfuj\xb1;\xbc<" +
-	"\x10&\xdd\xdd\xfc{f_\x1d\xe0\xd2\xc3\xaf\xdd/\xe6" +
-	"\x0bke\x1b\xd3\xacR\xed\xc1\x19f\xa51\x85\xe9." +
-	"\xac\xb3\xad\xd3\x99\xa1rKu1\xd5\xb8V\xefP\x0c" +
-	"\xc0~\xa0\x0f^\x10.\xdd%z\xc6\xa4Y\xe9\x91\xe8" +
-	"a\xd7B\x1f\xacJ\x0f:\xbf\xb5\xb3\x9f\xb8\x91f\xa7" +
-	"\x0d<\xca\x8f\xb8\xc6\xa4\xcd4;=\xcc\xa3\xfc\xb8k" +
-	"L\xdaB\xc4\xdf\xf2(?\x9d\xe36\xdd\xb3TF\xa0" +
-	"O\xd1\x8dp<i\xb8\xbf\xaa\x9af\xa7\x81\\\x00\x82" +
-	"ta\xce\x1d\x19\xb1\x07\x9d<`9\xdd]\xe6,G" +
-	"\xbc\xb4*{\xd0\xc8\x1b\xd8\xefo\xb8\xd9CX\x1e\x1a" +
-	"\xb3!Y\xa9\x06\x99<i\xb0\xad\xb6\x97\xd4\xbe\xc3\xa3" +
-	"\xfc\xb9\xcb\x93N\x90'\x1dK#\xf9\x16\xbc\x7f\x8a\xcc" +
-	"\xf1\x19\x8f\xc1\x02\xaa\xae)x_B\x1c\x02 \x9f\xb7" +
-	"\xf1}\xb4\xf0\xfd1\x00\x9dT\x13\xcbX\x0d\xe5R5" +
-	"\xb4\x04'f\xc0\xfeE|\xaa\x86\xfa\x18\xdd\x81\xfd\x05" +
-	"L\xd7P\xd4,\xd8\xbf\x1a\xf3w\xcb\xd5\xe9\xd4\xeeI" +
-	"\xea\x82a\xf4d/Q\x97\xf0\xdcK'\xec<\x81Y" +
-	"'\x07\xb9 \x9b*'\xdd\x88\xd9\xf1/\xae/\xfe\xe5" +
-	".\xcf\x97\x01\xbb(\xb8\x14X\xeb\xa7\xa6\x95\xe5$\xb6" +
-	"\x94qC\x18\x96\xd8L\xff8q\x18\xfd\xe3\xc5\x9a&" +
-	"\x00,\x10+\x87\x00\x08\x91DH\x88\xa9\x86\x90\x88\x84" +
-	"\xfdI]\xd5\x84\xa4\xa1\xe7\xe4\xc7Y\xe6\\\x17D\\" +
-	"a\x9bM!c,H\x19\xc3\xb2Z\x84RZ\x98G" +
-	"9\xe1\x02\x8e\xba\x89\xb8\x98G\xd9\xa0\x8c88\x95\x11" +
-	"\x97\xd1\xdb\x09\x1e\xe5[\xb9T\x9f2-\x1ef\xc1W" +
-	"\x00\x1c\x168\x8e\x916\xa6\xe5\x18\x96m\x8dH\xb7\x1a" +
-	"\xbe.i\xb8z\x9f\xfe\xf5\xbb\xe9\xf1\xd2\xd3k/q" +
-	"e\x86P\x9a\x19\xfcZG$\x8c\xc5\xc0aq\xff\xef" +
-	"\x94\xf2\xbb\x86\xb0\xa1\x92<\xe0g\x0b`H\xcf\xb5\xb4" +
-	"\xb3A\xb6\xae\x8dU\xae\xead\x9d\xda\xe6yN!\xb2" +
-	"}\xfd\x09\x0d@~\x9cGy\xa7\x9d{\xc4\x1d\xeb\x01" +
-	"\xe4\x9d<\xca/S\xe6\xe1Se\xecE\x8a\x94\x17x" +
-	"\x94_\xa5\xbcS\xc0\xf2\x8e\xb8\x97\xf6\xf4\x0a\x8f\xf2\x87" +
-	"\x99\x91\xa2\xb3\xd4\xefid\xd9\xd8\xa7\xea:\xd4F\xe2" +
-	"1\xd7\xdd\x9en\xc4\x13m\x8b\x0c\x15\xb5 \xe5\x8c\xf6" +
-	"8.\xfa\xdfC\x9b\xb3\xf6N\xac\x8a\x18\x98\xe3\xe9\xd9" +
-	"\x10[\x1e\xa7g\xd5\xe1\xfc\xea\x95\x0d4\xfe\xb8;\xb2" +
-	"\x9c/<m\x8c1\xafv4\xcb%W\xca\xa0\x99M" +
-	"\xc0\x0fo\xd3F\x07\xf30\xa8\x85\xf5i?\x9b\xdb\x93" +
-	"`\x17&r\x19s\xf0\x9a\x83,\x83\xd65\xb1\x0cz" +
-	"\xc5,\x00;\xd49\xad3\x19\xa3\x143\x93\x14,R" +
-	"B\xa8\xfa\x97\xe8\xf1\x98\xb9$\x9e$}\xe1\\ok" +
-	"\xeck\x17W\x9ai\xb0\xe7\xea\x126\xf8\xdaE\xd8\x1a" +
-	"\xabE\xa49\xb0\x8c\xc8\x83\xd0\xc9\xa3R%U~\xa7" +
-	"6\x8b<\x97\xea\x08\xae`\xb5<@\xf4\xc1\xe8\x04\xa6" +
-	"T\xc3\xc4W\x13\xbd\x01\x9d\xd8\x94\x861\xfe\xc1\xd6\xd5" +
-	"\xbeXT\x98\xea\x09\x1a\x91\xe6\xde\x06\xa2\x8fe=A" +
-	"Q\xaa'\x18\xcd\xe6\xf0QD\x9fD\xf4b!5W" +
-	"O`\xf2\xc7\x13}:\xd1K\x8a\xd3s5\x9b\xff[" +
-	"\x89>\x9bz\x88\x84\x16\x0f\xa9\xba>\x13\xd0\xce\x9e\x16" +
-	"\x0ed\x85\xba`(]\xd6\xe7)\xd4CD\x0c\xd7\xec" +
-	"\x1b\x89\x86\xa7So\xaf\xda,\x86\xa2u\xa9\x0e\x8b\x96" +
-	"\xd4\x0d25\x08.\x99fH\xd1\xba\xe27\xa8\x1a\xf8" +
-	"\xf5>\xe4\xb9\x9a\xea\x92\x97\x917\xac\\\xd2\xcfZ\xe9" +
-	"t\x18\xae\x96\x8f\xb2\xee[\xa9\x1foXI\xf7\xd0\xbc" +
-	"\xf4o7\x8e\xb8J\xe5a\x0a\xb7\xf7x\x94\xbf\xa1\xf3" +
-	"mMe\xdd\xd3\x14\x10_\xf1(\x9fw\x0d\x0fg)" +
-	"\xeb\x9eI\xf7\x866d\x82d\xfaN\xdbC,\xc4\xe4" +
-	"\x0a\xe6Q\xccCF\xa1\x0b1if\xdd\xde\x08\xa2\x8f" +
-	"\xc7\xccDM\xde\x1fO\x1aA\xe0\xd5\x90u\xe5\xf4\x03" +
-	"\xdd]6 \xe2\xffx\x8c\xef\xcf\x84\x90\xf3\xe4c_" +
-	"\xe4\xf4{\xf2\xb1\xb2^\x8ei\xcf\xbeZ\xb9<s\xb8" +
-	"\xab\x9b\xbbL\xd7\xeb}\x7f'\x96\xdf\x9d\xac}\xb3\x95" +
-	"\xd7\xb8\x95q\xb5\xe9\xba\xd0\xcb)3[w\x13\xecj" +
-	"B0\xb4\x1e\x0f.1\xc4\xf9\xfd\x83\xdd'5\x8fq" +
-	"~\x00!,U{\xeca|\xb9\x12M\xda\xc9\xe4\x7f" +
-	"\x02\x00\x00\xff\xff^\xc3g\x98"
+const schema_ffaaf7385bc4adad = "x\xda\xc4Z}p\x14e\x9a\x7f\x9e\xee$\x9d\x84L" +
+	"&MO\xf60&\x86@\xe0\x92,Y\x90\xc0\x09\x14" +
+	"\x14\x09\x109X\xd0t\x06\xf5\x84]\x8ff\xa6\x09\x03" +
+	"\x93\x99\xa1\xbb\x07\x08\xea\xa1\xeeq\xba\xf8\xb1\xc2a)" +
+	"\xd4R%~\xc3\x82\xe2\xee\xe2*\xca\x96\xb0Z\"\xea" +
+	"\x9d\xe1\x0eO-\xf1P`\x15JT\xfc(\x81\x02\xfb" +
+	"\xeayg\xfac:#\xcc\x04\xeb\xf6\x8fTf\x9e~" +
+	"\xfay\xde\xf7y\x9f\xcf\xdf;\xa3v\x97\xb5\x16\\\xe9" +
+	"\xfbb p\xf2\x07\x85E\xa6\xfeQ\x8f\xf6\xc4\xa6\xe9" +
+	"\xbf\x02q(\x02\x14\xa2\x00\xd0\xf2\xcb\x92\x8f\x11PZ" +
+	"Z2\x19\xd0\xfc\xf6\xb1}\x93\x1e\\\xfb\xc5\x1a7\xc3" +
+	"\xda\x14\xc3\xe3\x8c\xe1\x83qM\x0b\x1f\xe6g\xdd\xedf" +
+	"x\xbd\xe4}b8\xc4\x18\xfee\xbe\x7f\xfd\xbf\xffd" +
+	"\x1ec0O\xb5,<\xb4\xe1\xd3\xab\xfe\x04\x85E\xc4" +
+	"x\xbe\xe4}\x94.+\xa5\x8f\x95\xa5\xbfA@\xf3\xee" +
+	"\x9f\xb6\xc9\xa5\x0f<z\xbf[\xdc\xb7\x03N\x90\xb8\x92" +
+	"2\x127j\xe3\x1b#66?\xb9\xde#\x8e16" +
+	"\x96q\x9c\xd4^&\x00Hm\x8c\xf9\x8d+V\xde\xe0" +
+	"\x7f\xe2\xce\x87\xb21+e\x1f\xa3t+c\xeea\xcc" +
+	"\x9d\x03W\xcfy\xb0\xf3\x8eMn\xd5\xdb\xcb\x86p\x80" +
+	"\xd2\xab\x8ca\xf5\xf1k\x9e\xbb\xeeW_<\xecf8" +
+	"V\xf6\x15\xad\xed\x0cc\xd80\xef\xd3%\xed3\xfc\x8f" +
+	"d\xaa+ \xbe\x1a\xdfV\x94\xc6\xfa\x04\xe0\xcdg\xf7" +
+	"7wF[\xdfx\xd4-F\xf4\x9d%1\xc3|$" +
+	"\xe6'g\x8f<\xf6Np\xdc\x16\x90\x87b\x9fe\xb7" +
+	"\x93\xa0_\xfah\xd97\xfa\x96\x03\x9ac\x97?\xbb\xe8" +
+	"\xab\x89\xc7\xb7d\xdb\xe3N\xdfW(\xf52\xe6\xb7\x98" +
+	"\xe8\xfag\xfe\xd2\xbbf\xe2\xc8\xadn\xdd'}\x07H" +
+	"7\x96\x13\xc3\x9a'\xd5\xbf\xdf\xb3\xeb\xe7\xc4\xc09\xd2" +
+	"\x00[\xea\xca\xd7\xa04\xbe\x9cD\x8d-\xbf\x0a\xd0\\" +
+	">\x7f\xdf3+\xe5c\xdb\xb2lvR\xf9:\x94\xae" +
+	"+\xa7\xcdJ\xd3F\xbd\xf0NK\xd3\xf6\xac{\xb9\x92" +
+	"\xf8f0\x99\xed\xe5\xcf\x00~\xf7\xfd\xee+\x8e\x95\xde" +
+	"\xf4\xb4\xfb\xec\xcb\x9b\xe8\x00|~Z\xdc\x98\xcd\x7fx" +
+	"\xee\xbe\xcfW<M\xc2\xb8>\xc2\xfc\x8bQj\xf7\xff" +
+	"\x1d\x804\xdb\xff\x0c\xa0ys\xef\x89\xa7\xee\xbb\xbbm" +
+	"\xa7W5\xc7\xce\xcd\xbf\x17\xa5\xf3~\xfax\xc6_K" +
+	"\x9e\xc7\x1f>Zz_\xdb\xc8\xe7\xb2\xd9\xb1N\xdc\x8f" +
+	"\xd2$\x91\x16:^\xa4\x95\xd8\xcf\xc5j\xde\xdc\xbe\xfd" +
+	"\x95y\xe3\xbe\xdbj\x92\x99n\x14\xab\xb0%\"\xfe\x09" +
+	")N\xa4\xd78im\xa5\x00`6~v\xd7\x13w" +
+	"\xfe.\xb8+\x9b\xf0\x9e\xca\xbd\x98b\x93\xee\xad$\xe1" +
+	"\xfb\x9f\xdb2\xe1\xec\x91\xe5\xbb\xbc\x0b'_m\xd9S" +
+	"y\x00\xa5C\xc4\xdd\xf2^\xe5\x9d<\xa0Y1\xef?" +
+	"'}v\xd3__u\x9f\xe9\xec*\x16\x81J\x15\xc9" +
+	"\xfbDy\x91k\x7f+\xfa\x9a\x9bauU)\xd9u" +
+	"\x13cxu\xdc\xe0\x81\x9b\xdfU\xf7yV\xc7\x0c\xb5" +
+	"\xbbj\x08'\x1d\xaa\xa2\xd5\xbdWE\xfe\xf6oO\x0f" +
+	"_\xe1\xbb\xef\x9e\xfdY\xcd:\xfb\xf2\xb3(E.\xa7" +
+	"\x8f\xea\xe5\xcc\xac\x9f\x1c\xfd~qWb\xe4\x9bn\xe5" +
+	"\xbf\xae^G\xab\xdbPM\xca\x97\x0c\xd8\x17(\x99\xac" +
+	"\xff\x87\x9b\xe1\x85\xea\xbd\xc4\xf0:c8]\xf9\xe7\x07" +
+	"\xab&\xee\xca`8^\xcd\xf6w\x9e1\xd4U\xff\xf5" +
+	"v-R\xfd\xb6wE<;\xba\x9a\x13(M\xaa\xa1" +
+	"\x8f\xe3k^\xa3\x15U\xb5\xf5\x8e\xf1\xc7\xa6\xbf\x9dm" +
+	"\xb7\xc3j\x1fAiR-;\xe8Zr\xa2G\xbf~" +
+	"j\xfe\xce\xb5\x81w\xfa\xc4\xc3\xf1\xda\xc5(\x9dg\x9c" +
+	"gjW\x01\x9a\xe7VO\xbc\xad\xa6\xe6\x9d\xf7\xb2\xda" +
+	"\xa5y\xf0\x09\x94f\x0cf\x9e>\xf8\x13@s\xe3O" +
+	"\x97'nZ0\xe1C\x0f7\x0b\x9f\xba\xba\xf7Q\x9a" +
+	"T\xc7\x16QG\x1b\xbcm\xdb\x1dO\x1e\xf8|\xd7\x87" +
+	"\x19Y\xba\x8e%\x9e\xa5\x8c\xe1\xdc\x84s\x7f~xb" +
+	"\xe2\x7f\xbd\xba\x99\xb8\x07\xea\xd6\xa0\xb4\x9d\xc4\xb5l\xa9" +
+	"\xbb\x81,p]b\xba8\xbc\xb3\xfc\xb0[^\xcd\xd0" +
+	"\x81\xe4\x10c\x87\xb2${\xf3\xf4-7E\xa4#n" +
+	"\x86\x1b\x87n$\x85\x11\xc6\xf0\x0f\xd2_v\xc4\xd6\x9e" +
+	"8\xe6f\xb8w(K\xd3\x9b\x19\xc3\x8b7\x9f\x1a\xb4" +
+	"\xe3\xd8\x81\x93n\x86=C9Rq\x901\xec\x99\xd7" +
+	"\xd2\xf1?G\x86\x7f\x09b3\xe7\x046`\xcb\x99\xa1" +
+	"\xebP\x12\xebi\xf7\xbe\xfak\x01\xcd\xde\xcfk\xb7\xbd" +
+	"q\xec\xe7_{7W\xcc\xa2\xbe~#J3\xeaY" +
+	"f\xac\xbf\x8a\x034\x9fX\xfa\xe8\xfd\xa7\x87\x88\xdfx" +
+	"\x93\x04\xb3\xc5\x86\xe1\x1f\xa3\xb4s8}|v8\xf3" +
+	"\x86\xe77\xae\xff\xcd+\xa3\xa7\x7f\x93\xe1~\x0d,#" +
+	"\xbe\xd5@\x0b\xad\xfc\xe7\xdb\x0f7\x1d?\x92\xc1p\xb2" +
+	"a?K\x99\x8d\xc4pt\xcc'S\x07\xdd\xda\xf1]" +
+	"\xb6\xd8\x1e\xd6\xd8\xc4I\xed\x8d\xac\"1\xe6\x97p\xeb" +
+	"\x80_,\xfe\xf4\xb4[\x9a\xd2\xc8\x0c\x97d\x0c\xa77" +
+	"\xff\xae\xe5\xb6\xb7\xfep&KZ\xdd\xd0\xb8\x1f\xa5\x9d" +
+	"\x8d\x94V\xd7\xfd\xd7\xcc\xee\x0f\xcf\xbfx6\x9b\x0f\xaf" +
+	"m|\x04\xa5-L\xe7\xe3\x8d\xcb\xa1\xd9\x8c\xc4\x0cU" +
+	"\x8b)\xd1\xa2\x91\x09-n\xc4G\x86\xe2\xb1\xeex\xec" +
+	"g!%\x11KL\x98\x9a\xfa\xa2\xaePC\xc1\x9eX" +
+	"hj<f(\x91\x98\xaa\xd5w(\x9a\xa0t\xebr" +
+	"\x01_\x00P\x80\x00\xa2o\x0a\x80\\\xcc\xa3\x1c\xe0p" +
+	"\x95\xa6.M\xaa\xba\x81\x15\x8e\xc1\x01\xb1\x020'u" +
+	"!MU\x0c\xf5\x1a\xa5[\xd5\x13JH\xd5\xeb;U" +
+	"=)D\x8d\x0cu3\x01\xe42\x1e\xe5A\x1c\x9a\x9a" +
+	"\xaa'\xe21]\x05\x00\xacp\xea\xfa\xa5\xa8\xecP4" +
+	"\x85\xcfe\x83v\x07\x93\x87\xb6\xa9\x1em\x9d$\x8d\xd7" +
+	"\x8d\x0eD\xb9\xdaV\xb8s\x01\x80\xfcG\x1e\xe5\x979" +
+	"D\x0c \xd1v\xcf\x05\x90_\xe2Q~\x97C\x91\xc3" +
+	"\x00r\x00\xe2Ab\xfco\x1e\xe5/9\x14y.\x80" +
+	"<\x80x\x92\x88\x9f\xf1\x18,F\x0e\xc5\x02>\x80\x05" +
+	"\x00R!\xce\x04\x08\x16 \x8f\xc1\x0a\xa2\x17\x16\x04\xb0" +
+	"\x90\x82\x09G\x03\x04\x8b\x89\x1e zQa\x00\x8b\x00" +
+	"$\x91\xf1W\x10}\x04rhv\xab\x86\x12V\x0c\x05" +
+	"\x84k\xa3a(2c\xe9=\x00\xaf\xeaX\x0e\xd8\xc1" +
+	"#\xfa\x9d\xbc\x08HD3\x19\x09\xcfV\x12\x89\x08\x08" +
+	"\xb1.\x9b\xad\x0c8\xf6\xb0\xebB\x0f\x17(\xba\xda\xa1" +
+	"\x18\x8b\xe8d\x89V\x06X\x9b\x88\x87g\x84\xado\xce" +
+	"\x8a\x00\xac\x97+\x9c\x08H/ \x97C\xd1Um\x99" +
+	"\xda\xbeB\xcd\xf0r\xbf\x96\x93\x97\xdbE\xc6\xe3\x04\xc2" +
+	"\x05\xf4\x05I_\x9ba(\xa1E\xb6\xc6N\xcb\x91\xc9" +
+	"\x13\\Z\x878Z\x85\xa4\x16\xb57\xdf?g\xd3\x13" +
+	"q!\xa6\xab\x1e\x1ds\xd3\x01\xd5\xc0a\xd6c\xadp" +
+	"ZO\x8fU\x85\x8bY\xb5#\xae\x19W\xc7\xb5\xe5\x8a" +
+	"\x16\xeeG\x0a\xb1\x1b\x90<\"LS\xe3\x0956+" +
+	"\xde\xe5\xe8\xebTk\xf5d\xceI\xc4\xee\xd6=J\x0b" +
+	"/\xa0\xb4\xd3RJ&\xf6\xc7S&\xce\xdd\xf7<\xbe" +
+	"P?\x99rP.\x06\xb2\x9b\xae<\xd6j\xfb\x83{" +
+	"\xadr\xb1\xad\xaa\xb1\x09@\xae\xe7Q\x1e\xe5$\x9ff" +
+	"\xa25\xf0(\x8f\xe1\xd0o\xf4$TO\xa8\xfb\x01\xfd" +
+	"\x09\xc5X\x94\x97{\x06\xfb\x84]\xa7\xaa\xd7&\xe2}" +
+	"\x1d\xf4R\x82@\xf1\xd8\x96\x99\x16s\xb0\xad\xdd<\xe5" +
+	"a\xdb\xa9]Z<\x99\x98\xad\xc4\x94.U\x03\x16\xcb" +
+	"\xc5,Q\x8bSH\x8cX2\x13`\x95\xde\xa3\x1bj" +
+	"w\xd8\x0c1\xe6\x85:\x00\xe4$<\xe5%\xe9D\x81" +
+	"\x19\x1ev\xa1\xd7\xaeW5=\x12\x8f\xb1J\xa3#\xab" +
+	"4e\xf6\xde\xdbi\xef\xad<\xca\xb3\x9c\xc3\x9eA\xf5" +
+	"\xe3\x1fy\x94\xe7p\x88\\\xaa\xd0\xc8\x14/\x1d<\xca" +
+	"Q\x0eW-S\xb5\x05q]E\x04\x0e\x11\xfa\x96\x86" +
+	"\xbc\x12s\xffRH\xa7\xaa\xfbs\x0fi\xbb\x15\xf3\x1c" +
+	"e\xc1\x05t\xcf\x8awM\xd3\xfc\x91e\xaa&\x17\xa0" +
+	"\xbb/\xc5&\xff\x9c\x9e\x84\xea6bS\x16#\x12m" +
+	"\x1a\x8fr\x87\xab\\\xcf\x9e\xe2X\xd6\x0a#[p\x96" +
+	"0Z\xd5\xad\xac\x08FV\xaaX\x02\x1c\x96\xe4\x1cV" +
+	"\xc6\x0d\x91X8\xbe\x9c\xdeL\x9d\xba\xc1<1`/" +
+	"\xf8\xd6*\x00y\x05\x8f\xf2\xbf:\x0b\xbe}4\x80|" +
+	"\x0b\x8f\xf2]\xae\x05\xaf\x9e\x00 \xdf\xc6\xa3|\x0f\x87" +
+	"\xc8\xa7\xda\x8b_\x93{\xdc\xc5\xa3\xbc\x9e\xba\x0bd\xdd" +
+	"\x85\xb8\x96\x8c\x7f?\x8f\xf26\x0e\xf9\x88]\xa3k\x97" +
+	"G\xc2\xc6\"\x14\x80C\x01p\xf2\"5\xd2\xb5\xc8\xb0" +
+	"\xbe^\x9a\xdf\\\xd0\x04\x86\xa2\x19W\x87\x83\xf1\xd0\x12" +
+	"\xd5\xb0+\xab\xb7\xb469a\x9f=y\xf1?\xa4\x82" +
+	"\x8f\xc7\xe4(\xa2\x83b\x88\xbd+\x9dyD\xec\xbd\xc3" +
+	"\x99\xd5\xc5\xde]\xce\x18#\x1e\xect!)\x075g" +
+	"\xdc\x13\x0f\xeeu\x1af\xf1\xbd\xfd\xce\xd8(~t\xc0" +
+	"IE\xe2q\xcd\x05\xb0\x1c_\xe9\x1aZ\x8f\xafq\xe1" +
+	"L'\xd790\x87xj\xabkz\xf8\xf6\xf7.\xe4" +
+	"\xed\xcc^\xd7 {\xbe\xd3\x85\x8b\x9d\xdf\xef\xd4|\xa9" +
+	"\x10\xd79H\x85T\x82[\x1dPD\xf2\xe1\xef\x9d#" +
+	"\x92D\\\xe3tDR%\x1ep`(\xa9\x06\xdfw" +
+	"\xea\x954\x0c?v0;\xa9\x19O8\xc5\xbee," +
+	"\x96\xba\xc6\xa7\x966\x1c\x88\xa6\x95\xc5`r\xca\xa3m" +
+	"\x02o\x1do\xaa\xdbqj\x89\xc5\xc8\x029\xb2L\x05" +
+	"\xd4L+?C-\xcb\xd0\xa6\xf5N\xa1\xb7\x0bk\xf7" +
+	"\xce=V \x81i=\xe2\xbc\xbd\x1b\xaa\xa6\x95\xa2\xa1" +
+	"6\xa5\xdb\xfe>9%\xd7\xb4\x1a\x05\xecr\x04\xbai" +
+	"\x96 +\x88\xd1\x8ab?\x93\xe7%\xa7\xcb\xa5iu" +
+	"z|\xc6\\\xa1\x1b`\x15{tx\xb8\x8cv\x90\x05" +
+	"\x86\xe9\xb0\xb9\x96\x90\x0e\"LG\x91\xb5\x04\x0f\xd9Z" +
+	"\xc2\x1cu\x85A\x7f8[I\xb4\xc7\x0c\xad\x07\xc0\xb4" +
+	"*<\xe7\xb5#\x1a\xd9\x9f\x91n^WM\xabC\xe6" +
+	"2[\xe4\xa5I!e\x85\xacO\xd3\xddL\xeaqG" +
+	"\\\xe3\xfb\x94\x0d\xc7\xe6\x17\xe2I\x1b@\x1e\xc1\x17\x02" +
+	"\xd8@\x15Z\xe0\x87$\xe3\x14\xe0\xa4v\x14\xd0\x81\x09" +
+	"\xd0B\xa3\xa4\xf1x\x07p\xd2\x95( g\xc3\xe8h" +
+	"\x8d\xf7\xd20\\\x07\x9cT\x87\x02\xf26\xe8\x8a\x16R" +
+	"'U\xb2w}(`\x81\x0d\xa5\xa0\x05/K\x88\x1b" +
+	"\x81\x13\xcf\x0bXhCwhA6\xe2\xa9]\xc0\x89" +
+	"'\x05,\xb2\x91w\xb40z\xf1\xa35\xc0\x89\x87\x04" +
+	"\x14lP\x0d-\xf4B\xec\xd5\x80\x13_\x17\xb0\xd8\x86" +
+	"\xd8\xd1\x82\x95\xc4\xdd\xa4\xef\x05\x01Kll\x1a-\xfc" +
+	"F\xdc\xbe\x158q\x8b\x80\xa56>\x8e\xdf\xef\xbe\x02" +
+	"\x18L\xbb\xe9\x00p\xe2&\x81\xfa\x04\x0a\xd1V4C" +
+	"\xe98\xc3\xb4\x91\xa1\x15M\x0bZ@\xcb\xf4\xa8\xb5\xa2" +
+	"i\xb5knN\xcd\x0e\x904+\xaf\x12\xab\x9e\x11\x0c" +
+	"S\xe3\xb1\xc9\xa9Wl}\xd7(h\xf9:\x90\x1c=" +
+	"\xed\xbaP\xcb|\x97\x89H9!\x86<\x92S\x0e\x86" +
+	"\x96\x83\xf9\xd3r\xad\x86\x84\xf3\xba\x0d\xad=\xd7\x96\xdf" +
+	"S\x9d\x9c\x02\x9d\xa5\x97i\xe0~\xc49\xd7\x9b!]" +
+	"\x1da\xab\xa5Zz\x16\xab\x00\x82\xdbh\xee\x7f\x1e9" +
+	"\x14\xd3\xfd\x81\xb4\x13\xe7\x02\x04\xffH\xf4\x97\xd1n\x0c" +
+	"\xa5\xdd\x0c&x\x89\xc8\xfb\x88\x9dG\xd6%H\xaf2" +
+	"X\xe1e\xa2\xbf\xc9`\x08.\x05C\xbc\x8e\x9d\x00\xc1" +
+	"}D?\xca`\x08>\x05C|\x84\x8b\x01\x82\x87\x89" +
+	"~\x8e\xc1\x10\x05)\x18\xe2\x0cS{\x9a\xc1\x13\x1c\x87" +
+	"\xa2P\x18@\x01@\x129\xa2Wp<\x06G\x10\xbd" +
+	"\xb8(\x80\xc5\x00R#\xa37\x10}\x1a\xd1K\x84\x00" +
+	"\x96\x00Hm\xdc\x02\x80`+\xd1\x7f\xc1q\x88\xa5\x01" +
+	",\x05\x90nd\xe4\x7f\"r\x98\xd8\x07\x14\x07p\x00" +
+	"\x80\xa4p\xb4\xad\xf9D\xbf\x85\xe8e%\x01,\x03\x90" +
+	"z\xb8)\x00A\x83\xe8\xf7\x13\xdd\x87\x01\xf4\x01H\xf7" +
+	"r\x1a@\xf0\x1e\xa2?D\xf4\xf2\xd2\x00\x96\x03H\x0f" +
+	"0\xfaz\xa2\xef \xba\x7f@\x00\xfd\x00\xd2v&\xe7" +
+	")\xa2\xbf\xc2e\xb4L\xe6\x82d,\x1cU;\x14\xe0" +
+	"]-\x89\xa1j\xdd\x91\x98\x12%\x1fH\xb7\xdd\xb5\xba" +
+	"\x11\x8e\xc4\xec&\\]\x111\x18^\x82}\xa0\x94x" +
+	"\xbc\xbb\x9d\x9e\x82_1\x16\xf5y\x1a\xb5\xea#\xaf\xb9" +
+	"&~\x17\xf4\xca\xb8BQU\x89%\x13S\x81\xef\x0e" +
+	"\xf7\xc1q\xa2\xf1\x05J\xb4M\x03\xbe/\x8c\x13\x8aw" +
+	"w+\xb1p\x1b\x08Z\xdf\x87\xfdi\x00W\xa9\xb1e" +
+	"\xd7+\xee\xa5zC!\x94Y\xe4\xd1\xef\xf4\\\xa9\x1e" +
+	"\xdbT\xc2\xe1\x88\x11\x89\xc7\xa0V\x89^\x1d\xb6E\x95" +
+	"\xa4\x96\xb5*\xaa*K\xfa\x92\xfb5mv\xaaz2" +
+	"\xca\xe7:\xa7\xd8\xad]\x1e`\x92\xeen\xf7=c\xae" +
+	"\x0ep\xf19\xd7n\x14\xf3E\xb0\xb2\x0dfV\x8d\xf6" +
+	"@\x0a3\xd3\xf0\xc14'\xa1\x88m\x9d\xce\xd4\x94[" +
+	"\x8e\x8b\xa9\xc65z\x87b\x00\xf6\x03h\xf0\xe2m\xe9" +
+	"\xf6\xd03\x18\xcdL\x0fA\x0f\xb9\x16\xfa@Uz\xb6" +
+	"\xf9\xad3\x0fo\xa0ii=\x8f\xf2\xc3N\xce\x137" +
+	"\xd1\xb4\xf4\x10\x8f\xf2cN\xc2\x137\x13\xf1\xb7<\xca" +
+	"O\xe5\xb8M\xf7\xf8\x94\x11\xe2\x93u#\x1cO\x1a\xee" +
+	"\xaf\xaa\xa6\xd9\x09 \x17, ]\x91s\x07A\xec\x09" +
+	"'\x0f\x04Nw\xd77\xcb\x11/\xae\xca\x9e0\xf2\x06" +
+	"\xef\xfb\x1bn\xf6\xf4\x95\x87\xc6l\xa0U\xaa3&O" +
+	"\x1al\xab\xed%\xb5o\xf3(\x7f\xe6\xf2\xa4\xe3\xe4I" +
+	"G\xd3p=\x97v\xa5\x93d\x8eOy\x0c\x16\xa0=" +
+	"dK\x88C\x00\xe4s6\x88\x8f\x16\x88?\x1a\xa0\x93" +
+	"\x8aa\x19+\x9e\\\xaax\x96\xe0\x84\x0cl\xbf\x88O" +
+	"\x15O\x1f\xa3;\xd8\xbe\x80\xe9\xe2\x89\x9a\x85\xedWc" +
+	"\xfen\xb9*\x9d\xd4=\xe9\\0\x8c\x9e\xec\xc5\xe9\"" +
+	"\x9e{\xf1\x84\x9d'\x06\xeb\xe4 \x17HSua\xa4" +
+	"\xcb\xc6<\xdcP\x97\xbb._\x12ZQp1@\xd6" +
+	"Om*KFl\x11c\x870\xbc\xb0\x99\xfeq\xe2" +
+	"0\xfa\xc7\x8b5M\x00X V\x0e\x01\x10\"\x89\x90" +
+	"\x10S\x0d!\x11\x09\xfb\x93\xba\xaa\x09IC\xcf\xc9\x81" +
+	"\xb3L\xb6.\x18\xb8\xc2\xb6\x97Bf\x98\x9f2\x83e" +
+	"\xaf\x08\xe5\xb20\x8fr\xc2e\xafn\".\xe2Q6" +
+	"(\x15\x0eN\xa5\xc2\xa5\xf4v\x82G\xf9\x16.\xd5\x9a" +
+	"L\x8d\x87Y\xd4\x15\x00\x87\x05\x8eG\xf8\x80C\x9f\xe3" +
+	"\x11\xe9\xaf\xa6\x11\xe9V\xc3\xd7&\x0dW\xbb\xd3\xbf\x0e" +
+	"7=Pz\xba\xeb\xc5\xae\x94\x10J3\x83_\xeb\x88" +
+	"\x84\xb1\x188,\xee\xff\xbdQ~W\x0d68\x92\x07" +
+	"\xc4lA\x0a\xe9I\x96v6\xc8\xd6\xb5\xa1\xcaU\x96" +
+	"\xacS\xdb4\xd7\xa9@v\xd6y\\\x03\x90\x1f\xe3Q" +
+	"\xde\xe1 {\xdb\xd7\x01\xc8;x\x94_\xe2\x10\x0bR" +
+	"\xe5\xeb\x05\x0a\x91\xe7y\x94_q\x9auq\x0fm\xe9" +
+	"e\x1e\xe5\x0f2CDg)\xdf\xd3\xba\xb29O\xd5" +
+	"u\xa8\x8d\xc4c\xae\xeb;\xdd\x88'\xda\x16\x1a*j" +
+	"A\xca\x15\xedq\\\xf8\xff\x81(g\xed\x96X\xdd0" +
+	"0\xc7c\xb3\xd1\xb4<\x8e\xcd\xaa\xbc\xf9U(\x1bS" +
+	"\xbc\xb4\x0b\xb0\x9co3m81\xaf\x064\xcb\x0dV" +
+	"\xca\xa0\x99e\xff\x87\xb7i\x03\x81y\x18\xd4\x82\xf5\xb4" +
+	"\x9f\xcd\xe9I\xb0\xdb\x10\xb9\x8cyv\xcd\x01\x96:\xeb" +
+	"\x9aX\xea\xbcl&\x80\x1d\xe3\x9c\xd6\x99\x8cQn\x99" +
+	"A\x0a\x16*!T\xfd\x8b\xf5x\xcc\\\x1cO\x92\xbe" +
+	"p\xaeW1\xf6\x9d\x8a+\xbf4\xd8#t\x09\x9bq" +
+	"\xed\xb2kM\xd0\"\xd2\xccWF\xe4A\xe8$P\xa9" +
+	"\x92j\xbdS\x8d\xad{|\xe92V\xbd\x03D\x1f\xec" +
+	"\xbe\xc9\xafa\xe2\xab\x89\xde\xe0\xbe\xc9\x1f\xc6\xf8\x07[" +
+	"7\xf6\xf6M~#\xd2\x8c\xdb@\xf41\xac\x0b(J" +
+	"u\x01W\xb2\x91{\x14\xd1'\x12\xbdXH\x8d\xd0\xe3" +
+	"\x99\xfcqD\x9fF\xcb/IO\xd0l\xd2o%\xf2" +
+	",j\x1a\x12Z<\xa4\xea\xfa\x0c@;kZ\x88\x8f" +
+	"\x15\xe3\x82\xa1tY\x9f'S\xd3\x101\\cn$" +
+	"\x1a\x9eF\xcd\xbcj\xb3\x18\x8a\xd6\xa5:,ZR7" +
+	"\xc8\xd2 \xb8d\x9a!E\xeb\x8a_\xafj\xe0\xd7\xfb" +
+	"\x90\xe7h\xaaK\x9e+m\x08\xfd\xad\x8dN+\xe1\xea" +
+	"\xed(\xcb\xbe\x99\xfa)\x86\x95d\x0f\xceM\xff\x12\xe3" +
+	"\xb0\xab4\x1e\xa2({\x97G\xf9\x1b:\xd6\xd6T\x96" +
+	"=Eq\xf0%\x8f\xf29'\xcb\x9e\xa1,{:\xdd" +
+	"\x03\xdam\x1d\x92\xc5;m\xbf\xb0\xba\xba\xcb\x98\x1f1" +
+	"\xbf\x18\x85.H\xa4\x99uu#\x88>\x0e3\x133" +
+	"\xf9|<i\x04\x81WC\xd6e\xd2\x0ftq\xd9\xa0" +
+	"\x86\xbf\xd9\xa0\xde\x9f\x19 \xe7\xd9\xc6\xbe\xa3\xe9\xf7l" +
+	"ce\xb9\x1c\xd3\x9c}k\xf2\xe3L\xda\xae\xb6\xedG" +
+	"\xba+\xef\xfbk\xaf\xfc\xeeY\xedK\xab\xbc\x06\xaa\x8c" +
+	"\xebJ\xd7]]N\x99\xd8\xbav`\xb7\x0e\x82\xa1\xf5" +
+	"x\x90\x87!\xce\x8f\x19\xec\x86\xa8y\xb4\xf3k\x06a" +
+	"\x89\xdac\x8f\xdb\xcb\x94h\xd2\xce\x1e\xff\x17\x00\x00\xff" +
+	"\xff\x91\x18f\""
 
 func RegisterSchema(reg *schemas.Registry) {
 	reg.Register(&schemas.Schema{

--- a/vendor/github.com/containers/conmon-rs/pkg/client/attach.go
+++ b/vendor/github.com/containers/conmon-rs/pkg/client/attach.go
@@ -104,20 +104,12 @@ func (c *ConmonClient) AttachContainer(ctx context.Context, cfg *AttachConfig) e
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return fmt.Errorf("create RPC connection: %w", err)
+		return fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer func() {
-		if err := conn.Close(); err != nil {
-			c.logger.Errorf("Unable to close connection: %v", err)
-		}
-	}()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.AttachContainer(ctx, func(p proto.Conmon_attachContainer_Params) error {
+	future, free := rpcClient.AttachContainer(ctx, func(p proto.Conmon_attachContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -137,13 +129,20 @@ func (c *ConmonClient) AttachContainer(ctx context.Context, cfg *AttachConfig) e
 
 		req.SetStopAfterStdinEof(cfg.StopAfterStdinEOF)
 
-		// TODO: add exec session
+		if cfg.ExecSession != "" {
+			if err := req.SetExecSessionId(cfg.ExecSession); err != nil {
+				return fmt.Errorf("set exec session ID: %w", err)
+			}
+		}
+
 		return nil
 	})
 	defer free()
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return fmt.Errorf("create result: %w", err)
 	}
 
@@ -494,16 +493,12 @@ func (c *ConmonClient) SetWindowSizeContainer(ctx context.Context, cfg *SetWindo
 		return errTerminalSizeNil
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return fmt.Errorf("create RPC connection: %w", err)
+		return fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.SetWindowSizeContainer(ctx, func(p proto.Conmon_setWindowSizeContainer_Params) error {
+	future, free := rpcClient.SetWindowSizeContainer(ctx, func(p proto.Conmon_setWindowSizeContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -526,6 +521,8 @@ func (c *ConmonClient) SetWindowSizeContainer(ctx context.Context, cfg *SetWindo
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return fmt.Errorf("create result: %w", err)
 	}
 

--- a/vendor/github.com/containers/conmon-rs/pkg/client/client.go
+++ b/vendor/github.com/containers/conmon-rs/pkg/client/client.go
@@ -42,7 +42,6 @@ var (
 	errInvalidValue           = errors.New("invalid value")
 	errRunDirNotCreated       = errors.New("could not create RunDir")
 	errTimeoutWaitForPid      = errors.New("timed out waiting for server PID to disappear")
-	errUndefinedCgroupManager = errors.New("undefined cgroup manager")
 )
 
 // ConmonClient is the main client structure of this package.
@@ -55,6 +54,9 @@ type ConmonClient struct {
 	tracer         trace.Tracer
 	serverVersion  semver.Version
 	cgroupManager  CgroupManager
+	connMu         sync.Mutex
+	conn           *rpc.Conn
+	rpcClient      proto.Conmon
 }
 
 // ConmonServerConfig is the configuration for the conmon server instance.
@@ -410,22 +412,6 @@ func (c *ConmonClient) toArgs(config *ConmonServerConfig) (entrypoint string, ar
 		args = append(args, "--log-driver", string(config.LogDriver))
 	}
 
-	const cgroupManagerFlag = "--cgroup-manager"
-
-	switch config.CgroupManager {
-	case CgroupManagerSystemd:
-		args = append(args, cgroupManagerFlag, "systemd")
-
-	case CgroupManagerCgroupfs:
-		args = append(args, cgroupManagerFlag, "cgroupfs")
-
-	case CgroupManagerPerCommand:
-		// nothing to do, will use the cgroup manager specified per command
-
-	default:
-		return "", args, errUndefinedCgroupManager
-	}
-
 	if config.Tracing != nil && config.Tracing.Enabled {
 		c.tracingEnabled = true
 
@@ -516,13 +502,34 @@ func defaultContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), defaultTimeout)
 }
 
-func (c *ConmonClient) newRPCConn() (*rpc.Conn, error) {
-	socketConn, err := DialLongSocket("unix", c.socket())
-	if err != nil {
-		return nil, fmt.Errorf("dial long socket: %w", err)
+func (c *ConmonClient) client(ctx context.Context) (proto.Conmon, error) {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	if c.conn != nil {
+		return c.rpcClient, nil
 	}
 
-	return rpc.NewConn(rpc.NewStreamTransport(socketConn), nil), nil
+	socketConn, err := DialLongSocket("unix", c.socket())
+	if err != nil {
+		return proto.Conmon{}, fmt.Errorf("dial long socket: %w", err)
+	}
+
+	c.conn = rpc.NewConn(rpc.NewStreamTransport(socketConn), nil)
+	c.rpcClient = proto.Conmon(c.conn.Bootstrap(ctx))
+
+	return c.rpcClient, nil
+}
+
+func (c *ConmonClient) resetConn() {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	if c.conn != nil {
+		c.conn.Close()
+		c.conn = nil
+		c.rpcClient = proto.Conmon{}
+	}
 }
 
 // DialLongSocket is a wrapper around net.DialUnix.
@@ -603,16 +610,12 @@ func (c *ConmonClient) Version(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.Version(ctx, func(p proto.Conmon_version_Params) error {
+	future, free := rpcClient.Version(ctx, func(p proto.Conmon_version_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -635,6 +638,8 @@ func (c *ConmonClient) Version(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -813,16 +818,12 @@ func (c *ConmonClient) CreateContainer(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.CreateContainer(ctx, func(p proto.Conmon_createContainer_Params) error {
+	future, free := rpcClient.CreateContainer(ctx, func(p proto.Conmon_createContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -887,6 +888,8 @@ func (c *ConmonClient) CreateContainer(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -947,15 +950,12 @@ func (c *ConmonClient) ExecSyncContainer(ctx context.Context, cfg *ExecSyncConfi
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
-	defer conn.Close()
 
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ExecSyncContainer(ctx, func(p proto.Conmon_execSyncContainer_Params) error {
+	future, free := rpcClient.ExecSyncContainer(ctx, func(p proto.Conmon_execSyncContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -989,6 +989,8 @@ func (c *ConmonClient) ExecSyncContainer(ctx context.Context, cfg *ExecSyncConfi
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -1027,15 +1029,13 @@ func (c *ConmonClient) initLogDrivers(req *proto.Conmon_CreateContainerRequest, 
 
 	for i, logDriver := range logDrivers {
 		n := newLogDrivers.At(i)
-		if logDriver.Type == LogDriverTypeContainerRuntimeInterface {
+
+		switch logDriver.Type {
+		case LogDriverTypeContainerRuntimeInterface:
 			n.SetType(proto.Conmon_LogDriver_Type_containerRuntimeInterface)
-		}
-
-		if logDriver.Type == LogDriverTypeJSONLogger {
+		case LogDriverTypeJSONLogger:
 			n.SetType(proto.Conmon_LogDriver_Type_json)
-		}
-
-		if logDriver.Type == LogDriverTypeJournald {
+		case LogDriverTypeJournald:
 			n.SetType(proto.Conmon_LogDriver_Type_journald)
 		}
 
@@ -1067,6 +1067,8 @@ func (c *ConmonClient) Shutdown() error {
 
 		return true
 	})
+
+	c.resetConn()
 
 	pid := int(c.serverPID)
 	if err := syscall.Kill(pid, syscall.SIGINT); err != nil {
@@ -1117,16 +1119,12 @@ func (c *ConmonClient) ReopenLogContainer(ctx context.Context, cfg *ReopenLogCon
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return fmt.Errorf("create RPC connection: %w", err)
+		return fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ReopenLogContainer(ctx, func(p proto.Conmon_reopenLogContainer_Params) error {
+	future, free := rpcClient.ReopenLogContainer(ctx, func(p proto.Conmon_reopenLogContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1146,6 +1144,8 @@ func (c *ConmonClient) ReopenLogContainer(ctx context.Context, cfg *ReopenLogCon
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return fmt.Errorf("create result: %w", err)
 	}
 
@@ -1160,24 +1160,6 @@ type RequestWithMetadata interface {
 	NewMetadata(n int32) (proto.Conmon_TextTextMapEntry_List, error)
 }
 
-type RequestWithMetadataOld interface {
-	RequestWithMetadata
-	SetMetadataOld(v []byte) error
-}
-
-var (
-	_ RequestWithMetadataOld = nil
-	// verify that all existing messages are compatible with old conmon-rs servers
-	// (new messages don't need to support the old encoding).
-	_ = proto.Conmon_VersionRequest{}
-	_ = proto.Conmon_CreateContainerRequest{}
-	_ = proto.Conmon_ExecSyncContainerRequest{}
-	_ = proto.Conmon_AttachRequest{}
-	_ = proto.Conmon_ReopenLogRequest{}
-	_ = proto.Conmon_SetWindowSizeRequest{}
-	_ = proto.Conmon_CreateNamespacesRequest{}
-)
-
 // setMetadata sets the tracing metadata properties on the request.
 func (c *ConmonClient) setMetadata(ctx context.Context, req RequestWithMetadata) error {
 	if !c.tracingEnabled {
@@ -1185,27 +1167,18 @@ func (c *ConmonClient) setMetadata(ctx context.Context, req RequestWithMetadata)
 	}
 
 	span := trace.SpanFromContext(ctx)
+
+	if !span.SpanContext().HasSpanID() {
+		return stringStringMapToMapEntryList(nil, req.NewMetadata)
+	}
+
 	m := make(map[string]string)
 
-	if span.SpanContext().HasSpanID() {
-		c.logger.Tracef("Injecting tracing span ID %v", span.SpanContext().SpanID())
-		otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(m))
-	}
+	c.logger.Tracef("Injecting tracing span ID %v", span.SpanContext().SpanID())
+	otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(m))
 
 	if err := stringStringMapToMapEntryList(m, req.NewMetadata); err != nil {
-		return fmt.Errorf("set metadata2: %w", err)
-	}
-
-	// support old conmon-rs servers with json encoded metadata field
-	if req, ok := req.(RequestWithMetadataOld); ok {
-		metadataBytes, err := json.Marshal(m)
-		if err != nil {
-			return fmt.Errorf("marshal metadata: %w", err)
-		}
-
-		if err := req.SetMetadataOld(metadataBytes); err != nil {
-			return fmt.Errorf("set metadata: %w", err)
-		}
+		return fmt.Errorf("set metadata: %w", err)
 	}
 
 	return nil
@@ -1261,24 +1234,12 @@ func (c *ConmonClient) CreateNamespaces(
 		defer span.End()
 	}
 
-	// Feature not supported pre v0.5.0
-	const minMinor = 5
-
-	minVersion := semver.Version{Minor: minMinor}
-	if c.serverVersion.LT(minVersion) {
-		return nil, fmt.Errorf("requires at least %v: %w", minVersion, ErrUnsupported)
-	}
-
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.CreateNamespaces(ctx, func(p proto.Conmon_createNamespaces_Params) error {
+	future, free := rpcClient.CreateNamespaces(ctx, func(p proto.Conmon_createNamespaces_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1354,6 +1315,8 @@ func (c *ConmonClient) CreateNamespaces(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -1367,7 +1330,7 @@ func (c *ConmonClient) CreateNamespaces(
 		return nil, fmt.Errorf("set path: %w", err)
 	}
 
-	namespacesResponse := []*NamespacesResponse{}
+	namespacesResponse := make([]*NamespacesResponse, 0, namespaces.Len())
 
 	for i := range namespaces.Len() {
 		namespace := namespaces.At(i)
@@ -1409,7 +1372,8 @@ func (c *ConmonClient) CreateNamespaces(
 	}, nil
 }
 
-func mappingsToSlice(mappings []idtools.IDMap) (res []string) {
+func mappingsToSlice(mappings []idtools.IDMap) []string {
+	res := make([]string, 0, len(mappings))
 	for _, m := range mappings {
 		res = append(res, fmt.Sprintf("%d %d %d", m.ContainerID, m.HostID, m.Size))
 	}
@@ -1460,15 +1424,12 @@ func (c *ConmonClient) ServeExecContainer(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
-	defer conn.Close()
 
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ServeExecContainer(ctx, func(p proto.Conmon_serveExecContainer_Params) error {
+	future, free := rpcClient.ServeExecContainer(ctx, func(p proto.Conmon_serveExecContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1499,6 +1460,8 @@ func (c *ConmonClient) ServeExecContainer(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -1552,15 +1515,12 @@ func (c *ConmonClient) ServeAttachContainer(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
-	defer conn.Close()
 
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ServeAttachContainer(ctx, func(p proto.Conmon_serveAttachContainer_Params) error {
+	future, free := rpcClient.ServeAttachContainer(ctx, func(p proto.Conmon_serveAttachContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1584,6 +1544,8 @@ func (c *ConmonClient) ServeAttachContainer(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -1622,15 +1584,12 @@ func (c *ConmonClient) ServePortForwardContainer(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
-	defer conn.Close()
 
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ServePortForwardContainer(ctx, func(p proto.Conmon_servePortForwardContainer_Params) error {
+	future, free := rpcClient.ServePortForwardContainer(ctx, func(p proto.Conmon_servePortForwardContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1650,6 +1609,8 @@ func (c *ConmonClient) ServePortForwardContainer(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 

--- a/vendor/github.com/containers/conmon-rs/pkg/client/remote_fds.go
+++ b/vendor/github.com/containers/conmon-rs/pkg/client/remote_fds.go
@@ -84,7 +84,7 @@ func (r *RemoteFDs) Send(fds ...int) ([]RemoteFD, error) {
 
 	n, err := r.conn.Read(buf)
 	if err != nil {
-		return nil, fmt.Errorf("receviree reaponse: %w", err)
+		return nil, fmt.Errorf("receive response: %w", err)
 	}
 
 	buf = buf[:n]
@@ -137,20 +137,12 @@ func (c *ConmonClient) RemoteFDs(ctx context.Context) (*RemoteFDs, error) {
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer func() {
-		if err := conn.Close(); err != nil {
-			c.logger.Errorf("Unable to close connection: %v", err)
-		}
-	}()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.StartFdSocket(ctx, func(p proto.Conmon_startFdSocket_Params) error {
+	future, free := rpcClient.StartFdSocket(ctx, func(p proto.Conmon_startFdSocket_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -166,6 +158,8 @@ func (c *ConmonClient) RemoteFDs(ctx context.Context) (*RemoteFDs, error) {
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -232,8 +232,8 @@ github.com/containernetworking/plugins/pkg/ns
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit
 github.com/containers/conmon/runner/config
-# github.com/containers/conmon-rs v0.7.3
-## explicit; go 1.25
+# github.com/containers/conmon-rs v0.8.1-0.20260702110516-b5ec72de6187
+## explicit; go 1.26.3
 github.com/containers/conmon-rs/internal/proto
 github.com/containers/conmon-rs/pkg/client
 # github.com/containers/kubensmnt v1.2.0


### PR DESCRIPTION
/kind dependency-change

#### What this PR does / why we need it:
Bumps conmon-rs to the v1.0.0 pre-release (containers/conmon-rs#3269). This prepares CRI-O for the conmon-rs v1.0.0 release (containers/conmon-rs#3270) and enables follow-up work to remove the `cgroup_manager` flag.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```