### PR TITLE
utils: improve GetDiskUsageStats performance and sparse file accuracy

### DIFF
--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -2,29 +2,8 @@ package utils
 
 import (
 	"os"
-	"path/filepath"
 	"syscall"
 )
-
-// GetDiskUsageStats accepts a path to a directory or file
-// and returns the number of bytes and inodes used by the path.
-func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, _ error) {
-	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		// Walk does not follow symbolic links
-		if err != nil {
-			return err
-		}
-
-		dirSize += uint64(info.Size())
-		inodeCount++
-
-		return nil
-	}); err != nil {
-		return 0, 0, err
-	}
-
-	return dirSize, inodeCount, nil
-}
 
 // IsDirectory tests whether the given path exists and is a directory. It
 // follows symlinks.

--- a/utils/filesystem_linux.go
+++ b/utils/filesystem_linux.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// GetDiskUsageStats accepts a path to a directory or file
+// and returns the actual allocated disk blocks and inodes used by the path.
+func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, err error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	inodeCount++
+	dirSize += getAllocatedSize(fi)
+
+	if !fi.IsDir() {
+		return dirSize, inodeCount, nil
+	}
+
+	s, i, err := calculateDir(path)
+
+	return dirSize + s, inodeCount + i, err
+}
+
+func calculateDir(dirPath string) (dirSize, inodeCount uint64, err error) {
+	f, err := os.Open(dirPath)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer f.Close()
+
+	entries, err := f.ReadDir(-1)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for _, entry := range entries {
+		inodeCount++
+
+		info, err := entry.Info()
+		if err != nil {
+			return 0, 0, err
+		}
+
+		dirSize += getAllocatedSize(info)
+
+		if entry.IsDir() {
+			subSize, subInodes, err := calculateDir(filepath.Join(dirPath, entry.Name()))
+			if err != nil {
+				return 0, 0, err
+			}
+
+			dirSize += subSize
+			inodeCount += subInodes
+		}
+	}
+
+	return dirSize, inodeCount, nil
+}
+
+func getAllocatedSize(fi os.FileInfo) uint64 {
+	if sys := fi.Sys(); sys != nil {
+		if stat, ok := sys.(*syscall.Stat_t); ok {
+			return uint64(stat.Blocks) * 512
+		}
+	}
+
+	return uint64(fi.Size())
+}

--- a/utils/filesystem_unsupported.go
+++ b/utils/filesystem_unsupported.go
@@ -1,0 +1,28 @@
+//go:build !linux
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// GetDiskUsageStats accepts a path to a directory or file
+// and returns the number of bytes and inodes used by the path.
+func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, _ error) {
+	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		// Walk does not follow symbolic links
+		if err != nil {
+			return err
+		}
+
+		dirSize += uint64(info.Size())
+		inodeCount++
+
+		return nil
+	}); err != nil {
+		return 0, 0, err
+	}
+
+	return dirSize, inodeCount, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind cleanup

#### What this PR does / why we need it:

While working on Reflinks/Deduping I came across this improvement. This does not have any impact on the functionality but is a good performance improvement when trying to get stats for image FS. I tested Reflinked/dedupped filesystem also and saw no impact on the functionality. Its only a pref improvement.

Replace filepath.Walk with ReadDir and manual recursion for better performance and accuracy on Linux:

- 6-8% faster across all workload sizes
- Uses ReadDir(-1) without sorting as in file.Walk
- Reports actual allocated blocks (stat.Blocks * 512) instead of logical file size (fi.Size())

Platform-specific implementation:
- Linux: New ReadDir-based implementation in filesystem_linux.go
- FreeBSD/Other: Keep original filepath.Walk in platform-specific files

I have done following test on Linux, 4-core Intel Xeon @ 2.80GHz (Ubuntu on GCP VM):
- Small (10 files):      17,687 ns → 16,648 ns  (5.9% faster)
- Medium (1,000 files):  1,377,015 ns → 1,283,460 ns  (6.8% faster)
- Large (10,000 files):  16,624,500 ns → 15,353,141 ns  (7.6% faster)

I could see a larger impact when invoking this in a loop from a test as it had overall improved the performance.

AI Usage:
- I used AI for this function getAllocatedSize() - Reviewed it fully to make sure that its correct

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
- Currently used recursion. I don't see an issue with the usage in this context

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve disk usage stats performance on linux
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added disk usage statistics for files and directories.
  * Reports total storage consumption and inode counts.
  * Supports Linux-specific allocated-block accounting and compatible behavior on other platforms.
  * Handles both individual files and recursively traversed directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->