### PR TITLE
test: run crio-wipe tests serially to fix flake

### DIFF
--- a/test/crio-wipe.bats
+++ b/test/crio-wipe.bats
@@ -3,6 +3,10 @@
 # this test suite tests crio wipe running with combinations of cri-o and
 # podman.
 
+# These tests share the global /run/crio/crio-wipe-done marker, so they must
+# not run concurrently with each other or other tests.
+# bats file_tags=crio:serial
+
 load helpers
 PODMAN_BINARY=${PODMAN_BINARY:-$(command -v podman || true)}
 


### PR DESCRIPTION
/kind flake

#### What this PR does / why we need it:

The `crio-wipe.bats` tests share the global `/run/crio/crio-wipe-done` marker (a hardcoded path, not per-test). Run in the parallel pass, one test creating that marker makes another test's `crio wipe` short-circuit ("Unclean shutdown check already succeeded by previous crio wipe command"), so its container is never wiped and the assertion fails (~24% of runs).

Tag the whole suite `crio:serial` via `file_tags` so all its tests run in the serial pass (`--filter-tags 'crio:serial'`, no `--jobs`) instead of concurrently.

Root cause diagnosed by @ngopalak-redhat in the issue.

#### Which issue(s) this PR fixes:

Fixes #10085

#### Special notes for your reviewer:

Replaces the earlier single-test approach. `.bats` files are excluded from shfmt/shellcheck.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked the `crio-wipe` test suite to run serially, with documentation noting it relies on a shared completion marker. This prevents concurrent execution that could interfere with itself or related tests, improving overall test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->