### PR TITLE
server: fix ContainerEvents unit test flake

### DIFF
--- a/server/container_events.go
+++ b/server/container_events.go
@@ -31,16 +31,18 @@ func (s *Server) GetContainerEvents(_ *types.GetEventsRequest, ces types.Runtime
 		return nil
 	}
 
-	s.containerEventStreamBroadcaster.Do(func() {
-		// note that this function will run indefinitely until ContainerEventsChan is closed
-		go s.broadcastEvents()
-	})
-
 	conn := &containerEventConn{
 		ch:   make(chan struct{}),
 		once: sync.Once{},
 	}
+	// Register before starting the broadcaster so the client that triggers
+	// it does not miss already buffered events.
 	s.containerEventClients.Store(ces, conn)
+
+	s.containerEventStreamBroadcaster.Do(func() {
+		// note that this function will run indefinitely until ContainerEventsChan is closed
+		go s.broadcastEvents()
+	})
 
 	// wait here until we don't want to send events to this client anymore
 	conn.wait()

--- a/server/container_events_test.go
+++ b/server/container_events_test.go
@@ -1,15 +1,24 @@
 package server_test
 
 import (
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containereventservermock "github.com/cri-o/cri-o/test/mocks/containereventserver"
 )
+
+// eventTimeout is how long to wait for the events to be delivered. Everything
+// here is in-memory and takes way less than that, but a CI machine running the
+// race detector under load can be slow, and this is not a benchmark.
+const eventTimeout = 30 * time.Second
 
 var events = []types.ContainerEventResponse{
 	{
@@ -23,17 +32,67 @@ var events = []types.ContainerEventResponse{
 	},
 }
 
+// heartbeat is only used to detect that a client has been registered by the
+// server, so it must not collide with any of the events above.
+var heartbeat = types.ContainerEventResponse{
+	ContainerId: "heartbeat",
+}
+
+// protoMatcher matches a protobuf message using proto.Equal.
+type protoMatcher struct {
+	want *types.ContainerEventResponse
+}
+
+func (m *protoMatcher) Matches(x any) bool {
+	got, ok := x.(*types.ContainerEventResponse)
+
+	return ok && proto.Equal(m.want, got)
+}
+
+func (m *protoMatcher) String() string {
+	return fmt.Sprintf("is equal to %v", m.want)
+}
+
+// sendOf matches a single event sent to a client.
+//
+// gomock.Eq (which is what passing the message itself would use) compares with
+// reflect.DeepEqual, which is not a valid way to compare protobuf messages: it
+// also compares their internal state, which is populated lazily. The server
+// hands the very same message to every client, so as soon as anything looks at
+// it through the protobuf reflection, DeepEqual stops matching for all the
+// remaining clients.
+//
+// The message is cloned because both comparing and printing it populate that
+// internal state as well, which would race with the specs sending their own
+// copy of it.
+func sendOf(want *types.ContainerEventResponse) gomock.Matcher {
+	clone := &types.ContainerEventResponse{}
+	proto.Merge(clone, want)
+
+	return &protoMatcher{want: clone}
+}
+
+// waitFor blocks until wg is done, failing the spec rather than hanging
+// forever if that never happens.
+func waitFor(wg *sync.WaitGroup) {
+	GinkgoHelper()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer GinkgoRecover()
+
+		wg.Wait()
+		close(done)
+	}()
+
+	Eventually(done).WithTimeout(eventTimeout).Should(BeClosed())
+}
+
 var _ = t.Describe("ContainerEvents", func() {
 	BeforeEach(func() {
 		beforeEach()
 		setupSUT()
-
-		// close after all events have been processed,
-		// so we are not waiting for move events to come.
-		go func() {
-			time.Sleep(2 * time.Second)
-			close(sut.ContainerEventsChan)
-		}()
 	})
 
 	AfterEach(afterEach)
@@ -41,56 +100,105 @@ var _ = t.Describe("ContainerEvents", func() {
 	t.Describe("ContainerEvents", func() {
 		It("should send events to single client", func() {
 			cesMock := containereventservermock.NewMockRuntimeService_GetContainerEventsServer[string](mockCtrl)
-			// EXPECT expects the exact object, so we can't use the copy range gives us
+
+			var sent sync.WaitGroup
+
+			sent.Add(len(events))
+
 			for i := range events {
-				cesMock.EXPECT().Send(&events[i]).Return(nil)
+				cesMock.EXPECT().Send(sendOf(&events[i])).
+					Do(func(*types.ContainerEventResponse) { sent.Done() }).
+					Return(nil)
 			}
 
 			//nolint:govet // copylock is not harmful for this implementation
 			for _, event := range events {
 				sut.ContainerEventsChan <- event
 			}
+
+			// GetContainerEvents only returns once the events channel is
+			// closed, so close it as soon as everything has been delivered.
+			// The channel is captured because sut already belongs to the next
+			// spec by the time this goroutine runs.
+			eventsChan := sut.ContainerEventsChan
+
+			go func() {
+				defer GinkgoRecover()
+
+				sent.Wait()
+				close(eventsChan)
+			}()
 
 			err := sut.GetContainerEvents(nil, cesMock)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should send events all events to both clients", func() {
-			client1 := containereventservermock.NewMockRuntimeService_GetContainerEventsServer[string](mockCtrl)
-			client2 := containereventservermock.NewMockRuntimeService_GetContainerEventsServer[string](mockCtrl)
-
-			for i := range events {
-				client1.EXPECT().Send(&events[i]).Return(nil)
-				client2.EXPECT().Send(&events[i]).Return(nil)
+			clients := []*containereventservermock.MockRuntimeService_GetContainerEventsServer[string]{
+				containereventservermock.NewMockRuntimeService_GetContainerEventsServer[string](mockCtrl),
+				containereventservermock.NewMockRuntimeService_GetContainerEventsServer[string](mockCtrl),
 			}
 
-			recv := func(ces types.RuntimeService_GetContainerEventsServer) {
-				defer GinkgoRecover()
+			var (
+				sent       sync.WaitGroup
+				registered = make([]atomic.Bool, len(clients))
+			)
 
-				err := sut.GetContainerEvents(nil, ces)
-				Expect(err).ToNot(HaveOccurred())
+			sent.Add(len(clients) * len(events))
+
+			for n, client := range clients {
+				client.EXPECT().Send(sendOf(&heartbeat)).
+					Do(func(*types.ContainerEventResponse) { registered[n].Store(true) }).
+					Return(nil).AnyTimes()
+
+				for i := range events {
+					client.EXPECT().Send(sendOf(&events[i])).
+						Do(func(*types.ContainerEventResponse) { sent.Done() }).
+						Return(nil)
+				}
 			}
 
-			var wg sync.WaitGroup
-			wg.Add(2)
+			var received sync.WaitGroup
 
-			go func() { defer wg.Done(); recv(client1) }()
-			go func() { defer wg.Done(); recv(client2) }()
+			received.Add(len(clients))
 
-			// wait so that both goroutines are ready
-			// when we send the events
-			time.Sleep(1 * time.Second)
+			for _, client := range clients {
+				go func() {
+					defer GinkgoRecover()
+					defer received.Done()
+
+					err := sut.GetContainerEvents(nil, client)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+			}
+
+			// The clients register asynchronously, so keep sending heartbeats
+			// until every one of them received one. Otherwise an event could
+			// be sent while a client is not registered yet, and reach only
+			// some of them.
+			Eventually(func() bool {
+				sut.ContainerEventsChan <- heartbeat
+
+				for n := range registered {
+					if !registered[n].Load() {
+						return false
+					}
+				}
+
+				return true
+			}).WithTimeout(eventTimeout).Should(BeTrue())
 
 			//nolint:govet // copylock is not harmful for this implementation
 			for _, event := range events {
 				sut.ContainerEventsChan <- event
 			}
 
-			// wait for both goroutines to finish processing all events
-			// before AfterEach runs; ContainerEventsChan is buffered so sends
-			// above are non-blocking, and without this the mock Finish() check
-			// races against the broadcaster goroutine.
-			wg.Wait()
+			// Everything has to be delivered before the spec ends, otherwise
+			// the mock controller verification races the in-flight sends.
+			waitFor(&sent)
+
+			close(sut.ContainerEventsChan)
+			waitFor(&received)
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The `ContainerEvents` specs fail intermittently (seen on #10242, and reproducible
locally) with a panic raised from inside `broadcastEvents`. As that is production
code it has no `GinkgoRecover`, so a single bad send takes down the whole unit
test suite rather than failing one spec:

```
Unexpected call to MockRuntimeService_GetContainerEventsServer.Send()
server/container_events.go:78
```

There are three separate problems behind it.

**1. Protobuf messages compared with `reflect.DeepEqual`.** The expectations
passed the message itself, so gomock matched with `gomock.Eq`, i.e.
`reflect.DeepEqual`. That is not a valid way to compare protobuf messages: it
also compares their internal state, which is populated lazily. The server hands
the *very same* message to every client, so as soon as anything looks at it
through the protobuf reflection (gomock does, when formatting a failure),
`DeepEqual` stops matching for all the remaining clients. Instrumenting the
delivery shows it plainly — `c1` matches, `c2` matches nothing:

```
SEND c1 -> "2" deepEqualToEvents=[false true  false]
SEND c2 -> "2" deepEqualToEvents=[false false false]
```

Match with `proto.Equal` instead, against a private copy of the expected message
so that comparing it does not race with the specs sending their own copy.

**2. A `BeforeEach` goroutine closing the next spec's channel.** It closed
`sut.ContainerEventsChan` two seconds later, reading the package level `sut` at
that point rather than when it was spawned. By then `sut` usually belonged to a
later spec, so a spec could have its channel closed by its predecessor while it
was still sending to it. `-race` catches it directly — `container_events_test.go:34`
is the `close()`, `:50` is a *later* spec's send:

```
WARNING: DATA RACE
Write at 0x00c000447430 by goroutine 75:
  runtime.closechan()
  server_test.init.func12.1.1()  container_events_test.go:34
Previous read at 0x00c000447430 by goroutine 76:
  runtime.chansend()
  server_test.init.func12.2.1()  container_events_test.go:50
```

The specs now drive the channel themselves, closing it once everything has been
delivered.

**3. The spec ending with sends still in flight.** The two client spec returned
as soon as it had queued the events, so `mockCtrl.Finish()` in `AfterEach` raced
the in-flight sends. It now waits for the events to be delivered and for both
`GetContainerEvents` calls to return.

Additionally, `GetContainerEvents` now registers the client *before* starting the
broadcaster. The other way around, the broadcaster could deliver already buffered
events while the very client that started it was not in the map yet.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Reproducer for the race, which fails on `main` within ~15 iterations and passes
30/30 with this change:

```
ginkgo run --race --repeat=29 --focus=ContainerEvents \
    --tags "test $BUILDTAGS" --mod=vendor ./server
```

The specs no longer sleep, which takes them from about three seconds down to
fifty milliseconds. Full `./server` suite (178 specs) passes, `make lint` is
clean.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container event delivery reliability by ensuring connected clients are registered before events are broadcast.
  * Prevented early buffered events from being missed by clients.

* **Tests**
  * Strengthened container event coverage with synchronization and lifecycle checks.
  * Added validation that clients are ready before test events are sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->