### PR TITLE
Retry network fetches in the CI setup script

### DIFF
--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -24,7 +24,31 @@ main() {
 }
 
 curl_retry() {
-    sudo curl -sSfL --retry 5 --retry-delay 3 "$@"
+    # --retry alone only covers transient errors, which does not include the
+    # 403 a release download occasionally returns.
+    sudo curl -sSfL --retry 5 --retry-delay 3 --retry-all-errors "$@"
+}
+
+# Clone with retries. Every job in the matrix runs this script before any test
+# does, so one transient failure here costs a whole job.
+#
+# A failed clone can leave a partial directory behind and git refuses to clone
+# into a non-empty one, so clear the target before each attempt - otherwise
+# every retry fails with "already exists" instead of retrying the fetch.
+git_clone_retry() {
+    local url=$1 dir=${2:-}
+    [[ -n "$dir" ]] || dir=$(basename "$url" .git)
+
+    local i
+    for ((i = 1; i <= 5; i++)); do
+        sudo rm -rf "$dir"
+        if git clone "$url" "$dir"; then
+            return 0
+        fi
+        echo "Clone attempt $i of 5 failed: $url" >&2
+        sleep 3
+    done
+    return 1
 }
 
 prepare_system() {
@@ -57,7 +81,7 @@ install_from_github_org_repo() {
     URL=https://github.com/$1/$2
     DIR=$(mktemp -ud)
 
-    git clone "$URL" "$DIR"
+    git_clone_retry "$URL" "$DIR"
     pushd "$DIR"
     git checkout "$3"
     "${@:4}"
@@ -106,14 +130,14 @@ install_cni_plugins() {
     TARBALL="cni-plugins-linux-$GOARCH-${VERSIONS["cni-plugins"]}.tgz"
     CNI_DIR=/opt/cni/bin
     sudo mkdir -p "$CNI_DIR"
-    wget -O "$TARBALL" $URL/"${VERSIONS["cni-plugins"]}"/"$TARBALL"
+    curl_retry -o "$TARBALL" $URL/"${VERSIONS["cni-plugins"]}"/"$TARBALL"
     sudo tar xf "$TARBALL" -C "$CNI_DIR"
     rm "$TARBALL"
     ls -lah "$CNI_DIR"
 }
 
 install_crun() {
-    git clone https://github.com/containers/crun
+    git_clone_retry https://github.com/containers/crun
     pushd crun
     git checkout "${VERSIONS["crun"]}"
     ./autogen.sh
@@ -157,7 +181,7 @@ install_files() {
 install_buildah() {
     URL=https://github.com/containers/buildah.git
 
-    git clone $URL
+    git_clone_retry "$URL"
     pushd buildah
     git checkout "${VERSIONS["buildah"]}"
     make bin/buildah


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Every job in the integration matrix runs `scripts/github-actions-setup` before
any test does, so one transient network failure there costs a whole job before
a single test has run. Surveying recent pull requests, two jobs died exactly
this way — at 47s and 2m40s, short enough to be mistaken for a build break:

- [#9875](https://github.com/cri-o/cri-o/actions/runs/28502733790/job/84492545038): `curl: (22) The requested URL returned error: 403`
- [#9995](https://github.com/cri-o/cri-o/actions/runs/26818600353/job/79083434998): toolchain failure building runc from source

Two holes:

1. **`--retry` does not cover a 403.** `curl_retry` already passes `--retry 5`,
   but that only retries transient errors — timeouts, 429, 5xx. The #9875
   failure happened *inside* a `curl_retry` call which then declined to retry
   it. `--retry-all-errors` closes that.
2. **The three `git clone`s had no retry at all** —
   `install_from_github_org_repo`, crun and buildah.

Wrapping the clones needs a little care: a failed clone can leave a partial
directory behind, and git refuses to clone into a non-empty one, so a naive
retry loop fails every subsequent attempt with `already exists` instead of
retrying the fetch. `git_clone_retry` clears the target before each attempt.

This is the same reasoning as
[#10081](https://github.com/cri-o/cri-o/pull/10081) (retry remote fetches used
by the tests), applied one layer further out to the setup that every job
depends on.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

The cni-plugins download is switched from `wget` to `curl_retry` so that every
download in the script goes through one helper. Note this one is *consistency,
not a fix* — GNU wget already defaults to `--tries=20`, so it retried transient
errors; like curl it simply does not retry a fatal 4xx. Happy to drop that hunk
if you would rather keep the diff to the two real holes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability by adding stronger retry behavior for network downloads and repository checkouts during transient failures.
  * Prevented incomplete or pre-existing target directories from blocking retry attempts.
  * Enhanced setup of CNI plugins, crun, and Buildah with more resilient download/clone operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->