### PR TITLE
OCPBUGS-98876: fix /etc/passwd injection via HOME env (CVE-2026-15809)

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -241,7 +241,7 @@ func setupContainerUser(ctx context.Context, specgen *generate.Generator, rootfs
 	for _, env := range specgen.Config.Process.Env {
 		if after, ok := strings.CutPrefix(env, "HOME="); ok {
 			homedir = after
-			if idx := strings.Index(homedir, `\n`); idx > -1 {
+			if strings.ContainsAny(homedir, "\n\r") {
 				return errors.New("invalid HOME environment; newline not allowed")
 			}
 

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/opencontainers/runtime-tools/generate"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/factory/container"
@@ -394,6 +396,67 @@ func TestAddOCIBindsErrorWithoutIDMap(t *testing.T) {
 	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, true, false)
 	if err != nil {
 		t.Errorf("%v", err)
+	}
+}
+
+func TestSetupContainerUserRejectsNewlineInHOME(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		homeVal string
+		wantErr bool
+	}{
+		{
+			name:    "actual newline byte in HOME",
+			homeVal: "/root\nmalicious::0:0::/:/bin/bash",
+			wantErr: true,
+		},
+		{
+			name:    "carriage return in HOME",
+			homeVal: "/root\r\nmalicious::0:0::/:/bin/bash",
+			wantErr: true,
+		},
+		{
+			name:    "valid HOME value",
+			homeVal: "/home/user",
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			specgen, err := generate.New("linux")
+			if err != nil {
+				t.Fatalf("failed to create spec generator: %v", err)
+			}
+
+			specgen.AddProcessEnv("HOME", tc.homeVal)
+
+			sc := &types.LinuxContainerSecurityContext{
+				RunAsUser: &types.Int64Value{Value: 1000},
+			}
+
+			err = setupContainerUser(t.Context(), &specgen, t.TempDir(), "", t.TempDir(), sc, nil)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error for HOME with newline, got nil")
+				}
+
+				if !strings.Contains(err.Error(), "newline") {
+					t.Errorf("expected newline-related error, got: %v", err)
+				}
+			} else if err != nil {
+				// Valid HOME may still fail on missing rootfs files; that's fine.
+				// Only fail if the error is the newline check.
+				if strings.Contains(err.Error(), "newline") {
+					t.Errorf("unexpected newline error for valid HOME: %v", err)
+				}
+			}
+		})
 	}
 }
 

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1310,9 +1310,20 @@ function assert_log_linking() {
 	done
 }
 
-@test "ctr HOME env newline invalid" {
+@test "ctr HOME env escaped newline valid" {
 	start_crio
-	jq ' .envs = [{"key": "HOME=", "value": "/root:/sbin/nologin\\ntest::0:0::/:/bin/bash"}]' \
+	jq ' .envs = [{"key": "HOME", "value": "/root:/sbin/nologin\\ntest::0:0::/:/bin/bash"}]' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+
+	crictl run "$newconfig" "$TESTDATA"/sandbox_config.json
+}
+
+@test "ctr HOME env actual newline byte invalid" {
+	start_crio
+	# Use printf to embed an actual newline byte (0x0a) into the HOME value.
+	local payload
+	payload=$(printf '/root\nmalicious::0:0::/:/bin/bash')
+	jq --arg home "$payload" ' .envs = [{"key": "HOME", "value": $home}]' \
 		"$TESTDATA"/container_config.json > "$newconfig"
 
 	run ! crictl run "$newconfig" "$TESTDATA"/sandbox_config.json


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
Fixes CVE-2026-15809 — a bypass of the original CVE-2022-4318 fix for `/etc/passwd` injection via the `HOME` environment variable.
  
The original fix (commit `98a49cf00`, Dec 14, 2022) checked for newlines in `HOME` using a Go raw string literal (`` `\n` ``), which matches the **literal two-character sequence** backslash + n (`0x5c 0x6e`), not an actual newline byte (`0x0a`). An attacker who can set environment variables on a container can embed a real newline character in the `HOME` value, bypassing the check entirely. The unsanitized value is then passed to `utils.GeneratePasswd`, which uses `fmt.Sprintf` to construct the container's `/etc/passwd` content, allowing arbitrary line injection.
  
**Fix:** Replace the raw string literal with an interpreted string literal and use `strings.ContainsAny(homedir, "\n\r")` to correctly reject actual newline (`0x0a`) and carriage return (`0x0d`) bytes.

#### Which issue(s) this PR fixes:
Fixes [OCPBUGS-98876](https://redhat.atlassian.net/browse/OCPBUGS-98876)

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

  - The original check used `` `\n` `` (raw string = literal `\` + `n`). The fix
    uses `"\n"` (interpreted string = actual newline byte `0x0a`). Also adds `\r`
    rejection to prevent carriage-return based injection. 
  - Unit test added in `server/container_create_linux_test.go` covering actual
    newline byte, carriage return, and valid HOME values.
  - Integration test added in `test/ctr.bats` that uses `printf` to embed a real
    newline byte (not the escaped literal) into the HOME value

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed CVE-2026-15809: bypass of CVE-2022-4318 fix allowing /etc/passwd injection via newline characters in the HOME environment variable. The original check incorrectly matched the literal string "\n" instead of actual newline bytes.

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container creation now rejects `HOME` values containing newline (`\n`) and carriage return (`\r`) characters (including `\r\n`), preventing malformed environment data from being accepted.

* **Tests**
  * Added unit test coverage to confirm valid `HOME` values are accepted while newline/carriage-return cases are rejected.
  * Added end-to-end regression tests ensuring invalid `HOME` values cause `crictl run` to fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->