### PR TITLE
feat. Image pull progress through prometheus handler

### DIFF
--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -202,6 +202,10 @@ func mergeImageConfig(config *libconfig.Config, ctx *cli.Context) {
 		config.PullProgressTimeout = ctx.Duration("pull-progress-timeout")
 	}
 
+	if ctx.IsSet("pull-progress-interval") {
+		config.PullProgressInterval = ctx.Duration("pull-progress-interval")
+	}
+
 	if ctx.IsSet("pinned-images") {
 		config.PinnedImages = StringSliceTrySplit(ctx, "pinned-images")
 	}
@@ -1272,9 +1276,15 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.DurationFlag{
 			Name:    "pull-progress-timeout",
-			Usage:   "The timeout for an image pull to make progress until the pull operation gets canceled. This value will be also used for calculating the pull progress interval to --pull-progress-timeout / 10. Can be set to 0 to disable the timeout as well as the progress output.",
+			Usage:   "Maximum time an image pull may go without making progress before it is canceled. Set to 0 to disable the watchdog (recommended for unstable networks — pair with --pull-progress-interval). When non-zero and --pull-progress-interval is not set, the progress-event interval defaults to this value divided by 10.",
 			EnvVars: []string{"CONTAINER_PULL_PROGRESS_TIMEOUT"},
 			Value:   defConf.PullProgressTimeout,
+		},
+		&cli.DurationFlag{
+			Name:    "pull-progress-interval",
+			Usage:   "How often the image copy library emits per-layer progress events (drives crio_image_pulls_bytes_total and /image/progress). When 0 (default) the interval is derived from --pull-progress-timeout / 10. Set explicitly to decouple progress-bar update frequency from the cancellation timeout, e.g. --pull-progress-timeout=0 --pull-progress-interval=3s for frequent updates with no timeout.",
+			EnvVars: []string{"CONTAINER_PULL_PROGRESS_INTERVAL"},
+			Value:   defConf.PullProgressInterval,
 		},
 		&cli.BoolFlag{
 			Name:    "read-only",
@@ -1312,7 +1322,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:    "allowed-devices",
-			Usage:   "Devices a user is allowed to specify with the \"devices.crio.io\" allowed annotation.",
+			Usage:   "Devices a user is allowed to specify with the \"io.kubernetes.cri-o.Devices\" allowed annotation.",
 			Value:   cli.NewStringSlice(defConf.AllowedDevices...),
 			EnvVars: []string{"CONTAINER_ALLOWED_DEVICES"},
 		},

