### PR TITLE
[release-1.36] OCPNODE-4526: Strengthen additional artifact store path validation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1361,8 +1361,8 @@ func (c *RuntimeConfig) Validate(systemContext *types.SystemContext, onExecution
 	}
 
 	for _, p := range c.AdditionalArtifactStores {
-		if !filepath.IsAbs(p) {
-			return fmt.Errorf("additional_artifact_stores entry must be absolute: %q", p)
+		if err := validateStorePath(p); err != nil {
+			return fmt.Errorf("additional_artifact_stores: %w", err)
 		}
 	}
 
@@ -2347,4 +2347,40 @@ func (c *APIConfig) GetTLSMinVersion() uint16 {
 // The value is parsed and validated during Validate().
 func (c *APIConfig) GetTLSCipherSuites() []uint16 {
 	return c.tlsCipherSuitesParsed
+}
+
+var storePathRegexp = regexp.MustCompile(`^/[a-zA-Z0-9/._-]+$`)
+
+func validateStorePath(p string) error {
+	if p == "" {
+		return errors.New("path must not be empty")
+	}
+
+	if len(p) > 256 {
+		return fmt.Errorf("path %q must not exceed 256 characters", p)
+	}
+
+	if !storePathRegexp.MatchString(p) {
+		return fmt.Errorf("path %q must be absolute, non-root, and contain only alphanumeric characters, '/', '.', '_', and '-'", p)
+	}
+
+	if strings.HasSuffix(p, "/") {
+		return fmt.Errorf("path %q must not have a trailing slash", p)
+	}
+
+	if strings.Contains(p, "//") {
+		return fmt.Errorf("path %q must not contain consecutive forward slashes", p)
+	}
+
+	for component := range strings.SplitSeq(p, "/") {
+		if component == ".." {
+			return fmt.Errorf("path %q must not contain '..' components", p)
+		}
+
+		if component == "." {
+			return fmt.Errorf("path %q must not contain '.' components", p)
+		}
+	}
+
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -248,6 +249,158 @@ var _ = t.Describe("Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should succeed with empty additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed with valid absolute paths in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/mnt/nfs/store1", "/opt/artifacts"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should fail with relative path in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"./relative/path"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("additional_artifact_stores"))
+			Expect(err.Error()).To(ContainSubstring("./relative/path"))
+		})
+
+		It("should fail with mix of absolute and relative paths in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/valid/store", "relative/path"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("relative/path"))
+		})
+
+		It("should fail with dot-dot traversal in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/var/lib/../../etc"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'..'"))
+		})
+
+		It("should fail with path containing special characters in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/var/lib/store@v1"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be absolute"))
+		})
+
+		It("should fail with consecutive slashes in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/var//lib/store"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("consecutive forward slashes"))
+		})
+
+		It("should fail with empty path in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{""}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must not be empty"))
+		})
+
+		It("should succeed with double dots within a filename in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/var/lib/foo..bar"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should fail with single dot component in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/var/./lib"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'.'"))
+		})
+
+		It("should fail with trailing slash in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/var/lib/store/"}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("trailing slash"))
+		})
+
+		It("should succeed with path at exactly 256 characters in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/" + strings.Repeat("a", 255)}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should fail with path exceeding 256 characters in additional_artifact_stores", func() {
+			// Given
+			sut.AdditionalArtifactStores = []string{"/" + strings.Repeat("a", 256)}
+
+			// When
+			err := sut.RuntimeConfig.Validate(nil, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must not exceed 256 characters"))
+		})
 		It("should succeed during runtime", func() {
 			// Given
 			sut = runtimeValidConfig()

--- a/test/artifact_additional_stores.bats
+++ b/test/artifact_additional_stores.bats
@@ -57,7 +57,7 @@ additional_artifact_stores = [
 EOF
 
 	run -1 "$CRIO_BINARY_PATH" --config-dir "$CRIO_CONFIG_DIR" config
-	[[ "$output" == *'additional_artifact_stores entry must be absolute'* ]]
+	[[ "$output" == *'must be absolute'* ]]
 	[[ "$output" == *'./relative/path/store'* ]]
 }
 


### PR DESCRIPTION
Backport of #10254.

/kind cleanup

Replace the minimal filepath.IsAbs() check for additional artifact store paths with full validation matching the MCO's validateStorePath(): regex for allowed characters, no consecutive slashes, no '..' traversal, and max-length of 256.

This provides defense-in-depth consistency: if a config file is edited directly (bypassing MCO validation), CRI-O now rejects the same invalid paths the CRD would.

```release-note
None
```