### PR TITLE
Pin runc version

### DIFF
--- a/contrib/test/ci/build/runc.yml
+++ b/contrib/test/ci/build/runc.yml
@@ -1,27 +1,21 @@
 ---
-- name: clone runc source repo
-  git:
-    repo: "https://github.com/opencontainers/runc.git"
-    dest: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-    version: "{{ runc_git_version }}"
+- name: set runc checksum
+  set_fact:
+    runc_checksums:
+      amd64: "sha256:f6ae8efc0fa40079e1475e97cbe9d1bd3f106a28d6af78a11d9f1bd565515e60"
+      arm64: "sha256:633301e2e32f8a5ad54031aab4901eb00308bec677dd15faa2751e8f9dab5ca4"
 
-- name: clean runc build directory
-  command: make clean
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-
-- name: build runc
-  make:
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
-
-- name: install runc
-  make:
-    target: "install"
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
+- name: download prebuilt runc binary
+  get_url:
+    url: "https://github.com/opencontainers/runc/releases/download/{{ runc_git_version }}/runc.{{ ansible_architecture | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }}"
+    dest: /usr/sbin/runc
+    mode: "0755"
+    force: yes
+    checksum: "{{ runc_checksums[ansible_architecture | replace('x86_64', 'amd64') | replace('aarch64', 'arm64')] }}"
 
 - name: link runc
   file:
-    src: /usr/local/sbin/runc
+    src: /usr/sbin/runc
     dest: /usr/bin/runc
     state: link
     force: yes

--- a/contrib/test/ci/setup.yml
+++ b/contrib/test/ci/setup.yml
@@ -20,7 +20,7 @@
   include_tasks: "build/libpathrs.yml"
   when: ansible_distribution in ['Fedora']
 
-- name: clone build and install runc
+- name: install runc
   include_tasks: "build/runc.yml"
 
 - name: clone build and install crun

--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -186,5 +186,5 @@ kata_skip_annotation_migration_tests:
   - 'test "v1 umask annotation should still work"'
   - 'test "v2 unified-cgroup annotation for specific container with slash separator should work"'
 
-runc_git_version: main
+runc_git_version: v1.4.3
 crun_git_version: 1.23.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -71,10 +71,12 @@ dependencies:
         match: buildah
 
   - name: runc
-    version: main
+    version: v1.4.3
     refPaths:
       - path: scripts/versions
         match: runc
+      - path: contrib/test/ci/vars.yml
+        match: runc_git_version
 
   - name: libpathrs
     version: 0.2.4

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -162,13 +162,10 @@ install_libpathrs() {
 }
 
 install_runc() {
-    git clone https://github.com/opencontainers/runc
-    pushd runc
-    git checkout "${VERSIONS["runc"]}"
-    make
-    sudo install -D -m0755 runc /usr/sbin/runc
-    popd
-    rm -rf runc
+    curl_retry "https://github.com/opencontainers/runc/releases/download/${VERSIONS["runc"]}/runc.$GOARCH" \
+        -o /usr/sbin/runc
+    echo "${RUNC_CHECKSUMS[$GOARCH]}  /usr/sbin/runc" | sha256sum -c --strict -
+    sudo chmod +x /usr/sbin/runc
     runc --version
 }
 

--- a/scripts/versions
+++ b/scripts/versions
@@ -3,8 +3,13 @@ declare -A VERSIONS=(
     ["cni-plugins"]=v1.8.0
     ["conmon"]=v2.1.13
     ["cri-tools"]=v1.36.0
-    ["runc"]=main
+    ["runc"]=v1.4.3
     ["bats"]=v1.12.0
     ["buildah"]=v1.38.0
     ["libpathrs"]=0.2.4
+)
+
+declare -A RUNC_CHECKSUMS=(
+    ["amd64"]="f6ae8efc0fa40079e1475e97cbe9d1bd3f106a28d6af78a11d9f1bd565515e60"
+    ["arm64"]="633301e2e32f8a5ad54031aab4901eb00308bec677dd15faa2751e8f9dab5ca4"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR pins runc version, and installs pre-built runc instead of building it.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI to install the runtime from prebuilt release binaries (with checksum verification) instead of cloning and building from source.
  * Pinned the runtime dependency to **v1.4.3** for consistent CI/test behavior.

* **Tests**
  * Expanded the integration test matrix by enabling previously skipped `runc` coverage on both **amd64** and **arm64**, and added an additional `conmon` + `runc` run on **amd64** with increased workload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->