### PR TITLE
Add native Git hooks

### DIFF
--- a/.githooks/applypatch-msg
+++ b/.githooks/applypatch-msg
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hook_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+exec "$hook_dir/commit-msg" "$@"

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+commit_message=${1:?commit message file is required}
+
+# MERGE_HEAD is worktree-specific. Only an in-progress merge is exempt from the
+# sign-off requirement; a later amend must satisfy the normal policy.
+merge_head=$(git rev-parse --git-path MERGE_HEAD)
+if [[ -f $merge_head ]]; then
+    exit 0
+fi
+
+signoff_pattern='^Signed-off-by: [^<>[:space:]]+( [^<>[:space:]]+)* <[^<>[:space:]@]+@[^<>[:space:]@]+>$'
+
+# Consume all parsed trailers before reporting the match. Keeping both commands
+# in this pipefail-aware pipeline preserves interpret-trailers failures without
+# exposing an early match to SIGPIPE on large messages.
+parsed_signoff_is_valid() {
+    git interpret-trailers --parse "$commit_message" |
+        (
+            valid_signoff=false
+            while IFS= read -r trailer || [[ -n $trailer ]]; do
+                if [[ $trailer =~ $signoff_pattern ]]; then
+                    valid_signoff=true
+                fi
+            done
+            [[ $valid_signoff == true ]]
+        )
+}
+
+# interpret-trailers normalizes separator whitespace. Check the original line
+# in the terminal trailer paragraph as well so the committed message itself has
+# the canonical spelling required by the DCO policy.
+raw_signoff_is_valid() {
+    git stripspace --strip-comments <"$commit_message" |
+        awk -v signoff_pattern="$signoff_pattern" '
+            /^$/ {
+                after_blank = 1
+                next
+            }
+            {
+                if (after_blank) {
+                    valid_signoff = 0
+                    after_blank = 0
+                }
+                if ($0 ~ signoff_pattern) {
+                    valid_signoff = 1
+                }
+            }
+            END { exit valid_signoff ? 0 : 1 }
+        '
+}
+
+if parsed_signoff_is_valid && raw_signoff_is_valid; then
+    exit 0
+fi
+
+cat >&2 <<'EOF'
+error: commit message has a missing or malformed Signed-off-by trailer
+
+Expected: Signed-off-by: Name <email>
+Commit with `git commit --signoff` (or amend with `git commit --amend --signoff`).
+Use `git commit --no-verify` only when the hook must be bypassed intentionally.
+EOF
+exit 1

--- a/.githooks/pre-applypatch
+++ b/.githooks/pre-applypatch
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hook_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+exec "$hook_dir/pre-commit" "$@"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Inspect the index rather than the working tree so partially staged changes are
+# handled correctly. This catches whitespace errors and conflict markers.
+git diff --cached --check

