### PR TITLE
WIP: fix goroutine leaks across attach, exec, and server shutdown

### DIFF
--- a/internal/nri/nri.go
+++ b/internal/nri/nri.go
@@ -152,8 +152,12 @@ func (l *local) Stop() {
 	l.Lock()
 	defer l.Unlock()
 
+	// Idempotent: Shutdown and constructor rollback can both reach Stop,
+	// so a second call must be safe. Keep the adaptation pointer: upstream
+	// Stop is idempotent, and event methods after Stop must still resolve
+	// l.nri (nil-ing it would panic racy in-flight CRI calls that already
+	// passed IsEnabled, since IsEnabled only checks cfg.Enabled).
 	l.nri.Stop()
-	l.nri = nil
 }
 
 func (l *local) RunPodSandbox(ctx context.Context, pod PodSandbox) error {

--- a/internal/nri/nri_stop_test.go
+++ b/internal/nri/nri_stop_test.go
@@ -1,0 +1,204 @@
+package nri_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	nriadapt "github.com/containerd/nri/pkg/adaptation"
+
+	config "github.com/cri-o/cri-o/internal/config/nri"
+	nrilib "github.com/cri-o/cri-o/internal/nri"
+)
+
+// stubDomain satisfies the NRI domain with empty state so plugin
+// synchronization during Start has nothing to apply.
+type stubDomain struct{}
+
+func (stubDomain) GetName() string { return "test" }
+
+func (stubDomain) ListPodSandboxes(context.Context) []nrilib.PodSandbox { return nil }
+func (stubDomain) ListContainers() []nrilib.Container                   { return nil }
+
+func (stubDomain) GetPodSandbox(context.Context, string) (nrilib.PodSandbox, bool) {
+	return nil, false
+}
+
+func (stubDomain) GetContainer(string) (nrilib.Container, bool) { return nil, false }
+
+func (stubDomain) UpdateContainer(context.Context, *nriadapt.ContainerUpdate) error {
+	return nil
+}
+
+func (stubDomain) EvictContainer(context.Context, *nriadapt.ContainerEviction) error {
+	return nil
+}
+
+// testConfig returns an enabled NRI config rooted at dir, so the test never
+// touches the host default socket or plugin directories.
+func testConfig(dir string) *config.Config {
+	cfg := config.New()
+	cfg.Enabled = true
+	cfg.SocketPath = filepath.Join(dir, "nri.sock")
+	cfg.PluginPath = filepath.Join(dir, "plugins")
+	cfg.PluginConfigPath = filepath.Join(dir, "plugin-config")
+
+	return cfg
+}
+
+func dialSocket(t *testing.T, path string) error {
+	t.Helper()
+
+	conn, err := net.DialTimeout("unix", path, 2*time.Second)
+	if err != nil {
+		return err
+	}
+
+	conn.Close()
+
+	return nil
+}
+
+// TestStopReleasesListener proves the shutdown leak mechanism: while the
+// adaptation runs its socket is servable, so a Shutdown that never calls
+// Stop leaves the old listener accepting. Stop must close the listener
+// (dial refuses afterwards), be safe to call twice (Shutdown and
+// constructor rollback can both reach it), and still allow a same-process
+// restart to bind the same pathname.
+func TestStopReleasesListener(t *testing.T) {
+	nrilib.SetDomain(stubDomain{})
+
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+
+	api, err := nrilib.New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := api.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// While started the socket must be servable: this is the leaked state
+	// a Shutdown without Stop would leave behind.
+	if err := dialSocket(t, cfg.SocketPath); err != nil {
+		t.Fatalf("dial while started: %v", err)
+	}
+
+	api.Stop()
+
+	// After Stop no listener may serve the pathname anymore.
+	if err := dialSocket(t, cfg.SocketPath); err == nil {
+		t.Fatal("dial succeeded after Stop, listener was not released")
+	}
+
+	// Second Stop must be a safe no-op (upstream Stop is idempotent and the
+	// local adaptation pointer is retained).
+	api.Stop()
+
+	// A same-process restart rebinds the same pathname and serves again.
+	restarted, err := nrilib.New(cfg)
+	if err != nil {
+		t.Fatalf("New for restart: %v", err)
+	}
+
+	if err := restarted.Start(); err != nil {
+		t.Fatalf("restart Start: %v", err)
+	}
+
+	if err := dialSocket(t, cfg.SocketPath); err != nil {
+		t.Fatalf("dial after restart: %v", err)
+	}
+
+	restarted.Stop()
+
+	if err := dialSocket(t, cfg.SocketPath); err == nil {
+		t.Fatal("dial succeeded after restart Stop, listener was not released")
+	}
+}
+
+// stubPodSandbox and stubLinuxPodSandbox provide the minimal PodSandbox
+// surface needed to relay one event after Stop: with no plugins connected
+// the adaptation has nothing to fan out to, so the call must return nil
+// instead of panicking on a cleared adaptation pointer.
+type stubPodSandbox struct{}
+
+func (stubPodSandbox) GetDomain() string                 { return "test" }
+func (stubPodSandbox) GetID() string                     { return "pod-id" }
+func (stubPodSandbox) GetName() string                   { return "pod" }
+func (stubPodSandbox) GetUID() string                    { return "uid" }
+func (stubPodSandbox) GetNamespace() string              { return "ns" }
+func (stubPodSandbox) GetLabels() map[string]string      { return nil }
+func (stubPodSandbox) GetAnnotations() map[string]string { return nil }
+func (stubPodSandbox) GetRuntimeHandler() string         { return "" }
+func (stubPodSandbox) GetPid() uint32                    { return 0 }
+func (stubPodSandbox) GetIPs() []string                  { return nil }
+
+func (stubPodSandbox) GetLinuxPodSandbox() nrilib.LinuxPodSandbox {
+	return stubLinuxPodSandbox{}
+}
+
+type stubLinuxPodSandbox struct{}
+
+func (stubLinuxPodSandbox) GetLinuxNamespaces() []*nriadapt.LinuxNamespace { return nil }
+func (stubLinuxPodSandbox) GetPodLinuxOverhead() *nriadapt.LinuxResources  { return nil }
+func (stubLinuxPodSandbox) GetPodLinuxResources() *nriadapt.LinuxResources {
+	return nil
+}
+func (stubLinuxPodSandbox) GetCgroupParent() string                     { return "" }
+func (stubLinuxPodSandbox) GetCgroupsPath() string                      { return "" }
+func (stubLinuxPodSandbox) GetLinuxResources() *nriadapt.LinuxResources { return nil }
+
+// TestEventAfterStopDoesNotPanic covers the racy in-flight CRI call: an
+// event relayed after Stop already passed IsEnabled must still resolve the
+// adaptation instead of dereferencing a nil pointer.
+func TestEventAfterStopDoesNotPanic(t *testing.T) {
+	nrilib.SetDomain(stubDomain{})
+
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+
+	api, err := nrilib.New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := api.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	api.Stop()
+
+	// Must not panic; with no plugins connected there is nothing to fan
+	// out to, so the relay succeeds trivially.
+	if err := api.StopPodSandbox(context.Background(), stubPodSandbox{}); err != nil {
+		t.Fatalf("StopPodSandbox after Stop: %v", err)
+	}
+}
+
+// TestStopDisabledIsNoOp keeps the disabled configuration a safe no-op
+// across the same Start/Stop/Stop sequence Shutdown may invoke.
+func TestStopDisabledIsNoOp(t *testing.T) {
+	cfg := config.New()
+	cfg.Enabled = false
+
+	api, err := nrilib.New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := api.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	api.Stop()
+	api.Stop()
+
+	if _, err := os.Stat(cfg.SocketPath); !os.IsNotExist(err) {
+		t.Fatalf("disabled NRI must not create a socket, stat err: %v", err)
+	}
+}

--- a/internal/oci/goroutine_stacks_test.go
+++ b/internal/oci/goroutine_stacks_test.go
@@ -1,0 +1,48 @@
+package oci
+
+import (
+	"runtime"
+	"strings"
+)
+
+// goroutineStacks returns one entry per goroutine from a full stack dump,
+// growing the buffer until the dump is not truncated.
+func goroutineStacks() []string {
+	bufSize := 1 << 20
+
+	for {
+		buf := make([]byte, bufSize)
+
+		n := runtime.Stack(buf, true)
+		if n == len(buf) {
+			bufSize *= 2
+
+			continue
+		}
+
+		return strings.Split(string(buf[:n]), "\n\n")
+	}
+}
+
+// countGoroutines counts goroutines whose stack contains every needle.
+func countGoroutines(needles ...string) int {
+	count := 0
+
+	for _, stack := range goroutineStacks() {
+		matched := true
+
+		for _, needle := range needles {
+			if !strings.Contains(stack, needle) {
+				matched = false
+
+				break
+			}
+		}
+
+		if matched {
+			count++
+		}
+	}
+
+	return count
+}

--- a/internal/oci/oci_unix.go
+++ b/internal/oci/oci_unix.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/creack/pty"
 	"github.com/sirupsen/logrus"
@@ -17,6 +18,51 @@ import (
 
 	"github.com/cri-o/cri-o/utils"
 )
+
+// ttyTeardownTimeout bounds each teardown step after the TTY command exits,
+// so a backpressured output stream cannot gate return indefinitely when the
+// streaming idle timeout is disabled. It is a variable so tests can shorten
+// it.
+var ttyTeardownTimeout = 5 * time.Second
+
+// streamResetter is implemented by SPDY streams, whose Reset fully tears
+// down both directions of a stream. WebSocket channels do not implement it,
+// so the reset is a no-op there.
+type streamResetter interface {
+	Reset() error
+}
+
+// asyncReset best-effort resets a connection-owned stream without blocking
+// teardown on the reset frame write. For SPDY the local remote channels are
+// closed before the RST frame is queued, so a reader parked in Stream.Read
+// is released even while a graceful output write holds the framer lock.
+func asyncReset(s any) {
+	if r, ok := s.(streamResetter); ok && r != nil {
+		go func() {
+			if err := r.Reset(); err != nil {
+				logrus.Warnf("Failed to reset stream during teardown: %v", err)
+			}
+		}()
+	}
+}
+
+// closeWithTimeout bounds a potentially blocking graceful stream close
+// (a FIN write contends for the same framer lock as a stalled data write).
+// On timeout the caller should fall back to a full reset and return so the
+// connection-level teardown in ServeExec can release the transport.
+func closeWithTimeout(c io.Closer, timeout time.Duration) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Close()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s waiting for stream close", timeout)
+	}
+}
 
 // ptyStarter wraps pty.Start to implement the ExecStarter interface.
 // It stores the pty file descriptor for later use after Start() is called.
