### PR TITLE
Migrate remaining v1 annotation references in docs and tests

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -13,7 +13,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l absent-mount-sources-to-re
 complete -c crio -n '__fish_crio_no_subcommand' -f -l add-inheritable-capabilities -d 'Add capabilities to the inheritable set, as well as the default group of permitted, bounding and effective.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l additional-artifact-stores -r -d 'Additional read-only OCI artifact store paths.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l additional-devices -r -d 'Devices to add to the containers.'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l allowed-devices -r -d 'Devices a user is allowed to specify with the "io.kubernetes.cri-o.Devices" allowed annotation.'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l allowed-devices -r -d 'Devices a user is allowed to specify with the "devices.crio.io" allowed annotation.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l apparmor-profile -r -d 'Name of the apparmor profile to be used as the runtime\'s default. This only takes effect if the user does not specify a profile via the Kubernetes Pod\'s metadata annotation.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l auto-reload-registries -d 'If true, CRI-O will automatically reload the mirror registry when there is an update to the \'registries.conf.d\' directory. Default value is set to \'false\'.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l big-files-temporary-dir -r -d 'Path to the temporary directory to use for storing big files, used to store image blobs and data streams related to containers image management.'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -182,7 +182,7 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--additional-devices**="": Devices to add to the containers.
 
-**--allowed-devices**="": Devices a user is allowed to specify with the "io.kubernetes.cri-o.Devices" allowed annotation. (default: "/dev/fuse", "/dev/net/tun")
+**--allowed-devices**="": Devices a user is allowed to specify with the "devices.crio.io" allowed annotation. (default: "/dev/fuse", "/dev/net/tun")
 
 **--apparmor-profile**="": Name of the apparmor profile to be used as the runtime's default. This only takes effect if the user does not specify a profile via the Kubernetes Pod's metadata annotation. (default: "crio-default")
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -232,7 +232,7 @@ One example would be allowing ping inside of containers. On systems that support
 ```
 
 **allowed_devices**=[]
-List of devices on the host that a user can specify with the "io.kubernetes.cri-o.Devices" allowed annotation.
+List of devices on the host that a user can specify with the "devices.crio.io" allowed annotation.
 
 **additional_devices**=[]
 List of additional devices. Specified as "<device-on-host>:<device-on-container>:<permissions>", for example: "--additional-devices=/dev/sdc:/dev/xvdc:rwm". If it is empty or commented out, only the devices defined in the container json file by the user/kube will be added.
@@ -376,14 +376,14 @@ Whether this runtime handler prevents host devices from being passed to privileg
 **This field is currently DEPRECATED. If you'd like to use allowed_annotations, please use a workload.**
 A list of experimental annotations this runtime handler is allowed to process.
 The currently recognized values are:
-"io.kubernetes.cri-o.userns-mode" for configuring a user namespace for the pod.
-"io.kubernetes.cri-o.Devices" for configuring devices for the pod.
-"io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
-"io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
+"userns-mode.crio.io" for configuring a user namespace for the pod.
+"devices.crio.io" for configuring devices for the pod.
+"shm-size.crio.io" for configuring the size of /dev/shm.
+"unified-cgroup.crio.io/$CTR_NAME" for configuring the cgroup v2 unified block for a container.
 "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
-"seccomp-profile.kubernetes.cri-o.io" for setting the seccomp profile for: - a specific container by using: "seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>" - a whole pod by using: "seccomp-profile.kubernetes.cri-o.io/POD"
+"seccomp-profile.crio.io" for setting the seccomp profile for: - a specific container by using: "seccomp-profile.crio.io/<CONTAINER_NAME>" - a whole pod by using: "seccomp-profile.crio.io/POD"
 Note that the annotation works on containers as well as on images.
-For images, the plain annotation `seccomp-profile.kubernetes.cri-o.io`
+For images, the plain annotation `seccomp-profile.crio.io`
 can be used without the required `/POD` suffix or a container name.
 
 **container_min_memory**=""
@@ -428,18 +428,18 @@ The full annotation must be of the form `$annotation_prefix.$resource/$ctrname =
 **allowed_annotations**=[]
 allowed_annotations is a slice of experimental annotations that this workload is allowed to process.
 The currently recognized values are:
