### PR TITLE
Use reflect.TypeAssert for checked type assertions

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -245,7 +245,7 @@ func (i *Info) String() string {
 
 		case reflect.Slice:
 			// Only expecting []string here; ignore other slices.
-			if s, ok := value.Interface().([]string); ok {
+			if s, ok := reflect.TypeAssert[[]string](value); ok {
 				const sep = "\n  "
 
 				valueString = sep + strings.Join(s, sep)

--- a/test/docs-validation/main.go
+++ b/test/docs-validation/main.go
@@ -290,7 +290,7 @@ func recursiveEntries(
 				switch {
 				case field.Type.Implements(reflect.TypeFor[stringer]()):
 					// We need a checked type assertion to make golangci-lint happy...
-					if str, ok := vv.MethodByName("String").Interface().(func() string); ok {
+					if str, ok := reflect.TypeAssert[func() string](vv.MethodByName("String")); ok {
 						// if the field is a pointer and nil, skip validation
 						if vv.Kind() == reflect.Pointer && vv.IsNil() {
 							break


### PR DESCRIPTION
Go 1.25 added `reflect.TypeAssert`, which performs a checked type assertion on a `reflect.Value` without allocating via `Interface()`.

Generated by modernize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal reflection-based type handling for improved type safety.
  * Preserved existing output and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->