@@ -66,9 +112,6 @@ func ttyCmd(execCmd *exec.Cmd, stdin io.Reader, stdout io.WriteCloser, resizeCha
 	defer c.DeleteExecPID(pid)
 
 	p := starter.Pty()
-	defer p.Close()
-	// make sure to close the stdout stream
-	defer stdout.Close()
 
 	utils.HandleResizing(resizeChan, func(size remotecommand.TerminalSize) {
 		if err := setSize(p.Fd(), size); err != nil {
@@ -76,17 +119,75 @@ func ttyCmd(execCmd *exec.Cmd, stdin io.Reader, stdout io.WriteCloser, resizeCha
 		}
 	})
 
-	var stdinErr, stdoutErr error
+	// Buffered so neither copier blocks on reporting after teardown stops
+	// waiting for them.
+	stdinDone := make(chan error, 1)
+	stdoutDone := make(chan error, 1)
 
 	if stdin != nil {
-		go func() { _, stdinErr = pools.Copy(p, stdin) }()
+		go func() {
+			_, err := pools.Copy(p, stdin)
+			stdinDone <- err
+		}()
+	} else {
+		stdinDone <- nil
 	}
 
 	if stdout != nil {
-		go func() { _, stdoutErr = pools.Copy(stdout, p) }()
+		go func() {
+			_, err := pools.Copy(stdout, p)
+			stdoutDone <- err
+		}()
+	} else {
+		stdoutDone <- nil
 	}
 
 	err = execCmd.Wait()
+
+	// Break the SPDY backpressure cycle before any potentially blocking
+	// graceful close: the command has exited, so no further input is needed.
+	// Resetting the connection-owned stdin stream releases a copier parked
+	// in Stream.Read independently of outbound writes.
+	if stdin != nil {
+		asyncReset(stdin)
+	}
+
+	// Join the copiers, but do not let backpressured output gate return:
+	// ServeExec's deferred connection teardown is the actor that releases
+	// the transport, and it is only reachable once ttyCmd returns. The PTY
+	// is deliberately left open while joining so healthy output still
+	// drains instead of being discarded by an early master close.
+	timeout := time.After(ttyTeardownTimeout)
+
+	var stdinErr, stdoutErr error
+
+	stdinJoined, stdoutJoined := false, false
+	for !stdinJoined || !stdoutJoined {
+		select {
+		case stdinErr = <-stdinDone:
+			stdinJoined = true
+		case stdoutErr = <-stdoutDone:
+			stdoutJoined = true
+		case <-timeout:
+			logrus.Warnf("Timed out after %s waiting for TTY copy workers to exit", ttyTeardownTimeout)
+
+			stdinJoined, stdoutJoined = true, true
+		}
+	}
+
+	// Release copiers parked on the PTY side once draining is done or the
+	// join above gave up waiting.
+	_ = p.Close()
+
+	// A graceful FIN contends for the same framer lock as a stalled data
+	// write, so bound it even when the streaming idle timeout is disabled.
+	// On timeout fall back to a full reset so teardown still completes.
+	if stdout != nil {
+		if closeErr := closeWithTimeout(stdout, ttyTeardownTimeout); closeErr != nil {
+			logrus.Warnf("Stalled TTY stdout close, resetting stream: %v", closeErr)
+			asyncReset(stdout)
+		}
+	}
 
 	if stdinErr != nil {
 		logrus.Warnf("Stdin copy error: %v", stdinErr)

--- a/internal/oci/oci_unix_tty_teardown_test.go
+++ b/internal/oci/oci_unix_tty_teardown_test.go
@@ -1,0 +1,175 @@
+//go:build !windows
+
+package oci
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// gatedStream models a backpressured SPDY stream: reads block until Reset
+// (like Stream.Read selecting on closeChan), writes block until Reset (like a
+// data write stalled on the framer lock / transport backpressure), and Close
+// blocks while backpressured (like a FIN write contending for the same lock).
+// Reset releases local waiters immediately, mirroring closeRemoteChannels
+// running before the RST frame write.
+type gatedStream struct {
+	done       chan struct{}
+	once       sync.Once
+	resetCalls atomic.Int32
+}
+
+func newGatedStream() *gatedStream {
+	return &gatedStream{done: make(chan struct{})}
+}
+
+func (g *gatedStream) Reset() error {
+	g.resetCalls.Add(1)
+	g.once.Do(func() { close(g.done) })
+
+	return nil
+}
+
+func (g *gatedStream) resetDone() <-chan struct{} {
+	return g.done
+}
+
+type gatedStdin struct {
+	*gatedStream
+}
+
+func (s *gatedStdin) Read(p []byte) (int, error) {
+	select {
+	case <-s.resetDone():
+		return 0, io.EOF
+	case <-time.After(30 * time.Second):
+		return 0, errors.New("test timeout: stdin Read was never reset")
+	}
+}
+
+type gatedStdout struct {
+	*gatedStream
+}
+
+func (s *gatedStdout) Write(p []byte) (int, error) {
+	select {
+	case <-s.resetDone():
+		return 0, errors.New("stream reset")
+	case <-time.After(30 * time.Second):
+		return 0, errors.New("test timeout: stdout Write was never reset")
+	}
+}
+
+func (s *gatedStdout) Close() error {
+	select {
+	case <-s.resetDone():
+		return nil
+	case <-time.After(30 * time.Second):
+		return nil
+	}
+}
+
+func newTTYTestContainer(t *testing.T) *Container {
+	t.Helper()
+
+	c, err := NewContainer("tty-teardown-test", "name", t.TempDir(), "logPath",
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"image", nil, nil, "", &types.ContainerMetadata{}, "sandbox",
+		false, false, false, "", t.TempDir(), time.Now(), "")
+	if err != nil {
+		t.Fatalf("create test container: %v", err)
+	}
+
+	return c
+}
+
+// shortenTTYTeardownTimeout lowers the teardown bound for the duration of
+// the test so the bounded join and close paths finish quickly.
+func shortenTTYTeardownTimeout(t *testing.T) {
+	t.Helper()
+
+	orig := ttyTeardownTimeout
+	ttyTeardownTimeout = 200 * time.Millisecond
+
+	t.Cleanup(func() { ttyTeardownTimeout = orig })
+}
+
+// TestTTYCmdTeardownUnderOutputBackpressure covers the stalled-peer case:
+// the command exits while the stdin copier is parked in Read and the stdout
+// copier is parked in a backpressured Write. Without the fix, the deferred
+// graceful stdout.Close blocks behind the stalled write, ttyCmd never
+// returns, and ServeExec's deferred connection teardown is unreachable. The
+// fix must reset the connection-owned stdin stream and bound the output
+// close so ttyCmd returns.
+func TestTTYCmdTeardownUnderOutputBackpressure(t *testing.T) {
+	shortenTTYTeardownTimeout(t)
+
+	stdin := &gatedStdin{gatedStream: newGatedStream()}
+	stdout := &gatedStdout{gatedStream: newGatedStream()}
+
+	// Exits immediately with finite output; teardown must not wait for the
+	// gated peer.
+	execCmd := exec.Command("sh", "-c", "echo hi; exit 0")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ttyCmd(execCmd, stdin, stdout, nil, newTTYTestContainer(t))
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ttyCmd returned error: %v", err)
+		}
+	case <-time.After(25 * time.Second):
+		t.Fatal("ttyCmd did not return within 25s under output backpressure (teardown cycle)")
+	}
+
+	if stdin.resetCalls.Load() == 0 {
+		t.Fatal("command completion did not reset the stdin stream")
+	}
+}
+
+// TestTTYCmdHappyPathPreservesOutput guards the normal path: with a draining
+// peer, output is still copied and the command result returned.
+func TestTTYCmdHappyPathPreservesOutput(t *testing.T) {
+	stdin := strings.NewReader("")
+
+	var stdout bytes.Buffer
+
+	execCmd := exec.Command("sh", "-c", "echo hello; exit 0")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ttyCmd(execCmd, stdin, discardTTYCloser{Writer: &stdout}, nil, newTTYTestContainer(t))
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ttyCmd returned error: %v", err)
+		}
+	case <-time.After(25 * time.Second):
+		t.Fatal("ttyCmd did not return within 25s on happy path")
+	}
+
+	if !strings.Contains(stdout.String(), "hello") {
+		t.Fatalf("expected PTY output to contain %q, got %q", "hello", stdout.String())
+	}
+}
+
+type discardTTYCloser struct {
+	io.Writer
+}
+
+// discardTTYCloser collects PTY output without observing close signals.
+func (discardTTYCloser) Close() error { return nil }

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1407,7 +1407,7 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 
 	defer conn.Close()
 
-	receiveStdout := make(chan error)
+	receiveStdout := make(chan error, 1)
 
 	go func() {
 		receiveStdout <- redirectResponseToOutputStreams(outputStream, errorStream, conn)
@@ -1415,7 +1415,7 @@ func (r *runtimeOCI) AttachContainer(ctx context.Context, c *Container, inputStr
 		close(receiveStdout)
 	}()
 
-	stdinDone := make(chan error)
+	stdinDone := make(chan error, 1)
 
 	go func() {
 		var err, closeErr error

--- a/internal/oci/runtime_oci.go
+++ b/internal/oci/runtime_oci.go
@@ -1482,14 +1482,54 @@ func (r *runtimeOCI) ReopenContainerLog(ctx context.Context, c *Container) error
 	}
 	defer watcher.Close()
 
-	done := make(chan struct{})
-	doneClosed := false
-	errorCh := make(chan error)
+	// Adding the watch is best effort: conmon reopens the log either way,
+	// and returning an error here would make kubelet undo the rotation. On
+	// failure no worker is started and we do not wait for the new file.
+	var (
+		done    <-chan struct{}
+		errorCh <-chan error
+	)
+
+	cLogDir := filepath.Dir(c.LogPath())
+	if err := watcher.Add(cLogDir); err != nil {
+		log.Errorf(ctx, "Watcher.Add(%q) failed, not waiting for log file creation: %v", cLogDir, err)
+	} else {
+		done, errorCh = watchLogFileCreation(ctx, watcher, c)
+	}
+
+	if _, err = fmt.Fprintf(controlFile, "%d %d %d\n", 2, 0, 0); err != nil {
+		log.Debugf(ctx, "Failed to write to control file to reopen log file: %v", err)
+	}
+
+	if done == nil {
+		return nil
+	}
+
+	select {
+	case err := <-errorCh:
+		return err
+	case <-done:
+		return nil
+	}
+}
+
+// watchLogFileCreation starts a worker that signals done once the log file
+// of c is created or written in the directory already added to watcher, or
+// errorCh if the watcher reports an error. Each channel is buffered and
+// receives at most one value, so the worker never blocks on delivery, and it
+// exits when the fsnotify channels are closed.
+func watchLogFileCreation(ctx context.Context, watcher *fsnotify.Watcher, c *Container) (done <-chan struct{}, errorCh <-chan error) {
+	doneCh := make(chan struct{}, 1)
+	errCh := make(chan error, 1)
 
 	go func() {
 		for {
 			select {
-			case event := <-watcher.Events:
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
 				log.Debugf(ctx, "Event: %v", event)
 
 				if event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write {
@@ -1498,49 +1538,24 @@ func (r *runtimeOCI) ReopenContainerLog(ctx context.Context, c *Container) error
 					if event.Name == c.LogPath() {
 						log.Debugf(ctx, "Expected log file created")
 
-						done <- struct{}{}
+						doneCh <- struct{}{}
 
 						return
 					}
 				}
-			case err := <-watcher.Errors:
-				errorCh <- fmt.Errorf("watch error for container log reopen %v: %w", c.ID(), err)
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
 
-				close(errorCh)
+				errCh <- fmt.Errorf("watch error for container log reopen %v: %w", c.ID(), err)
 
 				return
 			}
 		}
 	}()
 
-	cLogDir := filepath.Dir(c.LogPath())
-	if err := watcher.Add(cLogDir); err != nil {
-		log.Errorf(ctx, "Watcher.Add(%q) failed: %s", cLogDir, err)
-		close(done)
-
-		doneClosed = true
-	}
-
-	if _, err = fmt.Fprintf(controlFile, "%d %d %d\n", 2, 0, 0); err != nil {
-		log.Debugf(ctx, "Failed to write to control file to reopen log file: %v", err)
-	}
-
-	select {
-	case err := <-errorCh:
-		if !doneClosed {
-			close(done)
-		}
-
-		return err
-	case <-done:
-		if !doneClosed {
-			close(done)
-		}
-
-		break
-	}
-
-	return nil
+	return doneCh, errCh
 }
 
 // prepareProcessExec returns the path of the process.json used in runc exec -p

