### PR TITLE
test: set BATS_TEST_TIMEOUT to prevent CI hangs

### DIFF
--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -47,6 +47,11 @@ export JOBS=${JOBS:-$(nproc --all)}
 # The maximum number of additional attempts that will be made on a failed test before it is finally considered failed.
 # https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-variables
 export BATS_TEST_RETRIES=1
+# The maximum time (in seconds) a single test may run before it's aborted by bats.
+# Prevents the whole CI job from blocking when an individual test hangs.
+# Tests that intentionally need more time can override this value per-file or per-test.
+# https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-variables
+export BATS_TEST_TIMEOUT=${BATS_TEST_TIMEOUT:-600}
 
 bats --version
 


### PR DESCRIPTION
## What this PR does

Integration tests can hang indefinitely when a single test gets stuck, blocking the entire CI job until the platform kills it (observed in the `ci-fedora-kata` Prow job for PR #10054).

`test/test_runner.sh` currently sets `BATS_TEST_RETRIES=1` but does not set `BATS_TEST_TIMEOUT`, so a hung test blocks the whole job.

This PR adds a default per-test timeout of 600 seconds (10 minutes):

```bash
export BATS_TEST_TIMEOUT=${BATS_TEST_TIMEOUT:-600}
```

A hung test is then aborted individually and easy to identify, rather than waiting for the whole job to time out.

### Notes
- The value is overridable via the `BATS_TEST_TIMEOUT` environment variable, so tests that intentionally need more time (or CI environments with slower runners) can bump it.
- 600s comfortably exceeds the longest legitimate sleep in the suite (`wait_clean` sleeps 150s in `test/timeout.bats`).
- BATS_TEST_TIMEOUT is per-test, not per-file, so tests using `wait_clean` followed by other steps still complete well within the limit.

Closes #10079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a default 10-minute timeout for individual test cases.
  * Test timeout can be customized through the environment when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->