### PR TITLE
statsserver: add Kubernetes labels to CRI metrics

### DIFF
--- a/internal/lib/statsserver/metrics.go
+++ b/internal/lib/statsserver/metrics.go
@@ -10,7 +10,11 @@ import (
 	"github.com/cri-o/cri-o/pkg/config"
 )
 
-var baseLabelKeys = []string{"id", "name", "image"}
+var (
+	runtimeLabelKeys    = []string{"id", "name", "image"}
+	kubernetesLabelKeys = []string{"namespace", "pod", "container"}
+	baseLabelKeys       = append(append([]string{}, runtimeLabelKeys...), kubernetesLabelKeys...)
+)
 
 type metricValue struct {
 	value      uint64
@@ -145,8 +149,13 @@ func computeSandboxMetrics(sb *sandbox.Sandbox, metrics []*containerMetric) []*t
 }
 
 func sandboxBaseLabelValues(sb *sandbox.Sandbox) []string {
+	namespace, podName := "", ""
+	if md := sb.Metadata(); md != nil {
+		namespace = md.GetNamespace()
+		podName = md.GetName()
+	}
 	// TODO FIXME: image?
-	return []string{sb.ID(), "POD", ""}
+	return []string{sb.ID(), "POD", "", namespace, podName, "POD"}
 }
 
 // computeContainerMetrics computes the metrics for container.
@@ -160,7 +169,7 @@ func containerBaseLabelValues(ctr *oci.Container) []string {
 		image = someNameOfTheImage.StringForOutOfProcessConsumptionOnly()
 	}
 
-	return []string{ctr.ID(), ctr.Name(), image}
+	return []string{ctr.ID(), ctr.Name(), image, "", "", ""}
 }
 
 func computeMetrics(baseLabels []string, metrics []*containerMetric) []*types.Metric {

--- a/internal/lib/statsserver/metrics_test.go
+++ b/internal/lib/statsserver/metrics_test.go
@@ -177,7 +177,7 @@ func testMemoryStats() cgroups.MemoryStats {
 // mirroring what generateSandboxNetworkMetrics does but without requiring a
 // real sandbox.Sandbox or netlink.LinkAttrs.
 func testNetworkMetrics() []*types.Metric {
-	sandboxBaseLabels := []string{"test-sandbox-id", "POD", ""}
+	sandboxBaseLabels := []string{"test-sandbox-id", "POD", "", "test-ns", "test-pod", "POD"}
 
 	networkDescs := []*types.MetricDescriptor{
 		containerNetworkReceiveBytesTotal,

--- a/internal/lib/statsserver/stats_server_linux.go
+++ b/internal/lib/statsserver/stats_server_linux.go
@@ -322,6 +322,22 @@ func (ss *StatsServer) containerMetricsFromContainerStats(sb *sandbox.Sandbox, c
 		}
 	}
 
+	namespace, podName, containerName := "", "", ""
+	if md := sb.Metadata(); md != nil {
+		namespace = md.GetNamespace()
+		podName = md.GetName()
+	}
+
+	if md := c.Metadata(); md != nil {
+		containerName = md.GetName()
+	}
+
+	for _, m := range metrics {
+		m.LabelValues[len(runtimeLabelKeys)] = namespace
+		m.LabelValues[len(runtimeLabelKeys)+1] = podName
+		m.LabelValues[len(runtimeLabelKeys)+2] = containerName
+	}
+
 	return &types.ContainerMetrics{
 		ContainerId: c.ID(),
 		Metrics:     metrics,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Include namespace, pod, and container labels in all CRI metrics to match the labels produced by the cadvisor metrics path. The descriptors declare these as base label keys, and the values are populated from sandbox and container metadata.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Fixes https://github.com/kubernetes/kubernetes/issues/140778

#### Special notes for your reviewer:

The Kubernetes labels are filled in after metric generation to avoid passing the sandbox through every generate function.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `namespace`, `pod`, and `container` labels to CRI metrics
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics now include additional runtime and Kubernetes context, including namespace, pod name, and container name.
  * Expanded metric label sets provide more granular visibility into sandbox and container activity.

* **Bug Fixes**
  * Updated generated network and container metrics so label values consistently match the expanded label definitions.

* **Tests**
  * Adjusted network metrics test expectations to reflect the expanded label values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->