### PR TITLE
Add 'crio dedup' command with FIEMAP physical disk usage

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -162,6 +162,7 @@ func main() {
 	app.Commands = append(app.Commands,
 		criocli.CheckCommand,
 		criocli.ConfigCommand,
+		criocli.DedupCommand,
 		criocli.PublishCommand,
 		criocli.StatusCommand,
 		criocli.VersionCommand,

--- a/completions/bash/crio
+++ b/completions/bash/crio
@@ -6,6 +6,7 @@ _cli_bash_autocomplete() {
 complete
 completion
 config
+dedup
 man
 markdown
 md

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -2,7 +2,7 @@
 
 function __fish_crio_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i check complete completion help h config man markdown md status config c containers container cs s info i goroutines g heap hp version wipe help h
+        if contains -- $i check complete completion help h config dedup man markdown md status config c containers container cs s info i goroutines g heap hp version wipe help h
             return 1
         end
     end
@@ -225,6 +225,28 @@ complete -r -c crio -n '__fish_crio_no_subcommand' -a 'config' -d 'Outputs a com
 by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.'
 complete -c crio -n '__fish_seen_subcommand_from config' -f -l default -d 'Output the default configuration (without taking into account any configuration options).'
+complete -c crio -n '__fish_seen_subcommand_from dedup' -f -l help -s h -d 'show help'
+complete -r -c crio -n '__fish_crio_no_subcommand' -a 'dedup' -d 'Deduplicate similar files in image layers using filesystem reflinks.
+
+    Deduplication uses copy-on-write (reflink) to share identical blocks across
+    image layers, reducing physical disk usage. Unlike hard links, reflinks allow
+    independent modification of files. Requires filesystem support (XFS with
+    reflink=1, Btrfs, etc).
+
+    Deduplication finds files with identical content across image layers and uses
+    the FIEMAP ioctl to deduplicate them via reflinks. The process uses SHA256
+    hashing to identify duplicate files.
+
+    This command should be run while CRI-O is stopped to avoid conflicts with
+    running containers.
+
+    When deduplication occurs: Deduplication happens after images are pulled
+    and stored. Space savings occur when multiple images share common layers or
+    when duplicate files exist across different image layers. Storage capacity
+    must still accommodate initial image pulls before deduplication runs.'
+complete -c crio -n '__fish_seen_subcommand_from dedup' -f -l physical-disk-usage -s p -d 'Measure and report actual physical disk usage before and after deduplication using FIEMAP ioctl.
+    This provides reflink-aware reporting that shows true space savings by accounting for shared extents.
+    Linux only.'
 complete -c crio -n '__fish_seen_subcommand_from man' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'man' -d 'Generate the man page documentation.'
 complete -c crio -n '__fish_seen_subcommand_from markdown md' -f -l help -s h -d 'show help'

--- a/completions/zsh/_crio
+++ b/completions/zsh/_crio
@@ -26,6 +26,24 @@ best if CRI-O and any currently running containers are stopped."
         'config:Outputs a commented version of the configuration file that could be used
 by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.'
+        'dedup:Deduplicate similar files in image layers using filesystem reflinks.
+
+    Deduplication uses copy-on-write (reflink) to share identical blocks across
+    image layers, reducing physical disk usage. Unlike hard links, reflinks allow
+    independent modification of files. Requires filesystem support (XFS with
+    reflink=1, Btrfs, etc).
+
+    Deduplication finds files with identical content across image layers and uses
+    the FIEMAP ioctl to deduplicate them via reflinks. The process uses SHA256
+    hashing to identify duplicate files.
+
+    This command should be run while CRI-O is stopped to avoid conflicts with
+    running containers.
+
+    When deduplication occurs: Deduplication happens after images are pulled
+    and stored. Space savings occur when multiple images share common layers or
+    when duplicate files exist across different image layers. Storage capacity
+    must still accommodate initial image pulls before deduplication runs.'
         'man:Generate the man page documentation.'
         'markdown:Generate the markdown documentation.'
         'md:Generate the markdown documentation.'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -537,6 +537,31 @@ it later with **--config**. Global options will modify the output.
 
 **--default**: Output the default configuration (without taking into account any configuration options).
 
+## dedup
+
+Deduplicate similar files in image layers using filesystem reflinks.
+
+    Deduplication uses copy-on-write (reflink) to share identical blocks across
+    image layers, reducing physical disk usage. Unlike hard links, reflinks allow
+    independent modification of files. Requires filesystem support (XFS with
+    reflink=1, Btrfs, etc).
+
+    Deduplication finds files with identical content across image layers and uses
+    the FIEMAP ioctl to deduplicate them via reflinks. The process uses SHA256
+    hashing to identify duplicate files.
+
+    This command should be run while CRI-O is stopped to avoid conflicts with
+    running containers.
+
+    When deduplication occurs: Deduplication happens after images are pulled
+    and stored. Space savings occur when multiple images share common layers or
+    when duplicate files exist across different image layers. Storage capacity
+    must still accommodate initial image pulls before deduplication runs.
+
+**--physical-disk-usage, -p**: Measure and report actual physical disk usage before and after deduplication using FIEMAP ioctl.
+    This provides reflink-aware reporting that shows true space savings by accounting for shared extents.
+    Linux only.
+
 ## man
 
 Generate the man page documentation.

--- a/internal/criocli/dedup.go
+++ b/internal/criocli/dedup.go
@@ -1,0 +1,70 @@
+package criocli
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/server"
+)
+
+// DedupCommand is the `crio dedup` subcommand for running storage
+// deduplication on demand. It opens the storage, runs deduplication
+// using reflinks, and reports the result. This should be run while
+// CRI-O is stopped to avoid lock contention with image pulls.
+var DedupCommand = &cli.Command{
+	Name: "dedup",
+	Usage: `Deduplicate similar files in image layers using filesystem reflinks.
+
+    Deduplication uses copy-on-write (reflink) to share identical blocks across
+    image layers, reducing physical disk usage. Unlike hard links, reflinks allow
+    independent modification of files. Requires filesystem support (XFS with
+    reflink=1, Btrfs, etc).
+
+    Deduplication finds files with identical content across image layers and uses
+    the FIEMAP ioctl to deduplicate them via reflinks. The process uses SHA256
+    hashing to identify duplicate files.
+
+    This command should be run while CRI-O is stopped to avoid conflicts with
+    running containers.
+
+    When deduplication occurs: Deduplication happens after images are pulled
+    and stored. Space savings occur when multiple images share common layers or
+    when duplicate files exist across different image layers. Storage capacity
+    must still accommodate initial image pulls before deduplication runs.`,
+	Action: crioDedup,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "physical-disk-usage",
+			Aliases: []string{"p"},
+			Usage: `Measure and report actual physical disk usage before and after deduplication using FIEMAP ioctl.
+    This provides reflink-aware reporting that shows true space savings by accounting for shared extents.
+    Linux only.`,
+		},
+	},
+}
+
+func crioDedup(c *cli.Context) error {
+	ctx := c.Context
+
+	config, err := GetConfigFromContext(c)
+	if err != nil {
+		return fmt.Errorf("unable to load configuration: %w", err)
+	}
+
+	store, err := config.GetStore()
+	if err != nil {
+		return fmt.Errorf("unable to open storage: %w", err)
+	}
+
+	defer func() {
+		if _, err := store.Shutdown(true); err != nil {
+			log.Errorf(ctx, "Unable to shutdown storage: %v", err)
+		}
+	}()
+
+	showPhysicalUsage := c.Bool("physical-disk-usage")
+
+	return server.RunDedup(ctx, store, showPhysicalUsage)
+}

