### PR TITLE
WIP oci: fix goroutine leak in TTY exec teardown

### DIFF
--- a/internal/oci/oci_unix.go
+++ b/internal/oci/oci_unix.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/creack/pty"
 	"github.com/sirupsen/logrus"
@@ -17,6 +18,47 @@ import (
 
 	"github.com/cri-o/cri-o/utils"
 )
+
+// ttyTeardownTimeout bounds each teardown step after the TTY command exits,
+// so a backpressured output stream cannot gate return indefinitely when the
+// streaming idle timeout is disabled.
+const ttyTeardownTimeout = 5 * time.Second
+
+// streamResetter is implemented by streaming transports (SPDY, WebSocket)
+// whose Reset fully tears down both directions of a stream.
+type streamResetter interface {
+	Reset() error
+}
+
+// asyncReset best-effort resets a connection-owned stream without blocking
+// teardown on the reset frame write. For SPDY the local remote channels are
+// closed before the RST frame is queued, so a reader parked in Stream.Read
+// is released even while a graceful output write holds the framer lock.
+func asyncReset(s any) {
+	if r, ok := s.(streamResetter); ok && r != nil {
+		go func() {
+			_ = r.Reset()
+		}()
+	}
+}
+
+// closeWithTimeout bounds a potentially blocking graceful stream close
+// (a FIN write contends for the same framer lock as a stalled data write).
+// On timeout the caller should fall back to a full reset and return so the
+// connection-level teardown in ServeExec can release the transport.
+func closeWithTimeout(c io.Closer, timeout time.Duration) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Close()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s waiting for stream close", timeout)
+	}
+}
 
 // ptyStarter wraps pty.Start to implement the ExecStarter interface.
 // It stores the pty file descriptor for later use after Start() is called.
