### PR TITLE
test: add serial-tagged placeholder to prevent empty suite error

### DIFF
--- a/test/critest.bats
+++ b/test/critest.bats
@@ -14,6 +14,15 @@ function teardown() {
 	cleanup_test
 }
 
+# Dummy test to ensure --filter-tags 'crio:serial' never produces an empty
+# test suite, which would cause bats to error out. This is needed because
+# critest.bats is the only test file run in conmon CI (via TESTS=critest.bats)
+# and the main test below has no tags.
+# bats test_tags=crio:serial
+@test "placeholder for serial tag filtering" {
+	true
+}
+
 @test "run the critest suite" {
 	WEBSOCKET_ARGS=()
 	if [[ $RUNTIME_TYPE == pod ]]; then


### PR DESCRIPTION
When conmon CI runs with `TESTS=critest.bats`, the serial pass
(`--filter-tags 'crio:serial'`) finds zero matching tests because
`critest.bats` has no tagged tests. With bats >= v1.14.0 this causes
a hard error on empty test suites.

Instead of bumping bats and adding `--allow-empty-suite` (which breaks
backward compatibility with older bats versions), add a minimal
serial-tagged placeholder test so the filtered pass always finds at
least one test.

This approach was suggested by @martin-schulze-vireso (bats-core maintainer)
in the [review discussion](https://github.com/cri-o/cri-o/pull/10244#issuecomment-3360710370).

Ref: https://github.com/containers/conmon/pull/672
Ref: https://github.com/bats-core/bats-core/issues/1239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a tagged placeholder test to ensure the serial test suite is detected when filtered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->