### PR TITLE
OCPBUGS-112620: Only promote to init SELinux label when no type was requested

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1211,6 +1211,16 @@ func (s *Server) configureSELinuxLabels(ctr container.Container, sb *sandbox.San
 	hostPID := securityContext.GetNamespaceOptions().GetPid() == types.NamespaceMode_NODE
 	hostNet := securityContext.GetNamespaceOptions().GetNetwork() == types.NamespaceMode_NODE
 
+	// requestedSelinuxType is the SELinux type the user actually asked for: an explicit
+	// container-level type wins, otherwise fall back to the pod-level type. Unlike
+	// processLabel/containerInfo.ProcessLabel, this is never non-empty unless the user
+	// requested it, since storage always defaults ProcessLabel to a concrete type
+	// (e.g. container_t) even when nothing was requested.
+	requestedSelinuxType := securityContext.GetSelinuxOptions().GetType()
+	if requestedSelinuxType == "" {
+		requestedSelinuxType = ctr.SandboxConfig().GetLinux().GetSecurityContext().GetSelinuxOptions().GetType()
+	}
+
 	// Don't use SELinux separation with Host Pid or IPC Namespace or privileged.
 	if hostPID || hostIPC {
 		processLabel, mountLabel = "", ""
@@ -1222,9 +1232,9 @@ func (s *Server) configureSELinuxLabels(ctr container.Container, sb *sandbox.San
 
 	// Newer versions of container-selinux, container-selinux-2.132.0 or newer,
 	// supply a container_init_t label. If CRI-O is running systemd or init inside
-	// the container and the process label is unset, the init selinux label is required
-	// to run the container.
-	if ctr.WillRunSystemd() && processLabel == "" {
+	// the container and the user didn't request a specific SELinux type, the init
+	// selinux label is required to run the container.
+	if ctr.WillRunSystemd() && requestedSelinuxType == "" {
 		processLabel, err = InitLabel(processLabel)
 		if err != nil {
 			return "", "", false, false, fmt.Errorf("failed to get init label: %w", err)
@@ -1237,9 +1247,7 @@ func (s *Server) configureSELinuxLabels(ctr container.Container, sb *sandbox.San
 
 	const superPrivilegedType = "spc_t"
 
-	if securityContext.GetSelinuxOptions().GetType() == superPrivilegedType || // super privileged container
-		(ctr.SandboxConfig().GetLinux().GetSecurityContext().GetSelinuxOptions().GetType() == superPrivilegedType && // super privileged pod
-			securityContext.GetSelinuxOptions().GetType() == "") {
+	if requestedSelinuxType == superPrivilegedType {
 		skipRelabel = true
 	}
 

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -3,11 +3,16 @@ package server
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/opencontainers/runtime-tools/generate"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/cri-o/cri-o/internal/factory/container"
+	"github.com/cri-o/cri-o/internal/hostport"
+	"github.com/cri-o/cri-o/internal/lib/sandbox"
+	"github.com/cri-o/cri-o/internal/memorystore"
+	"github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
 )
 
@@ -480,6 +485,173 @@ func TestIsSubDirectoryOf(t *testing.T) {
 			res := isSubDirectoryOf(tt.base, tt.target)
 			if res != tt.want {
 				t.Errorf("got %v, want %v", res, tt.want)
+			}
+		})
+	}
+}
+
+// newTestSandbox builds the minimal valid *sandbox.Sandbox that
+// configureSELinuxLabels needs (it only reads sb.Annotations()).
+func newTestSandbox(t *testing.T) *sandbox.Sandbox {
+	t.Helper()
+
+	b := sandbox.NewBuilder()
+	b.SetID("sandboxid")
+	b.SetName("sandboxname")
+	b.SetLogDir(t.TempDir())
+	b.SetShmPath("test")
+	b.SetNamespace("")
+	b.SetKubeName("")
+	b.SetMountLabel("")
+	b.SetProcessLabel("")
+	b.SetCgroupParent("")
+	b.SetRuntimeHandler("")
+	b.SetResolvPath("")
+	b.SetHostname("")
+	b.SetPortMappings([]*hostport.PortMapping{})
+	b.SetHostNetwork(false)
+	b.SetUsernsMode("")
+	b.SetPodLinuxOverhead(nil)
+	b.SetPodLinuxResources(nil)
+	b.SetCreatedAt(time.Now())
+
+	if err := b.SetCRISandbox(b.ID(), map[string]string{}, map[string]string{}, &types.PodSandboxMetadata{}); err != nil {
+		t.Fatalf("SetCRISandbox: %v", err)
+	}
+
+	b.SetPrivileged(false)
+	b.SetContainers(memorystore.New[*oci.Container]())
+
+	sb, err := b.GetSandbox()
+	if err != nil {
+		t.Fatalf("GetSandbox: %v", err)
+	}
+
+	return sb
+}
+
+// newSELinuxTestContainer builds a container.Container whose configured process
+// is either a systemd/init entrypoint or a regular command, with the given
+// container-level and pod-level SELinux types (empty string means unset).
+func newSELinuxTestContainer(t *testing.T, systemd bool, containerSelinuxType, podSelinuxType string) container.Container {
+	t.Helper()
+
+	command := []string{"/bin/sh"}
+	if systemd {
+		command = []string{"/sbin/init"}
+	}
+
+	cfg := &types.ContainerConfig{
+		Metadata: &types.ContainerMetadata{Name: "testctr"},
+		Command:  command,
+		Linux: &types.LinuxContainerConfig{
+			SecurityContext: &types.LinuxContainerSecurityContext{
+				NamespaceOptions: &types.NamespaceOption{},
+				SelinuxOptions:   &types.SELinuxOption{Type: containerSelinuxType},
+			},
+		},
+	}
+
+	sboxCfg := &types.PodSandboxConfig{
+		Metadata: &types.PodSandboxMetadata{Name: "testpod"},
+		Linux: &types.LinuxPodSandboxConfig{
+			SecurityContext: &types.LinuxSandboxSecurityContext{
+				SelinuxOptions: &types.SELinuxOption{Type: podSelinuxType},
+			},
+		},
+	}
+
+	ctr, err := container.New()
+	if err != nil {
+		t.Fatalf("container.New: %v", err)
+	}
+
+	if err := ctr.SetConfig(cfg, sboxCfg); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	if err := ctr.SpecSetProcessArgs(nil); err != nil {
+		t.Fatalf("SpecSetProcessArgs: %v", err)
+	}
+
+	return ctr
+}
+
+func TestConfigureSELinuxLabels(t *testing.T) {
+	const originalProcessLabel = "system_u:system_r:container_t:s0:c1,c2"
+
+	cases := []struct {
+		name                  string
+		systemd               bool
+		containerSelinuxType  string
+		podSelinuxType        string
+		wantProcessLabelUnset bool // true: InitLabel must NOT fire, processLabel stays as-is
+		wantSkipRelabel       bool
+	}{
+		{
+			name:                  "systemd, no type requested anywhere: promoted to init label",
+			systemd:               true,
+			wantProcessLabelUnset: false,
+			wantSkipRelabel:       false,
+		},
+		{
+			name:                  "systemd, explicit non-spc_t container type: respected",
+			systemd:               true,
+			containerSelinuxType:  "container_t",
+			wantProcessLabelUnset: true,
+			wantSkipRelabel:       false,
+		},
+		{
+			name:                  "systemd, explicit spc_t container type: respected and skips relabel",
+			systemd:               true,
+			containerSelinuxType:  "spc_t",
+			wantProcessLabelUnset: true,
+			wantSkipRelabel:       true,
+		},
+		{
+			name:                  "systemd, spc_t requested only at pod level: respected and skips relabel",
+			systemd:               true,
+			podSelinuxType:        "spc_t",
+			wantProcessLabelUnset: true,
+			wantSkipRelabel:       true,
+		},
+		{
+			name:                  "systemd, container-level type overrides pod-level spc_t",
+			systemd:               true,
+			containerSelinuxType:  "container_t",
+			podSelinuxType:        "spc_t",
+			wantProcessLabelUnset: true,
+			wantSkipRelabel:       false,
+		},
+		{
+			name:                  "non-systemd container, no type requested: never promoted",
+			systemd:               false,
+			wantProcessLabelUnset: true,
+			wantSkipRelabel:       false,
+		},
+	}
+
+	sb := newTestSandbox(t)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctr := newSELinuxTestContainer(t, tc.systemd, tc.containerSelinuxType, tc.podSelinuxType)
+			containerInfo := &storage.ContainerInfo{ProcessLabel: originalProcessLabel}
+
+			s := &Server{}
+
+			_, processLabel, _, skipRelabel, err := s.configureSELinuxLabels(ctr, sb, containerInfo)
+			if err != nil {
+				t.Fatalf("configureSELinuxLabels: %v", err)
+			}
+
+			gotUnset := processLabel == originalProcessLabel
+			if gotUnset != tc.wantProcessLabelUnset {
+				t.Errorf("processLabel = %q (unchanged=%v), want unchanged=%v", processLabel, gotUnset, tc.wantProcessLabelUnset)
+			}
+
+			if skipRelabel != tc.wantSkipRelabel {
+				t.Errorf("skipRelabel = %v, want %v", skipRelabel, tc.wantSkipRelabel)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

When CRI-O runs systemd/init inside a container, newer versions of container-selinux (2.132.0+) provide a container_init_t label, and CRI-O promotes the process to the init SELinux label. Previously the decision to promote used processLabel == "", but that check was unreliable: storage always defaults ContainerInfo.ProcessLabel to a concrete type (e.g. container_t) even when the user requested nothing, so the branch keyed on a value that was rarely truly empty.

This PR introduces requestedSelinuxType, which reflects the SELinux type the user actually asked for — an explicit container-level type wins, otherwise it falls back to the pod-level type — and is only non-empty when a type was genuinely requested. The init-label promotion now fires only when no type was requested (requestedSelinuxType == ""), so an explicitly requested SELinux type is always respected instead of being silently overridden by the init label.

It also simplifies the spc_t (super-privileged) detection to reuse the same requestedSelinuxType resolution, replacing the duplicated container/pod-level checks with a single comparison.

Adds unit tests (TestConfigureSELinuxLabels) covering: no type requested → promoted to init label; explicit container/pod types respected; spc_t skips relabel; container-level type overriding pod-level spc_t; and non-systemd containers never being promoted.

#### Which issue(s) this PR fixes:

 Fixes [OCPBUGS-112620](https://redhat.atlassian.net/browse/OCPBUGS-112620)

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

The key insight is that processLabel/ContainerInfo.ProcessLabel is not a reliable signal for "user requested no type" because storage defaults it to a concrete type. requestedSelinuxType is derived directly from the CRI SelinuxOptions (container-level preferred, pod-level fallback), which is the correct source of truth. The spc_t logic is functionally equivalent to before but consolidated.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed an issue where an explicitly requested SELinux type could be overridden by the container init SELinux label when running systemd/init inside a container. The init label is now only applied when no SELinux type was requested.
```
