### PR TITLE
test: fix flaky container disk metrics test

### DIFF
--- a/test/cri-metrics.bats
+++ b/test/cri-metrics.bats
@@ -333,6 +333,8 @@ EOF
 	crictl exec --sync "$CONTAINER_ID" mkdir -p /var/lib/mydisktest
 	crictl exec --sync "$CONTAINER_ID" /bin/sh -c "for i in \$(seq 1 50); do touch /var/lib/mydisktest/inode_test_file_\$i; done"
 	crictl exec --sync "$CONTAINER_ID" sync
+	# wait a bit for metrics sync - tests are more flaky without this
+	sleep 1
 
 	# Poll for inode metrics to be updated
 	local timeout=60 # Set a reasonable timeout in seconds
@@ -364,15 +366,21 @@ EOF
 
 	# Generate disk usage and validate increase
 	crictl exec --sync "$CONTAINER_ID" mkdir -p /var/lib/mydisktest
-	crictl exec --sync "$CONTAINER_ID" dd if=/dev/zero of=/var/lib/mydisktest/bloatfile bs=1024 count=4
+	crictl exec --sync "$CONTAINER_ID" dd if=/dev/zero of=/var/lib/mydisktest/bloatfile bs=1M count=10
 	crictl exec --sync "$CONTAINER_ID" sync
+
+	# Allow a 1 KiB tolerance on the disk usage comparison to avoid flaky failures
+	# due to filesystem metadata update timing and block allocation granularity.
+	DISK_METRIC_TOLERANCE=1024
+
 	# Polling loop for metrics to be updated
 	local timeout=60 # Set a reasonable timeout in seconds
 	local new_fs_usage=0
 	local found_increase=false
 	for ((i = 0; i < timeout; i++)); do
 		new_fs_usage=$(crictl metricsp | jq '.podMetrics[0].containerMetrics[0].metrics[] | select(.name == "container_fs_usage_bytes") | .value.value | tonumber')
-		if [[ "$new_fs_usage" -gt "$fs_usage" ]]; then
+		usage_diff=$((new_fs_usage - fs_usage))
+		if [[ $usage_diff -gt $DISK_METRIC_TOLERANCE ]]; then
 			found_increase=true
 			break
 		fi


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
The test wrote a 4KB file to trigger a detectable increase in `container_fs_usage_bytes`. On overlay filesystems, `GetDiskUsageStats()` uses logical file size via `filepath.Walk`, so a 4KB write can be invisible as a delta against the base image layer - the polling loop exhausts all 60 iterations without detecting any change.

##### Changes:
- increased test file from 4KB to 10MB so the delta is detectable
- `sleep 1` after inode `sync` before the inode poll loop
- tolerance-based comparison (`usage_diff -gt $DISK_METRIC_TOLERANCE`) instead of strict `new > old`

Tested locally 5× in a loop, all passed in ~12s.

#### Which issue(s) this PR fixes:
Fixes #10270

#### Special notes for your reviewer:
Core fix is the file size change. Rest follows the pattern from #10055 

#### Does this PR introduce a user-facing change?
```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Improved disk metrics validation with more representative inode and disk usage data.
  * Added synchronization waits to reduce timing-related test failures.
  * Added a tolerance when verifying disk usage increases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->