### PR TITLE
test: base64-encode env var values for cri-api v0.36.2 compatibility

### DIFF
--- a/test/cdi.bats
+++ b/test/cdi.bats
@@ -111,7 +111,8 @@ function annotate_ctr_with_unknown_cdidev {
 }
 
 function prepare_ctr_with_cdidev {
-	jq ".CDI_Devices |= . + [ { \"Name\": \"vendor0.com/device=loop8\" }, { \"Name\": \"vendor0.com/device=loop9\" } ] | .envs |= . + [ { \"key\": \"VENDOR0\", \"value\": \"unset\" }, { \"key\": \"LOOP8\", \"value\": \"unset\" } ]" \
+	jq --arg v "$(printf %s unset | base64 -w0)" \
+		'.CDI_Devices |= . + [{"Name": "vendor0.com/device=loop8"}, {"Name": "vendor0.com/device=loop9"}] | .envs |= . + [{"key": "VENDOR0", "value": $v}, {"key": "LOOP8", "value": $v}]' \
 		"$TESTDATA/container_sleep.json" > "$ctr_config"
 }
 

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -941,7 +941,7 @@ function assert_log_linking() {
 	start_crio
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	# XXX: this relies on PATH being the first element in envs[]
-	jq '	  .envs[0].value += ":/acustompathinpath"' \
+	jq '	  .envs[0].value = ((.envs[0].value | @base64d) + ":/acustompathinpath" | @base64)' \
 		"$TESTDATA"/container_config.json > "$newconfig"
 	ctr_id=$(crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json)
 
@@ -1312,7 +1312,8 @@ function assert_log_linking() {
 
 @test "ctr HOME env newline invalid" {
 	start_crio
-	jq ' .envs = [{"key": "HOME=", "value": "/root:/sbin/nologin\\ntest::0:0::/:/bin/bash"}]' \
+	jq --arg v "$(printf '%s' '/root:/sbin/nologin\ntest::0:0::/:/bin/bash' | base64 -w0)" \
+		' .envs = [{"key": "HOME=", "value": $v}]' \
 		"$TESTDATA"/container_config.json > "$newconfig"
 
 	run ! crictl run "$newconfig" "$TESTDATA"/sandbox_config.json

--- a/test/inject_gomaxprocs.bats
+++ b/test/inject_gomaxprocs.bats
@@ -134,9 +134,10 @@ function get_gomaxprocs() {
 
 	create_burstable_sandbox
 
-	jq '.linux.resources.cpu_shares = 2048
+	jq --arg gmp "$(printf %s 16 | base64 -w0)" \
+		'.linux.resources.cpu_shares = 2048
 		| .linux.resources.cpu_quota = 0
-		| .envs = [{"key": "GOMAXPROCS", "value": "16"}]' \
+		| .envs = [{"key": "GOMAXPROCS", "value": $gmp}]' \
 		"$TESTDATA"/container_sleep.json > "$ctrconfig"
 
 	ctr_id=$(crictl run "$ctrconfig" "$sboxconfig")

--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -13,23 +13,23 @@
   "envs": [
     {
       "key": "PATH",
-      "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      "value": "L3Vzci9sb2NhbC9zYmluOi91c3IvbG9jYWwvYmluOi91c3Ivc2JpbjovdXNyL2Jpbjovc2JpbjovYmlu"
     },
     {
       "key": "TERM",
-      "value": "xterm"
+      "value": "eHRlcm0="
     },
     {
       "key": "GLIBC_TUNABLES",
-      "value": "glibc.pthread.rseq=0"
+      "value": "Z2xpYmMucHRocmVhZC5yc2VxPTA="
     },
     {
       "key": "TESTDIR",
-      "value": "test/dir1"
+      "value": "dGVzdC9kaXIx"
     },
     {
       "key": "TESTFILE",
-      "value": "test/file1"
+      "value": "dGVzdC9maWxlMQ=="
     }
   ],
   "labels": {

--- a/test/testdata/container_config_ping.json
+++ b/test/testdata/container_config_ping.json
@@ -13,23 +13,23 @@
   "envs": [
     {
       "key": "PATH",
-      "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      "value": "L3Vzci9sb2NhbC9zYmluOi91c3IvbG9jYWwvYmluOi91c3Ivc2JpbjovdXNyL2Jpbjovc2JpbjovYmlu"
     },
     {
       "key": "TERM",
-      "value": "xterm"
+      "value": "eHRlcm0="
     },
     {
       "key": "GLIBC_TUNABLES",
-      "value": "glibc.pthread.rseq=0"
+      "value": "Z2xpYmMucHRocmVhZC5yc2VxPTA="
     },
     {
       "key": "TESTDIR",
-      "value": "test/dir1"
+      "value": "dGVzdC9kaXIx"
     },
     {
       "key": "TESTFILE",
-      "value": "test/file1"
+      "value": "dGVzdC9maWxlMQ=="
     }
   ],
   "labels": {

--- a/test/testdata/container_redis.json
+++ b/test/testdata/container_redis.json
@@ -11,27 +11,27 @@
   "envs": [
     {
       "key": "PATH",
-      "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      "value": "L3Vzci9sb2NhbC9zYmluOi91c3IvbG9jYWwvYmluOi91c3Ivc2JpbjovdXNyL2Jpbjovc2JpbjovYmlu"
     },
     {
       "key": "TERM",
-      "value": "xterm"
+      "value": "eHRlcm0="
     },
     {
       "key": "GLIBC_TUNABLES",
-      "value": "glibc.pthread.rseq=0"
+      "value": "Z2xpYmMucHRocmVhZC5yc2VxPTA="
     },
     {
       "key": "REDIS_VERSION",
-      "value": "6.0.18"
+      "value": "Ni4wLjE4"
     },
     {
       "key": "REDIS_DOWNLOAD_URL",
-      "value": "http://download.redis.io/releases/redis-6.0.18.tar.gz"
+      "value": "aHR0cDovL2Rvd25sb2FkLnJlZGlzLmlvL3JlbGVhc2VzL3JlZGlzLTYuMC4xOC50YXIuZ3o="
     },
     {
       "key": "REDIS_DOWNLOAD_SHA1",
-      "value": "d7b4f2a97fcab96727284092b0a4aa854af47d570803fa0e7a0345359743836e"
+      "value": "ZDdiNGYyYTk3ZmNhYjk2NzI3Mjg0MDkyYjBhNGFhODU0YWY0N2Q1NzA4MDNmYTBlN2EwMzQ1MzU5NzQzODM2ZQ=="
     }
   ],
   "labels": {

--- a/test/testdata/container_sleep.json
+++ b/test/testdata/container_sleep.json
@@ -12,11 +12,11 @@
   "envs": [
     {
       "key": "PATH",
-      "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      "value": "L3Vzci9sb2NhbC9zYmluOi91c3IvbG9jYWwvYmluOi91c3Ivc2JpbjovdXNyL2Jpbjovc2JpbjovYmlu"
     },
     {
       "key": "GLIBC_TUNABLES",
-      "value": "glibc.pthread.rseq=0"
+      "value": "Z2xpYmMucHRocmVhZC5yc2VxPTA="
     }
   ],
   "annotations": {


### PR DESCRIPTION
The cri-api v0.36.2 changed KeyValue.Value from string to bytes in the protobuf definition. Go's encoding/json expects base64-encoded strings when unmarshaling []byte fields, so crictl now requires env var values in JSON config files to be base64-encoded.

Update all test container configs and BATS scripts to provide base64-encoded env var values.


Assisted-by: Claude Code <https://claude.com/claude-code>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind failing-test
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

- https://github.com/kubernetes-sigs/cri-tools/issues/2127

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
