### PR TITLE
docs: clarify default_ulimits inheritance under systemd cgroup manager

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -123,7 +123,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 The _name_ of the OCI runtime to be used as the default. This option supports live configuration reload.
 
 **default_ulimits**=[]
-A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example: "nofile=1024:2048". If nothing is set here and `cgroup_manager` is `cgroupfs`, settings will be inherited from the CRI-O daemon. If `cgroup_manager` is `systemd`, conmon is moved into a transient systemd scope after being started, so any unset limits are instead inherited from systemd's own defaults (e.g. `DefaultLimitNOFILE=1024:524288`, see systemd-system.conf(5)) rather than from the CRI-O daemon.
+A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example: "nofile=1024:2048". If nothing is set here and `cgroup_manager` is `cgroupfs`, settings will be inherited from the CRI-O daemon. If `cgroup_manager` is `systemd`, unset limits are instead inherited from systemd's own defaults (e.g. `DefaultLimitNOFILE=1024:524288`, see systemd-system.conf(5)) rather than from the CRI-O daemon.
 
 **no_pivot**=false
 If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -123,7 +123,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 The _name_ of the OCI runtime to be used as the default. This option supports live configuration reload.
 
 **default_ulimits**=[]
-A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example:"nofile=1024:2048". If nothing is set here, settings will be inherited from the CRI-O daemon.
+A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example:"nofile=1024:2048". If nothing is set here and `cgroup_manager` is `cgroupfs`, settings will be inherited from the CRI-O daemon. If `cgroup_manager` is `systemd`, conmon is moved into a transient systemd scope after being started, so any unset limits are instead inherited from systemd's own defaults (e.g. `DefaultLimitNOFILE=1024:524288`, see systemd-system.conf(5)) rather than from the CRI-O daemon.
 
 **no_pivot**=false
 If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -123,7 +123,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 The _name_ of the OCI runtime to be used as the default. This option supports live configuration reload.
 
 **default_ulimits**=[]
-A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example:"nofile=1024:2048". If nothing is set here and `cgroup_manager` is `cgroupfs`, settings will be inherited from the CRI-O daemon. If `cgroup_manager` is `systemd`, conmon is moved into a transient systemd scope after being started, so any unset limits are instead inherited from systemd's own defaults (e.g. `DefaultLimitNOFILE=1024:524288`, see systemd-system.conf(5)) rather than from the CRI-O daemon.
+A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example: "nofile=1024:2048". If nothing is set here and `cgroup_manager` is `cgroupfs`, settings will be inherited from the CRI-O daemon. If `cgroup_manager` is `systemd`, conmon is moved into a transient systemd scope after being started, so any unset limits are instead inherited from systemd's own defaults (e.g. `DefaultLimitNOFILE=1024:524288`, see systemd-system.conf(5)) rather than from the CRI-O daemon.
 
 **no_pivot**=false
 If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -123,7 +123,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 The _name_ of the OCI runtime to be used as the default. This option supports live configuration reload.
 
 **default_ulimits**=[]