-"io.kubernetes.cri-o.userns-mode" for configuring a user namespace for the pod.
-"io.kubernetes.cri-o.cgroup2-mount-hierarchy-rw" for mounting cgroups writably when set to "true".
-"io.kubernetes.cri-o.Devices" for configuring devices for the pod.
-"io.kubernetes.cri-o.ShmSize" for configuring the size of /dev/shm.
-"io.kubernetes.cri-o.UnifiedCgroup.$CTR_NAME" for configuring the cgroup v2 unified block for a container.
+"userns-mode.crio.io" for configuring a user namespace for the pod.
+"cgroup2-mount-hierarchy-rw.crio.io" for mounting cgroups writably when set to "true".
+"devices.crio.io" for configuring devices for the pod.
+"shm-size.crio.io" for configuring the size of /dev/shm.
+"unified-cgroup.crio.io/$CTR_NAME" for configuring the cgroup v2 unified block for a container.
 "io.containers.trace-syscall" for tracing syscalls via the OCI seccomp BPF hook.
-"io.kubernetes.cri-o.seccompNotifierAction" for enabling the seccomp notifier feature.
-"io.kubernetes.cri-o.umask" for setting the umask for container init process.
+"seccomp-notifier-action.crio.io" for enabling the seccomp notifier feature.
+"umask.crio.io" for setting the umask for container init process.
 "io.kubernetes.cri.rdt-class" for setting the RDT class of a container
-"seccomp-profile.kubernetes.cri-o.io" for setting the seccomp profile for: - a specific container by using: "seccomp-profile.kubernetes.cri-o.io/<CONTAINER_NAME>" - a whole pod by using: "seccomp-profile.kubernetes.cri-o.io/POD"
+"seccomp-profile.crio.io" for setting the seccomp profile for: - a specific container by using: "seccomp-profile.crio.io/<CONTAINER_NAME>" - a whole pod by using: "seccomp-profile.crio.io/POD"
 Note that the annotation works on containers as well as on images.
-"io.kubernetes.cri-o.DisableFIPS" for disabling FIPS mode for a pod within a FIPS-enabled Kubernetes cluster.
+"disable-fips.crio.io" for disabling FIPS mode for a pod within a FIPS-enabled Kubernetes cluster.
 
 #### Using the seccomp notifier feature:
 
@@ -448,16 +448,16 @@ blocked syscalls (permission denied errors) have negative impact on the
 workload.
 
 To be able to use this feature, configure a runtime which has the annotation
-"io.kubernetes.cri-o.seccompNotifierAction" in the `allowed_annotations` array.
+"seccomp-notifier-action.crio.io" in the `allowed_annotations` array.
 
 It also requires at least runc 1.1.0 or crun 0.19 which support the notifier
 feature.
 
 If everything is setup, CRI-O will modify chosen seccomp profiles for containers
-if the annotation "io.kubernetes.cri-o.seccompNotifierAction" is set on the Pod
+if the annotation "seccomp-notifier-action.crio.io" is set on the Pod
 sandbox. CRI-O will then get notified if a container is using a blocked syscall
 and then terminate the workload after a timeout of 5 seconds if the value of
-"io.kubernetes.cri-o.seccompNotifierAction=stop".
+"seccomp-notifier-action.crio.io=stop".
 
 This also means that multiple syscalls can be captured during that period, while
 the timeout will get reset once a new syscall has been discovered.

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -1312,7 +1312,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:    "allowed-devices",
-			Usage:   "Devices a user is allowed to specify with the \"io.kubernetes.cri-o.Devices\" allowed annotation.",
+			Usage:   "Devices a user is allowed to specify with the \"devices.crio.io\" allowed annotation.",
 			Value:   cli.NewStringSlice(defConf.AllowedDevices...),
 			EnvVars: []string{"CONTAINER_ALLOWED_DEVICES"},
 		},

