### PR TITLE
statsserver: drop name label from CRI metrics

### DIFF
--- a/internal/lib/statsserver/metrics.go
+++ b/internal/lib/statsserver/metrics.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	runtimeLabelKeys    = []string{"id", "name", "image"}
+	runtimeLabelKeys    = []string{"id", "image"}
 	kubernetesLabelKeys = []string{"namespace", "pod", "container"}
 	baseLabelKeys       = append(append([]string{}, runtimeLabelKeys...), kubernetesLabelKeys...)
 )
@@ -154,8 +154,9 @@ func sandboxBaseLabelValues(sb *sandbox.Sandbox) []string {
 		namespace = md.GetNamespace()
 		podName = md.GetName()
 	}
+
 	// TODO FIXME: image?
-	return []string{sb.ID(), "POD", "", namespace, podName, "POD"}
+	return []string{sb.ID(), "", namespace, podName, "POD"}
 }
 
 // computeContainerMetrics computes the metrics for container.
@@ -169,7 +170,12 @@ func containerBaseLabelValues(ctr *oci.Container) []string {
 		image = someNameOfTheImage.StringForOutOfProcessConsumptionOnly()
 	}
 
-	return []string{ctr.ID(), ctr.Name(), image, "", "", ""}
+	containerName := ""
+	if md := ctr.Metadata(); md != nil {
+		containerName = md.GetName()
+	}
+
+	return []string{ctr.ID(), image, "", "", containerName}
 }
 
 func computeMetrics(baseLabels []string, metrics []*containerMetric) []*types.Metric {

--- a/internal/lib/statsserver/metrics_test.go
+++ b/internal/lib/statsserver/metrics_test.go
@@ -177,7 +177,7 @@ func testMemoryStats() cgroups.MemoryStats {
 // mirroring what generateSandboxNetworkMetrics does but without requiring a
 // real sandbox.Sandbox or netlink.LinkAttrs.
 func testNetworkMetrics() []*types.Metric {
-	sandboxBaseLabels := []string{"test-sandbox-id", "POD", "", "test-ns", "test-pod", "POD"}
+	sandboxBaseLabels := []string{"test-sandbox-id", "", "test-ns", "test-pod", "POD"}
 
 	networkDescs := []*types.MetricDescriptor{
 		containerNetworkReceiveBytesTotal,

--- a/internal/lib/statsserver/stats_server_linux.go
+++ b/internal/lib/statsserver/stats_server_linux.go
@@ -322,20 +322,15 @@ func (ss *StatsServer) containerMetricsFromContainerStats(sb *sandbox.Sandbox, c
 		}
 	}
 
-	namespace, podName, containerName := "", "", ""
+	namespace, podName := "", ""
 	if md := sb.Metadata(); md != nil {
 		namespace = md.GetNamespace()
 		podName = md.GetName()
 	}
 
-	if md := c.Metadata(); md != nil {
-		containerName = md.GetName()
-	}
-
 	for _, m := range metrics {
 		m.LabelValues[len(runtimeLabelKeys)] = namespace
 		m.LabelValues[len(runtimeLabelKeys)+1] = podName
-		m.LabelValues[len(runtimeLabelKeys)+2] = containerName
 	}
 
 	return &types.ContainerMetrics{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

The name label is a cadvisor implementation detail (the internal container alias) that provides no value to users. The id label already uniquely identifies the container, and namespace/pod/container provide the Kubernetes-level identity.

This aligns CRI-O's label set with containerd's: id, image, namespace, pod, container.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

Addresses https://github.com/cri-o/cri-o/pull/10173#discussion_r3625928517

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Drop the `name` label from CRI metrics
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected metric labels to consistently report image, namespace, pod, and container information.
  * Improved container and sandbox metric label ordering and values.
  * Removed incorrect container-name data from pod-level metric labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->