### PR TITLE
Fix prettier formatting for latest version

### DIFF
--- a/ANNOTATION_MIGRATION.md
+++ b/ANNOTATION_MIGRATION.md
@@ -191,8 +191,7 @@ metadata:
 # Old (deprecated) - for a specific container
 metadata:
   annotations:
-    seccomp-profile.kubernetes.cri-o.io/my-container:
-      "runtime/default"
+    seccomp-profile.kubernetes.cri-o.io/my-container: "runtime/default"
 
 # New (recommended) - for a specific container
 metadata:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ that we follow.
   - [Dependency management](#dependency-management)
   - [Sign your PRs](#sign-your-prs)
 - [Communications](#communications)
+
 <!-- /toc -->
 
 ## Reporting Issues

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,6 +29,7 @@
   - [Feature addition policy](#feature-addition-policy)
   - [Feature request policy](#feature-request-policy)
 - [Credits](#credits)
+
 <!-- /toc -->
 
 ## Values

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - [Governance](#governance)
 - [AI Assistants](#ai-assistants)
 - [License Scan](#license-scan)
+
 <!-- /toc -->
 
 ## Compatibility matrix: CRI-O ⬄ Kubernetes

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -237,7 +237,7 @@ List of devices on the host that a user can specify with the "io.kubernetes.cri-
 **additional_devices**=[]
 List of additional devices. Specified as "<device-on-host>:<device-on-container>:<permissions>", for example: "--additional-devices=/dev/sdc:/dev/xvdc:rwm". If it is empty or commented out, only the devices defined in the container json file by the user/kube will be added.
 
-**hooks_dir**=["*path*", ...]
+**hooks_dir**=["_path_", ...]
 Each `*.json` file in the path configures a hook for CRI-O containers. For more details on the syntax of the JSON files and the semantics of hook injection, see `oci-hooks(5)`. CRI-O currently support both the 1.0.0 and 0.1.0 hook schemas, although the 0.1.0 schema is deprecated.
 
 Paths listed later in the array have higher precedence (`oci-hooks(5)` discusses directory precedence).


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Fixes prettier formatting issues in 5 markdown files that started failing with prettier 3.9.x. The CI action uses `prettier_version: latest`, which recently upgraded from 3.8.5 to 3.9.1 with stricter formatting rules.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Changes are whitespace-only (blank lines before `<!-- /toc -->` markers, YAML line joining, italic marker style).

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved several docs and reference pages for consistency and readability.
  * Updated a seccomp example to use a cleaner inline format.
  * Refined table-of-contents entries and spacing in contributor, governance, and README docs.
  * Clarified a configuration option placeholder in the runtime reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->