### PR TITLE
WIP server: fix goroutine leak in mirror registry watcher

### DIFF
--- a/server/mirror_registry_watcher_leak_test.go
+++ b/server/mirror_registry_watcher_leak_test.go
@@ -1,0 +1,212 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	kclock "k8s.io/utils/clock"
+)
+
+type fakeMirrorRegistryTimer struct {
+	ticks   chan time.Time
+	resets  chan time.Duration
+	stopped chan struct{}
+	stop    sync.Once
+}
+
+func newFakeMirrorRegistryTimer() *fakeMirrorRegistryTimer {
+	return &fakeMirrorRegistryTimer{
+		ticks:   make(chan time.Time, 1),
+		resets:  make(chan time.Duration, 1),
+		stopped: make(chan struct{}),
+	}
+}
+
+func (t *fakeMirrorRegistryTimer) C() <-chan time.Time {
+	return t.ticks
+}
+
+func (t *fakeMirrorRegistryTimer) Stop() bool {
+	t.stop.Do(func() {
+		close(t.stopped)
+	})
+
+	return true
+}
+
+func (t *fakeMirrorRegistryTimer) Reset(d time.Duration) bool {
+	t.resets <- d
+
+	return true
+}
+
+func receiveMirrorWatcherValue[T any](t *testing.T, values <-chan T) T {
+	t.Helper()
+
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for mirror-registry watcher")
+	}
+
+	var zero T
+
+	return zero
+}
+
+func requireMirrorWatcherStopped(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	receiveMirrorWatcherValue(t, done)
+}
+
+func startMirrorRegistryEventLoop(
+	t *testing.T,
+	ctx context.Context,
+	events <-chan fsnotify.Event,
+	reload func(string),
+) (
+	timer *fakeMirrorRegistryTimer,
+	timerStarted <-chan time.Duration,
+	done <-chan struct{},
+) {
+	t.Helper()
+
+	timer = newFakeMirrorRegistryTimer()
+	timerStartedChannel := make(chan time.Duration, 1)
+	doneChannel := make(chan struct{})
+
+	go func() {
+		watchAndReloadMirrorRegistriesConfiguration(
+			ctx,
+			events,
+			make(chan error),
+			reload,
+			func(d time.Duration) kclock.Timer {
+				timerStartedChannel <- d
+
+				return timer
+			},
+		)
+		close(doneChannel)
+	}()
+
+	return timer, timerStartedChannel, doneChannel
+}
+
+func TestMirrorRegistryWatcherStop(t *testing.T) {
+	s := &Server{}
+	s.startMirrorRegistryWatcher(context.Background(), t.TempDir())
+
+	done := make(chan struct{})
+	go func() {
+		s.stopMirrorRegistryWatcher()
+		close(done)
+	}()
+
+	requireMirrorWatcherStopped(t, done)
+
+	// Stopping an already stopped watcher is safe.
+	s.stopMirrorRegistryWatcher()
+}
+
+func TestWatchAndReloadMirrorRegistriesConfiguration(t *testing.T) {
+	t.Run("debounces events", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		events := make(chan fsnotify.Event, 2)
+		reloads := make(chan string, 1)
+		timer, timerStarted, done := startMirrorRegistryEventLoop(t, ctx, events, func(name string) {
+			reloads <- name
+		})
+
+		events <- fsnotify.Event{Name: "first.conf", Op: fsnotify.Write}
+
+		if d := receiveMirrorWatcherValue(t, timerStarted); d != debounceDuration {
+			t.Fatalf("expected debounce duration %s, got %s", debounceDuration, d)
+		}
+
+		events <- fsnotify.Event{Name: "second.conf", Op: fsnotify.Write}
+
+		if d := receiveMirrorWatcherValue(t, timer.resets); d != debounceDuration {
+			t.Fatalf("expected reset duration %s, got %s", debounceDuration, d)
+		}
+
+		timer.ticks <- time.Now()
+
+		if name := receiveMirrorWatcherValue(t, reloads); name != "second.conf" {
+			t.Fatalf("expected latest event to trigger reload, got %q", name)
+		}
+
+		select {
+		case name := <-reloads:
+			t.Fatalf("expected events to be debounced, got extra reload for %q", name)
+		default:
+		}
+
+		cancel()
+		requireMirrorWatcherStopped(t, done)
+	})
+
+	t.Run("cancels pending reload", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		events := make(chan fsnotify.Event, 1)
+		reloads := make(chan string, 1)
+		timer, timerStarted, done := startMirrorRegistryEventLoop(t, ctx, events, func(name string) {
+			reloads <- name
+		})
+
+		events <- fsnotify.Event{Name: "pending.conf", Op: fsnotify.Write}
+
+		receiveMirrorWatcherValue(t, timerStarted)
+		cancel()
+		requireMirrorWatcherStopped(t, done)
+
+		select {
+		case <-timer.stopped:
+		default:
+			t.Fatal("pending debounce timer was not stopped")
+		}
+
+		timer.ticks <- time.Now()
+
+		select {
+		case name := <-reloads:
+			t.Fatalf("unexpected reload after cancellation for %q", name)
+		default:
+		}
+	})
+
+	t.Run("joins active reload", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		events := make(chan fsnotify.Event, 1)
+		reloadStarted := make(chan struct{})
+		releaseReload := make(chan struct{})
+		timer, timerStarted, done := startMirrorRegistryEventLoop(t, ctx, events, func(string) {
+			close(reloadStarted)
+			<-releaseReload
+		})
+
+		events <- fsnotify.Event{Name: "active.conf", Op: fsnotify.Write}
+
+		receiveMirrorWatcherValue(t, timerStarted)
+
+		timer.ticks <- time.Now()
+
+		receiveMirrorWatcherValue(t, reloadStarted)
+		cancel()
+
+		select {
+		case <-done:
+			t.Fatal("watcher stopped before active reload completed")
+		default:
+		}
+
+		close(releaseReload)
+		requireMirrorWatcherStopped(t, done)
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/cri-streaming/pkg/streaming"
 	kubetypes "k8s.io/kubelet/pkg/types"
+	kclock "k8s.io/utils/clock"
 
 	"github.com/cri-o/cri-o/internal/cert"
 	"github.com/cri-o/cri-o/internal/config/seccomp"
@@ -94,6 +95,11 @@ type Server struct {
 
 	containerEventClients           sync.Map
 	containerEventStreamBroadcaster sync.Once
+
+	// mirrorRegistryWatcherCancel ties the mirror-registry watcher to the
+	// Server lifecycle.
+	mirrorRegistryWatcherCancel context.CancelFunc
+	mirrorRegistryWatcherWG     sync.WaitGroup
 
 	// NRI runtime interface
 	nri *nriAPI
@@ -341,6 +347,8 @@ func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 
 // Shutdown attempts to shut down the server's storage cleanly.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.stopMirrorRegistryWatcher()
+
 	s.config.CNIManagerShutdown()
 	s.resourceStore.Close()
 
@@ -591,9 +599,16 @@ func New(
 
 	s.startReloadWatcher(ctx)
 
-	if s.config.AutoReloadRegistries {
-		go s.startWatcherForMirrorRegistries(ctx, s.config.SystemContext.SystemRegistriesConfDirPath)
+	cleanupMirrorRegistryWatcher := s.config.AutoReloadRegistries
+	if cleanupMirrorRegistryWatcher {
+		s.startMirrorRegistryWatcher(ctx, s.config.SystemContext.SystemRegistriesConfDirPath)
 	}
+	defer func() {
+		if cleanupMirrorRegistryWatcher {
+			s.stopMirrorRegistryWatcher()
+		}
+	}()
+
 	// Start the metrics server if configured to be enabled
 	if s.config.EnableMetrics {
 		if err := metrics.New(&s.config.MetricsConfig, &s.config.APIConfig).Start(ctx, s.monitorsChan); err != nil {
@@ -627,6 +642,8 @@ func New(
 	if err := watchdog.New(s.checkCRIHealth).Start(ctx); err != nil {
 		return nil, fmt.Errorf("start systemd watchdog: %w", err)
 	}
+
+	cleanupMirrorRegistryWatcher = false
 
 	return s, nil
 }
@@ -1062,10 +1079,10 @@ func isNotFound(err error) bool {
 	return false
 }
 
-// startWatcherForMirrorRegistries sets up a file watcher to monitor changes
-// in the "registries.conf.d" directory (default: "/etc/containers/registries.conf.d").
-// It then delegates the monitoring task to watchAndReloadMirrorRegistriesConfiguration.
-func (s *Server) startWatcherForMirrorRegistries(ctx context.Context, registriesConfDDir string) {
+// startMirrorRegistryWatcher monitors the registries.conf.d directory until
+// the server is stopped. Watch setup is synchronous so the goroutine is fully
+// owned before New continues.
+func (s *Server) startMirrorRegistryWatcher(ctx context.Context, registriesConfDDir string) {
 	if registriesConfDDir == "" {
 		log.Infof(ctx, "No registries.conf.d directory specified, defaulting to /etc/containers/registries.conf.d")
 
@@ -1077,44 +1094,72 @@ func (s *Server) startWatcherForMirrorRegistries(ctx context.Context, registries
 		log.Fatalf(ctx, "Failed to create new watcher: %v", err)
 	}
 
-	defer watcher.Close()
-
-	log.Infof(ctx, "Registered reload watcher for mirror registries configuration")
-
 	if err := watcher.Add(registriesConfDDir); err != nil {
 		log.Errorf(ctx, "Failed to add watcher for path %q: %s", registriesConfDDir, err)
+		watcher.Close()
 
 		return
 	}
 
-	s.watchAndReloadMirrorRegistriesConfiguration(ctx, watcher)
+	watcherCtx, cancel := context.WithCancel(ctx)
+	s.mirrorRegistryWatcherCancel = cancel
+
+	s.mirrorRegistryWatcherWG.Go(func() {
+		defer watcher.Close()
+
+		watchAndReloadMirrorRegistriesConfiguration(
+			watcherCtx,
+			watcher.Events,
+			watcher.Errors,
+			func(eventName string) {
+				log.Infof(ctx, "File %q changed, reloading registries configuration", eventName)
+
+				if err := s.config.ReloadRegistries(); err != nil {
+					log.Errorf(ctx, "Failed to reload registry configuration: %v", err)
+				}
+			},
+			func(d time.Duration) kclock.Timer {
+				return kclock.RealClock{}.NewTimer(d)
+			},
+		)
+	})
+
+	log.Infof(ctx, "Registered reload watcher for mirror registries configuration")
 }
 
-func (s *Server) watchAndReloadMirrorRegistriesConfiguration(ctx context.Context, watcher *fsnotify.Watcher) {
-	var timer *time.Timer
+func (s *Server) stopMirrorRegistryWatcher() {
+	if s.mirrorRegistryWatcherCancel != nil {
+		s.mirrorRegistryWatcherCancel()
+	}
 
-	reloadChannel := make(chan string, 1)
+	s.mirrorRegistryWatcherWG.Wait()
+}
 
-	go func() {
-		// The for loop ensures that the channel is properly drained, even if
-		// no new events are received, thus preventing potential deadlocks.
-		// For each event name received, the goroutine checks if it's not
-		// an empty string and then reloads the registries.
-		for evenName := range reloadChannel {
-			log.Infof(ctx, "File %q changed, reloading registries configuration", evenName)
+func watchAndReloadMirrorRegistriesConfiguration(
+	ctx context.Context,
+	events <-chan fsnotify.Event,
+	watcherErrors <-chan error,
+	reload func(string),
+	newTimer func(time.Duration) kclock.Timer,
+) {
+	var (
+		timer   kclock.Timer
+		timerCh <-chan time.Time
+		pending string
+	)
 
-			if err := s.config.ReloadRegistries(); err != nil {
-				log.Errorf(ctx, "Failed to reload registry configuration: %v", err)
-			}
+	defer func() {
+		if timer != nil {
+			timer.Stop()
 		}
 	}()
 
 	for {
 		select {
-		case event, ok := <-watcher.Events:
+		case <-ctx.Done():
+			return
+		case event, ok := <-events:
 			if !ok {
-				close(reloadChannel)
-
 				return
 			}
 
@@ -1122,21 +1167,32 @@ func (s *Server) watchAndReloadMirrorRegistriesConfiguration(ctx context.Context
 				continue
 			}
 
-			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Chmod) != 0 {
-				// Reset timer if exists, else create a new one.
-				if timer != nil {
-					timer.Reset(debounceDuration)
-				} else {
-					timer = time.AfterFunc(debounceDuration, func() {
-						reloadChannel <- event.Name
-					})
-				}
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Chmod) == 0 {
+				continue
 			}
 
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				close(reloadChannel)
+			pending = event.Name
 
+			if timer == nil {
+				timer = newTimer(debounceDuration)
+				timerCh = timer.C()
+			} else {
+				timer.Reset(debounceDuration)
+			}
+		case <-timerCh:
+			name := pending
+			timer = nil
+			timerCh = nil
+			pending = ""
+
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				reload(name)
+			}
+		case err, ok := <-watcherErrors:
+			if !ok {
 				return
 			}
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Tie the mirror-registry watcher to the `Server` lifecycle.

With `AutoReloadRegistries`, the watcher currently has no cancellation path: `Shutdown` does not stop it, its deferred `watcher.Close()` is not reached during normal operation, and its reload worker remains blocked on an open channel. Process exit reclaims those resources in the normal CRI-O daemon lifecycle, but `Server.Shutdown` should still stop work started by `Server.New`, particularly when the process remains alive. It should also prevent registry reload work from continuing into storage teardown.

This change:

- installs the fsnotify watch synchronously, then runs it with a server-owned cancel function;
- cancels and joins the watcher before the rest of `Shutdown`;
- rolls back this watcher when a later `New` step returns an error;
- replaces `time.AfterFunc` with a loop-owned timer and performs reloads in the watcher loop, avoiding callback/channel-close races and queued reloads after cancellation.

The constructor cleanup is intentionally scoped to this watcher; it does not claim to make every `Server.New` failure retry-safe.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Added deterministic tests for idle stop, debounce reset to the latest event, cancellation with a pending timer, and joining an active reload. Timer behavior is controlled by a fake timer rather than wall-clock sleeps.

Validation:

- focused watcher tests: Linux, Go 1.26, `-race -count=10` pass;
- project-version `golangci-lint`: 0 issues;
- `gofmt` and `git diff --check`: clean;
- full server Ginkgo suite: 164 executed specs passed. The standalone `TestAddOCIBindsRROMountsError` remains environment-dependent under Docker because `/` is not a shared mount.

#### Does this PR introduce a user-facing change?

```release-note
None
```
