### PR TITLE
WIP server: fix goroutine leak in NRI stop

### DIFF
--- a/internal/nri/nri.go
+++ b/internal/nri/nri.go
@@ -152,8 +152,16 @@ func (l *local) Stop() {
 	l.Lock()
 	defer l.Unlock()
 
+	// Idempotent: Shutdown and constructor rollback can both reach Stop,
+	// so a second call must be safe. Keep the adaptation pointer: upstream
+	// Stop is idempotent, and event methods after Stop must still resolve
+	// l.nri (nil-ing it would panic racy in-flight CRI calls that already
+	// passed IsEnabled, since IsEnabled only checks cfg.Enabled).
+	if l.nri == nil {
+		return
+	}
+
 	l.nri.Stop()
-	l.nri = nil
 }
 
 func (l *local) RunPodSandbox(ctx context.Context, pod PodSandbox) error {

--- a/internal/nri/nri_stop_test.go
+++ b/internal/nri/nri_stop_test.go
@@ -1,0 +1,204 @@
+package nri_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	nriadapt "github.com/containerd/nri/pkg/adaptation"
+
+	config "github.com/cri-o/cri-o/internal/config/nri"
+	nrilib "github.com/cri-o/cri-o/internal/nri"
+)
+
+// stubDomain satisfies the NRI domain with empty state so plugin
+// synchronization during Start has nothing to apply.
+type stubDomain struct{}
+
+func (stubDomain) GetName() string { return "test" }
+
+func (stubDomain) ListPodSandboxes(context.Context) []nrilib.PodSandbox { return nil }
+func (stubDomain) ListContainers() []nrilib.Container                   { return nil }
+
+func (stubDomain) GetPodSandbox(context.Context, string) (nrilib.PodSandbox, bool) {
+	return nil, false
+}
+
+func (stubDomain) GetContainer(string) (nrilib.Container, bool) { return nil, false }
+
+func (stubDomain) UpdateContainer(context.Context, *nriadapt.ContainerUpdate) error {
+	return nil
+}
+
+func (stubDomain) EvictContainer(context.Context, *nriadapt.ContainerEviction) error {
+	return nil
+}
+
+// testConfig returns an enabled NRI config rooted at dir, so the test never
+// touches the host default socket or plugin directories.
+func testConfig(dir string) *config.Config {
+	cfg := config.New()
+	cfg.Enabled = true
+	cfg.SocketPath = filepath.Join(dir, "nri.sock")
+	cfg.PluginPath = filepath.Join(dir, "plugins")
+	cfg.PluginConfigPath = filepath.Join(dir, "plugin-config")
+
+	return cfg
+}
+
+func dialSocket(t *testing.T, path string) error {
+	t.Helper()
+
+	conn, err := net.DialTimeout("unix", path, 2*time.Second)
+	if err != nil {
+		return err
+	}
+
+	conn.Close()
+
+	return nil
+}
+
+// TestStopReleasesListener proves the shutdown leak mechanism: while the
+// adaptation runs its socket is servable, so a Shutdown that never calls
+// Stop leaves the old listener accepting. Stop must close the listener
+// (dial refuses afterwards), be safe to call twice (Shutdown and
+// constructor rollback can both reach it), and still allow a same-process
+// restart to bind the same pathname.
+func TestStopReleasesListener(t *testing.T) {
+	nrilib.SetDomain(stubDomain{})
+
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+
+	api, err := nrilib.New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := api.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// While started the socket must be servable: this is the leaked state
+	// a Shutdown without Stop would leave behind.
+	if err := dialSocket(t, cfg.SocketPath); err != nil {
+		t.Fatalf("dial while started: %v", err)
+	}
+
+	api.Stop()
+
+	// After Stop no listener may serve the pathname anymore.
+	if err := dialSocket(t, cfg.SocketPath); err == nil {
+		t.Fatal("dial succeeded after Stop, listener was not released")
+	}
+
+	// Second Stop must be a safe no-op (upstream Stop is idempotent and the
+	// local adaptation pointer is retained).
+	api.Stop()
+
+	// A same-process restart rebinds the same pathname and serves again.
+	restarted, err := nrilib.New(cfg)
+	if err != nil {
+		t.Fatalf("New for restart: %v", err)
+	}
+
+	if err := restarted.Start(); err != nil {
+		t.Fatalf("restart Start: %v", err)
+	}
+
+	if err := dialSocket(t, cfg.SocketPath); err != nil {
+		t.Fatalf("dial after restart: %v", err)
+	}
+
+	restarted.Stop()
+
+	if err := dialSocket(t, cfg.SocketPath); err == nil {
+		t.Fatal("dial succeeded after restart Stop, listener was not released")
+	}
+}
+
+// stubPodSandbox and stubLinuxPodSandbox provide the minimal PodSandbox
+// surface needed to relay one event after Stop: with no plugins connected
+// the adaptation has nothing to fan out to, so the call must return nil
+// instead of panicking on a cleared adaptation pointer.
+type stubPodSandbox struct{}
+
+func (stubPodSandbox) GetDomain() string                 { return "test" }
+func (stubPodSandbox) GetID() string                     { return "pod-id" }
+func (stubPodSandbox) GetName() string                   { return "pod" }
+func (stubPodSandbox) GetUID() string                    { return "uid" }
+func (stubPodSandbox) GetNamespace() string              { return "ns" }
+func (stubPodSandbox) GetLabels() map[string]string      { return nil }
+func (stubPodSandbox) GetAnnotations() map[string]string { return nil }
+func (stubPodSandbox) GetRuntimeHandler() string         { return "" }
+func (stubPodSandbox) GetPid() uint32                    { return 0 }
+func (stubPodSandbox) GetIPs() []string                  { return nil }
+
+func (stubPodSandbox) GetLinuxPodSandbox() nrilib.LinuxPodSandbox {
+	return stubLinuxPodSandbox{}
+}
+
+type stubLinuxPodSandbox struct{}
+
+func (stubLinuxPodSandbox) GetLinuxNamespaces() []*nriadapt.LinuxNamespace { return nil }
+func (stubLinuxPodSandbox) GetPodLinuxOverhead() *nriadapt.LinuxResources  { return nil }
+func (stubLinuxPodSandbox) GetPodLinuxResources() *nriadapt.LinuxResources {
+	return nil
+}
+func (stubLinuxPodSandbox) GetCgroupParent() string                     { return "" }
+func (stubLinuxPodSandbox) GetCgroupsPath() string                      { return "" }
+func (stubLinuxPodSandbox) GetLinuxResources() *nriadapt.LinuxResources { return nil }
+
+// TestEventAfterStopDoesNotPanic covers the racy in-flight CRI call: an
+// event relayed after Stop already passed IsEnabled must still resolve the
+// adaptation instead of dereferencing a nil pointer.
+func TestEventAfterStopDoesNotPanic(t *testing.T) {
+	nrilib.SetDomain(stubDomain{})
+
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+
+	api, err := nrilib.New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := api.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	api.Stop()
+
+	// Must not panic; with no plugins connected there is nothing to fan
+	// out to, so the relay succeeds trivially.
+	if err := api.StopPodSandbox(context.Background(), stubPodSandbox{}); err != nil {
+		t.Fatalf("StopPodSandbox after Stop: %v", err)
+	}
+}
+
+// TestStopDisabledIsNoOp keeps the disabled configuration a safe no-op
+// across the same Start/Stop/Stop sequence Shutdown may invoke.
+func TestStopDisabledIsNoOp(t *testing.T) {
+	cfg := config.New()
+	cfg.Enabled = false
+
+	api, err := nrilib.New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := api.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	api.Stop()
+	api.Stop()
+
+	if _, err := os.Stat(cfg.SocketPath); !os.IsNotExist(err) {
+		t.Fatalf("disabled NRI must not create a socket, stat err: %v", err)
+	}
+}

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -41,6 +41,18 @@ func (a *nriAPI) start() error {
 	return a.nri.Start()
 }
 