--- a/test/config.bats
+++ b/test/config.bats
@@ -110,8 +110,8 @@ EOF
 	unset CONTAINER_DEFAULT_RUNTIME
 	cat << EOF >> "$TESTDIR"/workload.conf
 [crio.runtime.workloads.userns]
-activation_annotation = "io.kubernetes.cri-o.userns-mode"
-allowed_annotations = ["io.kubernetes.cri-o.userns-mode"]
+activation_annotation = "userns-mode.crio.io"
+allowed_annotations = ["userns-mode.crio.io"]
 EOF
 
 	# then

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -79,7 +79,7 @@ function setup_log_linking_test() {
 
 	# Create directories and set up pod/container.
 	mkdir -p "$pod_log_dir" "$pod_empty_dir_volume_path"
-	jq --arg pod_log_dir "$pod_log_dir" --arg pod_uid "$pod_uid" '.annotations["io.kubernetes.cri-o.LinkLogs"] = "logging-volume"
+	jq --arg pod_log_dir "$pod_log_dir" --arg pod_uid "$pod_uid" '.annotations["link-logs.crio.io"] = "logging-volume"
 	| .log_directory = $pod_log_dir | .metadata.uid = $pod_uid' \
 		"$TESTDATA/sandbox_config.json" > "$TESTDIR/sandbox_config.json"
 	pod_id=$(crictl runp "$TESTDIR/sandbox_config.json")
@@ -1337,7 +1337,7 @@ function assert_log_linking() {
 		skip "not applicable to vm runtime type"
 	fi
 	setup_crio
-	create_runtime_with_allowed_annotation logs io.kubernetes.cri-o.LinkLogs
+	create_runtime_with_allowed_annotation logs link-logs.crio.io
 	start_crio_no_setup
 
 	# Create directories created by the kubelet needed for log linking to work
@@ -1354,7 +1354,7 @@ function assert_log_linking() {
 	ctr_attempt=$(jq -r '.metadata.attempt' "$TESTDATA/container_config.json")
 
 	# Add annotation for log linking in the pod
-	jq --arg pod_log_dir "$pod_log_dir" --arg pod_uid "$pod_uid" '.annotations["io.kubernetes.cri-o.LinkLogs"] = "logging-volume"
+	jq --arg pod_log_dir "$pod_log_dir" --arg pod_uid "$pod_uid" '.annotations["link-logs.crio.io"] = "logging-volume"
 	| .log_directory = $pod_log_dir | .metadata.uid = $pod_uid' \
 		"$TESTDATA/sandbox_config.json" > "$TESTDIR/sandbox_config.json"
 	pod_id=$(crictl runp "$TESTDIR"/sandbox_config.json)
@@ -1402,8 +1402,8 @@ function assert_log_linking() {
 		skip "not applicable to vm runtime type"
 	fi
 	setup_crio
-	create_runtime_with_allowed_annotation logs io.kubernetes.cri-o.LinkLogs
-	create_workload_with_allowed_annotation io.kubernetes.cri-o.LinkLogs
+	create_runtime_with_allowed_annotation logs link-logs.crio.io
+	create_workload_with_allowed_annotation link-logs.crio.io
 	start_crio_no_setup
 
 	# Create directories created by the kubelet needed for log linking to work
@@ -1420,7 +1420,7 @@ function assert_log_linking() {
 	ctr_attempt=$(jq -r '.metadata.attempt' "$TESTDATA/container_config.json")
 
 	# Add annotation for log linking in the pod
-	jq --arg pod_log_dir "$pod_log_dir" --arg pod_uid "$pod_uid" '.annotations["io.kubernetes.cri-o.LinkLogs"] = "logging-volume"
+	jq --arg pod_log_dir "$pod_log_dir" --arg pod_uid "$pod_uid" '.annotations["link-logs.crio.io"] = "logging-volume"
 	| .log_directory = $pod_log_dir | .metadata.uid = $pod_uid' \
 		"$TESTDATA/sandbox_config.json" > "$TESTDIR/sandbox_config.json"
 	pod_id=$(crictl runp "$TESTDIR"/sandbox_config.json)
@@ -1468,7 +1468,7 @@ function assert_log_linking() {
 		skip "not applicable to vm runtime type"
 	fi
 	setup_crio
-	create_runtime_with_allowed_annotation logs io.kubernetes.cri-o.LinkLogs
+	create_runtime_with_allowed_annotation logs link-logs.crio.io
 	start_crio_no_setup
 
 	read -r pod_empty_dir_volume_path ctr_name ctr_attempt ctr_id <<< "$(setup_log_linking_test "../../../malicious")"
@@ -1481,7 +1481,7 @@ function assert_log_linking() {
 		skip "not applicable to vm runtime type"
 	fi
 	setup_crio
-	create_runtime_with_allowed_annotation logs io.kubernetes.cri-o.LinkLogs
+	create_runtime_with_allowed_annotation logs link-logs.crio.io
 	start_crio_no_setup
 
 	read -r pod_empty_dir_volume_path ctr_name ctr_attempt ctr_id <<< "$(setup_log_linking_test "invalid path")"

--- a/test/devices.bats
+++ b/test/devices.bats
@@ -67,10 +67,10 @@ function teardown() {
 
 @test "annotation devices support" {
 	setup_crio
-	create_runtime_with_allowed_annotation "device" "io.kubernetes.cri-o.Devices"
+	create_runtime_with_allowed_annotation "device" "devices.crio.io"
 	CONTAINER_ALLOWED_DEVICES="/dev/null" start_crio_no_setup
 
-	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm"' \
+	jq '      .annotations."devices.crio.io" = "/dev/null:/dev/qifoo:rwm"' \
 		"$TESTDATA"/sandbox_config.json > "$newconfig"
 
 	pod_id=$(crictl runp "$newconfig")
@@ -85,7 +85,7 @@ function teardown() {
 @test "annotation should not be processed if not allowed" {
 	CONTAINER_ALLOWED_DEVICES="/dev/null" start_crio
 
-	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm"' \
+	jq '      .annotations."devices.crio.io" = "/dev/null:/dev/qifoo:rwm"' \
 		"$TESTDATA"/sandbox_config.json > "$newconfig"
 
 	pod_id=$(crictl runp "$newconfig")
@@ -98,10 +98,10 @@ function teardown() {
 
 @test "annotation should override configured additional_devices" {
 	setup_crio
-	create_runtime_with_allowed_annotation "device" "io.kubernetes.cri-o.Devices"
+	create_runtime_with_allowed_annotation "device" "devices.crio.io"
 	CONTAINER_ALLOWED_DEVICES="/dev/urandom,/dev/null" CONTAINER_ADDITIONAL_DEVICES="/dev/urandom:/dev/qifoo:rwm" start_crio_no_setup
 
-	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm"' \
+	jq '      .annotations."devices.crio.io" = "/dev/null:/dev/qifoo:rwm"' \
 		"$TESTDATA"/sandbox_config.json > "$newconfig"
 
 	pod_id=$(crictl runp "$newconfig")
@@ -116,10 +116,10 @@ function teardown() {
 
 @test "annotation should not be processed if not allowed in allowed_devices" {
 	setup_crio
-	create_runtime_with_allowed_annotation "device" "io.kubernetes.cri-o.Devices"
+	create_runtime_with_allowed_annotation "device" "devices.crio.io"
 	start_crio_no_setup
 
-	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm"' \
+	jq '      .annotations."devices.crio.io" = "/dev/null:/dev/qifoo:rwm"' \
 		"$TESTDATA"/sandbox_config.json > "$newconfig"
 
 	pod_id=$(crictl runp "$newconfig")
@@ -129,10 +129,10 @@ function teardown() {
 
 @test "annotation should configure multiple devices" {
 	setup_crio
-	create_runtime_with_allowed_annotation "device" "io.kubernetes.cri-o.Devices"
+	create_runtime_with_allowed_annotation "device" "devices.crio.io"
 	CONTAINER_ALLOWED_DEVICES="/dev/urandom,/dev/null" start_crio_no_setup
 
-	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm,/dev/urandom:/dev/peterfoo:rwm"' \
+	jq '      .annotations."devices.crio.io" = "/dev/null:/dev/qifoo:rwm,/dev/urandom:/dev/peterfoo:rwm"' \
 		"$TESTDATA"/sandbox_config.json > "$newconfig"
 
 	pod_id=$(crictl runp "$newconfig")
@@ -149,10 +149,10 @@ function teardown() {
 
 @test "annotation should fail if one device is invalid" {
 	setup_crio
-	create_runtime_with_allowed_annotation "device" "io.kubernetes.cri-o.Devices"
+	create_runtime_with_allowed_annotation "device" "devices.crio.io"
 	CONTAINER_ALLOWED_DEVICES="/dev/null" start_crio_no_setup
 
-	jq '      .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/qifoo:rwm,/dove/null"' \
+	jq '      .annotations."devices.crio.io" = "/dev/null:/dev/qifoo:rwm,/dove/null"' \
 		"$TESTDATA"/sandbox_config.json > "$newconfig"
 
 	pod_id=$(crictl runp "$newconfig")

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -221,7 +221,7 @@ EOF
 		skip "The directory /proc/sys/crypto does not exist on this host."
 	fi
 	setup_crio
-	create_runtime_with_allowed_annotation logs io.kubernetes.cri-o.DisableFIPS
+	create_runtime_with_allowed_annotation logs disable-fips.crio.io
 	start_crio_no_setup
 
 	jq '   .labels["FIPS_DISABLE"] = "true"' \

--- a/test/seccomp_notifier.bats
+++ b/test/seccomp_notifier.bats
@@ -18,7 +18,7 @@ function teardown() {
 @test "seccomp notifier with runtime/default" {
 	# Run with enabled feature set
 	setup_crio
-	create_runtime_with_allowed_annotation seccomp io.kubernetes.cri-o.seccompNotifierAction
+	create_runtime_with_allowed_annotation seccomp seccomp-notifier-action.crio.io
 	PORT=$(free_port)
 	CONTAINER_ENABLE_METRICS=true CONTAINER_METRICS_PORT=$PORT start_crio_no_setup
 
@@ -27,7 +27,7 @@ function teardown() {
 		"$TESTDATA"/container_redis.json > "$TESTDIR"/container.json
 
 	# Enable the annotation in the sandbox
-	jq '.annotations += { "io.kubernetes.cri-o.seccompNotifierAction": "stop" }' \
+	jq '.annotations += { "seccomp-notifier-action.crio.io": "stop" }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
 	CTR=$(crictl run "$TESTDIR"/container.json "$TESTDIR"/sandbox.json)
@@ -51,7 +51,7 @@ function teardown() {
 @test "seccomp notifier with runtime/default but not stop" {
 	# Run with enabled feature set
 	setup_crio
-	create_runtime_with_allowed_annotation seccomp io.kubernetes.cri-o.seccompNotifierAction
+	create_runtime_with_allowed_annotation seccomp seccomp-notifier-action.crio.io
 	PORT=$(free_port)
 	CONTAINER_ENABLE_METRICS=true CONTAINER_METRICS_PORT=$PORT start_crio_no_setup
 
@@ -60,7 +60,7 @@ function teardown() {
 		"$TESTDATA"/container_redis.json > "$TESTDIR"/container.json
 
 	# Enable the annotation in the sandbox
-	jq '.annotations += { "io.kubernetes.cri-o.seccompNotifierAction": "" }' \
+	jq '.annotations += { "seccomp-notifier-action.crio.io": "" }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
 	CTR=$(crictl run "$TESTDIR"/container.json "$TESTDIR"/sandbox.json)
@@ -77,7 +77,7 @@ function teardown() {
 @test "seccomp notifier with custom profile" {
 	# Run with enabled feature set
 	setup_crio
-	create_runtime_with_allowed_annotation seccomp io.kubernetes.cri-o.seccompNotifierAction
+	create_runtime_with_allowed_annotation seccomp seccomp-notifier-action.crio.io
 	start_crio_no_setup
 
 	# Run with custom profile
@@ -89,7 +89,7 @@ function teardown() {
 		"$TESTDATA"/container_sleep.json > "$TESTDIR"/container.json
 
 	# Enable the annotation in the sandbox
-	jq '.annotations += { "io.kubernetes.cri-o.seccompNotifierAction": "stop" }' \
+	jq '.annotations += { "seccomp-notifier-action.crio.io": "stop" }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
 	CTR=$(crictl run "$TESTDIR"/container.json "$TESTDIR"/sandbox.json)
@@ -122,7 +122,7 @@ function teardown() {
 		"$TESTDATA"/container_sleep.json > "$TESTDIR"/container.json
 
 	# Enable the annotation in the sandbox
-	jq '.annotations += { "io.kubernetes.cri-o.seccompNotifierAction": "stop" }' \
+	jq '.annotations += { "seccomp-notifier-action.crio.io": "stop" }' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
 	CTR=$(crictl run "$TESTDIR"/container.json "$TESTDIR"/sandbox.json)

--- a/test/selinux.bats
+++ b/test/selinux.bats
@@ -38,11 +38,11 @@ function teardown() {
 	touch "$FILE"
 
 	setup_crio
-	create_runtime_with_allowed_annotation "selinux" "io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel"
+	create_runtime_with_allowed_annotation "selinux" "try-skip-volume-selinux-label.crio.io"
 	start_crio_no_setup
 
 	jq '	  .linux.security_context.selinux_options = {"level": "s0:c200,c100"}
-		|  .annotations["io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel"] = "true"' \
+		|  .annotations["try-skip-volume-selinux-label.crio.io"] = "true"' \
 		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
 
 	jq --arg path "$VOLUME" \

--- a/test/shm_size.bats
+++ b/test/shm_size.bats
@@ -12,10 +12,10 @@ function teardown() {
 
 @test "check /dev/shm is changed" {
 	setup_crio
-	create_runtime_with_allowed_annotation "shmsize" "io.kubernetes.cri-o.ShmSize"
+	create_runtime_with_allowed_annotation "shmsize" "shm-size.crio.io"
 	start_crio_no_setup
 	# Run base container to ensure it creates at all
-	pod_id=$(crictl runp <(jq '.annotations."io.kubernetes.cri-o.ShmSize" = "16Mi"' "$TESTDATA"/sandbox_config.json))
+	pod_id=$(crictl runp <(jq '.annotations."shm-size.crio.io" = "16Mi"' "$TESTDATA"/sandbox_config.json))
 
 	# Run multi-container pod to ensure that they all work together
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
@@ -30,11 +30,11 @@ function teardown() {
 
 @test "check /dev/shm fails with incorrect values" {
 	setup_crio
-	create_runtime_with_allowed_annotation "shmsize" "io.kubernetes.cri-o.ShmSize"
+	create_runtime_with_allowed_annotation "shmsize" "shm-size.crio.io"
 	start_crio_no_setup
 	# Ensure pod fails if /dev/shm size is negative
-	run ! crictl runp <(jq '.annotations."io.kubernetes.cri-o.ShmSize" = "-1"' "$TESTDATA"/sandbox_config.json)
+	run ! crictl runp <(jq '.annotations."shm-size.crio.io" = "-1"' "$TESTDATA"/sandbox_config.json)
 
 	# Ensure pod fails if /dev/shm size is not a size
-	run ! crictl runp <(jq '.annotations."io.kubernetes.cri-o.ShmSize" = "notanumber"' "$TESTDATA"/sandbox_config.json)
+	run ! crictl runp <(jq '.annotations."shm-size.crio.io" = "notanumber"' "$TESTDATA"/sandbox_config.json)
 }

--- a/test/umask_annotation.bats
+++ b/test/umask_annotation.bats
@@ -12,10 +12,10 @@ function teardown() {
 
 @test "check umask is changed" {
 	setup_crio
-	create_runtime_with_allowed_annotation "umask" "io.kubernetes.cri-o.umask"
+	create_runtime_with_allowed_annotation "umask" "umask.crio.io"
 	start_crio_no_setup
 	# Run base container to ensure it creates at all
-	pod_id=$(crictl runp <(jq '.annotations."io.kubernetes.cri-o.umask" = "077"' "$TESTDATA"/sandbox_config.json))
+	pod_id=$(crictl runp <(jq '.annotations."umask.crio.io" = "077"' "$TESTDATA"/sandbox_config.json))
 
 	# Run multi-container pod to ensure that they all work together
 	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)

--- a/test/userns_annotation.bats
+++ b/test/userns_annotation.bats
@@ -13,7 +13,7 @@ function setup() {
 	setup_test
 	sboxconfig="$TESTDIR/sandbox_config.json"
 	ctrconfig="$TESTDIR/container_config.json"
-	create_workload_with_allowed_annotation "io.kubernetes.cri-o.userns-mode"
+	create_workload_with_allowed_annotation "userns-mode.crio.io"
 	start_crio
 }
 
@@ -22,7 +22,7 @@ function teardown() {
 }
 
 @test "userns annotation auto should succeed" {
-	jq '      .annotations."io.kubernetes.cri-o.userns-mode" = "auto"' \
+	jq '      .annotations."userns-mode.crio.io" = "auto"' \
 		"$TESTDATA"/sandbox_config.json > "$sboxconfig"
 
 	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$sboxconfig")
@@ -36,14 +36,14 @@ function teardown() {
 }
 
 @test "userns annotation auto with keep-id and map-to-root should fail" {
-	jq '      .annotations."io.kubernetes.cri-o.userns-mode" = "auto:keep-id=true;map-to-root=true"' \
+	jq '      .annotations."userns-mode.crio.io" = "auto:keep-id=true;map-to-root=true"' \
 		"$TESTDATA"/sandbox_config.json > "$sboxconfig"
 
 	run ! crictl runp "$sboxconfig"
 }
 
 @test "userns annotation auto should map host run_as_user" {
-	jq '      .annotations."io.kubernetes.cri-o.userns-mode" = "auto"' \
+	jq '      .annotations."userns-mode.crio.io" = "auto"' \
 		"$TESTDATA"/sandbox_config.json > "$sboxconfig"
 
 	jq '	.linux.security_context.run_as_user.value = 1234

--- a/test/workloads.bats
+++ b/test/workloads.bats
@@ -290,11 +290,11 @@ function check_conmon_fields() {
 }
 
 @test "test workload allowed annotation should not work if not configured" {
-	create_workload_with_allowed_annotation "io.kubernetes.cri-o.ShmSize" "$activation"
+	create_workload_with_allowed_annotation "shm-size.crio.io" "$activation"
 
 	start_crio
 
-	jq '.annotations."io.kubernetes.cri-o.ShmSize" = "16Mi"' \
+	jq '.annotations."shm-size.crio.io" = "16Mi"' \
 		"$TESTDATA"/sandbox_config.json > "$sboxconfig"
 
 	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$sboxconfig")
@@ -308,13 +308,13 @@ function check_conmon_fields() {
 		skip "userNS enabled"
 	fi
 	setup_crio
-	create_workload_with_allowed_annotation "io.kubernetes.cri-o.Devices"
-	create_runtime_with_allowed_annotation "shmsize" "io.kubernetes.cri-o.ShmSize"
+	create_workload_with_allowed_annotation "devices.crio.io"
+	create_runtime_with_allowed_annotation "shmsize" "shm-size.crio.io"
 	CONTAINER_ALLOWED_DEVICES="/dev/null" start_crio_no_setup
 
 	jq --arg act "$activation" \
-		'   .annotations."io.kubernetes.cri-o.ShmSize" = "16Mi"
-	    |   .annotations."io.kubernetes.cri-o.Devices" = "/dev/null:/dev/peterfoo:rwm"' \
+		'   .annotations."shm-size.crio.io" = "16Mi"
+	    |   .annotations."devices.crio.io" = "/dev/null:/dev/peterfoo:rwm"' \
 		"$TESTDATA"/sandbox_config.json > "$sboxconfig"
 
 	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$sboxconfig")
@@ -327,13 +327,13 @@ function check_conmon_fields() {
 }
 
 @test "test workload allowed annotation works for pod" {
-	create_workload_with_allowed_annotation "io.kubernetes.cri-o.ShmSize"
+	create_workload_with_allowed_annotation "shm-size.crio.io"
 
 	name=POD
 	start_crio
 
 	jq --arg act "$activation" \
-		' .annotations."io.kubernetes.cri-o.ShmSize" = "16Mi"' \
+		' .annotations."shm-size.crio.io" = "16Mi"' \
 		"$TESTDATA"/sandbox_config.json > "$sboxconfig"
 
 	ctr_id=$(crictl run "$TESTDATA"/container_sleep.json "$sboxconfig")
@@ -380,11 +380,11 @@ function check_conmon_fields() {
 @test "test workload pod should not be set if annotation not specified even if prefix" {
 	start_crio
 
-	jq '   .annotations["io.kubernetes.cri-o.UnifiedCgroup.podsandbox-sleep"] = "memory.max=4294967296" |
+	jq '   .annotations["unified-cgroup.crio.io/podsandbox-sleep"] = "memory.max=4294967296" |
 	  .labels["io.kubernetes.container.name"] = "podsandbox-sleep"' \
 		"$TESTDATA"/sandbox_config.json > "$sboxconfig"
 
-	jq '   .annotations["io.kubernetes.cri-o.UnifiedCgroup.podsandbox-sleep"] = "memory.max=4294967296" |
+	jq '   .annotations["unified-cgroup.crio.io/podsandbox-sleep"] = "memory.max=4294967296" |
 	  .labels["io.kubernetes.container.name"] = "podsandbox-sleep"' \
 		"$TESTDATA"/container_sleep.json > "$ctrconfig"
 

--- a/tutorials/userns.md
+++ b/tutorials/userns.md
@@ -25,7 +25,7 @@ containers:100000:65536
 ### CRI-O configuration
 
 To enable pods to be able to use the userns-mode annotation, the pod must be
-allowed to interpret the experimental annotation `io.kubernetes.cri-o.userns-mode`.
+allowed to interpret the experimental annotation `userns-mode.crio.io`.
 
 #### 1.23.0 and beyond
 
@@ -34,11 +34,11 @@ This can be done by creating a file with the following contents in /etc/crio/cri
 
 ```toml
 [crio.runtime.workloads.userns]
-activation_annotation = "io.kubernetes.cri-o.userns-mode"
-allowed_annotations = ["io.kubernetes.cri-o.userns-mode"]
+activation_annotation = "userns-mode.crio.io"
+allowed_annotations = ["userns-mode.crio.io"]
 ```
 
-This will allow any pod with the `io.kubernetes.cri-o.userns-mode` annotation to
+This will allow any pod with the `userns-mode.crio.io` annotation to
 configure a user namespace. CRI-O opts for this approach to give administrators
 the ability to toggle the behavior on their nodes, just in case an administrator
 doesn't want their users to be able to create user namespace. An administrator
@@ -57,7 +57,7 @@ annotation, the following file can be created:
 [crio.runtime.runtimes.userns]
 runtime_path = "/usr/bin/runc"
 runtime_root = "/run/runc"
-allowed_annotations = ["io.kubernetes.cri-o.userns-mode"]
+allowed_annotations = ["userns-mode.crio.io"]
 ```
 
 `runtime_path` and `runtime_root` can be configured differently, but must be specified.
@@ -78,7 +78,7 @@ kind: Pod
 metadata:
   name: mypod
   annotations:
-    io.kubernetes.cri-o.userns-mode: "auto"
+    userns-mode.crio.io: "auto"
 ```
 
 In this case, upon pod creation, the pod will have a user namespace automatically


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Migrates remaining v1 (`io.kubernetes.cri-o.*`) annotation references to v2 (`*.crio.io`) in docs, tutorials, completions, CLI help text, and integration tests.
Internal annotations (ContainerType, SandboxID, Volumes, etc.) and the backwards-compatibility test in `test/annotation_migration.bats` are intentionally left unchanged.

#### Which issue(s) this PR fixes:
Ref #10194

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

```release-note
None
```