### PR TITLE
oci: use shared lock for read-only stats collection

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1335,8 +1335,8 @@ func (r *runtimeOCI) CgroupStats(ctx context.Context, c *Container, cgroup strin
 	_, span := log.StartSpan(ctx)
 	defer span.End()
 
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
+	c.opLock.RLock()
+	defer c.opLock.RUnlock()
 
 	return r.config.CgroupManager().ContainerCgroupStats(cgroup, c.ID())
 }
@@ -1346,8 +1346,8 @@ func (r *runtimeOCI) DiskStats(ctx context.Context, c *Container, cgroup string)
 	_, span := log.StartSpan(ctx)
 	defer span.End()
 
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
+	c.opLock.RLock()
+	defer c.opLock.RUnlock()
 
 	// Get disk usage from the container's mount point
 	mountPoint := c.MountPoint()


### PR DESCRIPTION
CgroupStats and DiskStats only read kernel/filesystem data and don't mutate container state, so they don't need exclusive opLock access. Using RLock allows concurrent stats readers to overlap instead of serializing behind each other.  DiskStats in particular calls filepath.Walk which can hold the lock for hundreds of milliseconds on large images.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness when collecting container and disk usage stats by reducing lock contention.
  * This helps status and usage information remain available with less blocking during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->