--- a/internal/oci/runtime_oci_attach_leak_linux_test.go
+++ b/internal/oci/runtime_oci_attach_leak_linux_test.go
@@ -1,0 +1,211 @@
+package oci_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/internal/oci"
+	libconfig "github.com/cri-o/cri-o/pkg/config"
+)
+
+type discardWriteCloser struct{ io.Writer }
+
+func (discardWriteCloser) Close() error { return nil }
+
+type attachWorkerState struct {
+	workers int
+	senders int
+}
+
+// attachWorkers finds AttachContainer's result workers by function name rather
+// than closure number, which shifts when unrelated literals are added.
+func attachWorkers() attachWorkerState {
+	bufSize := 1 << 20
+
+	for {
+		buf := make([]byte, bufSize)
+
+		n := runtime.Stack(buf, true)
+		if n == len(buf) {
+			bufSize *= 2
+
+			continue
+		}
+
+		state := attachWorkerState{}
+
+		for stack := range strings.SplitSeq(string(buf[:n]), "\n\n") {
+			if !strings.Contains(stack, "AttachContainer.func") {
+				continue
+			}
+
+			state.workers++
+			if strings.Contains(stack, "chan send") {
+				state.senders++
+			}
+		}
+
+		return state
+	}
+}
+
+func expectAttachWorkersExit(before attachWorkerState) {
+	GinkgoHelper()
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	for {
+		current := attachWorkers()
+		if current.senders > before.senders {
+			Fail(fmt.Sprintf("AttachContainer stranded %d sender goroutine(s)", current.senders-before.senders))
+		}
+
+		if current.workers <= before.workers {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			Fail(fmt.Sprintf("AttachContainer left %d worker goroutine(s) running", current.workers-before.workers))
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func newAttachTestFixture() (*net.UnixListener, oci.RuntimeOCI, *oci.Container) {
+	GinkgoHelper()
+
+	sockDir := t.MustTempDir("attach-socket")
+	bundleDir := t.MustTempDir("attach-bundle")
+
+	Expect(os.WriteFile(filepath.Join(bundleDir, "ctl"), nil, 0o600)).To(Succeed())
+
+	const testContainerID = "attach-leak-test"
+
+	Expect(os.MkdirAll(filepath.Join(sockDir, testContainerID), 0o750)).To(Succeed())
+
+	listener, err := net.ListenUnix("unixpacket", &net.UnixAddr{
+		Name: filepath.Join(sockDir, testContainerID, "attach"),
+		Net:  "unixpacket",
+	})
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(listener.Close()).To(Succeed())
+	})
+
+	cfg, err := libconfig.DefaultConfig()
+	Expect(err).NotTo(HaveOccurred())
+
+	cfg.ContainerAttachSocketDir = sockDir
+
+	r, err := oci.New(cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	container, err := oci.NewContainer(testContainerID, "name", bundleDir, "logPath",
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"image", nil, nil, "", &types.ContainerMetadata{}, "sandbox",
+		false, true, false, "", t.MustTempDir("attach-dir"), time.Now(), "")
+	Expect(err).NotTo(HaveOccurred())
+
+	return listener, oci.NewRuntimeOCI(r, &libconfig.RuntimeHandler{}), container
+}
+
+func runAttach(runtimeOCI oci.RuntimeOCI, container *oci.Container, input io.Reader) <-chan error {
+	done := make(chan error, 1)
+
+	go func() {
+		done <- runtimeOCI.AttachContainer(context.Background(), container, input,
+			discardWriteCloser{io.Discard}, discardWriteCloser{io.Discard}, false, nil)
+	}()
+
+	return done
+}
+
+func drainAttachPeer(listener *net.UnixListener) <-chan error {
+	done := make(chan error, 1)
+
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			done <- err
+
+			return
+		}
+		defer conn.Close()
+
+		var buf [512]byte
+		for {
+			if _, err := conn.Read(buf[:]); err != nil {
+				done <- nil
+
+				return
+			}
+		}
+	}()
+
+	return done
+}
+
+func closeAttachPeer(listener *net.UnixListener) <-chan error {
+	done := make(chan error, 1)
+
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			done <- err
+
+			return
+		}
+
+		done <- conn.Close()
+	}()
+
+	return done
+}
+
+var _ = t.Describe("Oci", func() {
+	Context("AttachContainer result workers", func() {
+		It("does not strand the stdout sender when stdin completes first", func() {
+			listener, runtimeOCI, container := newAttachTestFixture()
+			before := attachWorkers()
+			peerDone := drainAttachPeer(listener)
+			attachDone := runAttach(runtimeOCI, container, nil)
+
+			var attachErr error
+			Eventually(attachDone, 30*time.Second).Should(Receive(&attachErr))
+			Expect(attachErr).NotTo(HaveOccurred())
+			Eventually(peerDone, 5*time.Second).Should(Receive(Succeed()))
+			expectAttachWorkersExit(before)
+		})
+
+		It("does not strand the stdin sender when stdout completes first", func() {
+			listener, runtimeOCI, container := newAttachTestFixture()
+			before := attachWorkers()
+			inputReader, inputWriter := io.Pipe()
+
+			DeferCleanup(func() {
+				_ = inputReader.Close()
+				_ = inputWriter.Close()
+			})
+
+			peerDone := closeAttachPeer(listener)
+			attachDone := runAttach(runtimeOCI, container, inputReader)
+
+			Eventually(peerDone, 5*time.Second).Should(Receive(Succeed()))
+			Eventually(attachDone, 30*time.Second).Should(Receive())
+			Expect(inputWriter.Close()).To(Succeed())
+			expectAttachWorkersExit(before)
+		})
+	})
+})

--- a/internal/oci/runtime_oci_reopen_log_leak_test.go
+++ b/internal/oci/runtime_oci_reopen_log_leak_test.go
@@ -1,0 +1,151 @@
+package oci
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// newReopenTestContainer builds a minimal container pointing at bundleDir
+// and logPath for ReopenContainerLog tests.
+func newReopenTestContainer(t *testing.T, bundleDir, logPath string) *Container {
+	t.Helper()
+
+	c, err := NewContainer("reopen-leak-id", "name", bundleDir, logPath,
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"image", nil, nil, "", &types.ContainerMetadata{}, "sandbox",
+		false, false, false, "", t.TempDir(), time.Now(), "")
+	if err != nil {
+		t.Fatalf("create test container: %v", err)
+	}
+
+	return c
+}
+
+// writeCtl creates the bundle ctl file ReopenContainerLog opens.
+func writeCtl(t *testing.T, bundleDir string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(bundleDir, "ctl"), []byte{}, 0o644); err != nil {
+		t.Fatalf("write ctl file: %v", err)
+	}
+}
+
+// TestRuntimeOCIReopenContainerLogWatchFailureIsBestEffort is a regression
+// test for the reopen-watcher leak: the watcher goroutine was launched before
+// watcher.Add, so a missing log directory closed done, returned nil, closed
+// the fsnotify channels, and stranded the worker on an unbuffered errorCh
+// send. The Add failure must stay best effort (nil error, reopen command
+// still sent to conmon) because kubelet undoes the log rotation on error,
+// and the goroutine count must settle back to baseline, proving repeated
+// failing calls accumulate no stranded watcher goroutines.
+func TestRuntimeOCIReopenContainerLogWatchFailureIsBestEffort(t *testing.T) {
+	ctx := context.Background()
+	r := &runtimeOCI{}
+
+	bundleDir := t.TempDir()
+	writeCtl(t, bundleDir)
+
+	// Log directory intentionally absent so watcher.Add fails.
+	missingDir := filepath.Join(t.TempDir(), "missing-log-dir")
+	logPath := filepath.Join(missingDir, "ctr.log")
+	c := newReopenTestContainer(t, bundleDir, logPath)
+
+	if err := r.ReopenContainerLog(ctx, c); err != nil {
+		t.Fatalf("expected best-effort nil error for missing log directory, got %v", err)
+	}
+
+	ctl, err := os.ReadFile(filepath.Join(bundleDir, "ctl"))
+	if err != nil {
+		t.Fatalf("read ctl file: %v", err)
+	}
+
+	if got, want := string(ctl), "2 0 0\n"; got != want {
+		t.Fatalf("ctl file = %q, want reopen command %q", got, want)
+	}
+
+	// Repeated requests must keep succeeding the same way instead of
+	// accumulating stranded watcher goroutines.
+	baseline := runtime.NumGoroutine()
+
+	for range 20 {
+		if err := r.ReopenContainerLog(ctx, c); err != nil {
+			t.Fatalf("expected nil error on repeated call, got %v", err)
+		}
+	}
+
+	// The failing path launches no goroutine, so the count must settle back
+	// to baseline instead of growing with each request.
+	deadline := time.Now().Add(10 * time.Second)
+
+	for {
+		if n := runtime.NumGoroutine(); n <= baseline {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutine count did not settle: baseline %d, now %d", baseline, runtime.NumGoroutine())
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestRuntimeOCIReopenContainerLogSuccessPath ensures the reordered watch
+// still observes the expected log file creation.
+func TestRuntimeOCIReopenContainerLogSuccessPath(t *testing.T) {
+	ctx := context.Background()
+	r := &runtimeOCI{}
+
+	bundleDir := t.TempDir()
+	writeCtl(t, bundleDir)
+
+	logDir := t.TempDir()
+	logPath := filepath.Join(logDir, "ctr.log")
+	c := newReopenTestContainer(t, bundleDir, logPath)
+
+	// Recreate the log file in a poll loop so the create event is guaranteed
+	// to fire after the watch is registered, no matter when Add happens.
+	stop := make(chan struct{})
+	defer close(stop)
+
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				_ = os.Remove(logPath)
+
+				if err := os.WriteFile(logPath, []byte("log"), 0o644); err != nil {
+					t.Errorf("failed to rewrite log file: %v", err)
+
+					return
+				}
+			}
+		}
+	}()
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- r.ReopenContainerLog(ctx, c)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ReopenContainerLog returned error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for ReopenContainerLog success path")
+	}
+}

