### PR TITLE
OCPBUGS-114878: make version stamping build-injectable instead of sed-patched

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,7 +15,7 @@ packages:
       - src: .packit_rpm/cri-o.spec
         dest: cri-o.spec
     actions:
-      get-current-version: "bash -ec 'grep \"^const Version\" internal/version/version.go | cut -d\\\" -f2'"
+      get-current-version: "bash -ec 'grep -E \"^(const|var) Version\" internal/version/version.go | cut -d\\\" -f2'"
       post-upstream-clone:
         # Use the Fedora Rawhide specfile
         - git clone https://src.fedoraproject.org/rpms/cri-o .packit_rpm --depth=1

--- a/contrib/test/ci/cri-o.spec
+++ b/contrib/test/ci/cri-o.spec
@@ -63,7 +63,6 @@ sed -i 's/install.config: crio.conf/install.config:/' Makefile
 sed -i 's/install.bin: binaries/install.bin:/' Makefile
 sed -i 's/\.gopathok//' Makefile
 sed -i 's/go test/$(GO) test/' Makefile
-sed -i 's/%{version}/%{version}-%{release}/' internal/version/version.go
 sed -i 's/\/local//' contrib/systemd/%{service_name}.service
 
 %build
@@ -76,7 +75,8 @@ popd
 ln -s vendor src
 export GOPATH=$(pwd)/_output:$(pwd)
 export BUILDTAGS="selinux seccomp exclude_graphdriver_btrfs containers_image_ostree_stub containers_image_openpgp"
-make bin/crio bin/pinns
+# Inject the full RPM NVR at link time instead of sed-patching version.go.
+make EXTRA_LDFLAGS="-X github.com/cri-o/cri-o/internal/version.Version=%{version}-%{release}" bin/crio bin/pinns
 
 # build docs
 make GO_MD2MAN=go-md2man docs

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -20,8 +20,10 @@ import (
 	"go.podman.io/common/pkg/seccomp"
 )
 
-// Version is the version of the build.
-const Version = "1.37.0"
+// Version is the version of the build. Declared as a var (not const) so
+// downstream builds can override it via -ldflags -X at link time instead
+// of source patching.
+var Version = "1.37.0"
 
 // ReleaseMinorVersions are the currently supported minor versions.
 var ReleaseMinorVersions = []string{"1.36", "1.35", "1.34"}
