### PR TITLE
Skip normalizing bare tag artifact names from OCI layouts

### DIFF
--- a/internal/ociartifact/artifact.go
+++ b/internal/ociartifact/artifact.go
@@ -3,6 +3,7 @@ package ociartifact
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/opencontainers/go-digest"
 	"go.podman.io/common/pkg/libartifact"
@@ -35,7 +36,7 @@ type Artifact struct {
 }
 
 // newArtifact creates a new Artifact from a libartifact.Artifact.
-func (s *Store) newArtifact(art *libartifact.Artifact, rootPath string, pinned bool) *Artifact {
+func (s *Store) newArtifact(ctx context.Context, art *libartifact.Artifact, rootPath string, pinned bool) *Artifact {
 	artifact := &Artifact{
 		Artifact: art,
 		rootPath: rootPath,
@@ -43,14 +44,24 @@ func (s *Store) newArtifact(art *libartifact.Artifact, rootPath string, pinned b
 	}
 
 	if art.Name != "" {
-		namedRef, err := reference.ParseNormalizedNamed(art.Name)
-		if err != nil {
-			log.Warnf(context.Background(), "Failed to parse artifact name %s with the error %s", art.Name, err)
+		// Guard against bare tags from OCI layout annotations written by
+		// external tools (e.g. skopeo writes "1.14.4" instead of the full
+		// "docker.io/coredns/coredns:1.14.4"). ParseNormalizedNamed would
+		// turn these into nonsensical refs like "docker.io/library/1.14.4".
+		// The upstream fix lives in libartifact (container-libs #1027).
+		if !strings.Contains(art.Name, "/") {
+			log.Warnf(ctx,
+				"Artifact name %q looks like a bare tag, not a fully qualified reference; skipping normalization", art.Name)
+		} else {
+			namedRef, err := reference.ParseNormalizedNamed(art.Name)
+			if err != nil {
+				log.Warnf(ctx, "Failed to parse artifact name %s: %v", art.Name, err)
 
-			namedRef = unknownRef{}
+				namedRef = unknownRef{}
+			}
+
+			artifact.namedRef = namedRef
 		}
-
-		artifact.namedRef = namedRef
 	}
 
 	artifact.pinned = pinned || s.isArtifactPinned(artifact)

--- a/internal/ociartifact/store.go
+++ b/internal/ociartifact/store.go
@@ -133,7 +133,7 @@ func (s *Store) Pull(
 				if inspErr == nil {
 					log.Infof(ctx, "Artifact %s already exists in additional store %s, skipping pull", strRef, add.path)
 					// Force-pinned: additional stores are read-only and not subject to GC.
-					dgst := s.newArtifact(art, add.path, true).Digest()
+					dgst := s.newArtifact(ctx, art, add.path, true).Digest()
 
 					return &dgst, nil
 				}
@@ -246,7 +246,7 @@ func (s *Store) List(ctx context.Context) (res []*Artifact, err error) {
 
 		for _, art := range addArts {
 			// Force-pinned: additional stores are read-only and not subject to GC.
-			arts = append(arts, s.newArtifact(art, add.path, true))
+			arts = append(arts, s.newArtifact(ctx, art, add.path, true))
 		}
 	}
 
@@ -257,7 +257,7 @@ func (s *Store) List(ctx context.Context) (res []*Artifact, err error) {
 	}
 
 	for _, art := range mainArts {
-		arts = append(arts, s.newArtifact(art, s.rootPath, false))
+		arts = append(arts, s.newArtifact(ctx, art, s.rootPath, false))
 	}
 
 	// Deduplicate by reference, preserving priority (additional stores
@@ -292,7 +292,7 @@ func (s *Store) Status(ctx context.Context, nameOrDigest string) (*Artifact, err
 		artifact, err := add.store.Inspect(ctx, artRef)
 		if err == nil {
 			// Force-pinned: additional stores are read-only and not subject to GC.
-			return s.newArtifact(artifact, add.path, true), nil
+			return s.newArtifact(ctx, artifact, add.path, true), nil
 		}
 
 		if errors.Is(err, ErrNotFound) {
@@ -305,7 +305,7 @@ func (s *Store) Status(ctx context.Context, nameOrDigest string) (*Artifact, err
 	// Check main store
 	artifact, err := s.libartifactStore.Inspect(ctx, artRef)
 	if err == nil {
-		return s.newArtifact(artifact, s.rootPath, false), nil
+		return s.newArtifact(ctx, artifact, s.rootPath, false), nil
 	}
 
 	return nil, fmt.Errorf("inspect artifact: %w", err)

--- a/internal/ociartifact/store_test.go
+++ b/internal/ociartifact/store_test.go
@@ -567,6 +567,88 @@ var _ = t.Describe("Store", func() {
 		})
 	})
 
+	t.Describe("Bare tag artifact name", func() {
+		var (
+			storeMock *ociartifactmock.MockLibartifactStore
+			mockCtrl  *gomock.Controller
+			store     *ociartifact.Store
+		)
+
+		makeLibArtifact := func(name string) *libartifact.Artifact {
+			return &libartifact.Artifact{
+				Name:     name,
+				Digest:   testDigest,
+				Manifest: &manifest.OCI1{},
+			}
+		}
+
+		BeforeEach(func() {
+			logrus.SetOutput(io.Discard)
+
+			mockCtrl = gomock.NewController(GinkgoT())
+			storeMock = ociartifactmock.NewMockLibartifactStore(mockCtrl)
+
+			var err error
+
+			store, err = ociartifact.NewStore(t.MustTempDir("artifact"), nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			store.SetFakeStore(&ociartifact.FakeLibartifactStore{storeMock})
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		It("should treat bare version tag as unknown instead of normalizing it", func() {
+			// Given - simulates an OCI layout where org.opencontainers.image.ref.name
+			// contains only the tag portion (e.g. from skopeo copy)
+			storeMock.EXPECT().
+				List(gomock.Any()).
+				Return(libartifact.ArtifactList{makeLibArtifact("1.14.4")}, nil)
+
+			// When
+			arts, err := store.List(context.Background())
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts).To(HaveLen(1))
+			Expect(arts[0].Reference()).To(Equal("unknown"))
+			Expect(arts[0].CRIImage().GetRepoTags()).To(BeEmpty())
+		})
+
+		It("should treat bare 'latest' tag as unknown instead of normalizing it", func() {
+			// Given
+			storeMock.EXPECT().
+				List(gomock.Any()).
+				Return(libartifact.ArtifactList{makeLibArtifact("latest")}, nil)
+
+			// When
+			arts, err := store.List(context.Background())
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts).To(HaveLen(1))
+			Expect(arts[0].Reference()).To(Equal("unknown"))
+			Expect(arts[0].CRIImage().GetRepoTags()).To(BeEmpty())
+		})
+
+		It("should correctly parse fully qualified artifact names", func() {
+			// Given
+			storeMock.EXPECT().
+				List(gomock.Any()).
+				Return(libartifact.ArtifactList{makeLibArtifact("docker.io/coredns/coredns:1.14.4")}, nil)
+
+			// When
+			arts, err := store.List(context.Background())
+
+			// Then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arts).To(HaveLen(1))
+			Expect(arts[0].Reference()).To(Equal("docker.io/coredns/coredns:1.14.4"))
+			Expect(arts[0].CRIImage().GetRepoTags()).To(ConsistOf("docker.io/coredns/coredns:1.14.4"))
+		})
+	})
+
 	t.Describe("Additional stores", func() {
 		var (
 			mainStoreMock *ociartifactmock.MockLibartifactStore

--- a/test/oci_artifacts.bats
+++ b/test/oci_artifacts.bats
@@ -322,6 +322,40 @@ EOF
 		jq -e '.status.pinned == false'
 }
 
+@test "should treat bare tag in OCI layout as unknown reference" {
+	start_crio
+	crictl_pull $ARTIFACT_IMAGE
+
+	# Remember the artifact's image ID before we tamper with the layout.
+	imageId=$(crictl inspecti $ARTIFACT_IMAGE | jq -r '.status.id')
+
+	# Simulate an OCI layout written by an external tool (e.g. skopeo) that
+	# stores only the tag portion in org.opencontainers.image.ref.name.
+	local main_index="$TESTDIR/crio/artifacts/index.json"
+	jq '.manifests |= map(
+		if .annotations["org.opencontainers.image.ref.name"] then
+			.annotations["org.opencontainers.image.ref.name"] = "1.14.4"
+		else . end)' \
+		"$main_index" > "$main_index.tmp" && mv "$main_index.tmp" "$main_index"
+
+	# The artifact should appear with no repoTags and not the wrong
+	# docker.io/library/1.14.4 normalization.
+	crictl inspecti "$imageId" |
+		jq -e '(.status.repoTags | length == 0) and
+		       (.status.repoDigests | all(startswith("unknown@")))'
+}
+
+@test "should preserve fully qualified artifact name from OCI layout" {
+	start_crio
+	crictl_pull $ARTIFACT_IMAGE
+
+	crictl images | grep -qE "$ARTIFACT_REPO.*singlefile"
+
+	crictl inspecti $ARTIFACT_IMAGE |
+		jq -e '(.status.repoTags | length == 1) and
+		       (.status.repoTags[0] == "quay.io/crio/artifact:singlefile")'
+}
+
 @test "should pull multi-architecture image" {
 	start_crio
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
External tools like skopeo write only the tag portion (e.g. `1.14.4`) into the `org.opencontainers.image.ref.name` annotation in `index.json` when creating OCI layouts. `ParseNormalizedNamed` turns this bare tag into the nonsensical `docker.io/library/1.14.4`, producing a wrong image name and no tag in `crictl images` output. This PR detects names without a `/` as bare tags and leaves the reference as unknown instead of producing a wrong one.

#### Which issue(s) this PR fixes:
Fixes #10151

#### Special notes for your reviewer:
The upstream fix is podman-container-tools/container-libs#1027. This CRI-O-side guard prevents the wrong name from surfacing regardless.

#### Does this PR introduce a user-facing change?
```release-note
Fix artifact names from externally created OCI layouts (e.g. via skopeo) being incorrectly normalized to wrong docker references.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact name handling for bare tags, which are now treated as unknown references instead of being incorrectly normalized.
  * Preserved fully qualified artifact references, including registry, repository, and tag information.

* **Tests**
  * Added coverage for displaying bare tags as unknown and retaining fully qualified references in listings and inspection output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->