--- a/internal/oci/runtime_pod.go
+++ b/internal/oci/runtime_pod.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	conmonClient "github.com/containers/conmon-rs/pkg/client"
 	conmonconfig "github.com/containers/conmon/runner/config"
@@ -20,7 +21,6 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	"github.com/cri-o/cri-o/internal/opentelemetry"
 	"github.com/cri-o/cri-o/pkg/config"
-	"github.com/cri-o/cri-o/utils"
 )
 
 // runtimePod is the Runtime interface implementation relying on conmon-rs to
@@ -32,6 +32,11 @@ type runtimePod struct {
 	oci       *runtimeOCI
 	client    *conmonClient.ConmonClient
 	serverDir string
+	// attachFunc invokes the conmon attach RPC. Nil means use
+	// client.AttachContainer. Overridden in tests to simulate conmon
+	// without a real server; the stub must start a vendored resize
+	// receiver exactly like conmon does before dialing.
+	attachFunc func(ctx context.Context, cfg *conmonClient.AttachConfig) error
 }
 
 // newRuntimePod creates a new runtimePod instance.
@@ -305,18 +310,66 @@ func (r *runtimePod) DiskStats(ctx context.Context, c *Container, cgroup string)
 	return r.oci.DiskStats(ctx, c, cgroup)
 }
 
