### PR TITLE
Remove dead CODEOWNERS rule for non-existent pkg/storage/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,3 @@
 
 *                                       @mrunalp
 internal/oci/runtime_vm.go              @fidencio
-pkg/storage/**                          @nalind @rhatdan


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Hi, and thank you for CRI-O.

`.github/CODEOWNERS` (line 8) owns `pkg/storage/**` (@nalind @rhatdan), but no `pkg/storage/` path exists in the repo (`git ls-files | grep '^pkg/storage'` → 0; the contents API returns 404), so the rule matches nothing. This removes the dead line.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

For transparency: I used AI assistance to spot and draft this; I verified the path is absent myself.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments for selected source paths.
  * Removed an outdated storage ownership mapping while retaining runtime ownership coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
