### PR TITLE
ci: fix failures in kata_remote.bats execution

### DIFF
--- a/contrib/test/ci/build/kata.yml
+++ b/contrib/test/ci/build/kata.yml
@@ -238,3 +238,12 @@
         podman logs caa 2>&1 | tail -30
       args:
         executable: /bin/bash
+
+    - name: Stream CAA logs to artifact file
+      become: yes
+      shell: |
+        mkdir -p /tmp/artifacts
+        nohup podman logs -f caa >> /tmp/artifacts/caa.log 2>&1 &
+        echo $! > /tmp/caa_log_pid
+      args:
+        executable: /bin/bash

--- a/contrib/test/ci/integration-main.yml
+++ b/contrib/test/ci/integration-main.yml
@@ -26,6 +26,13 @@
     - name: run cri-o integration tests
       include_tasks: "integration.yml"
 
+    - name: stop CAA log streaming
+      become: yes
+      shell: kill $(cat /tmp/caa_log_pid) 2>/dev/null || true
+      args:
+        executable: /bin/bash
+      when: "build_kata | default(False) | bool"
+
     - name: changing permission of temp file
       become: yes
       file: dest=/tmp/artifacts owner=deadbeef group=deadbeef mode=0777 recurse=yes

--- a/test/kata-remote.bats
+++ b/test/kata-remote.bats
@@ -39,15 +39,42 @@ function require_caa() {
 	[[ "$caa_status" == "running" ]]
 }
 
+# wait_caa_vm_deleted polls the CAA container log until it confirms the peer
+# pod VM for the given sandbox has been fully deleted by libvirt.
+#
+# The VM name in CAA logs is derived from the first 8 hex chars of the sandbox
+# ID: podvm-podsandbox1-<pod_id[:8]>.  After the volumes are removed, the CAA
+# logs "deleted an instance N".  The awk pattern below waits for that sequence.
+function wait_caa_vm_deleted() {
+	local pod_id=$1
+	local vm_prefix="podvm-podsandbox1-${pod_id:0:8}"
+	local timeout=60
+	local elapsed=0
+
+	while [[ $elapsed -lt $timeout ]]; do
+		if sudo podman logs caa 2>&1 |
+			awk "/Deleting volume ${vm_prefix}/{found=1} found && /deleted an instance/{found=2; exit} END{exit (found < 2)}"; then
+			return 0
+		fi
+		sleep 2
+		((elapsed += 2))
+	done
+	echo "timeout: CAA did not confirm deletion of VM ${vm_prefix} after ${timeout}s" >&2
+	return 1
+}
+
 function cleanup() {
 	local ctr_id=$1
 	local pod_id=$2
+	local kata=${3:-true}
 
 	crictl stop "$ctr_id"
 	crictl rm "$ctr_id"
 	crictl stopp "$pod_id"
 	crictl rmp "$pod_id"
-
+	if [[ "$kata" == "true" ]]; then
+		wait_caa_vm_deleted "$pod_id"
+	fi
 }
 
 @test "Container creation with runtime_pull_image=true" {
@@ -290,6 +317,7 @@ function cleanup() {
 	# removes the on-disk artifact store under the pod's run directory.
 	crictl stopp "$pod_a"
 	crictl rmp "$pod_a"
+	wait_caa_vm_deleted "$pod_a"
 
 	# Pod B is a fresh sandbox with its own empty artifact store.
 	local pod_b
@@ -301,6 +329,7 @@ function cleanup() {
 
 	crictl stopp "$pod_b"
 	crictl rmp "$pod_b"
+	wait_caa_vm_deleted "$pod_b"
 }
 
 @test "runtime_pull_image: same image stored in artifact store for kata and containers/storage for default" {
@@ -364,7 +393,7 @@ function cleanup() {
 	[[ -n "$(crictl images --quiet "$test_image")" ]]
 
 	cleanup "$kata_ctr_id" "$kata_pod_id"
-	cleanup "$default_ctr_id" "$default_pod_id"
+	cleanup "$default_ctr_id" "$default_pod_id" false
 }
 
 @test "runtime_pull_image: runtimePulledImageService pulls own manifest even when image is already in containers/storage" {


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Adding some debug logs: Stream the Cloud API Adaptor container logs to /tmp/artifacts/caa.log from the moment CAA starts until the integration tests finish, so that peer pod failures (e.g. in-VM image pull errors) are captured alongside the test output.

Also add some synchronization to the kata_remote.bats tests: they are all run sequentially, and the intermittent failure we get seem to come from situations where the previous test is not totally cleaned up when the new one starts. The synchronization uses the logs from our proxy container "cloud-api-adaptor" (aka "CAA") to verify that the created VM was properly deleted before getting out of each test.

#### Which issue(s) this PR fixes:

Fixes #10290

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - CI integration tests now capture Cloud API Adaptor container logs as build artifacts.
  - Log collection stops automatically after integration tests complete.
  - Kata integration testing now runs the `kata-remote.bats` test file.
  - Sandbox cleanup now polls for virtual machine deletion events after pod removal, for up to 60 seconds.
  - Default-runtime cleanup skips the virtual machine deletion wait.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->