### PR TITLE
OCPBUGS-108950: Deduplicate concurrent image volume MountImage calls

### DIFF
--- a/internal/lib/container_server.go
+++ b/internal/lib/container_server.go
@@ -62,8 +62,21 @@ type ContainerServer struct {
 	state     *containerServerState
 	config    *libconfig.Config
 
+	// mountOperationsInProgress deduplicates concurrent MountImage calls for the
+	// same image ID, avoiding lock contention in containers/storage when many
+	// pods mount the same image volume simultaneously.
+	mountOperationsInProgress map[string]*mountOperation
+	mountOperationsLock       sync.Mutex
+
 	// monitorCh is used to signal the monitor goroutine to exit.
 	monitorCh chan struct{}
+}
+
+// mountOperation deduplicates concurrent MountImage calls for the same image.
+type mountOperation struct {
+	wg         sync.WaitGroup
+	mountPoint string
+	err        error
 }
 
 // Runtime returns the oci runtime for the ContainerServer.
@@ -74,6 +87,53 @@ func (c *ContainerServer) Runtime() *oci.Runtime {
 // Store returns the Store for the ContainerServer.
 func (c *ContainerServer) Store() cstorage.Store {
 	return c.store
+}
+
+// MountImageByID deduplicates concurrent MountImage calls for the same image
+// ID. Concurrent callers mounting the same image coalesce into a single
+// MountImage call through the containers/storage lock chain, avoiding the
+// serialization bottleneck when many pods mount the same image volume.
+//
+// This means the containers/storage mount ref count will be 1 instead of N for
+// N concurrent callers. All existing UnmountImage call sites use force=true, so
+// the lower ref count has no effect on cleanup.
+func (c *ContainerServer) MountImageByID(ctx context.Context, imageID string) (string, error) {
+	mountOp, inProgress := func() (*mountOperation, bool) {
+		c.mountOperationsLock.Lock()
+		defer c.mountOperationsLock.Unlock()
+
+		op, exists := c.mountOperationsInProgress[imageID]
+		if !exists {
+			op = &mountOperation{}
+			c.mountOperationsInProgress[imageID] = op
+			op.wg.Add(1)
+		}
+
+		return op, exists
+	}()
+
+	if !inProgress {
+		mountOp.err = errors.New("mountImage was aborted by a Go panic")
+
+		defer func() {
+			c.mountOperationsLock.Lock()
+			delete(c.mountOperationsInProgress, imageID)
+			mountOp.wg.Done()
+			c.mountOperationsLock.Unlock()
+		}()
+
+		options := []string{"ro", "noexec", "nosuid", "nodev"}
+		mountOp.mountPoint, mountOp.err = c.store.MountImage(imageID, options, "")
+
+		if mountOp.err == nil {
+			log.Infof(ctx, "Image mounted to: %s", mountOp.mountPoint)
+		}
+	} else {
+		log.Debugf(ctx, "Waiting for in-progress mount of image %s", imageID)
+		mountOp.wg.Wait()
+	}
+
+	return mountOp.mountPoint, mountOp.err
 }
 
 // StorageImageServer returns the ImageServer for the ContainerServer.
@@ -179,8 +239,9 @@ func New(ctx context.Context, configIface libconfig.Iface) (*ContainerServer, er
 			sandboxes:       memorystore.New[*sandbox.Sandbox](),
 			processLevels:   make(map[string]int),
 		},
-		config:    config,
-		monitorCh: make(chan struct{}),
+		config:                    config,
+		mountOperationsInProgress: make(map[string]*mountOperation),
+		monitorCh:                 make(chan struct{}),
 	}
 	c.StatsServer = statsserver.New(ctx, c)
 

--- a/internal/lib/container_server_test_inject.go
+++ b/internal/lib/container_server_test_inject.go
@@ -6,8 +6,18 @@
 package lib
 
 import (
+	cstorage "go.podman.io/storage"
+
 	"github.com/cri-o/cri-o/internal/storage"
 )
