### PR TITLE
stats: fix network metrics using host netns instead of pod's

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.1-0.20251205004911-5e639034dcdc
 	github.com/opencontainers/selinux v1.13.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/procfs v0.19.2
 	github.com/seccomp/libseccomp-golang v0.11.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/soheilhy/cmux v0.1.5
@@ -204,7 +205,6 @@ require (
 	github.com/proglottis/gpgme v0.1.6 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
-	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect

--- a/internal/lib/statsserver/network_metrics_linux.go
+++ b/internal/lib/statsserver/network_metrics_linux.go
@@ -1,7 +1,9 @@
 package statsserver
 
 import (
-	"github.com/vishvananda/netlink"
+	"fmt"
+
+	"github.com/prometheus/procfs"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
@@ -9,43 +11,65 @@ import (
 )
 
 func (ss *StatsServer) GenerateNetworkMetrics(sb *sandbox.Sandbox) []*types.Metric {
-	var metrics []*types.Metric
-
-	links, err := netlink.LinkList()
+	netDev, err := ss.readNetDev(sb)
 	if err != nil {
-		log.Errorf(ss.ctx, "Unable to retrieve network namespace links %s: %v", sb.ID(), err)
+		log.Errorf(ss.ctx, "Unable to retrieve network stats %s: %v", sb.ID(), err)
 
 		return nil
 	}
 
-	if len(links) == 0 {
+	if len(netDev) == 0 {
 		log.Warnf(ss.ctx, "Network links are not available.")
 
 		return nil
 	}
 
-	for i := range links {
-		if attrs := links[i].Attrs(); attrs != nil {
-			networkMetrics := generateSandboxNetworkMetrics(sb, attrs)
-			metrics = append(metrics, networkMetrics...)
-		}
+	var metrics []*types.Metric
+
+	for name := range netDev {
+		iface := netDev[name]
+		networkMetrics := generateSandboxNetworkMetrics(sb, &iface)
+		metrics = append(metrics, networkMetrics...)
 	}
 
 	return metrics
 }
 
-func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs) []*types.Metric {
-	if attr == nil || attr.Statistics == nil {
-		return []*types.Metric{}
+func (ss *StatsServer) readNetDev(sb *sandbox.Sandbox) (procfs.NetDev, error) {
+	if sb.HostNetwork() {
+		proc, err := procfs.Self()
+		if err != nil {
+			return nil, err
+		}
+
+		return proc.NetDev()
 	}
 
+	for _, ctr := range sb.Containers().List() {
+		pid, err := ctr.Pid()
+		if err != nil {
+			continue
+		}
+
+		proc, err := procfs.NewProc(pid)
+		if err != nil {
+			continue
+		}
+
+		return proc.NetDev()
+	}
+
+	return nil, fmt.Errorf("no running container in sandbox %s", sb.ID())
+}
+
+func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, iface *procfs.NetDevLine) []*types.Metric {
 	networkMetrics := []*containerMetric{
 		{
 			desc: containerNetworkReceiveBytesTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.RxBytes,
-					labels:     []string{attr.Name},
+					value:      iface.RxBytes,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -53,8 +77,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkReceivePacketsTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.RxPackets,
-					labels:     []string{attr.Name},
+					value:      iface.RxPackets,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -62,8 +86,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkReceivePacketsDroppedTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.RxDropped,
-					labels:     []string{attr.Name},
+					value:      iface.RxDropped,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -71,8 +95,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkReceiveErrorsTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.RxErrors,
-					labels:     []string{attr.Name},
+					value:      iface.RxErrors,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -80,8 +104,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkTransmitBytesTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.TxBytes,
-					labels:     []string{attr.Name},
+					value:      iface.TxBytes,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -89,8 +113,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkTransmitPacketsTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.TxPackets,
-					labels:     []string{attr.Name},
+					value:      iface.TxPackets,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -98,8 +122,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkTransmitPacketsDroppedTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.TxDropped,
-					labels:     []string{attr.Name},
+					value:      iface.TxDropped,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -107,8 +131,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkTransmitErrorsTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.TxErrors,
-					labels:     []string{attr.Name},
+					value:      iface.TxErrors,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},

--- a/test/cri-metrics.bats
+++ b/test/cri-metrics.bats
@@ -580,3 +580,31 @@ EOF
 	container_pressure_io_waiting_seconds_total=$(echo "$metrics" | jq 'select(.name == "container_pressure_io_waiting_seconds_total") | .value.value | tonumber')
 	[[ "$container_pressure_io_waiting_seconds_total" != "" ]]
 }
+
+@test "non-hostNetwork pod metrics match interfaces in the pod's network namespace" {
+	CONTAINER_ENABLE_METRICS="true" CONTAINER_METRICS_PORT=$(free_port) setup_crio
+	cat << EOF > "$CRIO_CONFIG"
+[crio.stats]
+collection_period = 0
+included_pod_metrics = [
+    "network",
+]
+EOF
+	start_crio_no_setup
+	check_images
+
+	# create a non-hostNetwork pod with a container so we can exec into it
+	POD_ID=$(crictl runp "$TESTDATA/sandbox_config.json")
+	CTR_ID=$(crictl create "$POD_ID" "$TESTDATA/container_sleep.json" "$TESTDATA/sandbox_config.json")
+	crictl start "$CTR_ID"
+
+	wait_for_metric "container_network_receive_bytes_total"
+
+	metrics=$(crictl metricsp)
+
+	# metrics must match the pod's own interfaces, not the host's
+	pod_metric_ifaces=$(echo "$metrics" | jq -r --arg id "$POD_ID" \
+		'[.podMetrics[] | select(.podSandboxId == $id) | .metrics[] | select(.name == "container_network_receive_bytes_total") | .labelValues[-1]] | unique | .[]' | sed '/^$/d' | sort)
+	pod_actual_ifaces=$(crictl exec --sync "$CTR_ID" ls /sys/class/net/ | sed '/^$/d' | sort)
+	[[ "$pod_metric_ifaces" == "$pod_actual_ifaces" ]]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Network metrics were previously collected using `netlink.LinkList()`, which
operates on whatever network namespace the calling thread is in. For
non-hostNetwork pods, this returned the host's interfaces instead of the pod's.

This replaces the netlink approach with reading `/proc/<pid>/net/dev` via the
`prometheus/procfs` library. Linux's procfs is namespace-aware: reading from the
infra container's PID gives the pod's network stats without needing to enter the
network namespace. This is the same approach cadvisor uses for container network
metrics collection.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix network metrics collection to use the pod's network namespace.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network metrics now reflect the exact set of interfaces available in each pod’s network namespace, including isolated (non-host) pods.
  * Host-network pods now report metrics based on host interfaces.
  * When interface/link data can’t be retrieved (or no links are available), network metrics stay unpopulated instead of being partially filled.
* **Tests**
  * Added a Bats test validating metric interface label values against `/sys/class/net` for isolated pods, and confirming expanded interface coverage for host-network pods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->