### PR TITLE
oci: fix goroutine leak in AttachContainer

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1407,7 +1407,7 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 
 	defer conn.Close()
 
-	receiveStdout := make(chan error)
+	receiveStdout := make(chan error, 1)
 
 	go func() {
 		receiveStdout <- redirectResponseToOutputStreams(outputStream, errorStream, conn)
@@ -1415,7 +1415,7 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 		close(receiveStdout)
 	}()
 
-	stdinDone := make(chan error)
+	stdinDone := make(chan error, 1)
 
 	go func() {
 		var err, closeErr error

--- a/internal/oci/runtime_oci_attach_leak_linux_test.go
+++ b/internal/oci/runtime_oci_attach_leak_linux_test.go
@@ -1,0 +1,211 @@
+package oci_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/oci"
+	libconfig "github.com/cri-o/cri-o/pkg/config"
+)
+
+type discardWriteCloser struct{ io.Writer }
+
+func (discardWriteCloser) Close() error { return nil }
+
+type attachWorkerState struct {
+	workers int
+	senders int
+}
+
+// attachWorkers finds AttachContainer's result workers by function name rather
+// than closure number, which shifts when unrelated literals are added.
+func attachWorkers() attachWorkerState {
+	bufSize := 1 << 20
+
+	for {
+		buf := make([]byte, bufSize)
+
+		n := runtime.Stack(buf, true)
+		if n == len(buf) {
+			bufSize *= 2
+
+			continue
+		}
+
+		state := attachWorkerState{}
+
+		for stack := range strings.SplitSeq(string(buf[:n]), "\n\n") {
+			if !strings.Contains(stack, "AttachContainer.func") {
+				continue
+			}
+
+			state.workers++
+			if strings.Contains(stack, "chan send") {
+				state.senders++
+			}
+		}
+
+		return state
+	}
+}
+
+func expectAttachWorkersExit(before attachWorkerState) {
+	GinkgoHelper()
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	for {
+		current := attachWorkers()
+		if current.senders > before.senders {
+			Fail(fmt.Sprintf("AttachContainer stranded %d sender goroutine(s)", current.senders-before.senders))
+		}
+
+		if current.workers <= before.workers {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			Fail(fmt.Sprintf("AttachContainer left %d worker goroutine(s) running", current.workers-before.workers))
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func newAttachTestFixture() (*net.UnixListener, oci.RuntimeOCI, *oci.Container) {
+	GinkgoHelper()
+
+	sockDir := t.MustTempDir("attach-socket")
+	bundleDir := t.MustTempDir("attach-bundle")
+
+	Expect(os.WriteFile(filepath.Join(bundleDir, "ctl"), nil, 0o600)).To(Succeed())
+
+	const testContainerID = "attach-leak-test"
+
+	Expect(os.MkdirAll(filepath.Join(sockDir, testContainerID), 0o750)).To(Succeed())
+
+	listener, err := net.ListenUnix("unixpacket", &net.UnixAddr{
+		Name: filepath.Join(sockDir, testContainerID, "attach"),
+		Net:  "unixpacket",
+	})
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(listener.Close()).To(Succeed())
+	})
+
+	cfg, err := libconfig.DefaultConfig()
+	Expect(err).NotTo(HaveOccurred())
+
+	cfg.ContainerAttachSocketDir = sockDir
+
+	r, err := oci.New(cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	container, err := oci.NewContainer(testContainerID, "name", bundleDir, "logPath",
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"image", nil, nil, "", &types.ContainerMetadata{}, "sandbox",
+		false, true, false, "", t.MustTempDir("attach-dir"), time.Now(), "")
+	Expect(err).NotTo(HaveOccurred())
+
+	return listener, oci.NewRuntimeOCI(r, &libconfig.RuntimeHandler{}), container
+}
+
+func runAttach(runtimeOCI oci.RuntimeOCI, container *oci.Container, input io.Reader) <-chan error {
+	done := make(chan error, 1)
+
+	go func() {
+		done <- runtimeOCI.AttachContainer(context.Background(), container, input,
+			discardWriteCloser{io.Discard}, discardWriteCloser{io.Discard}, false, nil)
+	}()
+
+	return done
+}
+
+func drainAttachPeer(listener *net.UnixListener) <-chan error {
+	done := make(chan error, 1)
+
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			done <- err
+
+			return
+		}
+		defer conn.Close()
+
+		var buf [512]byte
+		for {
+			if _, err := conn.Read(buf[:]); err != nil {
+				done <- nil
+
+				return
+			}
+		}
+	}()
+
+	return done
+}
+
+func closeAttachPeer(listener *net.UnixListener) <-chan error {
+	done := make(chan error, 1)
+
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			done <- err
+
+			return
+		}
+
+		done <- conn.Close()
+	}()
+
+	return done
+}
+
+var _ = t.Describe("Oci", func() {
+	Context("AttachContainer result workers", func() {
+		It("does not strand the stdout sender when stdin completes first", func() {
+			listener, runtimeOCI, container := newAttachTestFixture()
+			before := attachWorkers()
+			peerDone := drainAttachPeer(listener)
+			attachDone := runAttach(runtimeOCI, container, nil)
+
+			var attachErr error
+			Eventually(attachDone, 30*time.Second).Should(Receive(&attachErr))
+			Expect(attachErr).NotTo(HaveOccurred())
+			Eventually(peerDone, 5*time.Second).Should(Receive(Succeed()))
+			expectAttachWorkersExit(before)
+		})
+
+		It("does not strand the stdin sender when stdout completes first", func() {
+			listener, runtimeOCI, container := newAttachTestFixture()
+			before := attachWorkers()
+			inputReader, inputWriter := io.Pipe()
+
+			DeferCleanup(func() {
+				_ = inputReader.Close()
+				_ = inputWriter.Close()
+			})
+
+			peerDone := closeAttachPeer(listener)
+			attachDone := runAttach(runtimeOCI, container, inputReader)
+
+			Eventually(peerDone, 5*time.Second).Should(Receive(Succeed()))
+			Eventually(attachDone, 30*time.Second).Should(Receive())
+			Expect(inputWriter.Close()).To(Succeed())
+			expectAttachWorkersExit(before)
+		})
+	})
+})


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes a goroutine leak in `runtimeOCI.AttachContainer` (`internal/oci/runtime_oci.go`).

