### PR TITLE
restore: only recreate declared external bind mount sources

### DIFF
--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -9,6 +9,7 @@ import (
 
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/checkpoint-restore/go-criu/v8/stats"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/crutils"
@@ -153,20 +154,7 @@ func (c *ContainerServer) ContainerRestore(
 			}
 
 			for _, e := range externalBindMounts {
-				if func() bool {
-					for _, m := range ctrSpec.Config.Mounts {
-						if (m.Destination == e.Destination) && (m.Source != e.Source) {
-							// If the source differs this means that the external mount
-							// source has already been fixed up earlier by the restore
-							// code and no need to deal with it here.
-							// Good example is the /etc/resolv.conf bind mount is now
-							// pointing to the new /etc/resolv.conf of the new pod.
-							return true
-						}
-					}
-
-					return false
-				}() {
+				if !shouldRecreateExternalBindMount(ctrSpec.Config.Mounts, e) {
 					continue
 				}
 
@@ -346,6 +334,31 @@ func (c *ContainerServer) ContainerRestore(
 	}
 
 	return ctr.ID(), nil
+}
+
+// shouldRecreateExternalBindMount reports whether the missing source of an
+// external bind mount recorded in a checkpoint archive may be recreated on the
+// host. Only sources whose destination is declared by the restored container
+// spec (and whose source has not already been remapped) are recreated. A
+// checkpoint archive is attacker influenced, so without this a crafted
+// bind.mounts entry could make CRI-O create an arbitrary host path with
+// attacker chosen mode bits. CRImportCheckpoint enforces the same rule for the
+// spec mounts.
+func shouldRecreateExternalBindMount(mounts []rspec.Mount, e ExternalBindMount) bool {
+	for _, m := range mounts {
+		if m.Destination != e.Destination {
+			continue
+		}
+
+		// A matching destination whose source was already fixed up earlier by
+		// the restore code (e.g. /etc/resolv.conf now points at the new pod's
+		// file) needs no recreation here.
+		return m.Source == e.Source
+	}
+
+	// The checkpoint lists a bind mount the restored container never declared;
+	// do not touch the host for it.
+	return false
 }
 
 func (c *ContainerServer) restoreFileSystemChanges(ctr *oci.Container, mountPoint string) error {

--- a/internal/lib/restore.go
+++ b/internal/lib/restore.go
@@ -338,15 +338,16 @@ func (c *ContainerServer) ContainerRestore(
 
 // shouldRecreateExternalBindMount reports whether the missing source of an
 // external bind mount recorded in a checkpoint archive may be recreated on the
-// host. Only sources whose destination is declared by the restored container
-// spec (and whose source has not already been remapped) are recreated. A
-// checkpoint archive is attacker influenced, so without this a crafted
-// bind.mounts entry could make CRI-O create an arbitrary host path with
-// attacker chosen mode bits. CRImportCheckpoint enforces the same rule for the
-// spec mounts.
+// host. Only sources whose destination is declared as a bind mount by the
+// restored container spec (and whose source has not already been remapped) are
+// recreated. A checkpoint archive is attacker influenced, so without this a
+// crafted bind.mounts entry could make CRI-O create an arbitrary host path
+// with attacker chosen mode bits. CRImportCheckpoint enforces the same rule
+// for the spec mounts, and checkpointing only records bind mounts in
+// bind.mounts.
 func shouldRecreateExternalBindMount(mounts []rspec.Mount, e ExternalBindMount) bool {
 	for _, m := range mounts {
-		if m.Destination != e.Destination {
+		if m.Type != bindMount || m.Destination != e.Destination {
 			continue
 		}
 

--- a/internal/lib/restore_internal_test.go
+++ b/internal/lib/restore_internal_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var _ = Describe("shouldRecreateExternalBindMount", func() {
-	declared := []rspec.Mount{{Destination: "/data", Source: "/host/data"}}
+	declared := []rspec.Mount{{Destination: "/data", Source: "/host/data", Type: "bind"}}
 
 	It("recreates a declared mount whose source was not remapped", func() {
 		Expect(shouldRecreateExternalBindMount(declared, ExternalBindMount{
@@ -27,6 +27,15 @@ var _ = Describe("shouldRecreateExternalBindMount", func() {
 		Expect(shouldRecreateExternalBindMount(declared, ExternalBindMount{
 			Destination: "/not-declared",
 			Source:      "/etc/cron.d/evil",
+		})).To(BeFalse())
+	})
+
+	It("skips a matching mount whose declared type is not bind", func() {
+		Expect(shouldRecreateExternalBindMount([]rspec.Mount{
+			{Destination: "/run", Source: "tmpfs", Type: "tmpfs"},
+		}, ExternalBindMount{
+			Destination: "/run",
+			Source:      "tmpfs",
 		})).To(BeFalse())
 	})
 })

--- a/internal/lib/restore_internal_test.go
+++ b/internal/lib/restore_internal_test.go
@@ -1,0 +1,32 @@
+package lib
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+var _ = Describe("shouldRecreateExternalBindMount", func() {
+	declared := []rspec.Mount{{Destination: "/data", Source: "/host/data"}}
+
+	It("recreates a declared mount whose source was not remapped", func() {
+		Expect(shouldRecreateExternalBindMount(declared, ExternalBindMount{
+			Destination: "/data",
+			Source:      "/host/data",
+		})).To(BeTrue())
+	})
+
+	It("skips a declared mount whose source was already remapped", func() {
+		Expect(shouldRecreateExternalBindMount(declared, ExternalBindMount{
+			Destination: "/data",
+			Source:      "/old/host/data",
+		})).To(BeFalse())
+	})
+
+	It("skips a bind mount the container never declared", func() {
+		Expect(shouldRecreateExternalBindMount(declared, ExternalBindMount{
+			Destination: "/not-declared",
+			Source:      "/etc/cron.d/evil",
+		})).To(BeFalse())
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ContainerRestore` recreates the source path of any external bind mount listed in a checkpoint's `bind.mounts` file when that source is missing on the host. The destinations there are never checked against the restored container spec, so a crafted checkpoint image can list a bind mount the container never declared and have CRI-O create an arbitrary host path with the archive's own mode bits.

Repro: restore a checkpoint whose `bind.mounts` holds `{"source":"/etc/cron.d/x","destination":"/not-declared","file_type":"file","permissions":511}`.
Expected: nothing outside the restored container's declared mounts is touched.
Actual: `/etc/cron.d/x` is created on the host as an empty file, mode `0777`.
Fix: only recreate a source whose destination is present in `ctrSpec.Config.Mounts` (and whose source was not already remapped). `CRImportCheckpoint` already enforces the same rule for the spec mounts.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Legitimate `bind.mounts` entries are generated from the container's own spec mounts at checkpoint time, so their destinations always match a declared mount and restore behaviour for them is unchanged.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a checkpoint restore issue where a crafted archive could create arbitrary files or directories on the host.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint/restore handling for containers that use external bind mounts, preventing incorrect recreation of missing host paths.
  * Restore mount reconciliation is now more consistent with the container’s declared mount configuration.
* **Tests**
  * Added automated coverage for the external bind-mount restore decision logic, including matching mounts, already-remapped sources, and cases where the destination isn’t declared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->