--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hook_dir=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+exec "$hook_dir/pre-commit" "$@"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+remote=${1:-remote}
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/crio-pre-push.XXXXXX")
+tips_file=$tmpdir/tips
+worktree=
+git_env_vars=()
+while IFS= read -r name; do
+    git_env_vars+=("$name")
+done < <(git rev-parse --local-env-vars)
+: >"$tips_file"
+
+cleanup() {
+    if [[ -n $worktree ]]; then
+        git worktree remove --force "$worktree" >/dev/null 2>&1 || true
+    fi
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+# Validate every unique commit at the tips being pushed. Source notes, deleted
+# refs, and refs that do not resolve to commits have no source tree to validate.
+while read -r local_ref local_oid _remote_ref _remote_oid; do
+    if [[ $local_ref == refs/notes/* || $local_oid =~ ^0+$ ]]; then
+        continue
+    fi
+
+    if ! commit=$(git rev-parse --verify "${local_oid}^{commit}" 2>/dev/null); then
+        continue
+    fi
+
+    if ! grep -Fqx "$commit" "$tips_file"; then
+        printf '%s\n' "$commit" >>"$tips_file"
+    fi
+done
+
+while IFS= read -r commit; do
+    worktree=$tmpdir/worktree
+    echo "Running pre-push checks for $commit before pushing to $remote" >&2
+    git worktree add --quiet --detach "$worktree" "$commit"
+
+    (
+        # Git exports repository-local environment variables to hooks. Drop
+        # them so commands discover the disposable worktree after changing
+        # directories instead of operating on the active checkout.
+        unset "${git_env_vars[@]}"
+        cd "$worktree"
+        # The vendor check requires a pristine source tree, so run it before
+        # lint has an opportunity to create build artifacts.
+        make -s check-vendor
+        make -s lint
+        if [[ -e ./hack/run-on-linux.sh || -L ./hack/run-on-linux.sh ]]; then
+            ./hack/run-on-linux.sh make -s docs-validation
+        elif [[ $(uname -s) == Linux ]]; then
+            make -s docs-validation
+        else
+            echo "Pre-push checks for $commit cannot validate docs: the pushed tip lacks hack/run-on-linux.sh and requires Linux." >&2
+            exit 1
+        fi
+    )
+
+    git worktree remove --force "$worktree"
+    worktree=
+done <"$tips_file"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,6 +60,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: make shfmt
 
+  git-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: make test-git-hooks
+
   space-at-eol:
     runs-on: ubuntu-latest
     steps:
@@ -124,5 +130,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0 # v4.6
         with:
+          prettier_version: 3.9.6
           dry: true
           prettier_options: --write .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,9 @@ sudo -E ./test/test_runner.sh ctr.bats -f 'pattern'  # Filter
 - `make` / `make all` - Build binaries and docs
 - `make testunit` / `make localintegration` - Run tests
 - `make lint` - Run golangci-lint (required before PR)
+- `make git-hooks-install` - Enable the repository's native Git hooks once in
+  each worktree for commit, patch, merge, and pre-push verification
+- `make test-git-hooks` - Run the native Git hook test suites
 - `make prettier` / `make verify-prettier` - Format/verify markdown, YAML,
   JSON (required before PR)
 - `make verify-mdtoc` - Verify TOC in markdown files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,31 @@ Test your changes by running:
 make lint
 ```
 
+The repository also provides optional native Git hooks. Enable them once in
+each worktree:
+
+```shell
+make git-hooks-install
+```
+
+The installer configures `.githooks` for only the current worktree and never
+replaces a conflicting hook path. The pre-commit hook checks staged changes for
+whitespace errors and conflict markers. The commit-msg hook requires a
+canonical `Signed-off-by: Name <email>` trailer, intentionally stricter than
+Prow's prefix-only matcher. Only an in-progress merge identified by the
+worktree's `MERGE_HEAD` is exempt; a later amend is not. Native delegates apply
+the same message and staged-content checks to `git am` and automatic merges.
+
+Before a push, the hooks run the linter, vendor check and documentation
+validation in a disposable worktree for each pushed tip, using that tip's build
+path and `hack/run-on-linux.sh` without changing the active worktree. A
+historical tip without the helper validates documentation directly on Linux
+and cannot be pushed from another operating system.
+
+The hooks provide early feedback but do not replace CI. Git's native
+`--no-verify` option bypasses the applicable hooks for `git commit`, `git am`,
+`git merge`, or `git push`; use it only intentionally.
+
 And you can run the test suite if you have access to elevated permissions:
 
 ```shell

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ SHFMT := ${BUILD_BIN_PATH}/shfmt
 SHFMT_VERSION := v3.12.0
 SHELLCHECK := ${BUILD_BIN_PATH}/shellcheck
 SHELLCHECK_VERSION := v0.11.0
+PRETTIER_VERSION := 3.9.6
 BATS_FILES := $(wildcard test/*.bats)
 
 # pass crio CLI options to generate custom configuration options at build time
@@ -321,11 +322,26 @@ uninstall: ## Uninstall all files.
 
 ##@ Verify targets:
 
+# Lint with the Go version from go.mod and for GOOS=linux so that the results
+# match CI regardless of the Go toolchain and operating system of the host.
+# A go directive without a patch version (go 1.NN) is not a valid toolchain
+# name, so append .0 in that case. Both can be overridden, for example
+# LINT_GOTOOLCHAIN=local to use the installed Go, or LINT_GOOS=freebsd.
+GO_MOD_VERSION := $(shell sed -n 's/^go //p' go.mod)
+GO_TOOLCHAIN_VERSION := $(if $(word 3,$(subst ., ,$(GO_MOD_VERSION))),$(GO_MOD_VERSION),$(GO_MOD_VERSION).0)
+LINT_GOTOOLCHAIN ?= go$(GO_TOOLCHAIN_VERSION)
+LINT_GOOS ?= linux
+LINT_ENV := GOTOOLCHAIN=$(LINT_GOTOOLCHAIN) GOOS=$(LINT_GOOS)
+
 .PHONY: lint
-lint: ${GOLANGCI_LINT} ## Run the golang linter, supposed to not run on CI.
+lint: ${GOLANGCI_LINT} ## Run the golang linters.
 	${GOLANGCI_LINT} version
 	${GOLANGCI_LINT} linters
-	GL_DEBUG=gocritic ${GOLANGCI_LINT} run --fix
+	$(LINT_ENV) GL_DEBUG=gocritic ${GOLANGCI_LINT} run
+
+.PHONY: lint-fix
+lint-fix: ${GOLANGCI_LINT} ## Run the golang linters and apply fixes.
+	$(LINT_ENV) GL_DEBUG=gocritic ${GOLANGCI_LINT} run --fix
 
 .PHONY: check-log-lines
 check-log-lines: ## Verify that all log lines start with a capitalized letter.
@@ -337,8 +353,8 @@ check-config-template: ## Validate that the config template is correct.
 	./hack/validate-config.sh
 
 .PHONY: shellfiles
-shellfiles:
-	$(eval SHELLFILES=$(shell ${SHFMT} -f . | grep -v vendor/ | grep -v hack/lib | grep -v hack/build-rpms.sh | grep -v .bats))
+shellfiles: ${SHFMT}
+	$(eval SHELLFILES=$(shell ${SHFMT} -f . | grep -v vendor/ | grep -v hack/lib/ | grep -v hack/build-rpms.sh | grep -v '\.bats$$'))
 
 .PHONY: shfmt
 shfmt: ${SHFMT} shellfiles ## Run shfmt on all shell files.
@@ -580,11 +596,24 @@ docs-generation: ## Generate the documentation.
 .PHONY: prettier
 prettier: ## Prettify supported files.
 	$(CONTAINER_RUNTIME) run -it --privileged -v ${PWD}:/w -w /w --entrypoint bash node:latest -c \
-		'npm install -g prettier && prettier -w .'
+		'npm install -g prettier@$(PRETTIER_VERSION) && prettier -w .'
 
 .PHONY: docs-validation
-docs-validation: ## Validate the documentation.
+docs-validation: ## Validate the documentation (Linux only).
 	$(GO_RUN) -tags "$(BUILDTAGS)" ./test/docs-validation
+
+.PHONY: git-hooks-install
+git-hooks-install: ## Enable the repository's native Git hooks.
+	./hack/install-git-hooks.sh
+
+.PHONY: test-git-hooks
+test-git-hooks: ## Run the native Git hook tests.
+	bash test/git-hooks/commit.bash
+	bash test/git-hooks/install.bash
+	bash test/git-hooks/pre-push.bash
+
+.PHONY: git-hooks-test
+git-hooks-test: test-git-hooks ## Alias for the native Git hook tests.
 
 ##@ CI targets:
 

--- a/contrib/kube-local/kube-local
+++ b/contrib/kube-local/kube-local
@@ -282,6 +282,7 @@ function detect_system() {
     ##################################################################
 
     print_msg "DEBUG" "Detecting distro..."
+    # shellcheck disable=SC1091
     source /etc/os-release
     # shellcheck disable=SC2016
     NAME=$(echo "${NAME}" | ${AWK_BIN} '{print tolower($0)}')

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -150,6 +150,14 @@ dependencies:
       - path: Makefile
         match: MDTOC_VERSION
 
+  - name: prettier
+    version: 3.9.6
+    refPaths:
+      - path: Makefile
+        match: PRETTIER_VERSION
+      - path: .github/workflows/verify.yml
+        match: prettier_version
+
   - name: pause
     version: 3.10.1
     refPaths:

--- a/hack/install-git-hooks.sh
+++ b/hack/install-git-hooks.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly hooks_path=.githooks
+repo=$(git rev-parse --show-toplevel)
+cd "$repo"
+
+common_git_dir=$(git rev-parse --git-common-dir)
+common_git_dir=$(cd "$common_git_dir" && pwd -P)
+git_dir=$(git rev-parse --git-dir)
+git_dir=$(cd "$git_dir" && pwd -P)
+readonly common_git_dir git_dir
+readonly common_config=$common_git_dir/config
+readonly worktree_config=$git_dir/config.worktree
+readonly default_hooks=$common_git_dir/hooks
+
+state_dir=$(mktemp -d "${TMPDIR:-/tmp}/crio-install-git-hooks.XXXXXX")
+rollback_needed=false
+
+read_config_values() {
+    name=$1
+    shift
+
+    if git config "$@" --get-all "$name" >"$config_output"; then
+        return
+    else
+        status=$?
+    fi
+
+    if [[ $status -ne 1 ]]; then
+        echo "error: unable to inspect $name" >&2
+        exit "$status"
+    fi
+
+    : >"$config_output"
+}
+
+read_included_config_values() {
+    name=$1
+    file=$2
+    context=${3:-$repo}
+    included_output=$state_dir/included-output
+
+    if git -C "$context" config --includes --null --show-origin --file "$file" --get-all "$name" >"$included_output"; then
+        :
+    else
+        status=$?
+        if [[ $status -ne 1 ]]; then
+            echo "error: unable to inspect $name in $file" >&2
+            exit "$status"
+        fi
+    fi
+
+    : >"$config_output"
+    : >"$config_origin_output"
+    exec 3<"$included_output"
+    while IFS= read -r -d '' origin <&3; do
+        if ! IFS= read -r -d '' value <&3; then
+            echo "error: unable to determine the value of $name in $file" >&2
+            exit 1
+        fi
+        printf '%s\n' "$origin" >>"$config_origin_output"
+        printf '%s\n' "$value" >>"$config_output"
+    done
+    exec 3<&-
+}
+
+read_config_inventory() {
+    context=$1
+    file=$2
+    inventory_output=$state_dir/config-inventory
+    inventory_count=0
+    inventory_origin=
+    inventory_name=
+    inventory_value=
+
+    if [[ ! -e $file && ! -L $file ]]; then
+        return
+    fi
+    if ! git -C "$context" config --includes --null --show-origin --file "$file" --list >"$inventory_output"; then
+        echo "error: unable to inspect worktree configuration in $file" >&2
+        exit 1
+    fi
+
+    exec 3<"$inventory_output"
+    while IFS= read -r -d '' origin <&3; do
+        if ! IFS= read -r -d '' entry <&3; then
+            echo "error: unable to parse worktree configuration in $file" >&2
+            exit 1
+        fi
+        inventory_count=$((inventory_count + 1))
+        if [[ $inventory_count -eq 1 ]]; then
+            inventory_origin=$origin
+            inventory_name=${entry%%$'\n'*}
+            if [[ $entry == *$'\n'* ]]; then
+                inventory_value=${entry#*$'\n'}
+            fi
+        fi
+    done
+    exec 3<&-
+}
+
+count_config_values() {
+    config_count=0
+    config_value=
+    while IFS= read -r value || [[ -n $value ]]; do
+        config_count=$((config_count + 1))
+        if [[ $config_count -eq 1 ]]; then
+            config_value=$value
+        fi
+    done <"$config_output"
+}
+
+write_worktree_list() {
+    worktree_list=$state_dir/worktrees
+    if ! git worktree list --porcelain -z >"$worktree_list"; then
+        echo "error: unable to enumerate linked worktrees" >&2
+        exit 1
+    fi
+}
+
+resolve_worktree_git_dir() {
+    worktree_path=$1
+    if ! worktree_git_dir=$(git -C "$worktree_path" rev-parse --git-dir); then
+        echo "error: unable to inspect linked worktree at '$worktree_path'" >&2
+        exit 1
+    fi
+    case $worktree_git_dir in
+    /*) ;;
+    *) worktree_git_dir=$worktree_path/$worktree_git_dir ;;
+    esac
+    worktree_git_dir=$(cd "$worktree_git_dir" && pwd -P)
+}
+
+refuse_unsafe_shared_hook_migration() {
+    if [[ $prior_local_count -ne 1 ]]; then
+        return
+    fi
+
+    write_worktree_list
+    while IFS= read -r -d '' field; do
+        if [[ $field != worktree\ * ]]; then
+            continue
+        fi
+
+        worktree_path=${field#worktree }
+        config_output=$state_dir/shared-hooks
+        config_origin_output=$state_dir/shared-hook-origins
+        read_included_config_values core.hooksPath "$common_config" "$worktree_path"
+        count_config_values
+        IFS= read -r config_origin <"$config_origin_output" || config_origin=
+        if [[ $config_count -ne 1 || $config_value != "$hooks_path" || $config_origin != "file:$common_config" ]]; then
+            echo "error: linked worktree at '$worktree_path' has additional shared local core.hooksPath configuration" >&2
+            exit 1
+        fi
+    done <"$worktree_list"
+}
+
+refuse_dormant_worktree_configuration() {
+    write_worktree_list
+    while IFS= read -r -d '' field; do
+        if [[ $field != worktree\ * ]]; then
+            continue
+        fi
+
+        worktree_path=${field#worktree }
+        resolve_worktree_git_dir "$worktree_path"
+        candidate_config=$worktree_git_dir/config.worktree
+        read_config_inventory "$worktree_path" "$candidate_config"
+        if [[ $worktree_git_dir == "$git_dir" ]]; then
+            if [[ $inventory_count -eq 0 ]]; then
+                continue
+            fi
+            if [[ $inventory_count -eq 1 && $inventory_origin == "file:$candidate_config" && $inventory_name == core.hookspath && $inventory_value == "$hooks_path" ]]; then
+                continue
+            fi
+            echo "error: current worktree has dormant configuration beyond core.hooksPath=$hooks_path" >&2
+            exit 1
+        fi
+        if [[ $inventory_count -gt 0 ]]; then
+            echo "error: sibling worktree at '$worktree_path' has dormant worktree configuration" >&2
+            exit 1
+        fi
+    done <"$worktree_list"
+}
+
+restore_configuration() {
+    restore_failed=false
+
+    # Worktree configuration must remain enabled until its prior state is back.
+    git config --local --replace-all extensions.worktreeConfig true || restore_failed=true
+
+    if [[ $prior_worktree_count -eq 0 ]]; then
+        git config --worktree --unset-all core.hooksPath >/dev/null 2>&1 || {
+            status=$?
+            [[ $status -eq 5 ]] || restore_failed=true
+        }
+    else
+        git config --worktree --replace-all core.hooksPath "$prior_worktree_value" || restore_failed=true
+    fi
+
+    if [[ $prior_local_count -eq 0 ]]; then
+        git config --local --unset-all core.hooksPath >/dev/null 2>&1 || {
+            status=$?
+            [[ $status -eq 5 ]] || restore_failed=true
+        }
+    else
+        git config --local --replace-all core.hooksPath "$prior_local_value" || restore_failed=true
+    fi
+
+    git config --local --unset-all extensions.worktreeConfig >/dev/null 2>&1 || {
+        status=$?
+        [[ $status -eq 5 ]] || restore_failed=true
+    }
+    while IFS= read -r value || [[ -n $value ]]; do
+        git config --local --add extensions.worktreeConfig "$value" || restore_failed=true
+    done <"$state_dir/extensions"
+
+    if [[ $restore_failed == true ]]; then
+        echo "error: failed to fully restore Git hook configuration" >&2
+    fi
+}
+
+cleanup() {
+    status=$?
+    trap - EXIT INT TERM
+    if [[ $rollback_needed == true ]]; then
+        set +e
+        restore_configuration
+    fi
+    rm -rf "$state_dir"
+    exit "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+config_output=$state_dir/local
+read_config_values core.hooksPath --local
+count_config_values
+readonly prior_local_count=$config_count
+readonly prior_local_value=$config_value
+
+config_output=$state_dir/included-local
+config_origin_output=$state_dir/included-local-origins
+read_included_config_values core.hooksPath "$common_config"
+count_config_values
+readonly prior_included_local_count=$config_count
+readonly prior_included_local_value=$config_value
+IFS= read -r prior_included_local_origin <"$config_origin_output" || prior_included_local_origin=
+readonly prior_included_local_origin
+
+config_output=$state_dir/worktree
+read_config_values core.hooksPath --file "$worktree_config"
+count_config_values
+readonly prior_worktree_count=$config_count
+readonly prior_worktree_value=$config_value
+
+config_output=$state_dir/included-worktree
+config_origin_output=$state_dir/included-worktree-origins
+read_included_config_values core.hooksPath "$worktree_config"
+count_config_values
+readonly prior_included_worktree_count=$config_count
+readonly prior_included_worktree_value=$config_value
+
+config_output=$state_dir/extensions
+read_config_values extensions.worktreeConfig --local
+count_config_values
+readonly prior_extension_count=$config_count
+
+if [[ $prior_included_local_count -gt 1 ]]; then
+    echo "error: shared local core.hooksPath has multiple values" >&2
+    exit 1
+fi
+if [[ $prior_included_local_count -eq 1 && -z $prior_included_local_value ]]; then
+    echo "error: shared local core.hooksPath is explicitly empty" >&2
+    exit 1
+fi
+if [[ $prior_included_local_count -eq 1 && $prior_included_local_value != "$hooks_path" ]]; then
+    echo "error: shared local core.hooksPath is already set to '$prior_included_local_value'" >&2
+    exit 1
+fi
+if [[ $prior_included_local_count -eq 1 && $prior_included_local_origin != "file:$common_config" ]]; then
+    echo "error: shared local core.hooksPath is configured through an include" >&2
+    exit 1
+fi
+
+if [[ $prior_included_worktree_count -gt 1 ]]; then
+    echo "error: current worktree core.hooksPath has multiple values" >&2
+    exit 1
+fi
+if [[ $prior_included_worktree_count -eq 1 && -z $prior_included_worktree_value ]]; then
+    echo "error: current worktree core.hooksPath is explicitly empty" >&2
+    exit 1
+fi
+if [[ $prior_included_worktree_count -eq 1 && $prior_included_worktree_value != "$hooks_path" ]]; then
+    echo "error: current worktree core.hooksPath is already set to '$prior_included_worktree_value'" >&2
+    exit 1
+fi
+
+config_output=$state_dir/effective
+if git config --get core.hooksPath >"$config_output"; then
+    count_config_values
+    if [[ $config_count -ne 1 || -z $config_value ]]; then
+        echo "error: effective core.hooksPath is explicitly empty or malformed" >&2
+        exit 1
+    fi
+    if [[ $config_value != "$hooks_path" ]]; then
+        echo "error: effective core.hooksPath is set to '$config_value'" >&2
+        exit 1
+    fi
+    if [[ $prior_local_count -eq 0 && $prior_included_worktree_count -eq 0 ]]; then
+        echo "error: effective core.hooksPath is set outside the repository's local or worktree configuration" >&2
+        exit 1
+    fi
+else
+    status=$?
+    if [[ $status -ne 1 ]]; then
+        echo "error: unable to inspect the effective core.hooksPath" >&2
+        exit "$status"
+    fi
+fi
+
+extension_enabled=false
+if [[ $prior_extension_count -gt 0 ]]; then
+    if extension_value=$(git config --local --type=bool --get extensions.worktreeConfig); then
+        if [[ $extension_value == true ]]; then
+            extension_enabled=true
+        fi
+    else
+        echo "error: shared local extensions.worktreeConfig is not a valid boolean" >&2
+        exit 1
+    fi
+fi
+
+refuse_unsafe_shared_hook_migration
+
+if [[ $extension_enabled == false ]]; then
+    refuse_dormant_worktree_configuration
+fi
+
+installation_complete=false
+if [[ $extension_enabled == true && $prior_included_worktree_count -eq 1 && $prior_local_count -eq 0 ]]; then
+    installation_complete=true
+fi
+
+if [[ $installation_complete == false ]]; then
+    for hook in "$default_hooks"/*; do
+        if [[ -f $hook && -x $hook && $hook != *.sample ]]; then
+            cat >&2 <<EOF
+error: an executable Git hook already exists at '$hook'
+
+Changing core.hooksPath would disable or reactivate that hook. Remove it or
+migrate it into $hooks_path before running this installer again.
+EOF
+            exit 1
+        fi
+    done
+
+    rollback_needed=true
+
+    if [[ $extension_enabled == false ]]; then
+        git config --local --replace-all extensions.worktreeConfig true
+    fi
+
+    if [[ $prior_included_worktree_count -eq 0 ]]; then
+        git config --worktree --replace-all core.hooksPath "$hooks_path"
+    fi
+
+    if [[ $prior_local_count -eq 1 ]]; then
+        git config --local --unset-all core.hooksPath '^\.githooks$'
+    fi
+fi
+
+config_output=$state_dir/verify-local
+config_origin_output=$state_dir/verify-local-origins
+read_included_config_values core.hooksPath "$common_config"
+count_config_values
+if [[ $config_count -ne 0 ]]; then
+    echo "error: shared local core.hooksPath remains configured" >&2
+    exit 1
+fi
+
+config_output=$state_dir/verify-worktree
+config_origin_output=$state_dir/verify-worktree-origins
+read_included_config_values core.hooksPath "$worktree_config"
+count_config_values
+if [[ $config_count -ne 1 || $config_value != "$hooks_path" ]]; then
+    echo "error: current worktree core.hooksPath was not configured" >&2
+    exit 1
+fi
+
+if [[ $(git config --local --type=bool --get extensions.worktreeConfig) != true ]]; then
+    echo "error: extensions.worktreeConfig was not enabled" >&2
+    exit 1
+fi
+if [[ $(git config --get core.hooksPath) != "$hooks_path" ]]; then
+    echo "error: $hooks_path is not effective for the current worktree" >&2
+    exit 1
+fi
+
+rollback_needed=false
+echo "Enabled the CRI-O Git hooks from $hooks_path for this worktree"

--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-if [ "$(${GO:-go} env GOOS)" != "linux" ] ; then
-	exit 0
+if [ "$(${GO:-go} env GOOS)" != "linux" ]; then
+    exit 0
 fi
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT
-cc -o "$tmpdir"/libsubid_tag -l subid -x c - > /dev/null 2> /dev/null << EOF
+cc -o "$tmpdir"/libsubid_tag -l subid -x c - >/dev/null 2>/dev/null <<EOF
 #include <shadow/subid.h>
 int main() {
 	struct subid_range *ranges = NULL;
@@ -14,6 +14,6 @@ int main() {
 	return 0;
 }
 EOF
-if test $? -eq 0 ; then
-	echo libsubid
+if test $? -eq 0; then
+    echo libsubid
 fi

--- a/hack/run-on-linux.sh
+++ b/hack/run-on-linux.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Run a command that only works on Linux.
+#
+# On Linux the command is executed directly. On other operating systems it runs
+# inside a container based on the official Go image matching go.mod. The
+# container runtime is podman if it is installed and running, else docker; set
+# CONTAINER_RUNTIME to force one. The repository is mounted at the same path
+# and the Go caches are kept in named volumes so that repeated runs are fast.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: $0 COMMAND [ARGS...]" >&2
+    exit 2
+fi
+
+if [[ $(uname -s) == Linux ]]; then
+    exec "$@"
+fi
+
+runtime_is_usable() {
+    command -v "$1" >/dev/null 2>&1 && "$1" info >/dev/null 2>&1
+}
+
+RUNTIME=${CONTAINER_RUNTIME:-}
+if [[ -n $RUNTIME ]]; then
+    if ! runtime_is_usable "$RUNTIME"; then
+        echo "error: CONTAINER_RUNTIME=$RUNTIME is not installed or not running" >&2
+        exit 1
+    fi
+else
+    for candidate in podman docker; do
+        if runtime_is_usable "$candidate"; then
+            RUNTIME=$candidate
+            break
+        fi
+    done
+    if [[ -z $RUNTIME ]]; then
+        echo "error: '$*' needs Linux; install and start podman or docker to run it in a container on $(uname -s)" >&2
+        exit 1
+    fi
+fi
+
+REPO=$(git rev-parse --show-toplevel)
+GO_VERSION=$(sed -n 's/^go //p' "$REPO/go.mod")
+IMAGE=${CRIO_LINUX_IMAGE:-docker.io/library/golang:$GO_VERSION}
+
+echo "Running '$*' in a $RUNTIME container ($IMAGE)" >&2
+exec "$RUNTIME" run --rm \
+    -v "$REPO:$REPO" \
+    -v crio-go-build-cache:/root/.cache/go-build \
+    -v crio-go-mod-cache:/go/pkg/mod \
+    -w "$REPO" \
+    -e GOFLAGS=-mod=vendor \
+    "$IMAGE" "$@"

--- a/internal/config/device/device_unsupported.go
+++ b/internal/config/device/device_unsupported.go
@@ -4,11 +4,9 @@ package device
 
 // Device holds the runtime spec
 // fields needed for a device
-type Device struct {
-}
+type Device struct{}
 
-type Config struct {
-}
+type Config struct{}
 
 // New creates a new device Config
 func New() *Config {

--- a/internal/config/nsmgr/nsmgr_freebsd.go
+++ b/internal/config/nsmgr/nsmgr_freebsd.go
@@ -9,8 +9,7 @@ import (
 // NamespaceManager manages the server's namespaces.
 // Specifically, it is an interface for how the server is creating namespaces,
 // and can be requested to create namespaces for a pod.
-type NamespaceManager struct {
-}
+type NamespaceManager struct{}
 
 // New creates a new NamespaceManager.
 func New(namespacesDir, pinnsPath string) *NamespaceManager {

--- a/internal/config/nsmgr/nsmgr_unsupported.go
+++ b/internal/config/nsmgr/nsmgr_unsupported.go
@@ -10,8 +10,7 @@ import (
 // NamespaceManager manages the server's namespaces.
 // Specifically, it is an interface for how the server is creating namespaces,
 // and can be requested to create namespaces for a pod.
-type NamespaceManager struct {
-}
+type NamespaceManager struct{}
 
 // New creates a new NamespaceManager.
 func New(namespacesDir, pinnsPath string) *NamespaceManager {

--- a/internal/config/seccomp/notifier.go
+++ b/internal/config/seccomp/notifier.go
@@ -14,10 +14,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.podman.io/common/pkg/seccomp"
 	json "github.com/json-iterator/go"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	libseccomp "github.com/seccomp/libseccomp-golang"
+	"go.podman.io/common/pkg/seccomp"
 	"golang.org/x/sys/unix"
 
 	"github.com/cri-o/cri-o/internal/log"

--- a/internal/config/seccomp/seccomp.go
+++ b/internal/config/seccomp/seccomp.go
@@ -12,11 +12,11 @@ import (
 	"slices"
 	"sync"
 
-	"go.podman.io/common/pkg/seccomp"
-	imagetypes "go.podman.io/image/v5/types"
 	json "github.com/json-iterator/go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/common/pkg/seccomp"
+	imagetypes "go.podman.io/image/v5/types"
 	"golang.org/x/sys/unix"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 

--- a/internal/lib/sandbox/sandbox_freebsd.go
+++ b/internal/lib/sandbox/sandbox_freebsd.go
@@ -21,8 +21,7 @@ func getNetNs(path string) (*NetNs, error) {
 
 // NetNs handles data pertaining a network namespace
 // for non-linux this is a noop
-type NetNs struct {
-}
+type NetNs struct{}
 
 func (n *NetNs) Get() *NetNs {
 	return n

--- a/internal/lib/statsserver/stats_server_unsupported.go
+++ b/internal/lib/statsserver/stats_server_unsupported.go
@@ -3,9 +3,10 @@
 package statsserver
 
 import (
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
-	types "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // updateSandbox updates the StatsServer's entry for this sandbox, as well as each child container.

--- a/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_unsupported.go
+++ b/internal/runtimehandlerhooks/default_cpu_load_balance_hooks_unsupported.go
@@ -5,9 +5,10 @@ package runtimehandlerhooks
 import (
 	"context"
 
+	"github.com/opencontainers/runtime-tools/generate"
+
 	"github.com/cri-o/cri-o/internal/lib/sandbox"
 	"github.com/cri-o/cri-o/internal/oci"
-	"github.com/opencontainers/runtime-tools/generate"
 )
 
 // DefaultCPULoadBalanceHooks is used to run additional hooks that will configure containers for CPU load balancing.

--- a/scripts/github-actions-packages
+++ b/scripts/github-actions-packages
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck disable=SC1091
 . /etc/os-release
 CRIU_REPO="https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_$VERSION_ID"
 
-curl -fSsL $CRIU_REPO/Release.key | sudo apt-key add -
+curl -fSsL "$CRIU_REPO"/Release.key | sudo apt-key add -
 echo "deb $CRIU_REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
 
 sudo apt update

--- a/server/container_create_freebsd.go
+++ b/server/container_create_freebsd.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cri-o/cri-o/internal/log"
 	oci "github.com/cri-o/cri-o/internal/oci"
 	"github.com/cri-o/cri-o/internal/storage"
-	"github.com/cri-o/cri-o/pkg/annotations/v2"
+	v2 "github.com/cri-o/cri-o/pkg/annotations/v2"
 )
 
 // finalizeUserMapping changes the UID, GID and additional GIDs to reflect the new value in the user namespace.

--- a/server/container_create_generic.go
+++ b/server/container_create_generic.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"go.podman.io/storage/pkg/idtools"
+
 	"github.com/cri-o/cri-o/internal/oci"
 )
 

--- a/server/safemount_freebsd.go
+++ b/server/safemount_freebsd.go
@@ -1,7 +1,6 @@
 package server
 
-type safeMountInfo struct {
-}
+type safeMountInfo struct{}
 
 func (s *safeMountInfo) Close() {}
 

--- a/server/sandbox_run_freebsd.go
+++ b/server/sandbox_run_freebsd.go
@@ -11,6 +11,15 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	json "github.com/json-iterator/go"
+	"github.com/opencontainers/runtime-tools/generate"
+	selinux "github.com/opencontainers/selinux/go-selinux"
+	"github.com/sirupsen/logrus"
+	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/idtools"
+	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+	kubeletTypes "k8s.io/kubelet/pkg/types"
+
 	"github.com/cri-o/cri-o/internal/annotations"
 	"github.com/cri-o/cri-o/internal/config/node"
 	"github.com/cri-o/cri-o/internal/config/nsmgr"
@@ -23,14 +32,6 @@ import (
 	v2 "github.com/cri-o/cri-o/pkg/annotations/v2"
 	libconfig "github.com/cri-o/cri-o/pkg/config"
 	"github.com/cri-o/cri-o/utils"
-	json "github.com/json-iterator/go"
-	"github.com/opencontainers/runtime-tools/generate"
-	selinux "github.com/opencontainers/selinux/go-selinux"
-	"github.com/sirupsen/logrus"
-	"go.podman.io/storage"
-	"go.podman.io/storage/pkg/idtools"
-	types "k8s.io/cri-api/pkg/apis/runtime/v1"
-	kubeletTypes "k8s.io/kubelet/pkg/types"
 )
 
 func (s *Server) getSandboxIDMappings(ctx context.Context, sb *libsandbox.Sandbox) (*idtools.IDMappings, error) {

--- a/server/sandbox_run_unsupported.go
+++ b/server/sandbox_run_unsupported.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 
 	"go.podman.io/storage/pkg/idtools"
-	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 	types "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	libsandbox "github.com/cri-o/cri-o/internal/lib/sandbox"
 )
 
 func (s *Server) runPodSandbox(ctx context.Context, req *types.RunPodSandboxRequest) (*types.RunPodSandboxResponse, error) {

--- a/test/docs-validation/main.go
+++ b/test/docs-validation/main.go
@@ -42,6 +42,7 @@ var (
 		"apparmor_profile", // contains dynamic version number
 		"root",             // user dependent
 		"runroot",          // user dependent
+		"selinux",          // host dependent
 		"storage_driver",   // user dependent
 	}
 

--- a/test/git-hooks/commit.bash
+++ b/test/git-hooks/commit.bash
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+original_tmpdir=${TMPDIR:-/tmp}
+suite_tmp=$(mktemp -d "$original_tmpdir/crio-commit-hooks.XXXXXX")
+cleanup() {
+    rm -rf "$suite_tmp"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+mkdir -p "$suite_tmp/home" "$suite_tmp/xdg" "$suite_tmp/tmp"
+export HOME="$suite_tmp/home"
+export XDG_CONFIG_HOME="$suite_tmp/xdg"
+export TMPDIR="$suite_tmp/tmp"
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_AUTHOR_NAME='Hook Test'
+export GIT_AUTHOR_EMAIL='hook.test@example.com'
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+export LC_ALL=C
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_CONFIG_PARAMETERS
+
+commit_hook="$repo_root/.githooks/commit-msg"
+command_log="$suite_tmp/command.log"
+test_count=0
+
+fail() {
+    printf 'not ok - %s\n' "$1" >&2
+    exit 1
+}
+
+expect_success() {
+    description=$1
+    shift
+    : >"$command_log"
+    if "$@" >"$command_log" 2>&1; then
+        test_count=$((test_count + 1))
+        printf 'ok %d - %s\n' "$test_count" "$description"
+        return
+    fi
+
+    cat "$command_log" >&2
+    fail "$description"
+}
+
+expect_failure() {
+    description=$1
+    shift
+    : >"$command_log"
+    if "$@" >"$command_log" 2>&1; then
+        fail "$description (unexpected success)"
+    fi
+
+    test_count=$((test_count + 1))
+    printf 'ok %d - %s\n' "$test_count" "$description"
+}
+
+assert_equal() {
+    description=$1
+    expected=$2
+    actual=$3
+    if [[ $actual != "$expected" ]]; then
+        printf 'expected: %s\nactual:   %s\n' "$expected" "$actual" >&2
+        fail "$description"
+    fi
+}
+
+assert_contains() {
+    description=$1
+    file=$2
+    text=$3
+    if ! grep -Fq -- "$text" "$file"; then
+        printf 'missing text: %s\n' "$text" >&2
+        cat "$file" >&2
+        fail "$description"
+    fi
+}
+
+assert_not_contains() {
+    description=$1
+    file=$2
+    text=$3
+    if grep -Fq -- "$text" "$file"; then
+        printf 'unexpected text: %s\n' "$text" >&2
+        cat "$file" >&2
+        fail "$description"
+    fi
+}
+
+init_repo() {
+    git -c init.defaultBranch=main init -q "$1"
+}
+
+install_hooks() {
+    target_repo=$1
+    mkdir -p "$target_repo/.githooks"
+    for hook in commit-msg pre-commit applypatch-msg pre-applypatch pre-merge-commit; do
+        cp -p "$repo_root/.githooks/$hook" "$target_repo/.githooks/$hook"
+    done
+    git -C "$target_repo" config core.hooksPath .githooks
+}
+
+run_commit_hook() {
+    target_repo=$1
+    message_file=$2
+    (
+        cd "$target_repo"
+        "$commit_hook" "$message_file"
+    )
+}
+
+write_message() {
+    message_file=$1
+    message=$2
+    printf '%s\n' "$message" >"$message_file"
+}
+
+check_message_success() {
+    description=$1
+    message=$2
+    message_file="$suite_tmp/message-$test_count"
+    write_message "$message_file" "$message"
+    expect_success "$description" run_commit_hook "$direct_repo" "$message_file"
+}
+
+check_message_failure() {
+    description=$1
+    message=$2
+    message_file="$suite_tmp/message-$test_count"
+    write_message "$message_file" "$message"
+    expect_failure "$description" run_commit_hook "$direct_repo" "$message_file"
+    assert_contains "$description reports the expected trailer shape" "$command_log" \
+        'Signed-off-by: Name <email>'
+}
+
+for hook in commit-msg pre-commit applypatch-msg pre-applypatch pre-merge-commit; do
+    [[ -x $repo_root/.githooks/$hook ]] || fail "$hook is executable"
+done
+
+direct_repo="$suite_tmp/direct"
+init_repo "$direct_repo"
+check_message_success 'canonical one-token sign-off is accepted' \
+    $'Canonical\n\nSigned-off-by: Alice <alice@example.com>'
+check_message_success 'canonical multi-token sign-off is accepted' \
+    $'Canonical\n\nSigned-off-by: Alice B Example <alice.b@example.com>'
+check_message_success 'canonical sign-off among unrelated trailers is accepted' \
+    $'Canonical\n\nReviewed-by: Reviewer <reviewer@example.com>\nSigned-off-by: Alice Example <alice@example.com>\nAcked-by: Acker <acker@example.com>'
+check_message_failure 'missing sign-off is rejected' $'No trailer\n\nBody'
+check_message_failure 'short sign-off is rejected' $'Short\n\nSigned-off-by: x'
+check_message_failure 'name-less sign-off is rejected' \
+    $'No name\n\nSigned-off-by: <alice@example.com>'
+check_message_failure 'bracket-less sign-off is rejected' \
+    $'No brackets\n\nSigned-off-by: Alice alice@example.com'
+check_message_failure 'missing-at sign-off is rejected' \
+    $'No at\n\nSigned-off-by: Alice <alice.example.com>'
+check_message_failure 'empty local address component is rejected' \
+    $'Empty local\n\nSigned-off-by: Alice <@example.com>'
+check_message_failure 'empty domain address component is rejected' \
+    $'Empty domain\n\nSigned-off-by: Alice <alice@>'
+check_message_failure 'extra-at sign-off is rejected' \
+    $'Extra at\n\nSigned-off-by: Alice <alice@example@com>'
+check_message_failure 'address whitespace is rejected' \
+    $'Address whitespace\n\nSigned-off-by: Alice <alice @example.com>'
+check_message_failure 'lowercase noncanonical key is rejected' \
+    $'Wrong key\n\nsigned-off-by: Alice <alice@example.com>'
+check_message_failure 'whitespace before the sign-off colon is rejected' \
+    $'Wrong separator\n\nSigned-off-by : Alice Example <alice@example.com>'
+check_message_failure 'trailing sign-off content is rejected' \
+    $'Trailing\n\nSigned-off-by: Alice <alice@example.com> forged'
+check_message_failure 'Merge-looking subject without merge state is rejected' \
+    $'Merge branch topic\n\nThis is an ordinary message.'
+
+large_valid="$suite_tmp/large-valid-message"
+{
+    printf 'Large valid message\n\n'
+    printf 'Signed-off-by: Alice Example <alice@example.com>\n'
+    i=1
+    while ((i <= 50000)); do
+        printf 'Reviewed-by: Reviewer %d <reviewer%d@example.com>\n' "$i" "$i"
+        i=$((i + 1))
+    done
+} >"$large_valid"
+git -C "$direct_repo" interpret-trailers --parse "$large_valid" >"$suite_tmp/large-valid-parsed"
+large_valid_count=$(wc -l <"$suite_tmp/large-valid-parsed" | tr -d '[:space:]')
+assert_equal 'valid large message has 50,001 parsed trailers' 50001 "$large_valid_count"
+expect_success 'valid sign-off before 50,000 parsed trailers is accepted' \
+    run_commit_hook "$direct_repo" "$large_valid"
+
+large_invalid="$suite_tmp/large-invalid-message"
+{
+    printf 'Large invalid message\n\n'
+    i=1
+    while ((i <= 50000)); do
+        printf 'Reviewed-by: Reviewer %d <reviewer%d@example.com>\n' "$i" "$i"
+        i=$((i + 1))
+    done
+} >"$large_invalid"
+git -C "$direct_repo" interpret-trailers --parse "$large_invalid" >"$suite_tmp/large-invalid-parsed"
+large_invalid_count=$(wc -l <"$suite_tmp/large-invalid-parsed" | tr -d '[:space:]')
+assert_equal 'invalid large message has 50,000 parsed trailers' 50000 "$large_invalid_count"
+expect_failure '50,000 parsed trailers without a sign-off are rejected' \
+    run_commit_hook "$direct_repo" "$large_invalid"
+assert_contains 'large rejection reports the expected trailer shape' "$command_log" \
+    'Signed-off-by: Name <email>'
+
+real_git=$(command -v git)
+mkdir -p "$suite_tmp/failing-parser-bin"
+cat >"$suite_tmp/failing-parser-bin/git" <<'EOF'
+#!/usr/bin/env bash
+if [[ $1 == interpret-trailers ]]; then
+    printf 'Signed-off-by: Alice Example <alice@example.com>\n'
+    exit 17
+fi
+exec "$REAL_GIT" "$@"
+EOF
+chmod +x "$suite_tmp/failing-parser-bin/git"
+run_with_failing_parser() {
+    target_repo=$1
+    message_file=$2
+    (
+        cd "$target_repo"
+        REAL_GIT="$real_git" PATH="$suite_tmp/failing-parser-bin:$PATH" \
+            "$commit_hook" "$message_file"
+    )
+}
+expect_failure 'interpret-trailers failure rejects even a produced canonical sign-off' \
+    run_with_failing_parser "$direct_repo" "$large_valid"
+
+# Real commit plumbing must preserve the same canonical syntax distinction that
+# the direct hook checks exercise.
+syntax_repo="$suite_tmp/commit-syntax"
+init_repo "$syntax_repo"
+printf 'base\n' >"$syntax_repo/content.txt"
+git -C "$syntax_repo" add content.txt
+git -C "$syntax_repo" commit -q -m 'base'
+install_hooks "$syntax_repo"
+syntax_base=$(git -C "$syntax_repo" rev-parse HEAD)
+printf 'noncanonical\n' >"$syntax_repo/content.txt"
+git -C "$syntax_repo" add content.txt
+expect_failure 'git commit rejects whitespace before the sign-off colon' \
+    git -C "$syntax_repo" commit -m $'noncanonical sign-off\n\nSigned-off-by : Alice Example <alice@example.com>'
+assert_equal 'rejected noncanonical commit leaves HEAD unchanged' "$syntax_base" \
+    "$(git -C "$syntax_repo" rev-parse HEAD)"
+expect_success 'git commit accepts a canonical sign-off' \
+    git -C "$syntax_repo" commit -m $'canonical sign-off\n\nSigned-off-by: Alice Example <alice@example.com>'
+git -C "$syntax_repo" log -1 --format=%B >"$suite_tmp/canonical-commit-message"
+assert_contains 'real commit retains the canonical sign-off' "$suite_tmp/canonical-commit-message" \
+    'Signed-off-by: Alice Example <alice@example.com>'
+
+patch_repo="$suite_tmp/patch-source"
+init_repo "$patch_repo"
+printf 'base\n' >"$patch_repo/base.txt"
+git -C "$patch_repo" add base.txt
+git -C "$patch_repo" commit -q -m 'base'
+base_oid=$(git -C "$patch_repo" rev-parse HEAD)
+
+git -C "$patch_repo" checkout -q -b unsigned-patch
+printf 'unsigned clean\n' >"$patch_repo/unsigned.txt"
+git -C "$patch_repo" add unsigned.txt
+git -C "$patch_repo" commit -q -m 'unsigned clean patch'
+git -C "$patch_repo" format-patch -1 --stdout >"$suite_tmp/unsigned.patch"
+
+git -C "$patch_repo" checkout -q main
+git -C "$patch_repo" checkout -q -b noncanonical-signoff-patch
+printf 'noncanonical sign-off\n' >"$patch_repo/noncanonical.txt"
+git -C "$patch_repo" add noncanonical.txt
+git -C "$patch_repo" commit -q -m $'noncanonical sign-off patch\n\nSigned-off-by : Alice Example <alice@example.com>'
+git -C "$patch_repo" format-patch -1 --stdout >"$suite_tmp/noncanonical-signoff.patch"
+
+git -C "$patch_repo" checkout -q main
+git -C "$patch_repo" checkout -q -b whitespace-patch
+printf 'signed trailing whitespace   \n' >"$patch_repo/whitespace.txt"
+git -C "$patch_repo" add whitespace.txt
+git -C "$patch_repo" commit -q -s -m 'signed whitespace patch'
+git -C "$patch_repo" format-patch -1 --stdout >"$suite_tmp/whitespace.patch"
+
+git -C "$patch_repo" checkout -q main
+git -C "$patch_repo" checkout -q -b clean-patch
+printf 'signed clean\n' >"$patch_repo/clean.txt"
+git -C "$patch_repo" add clean.txt
+git -C "$patch_repo" commit -q -s -m 'signed clean patch'
+git -C "$patch_repo" format-patch -1 --stdout >"$suite_tmp/clean.patch"
+
+git -C "$patch_repo" checkout -q main
+am_repo="$suite_tmp/am-target"
+git clone -q "$patch_repo" "$am_repo"
+git -C "$am_repo" checkout -q --detach "$base_oid"
+install_hooks "$am_repo"
+am_base=$(git -C "$am_repo" rev-parse HEAD)
+expect_failure 'git am rejects an unsigned clean patch through applypatch-msg' \
+    git -C "$am_repo" am "$suite_tmp/unsigned.patch"
+assert_contains 'unsigned git am reports sign-off policy' "$command_log" \
+    'missing or malformed Signed-off-by trailer'
+assert_equal 'unsigned git am leaves HEAD unchanged' "$am_base" \
+    "$(git -C "$am_repo" rev-parse HEAD)"
+expect_success 'unsigned git am state can be aborted' git -C "$am_repo" am --abort
+
+expect_failure 'git am rejects whitespace before the sign-off colon through applypatch-msg' \
+    git -C "$am_repo" am "$suite_tmp/noncanonical-signoff.patch"
+assert_contains 'noncanonical git am reports sign-off policy' "$command_log" \
+    'missing or malformed Signed-off-by trailer'
+assert_equal 'noncanonical git am leaves HEAD unchanged' "$am_base" \
+    "$(git -C "$am_repo" rev-parse HEAD)"
+expect_success 'noncanonical git am state can be aborted' git -C "$am_repo" am --abort
+
+expect_failure 'git am rejects signed trailing whitespace through pre-applypatch' \
+    git -C "$am_repo" -c apply.whitespace=nowarn am "$suite_tmp/whitespace.patch"
+assert_contains 'whitespace git am reports the staged error' "$command_log" 'trailing whitespace.'
+assert_equal 'whitespace git am leaves HEAD unchanged' "$am_base" \
+    "$(git -C "$am_repo" rev-parse HEAD)"
+expect_success 'whitespace git am state can be aborted' git -C "$am_repo" am --abort
+
+expect_success 'git am applies a signed clean patch through both delegates' \
+    git -C "$am_repo" am "$suite_tmp/clean.patch"
+assert_equal 'signed clean patch creates one commit' "$am_base" \
+    "$(git -C "$am_repo" rev-parse HEAD^)"
+git -C "$am_repo" log -1 --format=%B >"$suite_tmp/canonical-am-message"
+assert_contains 'git am retains the canonical sign-off' "$suite_tmp/canonical-am-message" \
+    'Signed-off-by: Hook Test <hook.test@example.com>'
+
+merge_repo="$suite_tmp/merge-common"
+merge_linked="$suite_tmp/merge-linked"
+init_repo "$merge_repo"
+printf 'base\n' >"$merge_repo/base.txt"
+git -C "$merge_repo" add base.txt
+git -C "$merge_repo" commit -q -m 'base'
+git -C "$merge_repo" checkout -q -b topic
+echo 'topic' >"$merge_repo/topic.txt"
+git -C "$merge_repo" add topic.txt
+git -C "$merge_repo" commit -q -m 'topic change'
+git -C "$merge_repo" checkout -q main
+echo 'main' >"$merge_repo/main.txt"
+git -C "$merge_repo" add main.txt
+git -C "$merge_repo" commit -q -m 'main change'
+git -C "$merge_repo" checkout -q topic
+git -C "$merge_repo" worktree add -q "$merge_linked" main
+install_hooks "$merge_linked"
+expect_success 'unsigned custom-message automatic merge succeeds while MERGE_HEAD exists' \
+    git -C "$merge_linked" merge --no-ff -m 'Integrate topic changes' topic
+merge_oid=$(git -C "$merge_linked" rev-parse HEAD)
+git -C "$merge_linked" log -1 --format=%B >"$suite_tmp/unsigned-merge-message"
+assert_not_contains 'automatic merge is unsigned' "$suite_tmp/unsigned-merge-message" 'Signed-off-by:'
+merge_head_path=$(git -C "$merge_linked" rev-parse --git-path MERGE_HEAD)
+[[ ! -f $merge_head_path ]] || fail 'MERGE_HEAD is removed after an automatic merge'
+expect_failure 'immediate unsigned merge amend is rejected without MERGE_HEAD' \
+    git -C "$merge_linked" commit --amend --no-edit
+assert_equal 'rejected unsigned merge amend leaves HEAD unchanged' "$merge_oid" \
+    "$(git -C "$merge_linked" rev-parse HEAD)"
+expect_success 'signed merge amend succeeds' \
+    git -C "$merge_linked" commit --amend --no-edit -s
+signed_merge_oid=$(git -C "$merge_linked" rev-parse HEAD)
+[[ $signed_merge_oid != "$merge_oid" ]] || fail 'signed merge amend replaces the commit'
+git -C "$merge_linked" log -1 --format=%B >"$suite_tmp/signed-merge-message"
+assert_contains 'signed merge amend adds a canonical sign-off' "$suite_tmp/signed-merge-message" \
+    'Signed-off-by: Hook Test <hook.test@example.com>'
+
+whitespace_repo="$suite_tmp/whitespace-common"
+whitespace_linked="$suite_tmp/whitespace-linked"
+init_repo "$whitespace_repo"
+printf 'base\n' >"$whitespace_repo/base.txt"
+git -C "$whitespace_repo" add base.txt
+git -C "$whitespace_repo" commit -q -m 'base'
+git -C "$whitespace_repo" checkout -q -b topic
+printf 'bad merge content   \n' >"$whitespace_repo/bad.txt"
+git -C "$whitespace_repo" add bad.txt
+git -C "$whitespace_repo" commit -q -m 'topic with whitespace'
+git -C "$whitespace_repo" checkout -q main
+printf 'main\n' >"$whitespace_repo/main.txt"
+git -C "$whitespace_repo" add main.txt
+git -C "$whitespace_repo" commit -q -m 'diverging main change'
+git -C "$whitespace_repo" checkout -q topic
+git -C "$whitespace_repo" worktree add -q "$whitespace_linked" main
+install_hooks "$whitespace_linked"
+whitespace_head=$(git -C "$whitespace_linked" rev-parse HEAD)
+expect_failure 'automatic merge rejects staged trailing whitespace through pre-merge-commit' \
+    git -C "$whitespace_linked" merge --no-ff -m 'Integrate whitespace topic' topic
+assert_contains 'automatic merge reports trailing whitespace' "$command_log" 'trailing whitespace.'
+assert_equal 'rejected whitespace merge leaves HEAD unchanged' "$whitespace_head" \
+    "$(git -C "$whitespace_linked" rev-parse HEAD)"
+whitespace_merge_head=$(git -C "$whitespace_linked" rev-parse --git-path MERGE_HEAD)
+[[ -f $whitespace_merge_head ]] || fail 'failed automatic merge retains MERGE_HEAD for recovery'
+expect_success 'failed automatic merge can be aborted' git -C "$whitespace_linked" merge --abort
+
+printf '1..%d\n' "$test_count"

--- a/test/git-hooks/install.bash
+++ b/test/git-hooks/install.bash
@@ -1,0 +1,588 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+real_git=$(command -v git)
+readonly project_root real_git
+readonly installer=$project_root/hack/install-git-hooks.sh
+readonly original_path=$PATH
+
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/crio-git-hooks-install-test.XXXXXX")
+cleanup() {
+    status=$?
+    trap - EXIT INT TERM
+    rm -rf "$test_root"
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=$test_root/global.gitconfig
+export HOME=$test_root/home
+export GIT_AUTHOR_NAME='Hook Test'
+export GIT_AUTHOR_EMAIL=hook-test@example.com
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+export TMPDIR=$test_root/tmp
+mkdir -p "$HOME" "$TMPDIR"
+unset GIT_CONFIG_COUNT GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR
+
+fail() {
+    echo "not ok - $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "ok - $*"
+}
+
+assert_equal() {
+    expected=$1
+    actual=$2
+    description=$3
+    if [[ $actual != "$expected" ]]; then
+        printf "not ok - %s\nexpected: <%s>\nactual:   <%s>\n" "$description" "$expected" "$actual" >&2
+        exit 1
+    fi
+}
+
+new_repo() {
+    repo=$test_root/$1
+    git init -q "$repo"
+}
+
+new_committed_repo() {
+    new_repo "$1"
+    printf 'initial\n' >"$repo/README"
+    git -C "$repo" add README
+    git -C "$repo" commit -qm initial
+}
+
+worktree_config_path() {
+    target_repo=$1
+    target_git_dir=$(git -C "$target_repo" rev-parse --git-dir)
+    case $target_git_dir in
+    /*) ;;
+    *) target_git_dir=$target_repo/$target_git_dir ;;
+    esac
+    printf '%s/config.worktree\n' "$target_git_dir"
+}
+
+assert_config_value() {
+    expected=$1
+    target_repo=$2
+    scope=$3
+    name=$4
+    description="$scope $name"
+
+    case $scope in
+    local)
+        actual=$(git -C "$target_repo" config --local --get-all "$name") || fail "$description is unset"
+        ;;
+    worktree)
+        config_file=$(worktree_config_path "$target_repo")
+        actual=$(git config --file "$config_file" --get-all "$name") || fail "$description is unset"
+        ;;
+    effective)
+        actual=$(git -C "$target_repo" config --get "$name") || fail "$description is unset"
+        ;;
+    *) fail "unknown configuration scope $scope" ;;
+    esac
+    assert_equal "$expected" "$actual" "$description"
+}
+
+assert_config_unset() {
+    target_repo=$1
+    scope=$2
+    name=$3
+
+    case $scope in
+    local)
+        if git -C "$target_repo" config --local --get-all "$name" >/dev/null 2>&1; then
+            fail "$scope $name should be unset"
+        fi
+        ;;
+    worktree)
+        config_file=$(worktree_config_path "$target_repo")
+        if git config --file "$config_file" --get-all "$name" >/dev/null 2>&1; then
+            fail "$scope $name should be unset"
+        fi
+        ;;
+    effective)
+        if git -C "$target_repo" config --get "$name" >/dev/null 2>&1; then
+            fail "$scope $name should be unset"
+        fi
+        ;;
+    *) fail "unknown configuration scope $scope" ;;
+    esac
+}
+
+relevant_state() {
+    target_repo=$1
+    config_file=$(worktree_config_path "$target_repo")
+    printf '%s\n' 'local hooks:'
+    git -C "$target_repo" config --local --get-all core.hooksPath 2>/dev/null || true
+    printf '%s\n' 'worktree hooks:'
+    git config --file "$config_file" --get-all core.hooksPath 2>/dev/null || true
+    printf '%s\n' 'extensions:'
+    git -C "$target_repo" config --local --get-all extensions.worktreeConfig 2>/dev/null || true
+    printf '%s\n' 'effective hooks:'
+    git -C "$target_repo" config --get core.hooksPath 2>/dev/null || true
+    printf '%s\n' 'end'
+}
+
+run_install() {
+    target_repo=$1
+    (cd "$target_repo" && "$installer") >/dev/null
+}
+
+expect_install_failure() {
+    target_repo=$1
+    expected_message=$2
+    if failure_output=$(cd "$target_repo" && "$installer" 2>&1); then
+        fail "installer unexpectedly succeeded in $target_repo"
+    fi
+    case $failure_output in
+    *"$expected_message"*) ;;
+    *) fail "installer failure did not contain '$expected_message': $failure_output" ;;
+    esac
+}
+
+assert_refusal_preserves_state() {
+    target_repo=$1
+    expected_message=$2
+    before=$(relevant_state "$target_repo")
+    expect_install_failure "$target_repo" "$expected_message"
+    after=$(relevant_state "$target_repo")
+    assert_equal "$before" "$after" "refusal preserves configuration"
+}
+
+make_git_shim() {
+    shim_dir=$test_root/git-shim
+    mkdir -p "$shim_dir"
+    cat >"$shim_dir/git" <<'EOF'
+#!/usr/bin/env bash
+
+set -u
+
+is_mutation=false
+is_effective_hooks_query=false
+if [[ ${1-} == config ]]; then
+    if [[ $# -eq 3 && $2 == --get && $3 == core.hooksPath ]]; then
+        is_effective_hooks_query=true
+    fi
+    for arg in "$@"; do
+        case $arg in
+            --add | --replace-all | --unset-all)
+                is_mutation=true
+                ;;
+        esac
+    done
+fi
+
+if [[ $is_effective_hooks_query == true && -n ${GIT_EFFECTIVE_AFTER_MUTATION-} && -e $GIT_SHIM_STATE_DIR/mutated ]]; then
+    printf '%s\n' "$GIT_EFFECTIVE_AFTER_MUTATION"
+    exit 0
+fi
+
+status=0
+"$REAL_GIT" "$@" || status=$?
+
+if [[ $is_mutation == true && $status -eq 0 ]]; then
+    : >"$GIT_SHIM_STATE_DIR/mutated"
+    if [[ -n ${GIT_MUTATION_LOG-} ]]; then
+        effective=$("$REAL_GIT" config --get core.hooksPath 2>/dev/null || printf '<unset>')
+        printf '%s\n' "$effective" >>"$GIT_MUTATION_LOG"
+    fi
+
+    if [[ -n ${GIT_FAIL_MUTATION_AT-} && ! -e $GIT_SHIM_STATE_DIR/failed ]]; then
+        count=0
+        if [[ -f $GIT_SHIM_STATE_DIR/count ]]; then
+            IFS= read -r count <"$GIT_SHIM_STATE_DIR/count"
+        fi
+        count=$((count + 1))
+        printf '%s\n' "$count" >"$GIT_SHIM_STATE_DIR/count"
+        if [[ $count -eq $GIT_FAIL_MUTATION_AT ]]; then
+            : >"$GIT_SHIM_STATE_DIR/failed"
+            exit 97
+        fi
+    fi
+fi
+
+exit "$status"
+EOF
+    chmod +x "$shim_dir/git"
+}
+
+# A fresh installation is scoped to only the invoking worktree.
+new_committed_repo fresh-linked
+main_repo=$repo
+linked_repo=$test_root/fresh-linked-sibling
+git -C "$main_repo" worktree add -q -b hook-test-linked "$linked_repo"
+run_install "$linked_repo"
+assert_config_value true "$main_repo" local extensions.worktreeConfig
+assert_config_unset "$main_repo" local core.hooksPath
+assert_config_value .githooks "$linked_repo" worktree core.hooksPath
+assert_config_unset "$main_repo" worktree core.hooksPath
+assert_config_unset "$main_repo" effective core.hooksPath
+run_install "$main_repo"
+assert_config_value .githooks "$main_repo" worktree core.hooksPath
+assert_config_value .githooks "$main_repo" effective core.hooksPath
+before=$(relevant_state "$linked_repo")
+run_install "$linked_repo"
+after=$(relevant_state "$linked_repo")
+assert_equal "$before" "$after" "repeat installation is a configuration no-op"
+pass "fresh and repeat installations are worktree-scoped"
+
+# A dormant but valid raw worktree value is retained when the extension is
+# enabled, rather than being mistaken for an unset or shared value.
+new_repo dormant-worktree
+raw_config=$(worktree_config_path "$repo")
+git config --file "$raw_config" core.hooksPath .githooks
+run_install "$repo"
+assert_config_value true "$repo" local extensions.worktreeConfig
+assert_config_unset "$repo" local core.hooksPath
+assert_config_value .githooks "$repo" worktree core.hooksPath
+assert_config_value .githooks "$repo" effective core.hooksPath
+pass "raw worktree configuration is honored while the extension is disabled"
+
+# Enabling worktree configuration must not activate any unrelated setting in
+# the invoking worktree's otherwise valid dormant hook configuration.
+new_repo dormant-current-extra
+raw_config=$(worktree_config_path "$repo")
+git config --file "$raw_config" core.hooksPath .githooks
+git config --file "$raw_config" user.email dormant-current@example.com
+before=$(relevant_state "$repo")
+before_shared=$(cat "$repo/.git/config")
+before_raw=$(cat "$raw_config")
+expect_install_failure "$repo" "current worktree has dormant configuration beyond core.hooksPath=.githooks"
+after=$(relevant_state "$repo")
+assert_equal "$before" "$after" "dormant current-worktree refusal preserves configuration"
+assert_equal "$before_shared" "$(cat "$repo/.git/config")" "dormant current-worktree refusal preserves shared configuration exactly"
+assert_equal "$before_raw" "$(cat "$raw_config")" "dormant current-worktree refusal preserves worktree configuration exactly"
+assert_config_unset "$repo" local extensions.worktreeConfig
+assert_config_unset "$repo" effective core.hooksPath
+pass "unrelated dormant current-worktree configuration is not activated"
+
+# Includes are expanded before mutation, so enabling worktree configuration
+# cannot reveal a later conflicting value.
+new_repo included-worktree-conflict
+raw_config=$(worktree_config_path "$repo")
+included_config=$repo/included-worktree.config
+git config --file "$raw_config" core.hooksPath .githooks
+git config --file "$raw_config" include.path "$included_config"
+git config --file "$included_config" core.hooksPath custom-included
+before=$(relevant_state "$repo")
+before_raw=$(cat "$raw_config")
+before_included=$(cat "$included_config")
+expect_install_failure "$repo" "current worktree core.hooksPath has multiple values"
+after=$(relevant_state "$repo")
+assert_equal "$before" "$after" "included worktree refusal preserves configuration"
+assert_equal "$before_raw" "$(cat "$raw_config")" "included worktree refusal preserves the worktree config file"
+assert_equal "$before_included" "$(cat "$included_config")" "included worktree refusal preserves the included config file"
+assert_config_unset "$repo" local extensions.worktreeConfig
+assert_config_unset "$repo" effective core.hooksPath
+pass "included worktree conflicts are refused before mutation"
+
+# Enabling the shared extension must not activate dormant hooks configuration
+# in another linked worktree.
+new_committed_repo dormant-sibling
+main_repo=$repo
+sibling_repo=$test_root/dormant-sibling-linked
+git -C "$main_repo" worktree add -q -b dormant-sibling-linked "$sibling_repo"
+sibling_config=$(worktree_config_path "$sibling_repo")
+git config --file "$sibling_config" core.hooksPath custom-sibling
+before_main=$(relevant_state "$main_repo")
+before_sibling=$(relevant_state "$sibling_repo")
+before_shared=$(cat "$main_repo/.git/config")
+before_sibling_config=$(cat "$sibling_config")
+expect_install_failure "$main_repo" "has dormant worktree configuration"
+after_main=$(relevant_state "$main_repo")
+after_sibling=$(relevant_state "$sibling_repo")
+assert_equal "$before_main" "$after_main" "dormant sibling refusal preserves invoking configuration"
+assert_equal "$before_sibling" "$after_sibling" "dormant sibling refusal preserves sibling configuration"
+assert_equal "$before_shared" "$(cat "$main_repo/.git/config")" "dormant sibling refusal preserves shared configuration exactly"
+assert_equal "$before_sibling_config" "$(cat "$sibling_config")" "dormant sibling refusal preserves sibling configuration exactly"
+assert_config_unset "$main_repo" local extensions.worktreeConfig
+assert_config_unset "$main_repo" effective core.hooksPath
+assert_config_unset "$sibling_repo" effective core.hooksPath
+pass "dormant sibling hook configuration is not activated"
+
+# The complete sibling inventory includes include directives and their target
+# settings, and it is read in that sibling's own Git context.
+new_committed_repo dormant-sibling-include
+main_repo=$repo
+sibling_repo=$test_root/dormant-sibling-include-linked
+git -C "$main_repo" worktree add -q -b dormant-sibling-include-linked "$sibling_repo"
+main_config=$(worktree_config_path "$main_repo")
+sibling_config=$(worktree_config_path "$sibling_repo")
+sibling_include=$sibling_repo/dormant-worktree.config
+printf '# invoking worktree marker\n' >"$main_config"
+git config --file "$sibling_config" include.path "$sibling_include"
+git config --file "$sibling_include" user.email dormant-sibling@example.com
+before_main=$(relevant_state "$main_repo")
+before_sibling=$(relevant_state "$sibling_repo")
+before_shared=$(cat "$main_repo/.git/config")
+before_main_config=$(cat "$main_config")
+before_sibling_config=$(cat "$sibling_config")
+before_sibling_include=$(cat "$sibling_include")
+expect_install_failure "$main_repo" "has dormant worktree configuration"
+after_main=$(relevant_state "$main_repo")
+after_sibling=$(relevant_state "$sibling_repo")
+assert_equal "$before_main" "$after_main" "included sibling refusal preserves invoking configuration"
+assert_equal "$before_sibling" "$after_sibling" "included sibling refusal preserves sibling configuration"
+assert_equal "$before_shared" "$(cat "$main_repo/.git/config")" "included sibling refusal preserves shared configuration exactly"
+assert_equal "$before_main_config" "$(cat "$main_config")" "included sibling refusal preserves invoking worktree configuration exactly"
+assert_equal "$before_sibling_config" "$(cat "$sibling_config")" "included sibling refusal preserves sibling worktree configuration exactly"
+assert_equal "$before_sibling_include" "$(cat "$sibling_include")" "included sibling refusal preserves included configuration exactly"
+assert_config_unset "$main_repo" local extensions.worktreeConfig
+assert_config_unset "$main_repo" effective core.hooksPath
+assert_config_unset "$sibling_repo" effective core.hooksPath
+pass "included dormant sibling configuration is not activated"
+
+# An include-expanded shared-local inventory must expose values hidden before a
+# direct legacy .githooks entry. Refusal preserves every linked-worktree file
+# and leaves both worktrees on the old effective path.
+new_committed_repo included-shared-legacy
+main_repo=$repo
+sibling_repo=$test_root/included-shared-legacy-linked
+git -C "$main_repo" worktree add -q -b included-shared-legacy-linked "$sibling_repo"
+main_config=$(worktree_config_path "$main_repo")
+sibling_config=$(worktree_config_path "$sibling_repo")
+shared_include=$test_root/included-shared-legacy.config
+git -C "$main_repo" config --local include.path "$shared_include"
+git config --file "$shared_include" core.hooksPath custom-hidden
+git -C "$main_repo" config --local extensions.worktreeConfig false
+printf '\n[core]\n\thooksPath = .githooks\n' >>"$main_repo/.git/config"
+git config --file "$main_config" core.hooksPath .githooks
+printf '# sibling worktree marker\n' >"$sibling_config"
+assert_config_value .githooks "$main_repo" effective core.hooksPath
+assert_config_value .githooks "$sibling_repo" effective core.hooksPath
+before_main=$(relevant_state "$main_repo")
+before_sibling=$(relevant_state "$sibling_repo")
+before_shared=$(cat "$main_repo/.git/config")
+before_include=$(cat "$shared_include")
+before_main_config=$(cat "$main_config")
+before_sibling_config=$(cat "$sibling_config")
+expect_install_failure "$main_repo" "shared local core.hooksPath has multiple values"
+after_main=$(relevant_state "$main_repo")
+after_sibling=$(relevant_state "$sibling_repo")
+assert_equal "$before_main" "$after_main" "included shared-local refusal preserves invoking configuration"
+assert_equal "$before_sibling" "$after_sibling" "included shared-local refusal preserves sibling configuration"
+assert_equal "$before_shared" "$(cat "$main_repo/.git/config")" "included shared-local refusal preserves shared configuration exactly"
+assert_equal "$before_include" "$(cat "$shared_include")" "included shared-local refusal preserves included configuration exactly"
+assert_equal "$before_main_config" "$(cat "$main_config")" "included shared-local refusal preserves invoking worktree configuration exactly"
+assert_equal "$before_sibling_config" "$(cat "$sibling_config")" "included shared-local refusal preserves sibling worktree configuration exactly"
+assert_config_value false "$main_repo" local extensions.worktreeConfig
+assert_config_value .githooks "$main_repo" effective core.hooksPath
+assert_config_value .githooks "$sibling_repo" effective core.hooksPath
+pass "included shared-local hook conflicts are refused before migration"
+
+# Migrate only the installer's old shared .githooks value. An older sibling
+# must stop inheriting that relative path, and every mutation keeps this
+# worktree hooked.
+new_committed_repo legacy
+legacy_repo=$repo
+old_oid=$(git -C "$legacy_repo" rev-parse HEAD)
+mkdir "$legacy_repo/.githooks"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$legacy_repo/.githooks/pre-commit"
+chmod +x "$legacy_repo/.githooks/pre-commit"
+git -C "$legacy_repo" add .githooks/pre-commit
+git -C "$legacy_repo" commit -qm hooks
+old_worktree=$test_root/legacy-old-worktree
+git -C "$legacy_repo" worktree add -q --detach "$old_worktree" "$old_oid"
+git -C "$legacy_repo" config --local core.hooksPath .githooks
+make_git_shim
+migration_state=$test_root/migration-shim-state
+migration_log=$test_root/migration.log
+mkdir "$migration_state"
+(
+    cd "$legacy_repo"
+    env REAL_GIT="$real_git" \
+        GIT_SHIM_STATE_DIR="$migration_state" \
+        GIT_MUTATION_LOG="$migration_log" \
+        PATH="$shim_dir:$original_path" \
+        "$installer"
+) >/dev/null
+mutation_count=0
+while IFS= read -r effective; do
+    mutation_count=$((mutation_count + 1))
+    assert_equal .githooks "$effective" "migration mutation $mutation_count remains hooked"
+done <"$migration_log"
+assert_equal 3 "$mutation_count" "legacy migration mutation count"
+assert_config_unset "$legacy_repo" local core.hooksPath
+assert_config_value .githooks "$legacy_repo" worktree core.hooksPath
+assert_config_unset "$old_worktree" worktree core.hooksPath
+assert_config_unset "$old_worktree" effective core.hooksPath
+if [[ -e $old_worktree/.githooks ]]; then
+    fail "historical sibling unexpectedly contains .githooks"
+fi
+before=$(relevant_state "$legacy_repo")
+run_install "$legacy_repo"
+after=$(relevant_state "$legacy_repo")
+assert_equal "$before" "$after" "repeat migrated installation is a no-op"
+pass "legacy shared configuration migrates without an unhooked interval"
+
+# Hidden and raw repository values are checked independently before mutation.
+new_repo hidden-local
+git -C "$repo" config --local extensions.worktreeConfig true
+git -C "$repo" config --local core.hooksPath custom-local
+git -C "$repo" config --worktree core.hooksPath .githooks
+assert_refusal_preserves_state "$repo" "shared local core.hooksPath is already set"
+
+new_repo raw-worktree
+raw_config=$(worktree_config_path "$repo")
+git config --file "$raw_config" core.hooksPath custom-worktree
+assert_refusal_preserves_state "$repo" "current worktree core.hooksPath is already set"
+
+new_repo empty-local
+git -C "$repo" config --local core.hooksPath ''
+assert_refusal_preserves_state "$repo" "shared local core.hooksPath is explicitly empty"
+
+new_repo empty-worktree
+raw_config=$(worktree_config_path "$repo")
+git config --file "$raw_config" core.hooksPath ''
+assert_refusal_preserves_state "$repo" "current worktree core.hooksPath is explicitly empty"
+
+new_repo duplicate-local
+git -C "$repo" config --local --add core.hooksPath .githooks
+git -C "$repo" config --local --add core.hooksPath .githooks
+assert_refusal_preserves_state "$repo" "shared local core.hooksPath has multiple values"
+
+new_repo duplicate-worktree
+raw_config=$(worktree_config_path "$repo")
+git config --file "$raw_config" --add core.hooksPath .githooks
+git config --file "$raw_config" --add core.hooksPath .githooks
+assert_refusal_preserves_state "$repo" "current worktree core.hooksPath has multiple values"
+pass "local and raw worktree conflicts are refused before mutation"
+
+# Effective settings from outside the repository, including command-level
+# overrides that mask an installed worktree value, are never replaced.
+new_repo global-effective
+git config --global core.hooksPath global-custom
+assert_refusal_preserves_state "$repo" "effective core.hooksPath is set to 'global-custom'"
+git config --global core.hooksPath .githooks
+assert_refusal_preserves_state "$repo" "effective core.hooksPath is set outside"
+git config --global --unset-all core.hooksPath
+
+new_repo command-effective
+run_install "$repo"
+before=$(relevant_state "$repo")
+if failure_output=$(
+    cd "$repo" &&
+        env GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0=core.hooksPath \
+            GIT_CONFIG_VALUE_0=command-custom \
+            "$installer" 2>&1
+); then
+    fail "installer ignored a command-level core.hooksPath override"
+fi
+case $failure_output in
+*"effective core.hooksPath is set to 'command-custom'"*) ;;
+*) fail "command-level conflict had the wrong diagnostic: $failure_output" ;;
+esac
+after=$(relevant_state "$repo")
+assert_equal "$before" "$after" "command-level refusal preserves configuration"
+pass "custom effective configurations are refused"
+
+# Default hooks that would be disabled or reactivated block a transition.
+new_repo default-fresh-block
+printf '#!/usr/bin/env bash\nexit 0\n' >"$repo/.git/hooks/pre-commit"
+chmod +x "$repo/.git/hooks/pre-commit"
+assert_refusal_preserves_state "$repo" "an executable Git hook already exists"
+
+new_repo default-legacy-block
+git -C "$repo" config --local core.hooksPath .githooks
+printf '#!/usr/bin/env bash\nexit 0\n' >"$repo/.git/hooks/post-commit"
+chmod +x "$repo/.git/hooks/post-commit"
+assert_refusal_preserves_state "$repo" "an executable Git hook already exists"
+
+new_repo harmless-defaults
+printf '#!/usr/bin/env bash\nexit 0\n' >"$repo/.git/hooks/custom.sample"
+chmod +x "$repo/.git/hooks/custom.sample"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$repo/.git/hooks/not-executable"
+chmod -x "$repo/.git/hooks/not-executable"
+run_install "$repo"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$repo/.git/hooks/added-later"
+chmod +x "$repo/.git/hooks/added-later"
+before=$(relevant_state "$repo")
+run_install "$repo"
+after=$(relevant_state "$repo")
+assert_equal "$before" "$after" "completed repeat ignores a later default hook"
+pass "default hook conflicts are preserved without breaking completed repeats"
+
+# Failures returned after writes exercise rollback of both a fresh install and
+# a legacy migration whose final shared-local removal already took effect.
+new_repo rollback-fresh
+fresh_rollback_repo=$repo
+fresh_state=$test_root/fresh-rollback-shim
+mkdir "$fresh_state"
+before=$(relevant_state "$fresh_rollback_repo")
+if (
+    cd "$fresh_rollback_repo"
+    env REAL_GIT="$real_git" \
+        GIT_SHIM_STATE_DIR="$fresh_state" \
+        GIT_FAIL_MUTATION_AT=2 \
+        PATH="$shim_dir:$original_path" \
+        "$installer"
+) >/dev/null 2>&1; then
+    fail "injected fresh-install failure unexpectedly succeeded"
+fi
+after=$(relevant_state "$fresh_rollback_repo")
+assert_equal "$before" "$after" "fresh-install rollback restores configuration"
+git -C "$fresh_rollback_repo" status --short >/dev/null
+
+new_repo rollback-legacy
+git -C "$repo" config --local core.hooksPath .githooks
+git -C "$repo" config --local extensions.worktreeConfig false
+legacy_rollback_repo=$repo
+legacy_state=$test_root/legacy-rollback-shim
+mkdir "$legacy_state"
+before=$(relevant_state "$legacy_rollback_repo")
+if (
+    cd "$legacy_rollback_repo"
+    env REAL_GIT="$real_git" \
+        GIT_SHIM_STATE_DIR="$legacy_state" \
+        GIT_FAIL_MUTATION_AT=3 \
+        PATH="$shim_dir:$original_path" \
+        "$installer"
+) >/dev/null 2>&1; then
+    fail "injected legacy-migration failure unexpectedly succeeded"
+fi
+after=$(relevant_state "$legacy_rollback_repo")
+assert_equal "$before" "$after" "legacy rollback restores extension, worktree, and local state"
+assert_config_value false "$legacy_rollback_repo" local extensions.worktreeConfig
+assert_config_value .githooks "$legacy_rollback_repo" local core.hooksPath
+assert_config_unset "$legacy_rollback_repo" worktree core.hooksPath
+git -C "$legacy_rollback_repo" status --short >/dev/null
+
+# Verification failures after every intended write still trigger rollback.
+new_repo rollback-post-verify
+post_verify_repo=$repo
+post_verify_state=$test_root/post-verify-rollback-shim
+mkdir "$post_verify_state"
+before=$(relevant_state "$post_verify_repo")
+if failure_output=$(
+    cd "$post_verify_repo" &&
+        env REAL_GIT="$real_git" \
+            GIT_SHIM_STATE_DIR="$post_verify_state" \
+            GIT_EFFECTIVE_AFTER_MUTATION=custom-post-write \
+            PATH="$shim_dir:$original_path" \
+            "$installer" 2>&1
+); then
+    fail "post-write verification failure unexpectedly succeeded"
+fi
+case $failure_output in
+*".githooks is not effective for the current worktree"*) ;;
+*) fail "post-write verification failure had the wrong diagnostic: $failure_output" ;;
+esac
+after=$(relevant_state "$post_verify_repo")
+assert_equal "$before" "$after" "post-write verification rollback restores configuration"
+assert_config_unset "$post_verify_repo" local extensions.worktreeConfig
+assert_config_unset "$post_verify_repo" local core.hooksPath
+assert_config_unset "$post_verify_repo" worktree core.hooksPath
+assert_config_unset "$post_verify_repo" effective core.hooksPath
+pass "configuration writes and post-write verification failures roll back transactionally"

--- a/test/git-hooks/pre-push.bash
+++ b/test/git-hooks/pre-push.bash
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+hook=$repo_root/.githooks/pre-push
+base_tmp=${TMPDIR:-/tmp}
+test_root=$(mktemp -d "$base_tmp/crio-pre-push-test.XXXXXX")
+hook_tmp=$test_root/hook-tmp
+original_path=$PATH
+
+cleanup() {
+    rm -rf "$test_root"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+fail() {
+    echo "pre-push test failed: $*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local expected=$1
+    local file=$2
+
+    grep -Fq "$expected" "$file" || fail "expected '$expected' in $file"
+}
+
+assert_not_contains() {
+    local unexpected=$1
+    local file=$2
+
+    if grep -Fq "$unexpected" "$file"; then
+        fail "did not expect '$unexpected' in $file"
+    fi
+}
+
+assert_count() {
+    local expected=$1
+    local text=$2
+    local file=$3
+    local actual
+
+    actual=$(grep -Fxc "$text" "$file" || true)
+    [[ $actual == "$expected" ]] || fail "expected $expected '$text' lines in $file, found $actual"
+}
+
+directory_is_empty() {
+    local directory=$1
+    local entry
+
+    for entry in "$directory"/* "$directory"/.[!.]* "$directory"/..?*; do
+        if [[ -e $entry || -L $entry ]]; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+assert_hook_cleanup() {
+    local repo=$1
+    local worktree_count
+
+    if ! directory_is_empty "$hook_tmp"; then
+        fail "pre-push temporary data remains in $hook_tmp"
+    fi
+
+    worktree_count=$(git -C "$repo" worktree list --porcelain | awk '$1 == "worktree" { count++ } END { print count + 0 }')
+    [[ $worktree_count == 1 ]] || fail "a disposable worktree remains registered in $repo"
+}
+
+init_repo() {
+    local repo=$1
+
+    mkdir -p "$repo"
+    git init -q "$repo"
+}
+
+write_check_fixture() {
+    local repo=$1
+    local marker=$2
+
+    mkdir -p "$repo/hack"
+    cat >"$repo/Makefile" <<'EOF'
+BUILD_PATH ?= $(CURDIR)/build
+
+.PHONY: lint check-vendor docs-validation
+check-vendor:
+	@test -z "$$(git status --porcelain --untracked-files=all)"
+	@! test -e "$(BUILD_PATH)"
+	@printf 'vendor:%s\n' "$$(cat expected-marker)" >>"$(TEST_LOG)"
+
+lint:
+	@test "$(BUILD_PATH)" = "$(CURDIR)/build"
+	@! test -e "$(BUILD_PATH)/lint.marker"
+	@mkdir -p "$(BUILD_PATH)"
+	@./fake-lint >"$(BUILD_PATH)/lint.marker"
+	@cmp -s "$(BUILD_PATH)/lint.marker" expected-marker
+	@printf 'lint:%s\n' "$$(cat "$(BUILD_PATH)/lint.marker")" >>"$(TEST_LOG)"
+
+docs-validation:
+	@printf 'docs:%s\n' "$$(cat expected-marker)" >>"$(TEST_LOG)"
+EOF
+    printf '%s\n' "$marker" >"$repo/expected-marker"
+    cat >"$repo/fake-lint" <<EOF
+#!/usr/bin/env bash
+printf '%s\\n' '$marker'
+EOF
+    chmod +x "$repo/fake-lint"
+}
+
+write_helper() {
+    local repo=$1
+
+    mkdir -p "$repo/hack"
+    cat >"$repo/hack/run-on-linux.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'helper:%s\n' "$(cat expected-marker)" >>"$TEST_LOG"
+"$@"
+EOF
+    chmod +x "$repo/hack/run-on-linux.sh"
+}
+
+commit_all() {
+    local repo=$1
+    local subject=$2
+
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m "$subject"
+    git -C "$repo" rev-parse HEAD
+}
+
+write_push_record() {
+    local file=$1
+    local source_ref=$2
+    local source_oid=$3
+    local destination_ref=$4
+
+    printf '%s %s %s %040d\n' "$source_ref" "$source_oid" "$destination_ref" 0 >>"$file"
+}
+
+run_hook() {
+    local repo=$1
+    local input=$2
+    local output=$3
+
+    (
+        cd "$repo"
+        "$hook" origin <"$input"
+    ) >"$output.stdout" 2>"$output.stderr"
+}
+
+mkdir -p "$hook_tmp" "$test_root/home" "$test_root/xdg"
+export TMPDIR=$hook_tmp
+export HOME=$test_root/home
+export XDG_CONFIG_HOME=$test_root/xdg
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=$test_root/gitconfig
+export GIT_CONFIG_COUNT=0
+unset GIT_CONFIG_PARAMETERS GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX
+: >"$GIT_CONFIG_GLOBAL"
+git config --global user.name "Git Hook Test"
+git config --global user.email "git-hook@example.com"
+
+# Mixed input validates source-ref notes filtering, commit peeling,
+# deletion and non-commit skipping, unique-tip deduplication, and tip-local
+# build/helper use. The tag commits are not present in branch records so their
+# markers are meaningful controls for lightweight and annotated tag handling.
+mixed_repo=$test_root/mixed
+mixed_log=$test_root/mixed.log
+mixed_input=$test_root/mixed.input
+mixed_output=$test_root/mixed-output
+active_helper_log=$test_root/active-helper.log
+init_repo "$mixed_repo"
+write_check_fixture "$mixed_repo" tip-one
+write_helper "$mixed_repo"
+tip_one=$(commit_all "$mixed_repo" "tip one")
+write_check_fixture "$mixed_repo" tip-two
+write_helper "$mixed_repo"
+tip_two=$(commit_all "$mixed_repo" "tip two")
+write_check_fixture "$mixed_repo" lightweight-tag-only
+write_helper "$mixed_repo"
+lightweight_tip=$(commit_all "$mixed_repo" "lightweight tag-only tip")
+git -C "$mixed_repo" tag light-only "$lightweight_tip"
+write_check_fixture "$mixed_repo" annotated-tag-only
+write_helper "$mixed_repo"
+annotated_tip=$(commit_all "$mixed_repo" "annotated tag-only tip")
+git -C "$mixed_repo" tag -a -m "annotated tag-only tip" annotated-only "$annotated_tip"
+annotated_object=$(git -C "$mixed_repo" rev-parse annotated-only)
+write_check_fixture "$mixed_repo" notes-source
+write_helper "$mixed_repo"
+notes_tip=$(commit_all "$mixed_repo" "notes source tip")
+blob_oid=$(printf 'not a commit\n' | git -C "$mixed_repo" hash-object -w --stdin)
+cat >"$mixed_repo/hack/run-on-linux.sh" <<EOF
+#!/usr/bin/env bash
+printf 'active helper ran\\n' >>'$active_helper_log'
+exit 97
+EOF
+chmod +x "$mixed_repo/hack/run-on-linux.sh"
+active_helper_diff=$(git -C "$mixed_repo" diff --binary -- hack/run-on-linux.sh)
+: >"$mixed_input"
+write_push_record "$mixed_input" refs/heads/one "$tip_one" refs/heads/one
+write_push_record "$mixed_input" refs/heads/duplicate "$tip_one" refs/heads/duplicate
+write_push_record "$mixed_input" refs/tags/light-only "$lightweight_tip" refs/tags/light-only
+write_push_record "$mixed_input" refs/tags/annotated-only "$annotated_object" refs/tags/annotated-only
+write_push_record "$mixed_input" refs/heads/deleted 0000000000000000000000000000000000000000 refs/heads/deleted
+write_push_record "$mixed_input" refs/tags/blob "$blob_oid" refs/tags/blob
+write_push_record "$mixed_input" refs/notes/review "$notes_tip" refs/heads/from-notes
+write_push_record "$mixed_input" refs/heads/to-notes "$tip_two" refs/notes/review
+export TEST_LOG=$mixed_log
+run_hook "$mixed_repo" "$mixed_input" "$mixed_output" || fail "mixed push input was rejected"
+assert_count 1 lint:tip-one "$mixed_log"
+assert_count 1 vendor:tip-one "$mixed_log"
+assert_count 1 helper:tip-one "$mixed_log"
+assert_count 1 docs:tip-one "$mixed_log"
+assert_count 1 lint:lightweight-tag-only "$mixed_log"
+assert_count 1 vendor:lightweight-tag-only "$mixed_log"
+assert_count 1 helper:lightweight-tag-only "$mixed_log"
+assert_count 1 docs:lightweight-tag-only "$mixed_log"
+assert_count 1 lint:annotated-tag-only "$mixed_log"
+assert_count 1 vendor:annotated-tag-only "$mixed_log"
+assert_count 1 helper:annotated-tag-only "$mixed_log"
+assert_count 1 docs:annotated-tag-only "$mixed_log"
+assert_count 1 lint:tip-two "$mixed_log"
+assert_count 1 vendor:tip-two "$mixed_log"
+assert_count 1 helper:tip-two "$mixed_log"
+assert_count 1 docs:tip-two "$mixed_log"
+assert_not_contains notes-source "$mixed_log"
+[[ ! -e $active_helper_log ]] || fail "the dirty active-checkout helper ran"
+[[ ! -e $mixed_repo/build ]] || fail "tip checks wrote build output to the active checkout"
+[[ $(git -C "$mixed_repo" diff --binary -- hack/run-on-linux.sh) == "$active_helper_diff" ]] || fail "the active checkout changed"
+assert_hook_cleanup "$mixed_repo"
+
+# A helper-less historical tip validates docs directly only on Linux. A
+# present non-executable helper must fail rather than enable the fallback.
+historical_repo=$test_root/historical
+historical_log=$test_root/historical.log
+historical_input=$test_root/historical.input
+shim_dir=$test_root/uname-shim
+init_repo "$historical_repo"
+write_check_fixture "$historical_repo" historical
+rm -f "$historical_repo/hack/run-on-linux.sh"
+historical_tip=$(commit_all "$historical_repo" "historical helper-less tip")
+mkdir -p "$shim_dir"
+cat >"$shim_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+[[ ${1:-} == -s ]] || exit 2
+printf '%s\n' "$FAKE_UNAME"
+EOF
+chmod +x "$shim_dir/uname"
+export PATH=$shim_dir:$original_path
+: >"$historical_input"
+write_push_record "$historical_input" refs/heads/historical "$historical_tip" refs/heads/historical
+export TEST_LOG=$historical_log
+export FAKE_UNAME=Linux
+run_hook "$historical_repo" "$historical_input" "$test_root/historical-linux" || fail "helper-less Linux tip was rejected"
+assert_count 1 lint:historical "$historical_log"
+assert_count 1 vendor:historical "$historical_log"
+assert_count 0 helper:historical "$historical_log"
+assert_count 1 docs:historical "$historical_log"
+assert_hook_cleanup "$historical_repo"
+
+: >"$historical_log"
+export FAKE_UNAME=Darwin
+if run_hook "$historical_repo" "$historical_input" "$test_root/historical-darwin"; then
+    fail "helper-less non-Linux tip was accepted"
+fi
+assert_count 1 lint:historical "$historical_log"
+assert_count 1 vendor:historical "$historical_log"
+assert_count 0 helper:historical "$historical_log"
+assert_count 0 docs:historical "$historical_log"
+assert_contains "$historical_tip" "$test_root/historical-darwin.stderr"
+assert_contains "pushed tip lacks hack/run-on-linux.sh and requires Linux" "$test_root/historical-darwin.stderr"
+assert_hook_cleanup "$historical_repo"
+
+write_helper "$historical_repo"
+chmod -x "$historical_repo/hack/run-on-linux.sh"
+nonexec_tip=$(commit_all "$historical_repo" "non-executable helper")
+: >"$historical_input"
+write_push_record "$historical_input" refs/heads/nonexec "$nonexec_tip" refs/heads/nonexec
+: >"$historical_log"
+export FAKE_UNAME=Linux
+if run_hook "$historical_repo" "$historical_input" "$test_root/historical-nonexec"; then
+    fail "tip with a non-executable helper was accepted"
+fi
+assert_count 1 lint:historical "$historical_log"
+assert_count 1 vendor:historical "$historical_log"
+assert_count 0 helper:historical "$historical_log"
+assert_count 0 docs:historical "$historical_log"
+assert_hook_cleanup "$historical_repo"
+
+# Failures from each check propagate, while success and every failure remove
+# disposable worktrees and their temporary data.
+failure_repo=$test_root/failures
+failure_log=$test_root/failures.log
+failure_input=$test_root/failures.input
+init_repo "$failure_repo"
+write_check_fixture "$failure_repo" failure
+write_helper "$failure_repo"
+printf 'lint\n' >"$failure_repo/fail-stage"
+cat >"$failure_repo/Makefile" <<'EOF'
+BUILD_PATH ?= $(CURDIR)/build
+
+.PHONY: lint check-vendor docs-validation
+lint:
+	@printf 'lint:failure\n' >>"$(TEST_LOG)"
+	@test "$$(cat fail-stage)" != lint
+	@test "$(BUILD_PATH)" = "$(CURDIR)/build"
+	@mkdir -p "$(BUILD_PATH)"
+	@./fake-lint >"$(BUILD_PATH)/lint.marker"
+
+check-vendor:
+	@printf 'vendor:failure\n' >>"$(TEST_LOG)"
+	@test "$$(cat fail-stage)" != vendor
+
+docs-validation:
+	@printf 'docs:failure\n' >>"$(TEST_LOG)"
+	@test "$$(cat fail-stage)" != docs
+EOF
+lint_failure=$(commit_all "$failure_repo" "lint failure")
+printf 'vendor\n' >"$failure_repo/fail-stage"
+vendor_failure=$(commit_all "$failure_repo" "vendor failure")
+printf 'docs\n' >"$failure_repo/fail-stage"
+docs_failure=$(commit_all "$failure_repo" "docs failure")
+printf 'none\n' >"$failure_repo/fail-stage"
+success_tip=$(commit_all "$failure_repo" "successful checks")
+export TEST_LOG=$failure_log
+
+for failure_case in "lint:$lint_failure" "vendor:$vendor_failure" "docs:$docs_failure"; do
+    stage=${failure_case%%:*}
+    tip=${failure_case#*:}
+    : >"$failure_input"
+    write_push_record "$failure_input" "refs/heads/$stage" "$tip" "refs/heads/$stage"
+    : >"$failure_log"
+    if run_hook "$failure_repo" "$failure_input" "$test_root/failure-$stage"; then
+        fail "$stage failure did not propagate"
+    fi
+    assert_contains vendor:failure "$failure_log"
+    if [[ $stage == vendor ]]; then
+        assert_not_contains lint:failure "$failure_log"
+    else
+        assert_contains lint:failure "$failure_log"
+    fi
+    if [[ $stage == docs ]]; then
+        assert_contains helper:failure "$failure_log"
+        assert_contains docs:failure "$failure_log"
+    else
+        assert_not_contains helper:failure "$failure_log"
+        assert_not_contains docs:failure "$failure_log"
+    fi
+    assert_hook_cleanup "$failure_repo"
+done
+
+: >"$failure_input"
+write_push_record "$failure_input" refs/heads/success "$success_tip" refs/heads/success
+: >"$failure_log"
+run_hook "$failure_repo" "$failure_input" "$test_root/failure-success" || fail "successful checks were rejected"
+assert_contains lint:failure "$failure_log"
+assert_contains vendor:failure "$failure_log"
+assert_contains helper:failure "$failure_log"
+assert_contains docs:failure "$failure_log"
+[[ ! -e $failure_repo/build ]] || fail "successful tip wrote build output to the active checkout"
+assert_hook_cleanup "$failure_repo"
+
+printf 'pre-push hook tests passed\n'


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Replaces the `pre-commit` framework with optional native Git hooks that catch common verification failures locally without requiring another hook manager.

Run `make git-hooks-install` once in each worktree. The conflict-aware installer configures a worktree-scoped `.githooks` path, safely migrates the legacy shared setting, refuses hidden or included custom hook configuration, and rolls back failed changes.

The tracked hooks provide:

- `pre-commit` validation of staged whitespace and conflict markers.
- `commit-msg` validation of canonical `Signed-off-by: Name <email>` trailers. Only a merge with an active, worktree-specific `MERGE_HEAD` is exempt.
- `applypatch-msg`, `pre-applypatch`, and `pre-merge-commit` delegates so `git am` and automatic merges receive the same checks.
- `pre-push` lint, vendor, and documentation validation for every unique pushed source tip except `refs/notes/*` metadata. Checks run in disposable worktrees using each tip's build path and `hack/run-on-linux.sh`; historical tips without the helper validate directly on Linux and fail clearly elsewhere.

The hooks provide early feedback but do not replace CI and can be bypassed intentionally with Git's native `--no-verify` option.

This also keeps `make lint` read-only, provides `make lint-fix` for explicit fixes, aligns lint toolchain/OS selection with CI, pins Prettier, corrects shell-file discovery and exposed ShellCheck findings, formats files omitted by Linux-only linting, and makes documentation validation independent of the host SELinux default.

Hermetic test suites under `test/git-hooks/` cover commit, patch, merge, installer, linked-worktree, configuration-precedence, rollback, ref-selection, historical-tip, per-tip-tooling, and cleanup behavior. The lightweight `git-hooks` verification job runs them in CI.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Validated on the final combined change with:

- `make test-git-hooks` — commit/apply/merge checks 33/33; all 12 installer scenario groups; pre-push suite passed
- Bash syntax checks for every hook, installer, and hook test
- ShellCheck 0.11.0 and shfmt checks
- Prettier 3.9.6, markdownlint, and markdown TOC verification
- `make verify-dependencies`
- `make lint` — 0 issues
- `git diff --check`

The installer tests include negative controls for dormant and included configuration in the current and sibling worktrees. Pre-push tests include source-ref notes filtering, tag-only tips, poisoned Git environment cleanup, tip-local helpers and build state, vendor-before-lint cleanliness, historical Linux fallback, failure propagation, and worktree cleanup.

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional native Git hooks for commit sign-off checks, staged-change validation, linting, vendor checks, and documentation validation.
  - Added support for running Linux-only checks through Podman or Docker on other platforms.

- **Improvements**
  - `lint` now checks without modifying files; use `lint-fix` for automatic corrections.
  - Documentation validation is limited to Linux environments.
  - Prettier checks now use a consistent pinned version.
  - Git hooks are configured per worktree and preserve conflicting configurations.

- **Documentation**
  - Documented Git hook installation, checks, requirements, and bypass options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->