### PR TITLE
Fix flaky duplicate-events registry reload test

### DIFF
--- a/test/reload_system.bats
+++ b/test/reload_system.bats
@@ -37,13 +37,31 @@ function expect_log_failure() {
 	wait_for_log "system registries reload failed"
 }
 
-function count_log_entries() {
-	local search_pattern="$1"
-	local count
+function assert_debounced_reloads() {
+	# A burst normally coalesces into one reload, but a slow machine may fire
+	# the debounce timer more than once; consecutive reloads must still be at
+	# least the debounce interval apart (50ms slack for timestamp lag). We use
+	# the "reloading" log line (timer firing) rather than "Applied" (reload
+	# done) to measure timer cadence; success is checked by expect_log_success.
+	local -a reload_times
+	readarray -t reload_times < <(grep "reloading registries configuration" "$CRIO_LOG" |
+		grep -oE 'time="[^"]*"' | cut -d'"' -f2)
 
-	count=$(grep -c "$search_pattern" "$CRIO_LOG")
+	[ "${#reload_times[@]}" -ge 1 ]
 
-	echo "$count"
+	if [ "${#reload_times[@]}" -gt 1 ]; then
+		local timestamp prev_ns=0 curr_ns
+		for timestamp in "${reload_times[@]}"; do
+			if ! curr_ns=$(date -d "$timestamp" +%s%N); then
+				echo "could not parse reload timestamp: $timestamp" >&2
+				return 1
+			fi
+			if [ "$prev_ns" -gt 0 ]; then
+				[ $((curr_ns - prev_ns)) -ge 150000000 ]
+			fi
+			prev_ns=$curr_ns
+		done
+	fi
 }
 
 @test "reload system registries should succeed" {
@@ -113,6 +131,7 @@ function count_log_entries() {
 	drop_in_for_auto_reload_registries
 	start_crio
 
+	# when
 	sed -i 's;true;false;g' "$CONTAINER_REGISTRIES_CONF"
 	sed -i 's;true;false;g' "$CONTAINER_REGISTRIES_CONF_DIR/01-registry.conf"
 	cat << EOF >> "$CONTAINER_REGISTRIES_CONF_DIR/02-registry.conf"
@@ -120,10 +139,11 @@ function count_log_entries() {
 location = 'registry.k8s.io/pause'
 blocked = false
 EOF
-	sleep 1
+
 	# then
-	log_count=$(count_log_entries "Applied new registry configuration")
-	[ "$log_count" -eq 1 ]
+	expect_log_success
+	sleep 1
+	assert_debounced_reloads
 }
 
 @test "system handles duplicate events for the same file" {
@@ -135,8 +155,9 @@ EOF
 	for _ in {1..5}; do
 		sed -i 's;true;false;g' "$CONTAINER_REGISTRIES_CONF_DIR/01-registry.conf"
 	done
-	sleep 1
+
 	# then
-	log_count=$(count_log_entries "Applied new registry configuration")
-	[ "$log_count" -eq 1 ]
+	expect_log_success
+	sleep 1
+	assert_debounced_reloads
 }


### PR DESCRIPTION
Fix Flaky tests

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind ci
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes #10132 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved validation of configuration reloads during bursty file changes by verifying reload timestamps and enforcing debounce spacing (minimum spacing with small timing slack).
  * Updated relevant test flows to wait for successful configuration application before checking reload behavior.
  * Enhanced coverage to ensure duplicate file events don’t cause excessive or overly rapid successive reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->