### PR TITLE
ci: Re-enable runc integration tests with conmon

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,19 +60,15 @@ jobs:
       fail-fast: false
       matrix:
         run:
-          # TODO: Re-enable runc integration tests when mitigation is found
-          # Disabled due to AppArmor issue in nested environments
-          # See: https://github.com/cri-o/cri-o/issues/9573
-          # See: https://github.com/opencontainers/runc/issues/4968
-          # - name: critest / conmon / runc / amd64
-          #   arch: amd64
-          #   runner: ubuntu-latest
-          #   defaultRuntime: runc
-          #   runtimeType: oci
-          #   critest: 1
-          #   userns: 0
-          #   jobs: 1
-          #   timeout: 20
+          - name: critest / conmon / runc / amd64
+            arch: amd64
+            runner: ubuntu-latest
+            defaultRuntime: runc
+            runtimeType: oci
+            critest: 1
+            userns: 0
+            jobs: 1
+            timeout: 20
 
           - name: critest / conmon / crun / amd64
             arch: amd64
@@ -144,15 +140,15 @@ jobs:
             jobs: 1
             timeout: 20
 
-          # - name: integration / conmon / runc / amd64
-          #   arch: amd64
-          #   runner: ubuntu-latest
-          #   defaultRuntime: runc
-          #   runtimeType: oci
-          #   critest: 0
-          #   userns: 0
-          #   jobs: 2
-          #   timeout: 120
+          - name: integration / conmon / runc / amd64
+            arch: amd64
+            runner: ubuntu-latest
+            defaultRuntime: runc
+            runtimeType: oci
+            critest: 0
+            userns: 0
+            jobs: 2
+            timeout: 120
 
           - name: integration / conmon / crun / amd64
             arch: amd64


### PR DESCRIPTION
Re-enable the runc critest and integration test matrix entries for amd64 using conmon (OCI runtime type). The conmon-rs (pod runtime type) runc entries remain disabled.

Signed-off-by: Ayato Tokubi <atokubi@redhat.com>

Assisted-by: Claude Code <https://claude.com/claude-code>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled additional amd64 integration test configurations.
  * Added coverage for runc-specific critest and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->