+
+// NewContainerServerForTest creates a minimal ContainerServer for unit tests.
+func NewContainerServerForTest(store cstorage.Store) *ContainerServer {
+	return &ContainerServer{
+		store:                     store,
+		mountOperationsInProgress: make(map[string]*mountOperation),
+	}
+}
 
 // SetStorageRuntimeServer sets the runtime server for the ContainerServer.
 func (c *ContainerServer) SetStorageRuntimeServer(server storage.RuntimeServer) {

--- a/internal/lib/mount_image_test.go
+++ b/internal/lib/mount_image_test.go
@@ -1,0 +1,173 @@
+package lib
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	containerstoragemock "github.com/cri-o/cri-o/test/mocks/containerstorage"
+)
+
+// waitForMountInProgress polls the dedup map until an entry for imageID appears,
+// then waits briefly for remaining goroutines to reach wg.Wait().
+func waitForMountInProgress(t *testing.T, sut *ContainerServer, imageID string) {
+	t.Helper()
+
+	deadline := time.After(5 * time.Second)
+
+	for {
+		sut.mountOperationsLock.Lock()
+		_, exists := sut.mountOperationsInProgress[imageID]
+		sut.mountOperationsLock.Unlock()
+
+		if exists {
+			time.Sleep(10 * time.Millisecond)
+
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for mount operation to start")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func TestMountImageByIDDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	storeMock := containerstoragemock.NewMockStore(ctrl)
+
+	sut := NewContainerServerForTest(storeMock)
+
+	const (
+		imageID    = "abc123"
+		mountPoint = "/var/lib/containers/storage/overlay/abc123/merged"
+		concurrent = 50
+	)
+
+	var callCount atomic.Int32
+
+	unblock := make(chan struct{})
+
+	storeMock.EXPECT().
+		MountImage(imageID, []string{"ro", "noexec", "nosuid", "nodev"}, "").
+		DoAndReturn(func(string, []string, string) (string, error) {
+			<-unblock
+			callCount.Add(1)
+
+			return mountPoint, nil
+		}).
+		Times(1)
+
+	var wg sync.WaitGroup
+
+	for range concurrent {
+		wg.Go(func() {
+			mp, err := sut.MountImageByID(t.Context(), imageID)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if mp != mountPoint {
+				t.Errorf("expected mount point %q, got %q", mountPoint, mp)
+			}
+		})
+	}
+
+	waitForMountInProgress(t, sut, imageID)
+
+	close(unblock)
+	wg.Wait()
+
+	if c := callCount.Load(); c != 1 {
+		t.Errorf("expected exactly 1 MountImage call, got %d", c)
+	}
+}
+
+func TestMountImageByIDDistinctImages(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	storeMock := containerstoragemock.NewMockStore(ctrl)
+
+	sut := NewContainerServerForTest(storeMock)
+
+	storeMock.EXPECT().
+		MountImage(gomock.Any(), []string{"ro", "noexec", "nosuid", "nodev"}, "").
+		DoAndReturn(func(id string, _ []string, _ string) (string, error) {
+			return "/mnt/" + id, nil
+		}).
+		Times(2)
+
+	mp1, err := sut.MountImageByID(t.Context(), "image-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mp1 != "/mnt/image-a" {
+		t.Errorf("expected /mnt/image-a, got %s", mp1)
+	}
+
+	mp2, err := sut.MountImageByID(t.Context(), "image-b")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mp2 != "/mnt/image-b" {
+		t.Errorf("expected /mnt/image-b, got %s", mp2)
+	}
+}
+
+func TestMountImageByIDErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	storeMock := containerstoragemock.NewMockStore(ctrl)
+
+	sut := NewContainerServerForTest(storeMock)
+
+	const (
+		imageID    = "abc123"
+		concurrent = 20
+	)
+
+	mountErr := errors.New("storage locked")
+	unblock := make(chan struct{})
+
+	storeMock.EXPECT().
+		MountImage(imageID, []string{"ro", "noexec", "nosuid", "nodev"}, "").
+		DoAndReturn(func(string, []string, string) (string, error) {
+			<-unblock
+
+			return "", mountErr
+		}).
+		Times(1)
+
+	var wg sync.WaitGroup
+
+	for range concurrent {
+		wg.Go(func() {
+			mp, err := sut.MountImageByID(t.Context(), imageID)
+			if !errors.Is(err, mountErr) {
+				t.Errorf("expected %v, got %v", mountErr, err)
+			}
+
+			if mp != "" {
+				t.Errorf("expected empty mount point on error, got %q", mp)
+			}
+		})
+	}
+
+	waitForMountInProgress(t, sut, imageID)
+
+	close(unblock)
+	wg.Wait()
+}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -535,14 +535,10 @@ func (s *Server) mountImage(ctx context.Context, specgen *generate.Generator, im
 
 	log.Debugf(ctx, "Image ID to mount: %v", imageID)
 
-	options := []string{"ro", "noexec", "nosuid", "nodev"}
-
-	mountPoint, err := s.ContainerServer.Store().MountImage(imageID, options, "")
+	mountPoint, err := s.MountImageByID(ctx, imageID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("mount storage: %w", err)
 	}
-
-	log.Infof(ctx, "Image mounted to: %s", mountPoint)
 
 	var safeMount *safeMountInfo
 	if m.GetImageSubPath() != "" {


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

`containers/storage`'s `MountImage` acquires an exclusive graph lock for every call, even when the image layer is already mounted. When many pods mount the same image volume concurrently (e.g. 100 pods on the same node), all `MountImage` calls serialize on that lock, causing ~80% slower pod startup compared to emptyDir alternatives.

This adds singleflight-style deduplication for `MountImage`, matching the existing pull deduplication pattern (`pullOperationsInProgress`). Concurrent requests to mount the same image ID coalesce into a single `MountImage` call through the `containers/storage` lock chain; subsequent callers wait and reuse the mount point.

Since all existing `UnmountImage` call sites use `force=true`, the lower storage ref count (1 instead of N) has no effect on cleanup.

#### Which issue(s) this PR fixes:

https://redhat.atlassian.net/browse/OCPBUGS-108950

#### Special notes for your reviewer:

Reported by the KubeVirt team: ~100 concurrent pods on the same node, each with an image volume mounting the same OCI image, seeing ~80% slower pod startup compared to emptyDir with init containers.

KubeVirt workaround PR: https://github.com/kubevirt/kubevirt/pull/18800

#### Does this PR introduce a user-facing change?

```release-note
Deduplicate concurrent image volume MountImage calls to avoid containers/storage lock serialization when many pods mount the same image volume simultaneously.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved image mounting so simultaneous requests for the same image share a single mount operation.
  - Ensured all concurrent requests receive the same mount result or error.
  - Preserved independent mounting for different images.

- **Bug Fixes**
  - Mounting errors are now consistently propagated to all waiting requests.

- **Tests**
  - Added coverage for concurrent requests, separate images, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->