--- a/server/dedup.go
+++ b/server/dedup.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"go.podman.io/storage"
+	"golang.org/x/sys/unix"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/utils"
+)
+
+// RunDedup runs a single storage deduplication pass using reflinks.
+// It calls store.Dedup with SHA256 hashing. If showPhysicalUsage is true,
+// measures real physical disk usage before and after dedup using FIEMAP (Linux only).
+func RunDedup(ctx context.Context, store storage.Store, showPhysicalUsage bool) error {
+	var beforeUsage uint64
+
+	// Measure physical usage before dedup
+	if showPhysicalUsage {
+		log.Infof(ctx, "Measuring physical disk usage before deduplication...")
+
+		usage, err := measurePhysicalUsage(ctx, store)
+		if err != nil {
+			log.Warnf(ctx, "Failed to measure initial disk usage: %v", err)
+		} else {
+			beforeUsage = usage
+			log.Infof(ctx, "Physical disk usage before dedup: %s", formatBytes(beforeUsage))
+		}
+	}
+
+	log.Infof(ctx, "Starting storage deduplication (this may take several minutes)...")
+
+	_, err := store.Dedup(storage.DedupArgs{
+		Options: storage.DedupOptions{
+			HashMethod: storage.DedupHashSHA256,
+		},
+	})
+	if err != nil {
+		if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.EOPNOTSUPP) {
+			return fmt.Errorf("storage deduplication not supported on current filesystem: %w", err)
+		}
+
+		return fmt.Errorf("storage deduplication failed: %w", err)
+	}
+
+	log.Infof(ctx, "Storage deduplication complete")
+
+	// Measure physical usage after dedup and show savings
+	if showPhysicalUsage && beforeUsage > 0 {
+		log.Infof(ctx, "Measuring physical disk usage after deduplication...")
+
+		afterUsage, err := measurePhysicalUsage(ctx, store)
+		if err != nil {
+			log.Warnf(ctx, "Failed to measure final disk usage: %v", err)
+		} else {
+			log.Infof(ctx, "Physical disk usage after dedup: %s", formatBytes(afterUsage))
+
+			if beforeUsage > afterUsage {
+				saved := beforeUsage - afterUsage
+				pct := float64(saved) / float64(beforeUsage) * 100
+				log.Infof(ctx, "Space saved by deduplication: %s (%.1f%%)", formatBytes(saved), pct)
+			} else {
+				log.Infof(ctx, "No space savings detected (blocks may already be shared)")
+			}
+
+			// Show detailed breakdown (reuses afterUsage, only measures standard once)
+			if err := reportPhysicalUsage(ctx, store, afterUsage); err != nil {
+				log.Warnf(ctx, "Failed to report detailed physical disk usage: %v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func measurePhysicalUsage(_ context.Context, store storage.Store) (uint64, error) {
+	rootPath := store.GraphRoot()
+	imagePath := store.ImageStore()
+	storageDriver := store.GraphDriverName()
+
+	var totalReal uint64
+
+	overlayPath := path.Join(rootPath, storageDriver)
+
+	realBytes, _, err := utils.GetRealPhysicalUsage(overlayPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get real usage for %s: %w", overlayPath, err)
+	}
+
+	totalReal += realBytes
+
+	layersPath := path.Join(rootPath, storageDriver+"-layers")
+
+	realBytes, _, err = utils.GetRealPhysicalUsage(layersPath)
+	if err == nil {
+		totalReal += realBytes
+	}
+
+	if imagePath != "" {
+		imageOverlayPath := path.Join(imagePath, storageDriver)
+
+		realBytes, _, err = utils.GetRealPhysicalUsage(imageOverlayPath)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get real usage for %s: %w", imageOverlayPath, err)
+		}
+
+		totalReal += realBytes
+
+		imageLayersPath := path.Join(imagePath, storageDriver+"-layers")
+
+		realBytes, _, err = utils.GetRealPhysicalUsage(imageLayersPath)
+		if err == nil {
+			totalReal += realBytes
+		}
+	}
+
+	return totalReal, nil
+}
+
+func reportPhysicalUsage(ctx context.Context, store storage.Store, totalRealUsage uint64) error {
+	rootPath := store.GraphRoot()
+	imagePath := store.ImageStore()
+	storageDriver := store.GraphDriverName()
+
+	log.Infof(ctx, "=== Detailed Physical Disk Usage (FIEMAP - Reflink-Aware) ===")
+	log.Infof(ctx, "Storage driver: %s", storageDriver)
+	log.Infof(ctx, "Graph root: %s", rootPath)
+
+	var totalStandard uint64
+
+	overlayPath := path.Join(rootPath, storageDriver)
+	log.Infof(ctx, "Layer data storage: %s", overlayPath)
+
+	standardBytes, _, err := utils.GetDiskUsageStats(overlayPath)
+	if err != nil {
+		return fmt.Errorf("failed to get standard usage for %s: %w", overlayPath, err)
+	}
+
+	totalStandard += standardBytes
+
+	layersPath := path.Join(rootPath, storageDriver+"-layers")
+	log.Infof(ctx, "Layer metadata: %s", layersPath)
+
+	standardBytes, _, err = utils.GetDiskUsageStats(layersPath)
+	if err != nil {
+		log.Warnf(ctx, "Could not measure %s: %v", layersPath, err)
+	} else {
+		totalStandard += standardBytes
+	}
+
+	if imagePath != "" {
+		imageOverlayPath := path.Join(imagePath, storageDriver)
+		log.Infof(ctx, "Image layer data storage: %s", imageOverlayPath)
+
+		standardBytes, _, err = utils.GetDiskUsageStats(imageOverlayPath)
+		if err != nil {
+			return fmt.Errorf("failed to get standard usage for %s: %w", imageOverlayPath, err)
+		}
+
+		totalStandard += standardBytes
+
+		imageLayersPath := path.Join(imagePath, storageDriver+"-layers")
+		log.Infof(ctx, "Image layer metadata: %s", imageLayersPath)
+
+		standardBytes, _, err = utils.GetDiskUsageStats(imageLayersPath)
+		if err != nil {
+			log.Warnf(ctx, "Could not measure %s: %v", imageLayersPath, err)
+		} else {
+			totalStandard += standardBytes
+		}
+	}
+
+	// Summary
+	log.Infof(ctx, "=== Summary ===")
+
+	saved := int64(totalStandard) - int64(totalRealUsage)
+	if saved > 0 {
+		pct := float64(saved) / float64(totalStandard) * 100
+		log.Infof(ctx, "Standard reporting (stat.Blocks): %s", formatBytes(totalStandard))
+		log.Infof(ctx, "Real physical usage (FIEMAP):     %s", formatBytes(totalRealUsage))
+		log.Infof(ctx, "Shared blocks from reflinks:      %s (%.1f%%)", formatBytes(uint64(saved)), pct)
+	} else {
+		log.Infof(ctx, "Total physical usage: %s", formatBytes(totalRealUsage))
+		log.Infof(ctx, "No shared blocks detected (standard and FIEMAP match)")
+	}
+
+	return nil
+}
+
+func formatBytes(bytes uint64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+
+	div, exp := uint64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.2f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/server/dedup_test.go
+++ b/server/dedup_test.go
@@ -1,0 +1,84 @@
+package server_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	graphdriver "go.podman.io/storage/drivers"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/sys/unix"
+
+	"github.com/cri-o/cri-o/server"
+)
+
+var _ = t.Describe("Dedup", func() {
+	// Prepare the sut
+	BeforeEach(beforeEach)
+	AfterEach(afterEach)
+
+	t.Describe("RunDedup", func() {
+		It("should succeed when dedup saves bytes", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{Deduped: 1024}, nil)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed when dedup has no savings", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{Deduped: 0}, nil)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error on ENOTSUP", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{}, unix.ENOTSUP)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not supported"))
+		})
+
+		It("should return error on EOPNOTSUPP", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{}, unix.EOPNOTSUPP)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not supported"))
+		})
+
+		It("should return error on other failures", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{}, t.TestError)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed"))
+		})
+	})
+})

