### PR TITLE
Fix import grouping in server/utils_test.go

### DIFF
--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.podman.io/storage/pkg/mount"
-
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

The `lint` job currently fails on pull requests opened against `main`:

```
server/utils_test.go:12:1: File is not properly formatted (gci)
1 issues:
* gci: 1
```

`gci` is configured in `.golangci.yml` with the `standard`, `default` and
`localmodule` sections, so `k8s.io/cri-api` belongs to the same `default`
group as `github.com/opencontainers/...` and `go.podman.io/...`. A blank line
splits that group in two, which is the violation. Removing it is the whole
change.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

This is easy to miss locally: `make lint` runs `golangci-lint run --fix`, so it
repairs the file in your working tree and reports `0 issues`, while CI runs
without `--fix` and fails. Verified with `golangci-lint run ./server/...` (no
`--fix`), which reports `0 issues` with this change and reproduces the failure
without it.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Tidied import formatting without changing functionality or test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->