### PR TITLE
ci: install crun to /usr/local/bin to override runner image

### DIFF
--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -118,7 +118,7 @@ install_crun() {
     git checkout "${VERSIONS["crun"]}"
     ./autogen.sh
     ./configure
-    sudo make -j "$(nproc)" install prefix=/usr
+    sudo make -j "$(nproc)" install prefix=/usr/local
     popd
     sudo rm -rf crun
     crun --version


### PR DESCRIPTION
/kind ci

#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

The updated GitHub Actions runner image ships a pre-installed crun at
`/usr/local/bin` without systemd support. Since `/usr/local/bin` precedes
`/usr/bin` in `PATH`, the test framework (`command -v crun`) picks up the
runner's crun instead of the one CI builds from source (with `+SYSTEMD`).

This causes 253 test failures in the `userns / crun` integration job with
`systemd not supported: Not supported`.

The fix installs crun to `/usr/local/bin` (via `prefix=/usr/local`) so the
CI-built binary takes precedence.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```