### PR TITLE
Make docs generation hermetic by ignoring host storage config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -574,8 +574,8 @@ docs: $(MANPAGES) ## Build the man pages.
 
 .PHONY: docs-generation
 docs-generation: ## Generate the documentation.
-	bin/crio -d "" --config="" md  > docs/crio.8.md
-	bin/crio -d "" --config="" man > docs/crio.8
+	CONTAINERS_STORAGE_CONF=/dev/null bin/crio -d "" --config="" md  > docs/crio.8.md
+	CONTAINERS_STORAGE_CONF=/dev/null bin/crio -d "" --config="" man > docs/crio.8
 
 .PHONY: prettier
 prettier: ## Prettify supported files.


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
The `docs-generation` Makefile target runs `bin/crio md` and `bin/crio man` to produce documentation. Without a fixed storage config, the output picks up host-specific defaults (storage driver, root/runroot paths, storage-opt) from `/etc/containers/storage.conf`, causing `validate-docs` CI failures when runner environments change.

Setting `CONTAINERS_STORAGE_CONF=/dev/null` ensures the generated docs always reflect built-in defaults regardless of the host configuration.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation generation reliability by ensuring consistent container storage configuration when producing Markdown and man-page documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->