### PR TITLE
ci: default JOBS to nproc * 2

### DIFF
--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -43,7 +43,7 @@ if [[ "$RUN_CRITEST" == "1" ]]; then
 fi
 
 # The number of parallel jobs to execute tests
-export JOBS=${JOBS:-$(nproc --all)}
+export JOBS=${JOBS:-$(($(nproc --all) * 2))}
 # The maximum number of additional attempts that will be made on a failed test before it is finally considered failed.
 # https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-variables
 export BATS_TEST_RETRIES=1


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

Run twice as many parallel bats jobs as there are CPUs. Integration tests
spend a lot of time waiting on I/O rather than saturating the CPU, so
oversubscribing the runner reduces wall clock time.

A similar change in conmon CI gave about a 15% speedup on GitHub Actions;
see https://github.com/containers/conmon/pull/695.

`JOBS` can still be overridden from the environment.

## Which issue(s) this PR fixes

None

## Special notes for your reviewer

None

## Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test runs now use up to twice the number of available CPUs by default, potentially reducing execution time on multi-core systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->