### PR TITLE
Remove use-sigstore-attachments for registry.k8s.io

### DIFF
--- a/test/default.yaml
+++ b/test/default.yaml
@@ -1,2 +1,5 @@
 default-docker:
   use-sigstore-attachments: true
+docker:
+  registry.k8s.io:
+    use-sigstore-attachments: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind ci

#### What this PR does / why we need it:
The tests are failing with:
```
I0825 10:38:40.774134   23308 dump.go:53] At 2026-08-25 10:28:17 +0000 UTC - event for coredns-856c857856-zh452: {kubelet 10.0.0.2} Failed: Failed to pull image "registry.k8s.io/coredns/coredns:v1.14.4": unable to pull image or OCI artifact: pull image err: copying system image from manifest list: reading signatures: fetching blob: blob unknown: Unknown blob: sha256:8e2a7f5f802c3b9ebd6be56da45ee4f692b93621f1a0f18cb139c4dbe879ed6b; artifact err: image reference: reference is a container image, not an OCI artifact
```
https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-cri-o-cri-o-main-ci-cgroupv2-e2e-crun

So scoped the fix to just registry.k8s.io and removed the sigstore-attachments for it. This is an intermittent failure. But its occurring very often and blocking PR merging. 

Possible Root cause: https://github.com/openshift/release/pull/83757 - Added more regions.

The cosign signatures for coredns:v1.14.4 only exist in us-central1 -- every other regional backend returns 404 for both the sigstore attachment
  manifest and the signature blob:

  ┌────────────────────┬──────────┬──────┐
  │       Region       │ Manifest │ Blob │
  ├────────────────────┼──────────┼──────┤
  │ us-central1        │ 200      │ 200  │
  ├────────────────────┼──────────┼──────┤
  │ us-east4 (CI host) │ 404      │ 404  │
  ├────────────────────┼──────────┼──────┤
  │ us-east1           │ 404      │ 404  │
  ├────────────────────┼──────────┼──────┤
  │ asia-south1        │ 404      │ 404  │
  ├────────────────────┼──────────┼──────┤
  │ europe-west1       │ 404      │ 404  │
  └────────────────────┴──────────┴──────┘

The k8s-artifacts-prod project pushes cosign signatures only to the us-central1 Artifact Registry repository. The other regional repos are mirrors for image layers/manifests but don't replicate sigstore attachment tags. When registry.k8s.io redirects to the CI host's nearest regional backend, the signature simply isn't there.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
@saschagrunert This was introduced in  https://github.com/cri-o/cri-o/pull/7016. In my understanding its safe to skip sigstore attachment fetching for registry.k8s.io. I didn't go ahead investigating why the other regions don't have the sigstore attachment tags.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the default test configuration to disable Sigstore attachments for `docker.registry.k8s.io`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->