### PR TITLE
[release-1.33] User namespace - Handle UID/GID mappings from the infra container

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ that we follow.
   - [Dependency management](#dependency-management)
   - [Sign your PRs](#sign-your-prs)
 - [Communications](#communications)
+
 <!-- /toc -->
 
 ## Reporting Issues

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,6 +29,7 @@
   - [Feature addition policy](#feature-addition-policy)
   - [Feature request policy](#feature-request-policy)
 - [Credits](#credits)
+
 <!-- /toc -->
 
 ## Values

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [Weekly Meeting](#weekly-meeting)
 - [Governance](#governance)
 - [License Scan](#license-scan)
+
 <!-- /toc -->
 
 ## Compatibility matrix: CRI-O ⬄ Kubernetes

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -229,7 +229,7 @@ List of devices on the host that a user can specify with the "io.kubernetes.cri-
 **additional_devices**=[]
 List of additional devices. Specified as "<device-on-host>:<device-on-container>:<permissions>", for example: "--additional-devices=/dev/sdc:/dev/xvdc:rwm". If it is empty or commented out, only the devices defined in the container json file by the user/kube will be added.
 
-**hooks_dir**=["*path*", ...]
+**hooks_dir**=["_path_", ...]
 Each `*.json` file in the path configures a hook for CRI-O containers. For more details on the syntax of the JSON files and the semantics of hook injection, see `oci-hooks(5)`. CRI-O currently support both the 1.0.0 and 0.1.0 hook schemas, although the 0.1.0 schema is deprecated.
 
 Paths listed later in the array have higher precedence (`oci-hooks(5)` discusses directory precedence).

--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -355,6 +355,13 @@ func (c *ContainerServer) LoadSandbox(ctx context.Context, id string) (sb *sandb
 	scontainer.SetSpec(&m)
 	scontainer.SetMountPoint(m.Annotations[annotations.MountPoint])
 
+	// Restore ID mappings from the OCI spec if user namespace is in use
+	if m.Linux != nil && len(m.Linux.UIDMappings) > 0 && len(m.Linux.GIDMappings) > 0 {
+		mappings := ConvertOCIToStorageIDMappings(m.Linux.UIDMappings, m.Linux.GIDMappings)
+		scontainer.SetIDMappings(mappings)
+		log.Debugf(ctx, "Restored ID mappings for sandbox %s from OCI spec", id)
+	}
+
 	if err := restoreVolumes(&m, scontainer); err != nil {
 		return sb, fmt.Errorf("restore volumes: %w", err)
 	}

--- a/internal/lib/idmappings_freebsd.go
+++ b/internal/lib/idmappings_freebsd.go
@@ -1,0 +1,19 @@
+package lib
+
+import (
+	"github.com/containers/storage/pkg/idtools"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// ConvertOCIToStorageIDMappings converts OCI runtime spec ID mappings to storage ID mappings.
+func ConvertOCIToStorageIDMappings(uidMappings, gidMappings []rspec.LinuxIDMapping) *idtools.IDMappings {
+	// FreeBSD doesn't support user namespaces, so this is a no-op
+	return nil
+}
+
+// ConvertCRIToOCIMappings converts CRI ID mappings to OCI runtime spec ID mappings.
+func ConvertCRIToOCIMappings(m []*types.IDMapping) []rspec.LinuxIDMapping {
+	// FreeBSD doesn't support user namespaces, so this is a no-op
+	return nil
+}

--- a/internal/lib/idmappings_linux.go
+++ b/internal/lib/idmappings_linux.go
@@ -1,0 +1,45 @@
+package lib
+
+import (
+	"github.com/containers/storage/pkg/idtools"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// ConvertOCIToStorageIDMappings converts OCI runtime spec ID mappings to storage ID mappings.
+func ConvertOCIToStorageIDMappings(uidMappings, gidMappings []rspec.LinuxIDMapping) *idtools.IDMappings {
+	if len(uidMappings) == 0 || len(gidMappings) == 0 {
+		return nil
+	}
+
+	uids := make([]idtools.IDMap, len(uidMappings))
+	gids := make([]idtools.IDMap, len(gidMappings))
+
+	for i, v := range uidMappings {
+		uids[i] = idtools.IDMap{ContainerID: int(v.ContainerID), HostID: int(v.HostID), Size: int(v.Size)}
+	}
+
+	for i, v := range gidMappings {
+		gids[i] = idtools.IDMap{ContainerID: int(v.ContainerID), HostID: int(v.HostID), Size: int(v.Size)}
+	}
+
+	return idtools.NewIDMappingsFromMaps(uids, gids)
+}
+
+// ConvertCRIToOCIMappings converts CRI ID mappings to OCI runtime spec ID mappings.
+func ConvertCRIToOCIMappings(m []*types.IDMapping) []rspec.LinuxIDMapping {
+	if len(m) == 0 {
+		return nil
+	}
+
+	ids := make([]rspec.LinuxIDMapping, 0, len(m))
+	for _, mapping := range m {
+		ids = append(ids, rspec.LinuxIDMapping{
+			ContainerID: mapping.GetContainerId(),
+			HostID:      mapping.GetHostId(),
+			Size:        mapping.GetLength(),
+		})
+	}
+
+	return ids
+}

--- a/internal/lib/idmappings_linux_test.go
+++ b/internal/lib/idmappings_linux_test.go
@@ -1,0 +1,178 @@
+package lib
+
+import (
+	"testing"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestConvertCRIToOCIMappings(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    []*types.IDMapping
+		expected []rspec.LinuxIDMapping
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty input",
+			input:    []*types.IDMapping{},
+			expected: nil,
+		},
+		{
+			name: "single mapping",
+			input: []*types.IDMapping{
+				{ContainerId: 0, HostId: 1000, Length: 65536},
+			},
+			expected: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 65536},
+			},
+		},
+		{
+			name: "multiple mappings",
+			input: []*types.IDMapping{
+				{ContainerId: 0, HostId: 1000, Length: 1},
+				{ContainerId: 1, HostId: 100000, Length: 65536},
+			},
+			expected: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 1},
+				{ContainerID: 1, HostID: 100000, Size: 65536},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertCRIToOCIMappings(tc.input)
+
+			if len(result) != len(tc.expected) {
+				t.Fatalf("Expected %d mappings, got %d", len(tc.expected), len(result))
+			}
+
+			for i, mapping := range result {
+				if mapping.ContainerID != tc.expected[i].ContainerID {
+					t.Errorf("Mapping %d: expected ContainerID %d, got %d", i, tc.expected[i].ContainerID, mapping.ContainerID)
+				}
+
+				if mapping.HostID != tc.expected[i].HostID {
+					t.Errorf("Mapping %d: expected HostID %d, got %d", i, tc.expected[i].HostID, mapping.HostID)
+				}
+
+				if mapping.Size != tc.expected[i].Size {
+					t.Errorf("Mapping %d: expected Size %d, got %d", i, tc.expected[i].Size, mapping.Size)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertOCIToStorageIDMappings(t *testing.T) {
+	cases := []struct {
+		name        string
+		uidMappings []rspec.LinuxIDMapping
+		gidMappings []rspec.LinuxIDMapping
+		expectNil   bool
+	}{
+		{
+			name:        "nil inputs",
+			uidMappings: nil,
+			gidMappings: nil,
+			expectNil:   true,
+		},
+		{
+			name:        "empty UID mappings",
+			uidMappings: []rspec.LinuxIDMapping{},
+			gidMappings: []rspec.LinuxIDMapping{{ContainerID: 0, HostID: 1000, Size: 65536}},
+			expectNil:   true,
+		},
+		{
+			name:        "empty GID mappings",
+			uidMappings: []rspec.LinuxIDMapping{{ContainerID: 0, HostID: 1000, Size: 65536}},
+			gidMappings: []rspec.LinuxIDMapping{},
+			expectNil:   true,
+		},
+		{
+			name: "valid single mapping",
+			uidMappings: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 65536},
+			},
+			gidMappings: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 65536},
+			},
+			expectNil: false,
+		},
+		{
+			name: "valid multiple mappings",
+			uidMappings: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 1000, Size: 1},
+				{ContainerID: 1, HostID: 100000, Size: 65536},
+			},
+			gidMappings: []rspec.LinuxIDMapping{
+				{ContainerID: 0, HostID: 2000, Size: 1},
+				{ContainerID: 1, HostID: 200000, Size: 65536},
+			},
+			expectNil: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertOCIToStorageIDMappings(tc.uidMappings, tc.gidMappings)
+
+			if tc.expectNil {
+				if result != nil {
+					t.Fatalf("Expected nil result, got non-nil")
+				}
+
+				return
+			}
+
+			if result == nil {
+				t.Fatalf("Expected non-nil result, got nil")
+			}
+
+			uids := result.UIDs()
+			gids := result.GIDs()
+
+			if len(uids) != len(tc.uidMappings) {
+				t.Fatalf("Expected %d UID mappings, got %d", len(tc.uidMappings), len(uids))
+			}
+
+			if len(gids) != len(tc.gidMappings) {
+				t.Fatalf("Expected %d GID mappings, got %d", len(tc.gidMappings), len(gids))
+			}
+
+			for i, uid := range uids {
+				if uid.ContainerID != int(tc.uidMappings[i].ContainerID) {
+					t.Errorf("UID mapping %d: expected ContainerID %d, got %d", i, tc.uidMappings[i].ContainerID, uid.ContainerID)
+				}
+
+				if uid.HostID != int(tc.uidMappings[i].HostID) {
+					t.Errorf("UID mapping %d: expected HostID %d, got %d", i, tc.uidMappings[i].HostID, uid.HostID)
+				}
+
+				if uid.Size != int(tc.uidMappings[i].Size) {
+					t.Errorf("UID mapping %d: expected Size %d, got %d", i, tc.uidMappings[i].Size, uid.Size)
+				}
+			}
+
+			for i, gid := range gids {
+				if gid.ContainerID != int(tc.gidMappings[i].ContainerID) {
+					t.Errorf("GID mapping %d: expected ContainerID %d, got %d", i, tc.gidMappings[i].ContainerID, gid.ContainerID)
+				}
+
+				if gid.HostID != int(tc.gidMappings[i].HostID) {
+					t.Errorf("GID mapping %d: expected HostID %d, got %d", i, tc.gidMappings[i].HostID, gid.HostID)
+				}
+
+				if gid.Size != int(tc.gidMappings[i].Size) {
+					t.Errorf("GID mapping %d: expected Size %d, got %d", i, tc.gidMappings[i].Size, gid.Size)
+				}
+			}
+		})
+	}
+}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cri-o/cri-o/internal/config/device"
 	"github.com/cri-o/cri-o/internal/config/node"
 	ctrfactory "github.com/cri-o/cri-o/internal/factory/container"
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
@@ -374,8 +375,8 @@ func (s *Server) addOCIBindMounts(ctx context.Context, ctr ctrfactory.Container,
 			Image:             m.Image,
 		})
 
-		uidMappings := getOCIMappings(m.UidMappings)
-		gidMappings := getOCIMappings(m.GidMappings)
+		uidMappings := lib.ConvertCRIToOCIMappings(m.GetUidMappings())
+		gidMappings := lib.ConvertCRIToOCIMappings(m.GetGidMappings())
 
 		if (uidMappings != nil || gidMappings != nil) && !idMapSupport {
 			return nil, nil, nil, errors.New("idmap mounts specified but OCI runtime does not support them. Perhaps the OCI runtime is too old")
@@ -469,8 +470,8 @@ func (s *Server) mountArtifact(ctx context.Context, specgen *generate.Generator,
 			Source:      path.SourcePath,
 			Destination: dest,
 			Options:     options,
-			UIDMappings: getOCIMappings(m.UidMappings),
-			GIDMappings: getOCIMappings(m.GidMappings),
+			UIDMappings: lib.ConvertCRIToOCIMappings(m.GetUidMappings()),
+			GIDMappings: lib.ConvertCRIToOCIMappings(m.GetGidMappings()),
 		})
 	}
 
@@ -573,8 +574,8 @@ func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, im
 		Options: []string{
 			"lowerdir=" + mountPoint + ":" + imageVolumesPath,
 		},
-		UIDMappings: getOCIMappings(m.UidMappings),
-		GIDMappings: getOCIMappings(m.GidMappings),
+		UIDMappings: lib.ConvertCRIToOCIMappings(m.GetUidMappings()),
+		GIDMappings: lib.ConvertCRIToOCIMappings(m.GetGidMappings()),
 	})
 	log.Debugf(ctx, "Added overlay mount from %s to %s", mountPoint, imageVolumesPath)
 
@@ -623,23 +624,6 @@ func (s *Server) ensureImageVolumesPath(ctx context.Context, mounts []*types.Mou
 	}
 
 	return imageVolumesPath, nil
-}
-
-func getOCIMappings(m []*types.IDMapping) []rspec.LinuxIDMapping {
-	if len(m) == 0 {
-		return nil
-	}
-
-	ids := make([]rspec.LinuxIDMapping, 0, len(m))
-	for _, m := range m {
-		ids = append(ids, rspec.LinuxIDMapping{
-			ContainerID: m.ContainerId,
-			HostID:      m.HostId,
-			Size:        m.Length,
-		})
-	}
-
-	return ids
 }
 
 // mountExists returns true if dest exists in the list of mounts.

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
 	ctrfactory "github.com/cri-o/cri-o/internal/factory/container"
+	"github.com/cri-o/cri-o/internal/lib"
 	"github.com/cri-o/cri-o/internal/lib/constants"
 	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/linklogs"
@@ -358,25 +359,10 @@ func (s *Server) getSandboxIDMappings(ctx context.Context, sb *libsandbox.Sandbo
 		return nil, err
 	}
 
-	mappings := convertToStorageIDMappings(uids, gids)
+	mappings := lib.ConvertOCIToStorageIDMappings(uids, gids)
 	ic.SetIDMappings(mappings)
 
 	return mappings, nil
-}
-
-func convertToStorageIDMappings(uidMappings, gidMappings []spec.LinuxIDMapping) *idtools.IDMappings {
-	uids := make([]idtools.IDMap, len(uidMappings))
-	gids := make([]idtools.IDMap, len(gidMappings))
-
-	for i, v := range uidMappings {
-		uids[i] = idtools.IDMap{ContainerID: int(v.ContainerID), HostID: int(v.HostID), Size: int(v.Size)}
-	}
-
-	for i, v := range gidMappings {
-		gids[i] = idtools.IDMap{ContainerID: int(v.ContainerID), HostID: int(v.HostID), Size: int(v.Size)}
-	}
-
-	return idtools.NewIDMappingsFromMaps(uids, gids)
 }
 
 func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequest) (resp *types.RunPodSandboxResponse, retErr error) {

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -3,9 +3,6 @@
 load helpers
 
 function setup() {
-	if [ -z "$CONTAINER_UID_MAPPINGS" ]; then
-		skip "userns testing not enabled"
-	fi
 	setup_test
 	start_crio
 }
@@ -14,16 +11,87 @@ function teardown() {
 	cleanup_test
 }
 
-@test "ctr_userns run container" {
-	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
-	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json)
+function create_userns_sandbox_config() {
+	jq '.linux.security_context.namespace_options.userns_options = {
+		"mode": 0,
+		"uids": [{"container_id": 0, "host_id": 100000, "length": 100000}],
+		"gids": [{"container_id": 0, "host_id": 200000, "length": 100000}]
+	}' "$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox_userns.json
+}
+
+function run_userns_container_test() {
+	create_userns_sandbox_config
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
 	crictl start "$ctr_id"
 	state=$(crictl inspect "$ctr_id")
 	pid=$(echo "$state" | jq .info.pid)
 	grep 100000 /proc/"$pid"/uid_map
 	grep 200000 /proc/"$pid"/gid_map
+}
 
