### PR TITLE
[release-1.36]: ci: remove pre-installed runc and crun

### DIFF
--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -11,6 +11,7 @@ main() {
     set -x
     prepare_system
 
+    remove_runtimes
     install_bats
     install_conmon
     install_conmonrs
@@ -113,7 +114,29 @@ install_cni_plugins() {
     ls -lah "$CNI_DIR"
 }
 
+# remove_runtimes removes all the pre-installed OCI runtimes, so they can't
+# shadow the ones we install. The runner image ships a static podman bundle in
+# /usr/local/bin (which comes first in PATH) containing its own runc and crun
+# -- notably a crun built without systemd support, which breaks all the tests
+# using the systemd cgroup manager -- and docker brings its own /usr/bin/runc.
+remove_runtimes() {
+    sudo rm -f /usr/{local/,}{s,}bin/{runc,crun}
+}
+
+# check_not_installed makes sure $1 is not available in PATH, so that the
+# binary we're about to install is not shadowed by a pre-installed one (those
+# are removed by remove_runtimes).
+check_not_installed() {
+    local path
+    if path=$(command -v "$1"); then
+        echo "ERROR: $1 is already installed at $path, please remove it in remove_runtimes" >&2
+        return 1
+    fi
+}
+
 install_crun() {
+    check_not_installed crun
+
     git clone https://github.com/containers/crun
     pushd crun
     ./autogen.sh
@@ -162,6 +185,8 @@ install_libpathrs() {
 }
 
 install_runc() {
+    check_not_installed runc
+
     curl_retry "https://github.com/opencontainers/runc/releases/download/${VERSIONS["runc"]}/runc.$GOARCH" \
         -o /usr/sbin/runc
     echo "${RUNC_CHECKSUMS[$GOARCH]}  /usr/sbin/runc" | sha256sum -c --strict -


### PR DESCRIPTION
The GitHub runner image ships a static podman bundle in /usr/local/bin (actions/runner-images#14412), which includes its own runc and crun. As /usr/local/bin comes first in PATH, those shadow the runtimes installed by this script: the tests were run with runc 1.4.3 rather than the pinned v1.5.0, and, worse, with a crun built without systemd support:

	crun version 1.28
	+SELINUX +APPARMOR +CAP +SECCOMP +EBPF +JSON_C

The test suite uses the systemd cgroup manager, so every container creation failed with "systemd not supported: Not supported", failing all integration and critest jobs.

Remove all the pre-installed runc and crun binaries (in addition to the bundle, docker brings its own /usr/bin/runc), and check that none is left before installing ours, so that a future image change fails loudly rather than silently testing something else.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
