### PR TITLE
WIP:  utils: add GetRealPhysicalUsage for reflink-aware disk usage

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -162,6 +162,7 @@ func main() {
 	app.Commands = append(app.Commands,
 		criocli.CheckCommand,
 		criocli.ConfigCommand,
+		criocli.PhysicalDiskUsageCommand,
 		criocli.PublishCommand,
 		criocli.StatusCommand,
 		criocli.VersionCommand,

--- a/internal/criocli/physical_disk_usage.go
+++ b/internal/criocli/physical_disk_usage.go
@@ -1,0 +1,139 @@
+//go:build linux
+
+package criocli
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/cri-o/cri-o/utils"
+)
+
+var PhysicalDiskUsageCommand = &cli.Command{
+	Name:        "physical-disk-usage",
+	Usage:       "report real physical disk usage accounting for reflinks/deduplication",
+	Description: "Reports actual physical disk usage for container storage directories.",
+	Action:      physicalDiskUsage,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "verbose",
+			Aliases: []string{"v"},
+			Usage:   "show detailed breakdown per directory",
+		},
+	},
+}
+
+func physicalDiskUsage(c *cli.Context) error {
+	config, err := GetConfigFromContext(c)
+	if err != nil {
+		return err
+	}
+
+	store, err := config.GetStore()
+	if err != nil {
+		return err
+	}
+
+	rootPath := store.GraphRoot()
+	imagePath := store.ImageStore()
+	storageDriver := store.GraphDriverName()
+
+	verbose := c.Bool("verbose")
+
+	// Analyze container storage
+	var graphRootPath string
+	if imagePath == "" {
+		graphRootPath = path.Join(rootPath, storageDriver+"-images")
+	} else {
+		graphRootPath = path.Join(rootPath, storageDriver+"-containers")
+	}
+
+	fmt.Println("=== Physical Disk Usage (FIEMAP - Reflink-Aware) ===")
+	fmt.Printf("Storage driver: %s\n", storageDriver)
+	fmt.Printf("Graph root: %s\n\n", rootPath)
+
+	// Total usage across all storage
+	var totalStandard, totalReal uint64
+
+	// Container storage
+	fmt.Printf("Analyzing container storage: %s\n", graphRootPath)
+	standardBytes, standardInodes, err := utils.GetDiskUsageStats(graphRootPath)
+	if err != nil {
+		return fmt.Errorf("failed to get standard usage for %s: %w", graphRootPath, err)
+	}
+
+	realBytes, realInodes, err := utils.GetRealPhysicalUsage(graphRootPath)
+	if err != nil {
+		return fmt.Errorf("failed to get real usage for %s: %w", graphRootPath, err)
+	}
+
+	printUsage("Container storage", standardBytes, standardInodes, realBytes, realInodes, verbose)
+	totalStandard += standardBytes
+	totalReal += realBytes
+
+	// Image storage (if separate)
+	if imagePath != "" {
+		imageRoot := path.Join(imagePath, storageDriver+"-images")
+		fmt.Printf("\nAnalyzing image storage: %s\n", imageRoot)
+
+		standardBytes, standardInodes, err = utils.GetDiskUsageStats(imageRoot)
+		if err != nil {
+			return fmt.Errorf("failed to get standard usage for %s: %w", imageRoot, err)
+		}
+
+		realBytes, realInodes, err = utils.GetRealPhysicalUsage(imageRoot)
+		if err != nil {
+			return fmt.Errorf("failed to get real usage for %s: %w", imageRoot, err)
+		}
+
+		printUsage("Image storage", standardBytes, standardInodes, realBytes, realInodes, verbose)
+		totalStandard += standardBytes
+		totalReal += realBytes
+	}
+
+	// Summary
+	fmt.Println("\n=== Summary ===")
+	saved := int64(totalStandard) - int64(totalReal)
+	if saved > 0 {
+		pct := float64(saved) / float64(totalStandard) * 100
+		fmt.Printf("Standard reporting:  %s (%d inodes)\n", formatBytes(totalStandard), standardInodes)
+		fmt.Printf("Real physical usage: %s (%d inodes)\n", formatBytes(totalReal), realInodes)
+		fmt.Printf("Space saved by deduplication: %s (%.1f%%)\n", formatBytes(uint64(saved)), pct)
+	} else {
+		fmt.Printf("Total usage: %s\n", formatBytes(totalReal))
+		fmt.Println("No deduplication detected")
+	}
+
+	return nil
+}
+
+func printUsage(label string, standardBytes, standardInodes, realBytes, realInodes uint64, verbose bool) {
+	saved := int64(standardBytes) - int64(realBytes)
+
+	if verbose {
+		fmt.Printf("  Standard (stat.Blocks): %s (%d inodes)\n", formatBytes(standardBytes), standardInodes)
+		fmt.Printf("  Real (FIEMAP):          %s (%d inodes)\n", formatBytes(realBytes), realInodes)
+	}
+
+	if saved > 0 {
+		pct := float64(saved) / float64(standardBytes) * 100
+		fmt.Printf("  %s: %s (%.1f%% dedup savings)\n", label, formatBytes(realBytes), pct)
+	} else {
+		fmt.Printf("  %s: %s (no dedup)\n", label, formatBytes(realBytes))
+	}
+}
+
+func formatBytes(bytes uint64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := uint64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/utils/filesystem_fiemap_linux.go
+++ b/utils/filesystem_fiemap_linux.go
@@ -1,0 +1,150 @@
+//go:build linux
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+// GetRealPhysicalUsage returns actual disk usage accounting for shared extents (reflinks).
+// This uses the FIEMAP ioctl to get physical extent mappings and tracks which blocks
+// are shared between files to avoid double-counting deduplicated data.
+//
+// This is significantly more expensive than GetDiskUsageStats as it requires FIEMAP
+// ioctl calls for every regular file. Use this when accurate reflink-aware reporting
+// is critical (e.g., when containers-storage dedup is active).
+//
+// Returns bytes of unique physical blocks and inode count.
+func GetRealPhysicalUsage(path string) (uniqueBytes, inodeCount uint64, err error) {
+	seenExtents := make(map[uint64]uint64)
+
+	err = filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		inodeCount++
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		extents, err := getFileExtents(p)
+		if err != nil {
+			if sys := info.Sys(); sys != nil {
+				if stat, ok := sys.(*syscall.Stat_t); ok {
+					uniqueBytes += uint64(stat.Blocks) * 512
+				} else {
+					uniqueBytes += uint64(info.Size())
+				}
+			} else {
+				uniqueBytes += uint64(info.Size())
+			}
+			return nil
+		}
+
+		for _, ext := range extents {
+			if ext.Physical == 0 {
+				continue
+			}
+
+			if existingLen, seen := seenExtents[ext.Physical]; seen {
+				if ext.Length > existingLen {
+					uniqueBytes += ext.Length - existingLen
+					seenExtents[ext.Physical] = ext.Length
+				}
+			} else {
+				uniqueBytes += ext.Length
+				seenExtents[ext.Physical] = ext.Length
+			}
+		}
+
+		return nil
+	})
+
+	return uniqueBytes, inodeCount, err
+}
+
+// FiemapExtent represents a single extent from FIEMAP
+type FiemapExtent struct {
+	Logical  uint64
+	Physical uint64
+	Length   uint64
+	Flags    uint32
+}
+
+func getFileExtents(path string) ([]FiemapExtent, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if stat.Size() == 0 {
+		return nil, nil
+	}
+
+	const (
+		fiemapMaxExtents = 512
+		fiemapFlagSync   = 0x00000001
+	)
+
+	type fiemapExtent struct {
+		feLogical  uint64
+		fePhysical uint64
+		feLength   uint64
+		_          [2]uint64
+		feFlags    uint32
+		_          [3]uint32
+	}
+
+	type fiemap struct {
+		fmStart         uint64
+		fmLength        uint64
+		fmFlags         uint32
+		fmMappedExtents uint32
+		fmExtentCount   uint32
+		_               uint32
+		fmExtents       [fiemapMaxExtents]fiemapExtent
+	}
+
+	var fm fiemap
+	fm.fmStart = 0
+	fm.fmLength = uint64(stat.Size())
+	fm.fmFlags = fiemapFlagSync
+	fm.fmExtentCount = fiemapMaxExtents
+
+	const FS_IOC_FIEMAP = 0xC020660B
+
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		f.Fd(),
+		FS_IOC_FIEMAP,
+		uintptr(unsafe.Pointer(&fm)),
+	)
+
+	if errno != 0 {
+		return nil, fmt.Errorf("FIEMAP ioctl failed: %v", errno)
+	}
+
+	extents := make([]FiemapExtent, fm.fmMappedExtents)
+	for i := uint32(0); i < fm.fmMappedExtents; i++ {
+		extents[i] = FiemapExtent{
+			Logical:  fm.fmExtents[i].feLogical,
+			Physical: fm.fmExtents[i].fePhysical,
+			Length:   fm.fmExtents[i].feLength,
+			Flags:    fm.fmExtents[i].feFlags,
+		}
+	}
+
+	return extents, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind feature

#### What this PR does / why we need it:

Currently WIP: I'm trying to find a way to integrate this into dedup command or thinking if this should be a part of stats.

Follow up of https://github.com/cri-o/cri-o/pull/9824

Add GetRealPhysicalUsage() function and 'crio physical-disk-usage' command to accurately report disk usage when reflinks/deduplication is active.

Background:
- GetDiskUsageStats() counts stat.Blocks per file
- When files share blocks via reflinks (e.g., containers-storage dedup), shared extents are counted multiple times

- GetRealPhysicalUsage: Slow (FIEMAP ioctl per file), accurate

- Example output:
    Container storage: 56.00 MiB (26.3% dedup savings)
    Image storage: 120.50 MiB (18.5% dedup savings)
    Total saved by deduplication: 45.2 MiB

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

cc: @haircommander @asahay19 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
