### PR TITLE
Pin Go version in build-rpms.sh to match go.mod

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,6 +8,8 @@ dependencies:
         match: buildGo126Module
       - path: go.mod
         match: go
+      - path: hack/build-rpms.sh
+        match: go
 
   # For a new minor (1.x.0) release, move the "development version"
   # below to the "supported versions" section (by omitting the patch version).

--- a/hack/build-rpms.sh
+++ b/hack/build-rpms.sh
@@ -40,8 +40,8 @@ fi
 dnf -y install 'dnf-command(builddep)'
 dnf builddep -y "${OS_RPM_SPECFILE}" || true
 
-# Ensure to use latest golang
-GO_VERSION=$(curl -sSfL "https://go.dev/VERSION?m=text" | head -n1)
+# Keep in sync with go.mod via dependencies.yaml
+GO_VERSION=go1.26.4
 curl -sSfL -o- "https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz" | tar xfz - -C /usr/local
 export PATH=/usr/local/go/bin:$PATH
 


### PR DESCRIPTION
Go 1.27.0 broke RPM builds because vendored gRPC references http2.TrailerPrefix, which golang.org/x/net/http2 no longer exports under Go 1.27. Pin to go1.26.4 and track via dependencies.yaml.

Assisted-by: Claude Code <https://claude.com/claude-code>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind ci
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * RPM builds now use a consistent, pinned Go version, improving build reproducibility.
  * Go version checks are synchronized with the project’s declared dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->