### PR TITLE
Pin conmon-rs to v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.1
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/conmon-rs v0.8.1-0.20260702110516-b5ec72de6187
+	github.com/containers/conmon-rs v1.0.1
 	github.com/containers/kubensmnt v1.2.0
 	github.com/containers/ocicrypt v1.3.0
 	github.com/coreos/go-systemd/v22 v22.7.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/containernetworking/plugins v1.9.1 h1:8oU6WsIsU3bpnNZuvHp74a6cE1MJwbj
 github.com/containernetworking/plugins v1.9.1/go.mod h1:fj7kS55qg3o/RgS+WGsF3+ZxwIImMPusQZKzBpcSr4c=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/conmon-rs v0.8.1-0.20260702110516-b5ec72de6187 h1:kLsKL3QbDtFQ8ag1BcSG8RR5rk0X1YHRTGODFawyi14=
-github.com/containers/conmon-rs v0.8.1-0.20260702110516-b5ec72de6187/go.mod h1:W4UCCXxBHbmMIfLgd/7zrJFxOL4PxwviWxEC6yxQ2K4=
+github.com/containers/conmon-rs v1.0.1 h1:tP7XLV5iZ67UWi3WwfacxN+LfEK/aNxpOkTuxDHkixU=
+github.com/containers/conmon-rs v1.0.1/go.mod h1:W4UCCXxBHbmMIfLgd/7zrJFxOL4PxwviWxEC6yxQ2K4=
 github.com/containers/kubensmnt v1.2.0 h1:BDtkaOFQ5fN7FnB9kC6peMW50KkwI1KI8E9ROBFeQIg=
 github.com/containers/kubensmnt v1.2.0/go.mod h1:1/HG09N/a1+WSD3zkurzeWtqlKRSfUUnlIF/08zloqk=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/github.com/containers/conmon-rs/pkg/client/client.go
+++ b/vendor/github.com/containers/conmon-rs/pkg/client/client.go
@@ -37,11 +37,11 @@ const (
 )
 
 var (
-	errRuntimeUnspecified     = errors.New("runtime must be specified")
-	errRunDirUnspecified      = errors.New("RunDir must be specified")
-	errInvalidValue           = errors.New("invalid value")
-	errRunDirNotCreated       = errors.New("could not create RunDir")
-	errTimeoutWaitForPid      = errors.New("timed out waiting for server PID to disappear")
+	errRuntimeUnspecified = errors.New("runtime must be specified")
+	errRunDirUnspecified  = errors.New("RunDir must be specified")
+	errInvalidValue       = errors.New("invalid value")
+	errRunDirNotCreated   = errors.New("could not create RunDir")
+	errTimeoutWaitForPid  = errors.New("timed out waiting for server PID to disappear")
 )
 
 // ConmonClient is the main client structure of this package.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -232,7 +232,7 @@ github.com/containernetworking/plugins/pkg/ns
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit
 github.com/containers/conmon/runner/config
-# github.com/containers/conmon-rs v0.8.1-0.20260702110516-b5ec72de6187
+# github.com/containers/conmon-rs v1.0.1
 ## explicit; go 1.26.3
 github.com/containers/conmon-rs/internal/proto
 github.com/containers/conmon-rs/pkg/client


### PR DESCRIPTION
/kind dependency-change
/kind api-change

#### What type of PR is this?

Dependency update with breaking changes.

#### What this PR does / why we need it:

Updates conmon-rs from a pre-release pseudo-version to the stable v1.0.1 release. Pinning to v1.0.1 instead of v1.0.0 because a RUSTSEC advisory (RUSTSEC-2026-0007) was found after the v1.0.0 release. This is a breaking change: conmon-rs v1.0.0 removed deprecated `metadataOld` Cap'n Proto fields and `RequestWithMetadataOld` backward compatibility in the Go client, so previous conmon-rs versions are no longer supported.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Release notes: https://github.com/containers/conmon-rs/releases/tag/v1.0.1

#### Does this PR introduce a user-facing change?

```release-note
Add conmon-rs v1.0.1 support, drop backward compatibility with previous versions.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a bundled container-related dependency to `v1.0.1` to pick up the latest fixes and improvements.
  * Kept the rest of the project configuration unchanged, limiting the change to the dependency version only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->