### PR TITLE
ci: record dependency commit hashes and add bump job

### DIFF
--- a/.github/workflows/versions-commits.yml
+++ b/.github/workflows/versions-commits.yml
@@ -1,0 +1,37 @@
+name: versions-commits
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1" # Every Monday
+permissions:
+  contents: read
+
+jobs:
+  update-version-commits:
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.ref == 'refs/heads/main' && github.repository == 'cri-o/cri-o'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: make versions-commits
+      - name: Check workspace
+        id: create_pr
+        run: |
+          if [[ $(git diff --stat) != '' ]]; then
+            echo "create_pr=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create PR if required
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        if: ${{ steps.create_pr.outputs.create_pr == 'true' }}
+        with:
+          commit-message: Update dependency commit hashes
+          title: "Update dependency commit hashes"
+          body: Update the recorded upstream commit hashes in dependencies.yaml.
+          labels: kind/ci, release-note-none, ok-to-test
+          branch: versions-commits
+          delete-branch: true
+          signoff: true

--- a/Makefile
+++ b/Makefile
@@ -431,6 +431,10 @@ clean: ## Clean the repository.
 nixpkgs: ## Update the NIX package dependencies.
 	nix $(NIX_FLAKE_FLAGS) flake update
 
+.PHONY: versions-commits
+versions-commits: ## Resolve and record upstream commit hashes in dependencies.yaml.
+	./scripts/resolve-version-commits
+
 .PHONY: vendor
 vendor: export GOSUMDB :=
 vendor: ## Update the vendored dependencies.

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -56,6 +56,27 @@ dependencies:
       - path: scripts/versions
         match: conmon
 
+  - name: conmon-rs
+    version: main
+    refPaths:
+      - path: scripts/versions
+        match: conmon-rs
+
+  # Upstream commit hashes for tools built from source in CI. Recorded here so
+  # builds are reproducible and CI failures are easier to bisect. Kept up to
+  # date by `make versions-commits` (see scripts/resolve-version-commits).
+  - name: conmon-commit
+    version: 82de887596ed8ee6d9b2ee85e4f167f307bb569b
+
+  - name: conmon-rs-commit
+    version: 5d33ccee5201a07f48e12fbc949ee8a99d74e351
+
+  - name: cri-tools-commit
+    version: 88d8ad9d40f82726fda53c2d271e6172b4c619c9
+
+  - name: crun-commit
+    version: 54f16ffbefcd022bf032af768b5c5ce075c18bfc
+
   - name: cri-tools
     version: v1.36.0
     refPaths:

