### PR TITLE
CI: install json-c-devel for crun build

### DIFF
--- a/contrib/test/ci/build/crun.yml
+++ b/contrib/test/ci/build/crun.yml
@@ -24,6 +24,7 @@
       - pkgconf-pkg-config
       - gperf
       - libtool
+      - json-c-devel
 
 - name: Install go-md2man for RHEL9
   block:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind failing-test
#### What this PR does / why we need it:
`setup-periodic` and `setup-fedora-periodic` have been failing 100% of the time for the last 30 days, consuming ~21 hours/week of CI compute for zero signal. Both periodics were recently set to `cron: '@yearly'` (effectively disabled) by
an automated low-value job review: openshift/release#84359.


 Root cause

Both jobs build crun from source (`crun_git_version: 1.23.1`). crun's `configure` also configures its vendored `libocispec` submodule (`AC_CONFIG_SUBDIRS([libocispec])`), which requires `json-c >= 0.14` via pkg-config, independent of the `--enable-embedded-yajl` flag used for crun itself. `json-c-devel` was never added to the "Install crun dependencies" task in `contrib/test/ci/build/crun.yml`, so every run fails at the `configure` step


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes #10330 
#### Special notes for your reviewer:
This is a CI-only change (Ansible task), no product code is affected.
Note:-this fixes the crun build failure specifically. Sampling more failed runs of these periodics also turned up two unrelated CI-infra failure modes (GCP buildhost image `cri-o-gcloud-base-latest` returning "manifest unknown",
and image-stream `root` tag import failures) that this PR does not address.Those need separate follow-up before the `@yearly` cron revert in openshift/release will result in a consistently green job.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added the required JSON-C development package to the crun build environment, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->