### PR TITLE
OCPBUGS-112620: Restore container_init_t for systemd containers

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -693,6 +693,17 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 		}
 	}()
 
+	containerImageConfig := containerInfo.Config
+	if containerImageConfig == nil {
+		return nil, fmt.Errorf("empty image config for %s", imgInfo.userRequestedImage)
+	}
+
+	// Process args must be set before configureSELinuxLabels so WillRunSystemd()
+	// can see /sbin/init or systemd. generate.New() defaults Args to ["sh"].
+	if err := ctr.SpecSetProcessArgs(containerImageConfig); err != nil {
+		return nil, err
+	}
+
 	mountLabel, processLabel, maybeRelabel, skipRelabel, err := s.configureSELinuxLabels(ctr, sb, containerInfo)
 	if err != nil {
 		return nil, err
@@ -820,17 +831,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, ctr container.Conta
 	usernsEnabled := containerIDMappings != nil
 	hostNet := securityContext.GetNamespaceOptions().GetNetwork() == types.NamespaceMode_NODE
 	addSysfsMounts(ctr, containerConfig, hostNet, usernsEnabled)
-
-	containerImageConfig := containerInfo.Config
-	if containerImageConfig == nil {
-		err = fmt.Errorf("empty image config for %s", imgInfo.userRequestedImage)
-
-		return nil, err
-	}
-
-	if err := ctr.SpecSetProcessArgs(containerImageConfig); err != nil {
-		return nil, err
-	}
 
 	if err := s.setupCgroupNamespace(ctr, specgen); err != nil {
 		return nil, err

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1236,9 +1236,15 @@ func (s *Server) configureSELinuxLabels(ctr container.Container, sb *sandbox.San
 
 	// Newer versions of container-selinux, container-selinux-2.132.0 or newer,
 	// supply a container_init_t label. If CRI-O is running systemd or init inside
-	// the container and the process label is unset, the init selinux label is required
-	// to run the container.
-	if ctr.WillRunSystemd() && processLabel == "" {
+	// the container, the init selinux label is required unless the user
+	// explicitly requested a different SELinux type.
+	//
+	// processLabel is typically already populated with the storage-generated
+	// default (container_t) when SELinux is enabled, so a non-empty processLabel
+	// must not be treated as a user override. Checking the CRI SELinux type
+	// preserves user-specified labels while still applying container_init_t
+	// for the default systemd case.
+	if ctr.WillRunSystemd() && userSpecifiedSELinuxType(ctr) == "" {
 		processLabel, err = selinux.SetProcessKind(processLabel, selinux.ProcessKindInit)
 		if err != nil {
 			return "", "", false, false, fmt.Errorf("failed to get init label: %w", err)
@@ -1258,6 +1264,21 @@ func (s *Server) configureSELinuxLabels(ctr container.Container, sb *sandbox.San
 	}
 
 	return mountLabel, processLabel, maybeRelabel, skipRelabel, nil
+}
+
+// userSpecifiedSELinuxType returns the SELinux type explicitly requested by the
+// container or its sandbox. An empty string means CRI-O should apply its default
+// labeling, including container_init_t for systemd/init containers.
+func userSpecifiedSELinuxType(ctr container.Container) string {
+	if t := ctr.Config().GetLinux().GetSecurityContext().GetSelinuxOptions().GetType(); t != "" {
+		return t
+	}
+
+	if ctr.SandboxConfig() == nil {
+		return ""
+	}
+
+	return ctr.SandboxConfig().GetLinux().GetSecurityContext().GetSelinuxOptions().GetType()
 }
 
 // createStorageContainer creates the storage layer container with the specified image and ID mappings.

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -460,6 +460,61 @@ func TestSetupContainerUserRejectsNewlineInHOME(t *testing.T) {
 	}
 }
 
+func TestUserSpecifiedSELinuxType(t *testing.T) {
+	newCtr := func(containerType, sandboxType string) container.Container {
+		t.Helper()
+
+		ctr, err := container.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &types.ContainerConfig{
+			Metadata: &types.ContainerMetadata{Name: "testctr"},
+			Linux: &types.LinuxContainerConfig{
+				SecurityContext: &types.LinuxContainerSecurityContext{
+					SelinuxOptions: &types.SELinuxOption{Type: containerType},
+				},
+			},
+		}
+		sbox := &types.PodSandboxConfig{
+			Metadata: &types.PodSandboxMetadata{Name: "testpod"},
+			Linux: &types.LinuxPodSandboxConfig{
+				SecurityContext: &types.LinuxSandboxSecurityContext{
+					SelinuxOptions: &types.SELinuxOption{Type: sandboxType},
+				},
+			},
+		}
+
+		if err := ctr.SetConfig(cfg, sbox); err != nil {
+			t.Fatal(err)
+		}
+
+		return ctr
+	}
+
+	tests := []struct {
+		name          string
+		containerType string
+		sandboxType   string
+		want          string
+	}{
+		{name: "no type specified"},
+		{name: "container type", containerType: "container_init_t", want: "container_init_t"},
+		{name: "sandbox type", sandboxType: "spc_t", want: "spc_t"},
+		{name: "container type overrides sandbox", containerType: "container_t", sandboxType: "spc_t", want: "container_t"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := userSpecifiedSELinuxType(newCtr(tt.containerType, tt.sandboxType))
+			if got != tt.want {
+				t.Errorf("userSpecifiedSELinuxType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsSubDirectoryOf(t *testing.T) {
 	tests := []struct {
 		base, target string

--- a/test/selinux.bats
+++ b/test/selinux.bats
@@ -119,3 +119,60 @@ function teardown() {
 
 	[[ "$OLDLABEL" == "$NEWLABEL" ]]
 }
+
+@test "systemd container gets container_init_t when no SELinux type is set" {
+	skip_if_selinux_disabled
+
+	start_crio
+
+	# Default sandbox_config.json sets a type; that is a user override and must
+	# not be present for CRI-O to apply container_init_t.
+	jq 'del(.linux.security_context.selinux_options.type)' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
+
+	jq '	  .command = ["/sbin/init"]
+		| .args = []' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR"/container.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDIR"/container.json "$TESTDIR"/sandbox.json)
+
+	label=$(crictl inspect "$ctr_id" | jq -r '.info.runtimeSpec.process.selinuxLabel')
+	[[ "$label" == *":container_init_t:"* ]]
+}
+
+@test "systemd container keeps an explicit SELinux type" {
+	skip_if_selinux_disabled
+
+	start_crio
+
+	jq 'del(.linux.security_context.selinux_options.type)' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
+
+	jq '	  .command = ["/sbin/init"]
+		| .args = []
+		| .linux.security_context.selinux_options.type = "container_t"' \
+		"$TESTDATA"/container_sleep.json > "$TESTDIR"/container.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDIR"/container.json "$TESTDIR"/sandbox.json)
+
+	label=$(crictl inspect "$ctr_id" | jq -r '.info.runtimeSpec.process.selinuxLabel')
+	[[ "$label" == *":container_t:"* ]]
+	[[ "$label" != *":container_init_t:"* ]]
+}
+
+@test "non-systemd container does not get container_init_t" {
+	skip_if_selinux_disabled
+
+	start_crio
+
+	jq 'del(.linux.security_context.selinux_options.type)' \
+		"$TESTDATA"/sandbox_config.json > "$TESTDIR"/sandbox.json
+
+	pod_id=$(crictl runp "$TESTDIR"/sandbox.json)
+	ctr_id=$(crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDIR"/sandbox.json)
+
+	label=$(crictl inspect "$ctr_id" | jq -r '.info.runtimeSpec.process.selinuxLabel')
+	[[ "$label" != *":container_init_t:"* ]]
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

CRI-O is supposed to auto-relabel systemd/init containers (`/sbin/init` or `systemd`) with `container_init_t` so they can write their own cgroups. That path broke after #9666 wrapped `InitLabel()` in `processLabel == ""`.

On SELinux-enabled nodes, `processLabel` is already the storage default (`container_t:...`) by the time that check runs, so `InitLabel()` never runs. Systemd pods stay `container_t` and fail with:

```
Failed to create /init.scope control group: Permission denied
Failed to allocate manager object: Permission denied
[!!!!!!] Failed to allocate manager object, freezing.
```

This happens with both `hostUsers: false` and `hostUsers: true`. It is a regression, not a missing OpenShift systemd feature.

This change skips `InitLabel()` only when the user explicitly set `seLinuxOptions.type` on the container or sandbox. Default systemd pods get `container_init_t` again.

#### Which issue(s) this PR fixes:

https://issues.redhat.com/browse/OCPBUGS-112620

Related: #9666, OCPBUGS-69402

#### Special notes for your reviewer:

Reproduced on OpenShift (customer + lab):

| Stream | CRI-O | Default label | systemd |
|---|---|---|---|
| 4.20.25 (customer) | 1.33.z after the #9666 backport | `container_t` | `/init.scope` Permission denied |
| 4.21.17 | `1.34.8-3.rhaos4.21.git91b4b0b.el9` | `container_t` | exit 255, same error |
| 4.22.2 | `1.35.4-2.rhaos4.22.git6479b5e.el9` | `container_t` | exit 255, same error |

Workaround `securityContext.seLinuxOptions.type: container_init_t` starts cleanly (`graphical.target`) on the same clusters.

Please cherry-pick to release-1.33 / 1.34 / 1.35 after this lands.

#### Does this PR introduce a user-facing change?

```release-note
Fix SELinux labeling so systemd/init containers receive container_init_t again instead of remaining container_t and failing to create cgroups.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SELinux labeling for systemd/init containers.
  - Preserves explicitly configured container or sandbox SELinux types.
  - Applies the default initialization label only when no SELinux type is specified.
  - Ensures container-level settings take precedence over sandbox-level settings.
  - Improved container creation reliability through better image and storage service handling.
  - Skips malformed environment entries instead of failing container creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->