### PR TITLE
WIP oci: fix goroutine leak in log reopen watcher

### DIFF
--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1482,14 +1482,26 @@ func (r *runtimeOCI) ReopenContainerLog(ctx context.Context, c *Container) error
 	}
 	defer watcher.Close()
 
-	done := make(chan struct{})
-	doneClosed := false
-	errorCh := make(chan error)
+	cLogDir := filepath.Dir(c.LogPath())
+	if err := watcher.Add(cLogDir); err != nil {
+		return fmt.Errorf("failed to watch log directory %q: %w", cLogDir, err)
+	}
+
+	// Buffered so the one-shot worker never blocks on signal delivery: the
+	// parent receives exactly one of them in the select below. The goroutine
+	// is started only after a successful Add, so every launch has a live
+	// fsnotify backend and no Add-failure path can strand it.
+	done := make(chan struct{}, 1)
+	errorCh := make(chan error, 1)
 
 	go func() {
 		for {
 			select {
-			case event := <-watcher.Events:
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
 				log.Debugf(ctx, "Event: %v", event)
 
 				if event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write {
@@ -1498,28 +1510,28 @@ func (r *runtimeOCI) ReopenContainerLog(ctx context.Context, c *Container) error
 					if event.Name == c.LogPath() {
 						log.Debugf(ctx, "Expected log file created")
 
-						done <- struct{}{}
+						select {
+						case done <- struct{}{}:
+						default:
+						}
 
 						return
 					}
 				}
-			case err := <-watcher.Errors:
-				errorCh <- fmt.Errorf("watch error for container log reopen %v: %w", c.ID(), err)
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
 
-				close(errorCh)
+				select {
+				case errorCh <- fmt.Errorf("watch error for container log reopen %v: %w", c.ID(), err):
+				default:
+				}
 
 				return
 			}
 		}
 	}()
-
-	cLogDir := filepath.Dir(c.LogPath())
-	if err := watcher.Add(cLogDir); err != nil {
-		log.Errorf(ctx, "Watcher.Add(%q) failed: %s", cLogDir, err)
-		close(done)
-
-		doneClosed = true
-	}
 
 	if _, err = fmt.Fprintf(controlFile, "%d %d %d\n", 2, 0, 0); err != nil {
 		log.Debugf(ctx, "Failed to write to control file to reopen log file: %v", err)
@@ -1527,20 +1539,10 @@ func (r *runtimeOCI) ReopenContainerLog(ctx context.Context, c *Container) error
 
 	select {
 	case err := <-errorCh:
-		if !doneClosed {
-			close(done)
-		}
-
 		return err
 	case <-done:
-		if !doneClosed {
-			close(done)
-		}
-
-		break
+		return nil
 	}
-
-	return nil
 }
 
 // prepareProcessExec returns the path of the process.json used in runc exec -p