+// bridgePodAttachResize bridges upstream cri-streaming resize events to the
+// downstream libpod resize channel with an attach-scoped lifetime.
+//
+// Both resize.HandleResizing helpers (utils and go.podman.io/common) only exit
+// when their input channel is closed, and conmon-rs never closes the
+// downstream channel, so the caller owns that lifecycle. The returned cleanup
+// stops and joins the bridge before closing downstream, so a blocked bridge
+// send can never race with the close. Cleanup must run on every attach return
+// (normal completion and dial failure alike) to release the vendored resize
+// receiver started by conmon-rs before dialing the attach socket.
+func bridgePodAttachResize(upstream <-chan remotecommand.TerminalSize) (downstream <-chan resize.TerminalSize, cleanup func()) {
+	ch := make(chan resize.TerminalSize, 1)
+	downstream = ch
+	bridgeDone := make(chan struct{})
+
+	var wg sync.WaitGroup
+	if upstream != nil {
+		wg.Go(func() {
+			for {
+				select {
+				case <-bridgeDone:
+					return
+				case size, ok := <-upstream:
+					if !ok {
+						return
+					}
+
+					if size.Height < 1 || size.Width < 1 {
+						continue
+					}
+
+					event := resize.TerminalSize{Height: size.Height, Width: size.Width}
+					select {
+					case ch <- event:
+					case <-bridgeDone:
+						return
+					}
+				}
+			}
+		})
+	}
+
+	var once sync.Once
+
+	cleanup = func() {
+		once.Do(func() {
+			close(bridgeDone)
+			wg.Wait()
+			close(ch)
+		})
+	}
+
+	return downstream, cleanup
+}
+
 func (r *runtimePod) AttachContainer(ctx context.Context, c *Container, inputStream io.Reader, outputStream, errorStream io.WriteCloser, tty bool, resizeChan <-chan remotecommand.TerminalSize) error {
 	attachSocketPath := filepath.Join(r.serverDir, c.ID(), "attach")
-	libpodResize := make(chan resize.TerminalSize, 1)
 
-	utils.HandleResizing(resizeChan, func(size remotecommand.TerminalSize) {
-		var libpodEvent resize.TerminalSize
-
-		libpodEvent.Height = size.Height
-
-		libpodEvent.Width = size.Width
-		libpodResize <- libpodEvent
-	})
+	libpodResize, cleanupResize := bridgePodAttachResize(resizeChan)
+	defer cleanupResize()
 
 	var (
 		stdin          *conmonClient.In
@@ -335,7 +388,7 @@ func (r *runtimePod) AttachContainer(ctx context.Context, c *Container, inputStr
 		stderr = &conmonClient.Out{WriteCloser: errorStream}
 	}
 
-	return r.client.AttachContainer(ctx, &conmonClient.AttachConfig{
+	cfg := &conmonClient.AttachConfig{
 		ID:                c.ID(),
 		SocketPath:        attachSocketPath,
 		Tty:               tty,
@@ -347,7 +400,13 @@ func (r *runtimePod) AttachContainer(ctx context.Context, c *Container, inputStr
 			Stdout: stdout,
 			Stderr: stderr,
 		},
-	})
+	}
+
+	if r.attachFunc != nil {
+		return r.attachFunc(ctx, cfg)
+	}
+
+	return r.client.AttachContainer(ctx, cfg)
 }
 
 func (r *runtimePod) PortForwardContainer(ctx context.Context, c *Container, netNsPath string, port int32, stream io.ReadWriteCloser) error {

--- a/internal/oci/runtime_pod_attach_leak_test.go
+++ b/internal/oci/runtime_pod_attach_leak_test.go
@@ -1,0 +1,403 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	conmonClient "github.com/containers/conmon-rs/pkg/client"
+	"go.podman.io/common/pkg/resize"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/cri-streaming/pkg/streaming/remotecommand"
+)
+
+// countVendoredReceivers counts goroutines blocked inside the vendored
+// resize.HandleResizing helper used by conmon-rs. It is a secondary,
+// defense-in-depth signal; the primary leak oracle is requireDownstreamClosed,
+// which deterministically checks the ownership contract.
+func countVendoredReceivers() int {
+	return countGoroutines("HandleResizing", "chan receive")
+}
+
+// waitFor polls cond until true or the timeout expires, failing the test.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// requireDownstreamClosed drains any buffered sizes and requires the
+// downstream channel to be closed within the timeout. A non-closed channel
+// is exactly the leaked state: the vendored receiver can never exit.
+func requireDownstreamClosed(t *testing.T, ch <-chan resize.TerminalSize, what string) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for downstream to close (%s)", what)
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// newTestPodContainer builds a minimal container for attach tests.
+func newTestPodContainer(t *testing.T, id string, stdinOnce bool) *Container {
+	t.Helper()
+
+	c, err := NewContainer(id, "name", t.TempDir(), "logPath",
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"image", nil, nil, "", &types.ContainerMetadata{}, "sandbox",
+		false, true, stdinOnce, "", t.TempDir(), time.Now(), "")
+	if err != nil {
+		t.Fatalf("create test container: %v", err)
+	}
+
+	return c
+}
+
+// attachCapture stubs the conmon attach RPC. It starts the vendored resize
+// receiver exactly like conmon-rs does before dialing, records the downstream
+// channel it was given, signals once the receiver is installed, and then
+// blocks until released or fails with err, mimicking attach duration and
+// dial failure respectively.
+type attachCapture struct {
+	mu         sync.Mutex
+	downstream []<-chan resize.TerminalSize
+	started    chan struct{}
+	release    chan struct{}
+	onSize     func(resize.TerminalSize)
+	err        error
+
+	once sync.Once
+}
+
+// newAttachCapture returns a stub that reports sizes to onSize (or drops
+// them) and fails with err when set, mimicking dial failure.
+func newAttachCapture(onSize func(resize.TerminalSize), err error) *attachCapture {
+	if onSize == nil {
+		onSize = func(resize.TerminalSize) {}
+	}
+
+	return &attachCapture{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		onSize:  onSize,
+		err:     err,
+	}
+}
+
+// stub returns an attachFunc that installs the vendored receiver, records
+// the downstream channel, and blocks until released or fails immediately.
+func (a *attachCapture) stub() func(context.Context, *conmonClient.AttachConfig) error {
+	return func(_ context.Context, cfg *conmonClient.AttachConfig) error {
+		a.mu.Lock()
+		a.downstream = append(a.downstream, cfg.Resize)
+		a.mu.Unlock()
+
+		resize.HandleResizing(cfg.Resize, a.onSize)
+		a.once.Do(func() { close(a.started) })
+
+		if a.err != nil {
+			return a.err
+		}
+
+		<-a.release
+
+		return nil
+	}
+}
+
+// releaseAll unblocks a stub waiting in stub, exactly once.
+func (a *attachCapture) releaseAll() {
+	select {
+	case <-a.release:
+	default:
+		close(a.release)
+	}
+}
+
+// requireAllClosed requires every downstream channel the stub observed to
+// be closed, proving AttachContainer released conmon's receiver.
+func (a *attachCapture) requireAllClosed(t *testing.T, what string) {
+	t.Helper()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if len(a.downstream) == 0 {
+		t.Fatalf("stub never ran (%s)", what)
+	}
+
+	for _, ch := range a.downstream {
+		requireDownstreamClosed(t, ch, what)
+	}
+}
+
+// TestRuntimePodAttachContainerNoStrandedReceiver is a regression test for a
+// goroutine leak in pod attach: AttachContainer allocated the downstream
+// resize channel but never closed it, so the vendored resize receiver started
+// by conmon-rs blocked permanently. It drives the real AttachContainer with
+// a stubbed conmon attach (no live server needed). The primary oracle
+// requires each downstream channel to be closed; receiver stack scans are
+// secondary.
+func TestRuntimePodAttachContainerNoStrandedReceiver(t *testing.T) {
+	t.Run("nil upstream non-TTY", func(t *testing.T) {
+		before := countVendoredReceivers()
+		capture := newAttachCapture(nil, nil)
+
+		rp := &runtimePod{serverDir: t.TempDir(), attachFunc: capture.stub()}
+		c := newTestPodContainer(t, "pod-attach-leak-nil", false)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- rp.AttachContainer(context.Background(), c, nil, nil, nil, false, nil)
+		}()
+
+		select {
+		case <-capture.started:
+		case <-time.After(10 * time.Second):
+			t.Fatal("stub never started")
+		}
+
+		capture.releaseAll()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("AttachContainer returned error: %v", err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("AttachContainer did not return")
+		}
+
+		capture.requireAllClosed(t, "nil upstream")
+
+		waitFor(t, "vendored receiver to exit", func() bool {
+			return countVendoredReceivers()-before == 0
+		})
+	})
+
+	t.Run("TTY forwards then releases with upstream open", func(t *testing.T) {
+		before := countVendoredReceivers()
+
+		upstream := make(chan remotecommand.TerminalSize, 2)
+
+		t.Cleanup(func() {
+			select {
+			case <-upstream:
+			default:
+			}
+		})
+
+		received := make(chan resize.TerminalSize, 2)
+		capture := newAttachCapture(func(s resize.TerminalSize) {
+			received <- s
+		}, nil)
+
+		rp := &runtimePod{serverDir: t.TempDir(), attachFunc: capture.stub()}
+		c := newTestPodContainer(t, "pod-attach-leak-tty", false)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- rp.AttachContainer(context.Background(), c, nil, nil, nil, true, upstream)
+		}()
+
+		select {
+		case <-capture.started:
+		case <-time.After(10 * time.Second):
+			t.Fatal("stub never started")
+		}
+
+		upstream <- remotecommand.TerminalSize{Height: 24, Width: 80}
+
+		select {
+		case got := <-received:
+			if got.Height != 24 || got.Width != 80 {
+				t.Fatalf("forwarded size = %+v, want 24x80", got)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for forwarded resize event")
+		}
+
+		// Release attach while upstream is still open: cleanup must stop
+		// the bridge even though no upstream close arrived.
+		capture.releaseAll()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("AttachContainer returned error: %v", err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("AttachContainer did not return")
+		}
+
+		capture.requireAllClosed(t, "TTY")
+		// AttachContainer only returns after cleanup joins the bridge, so a
+		// return already proves bridge termination with upstream open.
+
+		waitFor(t, "vendored receiver to exit", func() bool {
+			return countVendoredReceivers()-before == 0
+		})
+	})
+
+	t.Run("dial failure still releases", func(t *testing.T) {
+		before := countVendoredReceivers()
+
+		dialErr := errors.New("failed to connect to container's attach socket")
+		capture := newAttachCapture(nil, dialErr)
+
+		rp := &runtimePod{serverDir: t.TempDir(), attachFunc: capture.stub()}
+		c := newTestPodContainer(t, "pod-attach-leak-dial", false)
+
+		upstream := make(chan remotecommand.TerminalSize)
+		defer close(upstream)
+
+		if err := rp.AttachContainer(context.Background(), c, nil, nil, nil, true, upstream); !errors.Is(err, dialErr) {
+			t.Fatalf("AttachContainer error = %v, want %v", err, dialErr)
+		}
+
+		capture.requireAllClosed(t, "dial failure")
+
+		waitFor(t, "vendored receiver to exit after dial failure", func() bool {
+			return countVendoredReceivers()-before == 0
+		})
+	})
+
+	t.Run("cancelled context still releases", func(t *testing.T) {
+		before := countVendoredReceivers()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		capture := newAttachCapture(nil, ctx.Err())
+
+		rp := &runtimePod{serverDir: t.TempDir(), attachFunc: capture.stub()}
+		c := newTestPodContainer(t, "pod-attach-leak-cancel", false)
+
+		if err := rp.AttachContainer(ctx, c, nil, nil, nil, false, nil); !errors.Is(err, context.Canceled) {
+			t.Fatalf("AttachContainer error = %v, want context.Canceled", err)
+		}
+
+		capture.requireAllClosed(t, "cancelled context")
+
+		waitFor(t, "vendored receiver to exit after cancel", func() bool {
+			return countVendoredReceivers()-before == 0
+		})
+	})
+
+	t.Run("leave-stdin-open flag propagates and releases", func(t *testing.T) {
+		before := countVendoredReceivers()
+
+		var gotEOF bool
+
+		capture := newAttachCapture(nil, nil)
+		orig := capture.stub()
+		rp := &runtimePod{
+			serverDir: t.TempDir(),
+			attachFunc: func(ctx context.Context, cfg *conmonClient.AttachConfig) error {
+				gotEOF = cfg.StopAfterStdinEOF
+
+				return orig(ctx, cfg)
+			},
+		}
+		// stdin=true, stdinOnce=true, non-TTY => StopAfterStdinEOF must be true.
+		c := newTestPodContainer(t, "pod-attach-leak-eof", true)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- rp.AttachContainer(context.Background(), c, nil, nil, nil, false, nil)
+		}()
+
+		select {
+		case <-capture.started:
+		case <-time.After(10 * time.Second):
+			t.Fatal("stub never started")
+		}
+
+		capture.releaseAll()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("AttachContainer returned error: %v", err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("AttachContainer did not return")
+		}
+
+		if !gotEOF {
+			t.Fatal("StopAfterStdinEOF = false, want true for stdinOnce container")
+		}
+
+		capture.requireAllClosed(t, "stdin-once")
+
+		waitFor(t, "vendored receiver to exit", func() bool {
+			return countVendoredReceivers()-before == 0
+		})
+	})
+
+	t.Run("repeated sessions do not accumulate", func(t *testing.T) {
+		before := countVendoredReceivers()
+
+		all := make([]*attachCapture, 0, 20)
+
+		for range 20 {
+			capture := newAttachCapture(nil, nil)
+			all = append(all, capture)
+
+			rp := &runtimePod{serverDir: t.TempDir(), attachFunc: capture.stub()}
+			c := newTestPodContainer(t, "pod-attach-leak-repeat", false)
+
+			done := make(chan error, 1)
+			go func() {
+				done <- rp.AttachContainer(context.Background(), c, nil, nil, nil, false, nil)
+			}()
+
+			select {
+			case <-capture.started:
+			case <-time.After(10 * time.Second):
+				t.Fatal("stub never started")
+			}
+
+			capture.releaseAll()
+
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("AttachContainer returned error: %v", err)
+				}
+			case <-time.After(30 * time.Second):
+				t.Fatal("AttachContainer did not return")
+			}
+		}
+
+		for _, capture := range all {
+			capture.requireAllClosed(t, "repeated sessions")
+		}
+
+		waitFor(t, "repeated receivers to exit", func() bool {
+			return countVendoredReceivers()-before == 0
+		})
+	})
+}

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -614,20 +614,31 @@ func (r *runtimeVM) execContainerCommon(ctx context.Context, c *Container, cmd [
 		timeoutCh = time.After(timeoutDuration)
 	}
 
-	execCh := make(chan error)
+	// execOutcome carries the one-shot result of the wait worker. The
+	// channel is buffered so the worker can publish after the parent has
+	// returned on the timeout Kill-failure path, and the worker only
+	// touches its own locals so it can never race the named returns.
+	type execOutcome struct {
+		code int32
+		err  error
+	}
+
+	execCh := make(chan execOutcome, 1)
 
 	go func() {
-		// Wait for the process to terminate
-		exitCode, err = r.wait(c.ID(), execID)
-		if err != nil {
-			execCh <- err
-		}
+		// Wait for the process to terminate. Publish to worker-local
+		// values only: the parent may already have returned on the
+		// timeout Kill-failure path, so the worker must not assign the
+		// named return variables.
+		code, err := r.wait(c.ID(), execID)
+		execCh <- execOutcome{code: code, err: err}
 
 		close(execCh)
 	}()
 
 	select {
-	case err = <-execCh:
+	case outcome := <-execCh:
+		exitCode, err = outcome.code, outcome.err
 		if err != nil {
 			if killErr := r.kill(c.ID(), execID, syscall.SIGKILL); killErr != nil {
 				return execError, killErr

--- a/internal/oci/runtime_vm_exec_leak_test.go
+++ b/internal/oci/runtime_vm_exec_leak_test.go
@@ -1,0 +1,206 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/ttrpc"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"google.golang.org/protobuf/types/known/emptypb"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/cri-o/cri-o/pkg/config"
+)
+
+// countExecWaitSenders counts goroutines blocked sending inside the
+// execContainerCommon wait worker. It is a secondary signal; the primary
+// oracle is that Wait can return after the parent took the timeout
+// Kill-failure path without stranding the worker.
+func countExecWaitSenders() int {
+	return countGoroutines("execContainerCommon", "chan send")
+}
+
+// fakeVMTask is a controllable task.TaskService for exec tests. Wait blocks
+// until releaseWait is closed and then returns waitErr, mimicking a pending
+// remote Wait that resolves after the parent timed out. Kill fails with
+// killErr to mimic the ttrpc connection closing before/during the timeout
+// kill, which makes the parent return without draining execCh.
+type fakeVMTask struct {
+	task.TaskService
+
+	mu          sync.Mutex
+	waitStarted chan struct{}
+	releaseWait chan struct{}
+	waitErr     error
+	killErr     error
+	waitCalls   int
+	killCalls   int
+
+	once sync.Once
+}
+
+func newFakeVMTask(waitErr, killErr error) *fakeVMTask {
+	return &fakeVMTask{
+		waitStarted: make(chan struct{}),
+		releaseWait: make(chan struct{}),
+		waitErr:     waitErr,
+		killErr:     killErr,
+	}
+}
+
+func (f *fakeVMTask) Exec(_ context.Context, _ *task.ExecProcessRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (f *fakeVMTask) Start(_ context.Context, _ *task.StartRequest) (*task.StartResponse, error) {
+	return &task.StartResponse{}, nil
+}
+
+func (f *fakeVMTask) Delete(_ context.Context, _ *task.DeleteRequest) (*task.DeleteResponse, error) {
+	return &task.DeleteResponse{}, nil
+}
+
+func (f *fakeVMTask) CloseIO(_ context.Context, _ *task.CloseIORequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (f *fakeVMTask) Wait(_ context.Context, _ *task.WaitRequest) (*task.WaitResponse, error) {
+	f.mu.Lock()
+	f.waitCalls++
+	f.mu.Unlock()
+	f.once.Do(func() { close(f.waitStarted) })
+
+	<-f.releaseWait
+
+	if f.waitErr != nil {
+		return nil, f.waitErr
+	}
+
+	return &task.WaitResponse{ExitStatus: 0}, nil
+}
+
+func (f *fakeVMTask) Kill(_ context.Context, _ *task.KillRequest) (*emptypb.Empty, error) {
+	f.mu.Lock()
+	f.killCalls++
+	f.mu.Unlock()
+
+	if f.killErr != nil {
+		return nil, f.killErr
+	}
+
+	return &emptypb.Empty{}, nil
+}
+
+// discardWriteCloser sinks exec output; Close is a no-op because the test
+// never observes close signals.
+type discardWriteCloser struct{}
+
+func (discardWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (discardWriteCloser) Close() error                { return nil }
+
+func newTestVMContainer(t *testing.T, id string) *Container {
+	t.Helper()
+
+	c, err := NewContainer(id, "name", t.TempDir(), t.TempDir()+"/log",
+		map[string]string{}, map[string]string{}, map[string]string{},
+		"image", nil, nil, "", &types.ContainerMetadata{}, "sandbox",
+		false, false, false, "", t.TempDir(), time.Now(), "")
+	if err != nil {
+		t.Fatalf("create test container: %v", err)
+	}
+
+	c.SetSpec(&rspec.Spec{
+		Process: &rspec.Process{
+			Args: []string{"echo", "hi"},
+			Cwd:  "/",
+			Env:  []string{},
+		},
+	})
+
+	return c
+}
+
+// TestRuntimeVMExecContainerCommonTimeoutKillFailure is a regression test for
+// a goroutine leak in execContainerCommon: with an unbuffered execCh, a
+// timeout followed by a failed Kill makes the parent return without ever
+// receiving from execCh, so the wait worker blocks forever on its one-shot
+// send once the pending Wait resolves. Buffering execCh (capacity 1) lets
+// that late send complete.
+func TestRuntimeVMExecContainerCommonTimeoutKillFailure(t *testing.T) {
+	before := countExecWaitSenders()
+
+	// The pending Wait resolves with a closed-connection error only after
+	// the timeout Kill has failed.
+	fake := newFakeVMTask(ttrpc.ErrClosed, errors.New("injected kill failure"))
+
+	// Build through the constructor so typeurl registrations for the exec
+	// spec survive, then swap in the controllable task service.
+	root := t.TempDir()
+
+	rr, ok := newRuntimeVM(&config.RuntimeHandler{RuntimeRoot: root}, t.TempDir()).(*runtimeVM)
+	if !ok {
+		t.Fatal("newRuntimeVM did not return *runtimeVM")
+	}
+
+	rr.task = fake
+	rr.ctx = context.Background()
+	r := rr
+	c := newTestVMContainer(t, "vm-exec-leak")
+
+	done := make(chan struct {
+		code int32
+		err  error
+	}, 1)
+	go func() {
+		code, err := r.execContainerCommon(context.Background(), c, []string{"echo", "hi"}, 1, nil, discardWriteCloser{}, discardWriteCloser{}, false, nil)
+		done <- struct {
+			code int32
+			err  error
+		}{code, err}
+	}()
+
+	// Wait until the worker is inside the pending Wait, then let the
+	// 1-second timeout fire and take the Kill-failure return. Surface an
+	// early return (e.g. spec marshal or Exec/Start failure) instead of
+	// hanging on waitStarted.
+	select {
+	case <-fake.waitStarted:
+	case res := <-done:
+		t.Fatalf("execContainerCommon returned early: code=%d err=%v", res.code, res.err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Wait never started")
+	}
+
+	var res struct {
+		code int32
+		err  error
+	}
+	select {
+	case res = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("execContainerCommon did not return after timeout")
+	}
+
+	if res.err == nil || !strings.Contains(res.err.Error(), "injected kill failure") {
+		t.Fatalf("execContainerCommon error = %v, want injected kill failure", res.err)
+	}
+
+	// Release the pending Wait after the parent returned. Before the fix
+	// this strands the worker on `execCh <- err`; after the fix the
+	// buffered send completes and the worker exits.
+	close(fake.releaseWait)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for countExecWaitSenders()-before != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("execContainerCommon stranded %d sender goroutine(s)", countExecWaitSenders()-before)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/server/mirror_registry_watcher_leak_test.go
+++ b/server/mirror_registry_watcher_leak_test.go
@@ -1,0 +1,213 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	kclock "k8s.io/utils/clock"
+)
+
+type fakeMirrorRegistryTimer struct {
+	ticks   chan time.Time
+	resets  chan time.Duration
+	stopped chan struct{}
+	stop    sync.Once
+}
+
+func newFakeMirrorRegistryTimer() *fakeMirrorRegistryTimer {
+	return &fakeMirrorRegistryTimer{
+		ticks:   make(chan time.Time, 1),
+		resets:  make(chan time.Duration, 1),
+		stopped: make(chan struct{}),
+	}
+}
+
+func (t *fakeMirrorRegistryTimer) C() <-chan time.Time {
+	return t.ticks
+}
+
+func (t *fakeMirrorRegistryTimer) Stop() bool {
+	t.stop.Do(func() {
+		close(t.stopped)
+	})
+
+	return true
+}
+
+func (t *fakeMirrorRegistryTimer) Reset(d time.Duration) bool {
+	t.resets <- d
+
+	return true
+}
+
+func receiveMirrorWatcherValue[T any](t *testing.T, values <-chan T) T {
+	t.Helper()
+
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for mirror-registry watcher")
+	}
+
+	var zero T
+
+	return zero
+}
+
+func requireMirrorWatcherStopped(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	receiveMirrorWatcherValue(t, done)
+}
+
+func startMirrorRegistryEventLoop(
+	t *testing.T,
+	ctx context.Context,
+	events <-chan fsnotify.Event,
+	reload func(string),
+) (
+	timer *fakeMirrorRegistryTimer,
+	timerStarted <-chan time.Duration,
+	done <-chan struct{},
+) {
+	t.Helper()
+
+	timer = newFakeMirrorRegistryTimer()
+	timerStartedChannel := make(chan time.Duration, 1)
+	doneChannel := make(chan struct{})
+
+	go func() {
+		watchAndReloadMirrorRegistriesConfiguration(
+			ctx,
+			events,
+			make(chan error),
+			reload,
+			func(d time.Duration) kclock.Timer {
+				timerStartedChannel <- d
+
+				return timer
+			},
+		)
+		close(doneChannel)
+	}()
+
+	return timer, timerStartedChannel, doneChannel
+}
+
+func TestMirrorRegistryWatcherStop(t *testing.T) {
+	s := &Server{}
+	s.startMirrorRegistryWatcher(context.Background(), t.TempDir())
+
+	done := make(chan struct{})
+
+	go func() {
+		s.stopMirrorRegistryWatcher()
+		close(done)
+	}()
+
+	requireMirrorWatcherStopped(t, done)
+
+	// Stopping an already stopped watcher is safe.
+	s.stopMirrorRegistryWatcher()
+}
+
+func TestWatchAndReloadMirrorRegistriesConfiguration(t *testing.T) {
+	t.Run("debounces events", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		events := make(chan fsnotify.Event, 2)
+		reloads := make(chan string, 1)
+		timer, timerStarted, done := startMirrorRegistryEventLoop(t, ctx, events, func(name string) {
+			reloads <- name
+		})
+
+		events <- fsnotify.Event{Name: "first.conf", Op: fsnotify.Write}
+
+		if d := receiveMirrorWatcherValue(t, timerStarted); d != debounceDuration {
+			t.Fatalf("expected debounce duration %s, got %s", debounceDuration, d)
+		}
+
+		events <- fsnotify.Event{Name: "second.conf", Op: fsnotify.Write}
+
+		if d := receiveMirrorWatcherValue(t, timer.resets); d != debounceDuration {
+			t.Fatalf("expected reset duration %s, got %s", debounceDuration, d)
+		}
+
+		timer.ticks <- time.Now()
+
+		if name := receiveMirrorWatcherValue(t, reloads); name != "second.conf" {
+			t.Fatalf("expected latest event to trigger reload, got %q", name)
+		}
+
+		select {
+		case name := <-reloads:
+			t.Fatalf("expected events to be debounced, got extra reload for %q", name)
+		default:
+		}
+
+		cancel()
+		requireMirrorWatcherStopped(t, done)
+	})
+
+	t.Run("cancels pending reload", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		events := make(chan fsnotify.Event, 1)
+		reloads := make(chan string, 1)
+		timer, timerStarted, done := startMirrorRegistryEventLoop(t, ctx, events, func(name string) {
+			reloads <- name
+		})
+
+		events <- fsnotify.Event{Name: "pending.conf", Op: fsnotify.Write}
+
+		receiveMirrorWatcherValue(t, timerStarted)
+		cancel()
+		requireMirrorWatcherStopped(t, done)
+
+		select {
+		case <-timer.stopped:
+		default:
+			t.Fatal("pending debounce timer was not stopped")
+		}
+
+		timer.ticks <- time.Now()
+
+		select {
+		case name := <-reloads:
+			t.Fatalf("unexpected reload after cancellation for %q", name)
+		default:
+		}
+	})
+
+	t.Run("joins active reload", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		events := make(chan fsnotify.Event, 1)
+		reloadStarted := make(chan struct{})
+		releaseReload := make(chan struct{})
+		timer, timerStarted, done := startMirrorRegistryEventLoop(t, ctx, events, func(string) {
+			close(reloadStarted)
+			<-releaseReload
+		})
+
+		events <- fsnotify.Event{Name: "active.conf", Op: fsnotify.Write}
+
+		receiveMirrorWatcherValue(t, timerStarted)
+
+		timer.ticks <- time.Now()
+
+		receiveMirrorWatcherValue(t, reloadStarted)
+		cancel()
+
+		select {
+		case <-done:
+			t.Fatal("watcher stopped before active reload completed")
+		default:
+		}
+
+		close(releaseReload)
+		requireMirrorWatcherStopped(t, done)
+	})
+}

--- a/server/nri-api.go
+++ b/server/nri-api.go
@@ -41,6 +41,18 @@ func (a *nriAPI) start() error {
 	return a.nri.Start()
 }
 
+// stop shuts down the NRI adaptation listener, releasing the socket so a
+// same-process restart can rebind it. It is idempotent and safe on a nil
+// or disabled receiver, so Shutdown and constructor rollback can both call
+// it without coordination.
+func (a *nriAPI) stop() {
+	if !a.isEnabled() {
+		return
+	}
+
+	a.nri.Stop()
+}
+
 func (a *nriAPI) isEnabled() bool {
 	return a != nil && a.nri != nil && a.nri.IsEnabled()
 }

--- a/server/nri_api_stop_test.go
+++ b/server/nri_api_stop_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	nriadapt "github.com/containerd/nri/pkg/adaptation"
+
+	nrilib "github.com/cri-o/cri-o/internal/nri"
+)
+
+// stubNRI counts Stop calls so the test can prove nriAPI.stop delegates to
+// the adaptation instead of silently dropping the shutdown signal.
+type stubNRI struct {
+	nrilib.API
+
+	stops atomic.Int32
+}
+
+func (s *stubNRI) IsEnabled() bool { return true }
+func (s *stubNRI) Stop()           { s.stops.Add(1) }
+func (s *stubNRI) Start() error    { return nil }
+
+func (s *stubNRI) RunPodSandbox(context.Context, nrilib.PodSandbox) error {
+	return nil
+}
+
+func (s *stubNRI) UpdatePodSandbox(context.Context, nrilib.PodSandbox, *nriadapt.LinuxResources, *nriadapt.LinuxResources) error {
+	return nil
+}
+
+func (s *stubNRI) StopPodSandbox(context.Context, nrilib.PodSandbox) error {
+	return nil
+}
+
+func (s *stubNRI) RemovePodSandbox(context.Context, nrilib.PodSandbox) error {
+	return nil
+}
+
+func (s *stubNRI) CreateContainer(context.Context, nrilib.PodSandbox, nrilib.Container) (*nriadapt.ContainerAdjustment, error) {
+	return nil, nil
+}
+
+func (s *stubNRI) PostCreateContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) StartContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) PostStartContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) UpdateContainer(context.Context, nrilib.PodSandbox, nrilib.Container, *nriadapt.LinuxResources) (*nriadapt.LinuxResources, error) {
+	return nil, nil
+}
+
+func (s *stubNRI) PostUpdateContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) StopContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+func (s *stubNRI) RemoveContainer(context.Context, nrilib.PodSandbox, nrilib.Container) error {
+	return nil
+}
+
+// TestNRIAPIStopDelegates verifies Shutdown's new cleanup path: stop must
+// reach the adaptation, stay safe to repeat (Shutdown and constructor
+// rollback can both fire), and never panic on a nil or disabled receiver.
+func TestNRIAPIStopDelegates(t *testing.T) {
+	stub := &stubNRI{}
+	a := &nriAPI{nri: stub}
+
+	a.stop()
+
+	if got := stub.stops.Load(); got != 1 {
+		t.Fatalf("stop did not reach adaptation, Stop calls = %d", got)
+	}
+
+	// Repeating must stay safe; the underlying local.Stop is idempotent.
+	a.stop()
+
+	if got := stub.stops.Load(); got < 1 {
+		t.Fatalf("repeated stop lost the shutdown signal, Stop calls = %d", got)
+	}
+
+	var nilAPI *nriAPI
+	nilAPI.stop()
+
+	(&nriAPI{}).stop()
+	(&nriAPI{nri: nil}).stop()
+}

