### PR TITLE
Update golangci-lint to v2.12.2 and modernize config

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ on:
       - update-nixpkgs-*
   pull_request:
 env:
-  GOLANGCI_LINT_VERSION: v2.10.1
+  GOLANGCI_LINT_VERSION: v2.12.2
 permissions:
   contents: read
 concurrency:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,7 @@ linters:
     - godot
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosmopolitan
     - govet
@@ -72,6 +72,7 @@ linters:
     - reassign
     - recvcheck
     - revive
+    - sloglint
     - rowserrcheck
     - spancheck
     - staticcheck
@@ -86,8 +87,10 @@ linters:
     - usestdlibvars
     - usetesting
     - wastedassign
+    - whitespace
     - wsl_v5
     - zerologlint
+    # - clickhouselint
     # - containedctx
     # - contextcheck
     # - cyclop
@@ -117,13 +120,11 @@ linters:
     # - noinlineerr
     # - nonamedreturns
     # - paralleltest
-    # - sloglint
     # - sqlclosecheck
     # - tagliatelle
     # - testpackage
     # - thelper
     # - varnamelen
-    # - whitespace
     # - wrapcheck
   settings:
     errcheck:
@@ -131,6 +132,15 @@ linters:
       check-blank: true
     goconst:
       min-occurrences: 6
+      ignore-string-values:
+        - bind
+        - tmpfs
+        - cgroup
+        - nodev
+        - nosuid
+        - noexec
+        - rbind
+        - /sys
     gocritic:
       enable-all: true
     gocyclo:
@@ -152,6 +162,10 @@ linters:
     presets:
       - comments
       - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - goconst
 formatters:
   enable:
     - gci

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ GO_MD2MAN ?= ${BUILD_BIN_PATH}/go-md2man
 GINKGO := ${BUILD_BIN_PATH}/ginkgo
 MOCKGEN := ${BUILD_BIN_PATH}/mockgen
 GOLANGCI_LINT := ${BUILD_BIN_PATH}/golangci-lint
-GOLANGCI_LINT_VERSION := v2.10.1
+GOLANGCI_LINT_VERSION := v2.12.2
 GO_MOD_OUTDATED := ${BUILD_BIN_PATH}/go-mod-outdated
 GO_MOD_OUTDATED_VERSION := 0.9.0
 GOSEC := ${BUILD_BIN_PATH}/gosec
@@ -166,9 +166,9 @@ $(MDTOC): $(BUILD_BIN_PATH)
 
 $(GOLANGCI_LINT):
 	export VERSION=$(GOLANGCI_LINT_VERSION) \
-		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
+		URL=https://golangci-lint.run \
 		BINDIR=${BUILD_BIN_PATH} && \
-	curl -sSfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
+	curl -sSfL $$URL/install.sh | sh -s $$VERSION
 
 $(SHELLCHECK): $(BUILD_BIN_PATH)
 	URL=https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).linux.x86_64.tar.xz \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -29,7 +29,7 @@ dependencies:
         match: ReleaseMinorVersions
 
   - name: golangci-lint
-    version: v2.10.1
+    version: v2.12.2
     refPaths:
       - path: .github/workflows/verify.yml
         match: GOLANGCI_LINT_VERSION

--- a/utils/utils_linux.go
+++ b/utils/utils_linux.go
@@ -21,11 +21,12 @@ func RunUnderSystemdScope(mgr *dbusmgr.DbusConnManager, pid int, slice, unitName
 		return errors.New("dbus manager is nil")
 	}
 
-	defaultProperties := []systemdDbus.Property{
+	defaultProperties := make([]systemdDbus.Property, 0, 3+len(properties))
+	defaultProperties = append(defaultProperties,
 		newProp("PIDs", []uint32{uint32(pid)}),
 		newProp("Delegate", true),
 		newProp("DefaultDependencies", false),
-	}
+	)
 
 	properties = append(defaultProperties, properties...)
 	if slice != "" {


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

#### What this PR does / why we need it:
Bumps golangci-lint from v2.10.1 to v2.12.2 and updates the configuration:
- Replace deprecated `gomodguard` with `gomodguard_v2`
- Enable `whitespace` and `sloglint` linters (zero existing issues)
- Add `clickhouselint` to commented-out list for completeness
- Exclude `goconst` from test files via exclusion rule
- Add `ignore-string-values` for standard mount vocabulary strings
- Switch install script URL to stable `https://golangci-lint.run`
- Apply `modernize` auto-fixes (`slices.Backward` for reverse loops)
- Preallocate slice in `utils_linux.go` (prealloc finding)

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The goconst linter in v2.12.0+ changed how test occurrences are counted. Rather than creating constants for standard Linux mount vocabulary (`bind`, `tmpfs`, `nodev`, etc.) or bumping the threshold, this PR uses two targeted approaches: an exclusion rule to skip goconst in test files, and `ignore-string-values` for mount-related strings that are clearer as literals.

#### Does this PR introduce a user-facing change?
```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated automated code-quality checks and linting configuration.
  - Expanded validation coverage for formatting, logging, and test code.
  - Refined linting rules to reduce unnecessary constant suggestions.

- **Refactor**
  - Streamlined system service scope setup while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->