--- a/internal/oci/runtime_oci_reopen_log_leak_test.go
+++ b/internal/oci/runtime_oci_reopen_log_leak_test.go
@@ -1,0 +1,140 @@
+package oci
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// newReopenTestContainer builds a minimal container pointing at bundleDir
+// and logPath for ReopenContainerLog tests.
+func newReopenTestContainer(t *testing.T, bundleDir, logPath string) *Container {
+	t.Helper()
+
+	c, err := NewContainer("reopen-leak-id", "name", bundleDir, logPath,
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"image", nil, nil, "", &types.ContainerMetadata{}, "sandbox",
+		false, false, false, "", t.TempDir(), time.Now(), "")
+	if err != nil {
+		t.Fatalf("create test container: %v", err)
+	}
+
+	return c
+}
+
+// writeCtl creates the bundle ctl file ReopenContainerLog opens.
+func writeCtl(t *testing.T, bundleDir string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(bundleDir, "ctl"), []byte{}, 0o644); err != nil {
+		t.Fatalf("write ctl file: %v", err)
+	}
+}
+
+// TestRuntimeOCIReopenContainerLogWatchFailure is a regression test for the
+// reopen-watcher leak: the watcher goroutine was launched before watcher.Add,
+// so a missing log directory closed done, returned nil, closed the fsnotify
+// channels, and stranded the worker on an unbuffered errorCh send. The
+// primary oracle requires the watch-add error to be returned; the goroutine
+// count must then settle back to baseline, proving repeated failing calls
+// accumulate no stranded watcher goroutines.
+func TestRuntimeOCIReopenContainerLogWatchFailure(t *testing.T) {
+	ctx := context.Background()
+	r := &runtimeOCI{}
+
+	bundleDir := t.TempDir()
+	writeCtl(t, bundleDir)
+
+	// Log directory intentionally absent so watcher.Add fails.
+	missingDir := filepath.Join(t.TempDir(), "missing-log-dir")
+	logPath := filepath.Join(missingDir, "ctr.log")
+	c := newReopenTestContainer(t, bundleDir, logPath)
+
+	err := r.ReopenContainerLog(ctx, c)
+	if err == nil {
+		t.Fatal("expected watch error for missing log directory, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to watch") {
+		t.Fatalf("error = %v, want watch failure", err)
+	}
+
+	// Repeated requests must keep failing the same way instead of
+	// accumulating stranded watcher goroutines.
+	baseline := runtime.NumGoroutine()
+	for range 20 {
+		if err := r.ReopenContainerLog(ctx, c); err == nil {
+			t.Fatal("expected watch error on repeated call, got nil")
+		}
+	}
+
+	// The failing path launches no goroutine, so the count must settle back
+	// to baseline instead of growing with each request.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if n := runtime.NumGoroutine(); n <= baseline {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutine count did not settle: baseline %d, now %d", baseline, runtime.NumGoroutine())
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestRuntimeOCIReopenContainerLogSuccessPath ensures the reordered watch
+// still observes the expected log file creation.
+func TestRuntimeOCIReopenContainerLogSuccessPath(t *testing.T) {
+	ctx := context.Background()
+	r := &runtimeOCI{}
+
+	bundleDir := t.TempDir()
+	writeCtl(t, bundleDir)
+
+	logDir := t.TempDir()
+	logPath := filepath.Join(logDir, "ctr.log")
+	c := newReopenTestContainer(t, bundleDir, logPath)
+
+	// Recreate the log file in a poll loop so the create event is guaranteed
+	// to fire after the watch is registered, no matter when Add happens.
+	stop := make(chan struct{})
+	defer close(stop)
+
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				_ = os.Remove(logPath)
+				_ = os.WriteFile(logPath, []byte("log"), 0o644)
+			}
+		}
+	}()
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- r.ReopenContainerLog(ctx, c)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ReopenContainerLog returned error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for ReopenContainerLog success path")
+	}
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes a goroutine leak in `ReopenContainerLog` (`internal/oci/runtime_oci.go`).

The function launched the watcher goroutine before watcher.Add. On missing log dir, Add failed, parent returned nil, deferred watcher.Close closed fsnotify chans, and the worker could strand on unbuffered errorCh.

Call watcher.Add before launch and return a wrapped error; buffered done/errorCh (cap 1) with non-blocking sends; comma-ok receives so Close lets the worker exit.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Tests `TestRuntimeOCIReopenContainerLogWatchFailure` (absent dir must return watch error, repeated requests do not accumulate) + `TestRuntimeOCIReopenContainerLogSuccessPath`. Proof on Linux (Go 1.26, Docker):

Without the fix — silent nil instead of the watch error:

```text
level=error msg="Watcher.Add(...) failed: no such file or directory"
    runtime_oci_reopen_log_leak_test.go:59: expected watch error for missing log directory, got nil
--- FAIL: TestRuntimeOCIReopenContainerLogWatchFailure
```

With the fix — passes, including race stress:

```text
=== RUN   TestRuntimeOCIReopenContainerLogWatchFailure
--- PASS: TestRuntimeOCIReopenContainerLogWatchFailure (0.00s)
=== RUN   TestRuntimeOCIReopenContainerLogSuccessPath
--- PASS: TestRuntimeOCIReopenContainerLogSuccessPath (0.21s)
PASS
ok      github.com/cri-o/cri-o/internal/oci 0.234s
```

`go test -race -count=5` on the new tests: `ok ... 2.1s`. `GOOS=linux go vet` pass; `gofmt` and `git diff --check` clean.

Update: buffering comment reworded to signal-decoupling; redundant `break` replaced with `return nil`; success-path test uses a poll-loop file write instead of a single 200ms-delayed create (removes the Add-vs-create flake); repeat-error test asserts no goroutine accumulation. Re-validated as above.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a goroutine leak in container log reopen handling.
```

