### PR TITLE
hack: add containerized build and unit test environment

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -10,6 +10,8 @@ dependencies:
         match: go
       - path: hack/build-rpms.sh
         match: go
+      - path: hack/Containerfile.dev
+        match: GOVERSION
 
   # For a new minor (1.x.0) release, move the "development version"
   # below to the "supported versions" section (by omitting the patch version).

--- a/hack/Containerfile.dev
+++ b/hack/Containerfile.dev
@@ -1,0 +1,36 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.8
+
+RUN dnf install -y \
+    autoconf \
+    automake \
+    gcc \
+    git \
+    glib2-devel \
+    glibc-static \
+    gpgme-devel \
+    libassuan-devel \
+    libcap-devel \
+    libseccomp-devel \
+    libtool \
+    make \
+    pkgconfig \
+    && dnf clean all
+
+# Install Go. Keep GOVERSION in sync with go.mod, and update the pinned
+# checksums below when bumping it (see https://go.dev/dl/?mode=json&include=all).
+ARG TARGETARCH
+ENV GOVERSION=1.26.4
+RUN case "${TARGETARCH}" in \
+        amd64)   GO_SHA256=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f ;; \
+        arm64)   GO_SHA256=ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768 ;; \
+        ppc64le) GO_SHA256=53f49b8c7eace2d30389327b4a516b13321f90377fdf5929a6b63174609bc22e ;; \
+        s390x)   GO_SHA256=1e12a2318f3dd4c57027c865f6cb51f5d1e36b02d10f3e6316ce7b61a27b3ca1 ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH:-unset}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz" -o /tmp/go.tar.gz && \
+    echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - && \
+    tar -C /usr/local -xzf /tmp/go.tar.gz && \
+    rm -f /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /src

