### PR TITLE
WIP oci: fix goroutine leak in VM ExecSync

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -614,20 +614,31 @@ func (r *runtimeVM) execContainerCommon(ctx context.Context, c *Container, cmd [
 		timeoutCh = time.After(timeoutDuration)
 	}
 
-	execCh := make(chan error)
+	// execOutcome carries the one-shot result of the wait worker. The
+	// channel is buffered so the worker can publish after the parent has
+	// returned on the timeout Kill-failure path, and the worker only
+	// touches its own locals so it can never race the named returns.
+	type execOutcome struct {
+		code int32
+		err  error
+	}
+
+	execCh := make(chan execOutcome, 1)
 
 	go func() {
-		// Wait for the process to terminate
-		exitCode, err = r.wait(c.ID(), execID)
-		if err != nil {
-			execCh <- err
-		}
+		// Wait for the process to terminate. Publish to worker-local
+		// values only: the parent may already have returned on the
+		// timeout Kill-failure path, so the worker must not assign the
+		// named return variables.
+		code, err := r.wait(c.ID(), execID)
+		execCh <- execOutcome{code: code, err: err}
 
 		close(execCh)
 	}()
 
 	select {
-	case err = <-execCh:
+	case outcome := <-execCh:
+		exitCode, err = outcome.code, outcome.err
 		if err != nil {
 			if killErr := r.kill(c.ID(), execID, syscall.SIGKILL); killErr != nil {
 				return execError, killErr

--- a/internal/oci/runtime_vm_exec_leak_test.go
+++ b/internal/oci/runtime_vm_exec_leak_test.go
@@ -1,0 +1,220 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/ttrpc"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"google.golang.org/protobuf/types/known/emptypb"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/pkg/config"
+)
+
+// countExecWaitSenders counts goroutines blocked sending inside the
+// execContainerCommon wait worker. It is a secondary signal; the primary
+// oracle is that Wait can return after the parent took the timeout
+// Kill-failure path without stranding the worker.
+func countExecWaitSenders() int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+
+	count := 0
+
+	for s := range strings.SplitSeq(string(buf[:n]), "\n\n") {
+		if strings.Contains(s, "execContainerCommon") && strings.Contains(s, "chan send") {
+			count++
+		}
+	}
+
+	return count
+}
+
+// fakeVMTask is a controllable task.TaskService for exec tests. Wait blocks
+// until releaseWait is closed and then returns waitErr, mimicking a pending
+// remote Wait that resolves after the parent timed out. Kill fails with
+// killErr to mimic the ttrpc connection closing before/during the timeout
+// kill, which makes the parent return without draining execCh.
+type fakeVMTask struct {
+	task.TaskService
+
+	mu          sync.Mutex
+	waitStarted chan struct{}
+	releaseWait chan struct{}
+	waitErr     error
+	killErr     error
+	waitCalls   int
+	killCalls   int
+
+	once sync.Once
+}
+
+func newFakeVMTask(waitErr, killErr error) *fakeVMTask {
+	return &fakeVMTask{
+		waitStarted: make(chan struct{}),
+		releaseWait: make(chan struct{}),
+		waitErr:     waitErr,
+		killErr:     killErr,
+	}
+}
+
+func (f *fakeVMTask) Exec(_ context.Context, _ *task.ExecProcessRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (f *fakeVMTask) Start(_ context.Context, _ *task.StartRequest) (*task.StartResponse, error) {
+	return &task.StartResponse{}, nil
+}
+
+func (f *fakeVMTask) Delete(_ context.Context, _ *task.DeleteRequest) (*task.DeleteResponse, error) {
+	return &task.DeleteResponse{}, nil
+}
+
+func (f *fakeVMTask) CloseIO(_ context.Context, _ *task.CloseIORequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (f *fakeVMTask) Wait(_ context.Context, _ *task.WaitRequest) (*task.WaitResponse, error) {
+	f.mu.Lock()
+	f.waitCalls++
+	f.mu.Unlock()
+	f.once.Do(func() { close(f.waitStarted) })
+
+	<-f.releaseWait
+
+	if f.waitErr != nil {
+		return nil, f.waitErr
+	}
+
+	return &task.WaitResponse{ExitStatus: 0}, nil
+}
+
+func (f *fakeVMTask) Kill(_ context.Context, _ *task.KillRequest) (*emptypb.Empty, error) {
+	f.mu.Lock()
+	f.killCalls++
+	f.mu.Unlock()
+
+	if f.killErr != nil {
+		return nil, f.killErr
+	}
+
+	return &emptypb.Empty{}, nil
+}
+
+// discardWriteCloser sinks exec output; Close is a no-op because the test
+// never observes close signals.
+type discardWriteCloser struct{}
+
+func (discardWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (discardWriteCloser) Close() error                { return nil }
+
+func newTestVMContainer(t *testing.T, id string) *Container {
+	t.Helper()
+
+	c, err := NewContainer(id, "name", t.TempDir(), t.TempDir()+"/log",
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"image", nil, nil, "", &types.ContainerMetadata{}, "sandbox",
+		false, false, false, "", t.TempDir(), time.Now(), "")
+	if err != nil {
+		t.Fatalf("create test container: %v", err)
+	}
+
+	c.SetSpec(&rspec.Spec{
+		Process: &rspec.Process{
+			Args: []string{"echo", "hi"},
+			Cwd:  "/",
+			Env:  []string{},
+		},
+	})
+
+	return c
+}
+
+// TestRuntimeVMExecContainerCommonTimeoutKillFailure is a regression test for
+// a goroutine leak in execContainerCommon: with an unbuffered execCh, a
+// timeout followed by a failed Kill makes the parent return without ever
+// receiving from execCh, so the wait worker blocks forever on its one-shot
+// send once the pending Wait resolves. Buffering execCh (capacity 1) lets
+// that late send complete.
+func TestRuntimeVMExecContainerCommonTimeoutKillFailure(t *testing.T) {
+	before := countExecWaitSenders()
+
+	// Faithful to the audit schedule: the pending Wait resolves with a
+	// closed-connection error after the timeout Kill fails.
+	fake := newFakeVMTask(ttrpc.ErrClosed, errors.New("injected kill failure"))
+
+	// Build through the constructor so typeurl registrations for the exec
+	// spec survive, then swap in the controllable task service.
+	root := t.TempDir()
+	rr, ok := newRuntimeVM(&config.RuntimeHandler{RuntimeRoot: root}, t.TempDir()).(*runtimeVM)
+	if !ok {
+		t.Fatal("newRuntimeVM did not return *runtimeVM")
+	}
+	rr.task = fake
+	rr.ctx = context.Background()
+	r := rr
+	c := newTestVMContainer(t, "vm-exec-leak")
+
+	done := make(chan struct {
+		code int32
+		err  error
+	}, 1)
+	go func() {
+		code, err := r.execContainerCommon(context.Background(), c, []string{"echo", "hi"}, 1, nil, discardWriteCloser{}, discardWriteCloser{}, false, nil)
+		done <- struct {
+			code int32
+			err  error
+		}{code, err}
+	}()
+
+	// Wait until the worker is inside the pending Wait, then let the
+	// 1-second timeout fire and take the Kill-failure return. Surface an
+	// early return (e.g. spec marshal or Exec/Start failure) instead of
+	// hanging on waitStarted.
+	select {
+	case <-fake.waitStarted:
+	case res := <-done:
+		t.Fatalf("execContainerCommon returned early: code=%d err=%v", res.code, res.err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Wait never started")
+	}
+
+	var res struct {
+		code int32
+		err  error
+	}
+	select {
+	case res = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("execContainerCommon did not return after timeout")
+	}
+
+	if res.err == nil || !strings.Contains(res.err.Error(), "injected kill failure") {
+		t.Fatalf("execContainerCommon error = %v, want injected kill failure", res.err)
+	}
+
+	// Release the pending Wait after the parent returned. Before the fix
+	// this strands the worker on `execCh <- err`; after the fix the
+	// buffered send completes and the worker exits.
+	close(fake.releaseWait)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if countExecWaitSenders()-before == 0 {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("execContainerCommon stranded %d sender goroutine(s)", countExecWaitSenders()-before)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes a goroutine leak in `runtimeVM.execContainerCommon` (`internal/oci/runtime_vm.go`).

The function starts a wait worker publishing to unbuffered `execCh`. On timeout + Kill failure the parent returns without `<-execCh`, stranding the worker once the pending Wait resolves (e.g. ttrpc.ErrClosed -> ErrNotFound).

Buffer the one-shot result channel (capacity 1) so the worker can always publish. The worker publishes to its own locals (`execOutcome{code, err}`) and never assigns the named returns, so it cannot race the parent's timeout return. Behavior otherwise unchanged.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

New regression test `TestRuntimeVMExecContainerCommonTimeoutKillFailure` drives the real `execContainerCommon` with a controllable fake task service (Wait blocks, Kill fails, 1s timeout), requires the Kill-failure return, releases Wait with ttrpc.ErrClosed, and requires worker exit via stack scan. Proof on Linux (Go 1.26, Docker):

Without the fix (temporarily unbuffered) — worker strands:

```text
--- FAIL: TestRuntimeVMExecContainerCommonTimeoutKillFailure (11s)
    execContainerCommon stranded 1 sender goroutine(s)
FAIL
```

With the fix — passes, including race stress:

```text
--- PASS: TestRuntimeVMExecContainerCommonTimeoutKillFailure (1.01s)
PASS
```

Full `internal/oci` package suite: `ok ... ~36.7s`. `go test -race -count=5` on the new test: pass. `go vet`, `gofmt`, and `git diff --check` clean.

Update: hardened the worker to use locals instead of assigning the shared named `exitCode` (a `-race` write/write race now that the worker completes instead of leaking); success/timeout-drain semantics unchanged. Re-validated: target test + `-race -count=5` PASS.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a goroutine leak in VM ExecSync timeout handling.
```

