### PR TITLE
config: remove experimental markers from additional_artifact_stores

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -132,7 +132,7 @@ If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.
 Path where the keys required for image decryption are located
 
 **additional_artifact_stores**=[]
-A list of additional read-only OCI artifact store paths (experimental, subject to change). CRI-O expects an "artifacts/" subdirectory within each configured path. All entries must be absolute paths. Artifacts in these stores take priority over the main store. Because these stores are read-only, CRI-O cannot remove artifacts from them. If a tag is re-pointed on the registry, the stale local copy in a read-only store will continue to be used; the artifact must be removed from the read-only store directly on the filesystem to pick up the new version.
+A list of additional read-only OCI artifact store paths. CRI-O expects an "artifacts/" subdirectory within each configured path. All entries must be absolute paths. Artifacts in these stores take priority over the main store. Because these stores are read-only, CRI-O cannot remove artifacts from them. If a tag is re-pointed on the registry, the stale local copy in a read-only store will continue to be used; the artifact must be removed from the read-only store directly on the filesystem to pick up the new version.
 
 **conmon**=""
 Path to the conmon binary, used for monitoring the OCI runtime. Will be searched for using $PATH if empty.

--- a/internal/ociartifact/store.go
+++ b/internal/ociartifact/store.go
@@ -129,12 +129,17 @@ func (s *Store) Pull(
 		artRef, err := libart.NewArtifactStorageReference(strRef)
 		if err == nil {
 			for _, add := range s.additionalStores {
-				if art, err := add.store.Inspect(ctx, artRef); err == nil {
+				art, inspErr := add.store.Inspect(ctx, artRef)
+				if inspErr == nil {
 					log.Infof(ctx, "Artifact %s already exists in additional store %s, skipping pull", strRef, add.path)
 					// Force-pinned: additional stores are read-only and not subject to GC.
 					dgst := s.newArtifact(art, add.path, true).Digest()
 
 					return &dgst, nil
+				}
+
+				if !errors.Is(inspErr, ErrNotFound) {
+					log.Warnf(ctx, "Failed to inspect artifact in additional store %q, pulling into main store: %v", add.path, inspErr)
 				}
 			}
 		}

--- a/internal/ociartifact/store_test.go
+++ b/internal/ociartifact/store_test.go
@@ -12,8 +12,11 @@ import (
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/common/libimage"
 	"go.podman.io/common/pkg/libartifact"
+	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/manifest"
+	"go.podman.io/image/v5/types"
 	"go.uber.org/mock/gomock"
 
 	"github.com/cri-o/cri-o/internal/ociartifact"
@@ -23,6 +26,37 @@ import (
 var errTest = errors.New("test")
 
 const testDigest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+type fakeImageRef struct {
+	ref reference.Named
+}
+
+func newFakeImageRef() *fakeImageRef {
+	ref, err := reference.ParseNormalizedNamed("docker.io/library/nginx:latest")
+	if err != nil {
+		panic(err)
+	}
+
+	return &fakeImageRef{ref: reference.TagNameOnly(ref)}
+}
+
+func (f *fakeImageRef) Transport() types.ImageTransport         { return nil }
+func (f *fakeImageRef) StringWithinTransport() string           { return f.ref.String() }
+func (f *fakeImageRef) DockerReference() reference.Named        { return f.ref }
+func (f *fakeImageRef) PolicyConfigurationIdentity() string     { return "" }
+func (f *fakeImageRef) PolicyConfigurationNamespaces() []string { return nil }
+func (f *fakeImageRef) NewImage(_ context.Context, _ *types.SystemContext) (types.ImageCloser, error) {
+	return nil, nil
+}
+
+func (f *fakeImageRef) NewImageSource(_ context.Context, _ *types.SystemContext) (types.ImageSource, error) {
+	return nil, nil
+}
+
+func (f *fakeImageRef) NewImageDestination(_ context.Context, _ *types.SystemContext) (types.ImageDestination, error) {
+	return nil, nil
+}
+func (f *fakeImageRef) DeleteImage(_ context.Context, _ *types.SystemContext) error { return nil }
 
 func makeOCIManifest(configMediaType, artifactType string) []byte {
 	m := map[string]any{
@@ -530,6 +564,448 @@ var _ = t.Describe("Store", func() {
 			// Then
 			Expect(err).NotTo(HaveOccurred())
 			Expect(arts[0].CRIImage().GetPinned()).To(BeTrue())
+		})
+	})
+
+	t.Describe("Additional stores", func() {
+		var (
+			mainStoreMock *ociartifactmock.MockLibartifactStore
+			addStoreMock1 *ociartifactmock.MockLibartifactStore
+			addStoreMock2 *ociartifactmock.MockLibartifactStore
+			implMock      *ociartifactmock.MockImpl
+			mockCtrl      *gomock.Controller
+			store         *ociartifact.Store
+		)
+
+		const (
+			addStorePath1 = "/additional/store1/artifacts"
+			addStorePath2 = "/additional/store2/artifacts"
+		)
+
+		makeLibArtifact := func(name string) *libartifact.Artifact {
+			return &libartifact.Artifact{
+				Name:     name,
+				Digest:   testDigest,
+				Manifest: &manifest.OCI1{},
+			}
+		}
+
+		BeforeEach(func() {
+			logrus.SetOutput(io.Discard)
+
+			mockCtrl = gomock.NewController(GinkgoT())
+			mainStoreMock = ociartifactmock.NewMockLibartifactStore(mockCtrl)
+			addStoreMock1 = ociartifactmock.NewMockLibartifactStore(mockCtrl)
+			addStoreMock2 = ociartifactmock.NewMockLibartifactStore(mockCtrl)
+			implMock = ociartifactmock.NewMockImpl(mockCtrl)
+
+			var err error
+
+			store, err = ociartifact.NewStore(t.MustTempDir("artifact"), nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			store.SetFakeStore(&ociartifact.FakeLibartifactStore{mainStoreMock})
+			store.SetFakeImpl(implMock)
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		t.Describe("List", func() {
+			It("should return artifacts from additional store when main store is empty", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				addStoreMock1.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+				mainStoreMock.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{}, nil)
+
+				// When
+				arts, err := store.List(context.Background())
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(arts).To(HaveLen(1))
+				Expect(arts[0].Reference()).To(Equal("docker.io/library/nginx:latest"))
+				Expect(arts[0].CRIImage().GetPinned()).To(BeTrue())
+				Expect(arts[0].RootPath()).To(Equal(addStorePath1))
+			})
+
+			It("should return artifacts from main store when no additional stores configured", func() {
+				// Given (no SetFakeAdditionalStores call)
+				mainStoreMock.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+
+				// When
+				arts, err := store.List(context.Background())
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(arts).To(HaveLen(1))
+				Expect(arts[0].CRIImage().GetPinned()).To(BeFalse())
+				Expect(arts[0].RootPath()).To(Equal(store.RootPath()))
+			})
+
+			It("should merge artifacts from additional and main stores", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				addStoreMock1.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+				mainStoreMock.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/redis:latest")}, nil)
+
+				// When
+				arts, err := store.List(context.Background())
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(arts).To(HaveLen(2))
+				Expect(arts[0].RootPath()).To(Equal(addStorePath1))
+				Expect(arts[1].RootPath()).To(Equal(store.RootPath()))
+			})
+
+			It("should deduplicate by reference with additional store winning", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				addStoreMock1.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+				mainStoreMock.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+
+				// When
+				arts, err := store.List(context.Background())
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(arts).To(HaveLen(1))
+				Expect(arts[0].CRIImage().GetPinned()).To(BeTrue())
+				Expect(arts[0].RootPath()).To(Equal(addStorePath1))
+			})
+
+			It("should continue listing main store when additional store returns error", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				addStoreMock1.EXPECT().
+					List(gomock.Any()).
+					Return(nil, errTest)
+				mainStoreMock.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/redis:latest")}, nil)
+
+				// When
+				arts, err := store.List(context.Background())
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(arts).To(HaveLen(1))
+				Expect(arts[0].Reference()).To(Equal("docker.io/library/redis:latest"))
+			})
+
+			It("should list artifacts from multiple additional stores", func() {
+				// Given
+				store.SetFakeAdditionalStores(
+					ociartifact.FakeAdditionalStore{
+						Path:  addStorePath1,
+						Store: addStoreMock1,
+					},
+					ociartifact.FakeAdditionalStore{
+						Path:  addStorePath2,
+						Store: addStoreMock2,
+					},
+				)
+				addStoreMock1.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/nginx:latest")}, nil)
+				addStoreMock2.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{makeLibArtifact("docker.io/library/redis:latest")}, nil)
+				mainStoreMock.EXPECT().
+					List(gomock.Any()).
+					Return(libartifact.ArtifactList{}, nil)
+
+				// When
+				arts, err := store.List(context.Background())
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(arts).To(HaveLen(2))
+				Expect(arts[0].RootPath()).To(Equal(addStorePath1))
+				Expect(arts[1].RootPath()).To(Equal(addStorePath2))
+			})
+		})
+
+		t.Describe("Status", func() {
+			It("should find artifact in additional store first with correct pinning and RootPath", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				addStoreMock1.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(makeLibArtifact("docker.io/library/nginx:latest"), nil)
+
+				// When
+				art, err := store.Status(context.Background(), "docker.io/library/nginx:latest")
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(art.Reference()).To(Equal("docker.io/library/nginx:latest"))
+				Expect(art.RootPath()).To(Equal(addStorePath1))
+				Expect(art.CRIImage().GetPinned()).To(BeTrue())
+			})
+
+			It("should fall back to main store when not in additional stores", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				addStoreMock1.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(nil, ociartifact.ErrNotFound)
+				mainStoreMock.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(makeLibArtifact("docker.io/library/nginx:latest"), nil)
+
+				// When
+				art, err := store.Status(context.Background(), "docker.io/library/nginx:latest")
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(art.RootPath()).To(Equal(store.RootPath()))
+				Expect(art.CRIImage().GetPinned()).To(BeFalse())
+			})
+
+			It("should return ErrNotFound-wrapped error when not in any store", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				addStoreMock1.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(nil, ociartifact.ErrNotFound)
+				mainStoreMock.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(nil, ociartifact.ErrNotFound)
+
+				// When
+				_, err := store.Status(context.Background(), "docker.io/library/nginx:latest")
+
+				// Then
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, ociartifact.ErrNotFound)).To(BeTrue())
+			})
+
+			It("should warn on non-ErrNotFound errors from additional store and fall back", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				addStoreMock1.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(nil, errTest)
+				mainStoreMock.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(makeLibArtifact("docker.io/library/nginx:latest"), nil)
+
+				// When
+				art, err := store.Status(context.Background(), "docker.io/library/nginx:latest")
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(art.RootPath()).To(Equal(store.RootPath()))
+			})
+		})
+
+		t.Describe("Remove", func() {
+			It("should only remove from main store", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				// addStoreMock1.Remove is NOT expected (gomock strict mode
+				// will fail the test if it gets called unexpectedly).
+				dgst := digest.Digest(testDigest)
+				mainStoreMock.EXPECT().
+					Remove(gomock.Any(), gomock.Any()).
+					Return(&dgst, nil)
+
+				// When
+				err := store.Remove(context.Background(), "docker.io/library/nginx:latest")
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return error from main store on remove failure", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				mainStoreMock.EXPECT().
+					Remove(gomock.Any(), gomock.Any()).
+					Return(nil, ociartifact.ErrNotFound)
+
+				// When
+				err := store.Remove(context.Background(), "docker.io/library/nginx:latest")
+
+				// Then
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, ociartifact.ErrNotFound)).To(BeTrue())
+			})
+		})
+
+		t.Describe("Pull", func() {
+			artifactManifest := makeOCIManifest(specs.MediaTypeImageConfig, "application/vnd.test.artifact")
+
+			It("should skip pull when artifact exists in additional store and return correct digest", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				mainStoreMock.EXPECT().SystemContext().Return(nil)
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(artifactManifest, specs.MediaTypeImageManifest, nil)
+				addStoreMock1.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(makeLibArtifact("docker.io/library/nginx:latest"), nil)
+
+				// When
+				dgst, err := store.Pull(context.Background(), newFakeImageRef(), &libimage.CopyOptions{})
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dgst).NotTo(BeNil())
+				Expect(*dgst).To(Equal(digest.Digest(testDigest)))
+			})
+
+			It("should fall through to normal pull when artifact not in additional store", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				mainStoreMock.EXPECT().SystemContext().Return(nil)
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(artifactManifest, specs.MediaTypeImageManifest, nil)
+				addStoreMock1.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(nil, ociartifact.ErrNotFound)
+				mainStoreMock.EXPECT().
+					Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(digest.Digest(testDigest), nil)
+
+				// When
+				dgst, err := store.Pull(context.Background(), newFakeImageRef(), &libimage.CopyOptions{})
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dgst).NotTo(BeNil())
+				Expect(*dgst).To(Equal(digest.Digest(testDigest)))
+			})
+
+			It("should fall through to normal pull when additional store inspect errors", func() {
+				// Given
+				store.SetFakeAdditionalStores(ociartifact.FakeAdditionalStore{
+					Path:  addStorePath1,
+					Store: addStoreMock1,
+				})
+				mainStoreMock.EXPECT().SystemContext().Return(nil)
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(artifactManifest, specs.MediaTypeImageManifest, nil)
+				addStoreMock1.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(nil, errTest)
+				mainStoreMock.EXPECT().
+					Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(digest.Digest(testDigest), nil)
+
+				// When
+				dgst, err := store.Pull(context.Background(), newFakeImageRef(), &libimage.CopyOptions{})
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dgst).NotTo(BeNil())
+				Expect(*dgst).To(Equal(digest.Digest(testDigest)))
+			})
+
+			It("should check additional stores in order and stop at first match", func() {
+				// Given
+				store.SetFakeAdditionalStores(
+					ociartifact.FakeAdditionalStore{
+						Path:  addStorePath1,
+						Store: addStoreMock1,
+					},
+					ociartifact.FakeAdditionalStore{
+						Path:  addStorePath2,
+						Store: addStoreMock2,
+					},
+				)
+				mainStoreMock.EXPECT().SystemContext().Return(nil)
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(artifactManifest, specs.MediaTypeImageManifest, nil)
+				addStoreMock1.EXPECT().
+					Inspect(gomock.Any(), gomock.Any()).
+					Return(makeLibArtifact("docker.io/library/nginx:latest"), nil)
+				// addStoreMock2.Inspect is NOT expected (gomock strict mode
+				// will fail the test if it gets called unexpectedly).
+
+				// When
+				dgst, err := store.Pull(context.Background(), newFakeImageRef(), &libimage.CopyOptions{})
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dgst).NotTo(BeNil())
+				Expect(*dgst).To(Equal(digest.Digest(testDigest)))
+			})
+
+			It("should not skip pull when artifact exists only in main store", func() {
+				// Given (no additional stores configured)
+				mainStoreMock.EXPECT().SystemContext().Return(nil)
+				implMock.EXPECT().
+					GetManifestFromRef(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(artifactManifest, specs.MediaTypeImageManifest, nil)
+				mainStoreMock.EXPECT().
+					Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(digest.Digest(testDigest), nil)
+
+				// When
+				dgst, err := store.Pull(context.Background(), newFakeImageRef(), &libimage.CopyOptions{})
+
+				// Then
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dgst).NotTo(BeNil())
+				Expect(*dgst).To(Equal(digest.Digest(testDigest)))
+			})
 		})
 	})
 })