--- a/install.md
+++ b/install.md
@@ -27,6 +27,7 @@ It is assumed you are running a Linux machine.
   - [Build](#build)
     - [Install with Ansible](#install-with-ansible)
     - [Build Tags](#build-tags)
+    - [Container-based build environment](#container-based-build-environment)
   - [Static builds](#static-builds)
   - [Download conmon](#download-conmon)
 - [Setup CNI networking](#setup-cni-networking)
@@ -349,6 +350,30 @@ which uses the following buildtags.
 | ostree                      | build storage using ostree          | ostree     |
 
 <!-- markdownlint-enable MD013 -->
+
+#### Container-based build environment
+
+As an alternative to installing build dependencies on the host, a
+`Containerfile` is provided to create a container image with all
+required build dependencies. This can be used to build CRI-O and run
+unit tests without modifying the host system.
+
+Note that integration tests cannot be run in a container as CRI-O
+requires a full system environment.
+
+Build the container image:
+
+```shell
+podman build -f hack/Containerfile.dev -t crio-dev .
+```
+
+Then use it to build and test:
+
+```shell
+podman run --rm -v .:/src:Z crio-dev make all
+podman run --rm -v .:/src:Z crio-dev make lint
+podman run --rm -v .:/src:Z crio-dev make testunit
+```
 
 ### Static builds
 

--- a/internal/factory/container/container_test.go
+++ b/internal/factory/container/container_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cri-o/cri-o/internal/annotations"
 	"github.com/cri-o/cri-o/internal/config/capabilities"
+	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/hostport"
 	"github.com/cri-o/cri-o/internal/lib/constants"
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
@@ -814,6 +815,10 @@ var _ = t.Describe("Container", func() {
 			Expect(sut.SpecSetLinuxContainerResources(resources, minMemory)).NotTo(Succeed())
 		})
 		It("Set memory limit to both swap and RAM when only MemoryLimit is set", func() {
+			if !node.CgroupHasMemorySwap() {
+				Skip("requires cgroup memory swap support")
+			}
+
 			// Given
 			resources := &types.LinuxContainerResources{
 				MemoryLimitInBytes: 4096,
@@ -827,6 +832,10 @@ var _ = t.Describe("Container", func() {
 			Expect(*sut.Spec().Config.Linux.Resources.Memory.Swap).To(Equal(resources.GetMemoryLimitInBytes()))
 		})
 		It("Set memory limits appropriately when Limit and SwapLimit are set", func() {
+			if !node.CgroupHasMemorySwap() {
+				Skip("requires cgroup memory swap support")
+			}
+
 			// Given
 			resources := &types.LinuxContainerResources{
 				MemoryLimitInBytes:     4096,

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runtime-tools/generate"
+	"go.podman.io/storage/pkg/mount"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/factory/container"
@@ -178,10 +179,11 @@ func TestAddOCIBindsRROMountsError(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		description string
-		rroSupport  bool
-		given       *types.Mount
-		want        string
+		description         string
+		rroSupport          bool
+		given               *types.Mount
+		want                string
+		requiresSharedMount bool
 	}{
 		{
 			"should fail to add an RRO mount without RRO mounts support",
@@ -194,6 +196,7 @@ func TestAddOCIBindsRROMountsError(t *testing.T) {
 				Propagation:       0,
 			},
 			`recursive read-only mount support is not available for hostPath "/mnt"`,
+			false,
 		},
 		{
 			"should fail to add an RRO mount without readonly option",
@@ -206,6 +209,7 @@ func TestAddOCIBindsRROMountsError(t *testing.T) {
 				Propagation:       0,
 			},
 			`recursive read-only mount conflicts with read-write mount for hostPath "/mnt"`,
+			false,
 		},
 		{
 			"should fail to add an RRO mount without private propagation",
@@ -218,6 +222,7 @@ func TestAddOCIBindsRROMountsError(t *testing.T) {
 				Propagation:       2,
 			},
 			`recursive read-only mount requires private propagation for hostPath "/mnt", got: PROPAGATION_BIDIRECTIONAL`,
+			true,
 		},
 	}
 
@@ -226,6 +231,19 @@ func TestAddOCIBindsRROMountsError(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
+
+			if tc.requiresSharedMount {
+				mountInfos, err := mount.GetMounts()
+				if err != nil {
+					t.Fatalf("Failed to get mount info: %v", err)
+				}
+
+				// Some test environments (e.g. running unit tests inside a container) do not have
+				// shared mounts, so skip in those environments.
+				if err := ensureShared(tc.given.GetHostPath(), mountInfos); err != nil {
+					t.Skipf("skipping: %v", err)
+				}
+			}
 
 			ctr, err := container.New()
 			if err != nil {


### PR DESCRIPTION

#### What type of PR is this?
/kind other

#### What this PR does / why we need it:
Add hack/Containerfile.dev, a UBI9-based image with all build dependencies, so CRI-O can be built and unit tested without installing toolchain and C dependencies on the host. Integration tests still require a full system and are out of scope for the container.

The Go toolchain is installed for the target architecture (via TARGETARCH) and the download is verified against a pinned checksum.

Two unit tests assumed capabilities that are not guaranteed in every environment, so guard them accordingly:

- SpecSetLinuxContainerResources swap tests dereferenced the OCI spec's memory swap field, which is only set when the node has cgroup memory swap support. Skip them when node.CgroupHasMemorySwap() is false to avoid a nil pointer dereference.

- TestAddOCIBindsRROMountsError's bidirectional-propagation case reaches ensureShared() before the assertion under test, which requires the host path to be a shared mount. Skip that case when it is not.

Document the workflow in install.md.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added instructions for setting up a container-based development environment with Podman.
  - Documented how to build the development image and run build, lint, and unit-test checks inside the container.
  - Clarified that integration tests are not supported in containerized development environments.
  - Documented a consistent, verified Go toolchain for container-based development.

- **Tests**
  - Improved test reliability by detecting unavailable host capabilities and skipping incompatible memory, swap, and mount-propagation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->