### PR TITLE
ci: pin cri-tools version to v1.36.0

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -13,7 +13,7 @@ use_conmonrs: "{{ USE_CONMONRS | default(False) | bool }}"
 evented_pleg_fg: "{{ EVENTED_PLEG | default(False) | bool }}"
 
 critest_mirror_repo: quay.io/crio
-cri_tools_git_version: master
+cri_tools_git_version: v1.36.0
 
 # For results.yml Paths use rsync 'source' conventions
 artifacts: "/tmp/artifacts" # Base-directory for collection

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,10 +57,12 @@ dependencies:
         match: conmon
 
   - name: cri-tools
-    version: master
+    version: v1.36.0
     refPaths:
       - path: contrib/test/ci/vars.yml
         match: cri_tools_git_version
+      - path: scripts/versions
+        match: cri-tools
 
   - name: buildah
     version: v1.38.0

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -95,7 +95,7 @@ install_critools() {
     install_from_github_org_repo \
         kubernetes-sigs \
         cri-tools \
-        master \
+        "${VERSIONS["cri-tools"]}" \
         sudo -E PATH="$PATH" GOTOOLCHAIN=auto make BINDIR=/usr/bin install
 
     sudo critest --version

--- a/scripts/versions
+++ b/scripts/versions
@@ -2,6 +2,7 @@
 declare -A VERSIONS=(
     ["cni-plugins"]=v1.8.0
     ["conmon"]=v2.1.13
+    ["cri-tools"]=v1.36.0
     ["runc"]=main
     ["bats"]=v1.12.0
     ["buildah"]=v1.38.0


### PR DESCRIPTION
Pin cri-tools from master to v1.36.0 to match the Kubernetes v1.36 dependency version used by CRI-O.

Assisted-by: Claude Code <https://claude.com/claude-code>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind failing-test
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Fixes the current integration test failures.
This is a temporary measure.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the cri-tools dependency reference to **v1.36.0** (replacing the previous **master** reference).
  * Adjusted CI and setup automation so test runs and installs consistently use **v1.36.0**.
  * Expanded version tracking/validation to ensure the cri-tools version stays aligned across configuration and install sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->