### PR TITLE
Add helper to check process state

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -11,6 +11,12 @@ function teardown() {
 	cleanup_test
 }
 
+function process_is_dead_or_zombie() {
+	local stat
+	stat=$(ps -p "$1" -o stat= 2> /dev/null) || return 0
+	[[ "$stat" == Z* ]]
+}
+
 # list_all_children lists children of a process recursively
 function list_all_children {
 	children=$(pgrep -P "$1")
@@ -1301,12 +1307,9 @@ function assert_log_linking() {
 
 	EXPECTED_EXIT_STATUS=137 wait_until_exit "$ctr_id"
 
-	# make sure crio syncs state
+	# After kill -9, children get reparented to PID 1; wait for systemd to reap them.
 	for process in ${processes}; do
-		# Ignore Z state (zombies) as the process has just been killed and reparented. Systemd will get to it.
-		# `pgrep` doesn't have a good mechanism for ignoring Z state, but including all others, so:
-		# shellcheck disable=SC2143
-		[ -z "$(ps -p "$process" o pid=,stat= | grep -v ' Z')" ]
+		retry 10 1 process_is_dead_or_zombie "$process"
 	done
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug

#### What this PR does / why we need it:
Adds a retry to check for the process state. Also added a helper for clarity.
#### Which issue(s) this PR fixes:
Fixes: #10133
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-termination cleanup checks by accounting for brief zombie states before the system finishes reaping.
  * Replaced a stricter one-time process-state check with a retry-based wait per process, reducing intermittent test failures during PID reparenting and system cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->