### PR TITLE
WIP server: fix goroutine leak in SIGHUP watcher

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -101,6 +101,19 @@ type Server struct {
 	hooksRetriever *runtimehandlerhooks.HooksRetriever
 
 	artifactStore *ociartifact.Store
+
+	// reloadWatcherDone closes to ask the SIGHUP reload watcher to exit.
+	// reloadWatcherStopped closes once that watcher has exited.
+	// Both are owned by startReloadWatcher and joined by stopReloadWatcher.
+	reloadWatcherDone     chan struct{}
+	reloadWatcherStopped  chan struct{}
+	reloadWatcherStopOnce sync.Once
+
+	// sighupReload performs one configuration reload for a SIGHUP
+	// notification. It is nil in production, in which case s.config.Reload
+	// is used; tests set it to observe HUP delivery without running the
+	// full production reload.
+	sighupReload func(ctx context.Context) error
 }
 
 // pullArguments are used to identify a pullOperation via an input image name and
@@ -341,6 +354,7 @@ func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 
 // Shutdown attempts to shut down the server's storage cleanly.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.stopReloadWatcher()
 	s.config.CNIManagerShutdown()
 	s.resourceStore.Close()
 
@@ -597,6 +611,7 @@ func New(
 	// Start the metrics server if configured to be enabled
 	if s.config.EnableMetrics {
 		if err := metrics.New(&s.config.MetricsConfig, &s.config.APIConfig).Start(ctx, s.monitorsChan); err != nil {
+			s.stopReloadWatcher()
 			return nil, err
 		}
 	} else {
@@ -606,12 +621,14 @@ func New(
 	if s.config.Seccomp().IsDisabled() {
 		log.Infof(ctx, "Seccomp is disabled. Not starting notifier watcher")
 	} else if err := s.startSeccompNotifierWatcher(ctx); err != nil {
+		s.stopReloadWatcher()
 		return nil, fmt.Errorf("start seccomp notifier watcher: %w", err)
 	}
 
 	// Set up our NRI adaptation.
 	api, err := nriIf.New(s.config.NRI.WithTracing(s.config.EnableTracing))
 	if err != nil {
+		s.stopReloadWatcher()
 		return nil, fmt.Errorf("failed to create NRI interface: %w", err)
 	}
 
@@ -621,10 +638,12 @@ func New(
 	}
 
 	if err := s.nri.start(); err != nil {
+		s.stopReloadWatcher()
 		return nil, err
 	}
 
 	if err := watchdog.New(s.checkCRIHealth).Start(ctx); err != nil {
+		s.stopReloadWatcher()
 		return nil, fmt.Errorf("start systemd watchdog: %w", err)
 	}
 
@@ -632,17 +651,51 @@ func New(
 }
 
 // startReloadWatcher starts a new SIGHUP go routine.
+// The watcher exits when stopReloadWatcher closes the Server-owned done
+// channel or when ctx is canceled, so a discarded Server never strands it.
 func (s *Server) startReloadWatcher(ctx context.Context) {
 	// Setup the signal notifier
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, signals.Hup)
+	s.serveReloadNotifications(ctx, ch)
+}
+
+// serveReloadNotifications serves configuration reloads for notifications
+// received on ch until stopReloadWatcher closes the Server-owned done
+// channel or ctx is canceled. Production passes the signal.Notify channel
+// created in startReloadWatcher; tests pass a synthetic channel and deliver
+// notifications directly, proving HUP wiring without signaling the test
+// process. signal.Stop is owned by the watcher goroutine and is a no-op for
+// channels that were never registered.
+func (s *Server) serveReloadNotifications(ctx context.Context, ch chan os.Signal) {
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	s.reloadWatcherDone = done
+	s.reloadWatcherStopped = stopped
+	s.reloadWatcherStopOnce = sync.Once{}
+
+	// s.config.Reload in production; tests override sighupReload to observe
+	// HUP delivery without running the full production reload.
+	reload := s.sighupReload
+	if reload == nil {
+		reload = s.config.Reload
+	}
 
 	go func() {
-		for {
-			// Block until the signal is received
-			<-ch
+		defer signal.Stop(ch)
+		defer close(stopped)
 
-			if err := s.config.Reload(ctx); err != nil {
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			// Block until the signal is received
+			case <-ch:
+			}
+
+			if err := reload(ctx); err != nil {
 				log.Errorf(ctx, "Unable to reload configuration: %v", err)
 
 				continue
@@ -675,6 +728,23 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 	}()
 
 	log.Infof(ctx, "Registered SIGHUP reload watcher")
+}
+
+// stopReloadWatcher asks the SIGHUP reload watcher to exit and waits for it.
+// It is idempotent and safe on a Server that never started the watcher.
+func (s *Server) stopReloadWatcher() {
+	if s == nil {
+		return
+	}
+
+	done := s.reloadWatcherDone
+	stopped := s.reloadWatcherStopped
+	if done == nil || stopped == nil {
+		return
+	}
+
+	s.reloadWatcherStopOnce.Do(func() { close(done) })
+	<-stopped
 }
 
 func useDefaultUmask(ctx context.Context) {

--- a/server/server_reload_watcher_leak_test.go
+++ b/server/server_reload_watcher_leak_test.go
@@ -1,0 +1,202 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cri-o/cri-o/internal/signals"
+)
+
+// reloadWatcherWorkers counts in-flight serveReloadNotifications goroutines
+// by function name rather than closure number, which shifts when unrelated
+// literals are added. The stack buffer grows instead of accepting a
+// truncated dump.
+func reloadWatcherWorkers() int {
+	bufSize := 1 << 20
+
+	for {
+		buf := make([]byte, bufSize)
+
+		n := runtime.Stack(buf, true)
+		if n == len(buf) {
+			bufSize *= 2
+
+			continue
+		}
+
+		workers := 0
+
+		for stack := range strings.SplitSeq(string(buf[:n]), "\n\n") {
+			if strings.Contains(stack, "serveReloadNotifications.func") {
+				workers++
+			}
+		}
+
+		return workers
+	}
+}
+
+func waitForReloadWatcherCount(want int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		if reloadWatcherWorkers() == want {
+			return true
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return reloadWatcherWorkers() == want
+}
+
+func TestStopReloadWatcherExitsWithoutSignal(t *testing.T) {
+	s := &Server{}
+	before := reloadWatcherWorkers()
+
+	s.startReloadWatcher(context.Background())
+
+	if !waitForReloadWatcherCount(before+1, 5*time.Second) {
+		t.Fatalf("reload watcher goroutine did not start (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+
+	// No SIGHUP is sent: the stop signal alone must release the watcher.
+	s.stopReloadWatcher()
+
+	if !waitForReloadWatcherCount(before, 5*time.Second) {
+		t.Fatalf("reload watcher goroutine did not exit after stop (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+}
+
+func TestStopReloadWatcherIdempotentAndNilSafe(t *testing.T) {
+	baseline := reloadWatcherWorkers()
+
+	s := &Server{}
+	s.startReloadWatcher(context.Background())
+
+	if !waitForReloadWatcherCount(baseline+1, 5*time.Second) {
+		t.Fatalf("expected reload watcher to be running (baseline=%d after=%d)", baseline, reloadWatcherWorkers())
+	}
+
+	s.stopReloadWatcher()
+	// Second stop must not block or panic once stopped is closed.
+	s.stopReloadWatcher()
+
+	if !waitForReloadWatcherCount(baseline, 5*time.Second) {
+		t.Fatalf("reload watcher did not exit: baseline=%d after=%d", baseline, reloadWatcherWorkers())
+	}
+
+	// Never-started and nil servers must be safe to stop.
+	(&Server{}).stopReloadWatcher()
+
+	var nilServer *Server
+
+	nilServer.stopReloadWatcher()
+}
+
+func TestReloadWatcherRepeatedLifecyclesDoNotAccumulate(t *testing.T) {
+	before := reloadWatcherWorkers()
+
+	for range 5 {
+		s := &Server{}
+		s.startReloadWatcher(context.Background())
+		s.stopReloadWatcher()
+	}
+
+	if !waitForReloadWatcherCount(before, 5*time.Second) {
+		t.Fatalf("repeated lifecycles accumulated watchers (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+}
+
+func TestReloadWatcherDeliversHUPToReload(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reloaded := make(chan struct{}, 1)
+
+	// An error return keeps the handler on its log-and-continue path, so no
+	// production post-reload work (metrics, image server, config dump) runs
+	// against this zero-value Server.
+	s := &Server{
+		sighupReload: func(context.Context) error {
+			select {
+			case reloaded <- struct{}{}:
+			default:
+			}
+
+			return errors.New("stub reload failure")
+		},
+	}
+
+	// Synthetic channel: proves HUP wiring without signaling the test process.
+	ch := make(chan os.Signal, 1)
+
+	s.serveReloadNotifications(ctx, ch)
+
+	// The stub must not fire before any notification arrives.
+	select {
+	case <-reloaded:
+		s.stopReloadWatcher()
+
+		t.Fatal("reload invoked without any HUP notification")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	before := reloadWatcherWorkers()
+
+	ch <- signals.Hup
+
+	select {
+	case <-reloaded:
+	case <-time.After(5 * time.Second):
+		s.stopReloadWatcher()
+
+		t.Fatal("synthetic SIGHUP did not invoke reload within 5s")
+	}
+
+	// The error-returning stub sends the handler back to its select, so the
+	// watcher must still be alive until explicitly stopped.
+	if !waitForReloadWatcherCount(before, time.Second) {
+		s.stopReloadWatcher()
+
+		t.Fatalf("watcher exited after handled HUP (workers=%d, want %d)", reloadWatcherWorkers(), before)
+	}
+
+	s.stopReloadWatcher()
+
+	if !waitForReloadWatcherCount(before-1, 5*time.Second) {
+		t.Fatalf("watcher did not exit after stop (workers=%d, want %d)", reloadWatcherWorkers(), before-1)
+	}
+}
+
+func TestReloadWatcherExitsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s := &Server{}
+	before := reloadWatcherWorkers()
+
+	s.startReloadWatcher(ctx)
+
+	if !waitForReloadWatcherCount(before+1, 5*time.Second) {
+		cancel()
+
+		t.Fatalf("reload watcher goroutine did not start (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+
+	cancel()
+
+	if !waitForReloadWatcherCount(before, 5*time.Second) {
+		// Join explicitly so the test never leaves a stray watcher behind.
+		s.stopReloadWatcher()
+
+		t.Fatalf("reload watcher did not exit on context cancel (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+
+	// Join explicitly; stopped is already closed so this returns immediately.
+	s.stopReloadWatcher()
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes a goroutine leak in the SIGHUP reload watcher (`server/server.go`).

Every `Server.New` started an infinite SIGHUP watcher gated only on <-ch, with no ctx select, no signal.Stop, and no Shutdown path — leaking Server after shutdown.

Store owned stop func + done channel on Server, select between SIGHUP and shutdown, defer signal.Stop(ch); Shutdown and post-launch constructor rollback stop and join the watcher.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

`startReloadWatcher` (production `signal.Notify` path, sole production caller) split from `serveReloadNotifications(ctx, ch)` with a `sighupReload` test seam (nil in production → `s.config.Reload`). The new `TestReloadWatcherDeliversHUPToReload` delivers a synthetic HUP to the watcher channel with a stubbed reload and requires invocation. Proof on Linux (Go 1.26, Docker):

Negative control (watcher pointed at a different channel) — fails as expected:

```text
--- FAIL: TestReloadWatcherDeliversHUPToReload
    synthetic SIGHUP did not invoke reload within 5s
FAIL
```

With the fix — all 5 pass, including race stress:

```text
--- PASS: TestReloadWatcherDeliversHUPToReload
PASS
```

5/5 PASS (`-count=1`); `-race -count=3` PASS. `go build` (linux tags) passes; `gofmt` and `git diff --check` clean. `signal.Stop` pairing verified by inspection (no public API introspects registrations). Full `./server` suite does not build at this base commit on main either (pre-existing inspect_test breakage), so tests were run isolated to this file.

#### Does this PR introduce a user-facing change?

```release-note
None
```

