### PR TITLE
[release-1.34] OCPBUGS-104594: reject actual newline bytes in HOME env to prevent /etc/passwd injection

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -231,7 +231,7 @@ func setupContainerUser(ctx context.Context, specgen *generate.Generator, rootfs
 	for _, env := range specgen.Config.Process.Env {
 		if strings.HasPrefix(env, "HOME=") {
 			homedir = strings.TrimPrefix(env, "HOME=")
-			if idx := strings.Index(homedir, `\n`); idx > -1 {
+			if strings.ContainsAny(homedir, "\n\r") {
 				return errors.New("invalid HOME environment; newline not allowed")
 			}
 

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/opencontainers/runtime-tools/generate"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/factory/container"
@@ -394,6 +396,67 @@ func TestAddOCIBindsErrorWithoutIDMap(t *testing.T) {
 	_, _, _, err = sut.addOCIBindMounts(t.Context(), ctr, ctrInfo, false, false, false, true, false)
 	if err != nil {
 		t.Errorf("%v", err)
+	}
+}
+
+func TestSetupContainerUserRejectsNewlineInHOME(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		homeVal string
+		wantErr bool
+	}{
+		{
+			name:    "actual newline byte in HOME",
+			homeVal: "/root\nmalicious::0:0::/:/bin/bash",
+			wantErr: true,
+		},
+		{
+			name:    "carriage return in HOME",
+			homeVal: "/root\r\nmalicious::0:0::/:/bin/bash",
+			wantErr: true,
+		},
+		{
+			name:    "valid HOME value",
+			homeVal: "/home/user",
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			specgen, err := generate.New("linux")
+			if err != nil {
+				t.Fatalf("failed to create spec generator: %v", err)
+			}
+
+			specgen.AddProcessEnv("HOME", tc.homeVal)
+
+			sc := &types.LinuxContainerSecurityContext{
+				RunAsUser: &types.Int64Value{Value: 1000},
+			}
+
+			err = setupContainerUser(t.Context(), &specgen, t.TempDir(), "", t.TempDir(), sc, nil)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error for HOME with newline, got nil")
+				}
+
+				if !strings.Contains(err.Error(), "newline") {
+					t.Errorf("expected newline-related error, got: %v", err)
+				}
+			} else if err != nil {
+				// Valid HOME may still fail on missing rootfs files; that's fine.
+				// Only fail if the error is the newline check.
+				if strings.Contains(err.Error(), "newline") {
+					t.Errorf("unexpected newline error for valid HOME: %v", err)
+				}
+			}
+		})
 	}
 }
 

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1304,9 +1304,20 @@ function assert_log_linking() {
 	done
 }
 
-@test "ctr HOME env newline invalid" {
+@test "ctr HOME env escaped newline valid" {
 	start_crio
-	jq ' .envs = [{"key": "HOME=", "value": "/root:/sbin/nologin\\ntest::0:0::/:/bin/bash"}]' \
+	jq ' .envs = [{"key": "HOME", "value": "/root:/sbin/nologin\\ntest::0:0::/:/bin/bash"}]' \
+		"$TESTDATA"/container_config.json > "$newconfig"
+
+	crictl run "$newconfig" "$TESTDATA"/sandbox_config.json
+}
+
+@test "ctr HOME env actual newline byte invalid" {
+	start_crio
+	# Use printf to embed an actual newline byte (0x0a) into the HOME value.
+	local payload
+	payload=$(printf '/root\nmalicious::0:0::/:/bin/bash')
+	jq --arg home "$payload" ' .envs = [{"key": "HOME", "value": $home}]' \
 		"$TESTDATA"/container_config.json > "$newconfig"
 
 	run ! crictl run "$newconfig" "$TESTDATA"/sandbox_config.json


### PR DESCRIPTION

Cherry pick of #10148

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed CVE-2026-15809: bypass of CVE-2022-4318 fix allowing /etc/passwd injection via newline characters in the HOME environment variable. The original check incorrectly matched the literal string "\n" instead of actual newline bytes.
```

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-104594
