### PR TITLE
[release-1.34] Pin conmon-rs to v0.8.0 in CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ that we follow.
   - [Dependency management](#dependency-management)
   - [Sign your PRs](#sign-your-prs)
 - [Communications](#communications)
+
 <!-- /toc -->
 
 ## Reporting Issues

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,6 +29,7 @@
   - [Feature addition policy](#feature-addition-policy)
   - [Feature request policy](#feature-request-policy)
 - [Credits](#credits)
+
 <!-- /toc -->
 
 ## Values

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [Weekly Meeting](#weekly-meeting)
 - [Governance](#governance)
 - [License Scan](#license-scan)
+
 <!-- /toc -->
 
 ## Compatibility matrix: CRI-O ⬄ Kubernetes

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -229,7 +229,7 @@ List of devices on the host that a user can specify with the "io.kubernetes.cri-
 **additional_devices**=[]
 List of additional devices. Specified as "<device-on-host>:<device-on-container>:<permissions>", for example: "--additional-devices=/dev/sdc:/dev/xvdc:rwm". If it is empty or commented out, only the devices defined in the container json file by the user/kube will be added.
 
-**hooks_dir**=["*path*", ...]
+**hooks_dir**=["_path_", ...]
 Each `*.json` file in the path configures a hook for CRI-O containers. For more details on the syntax of the JSON files and the semantics of hook injection, see `oci-hooks(5)`. CRI-O currently support both the 1.0.0 and 0.1.0 hook schemas, although the 0.1.0 schema is deprecated.
 
 Paths listed later in the array have higher precedence (`oci-hooks(5)` discusses directory precedence).

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -87,8 +87,8 @@ install_conmon() {
 }
 
 install_conmonrs() {
-    curl_retry https://raw.githubusercontent.com/containers/conmon-rs/main/scripts/get |
-        sudo -E PATH="$PATH" bash -s -- -a "$GOARCH" -o /usr/bin/conmonrs
+    curl_retry https://raw.githubusercontent.com/containers/conmon-rs/v0.8.0/scripts/get |
+        sudo -E PATH="$PATH" bash -s -- -l v0.8.0 -a "$GOARCH" -o /usr/bin/conmonrs
 }
 
 install_critools() {


### PR DESCRIPTION
/kind ci

#### What this PR does / why we need it:
Pin conmon-rs to v0.8.0 in CI. conmon-rs v1.0.0+ is incompatible with CRI-O <= v1.36, causing all conmon-rs critest/integration jobs to fail with "start server: run server command: exit status 2". This aligns with the packaging repo which uses v0.8.0 for CRI-O <= v1.36.

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

```release-note
None
```