The function waits on two unbuffered one-shot result channels (`receiveStdout`, `stdinDone`) and can return after either worker completes. The other worker then blocks forever when it eventually sends its result to a channel nobody receives from. Each triggering attach leaks one goroutine for the life of the daemon. This matches the "Early return" pattern from https://go.dev/blog/goroutine-leak-profiles.

Buffer both result channels (capacity 1) so either one-shot worker can complete its result send after the parent has returned. Behavior is otherwise unchanged.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Linux-specific Ginkgo regression specs drive the real `AttachContainer` against a fake `unixpacket` server and verify both completion orders:

- stdin completes first and the stdout worker sends after `AttachContainer` returns;
- stdout completes first and a blocked input reader is released after `AttachContainer` returns.

The checks detect both stranded senders and successful worker exit. Goroutine stack capture grows its buffer when needed rather than silently accepting a truncated dump.

Validated in a local Linux/arm64 Docker container with Go 1.26.6. Without the channel buffers, each case fails immediately with the expected leak:

```text
[FAILED] AttachContainer stranded 1 sender goroutine(s)
```

With the fix:

```text
Ran 2 of 93 Specs in 0.045 seconds
SUCCESS! -- 2 Passed | 0 Failed | 91 Skipped
PASS
ok      github.com/cri-o/cri-o/internal/oci  0.061s
```

The repository-pinned golangci-lint v2.12.2 passes for `internal/oci/...`; `gofmt` and `git diff --check` are clean.

The test remains in a `_linux_test.go` file because it requires `unixpacket`, while registering its specs with the existing Ginkgo suite.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a goroutine leak in OCI container attach sessions.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container attachment handling to prevent background processing from becoming stuck when input or output processing completes early.
  * Improved reliability for non-terminal container attachments, including sessions without an input stream.
  * Reduced the risk of attachment sessions failing to complete cleanly or leaving background activity running indefinitely.

* **Tests**
  * Added coverage for attachment cleanup across different input and output completion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->