### PR TITLE
test: retry OCI artifact image pulls

### DIFF
--- a/test/artifact_additional_stores.bats
+++ b/test/artifact_additional_stores.bats
@@ -20,7 +20,7 @@ function populate_additional_store() {
 	local additional_store="$1"
 
 	# Pull artifact into the main store
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 
 	# Copy the OCI artifact layout to the additional store
 	local main_store="$TESTDIR/crio/artifacts"
@@ -116,7 +116,7 @@ EOF
 	populate_additional_store "$ADDITIONAL_STORE"
 
 	# Pull again; should be skipped because it exists in the additional store
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 
 	# Verify the artifact is NOT in the main store (pull was skipped)
 	local main_index="$TESTDIR/crio/artifacts/index.json"
@@ -161,7 +161,7 @@ EOF
 	start_crio
 
 	# Pull artifact into main store
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 
 	# Copy to additional store (artifact now exists in both)
 	local main_store="$TESTDIR/crio/artifacts"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -87,6 +87,20 @@ function crictl() {
     "$CRICTL_BINARY" -t "$CRICTL_TIMEOUT" --config "$CRICTL_CONFIG_FILE" -r "unix://$CRIO_SOCKET" -i "unix://$CRIO_SOCKET" "$@"
 }
 
+# Pull an image, tolerating transient registry failures. copyimg already
+# retries for the preloaded images, but that only covers get_img(): a pull
+# issued inside a test goes through CRI-O and gets none. Fixed delay rather
+# than copyimg's backoff - neither jitters, and CRICTL_TIMEOUT dominates.
+#
+# Only for pulls expected to succeed: one expected to fail would be retried
+# three times first.
+# retry captures stdout, so re-emit it: callers parse the pulled reference out
+# of it, and it belongs in the log for a failing test either way.
+function crictl_pull() {
+    retry 3 5 crictl pull "$@" || return 1
+    printf '%s\n' "$output"
+}
+
 # Run the runtime binary with the specified RUNTIME_ROOT
 function runtime() {
     "$RUNTIME_BINARY_PATH" --root "$RUNTIME_ROOT" "$@"

--- a/test/image.bats
+++ b/test/image.bats
@@ -73,7 +73,7 @@ function teardown() {
 @test "container status when created by image list canonical reference" {
 	start_crio
 
-	crictl pull "$IMAGE_LIST_DIGEST"
+	crictl_pull "$IMAGE_LIST_DIGEST"
 
 	jq '.image.image = "'"$IMAGE_LIST_DIGEST"'" | .image.user_specified_image = "'"$IMAGE_LIST_DIGEST"'"' \
 		"$TESTDATA"/container_config.json > "$TESTDIR"/ctr.json
@@ -87,7 +87,7 @@ function teardown() {
 
 @test "image pull and list" {
 	start_crio
-	crictl pull "$IMAGE"
+	crictl_pull "$IMAGE"
 	imageid=$(crictl images --quiet "$IMAGE")
 	[ "$imageid" != "" ]
 
@@ -107,7 +107,7 @@ function teardown() {
 	# registry.fedoraproject.org is pretty flaky
 	# Moving to the stable quay.io
 	FEDORA="quay.io/fedora/fedora"
-	crictl pull $FEDORA
+	crictl_pull $FEDORA
 	imageid=$(crictl images --quiet "$FEDORA")
 	[ "$imageid" != "" ]
 
@@ -130,13 +130,13 @@ function teardown() {
 @test "image pull with signature" {
 	skip "registry has some issues"
 	start_crio
-	crictl pull "$SIGNED_IMAGE"
+	crictl_pull "$SIGNED_IMAGE"
 	cleanup_images
 }
 
 @test "image pull and list by tag and ID" {
 	start_crio
-	crictl pull "$IMAGE:go"
+	crictl_pull "$IMAGE:go"
 
 	imageid=$(crictl images --quiet "$IMAGE:go")
 	[ "$imageid" != "" ]
@@ -150,7 +150,7 @@ function teardown() {
 @test "image pull and list by digest and ID" {
 	start_crio
 	NGINX_IMAGE=quay.io/crio/nginx@sha256:960355a671fb88ef18a85f92ccf2ccf8e12186216c86337ad808c204d69d512d
-	crictl pull "$NGINX_IMAGE"
+	crictl_pull "$NGINX_IMAGE"
 
 	imageid=$(crictl images --quiet "$NGINX_IMAGE")
 	[ "$imageid" != "" ]
@@ -164,7 +164,7 @@ function teardown() {
 @test "image pull and list by manifest list digest" {
 	start_crio
 
-	crictl pull ${IMAGE_LIST_DIGEST}
+	crictl_pull ${IMAGE_LIST_DIGEST}
 
 	imageid=$(crictl images --quiet ${IMAGE_LIST_DIGEST})
 	[ "$imageid" != "" ]
@@ -190,7 +190,7 @@ function teardown() {
 @test "image pull and list by manifest list tag" {
 	start_crio
 
-	crictl pull ${IMAGE_LIST_TAG}
+	crictl_pull ${IMAGE_LIST_TAG}
 	imageid=$(crictl images --quiet ${IMAGE_LIST_TAG})
 	[ "$imageid" != "" ]
 
@@ -219,13 +219,13 @@ function teardown() {
 @test "image pull and list by manifest list and individual digest" {
 	start_crio
 
-	crictl pull ${IMAGE_LIST_DIGEST}
+	crictl_pull ${IMAGE_LIST_DIGEST}
 	imageid=$(crictl images --quiet ${IMAGE_LIST_DIGEST})
 	[ "$imageid" != "" ]
 
 	case $ARCH in
 	x86_64)
-		crictl pull ${IMAGE_LIST_DIGEST_AMD64}
+		crictl_pull ${IMAGE_LIST_DIGEST_AMD64}
 		output=$(crictl images -v ${IMAGE_LIST_DIGEST_AMD64})
 		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_AMD64}"* ]]
 		;;
@@ -245,13 +245,13 @@ function teardown() {
 
 	case $ARCH in
 	x86_64)
-		crictl pull ${IMAGE_LIST_DIGEST_AMD64}
+		crictl_pull ${IMAGE_LIST_DIGEST_AMD64}
 		output=$(crictl images -v ${IMAGE_LIST_DIGEST_AMD64})
 		[[ "$output" == *"RepoDigests: ${IMAGE_LIST_DIGEST_AMD64}"* ]]
 		;;
 	esac
 
-	crictl pull ${IMAGE_LIST_DIGEST}
+	crictl_pull ${IMAGE_LIST_DIGEST}
 
 	imageid=$(crictl images --quiet ${IMAGE_LIST_DIGEST})
 	[ "$imageid" != "" ]
@@ -267,7 +267,7 @@ function teardown() {
 
 @test "image list with filter" {
 	start_crio
-	crictl pull "$IMAGE"
+	crictl_pull "$IMAGE"
 	output=$(crictl images --quiet "$IMAGE")
 	[ "$output" != "" ]
 	for id in $output; do
@@ -280,7 +280,7 @@ function teardown() {
 
 @test "image list/remove" {
 	start_crio
-	crictl pull "$IMAGE"
+	crictl_pull "$IMAGE"
 	output=$(crictl images --quiet)
 	[ "$output" != "" ]
 	for id in $output; do
@@ -294,7 +294,7 @@ function teardown() {
 
 @test "image status/remove" {
 	start_crio
-	crictl pull "$IMAGE"
+	crictl_pull "$IMAGE"
 	output=$(crictl images --quiet)
 	[ "$output" != "" ]
 	for id in $output; do
@@ -352,7 +352,7 @@ EOF
 pinned_images = [ "quay.io/crio/hello-wasm:latest" ]
 EOF
 	start_crio
-	crictl pull quay.io/crio/hello-wasm:latest
+	crictl_pull quay.io/crio/hello-wasm:latest
 	output=$(crictl images -o json | jq '.images[] | select(.repoTags[] == "quay.io/crio/hello-wasm:latest") | .pinned')
 	[ "$output" == "true" ]
 }
@@ -395,7 +395,7 @@ EOF
 @test "pull progress timeout should not timeout when set to 0" {
 	CONTAINER_PULL_PROGRESS_TIMEOUT=0 start_crio
 
-	crictl pull "$IMAGE_LIST_TAG"
+	crictl_pull "$IMAGE_LIST_TAG"
 }
 
 @test "short name mode enabled should fail to pull ambiguous image" {
@@ -411,14 +411,14 @@ EOF
 	CONTAINER_SHORT_NAME_MODE="disabled" start_crio
 
 	# There should be many nginx images
-	crictl pull nginx
+	crictl_pull nginx
 }
 
 @test "image pull returns image ID not repo digest" {
 	start_crio
 
 	# Pull an image and capture the returned image reference
-	pulled_ref=$(crictl pull "$IMAGE")
+	pulled_ref=$(crictl_pull "$IMAGE")
 
 	# Extract the image ID from crictl output
 	# crictl may output "Image is up to date for <id>" or just "<id>"

--- a/test/namespaced_auth_dir.bats
+++ b/test/namespaced_auth_dir.bats
@@ -20,7 +20,7 @@ function teardown() {
 	echo '{}' > "$TESTDIR/auth/$NAMESPACE-$IMAGE_SHA256.json"
 	jq '.metadata.namespace = "'$NAMESPACE'"' "$TESTDATA/sandbox_config.json" > "$TESTDIR/sb.json"
 
-	crictl pull --pod-config "$TESTDIR/sb.json" $IMAGE
+	crictl_pull --pod-config "$TESTDIR/sb.json" $IMAGE
 
 	grep -q "Looking for namespaced auth JSON file in: .*$IMAGE_SHA256" "$CRIO_LOG"
 	grep -q "Using auth file for namespace $NAMESPACE" "$CRIO_LOG"
@@ -44,7 +44,7 @@ function teardown() {
 @test "should not use auth file if namespace does not match" {
 	AUTHFILE="$TESTDIR/auth/$NAMESPACE-$IMAGE_SHA256.json"
 	echo '{}' > "$AUTHFILE"
-	crictl pull --pod-config "$TESTDATA/sandbox_config.json" $IMAGE
+	crictl_pull --pod-config "$TESTDATA/sandbox_config.json" $IMAGE
 
 	grep -q "Looking for namespaced auth JSON file in: .*$IMAGE_SHA256" "$CRIO_LOG"
 	grep -vq "Using auth file for namespace $NAMESPACE" "$CRIO_LOG"

--- a/test/oci_artifacts.bats
+++ b/test/oci_artifacts.bats
@@ -18,7 +18,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 @test "should be able to pull and list an OCI artifact" {
 	start_crio
 	cleanup_images
-	crictl pull $ARTIFACT_IMAGE
+	crictl_pull $ARTIFACT_IMAGE
 
 	# Should get listed as filtered artifact
 	run crictl images -q $ARTIFACT_IMAGE
@@ -30,7 +30,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 
 @test "should be able to inspect an OCI artifact" {
 	start_crio
-	crictl pull $ARTIFACT_IMAGE
+	crictl_pull $ARTIFACT_IMAGE
 
 	crictl inspecti $ARTIFACT_IMAGE |
 		jq -e '
@@ -42,7 +42,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 
 @test "should be able to inspect an OCI artifact with other references" {
 	start_crio
-	crictl pull $ARTIFACT_IMAGE
+	crictl_pull $ARTIFACT_IMAGE
 
 	# canonical name
 	digestedRef=$(crictl inspecti $ARTIFACT_IMAGE | jq -r '.status.repoDigests[0]')
@@ -56,7 +56,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 
 @test "should be able to remove an OCI artifact" {
 	start_crio
-	crictl pull $ARTIFACT_IMAGE
+	crictl_pull $ARTIFACT_IMAGE
 	crictl rmi $ARTIFACT_IMAGE
 
 	[ "$(crictl images -q $ARTIFACT_IMAGE | wc -l)" == 0 ]
@@ -64,7 +64,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 
 @test "should be able to mount OCI Artifact" {
 	start_crio
-	crictl pull $ARTIFACT_IMAGE
+	crictl_pull $ARTIFACT_IMAGE
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	jq --arg ARTIFACT_IMAGE "$ARTIFACT_IMAGE" \
 		'.mounts = [ {
@@ -88,7 +88,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 @test "should be able to mount artifact with multiple files on directory" {
 	start_crio
 	IMAGE="$ARTIFACT_REPO:multiplefiles"
-	crictl pull $IMAGE
+	crictl_pull $IMAGE
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	jq --arg ARTIFACT_IMAGE "$IMAGE" \
 		'.mounts = [ {
@@ -111,7 +111,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 	skip_if_selinux_disabled
 	skip_if_vm_runtime
 	start_crio
-	crictl pull $ARTIFACT_IMAGE
+	crictl_pull $ARTIFACT_IMAGE
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	jq --arg ARTIFACT_IMAGE "$ARTIFACT_IMAGE" \
 		'.mounts = [ {
@@ -132,7 +132,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 
 @test "should return error when mounting artifact on file path" {
 	start_crio
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	jq --arg ARTIFACT_IMAGE "$ARTIFACT_IMAGE" \
 		'.mounts = [ {
@@ -146,7 +146,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 @test "should return error when running executable" {
 	start_crio
 	IMAGE="$ARTIFACT_REPO:exec"
-	crictl pull $IMAGE
+	crictl_pull $IMAGE
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	jq --arg ARTIFACT_IMAGE "$IMAGE" \
 		'.mounts = [ {
@@ -163,7 +163,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 
 @test "should return error when removing image that is in use" {
 	start_crio
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	jq --arg ARTIFACT_IMAGE "$ARTIFACT_IMAGE" \
 		'.mounts = [ {
@@ -188,7 +188,7 @@ ARTIFACT_IMAGE_SUBPATH="$ARTIFACT_REPO:subpath"
 oci_artifact_mount_support = false
 EOF
 	start_crio
-	crictl pull $ARTIFACT_IMAGE
+	crictl_pull $ARTIFACT_IMAGE
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	jq --arg ARTIFACT_IMAGE "$ARTIFACT_IMAGE" \
 		'.mounts = [ {
@@ -204,7 +204,7 @@ EOF
 
 @test "should be able to mount OCI Artifact with sub path" {
 	start_crio
-	crictl pull $ARTIFACT_IMAGE_SUBPATH
+	crictl_pull $ARTIFACT_IMAGE_SUBPATH
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	jq --arg ARTIFACT_IMAGE_SUBPATH "$ARTIFACT_IMAGE_SUBPATH" \
 		'.mounts = [ {
@@ -227,7 +227,7 @@ EOF
 
 @test "should fail to mount OCI Artifact with sub path if not existing" {
 	start_crio
-	crictl pull $ARTIFACT_IMAGE_SUBPATH
+	crictl_pull $ARTIFACT_IMAGE_SUBPATH
 	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
 	jq --arg ARTIFACT_IMAGE_SUBPATH "$ARTIFACT_IMAGE_SUBPATH" \
 		'.mounts = [ {
@@ -249,7 +249,7 @@ pinned_images = [ "$ARTIFACT_IMAGE" ]
 EOF
 
 	start_crio
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 
 	crictl inspecti "$ARTIFACT_IMAGE" |
 		jq -e '.status.pinned == true'
@@ -262,7 +262,7 @@ pinned_images = [ "quay.io/crio/artifact*" ]
 EOF
 
 	start_crio
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 
 	crictl inspecti "$ARTIFACT_IMAGE" |
 		jq -e '.status.pinned == true'
@@ -275,7 +275,7 @@ pinned_images = [ "quay.io/crio/nonexistent:latest" ]
 EOF
 
 	start_crio
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 
 	crictl inspecti "$ARTIFACT_IMAGE" |
 		jq -e '.status.pinned == false'
@@ -283,7 +283,7 @@ EOF
 
 @test "artifact pinned status should update after config reload" {
 	start_crio
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 
 	# Initially not pinned
 	crictl inspecti "$ARTIFACT_IMAGE" |
@@ -306,7 +306,7 @@ pinned_images = [ "$ARTIFACT_IMAGE" ]
 EOF
 
 	start_crio
-	crictl pull "$ARTIFACT_IMAGE"
+	crictl_pull "$ARTIFACT_IMAGE"
 
 	# Initially pinned
 	crictl inspecti "$ARTIFACT_IMAGE" |
@@ -328,7 +328,7 @@ EOF
 	# TODO(bitoku): use an image in quay.io/crio once quay.io supports multiarch artifacts
 	# This version doesn't have to be updated. It's specified only to keep the test consistent.
 	MULTIARCH_ARTIFACT="ghcr.io/cri-o/bundle:v1.32.4"
-	crictl pull "$MULTIARCH_ARTIFACT"
+	crictl_pull "$MULTIARCH_ARTIFACT"
 
 	jq --arg ARTIFACT_IMAGE "$MULTIARCH_ARTIFACT" \
 		'.mounts = [ {

--- a/test/oci_volumes.bats
+++ b/test/oci_volumes.bats
@@ -23,7 +23,7 @@ IMAGE=quay.io/crio/artifact:v1
 	start_crio
 
 	# Prepull the artifact
-	crictl pull "$IMAGE"
+	crictl_pull "$IMAGE"
 
 	# Set mounts in the same way as the kubelet would do
 	jq --arg IMAGE "$IMAGE" --arg CONTAINER_PATH "$CONTAINER_PATH" \
@@ -70,7 +70,7 @@ IMAGE=quay.io/crio/artifact:v1
 	start_crio
 
 	# Prepull the artifact
-	crictl pull "$IMAGE"
+	crictl_pull "$IMAGE"
 
 	# Build a second sandbox using a different level
 	jq '.metadata.name = "sb-1" |
@@ -120,7 +120,7 @@ IMAGE=quay.io/crio/artifact:v1
 	start_crio
 
 	# Prepull the artifact
-	crictl pull "$IMAGE"
+	crictl_pull "$IMAGE"
 
 	# Set mounts in the same way as the kubelet would do
 	jq --arg IMAGE "$IMAGE" --arg CONTAINER_PATH "$CONTAINER_PATH" \
@@ -147,7 +147,7 @@ IMAGE=quay.io/crio/artifact:v1
 	start_crio
 
 	# Prepull the artifact
-	crictl pull "$IMAGE"
+	crictl_pull "$IMAGE"
 
 	# Set mounts in the same way as the kubelet would do
 	jq --arg IMAGE "$IMAGE" --arg CONTAINER_PATH "$CONTAINER_PATH" \

--- a/test/policy.bats
+++ b/test/policy.bats
@@ -30,7 +30,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 @test "accept unsigned image with default policy" {
 	start_crio
 
-	crictl pull "$UNSIGNED_IMAGE"
+	crictl_pull "$UNSIGNED_IMAGE"
 
 	assert_log "$SIGNATURE_POLICY"
 }
@@ -46,7 +46,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 @test "deny unsigned image with restrictive policy if already pulled" {
 	start_crio
-	crictl pull "$UNSIGNED_IMAGE"
+	crictl_pull "$UNSIGNED_IMAGE"
 	stop_crio_no_clean
 
 	SIGNATURE_POLICY="$RESTRICTIVE_POLICY" start_crio
@@ -59,7 +59,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 @test "accept signed image with default policy" {
 	start_crio
 
-	crictl pull "$SIGNED_IMAGE"
+	crictl_pull "$SIGNED_IMAGE"
 
 	assert_log "$SIGNATURE_POLICY"
 }
@@ -67,7 +67,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 @test "accept signed image with restrictive policy" {
 	SIGNATURE_POLICY="$RESTRICTIVE_POLICY" start_crio
 
-	crictl pull "$SIGNED_IMAGE"
+	crictl_pull "$SIGNED_IMAGE"
 
 	assert_log "$RESTRICTIVE_POLICY"
 }
@@ -100,7 +100,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 	start_crio
 
-	crictl pull --pod-config "$NEW_SANDBOX_CONFIG" "$UNSIGNED_IMAGE"
+	crictl_pull --pod-config "$NEW_SANDBOX_CONFIG" "$UNSIGNED_IMAGE"
 
 	assert_log "$SIGNATURE_POLICY"
 }
@@ -110,7 +110,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 	jq '.metadata.namespace = "unrestrictive"' "$SANDBOX_CONFIG" > "$NEW_SANDBOX_CONFIG"
 	SIGNATURE_POLICY="$RESTRICTIVE_POLICY" start_crio
 
-	crictl pull --pod-config "$NEW_SANDBOX_CONFIG" "$UNSIGNED_IMAGE"
+	crictl_pull --pod-config "$NEW_SANDBOX_CONFIG" "$UNSIGNED_IMAGE"
 
 	assert_log "$SIGNATURE_POLICY_DIR/unrestrictive.json"
 }
@@ -131,7 +131,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 	jq '.metadata.namespace = "restrictive"' "$SANDBOX_CONFIG" > "$NEW_SANDBOX_CONFIG"
 	start_crio
 
-	crictl pull --pod-config "$NEW_SANDBOX_CONFIG" "$SIGNED_IMAGE"
+	crictl_pull --pod-config "$NEW_SANDBOX_CONFIG" "$SIGNED_IMAGE"
 
 	assert_log "$SIGNATURE_POLICY_DIR/restrictive.json"
 }
@@ -140,7 +140,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 	start_crio
 	# Pull returns the image ID directly now, use it to verify the exact data flow
 	# from PullImage to CreateContainer
-	IMAGE_ID=$(crictl pull "$SIGNED_IMAGE" | awk '{print $NF}')
+	IMAGE_ID=$(crictl_pull "$SIGNED_IMAGE" | awk '{print $NF}')
 	stop_crio_no_clean
 
 	SIGNATURE_POLICY="$RESTRICTIVE_POLICY" start_crio
@@ -158,7 +158,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 	start_crio
 	# Pull returns the image ID directly now, use it to verify the exact data flow
 	# from PullImage to CreateContainer
-	IMAGE_ID=$(crictl pull "$UNSIGNED_IMAGE" | awk '{print $NF}')
+	IMAGE_ID=$(crictl_pull "$UNSIGNED_IMAGE" | awk '{print $NF}')
 	stop_crio_no_clean
 
 	SIGNATURE_POLICY="$RESTRICTIVE_POLICY" start_crio
@@ -173,7 +173,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 @test "allow signed image with restrictive policy on container creation3 if already pulled (by ID)" {
 	start_crio
-	crictl pull "$SIGNED_IMAGE"
+	crictl_pull "$SIGNED_IMAGE"
 	IMAGE_ID=$(crictl images -q "$SIGNED_IMAGE")
 	stop_crio_no_clean
 
@@ -190,7 +190,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 @test "deny unsigned image with restrictive policy on container creation4 if already pulled (by ID)" {
 	start_crio
-	crictl pull "$UNSIGNED_IMAGE"
+	crictl_pull "$UNSIGNED_IMAGE"
 	IMAGE_ID=$(crictl images -q "$UNSIGNED_IMAGE")
 	stop_crio_no_clean
 
@@ -206,7 +206,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 @test "allow signed image with restrictive policy on container creation5 if already pulled (by tag)" {
 	start_crio
-	crictl pull "$SIGNED_IMAGE"
+	crictl_pull "$SIGNED_IMAGE"
 	stop_crio_no_clean
 
 	SIGNATURE_POLICY="$RESTRICTIVE_POLICY" start_crio
@@ -222,7 +222,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 @test "deny unsigned image with restrictive policy on container creation6 if already pulled (by tag)" {
 	start_crio
-	crictl pull "$UNSIGNED_IMAGE"
+	crictl_pull "$UNSIGNED_IMAGE"
 	stop_crio_no_clean
 
 	SIGNATURE_POLICY="$RESTRICTIVE_POLICY" start_crio
@@ -237,7 +237,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 @test "allow signed image with restrictive policy on container creation7 if already pulled (by tag and ID)" {
 	start_crio
-	crictl pull "$SIGNED_IMAGE"
+	crictl_pull "$SIGNED_IMAGE"
 	# Insert "latest" tag into the repoDigests field, and use that as the reference
 	# CRI-O should filter out the :latest bit, so it's a valid reference for c/image
 	REPO_TAG_DIGEST=$(crictl inspecti "$SIGNED_IMAGE" | jq -r .status.repoDigests[0] | sed "s|@|:latest@|g")
@@ -256,7 +256,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 @test "deny unsigned image with restrictive policy on container creation7 if already pulled (by tag and ID)" {
 	start_crio
-	crictl pull "$UNSIGNED_IMAGE"
+	crictl_pull "$UNSIGNED_IMAGE"
 	# Insert "latest" tag into the repoDigests field, and use that as the reference
 	# CRI-O should filter out the :latest bit, so it's a valid reference for c/image
 	REPO_TAG_DIGEST=$(crictl inspecti "$UNSIGNED_IMAGE" | jq -r .status.repoDigests[0] | sed "s|@|:latest@|g")
@@ -274,7 +274,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 @test "deny signed image with restrictive policy on container creation if invalid policy (subjectEmail)" {
 	start_crio
-	crictl pull "$SIGNED_IMAGE"
+	crictl_pull "$SIGNED_IMAGE"
 	# Insert "latest" tag into the repoDigests field, and use that as the reference
 	# CRI-O should filter out the :latest bit, so it's a valid reference for c/image
 	REPO_TAG_DIGEST=$(crictl inspecti "$SIGNED_IMAGE" | jq -r .status.repoDigests[0] | sed "s|@|:latest@|g")
@@ -295,7 +295,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 
 @test "deny signed image with restrictive policy on container creation if invalid policy (oidcIssuer)" {
 	start_crio
-	crictl pull "$SIGNED_IMAGE"
+	crictl_pull "$SIGNED_IMAGE"
 	# Insert "latest" tag into the repoDigests field, and use that as the reference
 	# CRI-O should filter out the :latest bit, so it's a valid reference for c/image
 	REPO_TAG_DIGEST=$(crictl inspecti "$SIGNED_IMAGE" | jq -r .status.repoDigests[0] | sed "s|@|:latest@|g")
@@ -319,7 +319,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 		skip "test fails in a user namespace"
 	fi
 	start_crio
-	crictl pull "$SIGNED_IMAGE"
+	crictl_pull "$SIGNED_IMAGE"
 	stop_crio_no_clean
 
 	SIGNATURE_POLICY="$RESTRICTIVE_POLICY" start_crio
@@ -339,7 +339,7 @@ SANDBOX_CONFIG="$TESTDATA/sandbox_config.json"
 		skip "test fails in a user namespace"
 	fi
 	start_crio
-	crictl pull "$UNSIGNED_IMAGE"
+	crictl_pull "$UNSIGNED_IMAGE"
 	stop_crio_no_clean
 
 	SIGNATURE_POLICY="$RESTRICTIVE_POLICY" start_crio

--- a/test/reload_system.bats
+++ b/test/reload_system.bats
@@ -88,7 +88,7 @@ function assert_debounced_reloads() {
 
 	# then
 	expect_log_success
-	crictl pull "$TEST_IMAGE"
+	crictl_pull "$TEST_IMAGE"
 }
 
 @test "reload system registries should fail on invalid syntax in file" {
@@ -113,7 +113,7 @@ function assert_debounced_reloads() {
 
 	# then
 	expect_log_success
-	crictl pull "$TEST_IMAGE2"
+	crictl_pull "$TEST_IMAGE2"
 }
 
 @test "system registries should fail on invalid syntax in file without reload" {

--- a/test/seccomp_oci_artifacts.bats
+++ b/test/seccomp_oci_artifacts.bats
@@ -34,7 +34,7 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 		'.image.image = $IMAGE | .image.user_specified_image = $IMAGE' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_ANNOTATION
+	crictl_pull $ARTIFACT_IMAGE_WITH_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
@@ -53,7 +53,7 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 		'.image.image = $IMAGE | .image.user_specified_image = $IMAGE' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
+	crictl_pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
@@ -72,7 +72,7 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 		'.image.image = $IMAGE | .image.user_specified_image = $IMAGE' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_CONTAINER_ANNOTATION
+	crictl_pull $ARTIFACT_IMAGE_WITH_CONTAINER_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
@@ -88,7 +88,7 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 		'.image.image = $IMAGE | .image.user_specified_image = $IMAGE' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
+	crictl_pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
@@ -108,7 +108,7 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 		| .linux.security_context.seccomp.profile_type = 1' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
+	crictl_pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
@@ -128,7 +128,7 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 		| .linux.security_context.seccomp.profile_type = 0' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
+	crictl_pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert
@@ -152,7 +152,7 @@ TEST_SYSCALL=OCI_ARTIFACT_TEST
 		| .linux.security_context.seccomp.localhost_ref = "'"$TESTDIR"'/profile.json"' \
 		"$TESTDATA/container_config.json" > "$TESTDIR/container.json"
 
-	crictl pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
+	crictl_pull $ARTIFACT_IMAGE_WITH_POD_ANNOTATION
 	CTR=$(crictl run "$TESTDIR/container.json" "$TESTDATA/sandbox_config.json")
 
 	# Assert


### PR DESCRIPTION
The OCI artifact tests pull their fixtures from quay.io in the middle of each test. When the registry is slow the pull fails with a TLS handshake timeout and the test fails, even though nothing about CRI-O misbehaved. Because whole blocks of tests pull the same fixtures, a single slow period takes out several consecutive tests.

Add a crictl_pull helper that wraps the pull in the existing retry helper, mirroring the --retry-attempts=3 that get_img() already passes to copyimg for the preloaded images, and use it for the pulls in the artifact tests.

Only pulls expected to succeed are wrapped; a pull expected to fail would otherwise be retried three times before failing.

/kind ci

Ref: https://github.com/cri-o/cri-o/issues/9859


```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **Tests**
  * Improved test reliability across image, OCI artifact, OCI volume, policy/signature, namespaced auth, registry reload, and seccomp scenarios by switching to a shared retry-enabled image pull helper.
  * Ensures tests consistently capture the pulled reference/digest for parsing and log output, without changing existing mount, SELinux relabeling, pinned, or runtime log assertions.
  * Updated artifact removal and pinned-status flows to pull via the helper before performing remove/verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->