### PR TITLE
ci: remove pre-installed runc and crun

### DIFF
--- a/contrib/test/ci/vars.yml
+++ b/contrib/test/ci/vars.yml
@@ -191,5 +191,5 @@ kata_skip_annotation_migration_tests:
   - 'test "v1 umask annotation should still work"'
   - 'test "v2 unified-cgroup annotation for specific container with slash separator should work"'
 
-runc_git_version: v1.5.0
-crun_git_version: 1.28
+runc_git_version: v1.5.1
+crun_git_version: 1.29.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -71,7 +71,7 @@ dependencies:
         match: buildah
 
   - name: crun
-    version: 1.28
+    version: 1.29.1
     refPaths:
       - path: scripts/versions
         match: crun
@@ -79,7 +79,7 @@ dependencies:
         match: crun_git_version
 
   - name: runc
-    version: v1.5.0
+    version: v1.5.1
     refPaths:
       - path: scripts/versions
         match: runc

--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -11,6 +11,7 @@ main() {
     set -x
     prepare_system
 
+    remove_runtimes
     install_bats
     install_conmon
     install_conmonrs
@@ -112,7 +113,29 @@ install_cni_plugins() {
     ls -lah "$CNI_DIR"
 }
 
+# remove_runtimes removes all the pre-installed OCI runtimes, so they can't
+# shadow the ones we install. The runner image ships a static podman bundle in
+# /usr/local/bin (which comes first in PATH) containing its own runc and crun
+# -- notably a crun built without systemd support, which breaks all the tests
+# using the systemd cgroup manager -- and docker brings its own /usr/bin/runc.
+remove_runtimes() {
+    sudo rm -f /usr/{local/,}{s,}bin/{runc,crun}
+}
+
+# check_not_installed makes sure $1 is not available in PATH, so that the
+# binary we're about to install is not shadowed by a pre-installed one (those
+# are removed by remove_runtimes).
+check_not_installed() {
+    local path
+    if path=$(command -v "$1"); then
+        echo "ERROR: $1 is already installed at $path, please remove it in remove_runtimes" >&2
+        return 1
+    fi
+}
+
 install_crun() {
+    check_not_installed crun
+
     git clone https://github.com/containers/crun
     pushd crun
     git checkout "${VERSIONS["crun"]}"
@@ -125,6 +148,8 @@ install_crun() {
 }
 
 install_runc() {
+    check_not_installed runc
+
     curl_retry "https://github.com/opencontainers/runc/releases/download/${VERSIONS["runc"]}/runc.$GOARCH" \
         -o /usr/sbin/runc
     echo "${RUNC_CHECKSUMS[$GOARCH]}  /usr/sbin/runc" | sha256sum -c --strict -

--- a/scripts/versions
+++ b/scripts/versions
@@ -3,13 +3,13 @@ declare -A VERSIONS=(
     ["cni-plugins"]=v1.8.0
     ["conmon"]=v2.1.13
     ["cri-tools"]=v1.36.0
-    ["crun"]=1.28
-    ["runc"]=v1.5.0
+    ["crun"]=1.29.1
+    ["runc"]=v1.5.1
     ["bats"]=v1.12.0
     ["buildah"]=v1.38.0
 )
 
 declare -A RUNC_CHECKSUMS=(
-    ["amd64"]="0363e69bebd3a027d1239364ab9b4f4873f6bc4e7a7878e94b4ea59f08551297"
-    ["arm64"]="1f6d8c553add066a6aaf838d3172d4c5ed3c6b065b6f7eed2f4a4aa4af261e59"
+    ["amd64"]="177df879d50c913eb205e898d5c1c05a18f574053c0ce5524c471208eaf06f6f"
+    ["arm64"]="ca70e7dbd6616ca782a59b5d3ac86909123fdaa9fa3f89dcf29051c70eee7ce9"
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

**1. `ci: remove pre-installed runc and crun`**

The GitHub runner image ships a static podman bundle in `/usr/local/bin`
(actions/runner-images#14412), which includes its own runc and crun. As
`/usr/local/bin` comes first in `PATH`, those shadow the runtimes installed by
`scripts/github-actions-setup`: the tests were run with runc 1.4.3 rather than
the pinned version and, worse, with a crun built without systemd support:

```
crun version 1.28
+SELINUX +APPARMOR +CAP +SECCOMP +EBPF +JSON_C
```

The test suite uses the systemd cgroup manager, so every container creation
failed with `container create failed: systemd not supported: Not supported`,
failing all `integration` and `critest` jobs on main and on every open PR.

This removes all the pre-installed runc and crun binaries (in addition to the
bundle, docker brings its own `/usr/bin/runc`), and checks that none is left
before installing ours, so that a future image change fails loudly rather than
silently testing something else.

Same fix as containers/conmon#672.

**2. `ci: bump crun to 1.29.1 and runc to v1.5.1`**

Update the pinned OCI runtimes to their latest releases. The runc checksums are
taken from the published `runc.sha256sum` of the v1.5.1 release.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

`runc` is still installed to `/usr/sbin/runc` (unlike the conmon fix, which
moved it to `/usr/bin`): nothing in the GitHub Actions path hardcodes the
location and `/usr/sbin` is in the runner `PATH`, so this keeps the change
minimal.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime setup by removing preinstalled runtime binaries before installation.
  * Added verification to ensure runtimes are no longer discoverable before proceeding.
  * Helps prevent conflicts caused by previously installed runtime versions.

* **Updates**
  * Updated the included `runc` and `crun` runtimes to newer versions.
  * Refreshed integrity checks for supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->