### PR TITLE
seccomp: keep logging blocked syscalls in not stop notifier mode

### DIFF
--- a/internal/config/seccomp/notifier.go
+++ b/internal/config/seccomp/notifier.go
@@ -87,17 +87,17 @@ type Notification struct {
 }
 
 // Ctx returns the context of the notification.
-func (n *Notification) Ctx() context.Context {
+func (n Notification) Ctx() context.Context {
 	return n.ctx
 }
 
 // ContainerID returns the container identifier for the notification.
-func (n *Notification) ContainerID() string {
+func (n Notification) ContainerID() string {
 	return n.containerID
 }
 
 // Syscall returns the syscall name for the notification.
-func (n *Notification) Syscall() string {
+func (n Notification) Syscall() string {
 	return n.syscall
 }
 
@@ -170,6 +170,15 @@ func NewNotifier(
 		return nil, fmt.Errorf("listen for seccomp socket: %w", err)
 	}
 
+	action, ok := v2.GetAnnotationValue(annotationMap, v2.SeccompNotifierAction)
+	if !ok {
+		if err := listener.Close(); err != nil {
+			log.Errorf(ctx, "Unable to close seccomp listener: %v", err)
+		}
+
+		return nil, fmt.Errorf("%s annotation not set on container", v2.SeccompNotifierAction)
+	}
+
 	go func() {
 		for {
 			conn, err := listener.Accept()
@@ -208,11 +217,6 @@ func NewNotifier(
 		}
 	}()
 
-	action, ok := v2.GetAnnotationValue(annotationMap, v2.SeccompNotifierAction)
-	if !ok {
-		return nil, fmt.Errorf("%s annotation not set on container", v2.SeccompNotifierAction)
-	}
-
 	return &Notifier{
 		listener:       listener,
 		syscalls:       sync.Map{},
@@ -222,7 +226,30 @@ func NewNotifier(
 	}, nil
 }
 
+// receiveErrorBackoff throttles the notifier polling loop after a transient
+// receive error to avoid a hot spin on repeated failures.
+const receiveErrorBackoff = 100 * time.Millisecond
+
+type notifierHandler struct {
+	notifReceive func(libseccomp.ScmpFd) (*libseccomp.ScmpNotifReq, error)
+	notifIDValid func(libseccomp.ScmpFd, uint64) error
+	notifRespond func(libseccomp.ScmpFd, *libseccomp.ScmpNotifResp) error
+}
+
 func handler(
+	ctx context.Context,
+	containerID string,
+	msgChan chan Notification,
+	fd libseccomp.ScmpFd,
+) {
+	notifierHandler{
+		notifReceive: libseccomp.NotifReceive,
+		notifIDValid: libseccomp.NotifIDValid,
+		notifRespond: libseccomp.NotifRespond,
+	}.handle(ctx, containerID, msgChan, fd)
+}
+
+func (h notifierHandler) handle(
 	ctx context.Context,
 	containerID string,
 	msgChan chan Notification,
@@ -230,9 +257,15 @@ func handler(
 ) {
 	defer unix.Close(int(fd))
 	for {
-		req, err := libseccomp.NotifReceive(fd)
+		req, err := h.notifReceive(fd)
 		if err != nil {
+			if errors.Is(err, unix.EBADF) || errors.Is(err, unix.ECANCELED) || errors.Is(err, unix.ENOENT) {
+				log.Infof(ctx, "Stopping notifier for container %s", containerID)
+				return
+			}
 			log.Errorf(ctx, "Unable to receive notification: %v", err)
+			time.Sleep(receiveErrorBackoff)
+
 			continue
 		}
 
@@ -257,18 +290,15 @@ func handler(
 		}
 
 		// TOCTOU check
-		if err := libseccomp.NotifIDValid(fd, req.ID); err != nil {
+		if err := h.notifIDValid(fd, req.ID); err != nil {
 			log.Errorf(ctx, "TOCTOU check failed: req.ID is no longer valid: %v", err)
 			continue
 		}
 
-		if err = libseccomp.NotifRespond(fd, resp); err != nil {
+		if err = h.notifRespond(fd, resp); err != nil {
 			log.Errorf(ctx, "Unable to send notification response: %v", err)
 			continue
 		}
-
-		// We only catch the first syscall
-		break
 	}
 }
 

--- a/internal/config/seccomp/notifier_test.go
+++ b/internal/config/seccomp/notifier_test.go
@@ -1,0 +1,207 @@
+//go:build seccomp && linux && cgo && test
+
+package seccomp_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	libseccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
+
+	"github.com/cri-o/cri-o/internal/config/seccomp"
+)
+
+var errReceiveAgain = errors.New("receive again")
+
+var _ = t.Describe("Notifier", func() {
+	t.Describe("handler", func() {
+		It("should keep polling notifications until the seccomp fd closes", func() {
+			// Given
+			msgChan := make(chan seccomp.Notification, 2)
+			notifReceive := stubNotifReceive("getpid", "getppid", unix.ENOENT)
+
+			// When
+			seccomp.RunHandlerForTest(
+				context.Background(),
+				"ctr",
+				msgChan,
+				libseccomp.ScmpFd(-1),
+				notifReceive,
+				stubNotifIDValid,
+				stubNotifRespond,
+			)
+
+			// Then
+			Expect(msgChan).To(HaveLen(2))
+			Expect((<-msgChan).Syscall()).To(Equal("getpid"))
+			Expect((<-msgChan).Syscall()).To(Equal("getppid"))
+		})
+
+		It("should continue polling after a transient receive error", func() {
+			// Given
+			msgChan := make(chan seccomp.Notification, 1)
+			notifReceive := stubNotifReceive(errReceiveAgain, "getpid", unix.ENOENT)
+
+			// When
+			seccomp.RunHandlerForTest(
+				context.Background(),
+				"ctr",
+				msgChan,
+				libseccomp.ScmpFd(-1),
+				notifReceive,
+				stubNotifIDValid,
+				stubNotifRespond,
+			)
+
+			// Then
+			Expect(msgChan).To(HaveLen(1))
+			Expect((<-msgChan).Syscall()).To(Equal("getpid"))
+		})
+
+		DescribeTable(
+			"should stop on a closed seccomp fd error",
+			func(terminalErr error) {
+				// Given
+				msgChan := make(chan seccomp.Notification, 1)
+				notifReceive := stubNotifReceive("getpid", terminalErr)
+
+				// When
+				seccomp.RunHandlerForTest(
+					context.Background(),
+					"ctr",
+					msgChan,
+					libseccomp.ScmpFd(-1),
+					notifReceive,
+					stubNotifIDValid,
+					stubNotifRespond,
+				)
+
+				// Then
+				Expect(msgChan).To(HaveLen(1))
+				Expect((<-msgChan).Syscall()).To(Equal("getpid"))
+			},
+			Entry("EBADF", unix.EBADF),
+			Entry("ECANCELED", unix.ECANCELED),
+			Entry("ENOENT", unix.ENOENT),
+		)
+
+		It("should skip a notification whose syscall name cannot be decoded", func() {
+			// Given
+			msgChan := make(chan seccomp.Notification, 1)
+			notifReceive := stubNotifReceive(libseccomp.ScmpSyscall(-2), "getpid", unix.ENOENT)
+
+			// When
+			seccomp.RunHandlerForTest(
+				context.Background(),
+				"ctr",
+				msgChan,
+				libseccomp.ScmpFd(-1),
+				notifReceive,
+				stubNotifIDValid,
+				stubNotifRespond,
+			)
+
+			// Then
+			Expect(msgChan).To(HaveLen(1))
+			Expect((<-msgChan).Syscall()).To(Equal("getpid"))
+		})
+
+		It("should continue polling when the TOCTOU check fails", func() {
+			// Given
+			msgChan := make(chan seccomp.Notification, 1)
+			notifReceive := stubNotifReceive("getpid", unix.ENOENT)
+
+			// When
+			seccomp.RunHandlerForTest(
+				context.Background(),
+				"ctr",
+				msgChan,
+				libseccomp.ScmpFd(-1),
+				notifReceive,
+				failingNotifIDValid,
+				stubNotifRespond,
+			)
+
+			// Then
+			Expect(msgChan).To(HaveLen(1))
+			Expect((<-msgChan).Syscall()).To(Equal("getpid"))
+		})
+
+		It("should continue polling when responding fails", func() {
+			// Given
+			msgChan := make(chan seccomp.Notification, 1)
+			notifReceive := stubNotifReceive("getpid", unix.ENOENT)
+
+			// When
+			seccomp.RunHandlerForTest(
+				context.Background(),
+				"ctr",
+				msgChan,
+				libseccomp.ScmpFd(-1),
+				notifReceive,
+				stubNotifIDValid,
+				failingNotifRespond,
+			)
+
+			// Then
+			Expect(msgChan).To(HaveLen(1))
+			Expect((<-msgChan).Syscall()).To(Equal("getpid"))
+		})
+	})
+})
+
+func stubNotifReceive(events ...any) seccomp.NotifReceiveFunc {
+	receiveCalls := 0
+
+	return func(fd libseccomp.ScmpFd) (*libseccomp.ScmpNotifReq, error) {
+		Expect(receiveCalls).To(BeNumerically("<", len(events)))
+
+		event := events[receiveCalls]
+		receiveCalls++
+
+		switch value := event.(type) {
+		case string:
+			syscallID, err := libseccomp.GetSyscallFromName(value)
+			Expect(err).ToNot(HaveOccurred())
+
+			return &libseccomp.ScmpNotifReq{
+				ID: uint64(receiveCalls),
+				Data: libseccomp.ScmpNotifData{
+					Syscall: syscallID,
+				},
+			}, nil
+		case libseccomp.ScmpSyscall:
+			return &libseccomp.ScmpNotifReq{
+				ID: uint64(receiveCalls),
+				Data: libseccomp.ScmpNotifData{
+					Syscall: value,
+				},
+			}, nil
+		case error:
+			return nil, value
+		default:
+			Fail("unsupported notifier receive event")
+
+			return nil, nil
+		}
+	}
+}
+
+func stubNotifIDValid(fd libseccomp.ScmpFd, id uint64) error {
+	return nil
+}
+
+func stubNotifRespond(fd libseccomp.ScmpFd, resp *libseccomp.ScmpNotifResp) error {
+	return nil
+}
+
+func failingNotifIDValid(fd libseccomp.ScmpFd, id uint64) error {
+	return errors.New("invalid notification ID")
+}
+
+func failingNotifRespond(fd libseccomp.ScmpFd, resp *libseccomp.ScmpNotifResp) error {
+	return errors.New("unable to respond")
+}

--- a/internal/config/seccomp/notifier_test_inject.go
+++ b/internal/config/seccomp/notifier_test_inject.go
@@ -1,0 +1,39 @@
+//go:build seccomp && linux && cgo && test
+
+// All *_inject.go files are meant to be used by tests only. Purpose of these
+// files is to provide a way to inject mocked data into the current setup.
+
+package seccomp
+
+import (
+	"context"
+
+	libseccomp "github.com/seccomp/libseccomp-golang"
+)
+
+// NotifReceiveFunc is a test hook for libseccomp.NotifReceive.
+type NotifReceiveFunc func(libseccomp.ScmpFd) (*libseccomp.ScmpNotifReq, error)
+
+// NotifIDValidFunc is a test hook for libseccomp.NotifIDValid.
+type NotifIDValidFunc func(libseccomp.ScmpFd, uint64) error
+
+// NotifRespondFunc is a test hook for libseccomp.NotifRespond.
+type NotifRespondFunc func(libseccomp.ScmpFd, *libseccomp.ScmpNotifResp) error
+
+// RunHandlerForTest runs the seccomp notifier handler with injected libseccomp
+// calls.
+func RunHandlerForTest(
+	ctx context.Context,
+	containerID string,
+	msgChan chan Notification,
+	fd libseccomp.ScmpFd,
+	notifReceive NotifReceiveFunc,
+	notifIDValid NotifIDValidFunc,
+	notifRespond NotifRespondFunc,
+) {
+	notifierHandler{
+		notifReceive: notifReceive,
+		notifIDValid: notifIDValid,
+		notifRespond: notifRespond,
+	}.handle(ctx, containerID, msgChan, fd)
+}

--- a/server/server_linux.go
+++ b/server/server_linux.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/config/seccomp"
 	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/server/metrics"
 )
 
@@ -89,8 +90,18 @@ func (s *Server) startSeccompNotifierWatcher(ctx context.Context) error {
 			ctx := msg.Ctx()
 			id := msg.ContainerID()
 			syscall := msg.Syscall()
+			ctr := s.GetContainer(ctx, id)
 
-			log.Infof(ctx, "Got seccomp notifier message for container ID: %s (syscall = %s)", id, syscall)
+			if ctr == nil {
+				log.Warnf(ctx, "Seccomp blocked syscall '%s' in container %s", syscall, id)
+				// The container name is unavailable, but the metric should still be emitted.
+				metrics.Instance().MetricContainersSeccompNotifierCountTotalInc(id, syscall)
+
+				continue
+			}
+
+			log.Infof(ctx, "Seccomp blocked syscall '%s' in container %s (%s)",
+				syscall, id, oci.LabelsToDescription(ctr.Labels()))
 
 			result, ok := s.seccompNotifiers.Load(id)
 			if !ok {
@@ -108,7 +119,6 @@ func (s *Server) startSeccompNotifierWatcher(ctx context.Context) error {
 
 			notifier.AddSyscall(syscall)
 
-			ctr := s.GetContainer(ctx, id)
 			usedSyscalls := notifier.UsedSyscalls()
 
 			if notifier.StopContainers() {

--- a/test/seccomp_notifier.bats
+++ b/test/seccomp_notifier.bats
@@ -40,7 +40,7 @@ function teardown() {
 	sleep 6 # wait until the notifier stop the workload
 
 	# Assert
-	grep -q "Got seccomp notifier message for container ID: $CTR (syscall = swapoff)" "$CRIO_LOG"
+	grep -q "Seccomp blocked syscall 'swapoff' in container $CTR" "$CRIO_LOG"
 	# Check if container exited
 	crictl inspect "$CTR" | jq -e '.status.state == "CONTAINER_EXITED"'
 	crictl inspect "$CTR" | jq -e '.status.reason == "seccomp killed"'
@@ -65,13 +65,11 @@ function teardown() {
 
 	CTR=$(crictl run "$TESTDIR"/container.json "$TESTDIR"/sandbox.json)
 
-	for _ in 1 2 3; do
-		run ! crictl exec -s "$CTR" swapoff -a
-		sleep 1
-	done
+	run ! crictl exec -s "$CTR" /bin/sh -c "swapoff -a; swapoff -a; swapoff -a"
+	sleep 1
 
-	# Assert
-	grep -q "Got seccomp notifier message for container ID: $CTR (syscall = swapoff)" "$CRIO_LOG"
+	# Assert the blocked syscall keeps being logged for every attempt
+	[[ $(grep -c "Seccomp blocked syscall 'swapoff' in container $CTR" "$CRIO_LOG") -ge 3 ]]
 	crictl inspect "$CTR" | jq -e '.status.state == "CONTAINER_RUNNING"'
 	curl -sf "http://localhost:$PORT/metrics" | grep 'container_runtime_crio_containers_seccomp_notifier_count_total{name="k8s_podsandbox1-redis_podsandbox1_redhat.test.crio_redhat-test-crio_0",syscall="swapoff"} 3'
 }
@@ -104,7 +102,7 @@ function teardown() {
 	sleep 6 # wait until the notifier stop the workload
 
 	# Assert
-	grep -q "Got seccomp notifier message for container ID: $CTR (syscall = swapoff)" "$CRIO_LOG"
+	grep -q "Seccomp blocked syscall 'swapoff' in container $CTR" "$CRIO_LOG"
 	# Check if container exited
 	crictl inspect "$CTR" | jq -e '.status.state == "CONTAINER_EXITED"'
 	crictl inspect "$CTR" | jq -e '.status.reason == "seccomp killed"'
@@ -131,6 +129,6 @@ function teardown() {
 	run ! crictl exec -s "$CTR" chmod 777 .
 
 	# Assert
-	run ! grep -q "Got seccomp notifier message for container ID: $CTR" "$CRIO_LOG"
+	run ! grep -q "Seccomp blocked syscall .* in container $CTR" "$CRIO_LOG"
 	crictl inspect "$CTR" | jq -e '.status.state == "CONTAINER_RUNNING"'
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

The seccomp notifier annotation (`seccomp-notifier-action.crio.io`) has two
behaviors: `stop` terminates the container after a blocked syscall, and any
other value keeps the container running while CRI-O logs the syscall and
increments `container_runtime_crio_containers_seccomp_notifier_count_total`.

The notifier handler loop broke out after handling the first syscall
(`// We only catch the first syscall`). In `stop` mode that's harmless since
the container is terminated anyway, but in the non-stop path the handler
goroutine exited after one syscall ,so the container silently stopped
logging further blocked syscalls and the metric could never increase past 1
for the rest of its lifetime.

This removes the early `break` so every blocked syscall keeps being logged
and counted. The loop now only exits on a terminal fd error
(EBADF/ECANCELED/ENOENT) or when the seccomp fd is closed. A short backoff
is added after transient receive errors to avoid a hot spin, and the log
line now includes the container's labels for easier attribution.

Also adds unit tests for the handler loop (injectable libseccomp calls) and
updates the integration test to assert repeated logging.

#### Which issue(s) this PR fixes:
Fixes https://github.com/cri-o/cri-o/issues/9872

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

This PR is taking over https://github.com/cri-o/cri-o/pull/9875 because of unresponsiveness from the contributor. 
I am adding previous contributor as a co-author.



#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
CRI-O now keeps logging blocked syscalls detected by the seccomp notifier instead of only reporting the first event when the notifier action is not "stop".
```
Co-authored-by: Asish Kumar <officialasishkumar@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Seccomp notifier logs now report the blocked syscall using a more readable, container-focused format.
* **Bug Fixes**
  * Seccomp-notifier annotation is validated immediately, providing clearer startup failures when required settings are missing.
  * Improved notifier watcher resilience: transient receive errors back off, the loop continues through validation/respond failures, and stops on terminal receive conditions.
  * If a container can’t be resolved for a notification, metrics/logging now fall back to an “unknown” container label.
* **Tests**
  * Expanded notifier test coverage and updated log assertions to match the new behavior and wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->