@@ -66,9 +108,6 @@ func ttyCmd(execCmd *exec.Cmd, stdin io.Reader, stdout io.WriteCloser, resizeCha
 	defer c.DeleteExecPID(pid)
 
 	p := starter.Pty()
-	defer p.Close()
-	// make sure to close the stdout stream
-	defer stdout.Close()
 
 	utils.HandleResizing(resizeChan, func(size remotecommand.TerminalSize) {
 		if err := setSize(p.Fd(), size); err != nil {
@@ -76,17 +115,73 @@ func ttyCmd(execCmd *exec.Cmd, stdin io.Reader, stdout io.WriteCloser, resizeCha
 		}
 	})
 
-	var stdinErr, stdoutErr error
+	// Buffered so neither copier blocks on reporting after teardown stops
+	// waiting for them.
+	stdinDone := make(chan error, 1)
+	stdoutDone := make(chan error, 1)
 
 	if stdin != nil {
-		go func() { _, stdinErr = pools.Copy(p, stdin) }()
+		go func() {
+			_, err := pools.Copy(p, stdin)
+			stdinDone <- err
+		}()
+	} else {
+		stdinDone <- nil
 	}
 
 	if stdout != nil {
-		go func() { _, stdoutErr = pools.Copy(stdout, p) }()
+		go func() {
+			_, err := pools.Copy(stdout, p)
+			stdoutDone <- err
+		}()
+	} else {
+		stdoutDone <- nil
 	}
 
 	err = execCmd.Wait()
+
+	// Break the SPDY backpressure cycle before any potentially blocking
+	// graceful close: the command has exited, so no further input is needed.
+	// Resetting the connection-owned stdin stream releases a copier parked
+	// in Stream.Read independently of outbound writes.
+	if stdin != nil {
+		asyncReset(stdin)
+	}
+
+	// Join the copiers, but do not let backpressured output gate return:
+	// ServeExec's deferred connection teardown is the actor that releases
+	// the transport, and it is only reachable once ttyCmd returns. The PTY
+	// is deliberately left open while joining so healthy output still
+	// drains instead of being discarded by an early master close.
+	timeout := time.After(ttyTeardownTimeout)
+	var stdinErr, stdoutErr error
+
+	stdinJoined, stdoutJoined := false, false
+	for !stdinJoined || !stdoutJoined {
+		select {
+		case stdinErr = <-stdinDone:
+			stdinJoined = true
+		case stdoutErr = <-stdoutDone:
+			stdoutJoined = true
+		case <-timeout:
+			logrus.Warnf("Timed out after %s waiting for TTY copy workers to exit", ttyTeardownTimeout)
+			stdinJoined, stdoutJoined = true, true
+		}
+	}
+
+	// Release copiers parked on the PTY side once draining is done or the
+	// join above gave up waiting.
+	_ = p.Close()
+
+	// A graceful FIN contends for the same framer lock as a stalled data
+	// write, so bound it even when the streaming idle timeout is disabled.
+	// On timeout fall back to a full reset so teardown still completes.
+	if stdout != nil {
+		if closeErr := closeWithTimeout(stdout, ttyTeardownTimeout); closeErr != nil {
+			logrus.Warnf("Stalled TTY stdout close, resetting stream: %v", closeErr)
+			asyncReset(stdout)
+		}
+	}
 
 	if stdinErr != nil {
 		logrus.Warnf("Stdin copy error: %v", stdinErr)

--- a/internal/oci/oci_unix_tty_teardown_test.go
+++ b/internal/oci/oci_unix_tty_teardown_test.go
@@ -1,0 +1,160 @@
+//go:build !windows
+
+package oci
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// gatedStream models a backpressured SPDY stream: reads block until Reset
+// (like Stream.Read selecting on closeChan), writes block until Reset (like a
+// data write stalled on the framer lock / transport backpressure), and Close
+// blocks while backpressured (like a FIN write contending for the same lock).
+// Reset releases local waiters immediately, mirroring closeRemoteChannels
+// running before the RST frame write.
+type gatedStream struct {
+	done       chan struct{}
+	once       sync.Once
+	resetCalls atomic.Int32
+}
+
+func newGatedStream() *gatedStream {
+	return &gatedStream{done: make(chan struct{})}
+}
+
+func (g *gatedStream) Reset() error {
+	g.resetCalls.Add(1)
+	g.once.Do(func() { close(g.done) })
+
+	return nil
+}
+
+func (g *gatedStream) resetDone() <-chan struct{} {
+	return g.done
+}
+
+type gatedStdin struct {
+	*gatedStream
+}
+
+func (s *gatedStdin) Read(p []byte) (int, error) {
+	select {
+	case <-s.resetDone():
+		return 0, io.EOF
+	case <-time.After(30 * time.Second):
+		return 0, errors.New("test timeout: stdin Read was never reset")
+	}
+}
+
+type gatedStdout struct {
+	*gatedStream
+}
+
+func (s *gatedStdout) Write(p []byte) (int, error) {
+	select {
+	case <-s.resetDone():
+		return 0, errors.New("stream reset")
+	case <-time.After(30 * time.Second):
+		return 0, errors.New("test timeout: stdout Write was never reset")
+	}
+}
+
+func (s *gatedStdout) Close() error {
+	select {
+	case <-s.resetDone():
+		return nil
+	case <-time.After(30 * time.Second):
+		return nil
+	}
+}
+
+func newTTYTestContainer(t *testing.T) *Container {
+	t.Helper()
+
+	c, err := NewContainer("tty-teardown-test", "name", t.TempDir(), "logPath",
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"image", nil, nil, "", &types.ContainerMetadata{}, "sandbox",
+		false, false, false, "", t.TempDir(), time.Now(), "")
+	if err != nil {
+		t.Fatalf("create test container: %v", err)
+	}
+
+	return c
+}
+
+// TestTTYCmdTeardownUnderOutputBackpressure reproduces A4: the command exits
+// while the stdin copier is parked in Read and the stdout copier is parked in
+// a backpressured Write. Without the fix, the deferred graceful stdout.Close
+// blocks behind the stalled write, ttyCmd never returns, and ServeExec's
+// deferred connection reset is unreachable. The fix must reset the
+// connection-owned stdin stream and bound the output close so ttyCmd returns.
+func TestTTYCmdTeardownUnderOutputBackpressure(t *testing.T) {
+	stdin := &gatedStdin{gatedStream: newGatedStream()}
+	stdout := &gatedStdout{gatedStream: newGatedStream()}
+
+	// Exits immediately with finite output; teardown must not wait for the
+	// gated peer.
+	execCmd := exec.Command("sh", "-c", "echo hi; exit 0")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ttyCmd(execCmd, stdin, stdout, nil, newTTYTestContainer(t))
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ttyCmd returned error: %v", err)
+		}
+	case <-time.After(25 * time.Second):
+		t.Fatal("ttyCmd did not return within 25s under output backpressure (teardown cycle)")
+	}
+
+	if stdin.resetCalls.Load() == 0 {
+		t.Fatal("command completion did not reset the stdin stream")
+	}
+}
+
+// TestTTYCmdHappyPathPreservesOutput guards the normal path: with a draining
+// peer, output is still copied and the command result returned.
+func TestTTYCmdHappyPathPreservesOutput(t *testing.T) {
+	stdin := strings.NewReader("")
+	var stdout bytes.Buffer
+
+	execCmd := exec.Command("sh", "-c", "echo hello; exit 0")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ttyCmd(execCmd, stdin, discardTTYCloser{Writer: &stdout}, nil, newTTYTestContainer(t))
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ttyCmd returned error: %v", err)
+		}
+	case <-time.After(25 * time.Second):
+		t.Fatal("ttyCmd did not return within 25s on happy path")
+	}
+
+	if !strings.Contains(stdout.String(), "hello") {
+		t.Fatalf("expected PTY output to contain %q, got %q", "hello", stdout.String())
+	}
+}
+
+type discardTTYCloser struct {
+	io.Writer
+}
+
+// discardTTYCloser collects PTY output without observing close signals.
+func (discardTTYCloser) Close() error { return nil }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes a goroutine leak in TTY exec teardown (`internal/oci/oci_unix.go`).

With SPDY output backpressure and `stream_idle_timeout="0"`, teardown can cycle: `ttyCmd` LIFO defers stdout.Close before PTY close; the close blocks on the framer writeLock held by the blocked stdout copier while stdin copier stays blocked, so ServeExec deferred connection reset is never reached.

Rework ttyCmd teardown: reset connection-owned stdin on command completion (releases SPDY Stream.Read independently of output backpressure), join copy workers with a 5s bound, then PTY close, then bounded graceful stdout close with reset fallback.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

New tests `TestTTYCmdTeardownUnderOutputBackpressure` (gated SPDY-like streams, finite command, asserts return + stdin reset) and `TestTTYCmdHappyPathPreservesOutput` (output preserved on draining peer). Proof on Linux (Go 1.26, Docker):

Without the fix (fix stashed) — teardown never completes:

```text
--- FAIL: TestTTYCmdTeardownUnderOutputBackpressure
    ttyCmd did not return within 25s
FAIL
```

With the fix — both pass (~10s = two 5s teardown bounds):

```text
--- PASS: TestTTYCmdTeardownUnderOutputBackpressure (~10s)
--- PASS: TestTTYCmdHappyPathPreservesOutput
PASS
```

Full `./internal/oci` suite: `ok ... 45.5s`. `-race`: pass. `gofmt`, `git diff --check`, and `go vet` clean. Docker `golang:1.26.6-bookworm`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a goroutine leak in TTY exec teardown under output backpressure.
```