@@ -78,7 +80,7 @@ func shouldCrioWipe(versionFileName, versionString string) (bool, error) {
 	// parse the version of the current binary
 	newVersion, err := parseVersionConstant(versionString, "")
 	if err != nil {
-		return true, fmt.Errorf("version constant %s malformatted: %w", versionString, err)
+		return true, fmt.Errorf("version string %s malformatted: %w", versionString, err)
 	}
 
 	// in every case that the minor and major version are out of sync,
@@ -126,12 +128,10 @@ func writeVersionFile(file, gitCommit, version string) error {
 	return renameio.WriteFile(file, j, 0o644)
 }
 
-// parseVersionConstant parses the Version variable above
-// a const crioVersion would be kept, but golang doesn't support
-// const structs. We will instead spend some runtime on CRI-O startup
+// parseVersionConstant parses versionString into a semver.Version.
 // Because the version string doesn't keep track of the git commit,
-// but it could be useful for debugging, we pass it in here
-// If our version constant is properly formatted, this should never error.
+// but it could be useful for debugging, we pass it in here.
+// If Version is properly formatted, this should never error.
 func parseVersionConstant(versionString, gitCommit string) (*semver.Version, error) {
 	v, err := semver.Make(versionString)
 	if err != nil {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -78,6 +78,13 @@ Dependencies:
 			_, err = parseVersionConstant("1.1.1-dev", "biglonggitcommit")
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("should succeed to parse downstream NVR version strings", func() {
+			v, err := parseVersionConstant("1.35.7-8.git1a2b3c4.el10", "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v.Major).To(Equal(uint64(1)))
+			Expect(v.Minor).To(Equal(uint64(35)))
+			Expect(v.Patch).To(Equal(uint64(7)))
+		})
 		It("should succeed to parse the version with a git commit", func() {
 			gitCommit := "\"myfavoritecommit\""
 			v, err := parseVersionConstant(tempVersion, gitCommit)
@@ -185,6 +192,22 @@ Dependencies:
 			Expect(upgrade).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("should not wipe when version only differs by NVR release tag", func() {
+			oldVersion := "1.33.13"
+			newVersion := "1.33.13-3.git1a2b3c4.el9"
+
+			tempFileName := tempFileName
+			_ = t.MustTempFile(tempFileName)
+
+			err := writeVersionFile(tempFileName, "", oldVersion)
+			defer os.Remove(tempFileName)
+
+			Expect(err).ToNot(HaveOccurred())
+
+			upgrade, err := shouldCrioWipe(tempFileName, newVersion)
+			Expect(upgrade).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
 		It("should upgrade between versions", func() {
 			oldVersion := "1.14.1"
 			newVersion := tempVersion2
@@ -230,6 +253,21 @@ Dependencies:
 			upgrade, err := shouldCrioWipe(tempFileName, newVersion)
 			Expect(upgrade).To(BeTrue())
 			Expect(err).To(HaveOccurred())
+		})
+	})
+	t.Describe("test build-time version overrides", func() {
+		It("should reflect a value injected into the Version variable via -ldflags -X", func() {
+			// Simulates build-time -ldflags -X injection. Proves Get()
+			// reads from the package-level var, not a stale copy.
+			original := Version
+			defer func() { Version = original }()
+
+			injected := "1.33.13-3.git1a2b3c4.el9"
+			Version = injected
+
+			info, err := Get(false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(info.Version).To(Equal(injected))
 		})
 	})
 	t.Describe("test generating string from info", func() {

--- a/scripts/utils/utils.go
+++ b/scripts/utils/utils.go
@@ -54,7 +54,10 @@ func ConvertStringToSemver(tag string) (res semver.Version, err error) {
 }
 
 func GetCurrentVersionFromVersionFile(versionFile string) (string, error) {
-	const versionPattern = `const\s+Version\s+=\s+"(.+)"`
+	// Matches both the legacy "const Version" declaration and the "var
+	// Version" declaration used so downstream builds can override the
+	// value via -ldflags -X.
+	const versionPattern = `(?:const|var)\s+Version\s+=\s+"(.+)"`
 
 	content, err := os.ReadFile(versionFile)
 	if err != nil {

--- a/scripts/version_bump.go
+++ b/scripts/version_bump.go
@@ -49,7 +49,10 @@ func main() {
 }
 
 func getCurrentVersion(versionFile string) (string, error) {
-	versionPattern := `const\s+Version\s+=\s+"(.+)"`
+	// Matches both the legacy "const Version" declaration and the "var
+	// Version" declaration used so downstream builds can override the
+	// value via -ldflags -X.
+	versionPattern := `(?:const|var)\s+Version\s+=\s+"(.+)"`
 
 	// Read the content of the version file
 	content, err := os.ReadFile(versionFile)
@@ -117,7 +120,10 @@ func updateSpecVersion(specFile, oldVersion, newVersion string) error {
 }
 
 func updateVersion(versionFile, newVersion string) error {
-	versionPattern := `const\s+Version\s+=\s+".+"`
+	// Capture the "const"/"var" keyword and surrounding whitespace so the
+	// replacement doesn't clobber a "var Version" declaration back into a
+	// "const" one.
+	versionPattern := `(const|var)(\s+Version\s+=\s+)".+"`
 
 	// Read the content of the version file
 	content, err := os.ReadFile(versionFile)
@@ -127,7 +133,7 @@ func updateVersion(versionFile, newVersion string) error {
 
 	// Replace the version string with the new version using regex
 	re := regexp.MustCompile(versionPattern)
-	newContent := re.ReplaceAll(content, fmt.Appendf(nil, `const Version = %q`, newVersion))
+	newContent := re.ReplaceAll(content, fmt.Appendf(nil, `${1}${2}%q`, newVersion))
 
 	// Write the updated content back to the version file
 	if err := os.WriteFile(versionFile, newContent, 0o644); err != nil {


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

`internal/version.Version` is currently declared as a `const`, so the only way for a packager to embed a fuller version string (for example, one that includes a distro package release tag) is to patch the literal string in the source file before compiling. That kind of text-based patching is fragile: if the substitution doesn't match for any reason, it silently no-ops with no error, and the binary ships reporting the wrong version string.

This PR changes `Version` from a `const` to a `var` so it can be overridden at link time via `-ldflags -X`, the same mechanism already used for `buildDate` and `buildCommit`. Packagers can now pass `EXTRA_LDFLAGS="-X github.com/cri-o/cri-o/internal/version.Version=<full-version-string>"` to `make` instead of patching source text — `contrib/test/ci/cri-o.spec` demonstrates the pattern.

Also updated the tooling that reads and rewrites the `Version` declaration in `internal/version/version.go` so it keeps working now that the declaration is a `var` instead of a `const`:
- `.packit.yaml`'s `get-current-version` action
- `scripts/utils/utils.go` and `scripts/version_bump.go` (release automation)

**Verification performed:**
- `go build`, `go vet`, and `gofmt` clean on `internal/version`
- `go test ./internal/version/...` passes, including new tests covering the `-ldflags -X` override path and NVR-style version-string parsing
- Confirmed with `make EXTRA_LDFLAGS="-X github.com/cri-o/cri-o/internal/version.Version=1.35.7-8.el10" bin/crio` that the override is correctly applied at link time, and that a default build with no override is unaffected

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

`Version` reads/usages elsewhere in the tree (`server/version.go`, `internal/criocli/version.go`, `scripts/release-notes/release_notes.go`) only read the value, so switching from `const` to `var` doesn't change behavior for any existing call site.

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Downstream builds can now override the application version at build time.
  * Version detection and updates support both constant and variable declarations.

* **Bug Fixes**
  * Improved version parsing and release comparisons for downstream packages.
  * Version bumping preserves existing declaration formatting.

* **Tests**
  * Added coverage for build-time version overrides, version parsing, and release-tag comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->