### PR TITLE
Fix Image Status Typo

### DIFF
--- a/server/image_status.go
+++ b/server/image_status.go
@@ -44,7 +44,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *types.ImageStatusRequest)
 		}
 
 		if errors.Is(err, ociartifact.ErrNotFound) {
-			log.Infof(ctx, "Neither image nor artfiact %s found", img.GetImage())
+			log.Infof(ctx, "Neither image nor artifact %s found", img.GetImage())
 		} else if err != nil {
 			log.Errorf(ctx, "Unable to get artifact: %v", err)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

This PR fixes a typo in image_status.go as follows:

`Neither image nor artfiact` > `Neither image nor artifact`

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the spelling of “artifact” in an image status error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->