### PR TITLE
Add BATS_TEST_TIMEOUT for integration tests

### DIFF
--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -47,6 +47,8 @@ export JOBS=${JOBS:-$(nproc --all)}
 # The maximum number of additional attempts that will be made on a failed test before it is finally considered failed.
 # https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-variables
 export BATS_TEST_RETRIES=1
+# Abort any individual test that exceeds 10 minutes so hung tests fail fast instead of blocking the entire CI job.
+export BATS_TEST_TIMEOUT=600
 
 bats --version
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
-->
/kind ci
<!--
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
Integration tests can hang indefinitely when a single BATS test gets stuck, blocking the entire CI job until the platform kills it. test/test_runner.sh already sets BATS_TEST_RETRIES=1 but did not set a per-test time limit.

This PR adds export BATS_TEST_TIMEOUT=600 (10 minutes) so any individual test that exceeds that limit is aborted and reported as timed out. That makes hung tests fail fast and easier to identify instead of waiting for the whole job to time out.
#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #10079 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test runner to stop any single test after 10 minutes, helping prevent hung tests from blocking validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->