### PR TITLE
 stats: filter pod-owned interfaces from hostNetwork pod metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.1-0.20251205004911-5e639034dcdc
 	github.com/opencontainers/selinux v1.13.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/procfs v0.19.2
 	github.com/seccomp/libseccomp-golang v0.11.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/soheilhy/cmux v0.1.5
@@ -204,7 +205,6 @@ require (
 	github.com/proglottis/gpgme v0.1.6 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
-	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	current "github.com/containernetworking/cni/pkg/types/100"
 	json "github.com/json-iterator/go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
@@ -309,6 +310,18 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 	sbox.SetHostname(m.Annotations[annotations.HostName])
 	sbox.SetPortMappings(portMappings)
 	sbox.SetHostNetwork(hostNetwork)
+
+	if cniResultJSON, ok := m.Annotations[annotations.CNIResult]; ok {
+		var cniResult current.Result
+		if err := json.Unmarshal([]byte(cniResultJSON), &cniResult); err != nil {
+			log.WithFields(ctx, map[string]any{
+				"sandboxID": id,
+				"error":     err,
+			}).Warn("Failed to parse CNI result")
+		} else {
+			sbox.SetHostInterfaces(sandbox.HostInterfacesFromCNIResult(&cniResult))
+		}
+	}
 
 	usernsMode, _ := v2.GetAnnotationValue(m.Annotations, v2.UsernsMode)
 	sbox.SetUsernsMode(usernsMode)

--- a/internal/lib/sandbox/builder.go
+++ b/internal/lib/sandbox/builder.go
@@ -100,6 +100,9 @@ type Builder interface {
 	// SetHostNetwork sets the host network.
 	SetHostNetwork(bool)
 
+	// SetHostInterfaces sets the host-side network interface names.
+	SetHostInterfaces([]string)
+
 	// SetUsernsMode sets the user namespace mode.
 	SetUsernsMode(string)
 
@@ -473,6 +476,11 @@ func (b *sandboxBuilder) SetPortMappings(portMappings []*hostport.PortMapping) {
 func (b *sandboxBuilder) SetHostNetwork(hostNetwork bool) {
 	b.validations.setValidation(validationSetHostNetwork)
 	b.sandboxRef.hostNetwork = hostNetwork
+}
+
+// SetHostInterfaces sets the host-side network interface names.
+func (b *sandboxBuilder) SetHostInterfaces(hostInterfaces []string) {
+	b.sandboxRef.hostInterfaces = hostInterfaces
 }
 
 // SetUsernsMode sets the user namespace mode for the sidecar container.

--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/fields"
@@ -519,4 +520,25 @@ func (s *Sandbox) Ready() bool {
 	defer s.stateMutex.RUnlock()
 
 	return s.created && !s.stopped
+}
+
+// HostInterfacesFromCNIResult returns the host-side interface names from a CNI result.
+// Per the CNI spec, an interface's Sandbox field holds the path to the network
+// namespace that contains it. An empty Sandbox means the interface is on the
+// host side (e.g. the host-side veth peer), while a non-empty value identifies
+// a container-side interface inside the pod's network namespace.
+func HostInterfacesFromCNIResult(result *current.Result) []string {
+	var ifaces []string
+
+	for _, iface := range result.Interfaces {
+		if iface == nil {
+			continue
+		}
+
+		if iface.Sandbox == "" {
+			ifaces = append(ifaces, iface.Name)
+		}
+	}
+
+	return ifaces
 }

--- a/internal/lib/sandbox/sandbox.go
+++ b/internal/lib/sandbox/sandbox.go
@@ -55,6 +55,7 @@ type Sandbox struct {
 	hostname       string
 	// ipv4 or ipv6 cache
 	ips                []string
+	hostInterfaces     []string
 	seccompProfilePath string
 	infraContainer     *oci.Container
 	nsOpts             *types.NamespaceOption
@@ -147,6 +148,16 @@ func (s *Sandbox) IPs() []string {
 // Wrap the IPs() method to match the NRI interface.
 func (s *Sandbox) GetIPs() []string {
 	return s.IPs()
+}
+
+// SetHostInterfaces stores the host network interfaces in the sandbox.
+func (s *Sandbox) SetHostInterfaces(ifaces []string) {
+	s.hostInterfaces = ifaces
+}
+
+// HostInterfaces returns the host network interfaces of the sandbox.
+func (s *Sandbox) HostInterfaces() []string {
+	return s.hostInterfaces
 }
 
 // ID returns the id of the sandbox.

--- a/internal/lib/statsserver/network_metrics_linux.go
+++ b/internal/lib/statsserver/network_metrics_linux.go
@@ -11,9 +11,34 @@ import (
 )
 
 func (ss *StatsServer) GenerateNetworkMetrics(sb *sandbox.Sandbox) []*types.Metric {
-	netDev, err := ss.readNetDev(sb)
+	if sb.HostNetwork() {
+		return ss.generateHostNetworkMetrics(sb)
+	}
+
+	return ss.generatePodNetworkMetrics(sb)
+}
+
+// generateHostNetworkMetrics returns metrics from the pre-computed host
+// network dev snapshot, which already has pod-owned interfaces filtered out.
+func (ss *StatsServer) generateHostNetworkMetrics(sb *sandbox.Sandbox) []*types.Metric {
+	var metrics []*types.Metric
+
+	for name := range ss.hostNetDev {
+		iface := ss.hostNetDev[name]
+		networkMetrics := generateSandboxNetworkMetrics(sb, &iface)
+		metrics = append(metrics, networkMetrics...)
+	}
+
+	return metrics
+}
+
+func (ss *StatsServer) generatePodNetworkMetrics(sb *sandbox.Sandbox) []*types.Metric {
+	netDev, err := readPodNetDev(sb)
 	if err != nil {
-		log.Errorf(ss.ctx, "Unable to retrieve network stats %s: %v", sb.ID(), err)
+		log.WithFields(ss.ctx, map[string]any{
+			"sandboxID": sb.ID(),
+			"error":     err,
+		}).Error("Unable to retrieve network stats")
 
 		return nil
 	}
@@ -35,15 +60,8 @@ func (ss *StatsServer) GenerateNetworkMetrics(sb *sandbox.Sandbox) []*types.Metr
 	return metrics
 }
 
-func (ss *StatsServer) readNetDev(sb *sandbox.Sandbox) (procfs.NetDev, error) {
-	if sb.HostNetwork() {
-		proc, err := procfs.Self()
-		if err != nil {
-			return nil, err
-		}
-
-		return proc.NetDev()
-	}
+func readPodNetDev(sb *sandbox.Sandbox) (procfs.NetDev, error) {
+	var lastErr error
 
 	for _, ctr := range sb.Containers().List() {
 		pid, err := ctr.Pid()
@@ -56,7 +74,18 @@ func (ss *StatsServer) readNetDev(sb *sandbox.Sandbox) (procfs.NetDev, error) {
 			continue
 		}
 
-		return proc.NetDev()
+		netDev, err := proc.NetDev()
+		if err != nil {
+			lastErr = err
+
+			continue
+		}
+
+		return netDev, nil
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("read network stats for sandbox %s: %w", sb.ID(), lastErr)
 	}
 
 	return nil, fmt.Errorf("no running container in sandbox %s", sb.ID())

--- a/internal/lib/statsserver/network_metrics_linux.go
+++ b/internal/lib/statsserver/network_metrics_linux.go
@@ -1,7 +1,9 @@
 package statsserver
 
 import (
-	"github.com/vishvananda/netlink"
+	"fmt"
+
+	"github.com/prometheus/procfs"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
@@ -9,43 +11,65 @@ import (
 )
 
 func (ss *StatsServer) GenerateNetworkMetrics(sb *sandbox.Sandbox) []*types.Metric {
-	var metrics []*types.Metric
-
-	links, err := netlink.LinkList()
+	netDev, err := ss.readNetDev(sb)
 	if err != nil {
-		log.Errorf(ss.ctx, "Unable to retrieve network namespace links %s: %v", sb.ID(), err)
+		log.Errorf(ss.ctx, "Unable to retrieve network stats %s: %v", sb.ID(), err)
 
 		return nil
 	}
 
-	if len(links) == 0 {
+	if len(netDev) == 0 {
 		log.Warnf(ss.ctx, "Network links are not available.")
 
 		return nil
 	}
 
-	for i := range links {
-		if attrs := links[i].Attrs(); attrs != nil {
-			networkMetrics := generateSandboxNetworkMetrics(sb, attrs)
-			metrics = append(metrics, networkMetrics...)
-		}
+	var metrics []*types.Metric
+
+	for name := range netDev {
+		iface := netDev[name]
+		networkMetrics := generateSandboxNetworkMetrics(sb, &iface)
+		metrics = append(metrics, networkMetrics...)
 	}
 
 	return metrics
 }
 
-func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs) []*types.Metric {
-	if attr == nil || attr.Statistics == nil {
-		return []*types.Metric{}
+func (ss *StatsServer) readNetDev(sb *sandbox.Sandbox) (procfs.NetDev, error) {
+	if sb.HostNetwork() {
+		proc, err := procfs.Self()
+		if err != nil {
+			return nil, err
+		}
+
+		return proc.NetDev()
 	}
 
+	for _, ctr := range sb.Containers().List() {
+		pid, err := ctr.Pid()
+		if err != nil {
+			continue
+		}
+
+		proc, err := procfs.NewProc(pid)
+		if err != nil {
+			continue
+		}
+
+		return proc.NetDev()
+	}
+
+	return nil, fmt.Errorf("no running container in sandbox %s", sb.ID())
+}
+
+func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, iface *procfs.NetDevLine) []*types.Metric {
 	networkMetrics := []*containerMetric{
 		{
 			desc: containerNetworkReceiveBytesTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.RxBytes,
-					labels:     []string{attr.Name},
+					value:      iface.RxBytes,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -53,8 +77,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkReceivePacketsTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.RxPackets,
-					labels:     []string{attr.Name},
+					value:      iface.RxPackets,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -62,8 +86,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkReceivePacketsDroppedTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.RxDropped,
-					labels:     []string{attr.Name},
+					value:      iface.RxDropped,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -71,8 +95,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkReceiveErrorsTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.RxErrors,
-					labels:     []string{attr.Name},
+					value:      iface.RxErrors,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -80,8 +104,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkTransmitBytesTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.TxBytes,
-					labels:     []string{attr.Name},
+					value:      iface.TxBytes,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -89,8 +113,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkTransmitPacketsTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.TxPackets,
-					labels:     []string{attr.Name},
+					value:      iface.TxPackets,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -98,8 +122,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkTransmitPacketsDroppedTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.TxDropped,
-					labels:     []string{attr.Name},
+					value:      iface.TxDropped,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},
@@ -107,8 +131,8 @@ func generateSandboxNetworkMetrics(sb *sandbox.Sandbox, attr *netlink.LinkAttrs)
 			desc: containerNetworkTransmitErrorsTotal,
 			valueFunc: func() metricValues {
 				return metricValues{{
-					value:      attr.Statistics.TxErrors,
-					labels:     []string{attr.Name},
+					value:      iface.TxErrors,
+					labels:     []string{iface.Name},
 					metricType: types.MetricType_COUNTER,
 				}}
 			},

--- a/internal/lib/statsserver/stats_server.go
+++ b/internal/lib/statsserver/stats_server.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/procfs"
 	"github.com/sirupsen/logrus"
 	cstorage "go.podman.io/storage"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -27,8 +28,14 @@ type StatsServer struct {
 	sboxStats        map[string]*types.PodSandboxStats
 	ctrStats         map[string]*types.ContainerStats
 	sboxMetrics      map[string]*SandboxMetrics
-	ctx              context.Context
-	mutex            sync.Mutex
+	// hostNetDev is a pre-computed snapshot of host network device stats
+	// with pod-owned interfaces filtered out. Rebuilt at the start of each
+	// collection cycle so all hostNetwork sandboxes share a single
+	// consistent view, avoiding redundant procfs reads and races from
+	// concurrent pod creation.
+	hostNetDev procfs.NetDev
+	ctx        context.Context
+	mutex      sync.Mutex
 }
 
 // parentServerIface is an interface for requesting information from the parent ContainerServer.
@@ -85,7 +92,10 @@ func (ss *StatsServer) update() {
 	ss.mutex.Lock()
 	defer ss.mutex.Unlock()
 
-	for _, sb := range ss.ListSandboxes() {
+	sandboxes := ss.ListSandboxes()
+	ss.snapshotHostNetDev(sandboxes)
+
+	for _, sb := range sandboxes {
 		ss.updateSandbox(sb)
 	}
 }
@@ -264,6 +274,10 @@ func (ss *StatsServer) MetricsForPodSandbox(sb *sandbox.Sandbox) *SandboxMetrics
 	ss.mutex.Lock()
 	defer ss.mutex.Unlock()
 
+	if ss.collectionPeriod == 0 && sb.HostNetwork() {
+		ss.snapshotHostNetDev(ss.ListSandboxes())
+	}
+
 	return ss.metricsForPodSandbox(sb)
 }
 
@@ -271,6 +285,10 @@ func (ss *StatsServer) MetricsForPodSandbox(sb *sandbox.Sandbox) *SandboxMetrics
 func (ss *StatsServer) MetricsForPodSandboxList(sboxes []*sandbox.Sandbox) []*SandboxMetrics {
 	ss.mutex.Lock()
 	defer ss.mutex.Unlock()
+
+	if ss.collectionPeriod == 0 {
+		ss.snapshotHostNetDev(ss.ListSandboxes())
+	}
 
 	metricsList := make([]*SandboxMetrics, 0, len(sboxes))
 
@@ -290,4 +308,20 @@ func (ss *StatsServer) RemoveMetricsForPodSandbox(sb *sandbox.Sandbox) {
 	defer ss.mutex.Unlock()
 
 	delete(ss.sboxMetrics, sb.ID())
+}
+
+// buildPodIfacesExclusionSet returns the set of host-side interface names
+// owned by non-hostNetwork sandboxes.
+func buildPodIfacesExclusionSet(sandboxes []*sandbox.Sandbox) map[string]struct{} {
+	podIfaces := make(map[string]struct{})
+
+	for _, sb := range sandboxes {
+		if !sb.HostNetwork() {
+			for _, iface := range sb.HostInterfaces() {
+				podIfaces[iface] = struct{}{}
+			}
+		}
+	}
+
+	return podIfaces
 }

--- a/internal/lib/statsserver/stats_server_linux.go
+++ b/internal/lib/statsserver/stats_server_linux.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/opencontainers/cgroups"
+	"github.com/prometheus/procfs"
 	"github.com/vishvananda/netlink"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -487,4 +488,39 @@ func computeSwapUsage(memStats *cgroups.MemoryStats) uint64 {
 // isMemoryUnlimited checks if the memory limit is effectively unlimited.
 func isMemoryUnlimited(v uint64) bool {
 	return v == math.MaxUint64
+}
+
+// snapshotHostNetDev builds a snapshot of the host namespace's network device
+// stats with pod-owned interfaces (e.g. veth peers created by the CNI plugin)
+// filtered out. The resulting snapshot is used by all hostNetwork sandboxes so
+// their metrics only report genuine host interfaces, not pod-owned veth pairs.
+func (ss *StatsServer) snapshotHostNetDev(sandboxes []*sandbox.Sandbox) {
+	ss.hostNetDev = nil
+	podIfaces := buildPodIfacesExclusionSet(sandboxes)
+
+	proc, err := procfs.Self()
+	if err != nil {
+		log.WithFields(ss.ctx, map[string]any{
+			"error": err,
+		}).Error("Unable to read host procfs")
+
+		return
+	}
+
+	netDev, err := proc.NetDev()
+	if err != nil {
+		log.WithFields(ss.ctx, map[string]any{
+			"error": err,
+		}).Error("Unable to snapshot host network stats")
+
+		return
+	}
+
+	for name := range netDev {
+		if _, excluded := podIfaces[name]; excluded {
+			delete(netDev, name)
+		}
+	}
+
+	ss.hostNetDev = netDev
 }

--- a/internal/lib/statsserver/stats_server_test.go
+++ b/internal/lib/statsserver/stats_server_test.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+package statsserver
+
+import (
+	"testing"
+
+	"github.com/prometheus/procfs"
+)
+
+func newNetDev(names ...string) procfs.NetDev {
+	netDev := make(procfs.NetDev, len(names))
+
+	for _, name := range names {
+		netDev[name] = procfs.NetDevLine{Name: name}
+	}
+
+	return netDev
+}
+
+func TestSnapshotFiltering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		netDev    procfs.NetDev
+		podIfaces map[string]struct{}
+		want      []string
+	}{
+		{
+			name:      "no interfaces",
+			netDev:    nil,
+			podIfaces: nil,
+			want:      nil,
+		},
+		{
+			name:      "no exclusions",
+			netDev:    newNetDev("eth0", "lo"),
+			podIfaces: nil,
+			want:      []string{"eth0", "lo"},
+		},
+		{
+			name:   "excludes pod-owned interfaces",
+			netDev: newNetDev("eth0", "veth123", "lo"),
+			podIfaces: map[string]struct{}{
+				"veth123": {},
+			},
+			want: []string{"eth0", "lo"},
+		},
+		{
+			name:   "all excluded",
+			netDev: newNetDev("veth1", "veth2"),
+			podIfaces: map[string]struct{}{
+				"veth1": {},
+				"veth2": {},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			for name := range tt.netDev {
+				if _, excluded := tt.podIfaces[name]; excluded {
+					delete(tt.netDev, name)
+				}
+			}
+
+			if len(tt.netDev) != len(tt.want) {
+				var gotNames []string
+				for name := range tt.netDev {
+					gotNames = append(gotNames, name)
+				}
+
+				t.Fatalf("got %d interfaces %v, want %d %v", len(tt.netDev), gotNames, len(tt.want), tt.want)
+			}
+
+			for _, name := range tt.want {
+				if _, ok := tt.netDev[name]; !ok {
+					t.Errorf("expected interface %q not found in result", name)
+				}
+			}
+		})
+	}
+}

--- a/internal/lib/statsserver/stats_server_unsupported.go
+++ b/internal/lib/statsserver/stats_server_unsupported.go
@@ -28,3 +28,5 @@ func (ss *StatsServer) updateContainerStats(c *oci.Container, sb *sandbox.Sandbo
 func (ss *StatsServer) metricsForPodSandbox(sb *sandbox.Sandbox) *SandboxMetrics {
 	return &SandboxMetrics{}
 }
+
+func (ss *StatsServer) snapshotHostNetDev(_ []*sandbox.Sandbox) {}

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -536,6 +536,8 @@ func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequ
 			return nil, err
 		}
 		g.AddAnnotation(annotations.CNIResult, string(cniResultJSON))
+
+		sb.SetHostInterfaces(libsandbox.HostInterfacesFromCNIResult(resultCurrent))
 	}
 
 	s.generateCRIEvent(ctx, sb.InfraContainer(), types.ContainerEventType_CONTAINER_CREATED_EVENT)

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -1503,6 +1503,8 @@ func (s *Server) setupSandboxNetwork(ctx context.Context, sb *libsandbox.Sandbox
 		}
 
 		g.AddAnnotation(annotations.CNIResult, string(cniResultJSON))
+
+		sb.SetHostInterfaces(libsandbox.HostInterfacesFromCNIResult(resultCurrent))
 	}
 
 	return ips, nil

--- a/test/cri-metrics.bats
+++ b/test/cri-metrics.bats
@@ -589,3 +589,53 @@ EOF
 	pod_actual_ifaces=$(crictl exec --sync "$CTR_ID" ls /sys/class/net/ | sed '/^$/d' | sort)
 	[[ "$pod_metric_ifaces" == "$pod_actual_ifaces" ]]
 }
+
+@test "hostNetwork pod metrics exclude pod-owned interfaces" {
+	CONTAINER_ENABLE_METRICS="true" CONTAINER_METRICS_PORT=$(free_port) setup_crio
+	cat << EOF > "$CRIO_CONFIG"
+[crio.stats]
+collection_period = 0
+included_pod_metrics = [
+    "network",
+]
+EOF
+	start_crio_no_setup
+	check_images
+
+	# create a non-hostNetwork pod with a container so we can exec into it
+	POD_ID=$(crictl runp "$TESTDATA/sandbox_config.json")
+	CTR_ID=$(crictl create "$POD_ID" "$TESTDATA/container_sleep.json" "$TESTDATA/sandbox_config.json")
+	crictl start "$CTR_ID"
+
+	wait_for_metric "container_network_receive_bytes_total"
+
+	# find the host-side veth peer for the pod's eth0 by reading the
+	# iflink index from inside the container and resolving it on the host
+	peer_idx=$(crictl exec "$CTR_ID" cat /sys/class/net/eth0/iflink)
+	host_veth=$(ip -o link | awk -F'[ :]+' -v idx="$peer_idx" '$1 == idx {print $2}' | sed 's/@.*//')
+	[[ -n "$host_veth" ]]
+
+	# create a hostNetwork pod
+	jq '.metadata.name = "podsandbox2"
+		| .metadata.uid = "redhat-test-crio-2"
+		| .linux.security_context.namespace_options.network = 2
+		| del(.annotations)
+		| del(.hostname)' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_hostnetwork.json
+	HOST_POD_ID=$(crictl runp "$TESTDIR/sandbox_hostnetwork.json")
+
+	metrics=$(crictl metricsp)
+
+	# collect the hostNetwork pod's metric interfaces
+	host_pod_metric_ifaces=$(echo "$metrics" | jq -r --arg id "$HOST_POD_ID" \
+		'[.podMetrics[] | select(.podSandboxId == $id) | .metrics[] | select(.name == "container_network_receive_bytes_total") | .labelValues[6]] | unique | .[]')
+
+	# the hostNetwork pod must report at least lo
+	[[ -n "$host_pod_metric_ifaces" ]]
+
+	# the pod's host-side veth must not appear in hostNetwork metrics
+	if echo "$host_pod_metric_ifaces" | grep -qx "$host_veth"; then
+		echo "hostNetwork metrics unexpectedly contain pod veth: $host_veth"
+		return 1
+	fi
+}

--- a/test/cri-metrics.bats
+++ b/test/cri-metrics.bats
@@ -561,3 +561,31 @@ EOF
 	container_pressure_io_waiting_seconds_total=$(echo "$metrics" | jq 'select(.name == "container_pressure_io_waiting_seconds_total") | .value.value | tonumber')
 	[[ "$container_pressure_io_waiting_seconds_total" != "" ]]
 }
+
+@test "non-hostNetwork pod metrics match interfaces in the pod's network namespace" {
+	CONTAINER_ENABLE_METRICS="true" CONTAINER_METRICS_PORT=$(free_port) setup_crio
+	cat << EOF > "$CRIO_CONFIG"
+[crio.stats]
+collection_period = 0
+included_pod_metrics = [
+    "network",
+]
+EOF
+	start_crio_no_setup
+	check_images
+
+	# create a non-hostNetwork pod with a container so we can exec into it
+	POD_ID=$(crictl runp "$TESTDATA/sandbox_config.json")
+	CTR_ID=$(crictl create "$POD_ID" "$TESTDATA/container_sleep.json" "$TESTDATA/sandbox_config.json")
+	crictl start "$CTR_ID"
+
+	wait_for_metric "container_network_receive_bytes_total"
+
+	metrics=$(crictl metricsp)
+
+	# metrics must match the pod's own interfaces, not the host's
+	pod_metric_ifaces=$(echo "$metrics" | jq -r --arg id "$POD_ID" \
+		'[.podMetrics[] | select(.podSandboxId == $id) | .metrics[] | select(.name == "container_network_receive_bytes_total") | .labelValues[6]] | unique | .[]' | sed '/^$/d' | sort)
+	pod_actual_ifaces=$(crictl exec --sync "$CTR_ID" ls /sys/class/net/ | sed '/^$/d' | sort)
+	[[ "$pod_metric_ifaces" == "$pod_actual_ifaces" ]]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### Summary

CRI network metrics (`container_network_*_total`) include an `interface` label. On a node with N pods, a hostNetwork pod sees every host interface including all N veth pairs created by the CNI plugin for other pods. Each veth has a unique name (e.g. `veth12ab34cd`), so the metric cardinality for a single hostNetwork pod scales as `N × 8 network metrics`. With multiple hostNetwork pods (node-exporter, kube-proxy, SDN pods, etc.) this becomes `hostNetwork_pods × N × 8`, a cardinality explosion that puts pressure on Prometheus TSDB, especially on large nodes.

This is one of two issues with CRI network metrics. The other is that `GenerateNetworkMetrics` currently reads links from the host namespace for all pods, not just hostNetwork ones. Non-hostNetwork pods should read from their own netns, and that fix is tracked separately in https://github.com/cri-o/cri-o/pull/10204.

This PR addresses the hostNetwork side by filtering pod-owned interfaces out of hostNetwork pod metrics. It tracks which host-side interfaces the CNI plugin creates and excludes them from the metrics snapshot.

#### Design

```
┌─────────────────────────────────────────────────────────┐
│                    Pod creation                         │
│                                                         │
│  RunPodSandbox ──► CNI plugin returns Result            │
│                     │                                   │
│                     ▼                                   │
│              HostInterfacesFromCNIResult()               │
│              Extracts iface names where                  │
│              Sandbox == "" (host-side)                   │
│                     │                                   │
│                     ▼                                   │
│              sandbox.SetHostInterfaces(["vethXXX"])      │
│                                                         │
│  LoadSandbox ──► Restores from CNI annotation            │
│                  (survives restarts)                     │
└─────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────┐
│               Metrics collection cycle                  │
│                                                         │
│  snapshotHostNetworkLinks(sandboxes)                     │
│  ┌────────────────────────────────────────────────────┐  │
│  │ 1. Build exclusion set from all non-hostNetwork    │  │
│  │    sandboxes' HostInterfaces                       │  │
│  │                                                    │  │
│  │    podIfaces = {"veth1", "veth2", "cni0", ...}     │  │
│  │                                                    │  │
│  │ 2. netlink.LinkList() -- single snapshot           │  │
│  │                                                    │  │
│  │ 3. Filter: keep links NOT in podIfaces             │  │
│  │                                                    │  │
│  │ 4. Store as ss.hostNetworkLinks                    │  │
│  └────────────────────────────────────────────────────┘  │
│                         │                               │
│                         ▼                               │
│  GenerateNetworkMetrics(sb)                              │
│    ├─ hostNetwork pod  → use ss.hostNetworkLinks         │
│    └─ regular pod      → netlink.LinkList() directly     │
└─────────────────────────────────────────────────────────┘
```

The snapshot is taken once per collection cycle (or once per on-demand request when `collection_period = 0`), so all hostNetwork sandboxes see a consistent set of interfaces without redundant netlink calls or races from concurrent pod creation.

#### Backward compatibility

Fully backward compatible. If the CNI result annotation is missing (older sandbox) or the CNI plugin doesn't report host-side interfaces, nothing enters the exclusion set and the hostNetwork sandbox reports all interfaces, same as before this change.

#### Commits

fb4d412b2620b683ce3cb6b613bb23778f890a9f **Add host interfaces field to sandbox**: `hostInterfaces []string` field with getter/setter on the `Sandbox` struct.
80cab997d57c23017a0832c90184aceb1885a81a **Populate host interfaces from CNI result**: extract host-side interface names (where `iface.Sandbox == ""`) from the CNI result at pod creation time (Linux and FreeBSD paths).
cdf6aeaae9de0c3bdbef66713577dcf1182aab49 **Restore host interfaces from CNI annotation**: on `LoadSandbox`, re-parse the persisted CNI result annotation to restore `hostInterfaces`, so filtering survives CRI-O restarts.
14dac55cb1e1ed851058b2c074ad0e79457609dd **Filter pod-owned interfaces from host network metrics**: pre-compute a filtered snapshot of host network links and use it for hostNetwork pod metrics. Includes unit tests for the filtering logic.
dd8d72917d9edc1187fc3475c5c43f89d5520eca **E2e test**: verify that a hostNetwork pod's CRI metrics do not include the veth peer of a non-hostNetwork pod.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Filter pod-owned interfaces (veth pairs) from hostNetwork pod CRI network metrics to prevent cardinality explosion in container_network_*.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Automatically identifies host-side network interfaces during container network setup.
- Improves network metrics by using interface data visible to each sandbox and cached host-network information.

## Bug Fixes
- Excludes pod-owned interfaces from host-network metrics.
- Handles unavailable or empty network-interface data more reliably.

## Tests
- Added coverage for filtering host and pod interfaces.
- Added integration coverage confirming accurate sandbox interfaces and host-network metric exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->