### PR TITLE
test: use tolerance for memory working set comparison

### DIFF
--- a/test/cri-metrics.bats
+++ b/test/cri-metrics.bats
@@ -114,7 +114,11 @@ EOF
 	fi
 
 	metrics_memory_working_set=$(crictl metricsp | jq '.podMetrics[0].containerMetrics[0].metrics[] | select(.name == "container_memory_working_set_bytes") | .value.value | tonumber')
-	[[ $metrics_memory_working_set == $((cgroup_memory_usage - cgroup_memory_inactive_file)) ]]
+	# the cgroup and metrics values are read at slightly different times, so
+	# allow a small tolerance instead of an exact match to avoid flakes
+	expected_memory_working_set=$((cgroup_memory_usage - cgroup_memory_inactive_file))
+	working_set_diff=$((metrics_memory_working_set - expected_memory_working_set))
+	[[ ${working_set_diff#-} -le 16384 ]]
 
 	# assert container_memory_rss == cgroup memory.stat:total_rss(cgroup v1) or memory.stat:anon(cgroup v2)
 	if is_cgroup_v2; then


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

`test/cri-metrics.bats` asserts that `container_memory_working_set_bytes`
from CRI-O's `/metrics` endpoint exactly equals `memory.current -
inactive_file` (or the cgroup v1 equivalents) read straight from the
cgroup filesystem. Since the metric and the cgroup files are read at
slightly different times, the two values can diverge by a small amount,
making the test flaky (see linked CI failure in the issue).

This replaces the exact `==` comparison with a tolerance-based check
(within 16 KiB), consistent with how transient reads are usually
compared in this kind of test.

#### Which issue(s) this PR fixes:

Fixes #10055

#### Special notes for your reviewer:

Scope is intentionally limited to the `container_memory_working_set_bytes`
assertion flagged in the issue; the `container_memory_usage_bytes` and
`container_memory_rss` assertions above/below it were left untouched since
they weren't reported as flaky.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved container memory metrics test stability by allowing a small variance in working set values caused by timing differences during metric collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->