-	out=$(echo -e "GET /info HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:"$CRIO_SOCKET")
-	[[ "$out" == *"100000"* ]]
-	[[ "$out" == *"200000"* ]]
+@test "ctr_userns run container" {
+	run_userns_container_test
+}
+
+@test "ctr_userns run container with drop_infra_ctr disabled" {
+	CONTAINER_DROP_INFRA_CTR=false restart_crio
+	run_userns_container_test
+}
+
+function run_userns_restart_test() {
+	create_userns_sandbox_config
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
+	restart_crio
+	crictl inspectp "$pod_id" | jq -e '.status.state == "SANDBOX_READY"'
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
+	crictl start "$ctr_id"
+	state=$(crictl inspect "$ctr_id")
+	pid=$(echo "$state" | jq .info.pid)
+	grep 100000 /proc/"$pid"/uid_map
+	grep 200000 /proc/"$pid"/gid_map
+}
+
+# This test follows a similar pattern to the one above but adds
+# an extra step of crio restart.
+@test "ctr_userns mappings persist after crio restart" {
+	run_userns_restart_test
+}
+
+@test "ctr_userns mappings persist after crio restart with drop_infra_ctr disabled" {
+	CONTAINER_DROP_INFRA_CTR=false restart_crio
+	run_userns_restart_test
+}
+
+function run_userns_kill_restart_test() {
+	create_userns_sandbox_config
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox_userns.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
+	crictl start "$ctr_id"
+
+	restart_crio
+
+	crictl stop "$ctr_id"
+	runtime delete -f "$ctr_id"
+	crictl rm "$ctr_id"
+
+	new_ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox_userns.json)
+	crictl start "$new_ctr_id"
+
+	state=$(crictl inspect "$new_ctr_id")
+	pid=$(echo "$state" | jq .info.pid)
+	grep 100000 /proc/"$pid"/uid_map
+	grep 200000 /proc/"$pid"/gid_map
+}
+
+@test "ctr_userns mappings persist after container kill and restart" {
+	run_userns_kill_restart_test
+}
+
+@test "ctr_userns mappings persist after container kill and restart with drop_infra_ctr disabled" {
+	CONTAINER_DROP_INFRA_CTR=false restart_crio
+	run_userns_kill_restart_test
 }


### PR DESCRIPTION
/kind bug

#### What type of PR is this?

This is a manual cherry-pick of #10014 to `release-1.33` (OCP 4.20).

#### What this PR does / why we need it:

When using user namespaces with ID-mapped mounts, containers fail with "permission denied" errors after:
1. CRI-O is restarted
2. The real container process is killed (kill 1)

This happens because the namespace mappings are not loaded on restart for running containers.

The fix loads UID and GID mappings from the sandbox's saved `config.json` during CRI-O startup, ensuring containers retain proper user namespace configuration across restarts.

#### Which issue(s) this PR fixes:

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-76990

#### Special notes for your reviewer:

- Cherry-pick of #10014 (merged to `main`)
- See #10075 (release-1.35 / OCP 4.22) and #10231 (release-1.34 / OCP 4.21) for the equivalent cherry-picks.

#### Does this PR introduce a user-facing change?

```release-note
User namespace UID/GID mappings are now correctly restored after CRI-O restart, fixing "permission denied" errors for containers using user namespaces with ID-mapped mounts.
```