--- a/internal/ociartifact/store_test_inject.go
+++ b/internal/ociartifact/store_test_inject.go
@@ -20,3 +20,18 @@ func (s *Store) SetFakeImpl(impl Impl) {
 type FakeLibartifactStore struct {
 	*ociartifactmock.MockLibartifactStore
 }
+
+type FakeAdditionalStore struct {
+	Path  string
+	Store LibartifactStore
+}
+
+func (s *Store) SetFakeAdditionalStores(stores ...FakeAdditionalStore) {
+	s.additionalStores = nil
+	for _, fas := range stores {
+		s.additionalStores = append(s.additionalStores, additionalStore{
+			path:  fas.Path,
+			store: fas.Store,
+		})
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -248,6 +248,53 @@ var _ = t.Describe("Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should succeed with empty additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed with valid absolute paths in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/mnt/nfs/store1", "/opt/artifacts"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should fail with relative path in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"./relative/path"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("additional_artifact_stores entry must be absolute"))
+			Expect(err.Error()).To(ContainSubstring("./relative/path"))
+		})
+
+		It("should fail with mix of absolute and relative paths in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/valid/store", "relative/path"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("relative/path"))
+		})
+
 		It("should succeed during runtime", func() {
 			// Given
 			sut = runtimeValidConfig()

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -961,8 +961,7 @@ const templateStringCrioRuntimeDecryptionKeysPath = `# decryption_keys_path is t
 
 `
 
-const templateStringCrioRuntimeAdditionalArtifactStores = `# A list of additional read-only OCI artifact store paths
-# (experimental, subject to change).
+const templateStringCrioRuntimeAdditionalArtifactStores = `# A list of additional read-only OCI artifact store paths.
 # CRI-O expects an "artifacts/" subdirectory within each configured path.
 # All entries must be absolute paths. Artifacts in these stores take priority
 # over the main store. Tag re-pointing is not supported for artifacts in

--- a/test/artifact_additional_stores.bats
+++ b/test/artifact_additional_stores.bats
@@ -127,6 +127,51 @@ EOF
 	grep -q "already exists in additional store" "$CRIO_LOG"
 }
 
+@test "should support multiple additional stores in config" {
+	ADDITIONAL_STORE1="$TESTDIR/additional-store1"
+	ADDITIONAL_STORE2="$TESTDIR/additional-store2"
+	mkdir -p "$ADDITIONAL_STORE1/artifacts" "$ADDITIONAL_STORE2/artifacts"
+
+	cat << EOF > "$CRIO_CONFIG_DIR/99-artifact.conf"
+[crio.runtime]
+additional_artifact_stores = [
+    "$ADDITIONAL_STORE1",
+    "$ADDITIONAL_STORE2"
+]
+EOF
+
+	start_crio
+
+	run -0 "${CRIO_BINARY_PATH}" status --socket="${CRIO_SOCKET}" config
+	[[ "$output" == *"$ADDITIONAL_STORE1"* ]]
+	[[ "$output" == *"$ADDITIONAL_STORE2"* ]]
+}
+
+@test "should deduplicate when same artifact exists in additional and main store" {
+	ADDITIONAL_STORE="$TESTDIR/additional-store"
+	mkdir -p "$ADDITIONAL_STORE"
+
+	cat << EOF > "$CRIO_CONFIG_DIR/99-artifact.conf"
+[crio.runtime]
+additional_artifact_stores = [
+    "$ADDITIONAL_STORE"
+]
+EOF
+
+	start_crio
+
+	# Pull artifact into main store
+	crictl pull "$ARTIFACT_IMAGE"
+
+	# Copy to additional store (artifact now exists in both)
+	local main_store="$TESTDIR/crio/artifacts"
+	cp -a "$main_store" "$ADDITIONAL_STORE/"
+
+	# Listing should show the artifact exactly once
+	count=$(crictl images 2> /dev/null | grep -cE "$ARTIFACT_REPO.*singlefile" || true)
+	[[ "$count" -eq 1 ]]
+}
+
 @test "should mount artifact from additional store" {
 	ADDITIONAL_STORE="$TESTDIR/additional-store"
 	mkdir -p "$ADDITIONAL_STORE"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Removes the "(experimental, subject to change)" markers from the `additional_artifact_stores` configuration option in the config template and man page for GA readiness.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Remove experimental markers from additional_artifact_stores configuration option.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `crio.runtime.additional_artifact_stores` documentation to remove the “experimental, subject to change” wording.

* **Bug Fixes**
  * Runtime config validation for `additional_artifact_stores` now also verifies each configured absolute path exists on the filesystem (invalid/non-existent paths are rejected with clear errors).

* **Tests**
  * Expanded validation tests for empty, absolute-only success, and relative/mixed/non-existent failure cases.
  * Added unit and end-to-end coverage for additional-store precedence, fallback behavior, removal-from-main-only, pull skip/deduplication when artifacts exist in additional stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->