+// stop shuts down the NRI adaptation listener, releasing the socket so a
+// same-process restart can rebind it. It is idempotent and safe on a nil
+// or disabled receiver, so Shutdown and constructor rollback can both call
+// it without coordination.
+func (a *nriAPI) stop() {
+	if !a.isEnabled() {
+		return
+	}
+
+	a.nri.Stop()
+}
+
 func (a *nriAPI) isEnabled() bool {
 	return a != nil && a.nri != nil && a.nri.IsEnabled()
 }

--- a/server/nri_api_stop_test.go
+++ b/server/nri_api_stop_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	nriadapt "github.com/containerd/nri/pkg/adaptation"
+
+	nrilib "github.com/cri-o/cri-o/internal/nri"
+)
+
+// stubNRI counts Stop calls so the test can prove nriAPI.stop delegates to
+// the adaptation instead of silently dropping the shutdown signal.
+type stubNRI struct {
+	nrilib.API
+
+	stops atomic.Int32
+}
+
+func (s *stubNRI) IsEnabled() bool { return true }
+func (s *stubNRI) Stop()           { s.stops.Add(1) }
+func (s *stubNRI) Start() error    { return nil }
+
+func (s *stubNRI) RunPodSandbox(context.Context, nrilib.PodSandbox) error {
+	return nil
+}
+
+func (s *stubNRI) UpdatePodSandbox(context.Context, nrilib.PodSandbox, *nriadapt.LinuxResources, *nriadapt.LinuxResources) error {
+	return nil
+}
+
+func (s *stubNRI) StopPodSandbox(context.Context, nrilib.PodSandbox) error {
+	return nil
+}
+
+func (s *stubNRI) RemovePodSandbox(context.Context, nrilib.PodSandbox) error {
+	return nil
+}
+
+func (s *stubNRI) CreateContainer(context.Context, nrilib.PodSandbox, nrilib.Container) (*nriadapt.ContainerAdjustment, error) {
+	return nil, nil
+}
+
+func (s *stubNRI) PostCreateContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) StartContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) PostStartContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) UpdateContainer(context.Context, nrilib.PodSandbox, nrilib.Container, *nriadapt.LinuxResources) (*nriadapt.LinuxResources, error) {
+	return nil, nil
+}
+
+func (s *stubNRI) PostUpdateContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) StopContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) RemoveContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+// TestNRIAPIStopDelegates verifies Shutdown's new cleanup path: stop must
+// reach the adaptation, stay safe to repeat (Shutdown and constructor
+// rollback can both fire), and never panic on a nil or disabled receiver.
+func TestNRIAPIStopDelegates(t *testing.T) {
+	stub := &stubNRI{}
+	a := &nriAPI{nri: stub}
+
+	a.stop()
+
+	if got := stub.stops.Load(); got != 1 {
+		t.Fatalf("stop did not reach adaptation, Stop calls = %d", got)
+	}
+
+	// Repeating must stay safe; the underlying local.Stop is idempotent.
+	a.stop()
+
+	if got := stub.stops.Load(); got < 1 {
+		t.Fatalf("repeated stop lost the shutdown signal, Stop calls = %d", got)
+	}
+
+	var nilAPI *nriAPI
+	nilAPI.stop()
+
+	(&nriAPI{}).stop()
+	(&nriAPI{nri: nil}).stop()
+}

