### PR TITLE
highperfhooks: move cpuset cleanup to post stop

### DIFF
--- a/internal/runtimehandlerhooks/high_performance_hooks_linux.go
+++ b/internal/runtimehandlerhooks/high_performance_hooks_linux.go
@@ -388,37 +388,6 @@ func (h *HighPerformanceHooks) PreStop(ctx context.Context, c *oci.Container, s 
 		return nil
 	}
 
-	containerName := c.CRIContainer().GetMetadata().GetName()
-
-	// disable the CPU load balancing for the container CPUs
-	if shouldCPULoadBalancingBeDisabled(ctx, s.Annotations(), containerName) {
-		podManager, containerManagers, err := h.PodAndContainerCgroupManagers(s.CgroupParent(), c.ID())
-		if err != nil {
-			return err
-		}
-
-		sharedCPUsRequested := requestedSharedCPUs(s.Annotations(), containerName)
-		if sharedCPUsRequested && node.CgroupIsV2() {
-			// Add the cgroup-child so that we can safely remove the isolated cpuset cgroup
-			// Otherwise cpuset may be kept isolated even after the cgroup is deleted.
-			actualContainerManager, err := getManagerByIndex(len(containerManagers)-1, containerManagers)
-			if err != nil {
-				return err
-			}
-
-			childCgroup, err := createChildCgroupManager(actualContainerManager.Path(""))
-			if err != nil {
-				return err
-			}
-
-			containerManagers = append(containerManagers, childCgroup)
-		}
-
-		if err := h.setCPULoadBalancing(ctx, c, podManager, containerManagers, true, sharedCPUsRequested); err != nil {
-			return fmt.Errorf("set CPU load balancing: %w", err)
-		}
-	}
-
 	// no need to reverse the cgroup CPU CFS quota setting as the pod cgroup will be deleted anyway
 
 	// Restore the c-state configuration for the container CPUs (only do this when the annotation is
@@ -454,8 +423,37 @@ func (h *HighPerformanceHooks) PostStop(ctx context.Context, c *oci.Container, s
 				return fmt.Errorf("set IRQ load balancing: %w", err)
 			}
 		}
-	}
+		// Re-enable CPU load balancing. It is done here because gracefully exiting containers won't have
+		// prestop hooks run, which causes issues with reserved CPUs taken by init containers for regular containers
+		// in the same pod.
+		if shouldCPULoadBalancingBeDisabled(ctx, s.Annotations(), containerName) {
+			podManager, containerManagers, err := h.PodAndContainerCgroupManagers(s.CgroupParent(), c.ID())
+			if err != nil {
+				return err
+			}
 
+			sharedCPUsRequested := requestedSharedCPUs(s.Annotations(), containerName)
+			if sharedCPUsRequested && node.CgroupIsV2() {
+				// Add the cgroup-child so that we can safely remove the isolated cpuset cgroup
+				// Otherwise cpuset may be kept isolated even after the cgroup is deleted.
+				actualContainerManager, err := getManagerByIndex(len(containerManagers)-1, containerManagers)
+				if err != nil {
+					return err
+				}
+
+				childCgroup, err := createChildCgroupManager(actualContainerManager.Path(""))
+				if err != nil {
+					return err
+				}
+
+				containerManagers = append(containerManagers, childCgroup)
+			}
+
+			if err := h.setCPULoadBalancing(ctx, c, podManager, containerManagers, true, sharedCPUsRequested); err != nil {
+				return fmt.Errorf("set CPU load balancing: %w", err)
+			}
+		}
+	}
 	// We could check if `!cpuLoadBalancingAllowed()` here, but it requires access to the config, which would be
 	// odd to plumb. Instead, always assume if they're using a HighPerformanceHook, they have CPULoadBalanceDisabled
 	// annotation allowed.
@@ -736,6 +734,12 @@ func (h *HighPerformanceHooks) addOrRemoveCpusetFromManager(mgr cgroups.Manager,
 
 	currentCpusStr, err := cgroups.ReadFile(mgr.Path(""), file)
 	if err != nil {
+		// If we're removing, we are racing against systemd cleaning up the cgroup.
+		// Ignore ENOENT so we can free the cpus for sibling cgroups
+		if !add && errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/test/cpu_load_balancing.bats
+++ b/test/cpu_load_balancing.bats
@@ -133,6 +133,13 @@ function check_partition() {
 	[[ $(cat "$CTR_CGROUP"/cpuset.cpus.partition) == "$expected" ]]
 }
 
+function check_pod_cpuset_exclusive() {
+	local ctr_id="$1"
+	local expected="$2"
+	set_container_pod_cgroup_root "" "$ctr_id"
+	[[ $(cat "$POD_CGROUP"/cpuset.cpus.exclusive) == "$expected" ]]
+}
+
 function create_container_config() {
 	local name="$1"
 	local outfile="$2"
@@ -216,4 +223,37 @@ function create_container_config() {
 	# Verify only container-a is isolated
 	check_partition "$ctr_a" "isolated"
 	check_partition "$ctr_b" "member"
+}
+
+# Verify cpuset.cpus.exclusive is cleaned up from the pod cgroup when a
+# container exits naturally. Without this cleanup, stale exclusive CPUs on
+# the pod cgroup prevent sibling containers from isolating the same CPUs.
+# This reproduces OCPBUGS-72546: an init container's stale cpuset.cpus.exclusive
+# caused EINVAL for main containers with overlapping CPU assignments.
+# bats test_tags=crio:serial
+@test "test cpu load balancing exclusive cpus cleaned up on container exit" {
+	setup_per_container_test
+	start_crio
+
+	jq '.annotations."cpu-load-balancing.crio.io" = "disable"' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sbox.json
+
+	jq '.command = ["/bin/sh", "-c", "exit 0"]
+		| .linux.resources.cpu_shares = 1024
+		| .linux.resources.cpuset_cpus = 2' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR"/ctr_init.json
+
+	pod_id=$(crictl runp --runtime high-performance "$TESTDIR"/sbox.json)
+
+	# Start a container that exits immediately (simulates an init container).
+	# PreStart sets cpuset.cpus.exclusive on the pod cgroup and container scope.
+	ctr_init=$(crictl create "$pod_id" "$TESTDIR"/ctr_init.json "$TESTDIR"/sbox.json)
+	crictl start "$ctr_init"
+	wait_until_exit "$ctr_init"
+
+	# After natural exit, PostStop must clean up cpuset.cpus.exclusive from
+	# the pod cgroup. The container scope may already be gone (systemd removes
+	# empty scopes), but the pod cgroup persists and must not retain stale
+	# exclusive CPUs.
+	check_pod_cpuset_exclusive "$ctr_init" ""
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
when a container gracefully shuts down, prestop hooks don't run (it's already stopped) that's generally fine. However, in the case where an init container runs and has an overlapping range with a container that will run after it, we will fail to run that container.

Move the cpuset cleanup to poststop so it runs on graceful exit

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a bug in high performance hooks where an init container would continue to hold a cpuset that could be used by a regular container in the same pod. 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU load-balancing restoration after containers stop naturally.
  * Ensured shared CPU assignments are restored during post-stop cleanup.
  * Prevented cleanup failures when system-managed cgroups have already been removed.
  * Resolved stale exclusive CPU assignments remaining on pod cgroups after container termination.

* **Tests**
  * Added regression coverage for post-stop CPU assignment cleanup, including immediately exiting containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->