### PR TITLE
Use fsNotify for fetching container exit

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1197,11 +1197,7 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 			// Wait for it to appear before defaulting to exit code 255.
 			// This prevents a race where fast-exiting containers
 			// get a spurious exit code 255.
-			// Release opLock before waiting to avoid blocking other operations.
-			c.opLock.Unlock()
-			waitErr := waitForExitFile(c)
-			c.opLock.Lock()
-
+			waitErr := waitForExitFile(ctx, c)
 			if waitErr != nil {
 				log.Errorf(ctx, "Failed to update container status from exit file for %s: %v", c.ID(), waitErr)
 				c.state.Finished = time.Now()
@@ -1240,7 +1236,7 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 	}
 
 	c.opLock.Unlock()
-	err = waitForExitFile(c)
+	err = waitForExitFile(ctx, c)
 	c.opLock.Lock()
 
 	// run command again
@@ -1285,9 +1281,9 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 }
 
 // waitForExitFile waits for the container's exit file to appear using
-// exponential backoff. Returns nil if the file appeared, or an error if it did
-// not appear within the timeout (~5s total: 500ms initial, 1.2 factor, 6 steps).
-func waitForExitFile(c *Container) error {
+// fsnotify. Returns nil if the file appeared, or an error if the context
+// is cancelled or the file did not appear within the 5s timeout.
+func waitForExitFile(ctx context.Context, c *Container) error {
 	exitFilePath := c.exitFilePath()
 
 	if _, err := os.Stat(exitFilePath); err == nil {
@@ -1305,27 +1301,37 @@ func waitForExitFile(c *Container) error {
 		return err
 	}
 
-	timeout := time.After(5 * time.Second)
+	if _, err := os.Stat(exitFilePath); err == nil {
+		return nil
+	}
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
 
 	for {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case event, ok := <-watcher.Events:
 			if !ok {
-				return kwait.ErrWaitTimeout
+				return kwait.ErrorInterrupted(errors.New("watcher closed before exit file appeared"))
 			}
+
 			if event.Name == exitFilePath && (event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write) {
 				return nil
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {
-				return kwait.ErrWaitTimeout
+				return kwait.ErrorInterrupted(errors.New("watcher error channel closed"))
 			}
+
 			return err
-		case <-timeout:
+		case <-timer.C:
 			if _, err := os.Stat(exitFilePath); err == nil {
 				return nil
 			}
-			return kwait.ErrWaitTimeout
+
+			return kwait.ErrorInterrupted(fmt.Errorf("timed out waiting for exit file: %s", exitFilePath))
 		}
 	}
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1197,7 +1197,11 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 			// Wait for it to appear before defaulting to exit code 255.
 			// This prevents a race where fast-exiting containers
 			// get a spurious exit code 255.
+			// Release opLock before waiting to avoid blocking other operations.
+			c.opLock.Unlock()
 			waitErr := waitForExitFile(c)
+			c.opLock.Lock()
+
 			if waitErr != nil {
 				log.Errorf(ctx, "Failed to update container status from exit file for %s: %v", c.ID(), waitErr)
 				c.state.Finished = time.Now()
@@ -1286,20 +1290,44 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 func waitForExitFile(c *Container) error {
 	exitFilePath := c.exitFilePath()
 
-	return kwait.ExponentialBackoff(
-		kwait.Backoff{
-			Duration: 500 * time.Millisecond,
-			Factor:   1.2,
-			Steps:    6,
-		},
-		func() (bool, error) {
-			_, err := os.Stat(exitFilePath)
-			if err != nil {
-				return false, nil
-			}
+	if _, err := os.Stat(exitFilePath); err == nil {
+		return nil
+	}
 
-			return true, nil
-		})
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	exitDir := filepath.Dir(exitFilePath)
+	if err := watcher.Add(exitDir); err != nil {
+		return err
+	}
+
+	timeout := time.After(5 * time.Second)
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return kwait.ErrWaitTimeout
+			}
+			if event.Name == exitFilePath && (event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write) {
+				return nil
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return kwait.ErrWaitTimeout
+			}
+			return err
+		case <-timeout:
+			if _, err := os.Stat(exitFilePath); err == nil {
+				return nil
+			}
+			return kwait.ErrWaitTimeout
+		}
+	}
 }
 
 // PauseContainer pauses a container.

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1195,11 +1195,7 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 			// Wait for it to appear before defaulting to exit code 255.
 			// This prevents a race where fast-exiting containers
 			// get a spurious exit code 255.
-			// Release opLock before waiting to avoid blocking other operations.
-			c.opLock.Unlock()
-			waitErr := waitForExitFile(c)
-			c.opLock.Lock()
-
+			waitErr := waitForExitFile(ctx, c)
 			if waitErr != nil {
 				log.Errorf(ctx, "Failed to update container status from exit file for %s: %v", c.ID(), waitErr)
 				c.state.Finished = time.Now()
@@ -1238,7 +1234,7 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 	}
 
 	c.opLock.Unlock()
-	err = waitForExitFile(c)
+	err = waitForExitFile(ctx, c)
 	c.opLock.Lock()
 
 	// run command again
@@ -1283,11 +1279,12 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 }
 
 // waitForExitFile waits for the container's exit file to appear using
