### PR TITLE
When CRI sets UsernsOptions to NODE check for userns-mode

### DIFF
--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -92,7 +92,15 @@ func (s *Server) configureSandboxIDMappings(
 	if sc.GetNamespaceOptions().GetUsernsOptions() != nil {
 		switch sc.GetNamespaceOptions().GetUsernsOptions().GetMode() {
 		case types.NamespaceMode_NODE:
-			return nil, nil
+			// If the UserNamespacesSupport feature gate is enabled on Kubelet, then
+			// NODE is set in the CRI request. However a CRI-O userns-mode annotation
+			// or config can be present and those should take precedence.
+			if mode == "" && s.defaultIDMappings == nil {
+				return nil, nil
+			}
+			// Clear UsernsOptions; CRI-O is going to use its own config instead.
+			sc.GetNamespaceOptions().UsernsOptions = nil
+
 		case types.NamespaceMode_POD:
 			return &storage.IDMappingOptions{
 				UIDMap: convertToStorageIDMap(


### PR DESCRIPTION
Kubelet will pass UsernsOptions with a mode of NODE when UserNamespacesSupport is enabled. This means once that feature gate is enabled the userns-mode support stops working. Ensure that userns-mode is still checked for and clear UsernsOptions in this case, so that other code does not attempt ID mappings or other native user namespace specific setup.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind bug


#### What this PR does / why we need it:

Enables mixing userns-mode and `UserNamespacesSupport` (kubelet feature gate). Previously enabling the kubelet feature gate would surprisingly make userns-mode stop working.

#### Which issue(s) this PR fixes:

Fixes #10341
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

Manually tested. I'm also happy to be told we're the only people using this and we can carry a patch, which would mean userns-mode could just be removed, as I suspect others aren't using it.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix userns-mode when combined with a Kubelet supporting user namespaces.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CRI-O user namespace configuration now takes precedence over the kubelet’s node-level request when applicable.
  * Sandbox ID mappings are applied correctly when user namespace settings or default mappings are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->