### PR TITLE
test: deflake default runtime metric test

### DIFF
--- a/test/metrics.bats
+++ b/test/metrics.bats
@@ -101,7 +101,7 @@ runtime_path = "$RUNTIME_BINARY_PATH"
 EOF
 
 	reload_crio
-	wait_for_log '"updating runtime configuration"'
+	wait_for_log '"Configuration reload completed"'
 
 	# Check that the new default runtime metric is present
 	METRIC=$(curl -sf "http://localhost:$PORT/metrics" | grep "^container_runtime_crio_default_runtime{runtime=\"new\"}")


### PR DESCRIPTION
/kind flake

#### What this PR does / why we need it:

The "default runtime metric" test waited for the `"updating runtime configuration"` log line, which is emitted when the reload *starts*, then queried the metrics endpoint before the reload finished, so it flaked (~24% of integration runs). Wait for the `"Configuration reload completed"` line instead, which is logged once the reload is done and the new default runtime metric is in place.

#### Which issue(s) this PR fixes:

Fixes #10086

#### Special notes for your reviewer:

`.bats` files are excluded from shfmt/shellcheck.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the reliability of the runtime metrics test after configuration reload by waiting for the correct CRI-O reload completion message before running post-reload assertions.
  * This reduces flakiness caused by timing differences between reload completion and metric availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->