### PR TITLE
stats: fix nil pointer dereference in updateSandbox

### DIFF
--- a/internal/lib/statsserver/stats_server_linux.go
+++ b/internal/lib/statsserver/stats_server_linux.go
@@ -75,6 +75,8 @@ func (ss *StatsServer) updateSandbox(sb *sandbox.Sandbox) *types.PodSandboxStats
 		ctrStats, err := ss.Runtime().ContainerStats(ss.ctx, c, sb.CgroupParent())
 		if err != nil {
 			log.Errorf(ss.ctx, "Error getting container stats %s: %v", c.ID(), err)
+
+			continue
 		}
 
 		diskStats, err := ss.Runtime().DiskStats(ss.ctx, c, sb.CgroupParent())
@@ -131,8 +133,6 @@ func (ss *StatsServer) updateContainerStats(c *oci.Container, sb *sandbox.Sandbo
 	diskStats, err := ss.Runtime().DiskStats(ss.ctx, c, sb.CgroupParent())
 	if err != nil {
 		log.Errorf(ss.ctx, "Error getting disk stats %s: %v", c.ID(), err)
-		// Continue without disk stats
-		diskStats = nil
 	}
 
 	cStats := containerCRIStats(ctrStats, diskStats, c, ctrStats.SystemNano)
@@ -237,7 +237,7 @@ func (ss *StatsServer) updatePodSandboxMetrics(sb *sandbox.Sandbox) *SandboxMetr
 // except for network metrics, which are collected at the pod level.
 func (ss *StatsServer) GenerateSandboxContainerMetrics(sb *sandbox.Sandbox, c *oci.Container, sm *SandboxMetrics) *types.ContainerMetrics {
 	ctrStats, err := ss.Runtime().ContainerStats(ss.ctx, c, sb.CgroupParent())
-	if err != nil || ctrStats == nil {
+	if err != nil {
 		log.Errorf(ss.ctx, "Error getting sandbox stats %s: %v", sb.ID(), err)
 
 		return nil
@@ -246,8 +246,6 @@ func (ss *StatsServer) GenerateSandboxContainerMetrics(sb *sandbox.Sandbox, c *o
 	diskStats, err := ss.Runtime().DiskStats(ss.ctx, c, sb.CgroupParent())
 	if err != nil {
 		log.Errorf(ss.ctx, "Error getting disk stats %s: %v", c.ID(), err)
-
-		return nil
 	}
 
 	return ss.containerMetricsFromContainerStats(sb, c, ctrStats, diskStats)
@@ -275,6 +273,10 @@ func (ss *StatsServer) containerMetricsFromContainerStats(sb *sandbox.Sandbox, c
 				metrics = append(metrics, hugetlbMetrics...)
 			}
 		case config.DiskMetrics:
+			if diskStats == nil {
+				continue
+			}
+
 			if diskMetrics := generateContainerDiskMetrics(c, &diskStats.Filesystem); diskMetrics != nil {
 				metrics = append(metrics, diskMetrics...)
 			}

--- a/internal/lib/statsserver/stats_server_linux_test.go
+++ b/internal/lib/statsserver/stats_server_linux_test.go
@@ -1,0 +1,194 @@
+package statsserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	cstorage "go.podman.io/storage"
+	drivers "go.podman.io/storage/drivers"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/lib/stats"
+	"github.com/cri-o/cri-o/internal/memorystore"
+	"github.com/cri-o/cri-o/internal/oci"
+	"github.com/cri-o/cri-o/pkg/config"
+)
+
+type fakeRuntimeImpl struct {
+	oci.RuntimeImpl
+
+	cgroupStats    *stats.CgroupStats
+	cgroupStatsErr error
+	diskStats      *stats.DiskStats
+	diskStatsErr   error
+}
+
+func (f *fakeRuntimeImpl) CgroupStats(_ context.Context, _ *oci.Container, _ string) (*stats.CgroupStats, error) {
+	return f.cgroupStats, f.cgroupStatsErr
+}
+
+func (f *fakeRuntimeImpl) DiskStats(_ context.Context, _ *oci.Container, _ string) (*stats.DiskStats, error) {
+	return f.diskStats, f.diskStatsErr
+}
+
+type fakeStore struct {
+	cstorage.Store
+}
+
+func (f *fakeStore) GraphDriver() (drivers.Driver, error) {
+	return nil, errors.New("no graph driver in test")
+}
+
+type fakeParentServer struct {
+	runtime *oci.Runtime
+	cfg     *config.Config
+}
+
+func (f *fakeParentServer) Runtime() *oci.Runtime              { return f.runtime }
+func (f *fakeParentServer) Store() cstorage.Store              { return &fakeStore{} }
+func (f *fakeParentServer) ListSandboxes() []*sandbox.Sandbox  { return nil }
+func (f *fakeParentServer) GetSandbox(string) *sandbox.Sandbox { return nil }
+func (f *fakeParentServer) Config() *config.Config             { return f.cfg }
+
+func newTestSandbox(t *testing.T, id string) *sandbox.Sandbox {
+	t.Helper()
+
+	b := sandbox.NewBuilder()
+	b.SetID(id)
+	b.SetName("test-sandbox")
+	b.SetLogDir("/tmp")
+	b.SetShmPath("/dev/shm")
+	b.SetNamespace("default")
+	b.SetKubeName("test-pod")
+	b.SetMountLabel("")
+	b.SetProcessLabel("")
+	b.SetCgroupParent("/kubepods/test")
+	b.SetRuntimeHandler("runc")
+	b.SetResolvPath("/etc/resolv.conf")
+	b.SetHostname("test-host")
+	b.SetPortMappings(nil)
+	b.SetPrivileged(false)
+	b.SetHostNetwork(false)
+	b.SetUsernsMode("")
+	b.SetPodLinuxOverhead(nil)
+	b.SetPodLinuxResources(nil)
+	b.SetCreatedAt(time.Now())
+
+	if err := b.SetCRISandbox(id, nil, nil, &types.PodSandboxMetadata{Name: "test-pod", Namespace: "default"}); err != nil {
+		t.Fatalf("SetCRISandbox: %v", err)
+	}
+
+	containers := memorystore.New[*oci.Container]()
+	b.SetContainers(containers)
+
+	sb, err := b.GetSandbox()
+	if err != nil {
+		t.Fatalf("GetSandbox: %v", err)
+	}
+
+	return sb
+}
+
+func newRunningContainer(t *testing.T, id, name string) *oci.Container {
+	t.Helper()
+
+	ctr, err := oci.NewContainer(
+		id, name, "", "", nil, nil, nil,
+		"", nil, nil, "", &types.ContainerMetadata{Name: name}, "",
+		false, false, false, "", "", time.Now(), "",
+	)
+	if err != nil {
+		t.Fatalf("NewContainer: %v", err)
+	}
+
+	ctr.SetStateAndSpoofPid(&oci.ContainerState{
+		State: specs.State{Status: oci.ContainerStateRunning},
+	})
+
+	return ctr
+}
+
+func newTestStatsServer(t *testing.T, rt *oci.Runtime, cfg *config.Config) *StatsServer {
+	t.Helper()
+
+	return &StatsServer{
+		parentServerIface: &fakeParentServer{runtime: rt, cfg: cfg},
+		sboxStats:         make(map[string]*types.PodSandboxStats),
+		ctrStats:          make(map[string]*types.ContainerStats),
+		sboxMetrics:       make(map[string]*SandboxMetrics),
+		ctx:               context.Background(),
+	}
+}
+
+func TestUpdateSandboxContainerStatsError(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+
+	rt := oci.NewTestRuntime()
+	ctr := newRunningContainer(t, "ctr-1", "test-container")
+
+	rt.SetRuntimeImpl("ctr-1", &fakeRuntimeImpl{
+		cgroupStatsErr: errors.New("cgroup deleted"),
+	})
+
+	sb := newTestSandbox(t, "sb-1")
+	sb.AddContainer(context.Background(), ctr)
+
+	ss := newTestStatsServer(t, rt, cfg)
+	result := ss.updateSandbox(sb)
+
+	if result == nil {
+		t.Fatal("updateSandbox returned nil")
+	}
+
+	if len(result.GetLinux().GetContainers()) != 0 {
+		t.Errorf("expected 0 container stats (error should skip), got %d", len(result.GetLinux().GetContainers()))
+	}
+}
+
+func TestUpdateSandboxDiskStatsError(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+
+	rt := oci.NewTestRuntime()
+	ctr := newRunningContainer(t, "ctr-1", "test-container")
+
+	rt.SetRuntimeImpl("ctr-1", &fakeRuntimeImpl{
+		cgroupStats:  &stats.CgroupStats{SystemNano: time.Now().UnixNano()},
+		diskStatsErr: errors.New("disk stats unavailable"),
+	})
+
+	sb := newTestSandbox(t, "sb-1")
+	sb.AddContainer(context.Background(), ctr)
+
+	ss := newTestStatsServer(t, rt, cfg)
+	result := ss.updateSandbox(sb)
+
+	if result == nil {
+		t.Fatal("updateSandbox returned nil")
+	}
+
+	if len(result.GetLinux().GetContainers()) != 1 {
+		t.Fatalf("expected 1 container stats despite disk error, got %d", len(result.GetLinux().GetContainers()))
+	}
+
+	if result.GetLinux().GetContainers()[0].GetCpu() == nil {
+		t.Error("expected CPU stats to be present")
+	}
+
+	if result.GetLinux().GetContainers()[0].GetMemory() == nil {
+		t.Error("expected memory stats to be present")
+	}
+}

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -466,7 +466,16 @@ func (r *Runtime) ContainerStats(ctx context.Context, c *Container, cgroup strin
 		return nil, err
 	}
 
-	return impl.CgroupStats(ctx, c, cgroup)
+	cgroupStats, err := impl.CgroupStats(ctx, c, cgroup)
+	if err != nil {
+		return nil, err
+	}
+
+	if cgroupStats == nil {
+		return nil, fmt.Errorf("no cgroup stats available for container %s", c.ID())
+	}
+
+	return cgroupStats, nil
 }
 
 // DiskStats provides disk statistics for a container.

--- a/internal/oci/runtime_test_inject.go
+++ b/internal/oci/runtime_test_inject.go
@@ -1,0 +1,19 @@
+//go:build test
+
+package oci
+
+// NewTestRuntime creates a Runtime suitable for unit tests,
+// without requiring a config or filesystem setup.
+func NewTestRuntime() *Runtime {
+	return &Runtime{
+		runtimeImplMap: make(map[string]RuntimeImpl),
+	}
+}
+
+// SetRuntimeImpl registers a RuntimeImpl for the given container ID.
+func (r *Runtime) SetRuntimeImpl(containerID string, impl RuntimeImpl) {
+	r.runtimeImplMapMutex.Lock()
+	defer r.runtimeImplMapMutex.Unlock()
+
+	r.runtimeImplMap[containerID] = impl
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind bug

#### What this PR does / why we need it:

When PodAndContainerStatsFromCRI is enabled, the kubelet calls ListPodSandboxStats via CRI. If a container's cgroup has already been cleaned up (e.g. during teardown), ContainerStats() returns (nil, error) but updateSandbox continued to dereference the nil result, crashing CRI-O with SIGSEGV.

Skip the container when ContainerStats fails or returns nil. On DiskStats error, nil out diskStats and continue so CPU/memory/process stats are still reported. Add matching nil guards in containerMetricsFromContainerStats and align error handling across updateContainerStats and GenerateSandboxContainerMetrics for consistency.

```
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]: panic: runtime error: invalid memory address or nil pointer dereference
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x400 pc=0x5597a59f4329]
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]:
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]: goroutine 42843 [running]:
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]: statsserver.(*StatsServer).updateSandbox()
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]:     stats_server_linux.go:85
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]: statsserver.(*StatsServer).statsForSandbox()
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]:     stats_server.go:177
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]: statsserver.(*StatsServer).StatsForSandboxes()
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]:     stats_server.go:165
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]: server.(*Server).listPodSandboxStats()
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]:     sandbox_stats_list.go:45
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]: server.(*Server).ListPodSandboxStats()
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]:     sandbox_stats_list.go:12
Jul 29 11:49:12 ip-10-0-0-203 crio[3916]: k8s.io/cri-api/.../v1._RuntimeService_ListPodSandboxStats_Handler()
```

During OpenShift bootstrap, this crash loop prevented control plane pods from stabilizing, causing the installer to time out.

Discovered via the `e2e-aws-ovn-techpreview` job on [openshift/api#2942](https://github.com/openshift/api/pull/2942):
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_api/2942/pull-ci-openshift-api-master-e2e-aws-ovn-techpreview/2082775409660792832

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

I made the checks for container and disk stats consistent across all the functions.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix CRI-O crash (nil pointer dereference) in ListPodSandboxStats when a container's cgroup is cleaned up during teardown.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when container or disk statistics are unavailable.
  * Prevented failures for one container from interrupting metrics collection for others.
  * Preserved available CPU and memory statistics when disk data cannot be retrieved.
  * Retained previously collected disk statistics when refreshed data is unavailable.
  * Skipped only unavailable disk metrics instead of discarding complete container statistics.
  * Improved handling of missing container statistics to prevent incomplete or invalid metrics results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->