### PR TITLE
ci: increase default integration test timeout to 150 minutes

### DIFF
--- a/contrib/test/ci/integration.yml
+++ b/contrib/test/ci/integration.yml
@@ -81,5 +81,5 @@
       vars:
         ansible_async_dir: "/tmp/artifacts/async"
       environment: "{{ int_test_env }}" # from vars.yml and main.yml
-      async: "{{ int_test_timeout | default(90 * 60) }}" # seconds
+      async: "{{ int_test_timeout | default(150 * 60) }}" # seconds
       poll: 30


### PR DESCRIPTION
The kata integration test suite now exceeds the previous 90-minute async timeout due to recently added test files (e.g. artifact_additional_stores.bats). Bump the default timeout to 150 minutes to provide sufficient headroom.

Assisted-by: Claude Code <https://claude.com/claude-code>

Failed runs:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/cri-o_cri-o/9974/pull-ci-cri-o-cri-o-main-ci-fedora-kata/2070150848968658944
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/cri-o_cri-o/10073/pull-ci-cri-o-cri-o-main-ci-fedora-kata/2069820295941722112

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind failing-test
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Increased the default async integration test timeout to 150 minutes (while keeping the existing override behavior when a custom timeout is set).

* **New Features**
  * Added an RPM packaging definition for `cri-o`, including build metadata, system integration assets, and install/uninstall steps for required runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->