### PR TITLE
Fix runtime vm nil task panic

### DIFF
--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -47,8 +47,9 @@ import (
 	"github.com/cri-o/cri-o/utils/errdefs"
 )
 
-// errTaskNotConnected is returned when the shim task client is not initialized,
-// e.g. after a CRI-O restart before reconnection to the shim.
+// errTaskNotConnected is returned when the shim task client is not initialized
+// and reconnection is not possible (e.g. address file missing for a stopped
+// container).
 var errTaskNotConnected = errors.New("task service not connected")
 
 // runtimeVM is the Runtime interface implementation that is more appropriate
@@ -381,6 +382,10 @@ func (r *runtimeVM) StartContainer(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
+	if err := r.ensureTask(ctx, c); err != nil {
+		return err
+	}
+
 	if err := r.start(c.ID(), ""); err != nil {
 		return err
 	}
@@ -576,8 +581,8 @@ func (r *runtimeVM) execContainerCommon(ctx context.Context, c *Container, cmd [
 	}
 
 	// Create the "exec" process
-	if r.task == nil {
-		return execError, errTaskNotConnected
+	if err := r.ensureTask(ctx, c); err != nil {
+		return execError, err
 	}
 	if _, err = r.task.Exec(r.ctx, request); err != nil {
 		return execError, errdefs.FromGRPC(err)
@@ -677,8 +682,8 @@ func (r *runtimeVM) UpdateContainer(ctx context.Context, c *Container, res *rspe
 		return err
 	}
 
-	if r.task == nil {
-		return errTaskNotConnected
+	if err := r.ensureTask(ctx, c); err != nil {
+		return err
 	}
 	if _, err := r.task.Update(r.ctx, &task.UpdateTaskRequest{
 		ID:        c.ID(),
@@ -713,6 +718,10 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 	// Lock the container
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
+
+	if err := r.ensureTask(ctx, c); err != nil {
+		return err
+	}
 
 	// Cancel the context before returning to ensure goroutines are stopped.
 	ctx, cancel := context.WithCancel(r.ctx)
@@ -839,6 +848,12 @@ func (r *runtimeVM) deleteContainer(c *Container, force bool) error {
 		return err
 	}
 
+	if err := r.ensureTask(r.ctx, c); err != nil {
+		if !force {
+			return err
+		}
+	}
+
 	if err := r.remove(c.ID(), ""); err != nil && !force {
 		return err
 	}
@@ -848,8 +863,6 @@ func (r *runtimeVM) deleteContainer(c *Container, force bool) error {
 		if err != nil && !errors.Is(err, ttrpc.ErrClosed) && !force {
 			return err
 		}
-	} else if !force {
-		return errTaskNotConnected
 	}
 
 	r.Lock()
@@ -871,6 +884,43 @@ func (r *runtimeVM) UpdateContainerStatus(ctx context.Context, c *Container) err
 	return r.updateContainerStatus(ctx, c)
 }
 
+// ensureTask checks whether the shim task client is connected and attempts to
+// reconnect if it is not.  This typically happens after a CRI-O restart when
+// containers from a previous run are being restored.  The shim address is read
+// from c's bundle directory.
+func (r *runtimeVM) ensureTask(ctx context.Context, c *Container) error {
+	if r.task != nil {
+		return nil
+	}
+
+	addressPath := filepath.Join(c.BundlePath(), "address")
+
+	data, err := os.ReadFile(addressPath)
+	if err != nil {
+		log.Warnf(ctx, "Failed to read shim address for %s: %v", c.ID(), err)
+
+		return errTaskNotConnected
+	}
+
+	address := strings.TrimSpace(string(data))
+
+	conn, err := client.Connect(address, client.AnonDialer)
+	if err != nil {
+		log.Warnf(ctx, "Failed to reconnect to shim for %s at %s: %v", c.ID(), address, err)
+
+		return errTaskNotConnected
+	}
+
+	options := ttrpc.WithOnClose(func() { conn.Close() })
+	cl := ttrpc.NewClient(conn, options)
+	r.client = cl
+	r.task = task.NewTaskClient(cl)
+
+	log.Infof(ctx, "Reconnected to shim for %s at %s", c.ID(), address)
+
+	return nil
+}
+
 // updateContainerStatus is a UpdateContainerStatus helper, which actually does the container's
 // status refresh.
 // It does **not** Lock the container, thus it's the caller responsibility to do so, when needed.
@@ -878,37 +928,14 @@ func (r *runtimeVM) updateContainerStatus(ctx context.Context, c *Container) err
 	log.Debugf(ctx, "RuntimeVM.updateContainerStatus() start")
 	defer log.Debugf(ctx, "RuntimeVM.updateContainerStatus() end")
 
-	// This can happen on restore. We need to read shim address from the bundle path.
-	// And then connect to the existing gRPC server with this address.
-	if r.task == nil {
-		addressPath := filepath.Join(c.BundlePath(), "address")
+	if err := r.ensureTask(ctx, c); err != nil {
+		if c.state.Status == ContainerStateStopped {
+			log.Debugf(ctx, "Skipping status update for stopped container: %+v", c.state)
 
-		data, err := os.ReadFile(addressPath)
-		if err != nil {
-			// If the container is actually removed, this error is expected and should be ignored.
-			// In this case, the container's status should be "Stopped".
-			if c.state.Status == ContainerStateStopped {
-				log.Debugf(ctx, "Skipping status update for: %+v", c.state)
-
-				return nil
-			}
-
-			log.Warnf(ctx, "Failed to read shim address: %v", err)
-
-			return errors.New("runtime not correctly setup")
+			return nil
 		}
 
-		address := strings.TrimSpace(string(data))
-
-		conn, err := client.Connect(address, client.AnonDialer)
-		if err != nil {
-			return err
-		}
-
-		options := ttrpc.WithOnClose(func() { conn.Close() })
-		cl := ttrpc.NewClient(conn, options)
-		r.client = cl
-		r.task = task.NewTaskClient(cl)
+		return err
 	}
 
 	response, err := r.task.State(r.ctx, &task.StateRequest{
@@ -1081,8 +1108,8 @@ func (r *runtimeVM) PauseContainer(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	if r.task == nil {
-		return errTaskNotConnected
+	if err := r.ensureTask(ctx, c); err != nil {
+		return err
 	}
 	if _, err := r.task.Pause(r.ctx, &task.PauseRequest{
 		ID: c.ID(),
@@ -1102,8 +1129,8 @@ func (r *runtimeVM) UnpauseContainer(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
-	if r.task == nil {
-		return errTaskNotConnected
+	if err := r.ensureTask(ctx, c); err != nil {
+		return err
 	}
 	if _, err := r.task.Resume(r.ctx, &task.ResumeRequest{
 		ID: c.ID(),

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -754,6 +754,7 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 		err := r.waitCtrTerminate(sig, stopCh, timeoutDuration)
 		if err == nil {
 			c.state.Finished = time.Now()
+			c.state.Status = ContainerStateStopped
 
 			return nil
 		}
@@ -774,6 +775,7 @@ func (r *runtimeVM) StopContainer(ctx context.Context, c *Container, timeout int
 	}
 
 	c.state.Finished = time.Now()
+	c.state.Status = ContainerStateStopped
 
 	return nil
 }

--- a/internal/oci/runtime_vm.go
+++ b/internal/oci/runtime_vm.go
@@ -47,6 +47,10 @@ import (
 	"github.com/cri-o/cri-o/utils/errdefs"
 )
 
+// errTaskNotConnected is returned when the shim task client is not initialized,
+// e.g. after a CRI-O restart before reconnection to the shim.
+var errTaskNotConnected = errors.New("task service not connected")
+
 // runtimeVM is the Runtime interface implementation that is more appropriate
 // for VM based container runtimes.
 type runtimeVM struct {
@@ -572,6 +576,9 @@ func (r *runtimeVM) execContainerCommon(ctx context.Context, c *Container, cmd [
 	}
 
 	// Create the "exec" process
+	if r.task == nil {
+		return execError, errTaskNotConnected
+	}
 	if _, err = r.task.Exec(r.ctx, request); err != nil {
 		return execError, errdefs.FromGRPC(err)
 	}
@@ -670,6 +677,9 @@ func (r *runtimeVM) UpdateContainer(ctx context.Context, c *Container, res *rspe
 		return err
 	}
 
+	if r.task == nil {
+		return errTaskNotConnected
+	}
 	if _, err := r.task.Update(r.ctx, &task.UpdateTaskRequest{
 		ID:        c.ID(),
 		Resources: protobuf.FromAny(anyType),
@@ -833,9 +843,13 @@ func (r *runtimeVM) deleteContainer(c *Container, force bool) error {
 		return err
 	}
 
-	_, err := r.task.Shutdown(r.ctx, &task.ShutdownRequest{ID: c.ID()})
-	if err != nil && !errors.Is(err, ttrpc.ErrClosed) && !force {
-		return err
+	if r.task != nil {
+		_, err := r.task.Shutdown(r.ctx, &task.ShutdownRequest{ID: c.ID()})
+		if err != nil && !errors.Is(err, ttrpc.ErrClosed) && !force {
+			return err
+		}
+	} else if !force {
+		return errTaskNotConnected
 	}
 
 	r.Lock()
@@ -1067,6 +1081,9 @@ func (r *runtimeVM) PauseContainer(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
+	if r.task == nil {
+		return errTaskNotConnected
+	}
 	if _, err := r.task.Pause(r.ctx, &task.PauseRequest{
 		ID: c.ID(),
 	}); err != nil {
@@ -1085,6 +1102,9 @@ func (r *runtimeVM) UnpauseContainer(ctx context.Context, c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 
+	if r.task == nil {
+		return errTaskNotConnected
+	}
 	if _, err := r.task.Resume(r.ctx, &task.ResumeRequest{
 		ID: c.ID(),
 	}); err != nil {
@@ -1172,6 +1192,9 @@ func (r *runtimeVM) ReopenContainerLog(ctx context.Context, c *Container) error 
 }
 
 func (r *runtimeVM) start(ctrID, execID string) error {
+	if r.task == nil {
+		return errTaskNotConnected
+	}
 	if _, err := r.task.Start(r.ctx, &task.StartRequest{
 		ID:     ctrID,
 		ExecID: execID,
@@ -1183,6 +1206,9 @@ func (r *runtimeVM) start(ctrID, execID string) error {
 }
 
 func (r *runtimeVM) wait(ctrID, execID string) (int32, error) {
+	if r.task == nil {
+		return -1, errdefs.ErrNotFound
+	}
 	resp, err := r.task.Wait(r.ctx, &task.WaitRequest{
 		ID:     ctrID,
 		ExecID: execID,
@@ -1199,12 +1225,15 @@ func (r *runtimeVM) wait(ctrID, execID string) (int32, error) {
 }
 
 func (r *runtimeVM) kill(ctrID, execID string, signal syscall.Signal) error {
+	if r.task == nil {
+		return errdefs.ErrNotFound
+	}
 	if _, err := r.task.Kill(r.ctx, &task.KillRequest{
 		ID:     ctrID,
 		ExecID: execID,
 		Signal: uint32(signal),
 		All:    false,
-	}); err != nil {
+	}); err != nil && !errors.Is(err, ttrpc.ErrClosed) {
 		return errdefs.FromGRPC(err)
 	}
 
@@ -1212,6 +1241,9 @@ func (r *runtimeVM) kill(ctrID, execID string, signal syscall.Signal) error {
 }
 
 func (r *runtimeVM) remove(ctrID, execID string) error {
+	if r.task == nil {
+		return nil
+	}
 	if _, err := r.task.Delete(r.ctx, &task.DeleteRequest{
 		ID:     ctrID,
 		ExecID: execID,
@@ -1223,6 +1255,9 @@ func (r *runtimeVM) remove(ctrID, execID string) error {
 }
 
 func (r *runtimeVM) resizePty(ctrID, execID string, size remotecommand.TerminalSize) error {
+	if r.task == nil {
+		return errTaskNotConnected
+	}
 	_, err := r.task.ResizePty(r.ctx, &task.ResizePtyRequest{
 		ID:     ctrID,
 		ExecID: execID,
@@ -1237,6 +1272,9 @@ func (r *runtimeVM) resizePty(ctrID, execID string, size remotecommand.TerminalS
 }
 
 func (r *runtimeVM) closeIO(ctrID, execID string) error {
+	if r.task == nil {
+		return errTaskNotConnected
+	}
 	_, err := r.task.CloseIO(r.ctx, &task.CloseIORequest{
 		ID:     ctrID,
 		ExecID: execID,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR aims to be a comprehensive fix of all crashing issues after cri-o restarts in presence of VM-based pods.  The fix is based on observing an OCP cluster degradation due to cri-o entering crash loop and kubelet exiting due to unavailability of `crio.sock` while running OCP test suite on kata runtime, and aided by Opus 4.6..  The main idea is to protect every CRI entry point in `runtime_vm.go` against nil `r.task` dereference, mostly by trying to reconnect first.

This PR is related to PR's #9776 and #9994 but while these two each seems to fix a particular symptom of the broader problem, this one is an attempt to fix the broader problem itself.  This PR is similar to #9776 in that like #9776, it factors the reconnection code out of `updateContainerStatus()`, though it then applies it to other vulnerable entry points  too, and adds custom protection to `kill()`.  It also subsumes the `ttrpc.ErrClosed` fix from #9994 (consistent with how the error is handled by `wait()` and other functions already), and also its container status fix in `StopContainer()` which seems to be a bit unrelated though definitely useful.

Tagging prior art authors @tobiasworkstech @thejasn 

#### Which issue(s) this PR fixes:

Fixes #9772

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container operation reliability after runtime restarts by automatically restoring required connections.
  * Lifecycle, execution, resource, pause, resume, and status operations now handle unavailable connections more consistently.
  * Containers are now consistently marked as stopped when stop operations complete.
  * Cleanup succeeds more reliably when a connection is already unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->