--- a/test/dedup.bats
+++ b/test/dedup.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+load helpers
+
+IMAGE=quay.io/crio/pause
+IMAGE2=quay.io/crio/fedora-crio-ci:latest
+IMAGE3=quay.io/crio/alpine:3.9
+IMAGE4=quay.io/saschagrunert/hello-world
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "dedup: crio dedup command succeeds with populated storage" {
+	start_crio
+
+	crictl pull "$IMAGE"
+
+	stop_crio
+
+	run "$CRIO_BINARY_PATH" \
+		-c "$CRIO_CONFIG" \
+		-d "$CRIO_CONFIG_DIR" \
+		dedup
+
+	if [[ "$output" == *"storage deduplication not supported on current filesystem"* ]]; then
+		skip "filesystem does not support reflinks"
+	fi
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Starting storage deduplication"* ]]
+	[[ "$output" == *"Storage deduplication complete"* ]]
+}
+
+@test "dedup: crio dedup with --physical-disk-usage shows savings" {
+	start_crio
+
+	crictl pull "$IMAGE"
+	crictl pull "$IMAGE2"
+	crictl pull "$IMAGE3"
+	crictl pull "$IMAGE4"
+
+	stop_crio
+
+	run "$CRIO_BINARY_PATH" \
+		-c "$CRIO_CONFIG" \
+		-d "$CRIO_CONFIG_DIR" \
+		dedup --physical-disk-usage
+
+	if [[ "$output" == *"storage deduplication not supported on current filesystem"* ]]; then
+		skip "filesystem does not support reflinks"
+	fi
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Starting storage deduplication"* ]]
+	[[ "$output" == *"Storage deduplication complete"* ]]
+	[[ "$output" == *"Measuring physical disk usage before deduplication"* ]]
+	[[ "$output" == *"Measuring physical disk usage after deduplication"* ]]
+
+	before_line=$(echo "$output" | grep "Physical disk usage before dedup:")
+	after_line=$(echo "$output" | grep "Physical disk usage after dedup:")
+
+	[ -n "$before_line" ]
+	[ -n "$after_line" ]
+
+	if [[ "$output" == *"No space savings detected"* ]]; then
+		skip "no deduplication savings (filesystem may not support reflinks or no duplicate data found)"
+	fi
+
+	[[ "$output" == *"Space saved by deduplication"* ]]
+
+	savings_line=$(echo "$output" | grep "Space saved by deduplication:")
+	[ -n "$savings_line" ]
+}
+
+@test "dedup: server remains functional after dedup on populated storage" {
+	start_crio
+
+	crictl pull "$IMAGE"
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+
+	stop_crio
+
+	run "$CRIO_BINARY_PATH" \
+		-c "$CRIO_CONFIG" \
+		-d "$CRIO_CONFIG_DIR" \
+		dedup
+
+	if [[ "$output" == *"storage deduplication not supported on current filesystem"* ]]; then
+		skip "filesystem does not support reflinks"
+	fi
+
+	[ "$status" -eq 0 ]
+
+	start_crio
+
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+}

