### PR TITLE
test: do not leak bats FD 3 into the runtime

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -222,7 +222,7 @@ function start_crio_no_setup() {
         -l debug \
         -c "$CRIO_CONFIG" \
         -d "$CRIO_CONFIG_DIR" \
-        &>"$CRIO_LOG" &
+        &>"$CRIO_LOG" 3>&- &
     CRIO_PID=$!
     wait_until_reachable
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

bats does not exit until FD 3 is closed by all of its descendants.
`start_crio_no_setup` backgrounds CRI-O redirecting only stdout and stderr, so
CRI-O inherits FD 3, and the monitor it spawns inherits it in turn.

conmon closes inherited descriptors above stderr (`close_other_fds()`,
`close_all_fds_ge_than(3)`), so this goes unnoticed there. conmon-rs does not,
and it is a daemon rather than a per-container process, so it holds FD 3 for as
long as it runs. When any conmon-rs is still alive after the last test, the
suite reports **every test as passing** and then hangs until the two hour job
timeout — the job ends up `cancelled`, with an empty `--log-failed`, which reads
as infrastructure noise.

Observed on four unrelated pull requests (#10155, #10143, #10062, #9988), always
`integration / conmon-rs / crun / amd64`, always with all 29 `crio:serial` tests
passing and no `not ok` anywhere in the job.

Closing FD 3 for CRI-O means neither it nor the monitor ever receives it.

Demonstrated standalone, with a bats test that backgrounds a child and ends
while it is still running:

| child | bats exit | elapsed |
| --- | --- | --- |
| inherits FD 3 | 0 | 20s, blocked until the child exited |
| `3>&-` | 0 | 0s |

#### Which issue(s) this PR fixes:

Fixes #10188

#### Special notes for your reviewer:

conmon-rs is being fixed to close inherited descriptors too, in
containers/conmon-rs#3363. That is the root cause, but it has to be released and
vendored before it takes effect anywhere, so this is worth having independently —
it also stops any future monitor from inheriting FD 3.

Full analysis, including the conmon versus conmon-rs difference and an A/B
reproducer against patched and unpatched conmon-rs, is in #10188.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background service startup behavior by ensuring an inherited file descriptor is closed when launching the process.
  * Maintained existing logging of standard output and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->