--- a/internal/storage/image_pull_progress.go
+++ b/internal/storage/image_pull_progress.go
@@ -1,0 +1,66 @@
+package storage
+
+import "sync"
+
+// layerProgress tracks the download progress of a single image layer (blob).
+type layerProgress struct {
+	Current int64 `json:"current"` // bytes downloaded so far
+	Total   int64 `json:"total"`   // registry-reported total size; -1 if unknown
+}
+
+// ImagePullTracker tracks per-layer pull progress for a single image.
+// It is safe for concurrent use.
+type ImagePullTracker struct {
+	mu     sync.Mutex
+	Layers map[string]layerProgress
+}
+
+// NewImagePullTracker allocates a fresh tracker for one image pull.
+func NewImagePullTracker() *ImagePullTracker {
+	return &ImagePullTracker{
+		Layers: make(map[string]layerProgress),
+	}
+}
+
+// UpdateLayer records the latest byte counts for one layer.
+//   - id      blob digest string (unique key per layer)
+//   - current cumulative bytes received so far  (= p.Offset in progress events)
+//   - total   registry-reported layer size       (= p.Artifact.Size; -1 if unknown)
+func (t *ImagePullTracker) UpdateLayer(id string, current, total int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Layers[id] = layerProgress{Current: current, Total: total}
+}
+
+// GetOverallPercentage returns the aggregate pull completion percentage [0, 100].
+// Returns -1 when any layer's total size is unknown (registry did not report it),
+// because an accurate percentage cannot be computed.
+func (t *ImagePullTracker) GetOverallPercentage() float64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	var totalBytes, currentBytes int64
+	for _, layer := range t.Layers {
+		if layer.Total <= 0 {
+			return -1 // unknown size — cannot produce a meaningful percentage
+		}
+		totalBytes += layer.Total
+		currentBytes += layer.Current
+	}
+	if totalBytes == 0 {
+		return 0
+	}
+	pct := (float64(currentBytes) / float64(totalBytes)) * 100
+	if pct > 100 {
+		pct = 100
+	}
+	return pct
+}
+
+// ActivePullProgress is the process-wide registry of in-flight image pulls.
+// Key:   image name string (full registry reference, e.g. "docker.io/library/nginx:latest")
+// Value: *ImagePullTracker
+//
+// Placed in internal/storage (imported by both server/ and server/metrics/) to
+// avoid the circular import that would arise if it lived in server/.
+var ActivePullProgress sync.Map

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -689,11 +689,27 @@ type ImageConfig struct {
 	// reload the mirror registry when there is an update to the
 	// 'registries.conf.d' directory.
 	AutoReloadRegistries bool `toml:"auto_reload_registries"`
-	// PullProgressTimeout is the timeout for an image pull to make progress
-	// until the pull operation gets canceled. This value will be also used for
-	// calculating the pull progress interval to pullProgressTimeout / 10.
-	// Can be set to 0 to disable the timeout as well as the progress output.
+	// PullProgressTimeout is the maximum time an image pull is allowed to go
+	// without making any progress before the pull is canceled.
+	// Set to 0 to disable the cancellation watchdog entirely (useful on
+	// unstable or slow networks where a long stall does not mean the pull
+	// is stuck).
 	PullProgressTimeout time.Duration `toml:"pull_progress_timeout"`
+	// PullProgressInterval controls how frequently the underlying image copy
+	// library reports per-layer progress events.  These events drive both the
+	// Prometheus counter crio_image_pulls_bytes_total and the custom
+	// /image/progress HTTP endpoint.
+	//
+	// When set to 0 (the default) the interval is derived automatically:
+	//   - if PullProgressTimeout > 0  →  interval = PullProgressTimeout / 10
+	//   - if PullProgressTimeout == 0 →  progress events are disabled
+	//
+	// Setting this field to a positive value decouples the two concerns so
+	// operators can have a long (or absent) cancellation timeout while still
+	// receiving frequent progress updates, e.g.:
+	//   pull_progress_timeout  = "0s"  # never cancel — unstable network
+	//   pull_progress_interval = "3s"  # update progress bar every 3 seconds
+	PullProgressInterval time.Duration `toml:"pull_progress_interval"`
 	// OCIArtifactMountSupport is used to determine if CRI-O should support OCI Artifacts.
 	OCIArtifactMountSupport bool `toml:"oci_artifact_mount_support"`
 	// ShortNameMode describes the mode of short name resolution.
@@ -970,14 +986,14 @@ func removeDupStorageOpts(storageOpts []string) []string {
 	var resOpts []string
 
 	opts := make(map[string]bool)
-	for _, storageOpt := range slices.Backward(storageOpts) {
-		if ok := opts[storageOpt]; ok {
+	for i := len(storageOpts) - 1; i >= 0; i-- {
+		if ok := opts[storageOpts[i]]; ok {
 			continue
 		}
 
-		opts[storageOpt] = true
+		opts[storageOpts[i]] = true
 
-		resOpts = append(resOpts, storageOpt)
+		resOpts = append(resOpts, storageOpts[i])
 	}
 
 	for i, j := 0, len(resOpts)-1; i < j; i, j = i+1, j-1 {

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -308,13 +308,32 @@ func (s *Server) pullImageCandidate(ctx context.Context, sourceCtx *imageTypes.S
 
 	// Cancel the pull if no progress is made
 	pullCtx, cancel := context.WithCancel(ctx)
-	go consumeImagePullProgress(ctx, cancel, s.ContainerServer.Config().PullProgressTimeout, progress, remoteCandidateName)
+	// go consumeImagePullProgress(ctx, cancel, s.ContainerServer.Config().PullProgressTimeout, progress, remoteCandidateName)
+
+	pullProgressTimeout := s.ContainerServer.Config().PullProgressTimeout
+
+	// Compute the effective progress-event interval independently of the
+	// cancellation timeout so operators can tune them separately.
+	//
+	//   PullProgressInterval == 0, PullProgressTimeout > 0  →  timeout/10 (legacy)
+	//   both == 0  →  progress events disabled (existing default)
+
+	var effectiveInterval time.Duration
+	switch {
+	case s.ContainerServer.Config().PullProgressInterval > 0:
+		effectiveInterval = s.ContainerServer.Config().PullProgressInterval
+	case pullProgressTimeout > 0:
+		effectiveInterval = pullProgressTimeout / 10
+	}
+
+	go consumeImagePullProgress(ctx, cancel, pullProgressTimeout, progress, remoteCandidateName)
 
 	repoDigest, err := s.ContainerServer.StorageImageServer().PullImage(pullCtx, remoteCandidateName, &storage.ImageCopyOptions{
 		SourceCtx:        sourceCtx,
 		DestinationCtx:   s.config.SystemContext,
 		OciDecryptConfig: decryptConfig,
-		ProgressInterval: s.ContainerServer.Config().PullProgressTimeout / 10,
+		//ProgressInterval: s.ContainerServer.Config().PullProgressTimeout / 10,
+		ProgressInterval: effectiveInterval,
 		Progress:         progress,
 		CgroupPull: storage.CgroupPullConfiguration{
 			UseNewCgroup: s.config.SeparatePullCgroup != "",
@@ -358,19 +377,33 @@ func (s *Server) resolveImageRefToID(ctx context.Context, imageRef storage.Regis
 // If the timeout is reached because no progress updates have been made, then
 // the cancel function will be called.
 func consumeImagePullProgress(ctx context.Context, cancel context.CancelFunc, pullProgressTimeout time.Duration, progress <-chan imageTypes.ProgressProperties, remoteCandidateName storage.RegistryImageReference) {
-	timer := time.AfterFunc(pullProgressTimeout, func() {
-		if pullProgressTimeout != 0 {
+	// Only create a watchdog timer when the operator configured a timeout.
+	// When pullProgressTimeout == 0 the pull runs without a cancellation
+	// deadline, which is correct for unstable / slow networks.
+	var timer *time.Timer
+	if pullProgressTimeout > 0 {
+		timer = time.AfterFunc(pullProgressTimeout, func() {
 			log.Warnf(ctx, "Timed out on waiting up to %s for image pull progress updates", pullProgressTimeout)
 			cancel()
-		}
-	})
+		})
+		timer.Stop()       // don't start the timer immediately
+		defer timer.Stop() // ensure that the timer is stopped when we exit the progress loop
+	}
 
-	timer.Stop()       // don't start the timer immediately
-	defer timer.Stop() // ensure that the timer is stopped when we exit the progress loop
+	// Register a tracker for the /image/progress API and clean it up on exit.
+	imageName := remoteCandidateName.StringForOutOfProcessConsumptionOnly()
+	tracker := storage.NewImagePullTracker()
+	storage.ActivePullProgress.Store(imageName, tracker)
+	defer storage.ActivePullProgress.Delete(imageName)
 
 	for p := range progress {
-		timer.Reset(pullProgressTimeout)
+		//timer.Reset(pullProgressTimeout)
 
+		// Reset the watchdog on every incoming progress event so that a
+		// slow-but-steady download on an unstable network is not canceled.
+		if timer != nil {
+			timer.Reset(pullProgressTimeout)
+		}
 		if p.Event == imageTypes.ProgressEventSkipped {
 			// Skipped digests metrics
 			tryRecordSkippedMetric(ctx, remoteCandidateName, p.Artifact.Digest)
@@ -397,6 +430,12 @@ func consumeImagePullProgress(ctx context.Context, cancel context.CancelFunc, pu
 		// Metrics for size histogram
 		if p.Event == imageTypes.ProgressEventDone {
 			metrics.Instance().MetricImagePullsLayerSizeObserve(p.Artifact.Size)
+		}
+		
+		if p.Event == imageTypes.ProgressEventSkipped {
+			tracker.UpdateLayer(p.Artifact.Digest.String(), p.Artifact.Size, p.Artifact.Size)
+		} else {
+			tracker.UpdateLayer(p.Artifact.Digest.String(), int64(p.Offset), p.Artifact.Size)
 		}
 	}
 }

--- a/server/metrics/image_pull_progress.go
+++ b/server/metrics/image_pull_progress.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/cri-o/cri-o/internal/storage"
+)
+
+// handleImageProgressQuery serves GET /image/progress.
+//
+// Returns a JSON object whose keys are full image registry references and
+// whose values contain the pull percentage.
+//
+// Example response while pulling:
+//
+//	{
+//	  "docker.io/library/nginx:latest": {"percentage": 54.38},
+//	}
+//
+// Returns {} when no image pull is currently in flight.
+// "percentage" is -1 when the registry did not report layer sizes.
+func handleImageProgressQuery(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	responsePayload := make(map[string]map[string]interface{})
+
+	storage.ActivePullProgress.Range(func(key, value interface{}) bool {
+		imgName := key.(string)
+		tracker := value.(*storage.ImagePullTracker)
+
+		responsePayload[imgName] = map[string]interface{}{
+			"percentage": tracker.GetOverallPercentage(),
+		}
+		return true
+	})
+
+	_ = json.NewEncoder(w).Encode(responsePayload)
+}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -509,6 +509,7 @@ func (m *Metrics) createEndpoint() (*http.ServeMux, error) {
 
 	mux := &http.ServeMux{}
 	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/image/progress", handleImageProgressQuery)
 
 	return mux, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature


#### What this PR does / why we need it:
This PR described on https://github.com/cri-o/cri-o/issues/10198 to use the  prometheus handler to let the user to poll the large image pull progress under unstable networks.

#### Which issue(s) this PR fixes:
https://github.com/cri-o/cri-o/issues/10198
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
N/A
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added image pull progress reporting through the `/image/progress` endpoint, including per-image completion percentages.
  - Added configurable pull progress intervals through the `--pull-progress-interval` option and corresponding configuration setting.
  - Image pulls now track progress across individual layers.

- **Bug Fixes**
  - Pull progress timeouts can now be disabled by setting the timeout to zero.
  - Updated `--allowed-devices` documentation to reference the correct Kubernetes annotation key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->