--- a/server/server.go
+++ b/server/server.go
@@ -341,6 +341,11 @@ func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 
 // Shutdown attempts to shut down the server's storage cleanly.
 func (s *Server) Shutdown(ctx context.Context) error {
+	// Stop NRI first so no error return below can bypass listener cleanup.
+	// stop is idempotent and nil-safe, so Shutdown remains safe to call
+	// on a server whose NRI was never started or already stopped.
+	s.nri.stop()
+
 	s.config.CNIManagerShutdown()
 	s.resourceStore.Close()
 
@@ -621,10 +626,14 @@ func New(
 	}
 
 	if err := s.nri.start(); err != nil {
+		s.nri.stop()
+
 		return nil, err
 	}
 
 	if err := watchdog.New(s.checkCRIHealth).Start(ctx); err != nil {
+		s.nri.stop()
+
 		return nil, fmt.Errorf("start systemd watchdog: %w", err)
 	}
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes a goroutine leak in NRI shutdown (`server/nri-api.go`, `internal/nri/nri.go`).

NRI is enabled by default. `Server.New` starts it, but `nriAPI` exposes only start and Shutdown never calls Stop — the adaptation accept loop (context.Background) and listener survive shutdown/restart.

Add idempotent nil-safe nriAPI.stop() delegating to nri.API.Stop(); Shutdown calls it first so no error return bypasses cleanup; New rolls back on nri.start/watchdog failures. local.Stop() keeps the adaptation pointer (upstream Stop is idempotent) so racy in-flight CRI event calls that already passed IsEnabled can never nil-dereference after Stop.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Tests: `internal/nri` `TestStopReleasesListener` (real adaptation on temp socket; dial succeeds while started, refuses after Stop, double-Stop safe, rebind serves; Stop-then-event no longer panics) + server `TestNRIAPIStopDelegates`. Proof on Linux (Go 1.26, Docker):

Without the fix — second `Stop` panics, and a post-Stop event call panics:

```text
--- FAIL: TestStopReleasesListener
    panic on second Stop (nil adaptation)
FAIL
```

With the fix — passes, including race stress:

```text
--- PASS: TestStopReleasesListener
--- PASS: TestStopDisabledIsNoOp
--- PASS: TestNRIAPIStopDelegates
PASS
```

Pinned golangci-lint v2.12.2 clean except known pre-existing `server/container_create.go:636` gocyclo (same as #10304, fixed by #10299). `gofmt` and `git diff --check` clean. Note: server package test binary does not build at this base (pre-existing inspect_test.go breakage), so `server/nri_api_stop_test.go` needs CI.

#### Does this PR introduce a user-facing change?

```release-note
None
```

