### PR TITLE
Retry in copyimg when using remote registries

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -130,7 +130,8 @@ function get_img() {
         if ! "$COPYIMG_BINARY" \
             --import-from="$img" \
             --export-to="dir:$dir" \
-            --signature-policy="$INTEGRATION_ROOT"/policy.json; then
+            --signature-policy="$INTEGRATION_ROOT"/policy.json \
+            --retry-attempts=3; then
             echo "Error pulling $img" >&2
             rm -fr "$dir"
             exit 1

--- a/test/copyimg/copyimg.go
+++ b/test/copyimg/copyimg.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -12,9 +15,56 @@ import (
 	"go.podman.io/image/v5/types"
 	sstorage "go.podman.io/storage"
 	"go.podman.io/storage/pkg/reexec"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/cri-o/cri-o/internal/log"
 )
+
+// isRemoteSource checks if the image reference is from a remote source
+// that requires network access (and thus might benefit from retries).
+func isRemoteSource(ref string) bool {
+	// Remote transports that require network access
+	remoteTransports := []string{"docker://", "docker-archive:", "docker-daemon:"}
+	for _, transport := range remoteTransports {
+		if strings.HasPrefix(ref, transport) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// copyImageWithRetry attempts to copy an image with exponential backoff retry.
+func copyImageWithRetry(ctx context.Context, policyContext *signature.PolicyContext, dest, src types.ImageReference, options *copy.Options, retryAttempts int) error {
+	backoff := wait.Backoff{
+		Duration: 2 * time.Second,
+		Factor:   2.0,
+		Steps:    retryAttempts,
+	}
+
+	var lastErr error
+
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		_, err := copy.Image(ctx, policyContext, dest, src, options)
+		if err != nil {
+			lastErr = err
+			logrus.Warnf("Image copy attempt failed (retrying): %v", err)
+
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		if lastErr != nil {
+			return lastErr
+		}
+
+		return err
+	}
+
+	return nil
+}
 
 func main() {
 	if reexec.Init() {
@@ -69,6 +119,11 @@ func main() {
 			Name:  "export-to",
 			Usage: "export target",
 		},
+		&cli.IntFlag{
+			Name:  "retry-attempts",
+			Usage: "number of retry attempts for image pull with exponential backoff (0 to disable, default: 3)",
+			Value: 3,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -88,6 +143,7 @@ func main() {
 		addName := c.String("add-name")
 		importFrom := c.String("import-from")
 		exportTo := c.String("export-to")
+		retryAttempts := c.Int("retry-attempts")
 
 		ctx := c.Context
 
@@ -177,7 +233,14 @@ func main() {
 
 		if imageName != "" {
 			if importFrom != "" {
-				_, err = copy.Image(ctx, policyContext, ref, importRef, options)
+				// Use retry logic only when pulling from remote sources and retry is enabled (retryAttempts > 0)
+				if retryAttempts > 0 && isRemoteSource(importFrom) {
+					logrus.Infof("Pulling image with retry enabled (max attempts: %d)", retryAttempts)
+					err = copyImageWithRetry(ctx, policyContext, ref, importRef, options, retryAttempts)
+				} else {
+					_, err = copy.Image(ctx, policyContext, ref, importRef, options)
+				}
+
 				if err != nil {
 					log.Fatalf(ctx, "Error importing %s: %v", importFrom, err)
 				}
@@ -202,7 +265,14 @@ func main() {
 				}
 			}
 		} else if importFrom != "" && exportTo != "" {
-			_, err = copy.Image(ctx, policyContext, exportRef, importRef, options)
+			// Use retry logic only when pulling from remote sources and retry is enabled (retryAttempts > 0)
+			if retryAttempts > 0 && isRemoteSource(importFrom) {
+				logrus.Infof("Pulling image with retry enabled (max attempts: %d)", retryAttempts)
+				err = copyImageWithRetry(ctx, policyContext, exportRef, importRef, options, retryAttempts)
+			} else {
+				_, err = copy.Image(ctx, policyContext, exportRef, importRef, options)
+			}
+
 			if err != nil {
 				log.Fatalf(ctx, "Error copying %s to %s: %v", importFrom, exportTo, err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind ci

#### What this PR does / why we need it:
This is a smaller attempt to reduce the failures in integration tests. Using a local registry is much larger change and required careful review of multiple test cases. Hence taking an smaller step by adding retry to the copyimg binary for now.

It will address one of the common errors:
```
time="2026-06-29T19:51:56Z" level=fatal msg="Error copying docker://quay.io/crio/hello-wasm:latest to dir:/home/runner/work/cri-o/cri-o/.artifacts/hello_wasm-image: reading blob sha256:eb7836fc120a3ace0ea10c2752ad9c3894643f7146ec7d05f8c56d8794c9f1c3: fetching blob: received unexpected HTTP status: 503 Service Unavailable"
```

#### Which issue(s) this PR fixes:
Partially fixes/ https://github.com/cri-o/cri-o/issues/9859
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
@bitoku The local registry approach fails for some test cases. Hence this smaller change
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a retry option for image copy operations, helping remote image pulls recover from temporary failures.

* **Bug Fixes**
  * Improved the image copy flow so remote source handling is more reliable.
  * Corrected command argument handling in the shared test script to ensure options are passed properly during copy operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->