-A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example: "nofile=1024:2048". If nothing is set here and `cgroup_manager` is `cgroupfs`, settings will be inherited from the CRI-O daemon. If `cgroup_manager` is `systemd`, unset limits are instead inherited from systemd's own defaults (e.g. `DefaultLimitNOFILE=1024:524288`, see systemd-system.conf(5)) rather than from the CRI-O daemon.
+A list of ulimits to be set in containers by default, specified as "<ulimit name>=<soft limit>:<hard limit>", for example: "nofile=1024:2048". If nothing is set here, containers inherit whatever rlimits the CRI-O daemon itself was started with (for example, via its systemd unit's `LimitNOFILE=`), regardless of the configured `cgroup_manager`. Set `default_ulimits` explicitly if a deterministic limit is required.
 
 **no_pivot**=false
 If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -944,7 +944,10 @@ const templateStringCrioRuntime = `# The crio.runtime table contains settings pe
 const templateStringCrioRuntimeDefaultUlimits = `# A list of ulimits to be set in containers by default, specified as
 # "<ulimit name>=<soft limit>:<hard limit>", for example:
 # "nofile=1024:2048"
-# If nothing is set here, settings will be inherited from the CRI-O daemon
+# If nothing is set here and cgroup_manager is cgroupfs, settings will be
+# inherited from the CRI-O daemon. If cgroup_manager is systemd, unset limits
+# are instead inherited from systemd's own defaults (e.g.
+# DefaultLimitNOFILE=1024:524288), not from the CRI-O daemon
 {{ $.Comment }}default_ulimits = [
 {{ range $ulimit := .DefaultUlimits }}{{ $.Comment }}{{ printf "\t%q,\n" $ulimit }}{{ end }}{{ $.Comment }}]
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -944,10 +944,9 @@ const templateStringCrioRuntime = `# The crio.runtime table contains settings pe
 const templateStringCrioRuntimeDefaultUlimits = `# A list of ulimits to be set in containers by default, specified as
 # "<ulimit name>=<soft limit>:<hard limit>", for example:
 # "nofile=1024:2048"
-# If nothing is set here and cgroup_manager is cgroupfs, settings will be
-# inherited from the CRI-O daemon. If cgroup_manager is systemd, unset limits
-# are instead inherited from systemd's own defaults (e.g.
-# DefaultLimitNOFILE=1024:524288), not from the CRI-O daemon
+# If nothing is set here, containers inherit whatever rlimits the CRI-O
+# daemon itself was started with, regardless of cgroup_manager. Set
+# default_ulimits explicitly if a deterministic limit is required
 {{ $.Comment }}default_ulimits = [
 {{ range $ulimit := .DefaultUlimits }}{{ $.Comment }}{{ printf "\t%q,\n" $ulimit }}{{ end }}{{ $.Comment }}]
 


### PR DESCRIPTION
/kind documentation

What this PR does / why we need it:

Motivation:
The docs for `default_ulimits` state that, when unset, limits are
"inherited from the CRI-O daemon". This is only true when
`cgroup_manager` is `cgroupfs`. When `cgroup_manager` is `systemd`,
conmon is started by CRI-O (inheriting the daemon's rlimits via
fork/exec) but is then moved into a transient systemd scope
(MoveConmonToCgroup -> RunUnderSystemdScope). CRI-O does not set any
`Limit*` property on that transient unit, so systemd applies its own
defaults (e.g. `DefaultLimitNOFILE=1024:524288`, see
systemd-system.conf(5)) to the scope, silently overriding the limit
conmon originally inherited from the daemon. This can surprise
operators who set a high `nofile` limit on the CRI-O daemon expecting
containers to inherit it.

Approach:
This is a documentation-only fix, as agreed on the issue by a
maintainer. A prior attempt to fix this by changing CRI-O's default
ulimit values in code (#10135) was rejected, since a default nofile
value cannot be chosen correctly for all workloads. Instead, this
updates the `default_ulimits` description in docs/crio.conf.5.md and
the matching comment in pkg/config/template.go (used to generate the
default crio.conf) to explain the systemd-scope behavior.

Validation:
Ran `go build ./pkg/config/...` (passes) and
`go run ./test/docs-validation/...` to confirm no new doc/template
tag mismatches are introduced by this change (pre-existing,
unrelated failures for `default_runtime`/`cgroup_manager` are present
identically on main, due to missing runtime binaries in this
environment, and are not affected by this change).

Which issue(s) this PR fixes:

Fixes #10006

Special notes for your reviewer:
None.

Does this PR introduce a user-facing change?

```release-note
NONE
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that containers inherit the CRI-O daemon’s resource limits when no default ulimits are configured, regardless of the selected cgroup manager.
  - Recommended explicitly setting `default_ulimits` when deterministic limits are required.
  - Updated the embedded configuration template comments to match the documented inheritance behavior.
  - Retained guidance on the expected default ulimits entry format, such as `nofile=1024:2048`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->