--- a/scripts/resolve-version-commits
+++ b/scripts/resolve-version-commits
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the upstream commit hash for each dependency that CI builds from
+# source and record it in dependencies.yaml, under the matching "<tool>-commit"
+# entry. This keeps builds reproducible and makes CI failures easier to bisect,
+# since the exact upstream commit each version was built against is captured
+# in-tree.
+#
+# Only the tools that are built from source in CI are tracked. runc is
+# deliberately excluded: it is installed from a released binary (see
+# RUNC_CHECKSUMS in scripts/versions), so there is nothing to build and no need
+# to pin a commit.
+#
+# Run via: make versions-commits
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSIONS_FILE="$ROOT/scripts/versions"
+DEPS_FILE="$ROOT/dependencies.yaml"
+
+# shellcheck source=scripts/versions
+source "$VERSIONS_FILE"
+
+# Upstream git repositories for each dependency whose commit we record. The keys
+# match the names used in the VERSIONS array in scripts/versions.
+declare -A REPOS=(
+    ["conmon"]=https://github.com/containers/conmon
+    ["conmon-rs"]=https://github.com/containers/conmon-rs
+    ["cri-tools"]=https://github.com/kubernetes-sigs/cri-tools
+    ["crun"]=https://github.com/containers/crun
+)
+
+# Temp file, cleaned up on exit. Declared at script scope so the EXIT trap can
+# still see it after main() returns.
+tmp=""
+cleanup() { rm -f "$tmp"; }
+trap cleanup EXIT
+
+# resolve_commit prints the commit hash a ref points at. It resolves, in order:
+# an annotated tag (dereferenced with ^{} so we record the commit, not the tag
+# object), a lightweight tag, then a branch head. The branch case covers deps
+# that track a moving branch rather than a release tag (e.g. conmon-rs on main).
+resolve_commit() {
+    local url=$1 ref=$2 sha
+    sha=$(git ls-remote "$url" "refs/tags/$ref^{}" | awk '{print $1}')
+    if [[ -z "$sha" ]]; then
+        sha=$(git ls-remote "$url" "refs/tags/$ref" | awk '{print $1}')
+    fi
+    if [[ -z "$sha" ]]; then
+        sha=$(git ls-remote "$url" "refs/heads/$ref" | awk '{print $1}')
+    fi
+    if [[ -z "$sha" ]]; then
+        echo "error: could not resolve commit for $url @ $ref" >&2
+        return 1
+    fi
+    echo "$sha"
+}
+
+# update_commit rewrites the "version:" line of the "<name>-commit" entry in
+# dependencies.yaml. It matches the specific "- name: <name>-commit" line, then
+# replaces the "version:" on the following line. It fails closed: if the entry is
+# missing, or its "version:" line is absent (a new "- name:" is reached first),
+# nothing is written and the script aborts, rather than silently corrupting an
+# adjacent entry or leaving a stale hash in place.
+update_commit() {
+    local name=$1 sha=$2
+    tmp=$(mktemp)
+    if ! awk -v name="$name-commit" -v sha="$sha" '
+        $0 ~ "^  - name: " name "$" { found = 1; print; next }
+        found && /^  - name: / { found = 0 }
+        found && /^    version:/ {
+            sub(/version:.*/, "version: " sha)
+            found = 0
+            replaced++
+        }
+        { print }
+        END { exit(replaced == 1 ? 0 : 1) }
+    ' "$DEPS_FILE" >"$tmp"; then
+        echo "error: expected exactly one '$name-commit' entry with a version line in $DEPS_FILE" >&2
+        return 1
+    fi
+    mv "$tmp" "$DEPS_FILE"
+}
+
+main() {
+    local name sha names
+    mapfile -t names < <(printf '%s\n' "${!REPOS[@]}" | sort)
+    for name in "${names[@]}"; do
+        sha=$(resolve_commit "${REPOS[$name]}" "${VERSIONS[$name]}")
+        printf 'resolved %-12s %-8s -> %s\n' "$name" "${VERSIONS[$name]}" "$sha" >&2
+        update_commit "$name" "$sha"
+    done
+}
+
+main "$@"

--- a/scripts/versions
+++ b/scripts/versions
@@ -2,6 +2,7 @@
 declare -A VERSIONS=(
     ["cni-plugins"]=v1.8.0
     ["conmon"]=v2.1.13
+    ["conmon-rs"]=main # tracks the main branch; no release pin
     ["cri-tools"]=v1.36.0
     ["crun"]=1.28
     ["runc"]=v1.5.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind ci

#### What this PR does / why we need it:

scripts/versions pins each dependency to a release tag (or main for
conmon-rs), but doesn't record the commit that tag resolves to. This adds a
VERSION_COMMITS array recording that commit for every dependency, so you can
see exactly which upstream commit CI built against.

make versions-commits regenerates the hashes (scripts/resolve-version-commits).

A weekly workflow runs it and opens a PR when a hash changes mainly for
conmon-rs, which tracks main and moves over time.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #10193

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated tracking of upstream dependency commit revisions.
  * Added support for tracking the `conmon-rs` main branch.
  * Added scheduled and manually triggered checks that detect revision changes and open pull requests.

* **Chores**
  * Added a command for regenerating recorded dependency revisions.
  * Recorded current upstream commit references for tracked components.
  * Improved consistency by keeping revision information sorted and up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->