### PR TITLE
fix: make runtime handlers added by SIGHUP reload available to RunPodSandbox

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -46,8 +46,26 @@ const (
 // information about the runtime.
 type Runtime struct {
 	config              *config.Config
+	configMutex         sync.RWMutex
 	runtimeImplMap      map[string]RuntimeImpl
 	runtimeImplMapMutex sync.RWMutex
+}
+
+// UpdateRuntimeConfig replaces the runtime handler configuration this Runtime
+// resolves handlers against. It is called after a SIGHUP configuration reload
+// so that newly added runtime handlers become available to RunPodSandbox
+// without restarting CRI-O.
+//
+// Server.config is a distinct value from the *config.Config this Runtime was
+// constructed with, so reloading the former does not update the latter. The
+// reload path must push the new values in explicitly, in the same way it
+// already does for the pinned image list.
+func (r *Runtime) UpdateRuntimeConfig(runtimes config.Runtimes, defaultRuntime string) {
+	r.configMutex.Lock()
+	defer r.configMutex.Unlock()
+
+	r.config.Runtimes = runtimes
+	r.config.DefaultRuntime = defaultRuntime
 }
 
 // RuntimeImpl is an interface used by the caller to interact with the
@@ -110,10 +128,14 @@ func (r *Runtime) ValidateRuntimeHandler(handler string) (*config.RuntimeHandler
 		return nil, errors.New("empty runtime handler")
 	}
 
+	r.configMutex.RLock()
 	runtimeHandler, ok := r.config.Runtimes[handler]
+	runtimes := r.config.Runtimes
+	r.configMutex.RUnlock()
+
 	if !ok {
 		return nil, fmt.Errorf("failed to find runtime handler %s from runtime list %v",
-			handler, r.config.Runtimes)
+			handler, runtimes)
 	}
 
 	if runtimeHandler.RuntimePath == "" {

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -118,6 +118,9 @@ func New(c *config.Config) (*Runtime, error) {
 
 // Runtimes returns the map of OCI runtimes.
 func (r *Runtime) Runtimes() config.Runtimes {
+	r.configMutex.RLock()
+	defer r.configMutex.RUnlock()
+
 	return r.config.Runtimes
 }
 
@@ -147,7 +150,13 @@ func (r *Runtime) ValidateRuntimeHandler(handler string) (*config.RuntimeHandler
 
 func (r *Runtime) getRuntimeHandler(handler string) (*config.RuntimeHandler, error) {
 	// Define the current runtime handler as the default runtime handler.
+	// Read both fields under a single lock so the default handler cannot be
+	// resolved against a runtime map from a different reload. The lock is
+	// released before ValidateRuntimeHandler below, which takes it itself:
+	// a blocked writer stops new readers, so a nested RLock could deadlock.
+	r.configMutex.RLock()
 	rh := r.config.Runtimes[r.config.DefaultRuntime]
+	r.configMutex.RUnlock()
 
 	// Override the current runtime handler with the runtime handler
 	// corresponding to the runtime handler key provided with this

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -45,7 +45,16 @@ const (
 // Runtime is the generic structure holding both global and specific
 // information about the runtime.
 type Runtime struct {
-	config              *config.Config
+	config *config.Config
+	// runtimes and defaultRuntime are owned by this Runtime rather than read
+	// through config. The *config.Config that config points at is the one
+	// Config.GetData returns, which is the same pointer held by ContainerServer
+	// and by HooksRetriever, and HooksRetriever reads Runtimes without any
+	// synchronisation from gRPC handler goroutines. Writing the reloaded values
+	// back through config would therefore race with those readers, so the
+	// reload updates these fields instead and leaves the shared config alone.
+	runtimes            config.Runtimes
+	defaultRuntime      string
 	configMutex         sync.RWMutex
 	runtimeImplMap      map[string]RuntimeImpl
 	runtimeImplMapMutex sync.RWMutex
@@ -60,12 +69,15 @@ type Runtime struct {
 // constructed with, so reloading the former does not update the latter. The
 // reload path must push the new values in explicitly, in the same way it
 // already does for the pinned image list.
+//
+// The values are stored on the Runtime rather than written back through the
+// shared *config.Config; see the field comments above.
 func (r *Runtime) UpdateRuntimeConfig(runtimes config.Runtimes, defaultRuntime string) {
 	r.configMutex.Lock()
 	defer r.configMutex.Unlock()
 
-	r.config.Runtimes = runtimes
-	r.config.DefaultRuntime = defaultRuntime
+	r.runtimes = runtimes
+	r.defaultRuntime = defaultRuntime
 }
 
 // RuntimeImpl is an interface used by the caller to interact with the
@@ -112,6 +124,8 @@ func New(c *config.Config) (*Runtime, error) {
 
 	return &Runtime{
 		config:         c,
+		runtimes:       c.Runtimes,
+		defaultRuntime: c.DefaultRuntime,
 		runtimeImplMap: make(map[string]RuntimeImpl),
 	}, nil
 }
@@ -121,7 +135,7 @@ func (r *Runtime) Runtimes() config.Runtimes {
 	r.configMutex.RLock()
 	defer r.configMutex.RUnlock()
 
-	return r.config.Runtimes
+	return r.runtimes
 }
 
 // ValidateRuntimeHandler returns an error if the runtime handler string
@@ -132,8 +146,8 @@ func (r *Runtime) ValidateRuntimeHandler(handler string) (*config.RuntimeHandler
 	}
 
 	r.configMutex.RLock()
-	runtimeHandler, ok := r.config.Runtimes[handler]
-	runtimes := r.config.Runtimes
+	runtimeHandler, ok := r.runtimes[handler]
+	runtimes := r.runtimes
 	r.configMutex.RUnlock()
 
 	if !ok {
@@ -155,7 +169,7 @@ func (r *Runtime) getRuntimeHandler(handler string) (*config.RuntimeHandler, err
 	// released before ValidateRuntimeHandler below, which takes it itself:
 	// a blocked writer stops new readers, so a nested RLock could deadlock.
 	r.configMutex.RLock()
-	rh := r.config.Runtimes[r.config.DefaultRuntime]
+	rh := r.runtimes[r.defaultRuntime]
 	r.configMutex.RUnlock()
 
 	// Override the current runtime handler with the runtime handler

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -113,6 +113,36 @@ var _ = t.Describe("Oci", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(handler).To(Equal(runtimes[defaultRuntime]))
 		})
+		It("should make a runtime handler added after a reload available (#10202)", func() {
+			// Given a handler that is not present at construction time
+			const newHandler = "kata-qemu"
+
+			_, err := sut.ValidateRuntimeHandler(newHandler)
+			Expect(err).To(HaveOccurred())
+
+			// When the reload path pushes an updated runtime map in
+			updated := libconfig.Runtimes{}
+			for name, handler := range runtimes {
+				updated[name] = handler
+			}
+
+			updated[newHandler] = &libconfig.RuntimeHandler{
+				RuntimePath: "/opt/kata/bin/containerd-shim-kata-v2",
+				RuntimeType: "vm",
+			}
+
+			sut.UpdateRuntimeConfig(updated, defaultRuntime)
+
+			// Then it resolves for new RunPodSandbox requests
+			handler, err := sut.ValidateRuntimeHandler(newHandler)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handler).To(Equal(updated[newHandler]))
+
+			// And the pre-existing handlers still resolve
+			handler, err = sut.ValidateRuntimeHandler(defaultRuntime)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(handler).To(Equal(runtimes[defaultRuntime]))
+		})
 		It("should return an OCI runtime type if none is set", func() {
 			// Given
 			// When

--- a/server/server.go
+++ b/server/server.go
@@ -635,6 +635,13 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 
 			metrics.Instance().MetricDefaultRuntimeSet(s.config.DefaultRuntime)
 
+			// oci.Runtime holds its own *config.Config, distinct from
+			// s.config, so the reload above does not reach it. Push the
+			// reloaded runtime handlers in explicitly, otherwise a handler
+			// added by SIGHUP shows up in "crio status config" but stays
+			// invisible to RunPodSandbox.
+			s.ContainerServer.Runtime().UpdateRuntimeConfig(s.config.Runtimes, s.config.DefaultRuntime)
+
 			// ImageServer compiles the list with regex for both
 			// pinned and sandbox/pause images, we need to update them
 			s.ContainerServer.StorageImageServer().UpdatePinnedImagesList(append(s.config.PinnedImages, s.config.PauseImage))

--- a/server/server.go
+++ b/server/server.go
@@ -635,11 +635,16 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 
 			metrics.Instance().MetricDefaultRuntimeSet(s.config.DefaultRuntime)
 
-			// oci.Runtime holds its own *config.Config, distinct from
-			// s.config, so the reload above does not reach it. Push the
-			// reloaded runtime handlers in explicitly, otherwise a handler
+			// s.config is a value copy, so the reload above does not reach
+			// the *config.Config that oci.Runtime was constructed with. Push
+			// the reloaded runtime handlers in explicitly, otherwise a handler
 			// added by SIGHUP shows up in "crio status config" but stays
 			// invisible to RunPodSandbox.
+			//
+			// UpdateRuntimeConfig stores these on the Runtime rather than
+			// writing them back through that *config.Config, which is shared
+			// with ContainerServer and HooksRetriever and is read without
+			// synchronisation from request handlers.
 			s.ContainerServer.Runtime().UpdateRuntimeConfig(s.config.Runtimes, s.config.DefaultRuntime)
 
 			// ImageServer compiles the list with regex for both


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

A runtime handler added through a drop-in config and picked up by SIGHUP shows up in `crio status config`, but `RunPodSandbox` keeps rejecting it:

```
failed to find runtime handler kata-qemu from runtime list map[crun:0x... runc:0x...]
```

`Server.config` is a value copy (`server/server.go:469` stores `*config`), while `lib.New` / `oci.New` retain the original `*config.Config`. The SIGHUP handler calls `s.config.Reload()`, so only the copy is updated, and `oci.Runtime` goes on resolving handlers against the map it was constructed with.

The reload path already pushes reloaded values into subsystems that keep their own state — `UpdatePinnedImagesList`, `SetPinnedImageRegexps`. The runtime handler map was just never wired in. This follows that same pattern:

- `oci.Runtime.UpdateRuntimeConfig()`, guarded by a new `RWMutex`. The existing `runtimeImplMapMutex` covers `runtimeImplMap` only, and the handler lookups read `r.config.Runtimes` with no synchronisation at all, so the new mutex covers the map now that it can be written after startup.
- `ValidateRuntimeHandler` takes the read lock and snapshots the map it reports in its error message.
- `startReloadWatcher` calls it after a successful reload, alongside the existing pinned-image push.

I also tried simply sharing the `*config.Config` pointer with `oci.Runtime` instead. It's smaller and it compiles, but reload mutates the config in place while gRPC handlers read it concurrently, and nothing in `pkg/config` is synchronised — that trades a stale-read bug for a data race, so I didn't go that way. Happy to revisit if maintainers prefer a different shape.

## Which issue(s) this PR fixes

Fixes #10202

## Special notes for your reviewer

The regression test covers a handler absent at construction time, resolving after `UpdateRuntimeConfig`, and pre-existing handlers still resolving.

Full `internal/oci` suite run on Linux: 84 passed, 0 failed, 8 skipped.

Happy to add a server-level test exercising the SIGHUP path end to end if that would be preferred.

## Does this PR introduce a user-facing change?

```release-note
Fixed runtime handlers added by a SIGHUP configuration reload not becoming available to RunPodSandbox until CRI-O was restarted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime configuration changes now take effect safely when server configuration is reloaded.
  * Newly configured runtime handlers become available immediately, while existing handlers continue to work.
  * The configured default runtime is updated alongside other runtime settings.

* **Bug Fixes**
  * Improved runtime configuration consistency during concurrent access and reloads.
  * Runtime handler validation now reflects the latest available configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->