### PR TITLE
Pin version of crun in CI to 1.28

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -187,4 +187,4 @@ kata_skip_annotation_migration_tests:
   - 'test "v2 unified-cgroup annotation for specific container with slash separator should work"'
 
 runc_git_version: v1.5.0
-crun_git_version: 1.23.1
+crun_git_version: 1.28

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,6 +70,14 @@ dependencies:
       - path: scripts/versions
         match: buildah
 
+  - name: crun
+    version: 1.28
+    refPaths:
+      - path: scripts/versions
+        match: crun
+      - path: contrib/test/ci/vars.yml
+        match: crun_git_version
+
   - name: runc
     version: v1.5.0
     refPaths:

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -115,6 +115,7 @@ install_cni_plugins() {
 install_crun() {
     git clone https://github.com/containers/crun
     pushd crun
+    git checkout "${VERSIONS["crun"]}"
     ./autogen.sh
     ./configure
     sudo make -j "$(nproc)" install prefix=/usr

--- a/scripts/versions
+++ b/scripts/versions
@@ -3,6 +3,7 @@ declare -A VERSIONS=(
     ["cni-plugins"]=v1.8.0
     ["conmon"]=v2.1.13
     ["cri-tools"]=v1.36.0
+    ["crun"]=1.28
     ["runc"]=v1.5.0
     ["bats"]=v1.12.0
     ["buildah"]=v1.38.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind ci

#### What this PR does / why we need it:

Pins the version of crun. Uses the version from:
https://github.com/cri-o/cri-o/blob/main/contrib/test/ci/vars.yml#L190

This fixes the failing test in the CI:
```
2026-07-06T10:25:15.2798548Z [38;5;9m• [FAILED] [1.946 seconds][0m
2026-07-06T10:25:15.2800448Z [0m[k8s.io] Container Mount Propagation [38;5;243mruntime should support mount propagation [38;5;9m[1m[It] mount with 'rshared' should support propagation from host to container and vice versa[0m
```

Failed CI runs: https://github.com/cri-o/cri-o/actions/runs/28777733242/job/85348127167?pr=10111

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
