### PR TITLE
config: default gRPC max message size to 16 MiB to match the cri-client receive cap

### DIFF
--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -66,7 +66,7 @@ complete -c crio -n '__fish_crio_no_subcommand' -f -l enable-tracing -d 'Enable 
 complete -c crio -n '__fish_crio_no_subcommand' -f -l gid-mappings -r -d 'Specify the GID mappings to use for the user namespace. This option is deprecated, and will be replaced with Kubernetes user namespace (KEP-127) support in the future.'
 complete -c crio -n '__fish_crio_no_subcommand' -l global-auth-file -r -d 'Path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l grpc-max-recv-msg-size -r -d 'Maximum grpc receive message size in bytes.'
-complete -c crio -n '__fish_crio_no_subcommand' -f -l grpc-max-send-msg-size -r -d 'Maximum grpc receive message size.'
+complete -c crio -n '__fish_crio_no_subcommand' -f -l grpc-max-send-msg-size -r -d 'Maximum grpc send message size in bytes.'
 complete -c crio -n '__fish_crio_no_subcommand' -f -l hooks-dir -r -d 'Set the OCI hooks directory path (may be set multiple times)
     If one of the directories does not exist, then CRI-O will automatically
     skip them.

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -277,9 +277,9 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--global-auth-file**="": Path to a file like /var/lib/kubelet/config.json holding credentials necessary for pulling images from secure registries.
 
-**--grpc-max-recv-msg-size**="": Maximum grpc receive message size in bytes. (default: 83886080)
+**--grpc-max-recv-msg-size**="": Maximum grpc receive message size in bytes. (default: 16777216)
 
-**--grpc-max-send-msg-size**="": Maximum grpc receive message size. (default: 83886080)
+**--grpc-max-send-msg-size**="": Maximum grpc send message size in bytes. (default: 16777216)
 
 **--help, -h**: show help
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -109,11 +109,11 @@ Minimum TLS version for streaming and metrics servers. Valid values are "Version
 **tls_cipher_suites**=[]
 List of cipher suites for TLS 1.2. If omitted, the default Go cipher suites will be used. This has no effect on TLS 1.3 as Go manages cipher suites automatically.
 
-**grpc_max_send_msg_size**=83886080
-Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 80 _ 1024 _ 1024.
+**grpc_max_send_msg_size**=16777216
+Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 16 _ 1024 _ 1024.
 
-**grpc_max_recv_msg_size**=83886080
-Maximum grpc receive message size. If not set or <= 0, then CRI-O will default to 80 _ 1024 _ 1024.
+**grpc_max_recv_msg_size**=16777216
+Maximum grpc receive message size. If not set or <= 0, then CRI-O will default to 16 _ 1024 _ 1024.
 
 ## CRIO.RUNTIME TABLE
 

--- a/internal/criocli/criocli.go
+++ b/internal/criocli/criocli.go
@@ -1358,7 +1358,7 @@ func getCrioFlags(defConf *libconfig.Config) []cli.Flag {
 		},
 		&cli.IntFlag{
 			Name:    "grpc-max-send-msg-size",
-			Usage:   "Maximum grpc receive message size.",
+			Usage:   "Maximum grpc send message size in bytes.",
 			Value:   defConf.GRPCMaxSendMsgSize,
 			EnvVars: []string{"CONTAINER_GRPC_MAX_SEND_MSG_SIZE"},
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,11 @@ import (
 
 // Defaults if none are specified.
 const (
-	defaultGRPCMaxMsgSize = 80 * 1024 * 1024
+	// defaultGRPCMaxMsgSize matches the 16 MiB receive cap every CRI client
+	// (kubelet, crictl) sets via k8s.io/cri-client. Responses larger than that
+	// are rejected by the client regardless of the server cap, and no CRI
+	// request comes close to 16 MiB, so a larger cap serves no purpose.
+	defaultGRPCMaxMsgSize = 16 * 1024 * 1024
 	// default minimum memory for all other runtimes.
 	defaultContainerMinMemory = 12 * 1024 * 1024 // 12 MiB
 	// defaultContainerCreateTimeout is the default timeout for container creation operations in seconds.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -929,12 +929,12 @@ const templateStringCrioAPITLSCipherSuites = `# List of cipher suites for TLS 1.
 
 `
 
-const templateStringCrioAPIGrpcMaxSendMsgSize = `# Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 80 * 1024 * 1024.
+const templateStringCrioAPIGrpcMaxSendMsgSize = `# Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 16 * 1024 * 1024.
 {{ $.Comment }}grpc_max_send_msg_size = {{ .GRPCMaxSendMsgSize }}
 
 `
 
-const templateStringCrioAPIGrpcMaxRecvMsgSize = `# Maximum grpc receive message size. If not set or <= 0, then CRI-O will default to 80 * 1024 * 1024.
+const templateStringCrioAPIGrpcMaxRecvMsgSize = `# Maximum grpc receive message size. If not set or <= 0, then CRI-O will default to 16 * 1024 * 1024.
 {{ $.Comment }}grpc_max_recv_msg_size = {{ .GRPCMaxRecvMsgSize }}
 
 `


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
CRI-O now defaults `grpc_max_send_msg_size` and `grpc_max_recv_msg_size` to 16 MiB (previously 80 MiB), matching the receive cap kubelet and crictl set via k8s.io/cri-client.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Reduced the default maximum gRPC message size for sending and receiving from 80 MiB to 16 MiB.

* **Documentation**
  * Updated configuration references, command-line help, and shell completion descriptions to reflect the 16 MiB defaults.
  * Corrected the description of the maximum gRPC send message size option to accurately identify it as a send limit in bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->