--- a/utils/filesystem_fiemap_linux.go
+++ b/utils/filesystem_fiemap_linux.go
@@ -1,0 +1,157 @@
+//go:build linux
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+// GetRealPhysicalUsage returns actual disk usage accounting for shared extents (reflinks).
+// This uses the FIEMAP ioctl to get physical extent mappings and tracks which blocks
+// are shared between files to avoid double-counting deduplicated data.
+//
+// This is significantly more expensive than GetDiskUsageStats as it requires FIEMAP
+// ioctl calls for every regular file. Use this when accurate reflink-aware reporting
+// is critical (e.g., when containers-storage dedup is active).
+//
+// Returns bytes of unique physical blocks and inode count.
+func GetRealPhysicalUsage(path string) (uniqueBytes, inodeCount uint64, err error) {
+	seenExtents := make(map[uint64]uint64)
+
+	err = filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			// Skip files that disappeared during traversal
+			if os.IsNotExist(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		inodeCount++
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		extents, err := getFileExtents(p)
+		if err != nil {
+			if sys := info.Sys(); sys != nil {
+				if stat, ok := sys.(*syscall.Stat_t); ok {
+					uniqueBytes += uint64(stat.Blocks) * 512
+				} else {
+					uniqueBytes += uint64(info.Size())
+				}
+			} else {
+				uniqueBytes += uint64(info.Size())
+			}
+
+			return nil
+		}
+
+		for _, ext := range extents {
+			if ext.Physical == 0 {
+				continue
+			}
+
+			if existingLen, seen := seenExtents[ext.Physical]; seen {
+				if ext.Length > existingLen {
+					uniqueBytes += ext.Length - existingLen
+					seenExtents[ext.Physical] = ext.Length
+				}
+			} else {
+				uniqueBytes += ext.Length
+				seenExtents[ext.Physical] = ext.Length
+			}
+		}
+
+		return nil
+	})
+
+	return uniqueBytes, inodeCount, err
+}
+
+// FiemapExtent represents a single extent from FIEMAP.
+type FiemapExtent struct {
+	Logical  uint64
+	Physical uint64
+	Length   uint64
+	Flags    uint32
+}
+
+func getFileExtents(path string) ([]FiemapExtent, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if stat.Size() == 0 {
+		return nil, nil
+	}
+
+	const (
+		fiemapMaxExtents = 512
+		fiemapFlagSync   = 0x00000001
+	)
+
+	type fiemapExtent struct {
+		feLogical  uint64
+		fePhysical uint64
+		feLength   uint64
+		_          [2]uint64
+		feFlags    uint32
+		_          [3]uint32
+	}
+
+	type fiemap struct {
+		fmStart         uint64
+		fmLength        uint64
+		fmFlags         uint32
+		fmMappedExtents uint32
+		fmExtentCount   uint32
+		_               uint32
+		fmExtents       [fiemapMaxExtents]fiemapExtent
+	}
+
+	var fm fiemap
+
+	fm.fmStart = 0
+	fm.fmLength = uint64(stat.Size())
+	fm.fmFlags = fiemapFlagSync
+	fm.fmExtentCount = fiemapMaxExtents
+
+	const FS_IOC_FIEMAP = 0xC020660B
+
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		f.Fd(),
+		FS_IOC_FIEMAP,
+		uintptr(unsafe.Pointer(&fm)),
+	)
+
+	if errno != 0 {
+		return nil, fmt.Errorf("FIEMAP ioctl failed: %w", errno)
+	}
+
+	extents := make([]FiemapExtent, fm.fmMappedExtents)
+	for i := range fm.fmMappedExtents {
+		extents[i] = FiemapExtent{
+			Logical:  fm.fmExtents[i].feLogical,
+			Physical: fm.fmExtents[i].fePhysical,
+			Length:   fm.fmExtents[i].feLength,
+			Flags:    fm.fmExtents[i].feFlags,
+		}
+	}
+
+	return extents, nil
+}

