### PR TITLE
Populate container name and pod sandbox ID in NRI events

### DIFF
--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -13,6 +13,7 @@ import (
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1"
+	kubeletTypes "k8s.io/kubelet/pkg/types"
 	"tags.cncf.io/container-device-interface/pkg/cdi"
 
 	"github.com/cri-o/cri-o/internal/annotations"
@@ -668,11 +669,27 @@ func (c *criContainer) GetID() string {
 }
 
 func (c *criContainer) GetPodSandboxID() string {
-	return c.GetSpec().Annotations[annotations.SandboxID]
+	if id := c.GetSpec().Annotations[annotations.SandboxID]; id != "" {
+		return id
+	}
+
+	if c.ctr != nil {
+		return c.ctr.Sandbox()
+	}
+
+	return ""
 }
 
 func (c *criContainer) GetName() string {
-	return c.GetSpec().Annotations["io.kubernetes.container.name"]
+	if name := c.GetSpec().Annotations[kubeletTypes.KubernetesContainerNameLabel]; name != "" {
+		return name
+	}
+
+	if c.ctr != nil {
+		return c.ctr.Metadata().GetName()
+	}
+
+	return ""
 }
 
 func (c *criContainer) GetStatus() *nri.ContainerStatus {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:

The `GetName()` method on `criContainer` in `server/nri-api.go` reads the container name solely from the OCI spec annotation `io.kubernetes.container.name`. This annotation originates as a CRI label set by the kubelet, so when a CRI client (like critest) doesn't set this label, the NRI `CreateContainer` event has an empty `ContainerName`.

This PR adds a fallback to `c.ctr.Metadata().GetName()`, which reads the container name from the CRI `ContainerConfig.Metadata.Name` field which is a required field that every CRI client populates.

Additionally, `GetPodSandboxID()` had the same annotation-only pattern and would return empty for CRI clients that don't set the annotation. This PR applies the same fallback, using `c.ctr.Sandbox()` when the annotation is missing.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes #10011
#### Special notes for your reviewer:

The cri-tools NRI conformance test (https://github.com/kubernetes-sigs/cri-tools/pull/2118) currently skips on CRI-O.

**Before fix:**
```
[SKIPPED] spec discrepancy: runtime does not populate container name in NRI CreateContainer event metadata
Ran 0 of 157 Specs — 0 Passed | 157 Skipped
```



**After fix:**
```
STEP: verifying CreateContainer event has correct metadata
• [2.683 seconds]
Ran 2 of 157 Specs — 2 Passed | 155 Skipped
```
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NRI container lifecycle events now correctly include the container name and pod sandbox ID.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container name and sandbox ID resolution so the app now uses fallback values when annotations are missing or empty.
  * This helps prevent blank or incorrect container metadata from appearing in related views and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->