### PR TITLE
deps: bump go to 1.26.4

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -2,7 +2,7 @@
 # It verifies that the versions specified here match across all referenced files.
 dependencies:
   - name: go
-    version: 1.26.3
+    version: 1.26.4
     refPaths:
       - path: nix/derivation.nix
         match: buildGo126Module

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.26.3
+go 1.26.4
 
 module github.com/cri-o/cri-o
 

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -2,7 +2,7 @@
 , pkgs
 , gitCommit ? "unknown"
 }:
-with pkgs; buildGo126Module /* use go 1.26.3 */ {
+with pkgs; buildGo126Module /* use go 1.26.4 */ {
   name = "cri-o";
   src = nix-gitignore.gitignoreSourcePure [ ../.gitignore ] ./..;
   vendorHash = null;


### PR DESCRIPTION
## Description

Bumps the Go toolchain from **1.26.3** to **1.26.4**, a security patch release.

Go 1.26.4 addresses the following CVEs:

- **CVE-2026-27145** — `crypto/x509`: Denial of Service via excessive processing of DNS SAN entries.
  `(*x509.Certificate).VerifyHostname` previously called `matchHostnames` in a loop over all DNS Subject Alternative Name (SAN) entries, causing `strings.Split(host, ".")` to execute repeatedly on the same input hostname. With a large DNS SAN list, verification costs scaled quadratically (O(N × L)) based on the number of SAN entries multiplied by the hostname's label count. This overhead occurred even for untrusted certificates because `x509.Verify` validates hostnames before building the certificate chain.
  ([NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-27145) | [Go issue](https://github.com/golang/go/issues/79694) | [Advisory](https://pkg.go.dev/vuln/GO-2026-5037))

- **CVE-2026-42504** — `mime`: quadratic complexity in `WordDecoder.DecodeHeader`.
  ([Go issue](https://github.com/golang/go/issues/79217))

- **CVE-2026-42507** — `net/textproto`: arbitrary input included in errors without escaping.
  ([Go issue](https://github.com/golang/go/issues/79346))

Release notes: https://go.dev/doc/devel/release#go1.26.4

## Changes

- `go.mod`: `go 1.26.3` → `go 1.26.4`
- `dependencies.yaml`: `version: 1.26.3` → `version: 1.26.4`
- `nix/derivation.nix`: updated comment to reflect `go 1.26.4`

## Tracker

- https://redhat.atlassian.net/browse/OCPBUGS-93911

```release-note
Bump Go toolchain to 1.26.4 to fix CVE-2026-27145, CVE-2026-42504, and CVE-2026-42507.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to version 1.26.4.
  * Aligned the project’s build configuration with the updated Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->