--- a/server/server.go
+++ b/server/server.go
@@ -354,6 +354,10 @@ func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 
 // Shutdown attempts to shut down the server's storage cleanly.
 func (s *Server) Shutdown(ctx context.Context) error {
+	// Stop NRI first so no error return below can bypass listener cleanup.
+	// stop is idempotent and nil-safe, so Shutdown remains safe to call
+	// on a server whose NRI was never started or already stopped.
+	s.nri.stop()
 	s.stopReloadWatcher()
 	s.stopMirrorRegistryWatcher()
 	s.config.CNIManagerShutdown()
@@ -614,6 +618,7 @@ func New(
 	// discarded Server strands no goroutines.
 	defer func() {
 		if retErr != nil {
+			s.nri.stop()
 			s.stopMirrorRegistryWatcher()
 			s.stopReloadWatcher()
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/cri-streaming/pkg/streaming"
 	kubetypes "k8s.io/kubelet/pkg/types"
+	kclock "k8s.io/utils/clock"
 
 	"github.com/cri-o/cri-o/internal/cert"
 	"github.com/cri-o/cri-o/internal/config/seccomp"
@@ -94,6 +95,11 @@ type Server struct {
 
 	containerEventClients           sync.Map
 	containerEventStreamBroadcaster sync.Once
+
+	// mirrorRegistryWatcherCancel ties the mirror-registry watcher to the
+	// Server lifecycle.
+	mirrorRegistryWatcherCancel context.CancelFunc
+	mirrorRegistryWatcherWG     sync.WaitGroup
 
 	// NRI runtime interface
 	nri *nriAPI
@@ -349,6 +355,7 @@ func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 // Shutdown attempts to shut down the server's storage cleanly.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.stopReloadWatcher()
+	s.stopMirrorRegistryWatcher()
 	s.config.CNIManagerShutdown()
 	s.resourceStore.Close()
 
@@ -599,17 +606,19 @@ func New(
 
 	s.startReloadWatcher(ctx)
 
-	// Roll back every worker started from here on when a later step fails,
-	// so a discarded Server strands no goroutines.
+	if s.config.AutoReloadRegistries {
+		s.startMirrorRegistryWatcher(ctx, s.config.SystemContext.SystemRegistriesConfDirPath)
+	}
+
+	// Roll back every worker started above when a later step fails, so a
+	// discarded Server strands no goroutines.
 	defer func() {
 		if retErr != nil {
+			s.stopMirrorRegistryWatcher()
 			s.stopReloadWatcher()
 		}
 	}()
 
-	if s.config.AutoReloadRegistries {
-		go s.startWatcherForMirrorRegistries(ctx, s.config.SystemContext.SystemRegistriesConfDirPath)
-	}
 	// Start the metrics server if configured to be enabled
 	if s.config.EnableMetrics {
 		if err := metrics.New(&s.config.MetricsConfig, &s.config.APIConfig).Start(ctx, s.monitorsChan); err != nil {
@@ -1123,10 +1132,10 @@ func isNotFound(err error) bool {
 	return false
 }
 
-// startWatcherForMirrorRegistries sets up a file watcher to monitor changes
-// in the "registries.conf.d" directory (default: "/etc/containers/registries.conf.d").
-// It then delegates the monitoring task to watchAndReloadMirrorRegistriesConfiguration.
-func (s *Server) startWatcherForMirrorRegistries(ctx context.Context, registriesConfDDir string) {
+// startMirrorRegistryWatcher monitors the registries.conf.d directory until
+// the server is stopped. Watch setup is synchronous so the goroutine is fully
+// owned before New continues.
+func (s *Server) startMirrorRegistryWatcher(ctx context.Context, registriesConfDDir string) {
 	if registriesConfDDir == "" {
 		log.Infof(ctx, "No registries.conf.d directory specified, defaulting to /etc/containers/registries.conf.d")
 
@@ -1138,44 +1147,72 @@ func (s *Server) startWatcherForMirrorRegistries(ctx context.Context, registries
 		log.Fatalf(ctx, "Failed to create new watcher: %v", err)
 	}
 
-	defer watcher.Close()
-
-	log.Infof(ctx, "Registered reload watcher for mirror registries configuration")
-
 	if err := watcher.Add(registriesConfDDir); err != nil {
 		log.Errorf(ctx, "Failed to add watcher for path %q: %s", registriesConfDDir, err)
+		watcher.Close()
 
 		return
 	}
 
-	s.watchAndReloadMirrorRegistriesConfiguration(ctx, watcher)
+	watcherCtx, cancel := context.WithCancel(ctx)
+	s.mirrorRegistryWatcherCancel = cancel
+
+	s.mirrorRegistryWatcherWG.Go(func() {
+		defer watcher.Close()
+
+		watchAndReloadMirrorRegistriesConfiguration(
+			watcherCtx,
+			watcher.Events,
+			watcher.Errors,
+			func(eventName string) {
+				log.Infof(ctx, "File %q changed, reloading registries configuration", eventName)
+
+				if err := s.config.ReloadRegistries(); err != nil {
+					log.Errorf(ctx, "Failed to reload registry configuration: %v", err)
+				}
+			},
+			func(d time.Duration) kclock.Timer {
+				return kclock.RealClock{}.NewTimer(d)
+			},
+		)
+	})
+
+	log.Infof(ctx, "Registered reload watcher for mirror registries configuration")
 }
 
-func (s *Server) watchAndReloadMirrorRegistriesConfiguration(ctx context.Context, watcher *fsnotify.Watcher) {
-	var timer *time.Timer
+func (s *Server) stopMirrorRegistryWatcher() {
+	if s.mirrorRegistryWatcherCancel != nil {
+		s.mirrorRegistryWatcherCancel()
+	}
 
-	reloadChannel := make(chan string, 1)
+	s.mirrorRegistryWatcherWG.Wait()
+}
 
-	go func() {
-		// The for loop ensures that the channel is properly drained, even if
-		// no new events are received, thus preventing potential deadlocks.
-		// For each event name received, the goroutine checks if it's not
-		// an empty string and then reloads the registries.
-		for evenName := range reloadChannel {
-			log.Infof(ctx, "File %q changed, reloading registries configuration", evenName)
+func watchAndReloadMirrorRegistriesConfiguration(
+	ctx context.Context,
+	events <-chan fsnotify.Event,
+	watcherErrors <-chan error,
+	reload func(string),
+	newTimer func(time.Duration) kclock.Timer,
+) {
+	var (
+		timer   kclock.Timer
+		timerCh <-chan time.Time
+		pending string
+	)
 
-			if err := s.config.ReloadRegistries(); err != nil {
-				log.Errorf(ctx, "Failed to reload registry configuration: %v", err)
-			}
+	defer func() {
+		if timer != nil {
+			timer.Stop()
 		}
 	}()
 
 	for {
 		select {
-		case event, ok := <-watcher.Events:
+		case <-ctx.Done():
+			return
+		case event, ok := <-events:
 			if !ok {
-				close(reloadChannel)
-
 				return
 			}
 
@@ -1183,21 +1220,32 @@ func (s *Server) watchAndReloadMirrorRegistriesConfiguration(ctx context.Context
 				continue
 			}
 
-			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Chmod) != 0 {
-				// Reset timer if exists, else create a new one.
-				if timer != nil {
-					timer.Reset(debounceDuration)
-				} else {
-					timer = time.AfterFunc(debounceDuration, func() {
-						reloadChannel <- event.Name
-					})
-				}
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Chmod) == 0 {
+				continue
 			}
 
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				close(reloadChannel)
+			pending = event.Name
 
+			if timer == nil {
+				timer = newTimer(debounceDuration)
+				timerCh = timer.C()
+			} else {
+				timer.Reset(debounceDuration)
+			}
+		case <-timerCh:
+			name := pending
+			timer = nil
+			timerCh = nil
+			pending = ""
+
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				reload(name)
+			}
+		case err, ok := <-watcherErrors:
+			if !ok {
 				return
 			}
 

--- a/server/server.go
+++ b/server/server.go
@@ -101,6 +101,13 @@ type Server struct {
 	hooksRetriever *runtimehandlerhooks.HooksRetriever
 
 	artifactStore *ociartifact.Store
+
+	// reloadWatcherDone closes to ask the SIGHUP reload watcher to exit.
+	// reloadWatcherStopped closes once that watcher has exited.
+	// Both are owned by startReloadWatcher and joined by stopReloadWatcher.
+	reloadWatcherDone     chan struct{}
+	reloadWatcherStopped  chan struct{}
+	reloadWatcherStopOnce sync.Once
 }
 
 // pullArguments are used to identify a pullOperation via an input image name and
@@ -341,6 +348,7 @@ func (s *Server) restore(ctx context.Context) []storage.StorageImageID {
 
 // Shutdown attempts to shut down the server's storage cleanly.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.stopReloadWatcher()
 	s.config.CNIManagerShutdown()
 	s.resourceStore.Close()
 
@@ -407,7 +415,7 @@ func getIDMappings(config *libconfig.Config) (*idtools.IDMappings, error) {
 func New(
 	ctx context.Context,
 	configIface libconfig.Iface,
-) (*Server, error) {
+) (_ *Server, retErr error) {
 	if configIface == nil || configIface.GetData() == nil {
 		return nil, errors.New("provided configuration interface or its data is nil")
 	}
@@ -591,6 +599,14 @@ func New(
 
 	s.startReloadWatcher(ctx)
 
+	// Roll back every worker started from here on when a later step fails,
+	// so a discarded Server strands no goroutines.
+	defer func() {
+		if retErr != nil {
+			s.stopReloadWatcher()
+		}
+	}()
+
 	if s.config.AutoReloadRegistries {
 		go s.startWatcherForMirrorRegistries(ctx, s.config.SystemContext.SystemRegistriesConfDirPath)
 	}
@@ -632,17 +648,44 @@ func New(
 }
 
 // startReloadWatcher starts a new SIGHUP go routine.
+// The watcher exits when stopReloadWatcher closes the Server-owned done
+// channel or when ctx is canceled, so a discarded Server never strands it.
 func (s *Server) startReloadWatcher(ctx context.Context) {
 	// Setup the signal notifier
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, signals.Hup)
+	s.serveReloadNotifications(ctx, ch, s.config.Reload)
+}
+
+// serveReloadNotifications calls reload for every notification received on
+// ch until stopReloadWatcher closes the Server-owned done channel or ctx is
+// canceled. Production passes the signal.Notify channel created in
+// startReloadWatcher and s.config.Reload; tests pass a synthetic channel and
+// a stub reload, proving HUP wiring without signaling the test process.
+// signal.Stop is owned by the watcher goroutine and is a no-op for channels
+// that were never registered.
+func (s *Server) serveReloadNotifications(ctx context.Context, ch chan os.Signal, reload func(context.Context) error) {
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	s.reloadWatcherDone = done
+	s.reloadWatcherStopped = stopped
+	s.reloadWatcherStopOnce = sync.Once{}
 
 	go func() {
-		for {
-			// Block until the signal is received
-			<-ch
+		defer signal.Stop(ch)
+		defer close(stopped)
 
-			if err := s.config.Reload(ctx); err != nil {
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			// Block until the signal is received
+			case <-ch:
+			}
+
+			if err := reload(ctx); err != nil {
 				log.Errorf(ctx, "Unable to reload configuration: %v", err)
 
 				continue
@@ -675,6 +718,24 @@ func (s *Server) startReloadWatcher(ctx context.Context) {
 	}()
 
 	log.Infof(ctx, "Registered SIGHUP reload watcher")
+}
+
+// stopReloadWatcher asks the SIGHUP reload watcher to exit and waits for it.
+// It is idempotent and safe on a Server that never started the watcher.
+func (s *Server) stopReloadWatcher() {
+	if s == nil {
+		return
+	}
+
+	done := s.reloadWatcherDone
+
+	stopped := s.reloadWatcherStopped
+	if done == nil || stopped == nil {
+		return
+	}
+
+	s.reloadWatcherStopOnce.Do(func() { close(done) })
+	<-stopped
 }
 
 func useDefaultUmask(ctx context.Context) {

--- a/server/server_reload_watcher_leak_test.go
+++ b/server/server_reload_watcher_leak_test.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cri-o/cri-o/internal/signals"
+)
+
+// reloadWatcherWorkers counts in-flight serveReloadNotifications goroutines
+// by function name rather than closure number, which shifts when unrelated
+// literals are added. The stack buffer grows instead of accepting a
+// truncated dump.
+func reloadWatcherWorkers() int {
+	bufSize := 1 << 20
+
+	for {
+		buf := make([]byte, bufSize)
+
+		n := runtime.Stack(buf, true)
+		if n == len(buf) {
+			bufSize *= 2
+
+			continue
+		}
+
+		workers := 0
+
+		for stack := range strings.SplitSeq(string(buf[:n]), "\n\n") {
+			if strings.Contains(stack, "serveReloadNotifications.func") {
+				workers++
+			}
+		}
+
+		return workers
+	}
+}
+
+func waitForReloadWatcherCount(want int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		if reloadWatcherWorkers() == want {
+			return true
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return reloadWatcherWorkers() == want
+}
+
+func TestStopReloadWatcherExitsWithoutSignal(t *testing.T) {
+	s := &Server{}
+	before := reloadWatcherWorkers()
+
+	s.startReloadWatcher(context.Background())
+
+	if !waitForReloadWatcherCount(before+1, 5*time.Second) {
+		t.Fatalf("reload watcher goroutine did not start (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+
+	// No SIGHUP is sent: the stop signal alone must release the watcher.
+	s.stopReloadWatcher()
+
+	if !waitForReloadWatcherCount(before, 5*time.Second) {
+		t.Fatalf("reload watcher goroutine did not exit after stop (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+}
+
+func TestStopReloadWatcherIdempotentAndNilSafe(t *testing.T) {
+	baseline := reloadWatcherWorkers()
+
+	s := &Server{}
+	s.startReloadWatcher(context.Background())
+
+	if !waitForReloadWatcherCount(baseline+1, 5*time.Second) {
+		t.Fatalf("expected reload watcher to be running (baseline=%d after=%d)", baseline, reloadWatcherWorkers())
+	}
+
+	s.stopReloadWatcher()
+	// Second stop must not block or panic once stopped is closed.
+	s.stopReloadWatcher()
+
+	if !waitForReloadWatcherCount(baseline, 5*time.Second) {
+		t.Fatalf("reload watcher did not exit: baseline=%d after=%d", baseline, reloadWatcherWorkers())
+	}
+
+	// Never-started and nil servers must be safe to stop.
+	(&Server{}).stopReloadWatcher()
+
+	var nilServer *Server
+
+	nilServer.stopReloadWatcher()
+}
+
+func TestReloadWatcherRepeatedLifecyclesDoNotAccumulate(t *testing.T) {
+	before := reloadWatcherWorkers()
+
+	for range 5 {
+		s := &Server{}
+		s.startReloadWatcher(context.Background())
+		s.stopReloadWatcher()
+	}
+
+	if !waitForReloadWatcherCount(before, 5*time.Second) {
+		t.Fatalf("repeated lifecycles accumulated watchers (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+}
+
+func TestReloadWatcherDeliversHUPToReload(t *testing.T) {
+	ctx := t.Context()
+
+	reloaded := make(chan struct{}, 1)
+
+	// An error return keeps the handler on its log-and-continue path, so no
+	// production post-reload work (metrics, image server, config dump) runs
+	// against this zero-value Server.
+	reload := func(context.Context) error {
+		select {
+		case reloaded <- struct{}{}:
+		default:
+		}
+
+		return errors.New("stub reload failure")
+	}
+
+	s := &Server{}
+
+	// Synthetic channel: proves HUP wiring without signaling the test process.
+	ch := make(chan os.Signal, 1)
+
+	s.serveReloadNotifications(ctx, ch, reload)
+
+	// The stub must not fire before any notification arrives.
+	select {
+	case <-reloaded:
+		s.stopReloadWatcher()
+
+		t.Fatal("reload invoked without any HUP notification")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	before := reloadWatcherWorkers()
+
+	ch <- signals.Hup
+
+	select {
+	case <-reloaded:
+	case <-time.After(5 * time.Second):
+		s.stopReloadWatcher()
+
+		t.Fatal("synthetic SIGHUP did not invoke reload within 5s")
+	}
+
+	// The error-returning stub sends the handler back to its select, so the
+	// watcher must still be alive until explicitly stopped.
+	if !waitForReloadWatcherCount(before, time.Second) {
+		s.stopReloadWatcher()
+
+		t.Fatalf("watcher exited after handled HUP (workers=%d, want %d)", reloadWatcherWorkers(), before)
+	}
+
+	s.stopReloadWatcher()
+
+	if !waitForReloadWatcherCount(before-1, 5*time.Second) {
+		t.Fatalf("watcher did not exit after stop (workers=%d, want %d)", reloadWatcherWorkers(), before-1)
+	}
+}
+
+func TestReloadWatcherExitsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s := &Server{}
+	before := reloadWatcherWorkers()
+
+	s.startReloadWatcher(ctx)
+
+	if !waitForReloadWatcherCount(before+1, 5*time.Second) {
+		cancel()
+
+		t.Fatalf("reload watcher goroutine did not start (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+
+	cancel()
+
+	if !waitForReloadWatcherCount(before, 5*time.Second) {
+		// Join explicitly so the test never leaves a stray watcher behind.
+		s.stopReloadWatcher()
+
+		t.Fatalf("reload watcher did not exit on context cancel (before=%d after=%d)", before, reloadWatcherWorkers())
+	}
+
+	// Join explicitly; stopped is already closed so this returns immediately.
+	s.stopReloadWatcher()
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes eight goroutine leaks (one per commit, each with a regression test):

- OCI attach (`internal/oci/runtime_oci.go`): buffer the two one-shot result channels so neither worker strands after the parent returns.
- Pod attach resize (`internal/oci/runtime_pod.go`): attach-scoped resize bridge; stop/join it and close the downstream channel on every return so conmon-rs's receiver exits.
- VM ExecSync (`internal/oci/runtime_vm.go`): buffered one-shot result channel; worker publishes via locals so it can't race the timeout return.
- TTY exec teardown (`internal/oci/oci_unix.go`): reset stdin on command completion, bounded worker join, PTY close before bounded stdout close — breaks the SPDY backpressure cycle.
- Log reopen (`internal/oci/runtime_oci.go`): `watcher.Add` before goroutine launch so an Add failure can never strand the worker; the failure stays best effort (logged, reopen command still sent to conmon, nil returned) because kubelet undoes the log rotation on error. Buffered one-shot channels, worker exits when the fsnotify channels close.
- SIGHUP watcher (`server/server.go`): Server-owned stop/done channels, `signal.Stop` pairing; `Shutdown` and all post-launch `New` failures stop and join it.
- Mirror-registry watcher (`server/server.go`): Server-owned watcher with shutdown select; loop-owned `Timer` replaces `AfterFunc` (single sender, race-free close); `Shutdown` and `New` rollbacks stop and join both workers.
- NRI (`server/nri-api.go`, `internal/nri/nri.go`): new idempotent `nriAPI.stop()` called first in `Shutdown` and on `New` rollbacks; `Stop` keeps the adaptation pointer so in-flight events can't nil-dereference.
- `Server.New` rolls back the SIGHUP watcher, mirror-registry watcher, and NRI through a single deferred cleanup on any later failure, replacing per-error-path stop calls.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The leaks were found with the Go 1.26 goroutine leak profiler (`GOEXPERIMENT=goroutineleakprofile`, https://go.dev/blog/goroutine-leak-profiles). Each regression test fails with its fix reverted and passes with it (Linux, `golang:1.26`, `-mod=vendor`, `-race`):

- AttachContainer (2 specs), pod attach resize (6 sub-tests), VM ExecSync, TTY teardown (backpressure + happy path, 0.4s total), log reopen (best-effort Add failure + success path), SIGHUP watcher (5), mirror watcher (5), NRI stop (server + internal/nri).
- Full `./internal/oci` and `./internal/nri` suites pass under `-race`; `golangci-lint` v2.12.2 reports 0 issues on the touched packages; each commit builds and vets on its own.
- The `./server` suite has pre-existing `inspect_test` breakage at base, so its leak tests were run in isolation.

Supersedes #10304, #10305, #10307, #10308, #10309, #10310, #10311, #10312.

#### Does this PR introduce a user-facing change?

```release-note
Fixed goroutine leaks in container attach, VM exec, TTY exec teardown, log reopen, and server shutdown paths.
```