-// exponential backoff. Returns nil if the file appeared, or an error if it did
-// not appear within the timeout (~5s total: 500ms initial, 1.2 factor, 6 steps).
-func waitForExitFile(c *Container) error {
+// fsnotify. Returns nil if the file appeared, or an error if the context
+// is cancelled or the file did not appear within the 5s timeout.
+func waitForExitFile(ctx context.Context, c *Container) error {
 	exitFilePath := c.exitFilePath()
 
+	// Fast path: skip watcher setup if the file already exists.
 	if _, err := os.Stat(exitFilePath); err == nil {
 		return nil
 	}
@@ -1303,27 +1300,39 @@ func waitForExitFile(c *Container) error {
 		return err
 	}
 
-	timeout := time.After(5 * time.Second)
+	// Re-check after watcher.Add: the file may have appeared between
+	// the fast-path check above and the watcher registration.
+	if _, err := os.Stat(exitFilePath); err == nil {
+		return nil
+	}
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
 
 	for {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case event, ok := <-watcher.Events:
 			if !ok {
-				return kwait.ErrWaitTimeout
+				return kwait.ErrorInterrupted(errors.New("watcher closed before exit file appeared"))
 			}
+
 			if event.Name == exitFilePath && (event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write) {
 				return nil
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {
-				return kwait.ErrWaitTimeout
+				return kwait.ErrorInterrupted(errors.New("watcher error channel closed"))
 			}
+
 			return err
-		case <-timeout:
+		case <-timer.C:
 			if _, err := os.Stat(exitFilePath); err == nil {
 				return nil
 			}
-			return kwait.ErrWaitTimeout
+
+			return kwait.ErrorInterrupted(fmt.Errorf("timed out waiting for exit file: %s", exitFilePath))
 		}
 	}
 }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1195,7 +1195,11 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 			// Wait for it to appear before defaulting to exit code 255.
 			// This prevents a race where fast-exiting containers
 			// get a spurious exit code 255.
+			// Release opLock before waiting to avoid blocking other operations.
+			c.opLock.Unlock()
 			waitErr := waitForExitFile(c)
+			c.opLock.Lock()
+
 			if waitErr != nil {
 				log.Errorf(ctx, "Failed to update container status from exit file for %s: %v", c.ID(), waitErr)
 				c.state.Finished = time.Now()
@@ -1284,20 +1288,44 @@ func (r *runtimeOCI) UpdateContainerStatus(ctx context.Context, c *Container) er
 func waitForExitFile(c *Container) error {
 	exitFilePath := c.exitFilePath()
 
-	return kwait.ExponentialBackoff(
-		kwait.Backoff{
-			Duration: 500 * time.Millisecond,
-			Factor:   1.2,
-			Steps:    6,
-		},
-		func() (bool, error) {
-			_, err := os.Stat(exitFilePath)
-			if err != nil {
-				return false, nil
-			}
+	if _, err := os.Stat(exitFilePath); err == nil {
+		return nil
+	}
 
-			return true, nil
-		})
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	exitDir := filepath.Dir(exitFilePath)
+	if err := watcher.Add(exitDir); err != nil {
+		return err
+	}
+
+	timeout := time.After(5 * time.Second)
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return kwait.ErrWaitTimeout
+			}
+			if event.Name == exitFilePath && (event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write) {
+				return nil
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return kwait.ErrWaitTimeout
+			}
+			return err
+		case <-timeout:
+			if _, err := os.Stat(exitFilePath); err == nil {
+				return nil
+			}
+			return kwait.ErrWaitTimeout
+		}
+	}
 }
 
 // PauseContainer pauses a container.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind cleanup

#### What this PR does / why we need it:
Use a faster way to detect presence of container exit file

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exit-file detection by switching from periodic polling to real-time filesystem event monitoring, reducing delays.
  * Added an immediate initial check for the exit file before starting event monitoring.
  * Made the wait operation context-aware, so cancellation returns promptly with the correct error.
  * Kept waiting behavior bounded with a hard timeout and a final fallback check to prevent indefinite waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->