### PR TITLE
Set default nofile ulimit to avoid EMFILE errors at scale

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -251,7 +251,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--default-transport**="": A prefix to prepend to image names that cannot be pulled as-is. (default: "docker://")
 
-**--default-ulimits**="": Ulimits to apply to containers by default (name=soft:hard).
+**--default-ulimits**="": Ulimits to apply to containers by default (name=soft:hard). (default: "nofile=65536:524288")
 
 **--device-ownership-from-security-context**: Set devices' uid/gid ownership from runAsUser/runAsGroup.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -122,8 +122,8 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 **default_runtime**="crun"
 The _name_ of the OCI runtime to be used as the default. This option supports live configuration reload.
 
-**default_ulimits**=[]
-A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example:"nofile=1024:2048". If nothing is set here, settings will be inherited from the CRI-O daemon.
+**default_ulimits**=["nofile=65536:524288"]
+A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example: "nofile=65536:524288". If set to an empty list, settings will be inherited from the CRI-O daemon.
 
 **no_pivot**=false
 If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,6 +156,10 @@ const (
 	// DefaultLogSizeMax is the default value for the maximum log size
 	// allowed for a container. Negative values mean that no limit is imposed.
 	DefaultLogSizeMax = -1
+
+	// DefaultNofileUlimit is the default nofile ulimit for containers.
+	// Soft limit (65536) avoids EMFILE for high-connection workloads; hard limit (524288) matches systemd v240+.
+	DefaultNofileUlimit = "nofile=65536:524288"
 )
 
 const (
@@ -1149,6 +1153,7 @@ func DefaultRuntimeConfig(cgroupManager cgmgr.CgroupManager) *RuntimeConfig {
 		LogSizeMax:                  DefaultLogSizeMax,
 		CtrStopTimeout:              defaultCtrStopTimeout,
 		DefaultCapabilities:         capabilities.Default(),
+		DefaultUlimits:              []string{DefaultNofileUlimit},
 		LogLevel:                    "info",
 		HooksDir:                    []string{hooks.DefaultDir},
 		CDISpecDirs:                 cdi.DefaultSpecDirs,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -143,6 +143,35 @@ var _ = t.Describe("Config", func() {
 			// Then
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("should have default nofile ulimit configured", func() {
+			// Given
+			c, err := config.DefaultConfig()
+			Expect(err).ToNot(HaveOccurred())
+
+			// When
+			err = c.Validate(false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.DefaultUlimits).To(ContainElement(config.DefaultNofileUlimit))
+
+			ulimits := c.Ulimits()
+			Expect(ulimits).ToNot(BeEmpty())
+
+			found := false
+
+			for _, u := range ulimits {
+				if u.Name == "RLIMIT_NOFILE" {
+					Expect(u.Soft).To(Equal(uint64(65536)))
+					Expect(u.Hard).To(Equal(uint64(524288)))
+
+					found = true
+				}
+			}
+
+			Expect(found).To(BeTrue())
+		})
 	})
 
 	t.Describe("ValidateAPIConfig", func() {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -943,8 +943,8 @@ const templateStringCrioRuntime = `# The crio.runtime table contains settings pe
 
 const templateStringCrioRuntimeDefaultUlimits = `# A list of ulimits to be set in containers by default, specified as
 # "<ulimit name>=<soft limit>:<hard limit>", for example:
-# "nofile=1024:2048"
-# If nothing is set here, settings will be inherited from the CRI-O daemon
+# "nofile=65536:524288"
+# If set to an empty list, settings will be inherited from the CRI-O daemon.
 {{ $.Comment }}default_ulimits = [
 {{ range $ulimit := .DefaultUlimits }}{{ $.Comment }}{{ printf "\t%q,\n" $ulimit }}{{ end }}{{ $.Comment }}]
 


### PR DESCRIPTION
## Summary

CRI-O ships no `default_ulimits` for `nofile`. Containers inherit the systemd soft limit of 1024, which is insufficient for workloads like Ceph OSDs that maintain thousands of peer connections at scale (e.g., 222 OSDs × 3-5 connections each ≈ 1500+ FDs per OSD process).

This partially reverts the default introduced in #7703, which aligned with systemd's soft=1024 but proved too restrictive for real-world workloads at scale.

This PR sets `default_ulimits = ["nofile=65536:524288"]` so containers get an adequate soft limit by default:
- **Soft limit (65536):** Provides headroom for high-connection workloads while remaining low enough to avoid FD-iteration overhead in programs that close all descriptors before exec.
- **Hard limit (524288):** Matches the systemd v240+ default. Unchanged from what containers already inherit.

Admins can override via config or set `default_ulimits = []` to inherit from the CRI-O daemon process.

Fixes: https://issues.redhat.com/browse/OCPBUGS-98458

```release-note
Set default container nofile ulimit to 65536:524288 to prevent EMFILE errors for workloads with high file descriptor usage
```

## Test Evidence

**Cluster:** OCP 4.22.0-0.nightly-2026-07-05-180412 (3 masters + 3 workers)

### Before fix (soft nofile = 1024):
```
=== Current ulimits ===
Soft nofile: 1024
Hard nofile: 524288

=== Attempting to open 1500 file descriptors ===
FAILED at FD #1021: [Errno 24] Too many open files
Total FDs opened: 1021
```

### After fix (soft nofile = 65536):

Applied via drop-in config (`/etc/crio/crio.conf.d/99-nofile-fix.conf`), restarted CRI-O:
```
=== Current ulimits ===
Soft nofile: 65536
Hard nofile: 524288

=== Attempting to open 1500 file descriptors ===
SUCCESS: Opened all 1500 sockets
Total FDs opened: 1500
```

Container inspection confirms:
```
$ ulimit -n
65536
$ ulimit -Hn
524288
$ cat /proc/self/limits | grep "open files"
Max open files            65536                524288               files
```

## Changes

| File | Change |
|------|--------|
| `pkg/config/config.go` | Add `DefaultNofileUlimit` constant, set it in `DefaultRuntimeConfig()` |
| `pkg/config/config_test.go` | Test that default config validates and produces correct RLIMIT_NOFILE |
| `pkg/config/template.go` | Update config template example and opt-out documentation |
| `docs/crio.conf.5.md` | Update manpage with new default and opt-out info |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CRI-O now sets a default `nofile` (open-file) ulimit to `65,536` soft and `524,288` hard when no `default_ulimits` are configured.
* **Documentation**
  * Updated `crio.conf` and `crio` option docs to show the new `--default-ulimits` default value and clarify behavior when `default_ulimits` is an empty list.
* **Tests**
  * Added validation coverage to ensure the default `RLIMIT_NOFILE` ulimit is present and matches the expected soft/hard values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->