### PR TITLE
docs: fix broken OWNERS link in GOVERNANCE

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -128,7 +128,7 @@ reviewers, approvers and emeritus approvers.
 - Monitor our channel [#crio](https://kubernetes.slack.com/archives/crio) on the
   Kubernetes Slack instance and answer questions where possible.
 - Triage GitHub issues and review pull requests. The areas of specialization
-  listed in [OWNERS.md](OWNERS.md) can be used to help with routing an issue/question
+  listed in [OWNERS](OWNERS) can be used to help with routing an issue/question
   to the right person.
 - Triage CI issues - file issues for known flaky CI runs or bugs, and either fix
   or find someone to fix any breakages.
@@ -169,7 +169,7 @@ reviewers, approvers and emeritus approvers.
 - The person in question for approvership can nominate themselves, or be nominated
   by someone else.
   - A contributor is nominated by someone submitting a PR to add their github
-    handle to the approvers section of the [OWNERS](OWNERS.md) file.
+    handle to the approvers section of the [OWNERS](OWNERS) file.
 - To become an approver, a simple majority vote among the current approvers
   should be performed.
   - See [conflict resolution](#conflict-resolution-and-voting) for more information


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

`GOVERNANCE.md` linked to `OWNERS.md` in two places, but the file at the repo root is `OWNERS` (a Prow-style YAML file with no `.md` extension), so both links 404. This fixes the link targets to point at `OWNERS`. The visible link text was already `OWNERS`, so only the target was wrong.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Docs-only change, no behavior impact. The two links are on GOVERNANCE.md lines 131 and 172.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```