--- a/utils/filesystem_fiemap_unsupported.go
+++ b/utils/filesystem_fiemap_unsupported.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package utils
+
+import "fmt"
+
+// GetRealPhysicalUsage is not supported on non-Linux platforms.
+func GetRealPhysicalUsage(path string) (uniqueBytes, inodeCount uint64, err error) {
+	return 0, 0, fmt.Errorf("GetRealPhysicalUsage is only supported on Linux")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind feature

#### What this PR does / why we need it:
Add support for Dedup and calculate disk usage. Most of the details are in the doc change in this PR.

Regarding the bats test. The Bats test runs on `/tmp` where dedup can't happen. For proper error reporting I'm discussing here: https://github.com/podman-container-tools/container-libs/pull/961

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
cc: @haircommander @asahay19 I have only retained the dedup command added the calculation of storage
Reference PR from @harche : https://github.com/cri-o/cri-o/pull/9824

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add support for dedup command and physical disk usage calculation
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a `crio dedup` command to deduplicate image storage using reflinks and SHA256 hashing.
  * Added `--physical-disk-usage/-p` to measure physical usage before/after deduplication (Linux only).
  * Updated bash, fish, and zsh completions; added the `dedup` section to the `crio` man page.
* **Bug Fixes**
  * Improved handling and messaging for unsupported filesystem/dedup scenarios.
* **Tests**
  * Added unit tests for `RunDedup` and Bats integration tests covering dedup runs and CRI-O operability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->